### PR TITLE
[MB-2115] Add post-counseling-info endpoint to prime-api-client

### DIFF
--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -83,6 +83,16 @@ func main() {
 	initUpdateMTOShipmentFlags(updateMTOShipmentCommand.Flags())
 	root.AddCommand(updateMTOShipmentCommand)
 
+	updatePostCounselingInfo := &cobra.Command{
+		Use:          "update-post-counseling-info",
+		Short:        "update post counseling info",
+		Long:         "update post counseling info such as discovering that customer has a PPM",
+		RunE:         updatePostCounselingInfo,
+		SilenceUsage: true,
+	}
+	initUpdatePostCounselingInfoFlags(updatePostCounselingInfo.Flags())
+	root.AddCommand(updatePostCounselingInfo)
+
 	createMTOServiceItemCommand := &cobra.Command{
 		Use:          "create-mto-service-item",
 		Short:        "Create mto service item",

--- a/cmd/prime-api-client/update_post_counseling_info.go
+++ b/cmd/prime-api-client/update_post_counseling_info.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	mto "github.com/transcom/mymove/pkg/gen/primeclient/move_task_order"
+)
+
+func initUpdatePostCounselingInfoFlags(flag *pflag.FlagSet) {
+	flag.String(FilenameFlag, "", "Name of the file being passed in")
+	flag.String(ETagFlag, "", "ETag for the mto shipment being updated")
+
+	flag.SortFlags = false
+}
+
+func checkUpdatePostCounselingInfoConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := CheckRootConfig(v)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if v.GetString(ETagFlag) == "" {
+		logger.Fatal(errors.New("update-post-counseling-info expects an etag"))
+	}
+
+	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {
+		logger.Fatal(errors.New("update-post-counseling-info expects a file to be passed in"))
+	}
+
+	return nil
+}
+
+func updatePostCounselingInfo(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	//  Create the logger
+	//  Remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkUpdatePostCounselingInfoConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	primeGateway, cacStore, errCreateClient := CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer cacStore.Close()
+	}
+
+	// Decode json from file that was passed into MTOShipment
+	filename := v.GetString(FilenameFlag)
+	var reader *bufio.Reader
+	if filename != "" {
+		file, fileErr := os.Open(filepath.Clean(filename))
+		if fileErr != nil {
+			logger.Fatal(fileErr)
+		}
+		reader = bufio.NewReader(file)
+	}
+
+	if len(args) > 0 && containsDash(args) {
+		reader = bufio.NewReader(os.Stdin)
+	}
+
+	jsonDecoder := json.NewDecoder(reader)
+	var postCounselingInfo mto.UpdateMTOPostCounselingInformationBody
+	err = jsonDecoder.Decode(&postCounselingInfo)
+	if err != nil {
+		return fmt.Errorf("decoding data failed: %w", err)
+	}
+
+	params := mto.UpdateMTOPostCounselingInformationParams{
+		MoveTaskOrderID: postCounselingInfo.MoveTaskOrderID,
+		Body:            postCounselingInfo,
+		IfMatch:         v.GetString(ETagFlag),
+	}
+	params.SetTimeout(time.Second * 30)
+
+	resp, errUpdatePostCounselingInfo := primeGateway.MoveTaskOrder.UpdateMTOPostCounselingInformation(&params)
+	if errUpdatePostCounselingInfo != nil {
+		// If the response cannot be parsed as JSON you may see an error like
+		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
+		// Likely this is because the API doesn't return JSON response for BadRequest OR
+		// The response type is not being set to text
+		logger.Fatal(errUpdatePostCounselingInfo.Error())
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -338,6 +338,9 @@ func init() {
             "schema": {
               "type": "object",
               "properties": {
+                "moveTaskOrderID": {
+                  "type": "string"
+                },
                 "pointOfContact": {
                   "description": "Email or id of a contact person for this update",
                   "type": "string"
@@ -2113,6 +2116,9 @@ func init() {
             "schema": {
               "type": "object",
               "properties": {
+                "moveTaskOrderID": {
+                  "type": "string"
+                },
                 "pointOfContact": {
                   "description": "Email or id of a contact person for this update",
                   "type": "string"

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
@@ -68,6 +68,9 @@ func (o *UpdateMTOPostCounselingInformation) ServeHTTP(rw http.ResponseWriter, r
 // swagger:model UpdateMTOPostCounselingInformationBody
 type UpdateMTOPostCounselingInformationBody struct {
 
+	// move task order ID
+	MoveTaskOrderID string `json:"moveTaskOrderID,omitempty"`
+
 	// Email or id of a contact person for this update
 	PointOfContact string `json:"pointOfContact,omitempty"`
 

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -302,6 +302,9 @@ swagger:model UpdateMTOPostCounselingInformationBody
 */
 type UpdateMTOPostCounselingInformationBody struct {
 
+	// move task order ID
+	MoveTaskOrderID string `json:"moveTaskOrderID,omitempty"`
+
 	// Email or id of a contact person for this update
 	PointOfContact string `json:"pointOfContact,omitempty"`
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -71,6 +71,8 @@ paths:
           schema:
             type: object
             properties:
+              moveTaskOrderID:
+                type: string
               ppmType:
                 type: string
                 enum:


### PR DESCRIPTION
## Description

Added Updating Post Counseling Information endpoint to prime-api-client
## Reviewer Notes
- I Added the moveTaskOrderID as optional params to the endpoint to get the prime-api-client to work. Once [this card](https://dp3.atlassian.net/browse/MB-2434) gets finished we should have a better way of adding params to the request
- also added [documentation to the wiki](https://github.com/transcom/mymove/wiki/Testing-the-prime-api-client-locally#testing-prime-api-update-mto-post-counseling-information)

## Setup
`prime-api-client fetch-mtos --insecure | jq`
Find a MTO you want to add post counseling information to
create a JSON file you will be passing to the tool
```
{
  "moveTaskOrderID": "id of mto you want to edit"
  "ppm_type: "FULL",
  "ppm_estimated_weight": 4000
}
```
Run the following command with your information
```
prime-api-client update-post-counseling-info --insecure --etag {ETag of MTO you are updating} --filename {path to file you made} | jq
```
## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2435) for this change

