### PR TITLE
[MB-1894] Changed nullability of some columns in tariff400ng_zip5_rate_areas

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -502,3 +502,4 @@
 20200410194345_change_nullability_in_tariff400ng_shorthaul_rate.up.sql
 20200413185502_change_nullability_in_tariff400ng_zip3s.up.sql
 20200420154249_add_crating_standalone.up.sql
+20200422184129_change_nullability_in_tariff400ng_zip5_rate_areas.up.sql

--- a/migrations/app/schema/20200422184129_change_nullability_in_tariff400ng_zip5_rate_areas.up.sql
+++ b/migrations/app/schema/20200422184129_change_nullability_in_tariff400ng_zip5_rate_areas.up.sql
@@ -1,0 +1,6 @@
+-- Change nullability
+ALTER TABLE tariff400ng_zip5_rate_areas
+    ALTER COLUMN zip5 SET NOT NULL,
+    ALTER COLUMN rate_area SET NOT NULL,
+    ALTER COLUMN created_at SET NOT NULL,
+    ALTER COLUMN updated_at SET NOT NULL;

--- a/pkg/models/tariff400ng_zip5_rate_area.go
+++ b/pkg/models/tariff400ng_zip5_rate_area.go
@@ -15,8 +15,8 @@ type Tariff400ngZip5RateArea struct {
 	ID        uuid.UUID `json:"id" db:"id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
-	RateArea  string    `json:"rate_area" db:"rate_area"`
 	Zip5      string    `json:"zip5" db:"zip5"`
+	RateArea  string    `json:"rate_area" db:"rate_area"`
 }
 
 // Tariff400ngZip5RateAreas is not required by pop and may be deleted
@@ -25,8 +25,8 @@ type Tariff400ngZip5RateAreas []Tariff400ngZip5RateArea
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 func (t *Tariff400ngZip5RateArea) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
+		&validators.StringLengthInRange{Field: t.Zip5, Name: "Zip5", Min: 5, Max: 5},
 		&validators.StringIsPresent{Field: t.RateArea, Name: "RateArea"},
 		&validators.RegexMatch{Field: t.RateArea, Name: "RateArea", Expr: "^(ZIP|US[0-9]+)$"},
-		&validators.StringLengthInRange{Field: t.Zip5, Name: "Zip5", Min: 5, Max: 5},
 	), nil
 }

--- a/pkg/models/tariff400ng_zip5_rate_area_test.go
+++ b/pkg/models/tariff400ng_zip5_rate_area_test.go
@@ -1,27 +1,29 @@
 package models_test
 
 import (
+	"testing"
+
 	. "github.com/transcom/mymove/pkg/models"
 )
 
-func (suite *ModelSuite) Test_Zip5RateAreaValidation() {
-	validZip5RateArea := Tariff400ngZip5RateArea{
-		Zip5:     "13945",
-		RateArea: "US14",
-	}
+func (suite *ModelSuite) Test_Tariff400ngZip5RateAreaValidation() {
+	suite.T().Run("test valid Tariff400ngZip5RateArea", func(t *testing.T) {
+		validTariff400ngZip5RateArea := Tariff400ngZip5RateArea{
+			Zip5:     "13945",
+			RateArea: "US14",
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validTariff400ngZip5RateArea, expErrors)
+	})
 
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validZip5RateArea, expErrors)
-
-	invalidZip5RateArea := Tariff400ngZip5RateArea{
-		Zip5:     "2914",
-		RateArea: "US14",
-	}
-
-	expErrors = map[string][]string{
-		"zip5": {"Zip5 not in range(5, 5)"},
-	}
-	suite.verifyValidationErrors(&invalidZip5RateArea, expErrors)
+	suite.T().Run("test invalid Tariff400ngZip5RateArea", func(t *testing.T) {
+		invalidTariff400ngZip5RateArea := Tariff400ngZip5RateArea{}
+		expErrors := map[string][]string{
+			"zip5":      {"Zip5 not in range(5, 5)"},
+			"rate_area": {"RateArea can not be blank.", "RateArea does not match the expected format."},
+		}
+		suite.verifyValidationErrors(&invalidTariff400ngZip5RateArea, expErrors)
+	})
 }
 
 func (suite *ModelSuite) Test_Zip5RateAreaCreateAndSave() {


### PR DESCRIPTION
## Description

In anticipation of turning on the new `model-vet` pre-commit hook (see #3591), we have a series of stories to fix the issues it has identified.  This PR handles the identified problems in the `Tariff400ngZip5RateArea` model.  Specifically, we're addressing the disconnect that the columns noted below are values in the model (can't be nil) but nullable in the database.

```
Tariff400ngZip5RateArea
	CreatedAt : created_at is NULL
	UpdatedAt : updated_at is NULL
	RateArea : rate_area is NULL
	Zip5 : zip5 is NULL
```

For the `tariff400ng_*` tables, all these columns should be required, so we're making them `NOT NULL` in the database.  In addition, we're making sure the model validations reflect the required fields.

## Setup

- `make server_test` to ensure server tests still run as expected.
- `make e2e_test` to ensure integration tests still run as expected.
- `make db_dev_migrate` to apply the new nullability changes.
- `go run cmd/model-vet/main.go` to run the `model-vet` tool and get a report of issues.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1894) for this change
