### PR TITLE
[MB-2419] Copy changes - SM Create profile / Upload Your Orders page

### DIFF
--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -63,7 +63,7 @@ export class UploadOrders extends Component {
         error={error}
       >
         <div>
-          <h1 className="sm-heading">Upload Your Orders</h1>
+          <h1 className="sm-heading">Upload your orders</h1>
           <p>In order to schedule your move, we need to have a complete copy of your orders.</p>
           <p>You can upload a PDF, or you can take a picture of each page and upload the images.</p>
           <p>{documentSizeLimitMsg}</p>
@@ -81,7 +81,7 @@ export class UploadOrders extends Component {
               onChange={this.onChange}
               options={{ labelIdle: uploaderLabelIdle }}
             />
-            <div className="hint">(Each page must be clear and legible)</div>
+            <div className="hint">(Each page must be clear and legible.)</div>
           </div>
         )}
 


### PR DESCRIPTION
## Description

Continued copy changes on SM create profile.
- Heading `Upload Your Orders` becomes `Upload your orders`
- Adding a period after the word "legible" `(Each page must be clear and legible.)`

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

Navigate http://milmovelocal:3000/ and login (I used needs@orde.rs), click `Continue Move Setup`, view the heading `Upload your orders`

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2419) for this change

## Screenshots

**Fixed copy**
<img width="684" alt="Screen Shot 2020-04-22 at 1 24 32 PM" src="https://user-images.githubusercontent.com/16230705/80030583-41639a80-849d-11ea-9566-167836f0e20a.png">



**Before fix**
<img width="760" alt="MB-2419" src="https://user-images.githubusercontent.com/16230705/80030563-3b6db980-849d-11ea-966b-8c97644588c2.png">
