### PR TITLE
MB-1288 Don't fetch access codes in dev

### DIFF
--- a/pkg/handlers/internalapi/access_code.go
+++ b/pkg/handlers/internalapi/access_code.go
@@ -1,13 +1,13 @@
 package internalapi
 
 import (
-	"os"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/cli"
 	accesscodeop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/accesscode"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -42,7 +42,8 @@ type FetchAccessCodeHandler struct {
 
 // Handle fetches the access code for a service member
 func (h FetchAccessCodeHandler) Handle(params accesscodeop.FetchAccessCodeParams) middleware.Responder {
-	if os.Getenv("FEATURE_FLAG_ACCESS_CODE") == "false" {
+	accessCodeRequired := h.HandlerContext.GetFeatureFlag(cli.FeatureFlagAccessCode)
+	if accessCodeRequired == false {
 		return nil
 	}
 

--- a/pkg/handlers/internalapi/access_code.go
+++ b/pkg/handlers/internalapi/access_code.go
@@ -1,6 +1,7 @@
 package internalapi
 
 import (
+	"os"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -41,6 +42,10 @@ type FetchAccessCodeHandler struct {
 
 // Handle fetches the access code for a service member
 func (h FetchAccessCodeHandler) Handle(params accesscodeop.FetchAccessCodeParams) middleware.Responder {
+	if os.Getenv("FEATURE_FLAG_ACCESS_CODE") == "false" {
+		return nil
+	}
+
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	if session == nil {


### PR DESCRIPTION
**Description** 
If the ENV var `FEATURE_FLAG_ACCESS_CODE` is `false`,
as it is by default in development, when the `/access_codes` endpoint
is called, it should not try to fetch access codes from the DB. If
fetching happens, it generates a stack trace, which makes the logs
noisy and  can obscure other legitimate errors.

## Reviewer Notes
Please let me know if there's a better way to handle this.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [x] There are no aXe warnings for UI.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
