### PR TITLE
[MB-2465] Copy changes - SM Create profile / Current residence page

### DIFF
--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -47,7 +47,7 @@ export class ResidentialAddress extends Component {
       >
         <div className="grid-row grid-gap">
           <div className="grid-col-12">
-            <h1 className="sm-heading">Current Residence Address</h1>
+            <h1 className="sm-heading">Current residence</h1>
           </div>
         </div>
         <AddressForm schema={this.props.schema} />


### PR DESCRIPTION
## Description

Continued copy changes on SM create profile; this time on Current residence page:
- heading `Current Residence Address` becomes `Current residence`

## Setup

```sh
make server_run
make client_run
```
Navigate to http://milmovelocal:3000/ , create a new SM, get creative through pages `Create your profile` > `Name` > `Your contact info` > `Current duty station` then view the `Current residence` page

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2465) for this change


## Screenshots
**Fixed copy**
<img width="582" alt="Screen Shot 2020-04-22 at 3 20 53 PM" src="https://user-images.githubusercontent.com/16230705/80040106-3107eb80-84ae-11ea-88fd-fcfce6ed83c5.png">




**Before copy fix**
<img width="794" alt="MB-2465" src="https://user-images.githubusercontent.com/16230705/80040237-804e1c00-84ae-11ea-8cec-59eee751e961.png">


