### PR TITLE
[MB-2421] Copy changes - SM Create profile / PPM dates & locations

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3567,7 +3567,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -5010,7 +5010,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -5260,7 +5260,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -6020,7 +6020,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -9771,7 +9771,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -11220,7 +11220,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -11472,7 +11472,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -12234,7 +12234,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Do you have stuff at another pickup location?",
+          "title": "Will you move anything from another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3548,7 +3548,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "x-nullable": true
         },
@@ -4996,7 +4996,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "x-nullable": true
         },
@@ -5241,7 +5241,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "x-nullable": true
         },
@@ -6001,7 +6001,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "x-nullable": true
         },
@@ -9751,7 +9751,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "minimum": 0,
           "x-nullable": true
@@ -11205,7 +11205,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "minimum": 0,
           "x-nullable": true
@@ -11452,7 +11452,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "minimum": 0,
           "x-nullable": true
@@ -12214,7 +12214,7 @@ func init() {
         },
         "days_in_storage": {
           "type": "integer",
-          "title": "How many days do you plan to put your stuff in storage?",
+          "title": "How many days of storage do you think you'll need?",
           "maximum": 90,
           "minimum": 0,
           "x-nullable": true

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3535,7 +3535,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -3555,7 +3555,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -3615,7 +3615,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -4983,7 +4983,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5003,7 +5003,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5059,7 +5059,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5217,7 +5217,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5248,7 +5248,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5345,7 +5345,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -5988,7 +5988,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -6008,7 +6008,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -6069,7 +6069,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -9738,7 +9738,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -9759,7 +9759,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -9819,7 +9819,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11192,7 +11192,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11213,7 +11213,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11269,7 +11269,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11428,7 +11428,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11460,7 +11460,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -11557,7 +11557,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -12201,7 +12201,7 @@ func init() {
         "additional_pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -12222,7 +12222,7 @@ func init() {
         "destination_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"
@@ -12283,7 +12283,7 @@ func init() {
         "pickup_postal_code": {
           "type": "string",
           "format": "zip",
-          "title": "ZIP/Postal Code",
+          "title": "ZIP code",
           "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
           "x-nullable": true,
           "example": "90210"

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3567,7 +3567,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -3596,7 +3596,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {
@@ -5010,7 +5010,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -5040,7 +5040,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {
@@ -5260,7 +5260,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -5300,7 +5300,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "id": {
@@ -6020,7 +6020,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -6050,7 +6050,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {
@@ -9771,7 +9771,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -9800,7 +9800,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {
@@ -11220,7 +11220,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -11250,7 +11250,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {
@@ -11472,7 +11472,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -11512,7 +11512,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "id": {
@@ -12234,7 +12234,7 @@ func init() {
         },
         "has_additional_postal_code": {
           "type": "boolean",
-          "title": "Will you move anything from another pickup location?",
+          "title": "Do you have stuff at another pickup location?",
           "x-nullable": true
         },
         "has_pro_gear": {
@@ -12264,7 +12264,7 @@ func init() {
         },
         "has_sit": {
           "type": "boolean",
-          "title": "Are you going to put your stuff in temporary storage before moving into your new home?",
+          "title": "Will you put anything in storage?",
           "x-nullable": true
         },
         "net_weight": {

--- a/pkg/gen/internalmessages/create_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/create_personally_procured_move_payload.go
@@ -19,7 +19,7 @@ import (
 // swagger:model CreatePersonallyProcuredMovePayload
 type CreatePersonallyProcuredMovePayload struct {
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	AdditionalPickupPostalCode *string `json:"additional_pickup_postal_code,omitempty"`
 
@@ -34,7 +34,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
@@ -66,7 +66,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// Format: date
 	OriginalMoveDate *strfmt.Date `json:"original_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	PickupPostalCode *string `json:"pickup_postal_code,omitempty"`
 

--- a/pkg/gen/internalmessages/create_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/create_personally_procured_move_payload.go
@@ -41,7 +41,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Do you have stuff at another pickup location?
+	// Will you move anything from another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear

--- a/pkg/gen/internalmessages/create_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/create_personally_procured_move_payload.go
@@ -41,7 +41,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Will you move anything from another pickup location?
+	// Do you have stuff at another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear
@@ -55,7 +55,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// Would you like an advance of up to 60% of your PPM incentive?
 	HasRequestedAdvance bool `json:"has_requested_advance,omitempty"`
 
-	// Are you going to put your stuff in temporary storage before moving into your new home?
+	// Will you put anything in storage?
 	HasSit *bool `json:"has_sit,omitempty"`
 
 	// Net Weight

--- a/pkg/gen/internalmessages/create_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/create_personally_procured_move_payload.go
@@ -29,7 +29,7 @@ type CreatePersonallyProcuredMovePayload struct {
 	// advance worksheet
 	AdvanceWorksheet *DocumentPayload `json:"advance_worksheet,omitempty"`
 
-	// How many days do you plan to put your stuff in storage?
+	// How many days of storage do you think you'll need?
 	// Maximum: 90
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`

--- a/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
@@ -42,7 +42,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
-	// Will you move anything from another pickup location?
+	// Do you have stuff at another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear
@@ -56,7 +56,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Would you like an advance of up to 60% of your PPM incentive?
 	HasRequestedAdvance *bool `json:"has_requested_advance,omitempty"`
 
-	// Are you going to put your stuff in temporary storage before moving into your new home?
+	// Will you put anything in storage?
 	HasSit *bool `json:"has_sit,omitempty"`
 
 	// Net Weight

--- a/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
@@ -23,7 +23,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Format: date
 	ActualMoveDate *strfmt.Date `json:"actual_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	AdditionalPickupPostalCode *string `json:"additional_pickup_postal_code,omitempty"`
 
@@ -38,7 +38,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
@@ -67,7 +67,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Format: date
 	OriginalMoveDate *strfmt.Date `json:"original_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	PickupPostalCode *string `json:"pickup_postal_code,omitempty"`
 

--- a/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
@@ -42,7 +42,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
-	// Do you have stuff at another pickup location?
+	// Will you move anything from another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear

--- a/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/patch_personally_procured_move_payload.go
@@ -33,7 +33,7 @@ type PatchPersonallyProcuredMovePayload struct {
 	// advance worksheet
 	AdvanceWorksheet *DocumentPayload `json:"advance_worksheet,omitempty"`
 
-	// How many days do you plan to put your stuff in storage?
+	// How many days of storage do you think you'll need?
 	// Maximum: 90
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`

--- a/pkg/gen/internalmessages/personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/personally_procured_move_payload.go
@@ -54,7 +54,7 @@ type PersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Do you have stuff at another pickup location?
+	// Will you move anything from another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear

--- a/pkg/gen/internalmessages/personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/personally_procured_move_payload.go
@@ -42,7 +42,7 @@ type PersonallyProcuredMovePayload struct {
 	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"created_at"`
 
-	// How many days do you plan to put your stuff in storage?
+	// How many days of storage do you think you'll need?
 	// Maximum: 90
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`

--- a/pkg/gen/internalmessages/personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/personally_procured_move_payload.go
@@ -54,7 +54,7 @@ type PersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Will you move anything from another pickup location?
+	// Do you have stuff at another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear
@@ -68,7 +68,7 @@ type PersonallyProcuredMovePayload struct {
 	// Would you like an advance of up to 60% of your PPM incentive?
 	HasRequestedAdvance *bool `json:"has_requested_advance,omitempty"`
 
-	// Are you going to put your stuff in temporary storage before moving into your new home?
+	// Will you put anything in storage?
 	HasSit *bool `json:"has_sit,omitempty"`
 
 	// id

--- a/pkg/gen/internalmessages/personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/personally_procured_move_payload.go
@@ -23,7 +23,7 @@ type PersonallyProcuredMovePayload struct {
 	// Format: date
 	ActualMoveDate *strfmt.Date `json:"actual_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	AdditionalPickupPostalCode *string `json:"additional_pickup_postal_code,omitempty"`
 
@@ -47,7 +47,7 @@ type PersonallyProcuredMovePayload struct {
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
@@ -97,7 +97,7 @@ type PersonallyProcuredMovePayload struct {
 	// Format: date
 	OriginalMoveDate *strfmt.Date `json:"original_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	PickupPostalCode *string `json:"pickup_postal_code,omitempty"`
 

--- a/pkg/gen/internalmessages/update_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/update_personally_procured_move_payload.go
@@ -45,7 +45,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Will you move anything from another pickup location?
+	// Do you have stuff at another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear
@@ -59,7 +59,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Would you like an advance of up to 60% of your PPM incentive?
 	HasRequestedAdvance *bool `json:"has_requested_advance,omitempty"`
 
-	// Are you going to put your stuff in temporary storage before moving into your new home?
+	// Will you put anything in storage?
 	HasSit *bool `json:"has_sit,omitempty"`
 
 	// Net Weight

--- a/pkg/gen/internalmessages/update_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/update_personally_procured_move_payload.go
@@ -45,7 +45,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Estimated Storage Reimbursement
 	EstimatedStorageReimbursement *string `json:"estimated_storage_reimbursement,omitempty"`
 
-	// Do you have stuff at another pickup location?
+	// Will you move anything from another pickup location?
 	HasAdditionalPostalCode *bool `json:"has_additional_postal_code,omitempty"`
 
 	// Has Pro-Gear

--- a/pkg/gen/internalmessages/update_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/update_personally_procured_move_payload.go
@@ -23,7 +23,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Format: date
 	ActualMoveDate *strfmt.Date `json:"actual_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	AdditionalPickupPostalCode *string `json:"additional_pickup_postal_code,omitempty"`
 
@@ -38,7 +38,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	DestinationPostalCode *string `json:"destination_postal_code,omitempty"`
 
@@ -70,7 +70,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// Format: date
 	OriginalMoveDate *strfmt.Date `json:"original_move_date,omitempty"`
 
-	// ZIP/Postal Code
+	// ZIP code
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	PickupPostalCode *string `json:"pickup_postal_code,omitempty"`
 

--- a/pkg/gen/internalmessages/update_personally_procured_move_payload.go
+++ b/pkg/gen/internalmessages/update_personally_procured_move_payload.go
@@ -33,7 +33,7 @@ type UpdatePersonallyProcuredMovePayload struct {
 	// advance worksheet
 	AdvanceWorksheet *DocumentPayload `json:"advance_worksheet,omitempty"`
 
-	// How many days do you plan to put your stuff in storage?
+	// How many days of storage do you think you'll need?
 	// Maximum: 90
 	// Minimum: 0
 	DaysInStorage *int64 `json:"days_in_storage,omitempty"`

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -148,7 +148,7 @@ export class DateAndLocation extends Component {
               )}
             </Fragment>
           )}
-          <h3>Destination Location</h3>
+          <h3>Destination location</h3>
           <p>
             Enter the ZIP for your new home if you know it, or for{' '}
             {this.props.currentOrders && this.props.currentOrders.new_duty_station.name} if you don't.

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -162,7 +162,7 @@ export class DateAndLocation extends Component {
           <div style={{ marginTop: '0.5rem' }}>
             <span className="grey">
               The ZIP code for {currentOrders && currentOrders.new_duty_station.name} is{' '}
-              {currentOrders && currentOrders.new_duty_station.address.postal_code}{' '}
+              {currentOrders && currentOrders.new_duty_station.address.postal_code}.
             </span>
           </div>
           <SwaggerField fieldName="has_sit" swagger={this.props.schema} component={YesNoBoolean} />

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -120,9 +120,9 @@ export class DateAndLocation extends Component {
           enableReinitialize={true} //this is needed as the pickup_postal_code value needs to be initialized to the users residential address
         >
           <h1 data-cy="location-page-title">PPM dates & locations</h1>
-          <h3> Move Date </h3>
+          <h3> Move date </h3>
           <SwaggerField fieldName="original_move_date" swagger={this.props.schema} required />
-          <h3>Pickup Location</h3>
+          <h3>Pickup location</h3>
           <SwaggerField fieldName="pickup_postal_code" swagger={this.props.schema} required />
           <SwaggerField fieldName="has_additional_postal_code" swagger={this.props.schema} component={YesNoBoolean} />
           {get(this.props, 'formValues.has_additional_postal_code', false) && (

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -119,7 +119,7 @@ export class DateAndLocation extends Component {
           initialValues={initialValues}
           enableReinitialize={true} //this is needed as the pickup_postal_code value needs to be initialized to the users residential address
         >
-          <h1 data-cy="location-page-title">PPM Dates & Locations</h1>
+          <h1 data-cy="location-page-title">PPM dates & locations</h1>
           <h3> Move Date </h3>
           <SwaggerField fieldName="original_move_date" swagger={this.props.schema} required />
           <h3>Pickup Location</h3>

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -151,7 +151,7 @@ definitions:
       pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -162,14 +162,14 @@ definitions:
       additional_pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
       destination_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -240,7 +240,7 @@ definitions:
       pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -251,14 +251,14 @@ definitions:
       additional_pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
       destination_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -335,7 +335,7 @@ definitions:
       pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -346,14 +346,14 @@ definitions:
       additional_pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
       destination_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -446,7 +446,7 @@ definitions:
       pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
@@ -457,14 +457,14 @@ definitions:
       additional_pickup_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true
       destination_postal_code:
         type: string
         format: zip
-        title: ZIP/Postal Code
+        title: ZIP code
         example: '90210'
         pattern: '^(\d{5}([\-]\d{4})?)$'
         x-nullable: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -158,7 +158,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Will you move anything from another pickup location?
+        title: Do you have stuff at another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -176,7 +176,7 @@ definitions:
       has_sit:
         type: boolean
         x-nullable: true
-        title: Are you going to put your stuff in temporary storage before moving into your new home?
+        title: Will you put anything in storage?
       days_in_storage:
         type: integer
         title: How many days do you plan to put your stuff in storage?
@@ -247,7 +247,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Will you move anything from another pickup location?
+        title: Do you have stuff at another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -265,7 +265,7 @@ definitions:
       has_sit:
         type: boolean
         x-nullable: true
-        title: Are you going to put your stuff in temporary storage before moving into your new home?
+        title: Will you put anything in storage?
       days_in_storage:
         type: integer
         title: How many days do you plan to put your stuff in storage?
@@ -342,7 +342,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Will you move anything from another pickup location?
+        title: Do you have stuff at another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -360,7 +360,7 @@ definitions:
       has_sit:
         type: boolean
         x-nullable: true
-        title: Are you going to put your stuff in temporary storage before moving into your new home?
+        title: Will you put anything in storage?
       days_in_storage:
         type: integer
         title: How many days do you plan to put your stuff in storage?
@@ -453,7 +453,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Will you move anything from another pickup location?
+        title: Do you have stuff at another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -471,7 +471,7 @@ definitions:
       has_sit:
         type: boolean
         x-nullable: true
-        title: Are you going to put your stuff in temporary storage before moving into your new home?
+        title: Will you put anything in storage?
       days_in_storage:
         type: integer
         title: How many days do you plan to put your stuff in storage?

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -179,7 +179,7 @@ definitions:
         title: Will you put anything in storage?
       days_in_storage:
         type: integer
-        title: How many days do you plan to put your stuff in storage?
+        title: How many days of storage do you think you'll need?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -268,7 +268,7 @@ definitions:
         title: Will you put anything in storage?
       days_in_storage:
         type: integer
-        title: How many days do you plan to put your stuff in storage?
+        title: How many days of storage do you think you'll need?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -363,7 +363,7 @@ definitions:
         title: Will you put anything in storage?
       days_in_storage:
         type: integer
-        title: How many days do you plan to put your stuff in storage?
+        title: How many days of storage do you think you'll need?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -474,7 +474,7 @@ definitions:
         title: Will you put anything in storage?
       days_in_storage:
         type: integer
-        title: How many days do you plan to put your stuff in storage?
+        title: How many days of storage do you think you'll need?
         minimum: 0
         maximum: 90
         x-nullable: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -158,7 +158,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Do you have stuff at another pickup location?
+        title: Will you move anything from another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -247,7 +247,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Do you have stuff at another pickup location?
+        title: Will you move anything from another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -342,7 +342,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Do you have stuff at another pickup location?
+        title: Will you move anything from another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip
@@ -453,7 +453,7 @@ definitions:
       has_additional_postal_code:
         type: boolean
         x-nullable: true
-        title: Do you have stuff at another pickup location?
+        title: Will you move anything from another pickup location?
       additional_pickup_postal_code:
         type: string
         format: zip


### PR DESCRIPTION
## Description

Continued copy changes on SM create profile; PPM dates & locations page:

1. Heading - lowercase D and L "PPM Dates & Locations"
2. Subheading lowercase D in "Move Date"
3. Subheading lowercase L in "Pickup Location"
4. “Zip/Postal Code” changes to “ZIP code”
5. Replace copy for “Do you have stuff...?” with "Will you move anything from another pickup location?" 
6. “Zip/Postal Code” changes to “ZIP code” 
7. Subheading lowercase L in ` Destination Location 
8. “Zip/Postal Code” changes to “ZIP code”
9. Replace copy for “Are you going to put your stuff in temp…” with "Will you put anything in storage?"
10. Replace copy for “How many days do you plan to put your stuff in storage?” with "How many days of storage do you think you'll need?"


## Setup

```sh
make server_run
make client_run
```

Navigate to http://milmovelocal:3000/ and login (I used profile@complete.draft), click `Continue Move Setup` to view PPM dates & locations page

(click Yes to `Will you put anything in storage?` to see the next question)



## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2421) for this change

## Screenshots

### Fixed copy
<img width="343" alt="MB-2421 AFTERPARTY" src="https://user-images.githubusercontent.com/16230705/80146134-345eae00-8566-11ea-997f-b01baba2a263.png">

(_commenting here to denote these are two screenshots, there isn't an excessive amount of space between above and below, I just found it imprudent to go through the process of redoing all of the markup above_)

<img width="299" alt="MB-2421 AFTERAFTERPARTY" src="https://user-images.githubusercontent.com/16230705/80146191-53f5d680-8566-11ea-8c08-bdc178f04986.png">





### Before copy changes
<img width="456" alt="MB-2421 BEFORE" src="https://user-images.githubusercontent.com/16230705/80046277-04100480-84bf-11ea-9f78-563d73e9202b.png">
