### PR TITLE
[MB-2417] Copy changes - SM Create profile / Backup mailing address page

### DIFF
--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -37,8 +37,8 @@ export class BackupMailingAddress extends Component {
           <div className="grid-col-12">
             <h1 className="sm-heading">Backup mailing address</h1>
             <p>
-              Enter the address where mail will reach you if we can’t reach you at your primary address, such as your
-              parents’ address.
+              Where should we send mail if we can’t reach you at your primary address? You might use a parent's or
+              friend’s address, or a post office box.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Description

Continued copy changes on SM create profile; this change is on the Backup mailing address page. Please see screenshots below.


## Setup

```sh
make server_run
make client_run
```
Navigate to http://milmovelocal:3000/ and login (I used leo_spaceman_sm@example.com) continue through Create your profile > Name > Your contact info > Current duty station > Current residence address pages to the heading Backup mailing address; view the copy below that heading

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2417) for this change

## Screenshots
**Fixed copy**
<img width="573" alt="Screen Shot 2020-04-22 at 6 50 55 PM" src="https://user-images.githubusercontent.com/16230705/80050577-e052bb80-84ca-11ea-8bf9-40aa06068b27.png">




**Before copy change**
<img width="914" alt="MB-2417" src="https://user-images.githubusercontent.com/16230705/80049774-aaacd300-84c8-11ea-9bc3-93645ba7feec.png">
