### PR TITLE
Fixed some old Go 1.13.x references

### DIFF
--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.8'
+          go-version: '1.14'
       - name: Tidy
         run: |
           go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transcom/mymove
 
-go 1.13
+go 1.14
 
 require (
 	github.com/0xAX/notificator v0.0.0-20191016112426-3962a5ea8da1 // indirect


### PR DESCRIPTION
## Description

I noticed we had a couple of places that still referred to Go 1.13.x:

- `go.mod`
- `go-auto-approve.yml`

I also checked our [Wiki page](https://github.com/transcom/mymove/wiki/upgrade-go-version) for upgrading the go version and `go-auto-approve.yml` was already noted, but I added a note about `go.mod`.  We appear to be using go `1.14` right now based on the version of the docker image.