### PR TITLE
[MB-2423] Copy changes - SM Create profile / PPM Incentive page

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -329,7 +329,7 @@ export class PpmWeight extends Component {
               <RadioButton
                 inputClassName="usa-radio__input inline_radio"
                 labelClassName="usa-radio__label inline_radio"
-                label="Not Sure"
+                label="Not sure"
                 value="Not Sure"
                 name="includesProgear"
                 checked={includesProgear === 'Not Sure'}
@@ -369,7 +369,7 @@ export class PpmWeight extends Component {
                   <RadioButton
                     inputClassName="usa-radio__input inline_radio"
                     labelClassName="usa-radio__label inline_radio"
-                    label="Not Sure"
+                    label="Not sure"
                     value="Not Sure"
                     name="isProgearMoreThan1000"
                     checked={isProgearMoreThan1000 === 'Not Sure'}


### PR DESCRIPTION
## Description

Continued copy changes on SM create profile, PPM Incentive page; updated radio button labels:
- `Not Sure` becomes `Not sure` below the questions:
  - `Do you also have pro-gear to move?`
  - `Do you think your pro-gear weighs 1000 lbs or more?`


## Setup

```sh
make server_run
make client_run
```
Navigate to http://milmovelocal:3000/ and login (I used profile@comple.te), click Continue Move Setup, then Upload your orders, then PPM Dates & Locations, view page `How much do you think you'll move?` with the slider bar. Click `Yes` below `Do you also have pro-gear to move?` to see the second set of radio buttons

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2423) for this change


## Screenshots
**Fixed copy**
<img width="618" alt="MB-2423" src="https://user-images.githubusercontent.com/16230705/80037274-20547700-84a8-11ea-999f-a508fc5e4c9f.png">



**Before the fix**
<img width="1077" alt="MB-2423" src="https://user-images.githubusercontent.com/16230705/80037298-2d716600-84a8-11ea-9746-0f63c1d08044.png">
