### PR TITLE
MB-2437 Add ADR 0045 to eliminate nesting parent IDs in swagger paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,6 @@ If you are looking to understand choices made in this project, see the list of [
 * 0042 [Use If-Match / E-tags for optimistic locking](adr/0042-optimistic-locking.md#use-if-match-e-tags-for-optimistic-locking)
 * 0043 [*Handling time in the Prime API*](adr/0043-prime-time.md#handling-time-in-the-prime-api)
 * 0044 [Use camelCase for API params](adr/0044-params-styling.md#use-camelcase-for-api-params)
-* 0045 [Nesting Swagger paths in the Prime API with parent IDs](adr/0045-nesting-swagger-paths.md#nesting-swagger-paths-in-the-prime-api-with-parent-ids)
+* 0045 [Nesting Swagger paths in the Prime API with multiple IDs](adr/0045-nesting-swagger-paths.md#nesting-swagger-paths-in-the-prime-api-with-multiple-ids)
 
 <!--endindex-->

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,5 +78,6 @@ If you are looking to understand choices made in this project, see the list of [
 * 0042 [Use If-Match / E-tags for optimistic locking](adr/0042-optimistic-locking.md#use-if-match-e-tags-for-optimistic-locking)
 * 0043 [*Handling time in the Prime API*](adr/0043-prime-time.md#handling-time-in-the-prime-api)
 * 0044 [Use camelCase for API params](adr/0044-params-styling.md#use-camelcase-for-api-params)
+* 0045 [Nesting Swagger paths in the Prime API with parent IDs](adr/0045-nesting-swagger-paths.md#nesting-swagger-paths-in-the-prime-api-with-parent-ids)
 
 <!--endindex-->

--- a/docs/adr/0045-nesting-swagger-paths.md
+++ b/docs/adr/0045-nesting-swagger-paths.md
@@ -1,7 +1,11 @@
-# Nesting Swagger paths in the Prime API with parent IDs
+# Nesting Swagger paths in the Prime API with multiple IDs
 
 The Prime API manages Move Task Orders and the child objects for these orders, such as shipments and payment requests.
-When writing the paths for the endpoints to access these objects, two distinct strategies have been used:
+The relationship between these objects is a straight-forward Many-to-One (many shipments or payment requests
+to one MTO), and the IDs for the child objects can be used alone to uniquely identify a record. The endpoints for this
+API follow a standard pattern of basing updates and reads off of one record at a time (sometimes returning multiple
+records when children of the base object are included). When writing the paths for these endpoints, two distinct
+strategies have been used:
 
 1. Nest the path for the new endpoint by including the ID of the parent Move Task Order for the object, e.g.
 `/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}`
@@ -9,29 +13,39 @@ When writing the paths for the endpoints to access these objects, two distinct s
 `/payment-requests/{paymentRequestID}`
 
 The first strategy is problematic because the `moveTaskOrderID` in the path is not validated, so there is no meaningful
-connection between that value and the ID of the child object. Only the ID of the child object - the `mtoShipmentID` in this example -
-is validated and used for updates. The UUIDs also make the paths extremely long.
+connection between that value and the ID of the child object. Only the ID of the child object - the `mtoShipmentID` in
+this example - is needed to fetch, validate, and update the record. The UUIDs also make the paths extremely long.
 
-The second strategy is problematic because it is inconsistent with the other the endpoints. It also obfuscates the relationships
-between objects.
+The second strategy is problematic because it is inconsistent with the other the endpoints. It also obfuscates the
+relationships between objects.
+
+Ultimately, the question is whether or not we should be including IDs that are functionally unnecessary in the path for
+the sake of a clear hierarchical structure in the API. This ADR sets this question within the context of the Prime API,
+but aims to propose a generic solution that is acceptable for most other APIs as well.
 
 ## Considered Alternatives
 
 * Leave the codebase as-is
 * Nest all paths with the IDs of the parent objects
-* Do not nest paths with parents - start a new root
+* Do not include multiple IDs unless functionally necessary. Start a new root for an object that is uniquely
+identifiable by one ID.
 
 ## Decision Outcome
 
-### Chosen Alternative: *Do not nest paths with parents - start a new root*
+### Chosen Alternative: *Do not include multiple IDs unless functionally necessary*
 
-* **Justification:** Using a new root for accessing each objects simplifies the endpoint paths dramatically. It also
-eliminates the overhead of having to grab more ID values for testing and the burden of validating those values in handlers.
-Furthermore, because we already tag all of the endpoints with the object type being accessed, the structure of the generated
+* **Justification:** Philosophically, we should not require input that is unnecessary for our processing. In the Prime
+API, we can grab all the information we need for security and general validation using the UUID of the child object.
+Requiring extra IDs in the paths for the endpoints therefore becomes an aesthetic decision, and provides little benefit
+to the usability of the API. The clarity it provides to object relationships could (and perhaps should) be subsumed into
+a well-documented ERD.
+
+Functionally, using a new root for accessing each object simplifies the endpoint paths dramatically. It also eliminates
+the overhead of having to grab more ID values for testing and the burden of validating those values in handlers.
+Furthermore, because we already tag the endpoints with the object type being accessed, the structure of the generated
 Swagger docs should not change.
 
 For example, given the two endpoints:
-
 
 ```yaml
   '/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}':
@@ -96,7 +110,33 @@ For example, given the two endpoints:
         [...]
 ```
 
-Because of the different values in the `tags` attribute, they will be grouped separately in the generated docs despite the detailed nesting in the path.
+Because of the different values in the `tags` attribute, they will be grouped separately in the generated docs despite
+the detailed nesting in the path.
+
+Therefore, in this context, writing an endpoint path like
+
+`/child-object/{:childID}`
+
+is functionally and structurally congruent to
+
+`/parent-object/{:parentID}/child-object/{:childID}`,
+
+and the former benefits from more simplicity and ease of use.
+
+It is important to note that this endpoint structure is only valid because of the Many-to-One relationship of these
+objects. For an API being designed with different data models, such as a Many-to-Many relationship that might need to be
+represented with a query like the following:
+
+```sql
+SELECT mto_shipments.id, mto_shipments.move_task_order_id, move_task_orders.available_to_prime
+FROM mto_shipments
+JOIN move_task_orders ON move_task_orders.id = mto_shipments.move_task_order_id
+WHERE mto_shipments.id = id_from_path
+AND mto_shipments.move_task_order_id = mto_id_from_path
+```
+
+it may indeed be necessary to include both IDs in the path. As such, this ADR is making the distinction that endpoint
+paths should not be nested with IDs *that are not functionally necessary for security, validation, or retrieval.*
 
 * **Consequences:** All existing nested endpoints will need the following updates:
   * The path and the parameter attributes in the .yaml file will need changes
@@ -117,7 +157,18 @@ Because of the different values in the `tags` attribute, they will be grouped se
 ### *Nest all paths with the IDs of the parent objects*
 
 * `+` Object relationships are explicit and clear to anyone using the API
-* `+` Provides an extra value to check that the correct record is being updated
+* `+` Provides an extra value to double-check that the correct record is being updated
+* `-` Parent ID value is functionally irrelevant for identifying the correct record and presents an extra failure point
+for user input
 * `-` Paths with multiple UUIDs quickly become long and unwieldy
 * `-` Development burden to validate that the parent ID matches the child's ID
 * `-` Testing burden to always require the parent ID
+
+### *Do not include multiple IDs unless functionally necessary. Start a new root uniquely identifiable objects*
+
+* `+` Endpoint paths are simpler and more readable
+* `+` Less input required from the user
+* `+` Security can be handled discretely in the handlers
+* `+` It's clear which object is being accessed and updated, or what the base object is (for lists)
+* `-` Relationships between objects is unclear in the yaml file
+* `-` Requires a specific data model to be effective

--- a/docs/adr/0045-nesting-swagger-paths.md
+++ b/docs/adr/0045-nesting-swagger-paths.md
@@ -1,0 +1,123 @@
+# Nesting Swagger paths in the Prime API with parent IDs
+
+The Prime API manages Move Task Orders and the child objects for these orders, such as shipments and payment requests.
+When writing the paths for the endpoints to access these objects, two distinct strategies have been used:
+
+1. Nest the path for the new endpoint by including the ID of the parent Move Task Order for the object, e.g.
+`/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}`
+2. Do not nest under the parent MTO and only include the ID of the object being accessed in the path, e.g.
+`/payment-requests/{paymentRequestID}`
+
+The first strategy is problematic because the `moveTaskOrderID` in the path is not validated, so there is no meaningful
+connection between that value and the ID of the child object. Only the ID of the child object - the `mtoShipmentID` in this example -
+is validated and used for updates. The UUIDs also make the paths extremely long.
+
+The second strategy is problematic because it is inconsistent with the other the endpoints. It also obfuscates the relationships
+between objects.
+
+## Considered Alternatives
+
+* Leave the codebase as-is
+* Nest all paths with the IDs of the parent objects
+* Do not nest paths with parents - start a new root
+
+## Decision Outcome
+
+### Chosen Alternative: *Do not nest paths with parents - start a new root*
+
+* **Justification:** Using a new root for accessing each objects simplifies the endpoint paths dramatically. It also
+eliminates the overhead of having to grab more ID values for testing and the burden of validating those values in handlers.
+Furthermore, because we already tag all of the endpoints with the object type being accessed, the structure of the generated
+Swagger docs should not change.
+
+For example, given the two endpoints:
+
+
+```yaml
+  '/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}':
+    put:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      summary: Updates mto shipment
+      operationId: updateMTOShipment
+      tags:
+        - mtoShipment
+      parameters:
+        - in: path
+          name: moveTaskOrderID
+          required: true
+          format: uuid
+          type: string
+        - in: path
+          name: mtoShipmentID
+          required: true
+          format: uuid
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/MTOShipment'
+        - in: header
+          name: If-Match
+          type: string
+          required: true
+      responses:
+        [...]
+  '/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items':
+    post:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      summary: Creates mto service items
+      operationId: createMTOServiceItem
+      tags:
+        - mtoServiceItem
+      parameters:
+        - in: path
+          name: moveTaskOrderID
+          required: true
+          format: uuid
+          type: string
+        - in: path
+          name: mtoShipmentID
+          required: true
+          format: uuid
+          type: string
+        - in: body
+          name: body
+          schema:
+            description: This may be a MTOServiceItemBasic, MTOServiceItemDOFSIT or etc.
+            $ref: '#/definitions/MTOServiceItem'
+      responses:
+        [...]
+```
+
+Because of the different values in the `tags` attribute, they will be grouped separately in the generated docs despite the detailed nesting in the path.
+
+* **Consequences:** All existing nested endpoints will need the following updates:
+  * The path and the parameter attributes in the .yaml file will need changes
+  * `/gen/` code will need to be regenerated
+  * Integration tests will need changes
+  * `/cmd/` code for the API CLI will need changes
+  * Handlers may not need changes, but all modified endpoints will need to be retested
+
+## Pros and Cons of the Alternatives
+
+### *Leave the codebase as-is*
+
+* `+` Less work now
+* `-` Endpoints are inconsistent
+* `-` MTO IDs for shipments are still not being validated
+* `-` Future developers will not know which convention to use
+
+### *Nest all paths with the IDs of the parent objects*
+
+* `+` Object relationships are explicit and clear to anyone using the API
+* `+` Provides an extra value to check that the correct record is being updated
+* `-` Paths with multiple UUIDs quickly become long and unwieldy
+* `-` Development burden to validate that the parent ID matches the child's ID
+* `-` Testing burden to always require the parent ID

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -49,6 +49,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0042](0042-optimistic-locking.md) - Use If-Match / E-tags for optimistic locking
 - [ADR-0043](0043-prime-time.md) - *Handling time in the Prime API*
 - [ADR-0044](0044-params-styling.md) - Use camelCase for API params
+- [ADR-0045](0045-nesting-swagger-paths.md) - Nesting Swagger paths in the Prime API with parent IDs
 
 <!-- adrlogstop -->
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -49,7 +49,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0042](0042-optimistic-locking.md) - Use If-Match / E-tags for optimistic locking
 - [ADR-0043](0043-prime-time.md) - *Handling time in the Prime API*
 - [ADR-0044](0044-params-styling.md) - Use camelCase for API params
-- [ADR-0045](0045-nesting-swagger-paths.md) - Nesting Swagger paths in the Prime API with parent IDs
+- [ADR-0045](0045-nesting-swagger-paths.md) - Nesting Swagger paths in the Prime API with multiple IDs
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
## Description

This ADR suggests eliminating nesting endpoint paths with the parent IDs of the object being accessed. Instead, we would have an independent path for the object. For example:

```
/move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}
```

would become:

```
/mto-shipments/{mtoShipmentID}
```

Approving this PR would necessitate creating a new Jira ticket to update the existing Prime endpoints to the new, un-nested path format. 

## Reviewer Notes

Please edit my prose freely! 

## References

- [Jira story](https://dp3.atlassian.net/browse/MB-2437) for this change