### PR TITLE
MB-2238 add required delivery date to shipments

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1304,6 +1304,10 @@ func init() {
           "type": "string",
           "format": "date"
         },
+        "requiredDeliveryDate": {
+          "type": "string",
+          "format": "date"
+        },
         "scheduledPickupDate": {
           "type": "string",
           "format": "date"
@@ -3099,6 +3103,10 @@ func init() {
           "format": "date"
         },
         "requestedPickupDate": {
+          "type": "string",
+          "format": "date"
+        },
+        "requiredDeliveryDate": {
           "type": "string",
           "format": "date"
         },

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -75,6 +75,10 @@ type MTOShipment struct {
 	// Format: date
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
+	// required delivery date
+	// Format: date
+	RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
+
 	// scheduled pickup date
 	// Format: date
 	ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
@@ -142,6 +146,10 @@ func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRequestedPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRequiredDeliveryDate(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -325,6 +333,19 @@ func (m *MTOShipment) validateRequestedPickupDate(formats strfmt.Registry) error
 	}
 
 	if err := validate.FormatOf("requestedPickupDate", "body", "date", m.RequestedPickupDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) validateRequiredDeliveryDate(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.RequiredDeliveryDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("requiredDeliveryDate", "body", "date", m.RequiredDeliveryDate.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -280,6 +280,10 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		payload.FirstAvailableDeliveryDate = strfmt.Date(*mtoShipment.FirstAvailableDeliveryDate)
 	}
 
+	if mtoShipment.RequiredDeliveryDate != nil && !mtoShipment.RequiredDeliveryDate.IsZero() {
+		payload.RequiredDeliveryDate = strfmt.Date(*mtoShipment.RequiredDeliveryDate)
+	}
+
 	if mtoShipment.PrimeEstimatedWeight != nil && mtoShipment.PrimeEstimatedWeightRecordedDate != nil {
 		payload.PrimeEstimatedWeight = int64(*mtoShipment.PrimeEstimatedWeight)
 		payload.PrimeEstimatedWeightRecordedDate = strfmt.Date(*mtoShipment.PrimeEstimatedWeightRecordedDate)

--- a/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
@@ -92,6 +92,11 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 		model.ActualPickupDate = &actualPickupDate
 	}
 
+	requiredDeliveryDate := time.Time(mtoShipment.RequiredDeliveryDate)
+	if !requiredDeliveryDate.IsZero() {
+		model.RequiredDeliveryDate = &requiredDeliveryDate
+	}
+
 	if mtoShipment.PickupAddress != nil {
 		model.PickupAddress = AddressModel(mtoShipment.PickupAddress)
 	}

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -36,14 +36,12 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	// mock dates
 	scheduledPickupDate := time.Date(TestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
 	requestedPickupDate := time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
-	requiredDeliveryDate := time.Date(TestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
 
 	MTOShipment := models.MTOShipment{
 		MoveTaskOrder:            moveTaskOrder,
 		MoveTaskOrderID:          moveTaskOrder.ID,
 		ScheduledPickupDate:      &scheduledPickupDate,
 		RequestedPickupDate:      &requestedPickupDate,
-		RequiredDeliveryDate:     &requiredDeliveryDate,
 		CustomerRemarks:          &remarks,
 		PickupAddress:            &pickupAddress,
 		PickupAddressID:          &pickupAddress.ID,
@@ -60,6 +58,11 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	if assertions.MTOShipment.Status == models.MTOShipmentStatusApproved {
 		approvedDate := time.Date(TestYear, time.March, 20, 0, 0, 0, 0, time.UTC)
 		MTOShipment.ApprovedDate = &approvedDate
+	}
+
+	if assertions.MTOShipment.Status == models.MTOShipmentStatusRejected {
+		requiredDeliveryDate := time.Date(TestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
+		MTOShipment.RequiredDeliveryDate = &requiredDeliveryDate
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -60,7 +60,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 		MTOShipment.ApprovedDate = &approvedDate
 	}
 
-	if assertions.MTOShipment.Status == models.MTOShipmentStatusRejected {
+	if assertions.MTOShipment.ScheduledPickupDate != nil {
 		requiredDeliveryDate := time.Date(TestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
 		MTOShipment.RequiredDeliveryDate = &requiredDeliveryDate
 	}

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -36,12 +36,14 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	// mock dates
 	scheduledPickupDate := time.Date(TestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
 	requestedPickupDate := time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
+	requiredDeliveryDate := time.Date(TestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
 
 	MTOShipment := models.MTOShipment{
 		MoveTaskOrder:            moveTaskOrder,
 		MoveTaskOrderID:          moveTaskOrder.ID,
 		ScheduledPickupDate:      &scheduledPickupDate,
 		RequestedPickupDate:      &requestedPickupDate,
+		RequiredDeliveryDate:     &requiredDeliveryDate,
 		CustomerRemarks:          &remarks,
 		PickupAddress:            &pickupAddress,
 		PickupAddressID:          &pickupAddress.ID,

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -814,6 +814,9 @@ definitions:
       actualPickupDate:
         format: date
         type: string
+      requiredDeliveryDate:
+        format: date
+        type: string
       agents:
         $ref: '#/definitions/MTOAgents'
       customerRemarks:


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Add `RequiredDeliveryDate` to mto shipment object. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```
To see that `RequiredDeliveryDate` is part of the response:
```sh
rm -f bin/prime-api-client && make bin/prime-api-client
prime-api-client --insecure fetch-mtos
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2238) for this change