### PR TITLE
MB-2257 Prime create mto service item domestic crating stand alone

### DIFF
--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -323,7 +323,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			TimeMilitary2:               handlers.FmtString(secondContact.TimeMilitary),
 			FirstAvailableDeliveryDate2: handlers.FmtDate(secondContact.FirstAvailableDeliveryDate),
 		}
-	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT:
+	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
 		item := getDimension(mtoServiceItem.Dimensions, models.DimensionTypeItem)
 		crate := getDimension(mtoServiceItem.Dimensions, models.DimensionTypeCrate)
 		payload = &primemessages.MTOServiceItemDomesticCrating{

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -24,7 +24,7 @@ type mtoServiceItemCreator struct {
 	createNewBuilder func(db *pop.Connection) createMTOServiceItemQueryBuilder
 }
 
-// CreateMTOServiceItem creates an MTO Service Item
+// CreateMTOServiceItem creates a MTO Service Item
 func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServiceItem) (*models.MTOServiceItem, *validate.Errors, error) {
 	var verrs *validate.Errors
 	var err error
@@ -40,7 +40,8 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		return nil, nil, services.NewNotFoundError(moveTaskOrderID, fmt.Sprintf("MoveTaskOrderID: %s", err))
 	}
 
-	// check if shipment exists
+	// TODO: Once customer onboarding is built, we can revisit to figure out which service items goes under each type of shipment
+	// check if shipment exists linked by MoveTaskOrderID
 	var mtoShipment models.MTOShipment
 	var mtoShipmentID uuid.UUID
 	if serviceItem.MTOShipmentID != nil {
@@ -48,10 +49,12 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	}
 	queryFilters = []services.QueryFilter{
 		query.NewQueryFilter("id", "=", mtoShipmentID),
+		query.NewQueryFilter("move_task_order_id", "=", moveTaskOrderID),
 	}
 	err = o.builder.FetchOne(&mtoShipment, queryFilters)
 	if err != nil {
-		return nil, nil, services.NewNotFoundError(mtoShipmentID, fmt.Sprintf("MTOShipmentID: %s", err))
+		return nil, nil, services.NewNotFoundError(mtoShipmentID,
+			fmt.Sprintf("MTOShipmentID with MoveTaskOrderID (%s): %s", moveTaskOrderID.String(), err))
 	}
 
 	// find the re service code id


### PR DESCRIPTION
## Description

**Outcome**
The Prime can request Dom. Crating - Stand Alone service item. Should implement endpoint consistently with the pattern used in MB-1317: Service Items: Dom Origin 1st Day SITACCEPTED . 

**Acceptance Criteria**

- Shipment this service item is associated w/ or for. 
- Name of Service Item: “Dom. Crating - Stand Alone”
- The service item code: DCRTSA
- Prime must return the following with a Dom. Crating service item request
  - Dimensions for the ITEM
    - length, height, and width (inches)
  - What level of precision do we need on this unit?
    - (We stored in thousandths of inches in our previous dimensions table.)
  - Do we need the dimensions of just the crate or the object and the crate?
    - Dimensions for the CRATE
      - length, height, and width (inches)
  - What level of precision do we need on this unit?
    - (We stored in thousandths of inches in our previous dimensions table.)
  - Description of the item to be crated

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
```

**Testing with prime api client**

data.json, remember to replace moveTaskOrderID and mtoShipmentID with known ids:
```json
{
  "modelType": "MTOServiceItemDomesticCrating",
  "moveTaskOrderID": "da3f34cc-fb94-4e0b-1c90-ba3333cb7791",
  "mtoShipmentID": "87bd2943-e616-4c63-a15b-9e6bcd420829",
  "reServiceCode": "DCRTSA",
  "crate": {
    "height": 12000,
    "length": 12000,
    "width": 12000
  },
  "item": {
    "height": 11000,
    "length": 11000,
    "width": 11000
  },
  "description": "Stand-up decorated horse head."
}
```

Prime api client cmd to test locally:
```sh
 go run ./cmd/prime-api-client --insecure create-mto-service-item --filename data-domestic-crate.json -v | jq
```

Prime api client cmd to test staging w/cac:
```sh
 go run ./cmd/prime-api-client --cac --hostname api.staging.move.mil --port 443 create-mto-service-item --filename data-domestic-crate.json -v | jq
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2257) for this change