### PR TITLE
MB-2182 - Upgrade development and testing postgres to 12.2 from 11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ version: '2.1'
 # References for variables shared across the file
 references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-ce60239ffca056a033af6330daf922a5a9635066
-  postgres: &postgres postgres:11.7
+  postgres: &postgres postgres:12.2
 
 executors:
   av_medium:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/ppp-infra/blob/7ba2e1086ab1b2a0d4f917b407890817327ffb3d/modules/aws-app-environment/database/variables.tf#L48
-DB_DOCKER_CONTAINER_IMAGE = postgres:11.7
+DB_DOCKER_CONTAINER_IMAGE = postgres:12.2
 TASKS_DOCKER_CONTAINER = tasks
 export PGPASSWORD=mysecretpassword
 

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     deploy:
       resources:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls_local.yml
+++ b/docker-compose.mtls_local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.prime.yml
+++ b/docker-compose.prime.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:11.7
+    image: postgres:12.2
     restart: always
     ports:
       - '6432:5432'


### PR DESCRIPTION
## Description

Upgrades to 12.2 so we can begin to close open CVE against earlier versions.

## Setup

```sh
docker pull postgres:12.2
```