### PR TITLE
MB-2336 Move details page placeholder

### DIFF
--- a/src/pages/TOO/moveDetails.jsx
+++ b/src/pages/TOO/moveDetails.jsx
@@ -10,7 +10,7 @@ class MoveDetails extends Component {
   render() {
     return (
       <div className="maxw-desktop-lg" data-cy="too-move-details">
-        <h1>Move Details</h1>
+        <h1>Move details</h1>
       </div>
     );
   }

--- a/src/pages/TOO/moveDetails.jsx
+++ b/src/pages/TOO/moveDetails.jsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import '../../index.scss';
+import '../../ghc_index.scss';
+
+class MoveDetails extends Component {
+  componentDidMount() {}
+
+  render() {
+    return (
+      <div className="maxw-desktop-lg" data-cy="too-move-details">
+        <h1>Move Details</h1>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = () => {
+  return {};
+};
+
+const mapDispatchToProps = {};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(MoveDetails));

--- a/src/pages/TOO/moveDetails.test.jsx
+++ b/src/pages/TOO/moveDetails.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+import { history, store } from '../../shared/store';
+import MoveDetails from './moveDetails';
+
+describe('MoveDetails', () => {
+  const wrapper = mount(
+    <Provider store={store}>
+      clear
+      <ConnectedRouter history={history}>
+        <MoveDetails />
+      </ConnectedRouter>
+    </Provider>,
+  );
+
+  it('renders the h1', () => {
+    expect(wrapper.find({ 'data-cy': 'too-move-details' }).exists()).toBe(true);
+  });
+});

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -34,6 +34,7 @@ const TIO = lazy(() => import('./TIO/tio'));
 const TOOVerificationInProgress = lazy(() => import('./TOO/tooVerificationInProgress'));
 const PaymentRequestShow = lazy(() => import('./TIO/paymentRequestShow'));
 const PaymentRequestIndex = lazy(() => import('./TIO/paymentRequestIndex'));
+const MoveDetails = lazy(() => import('pages/TOO/moveDetails'));
 
 export class RenderWithOrWithoutHeader extends Component {
   render() {
@@ -165,6 +166,7 @@ export class OfficeWrapper extends Component {
                   <Switch>
                     {too && <PrivateRoute path="/too/customer-moves" exact component={TOO} />}
                     {too && <PrivateRoute path="/move/mto/:moveTaskOrderId" exact component={TOOMoveTaskOrder} />}
+                    {too && <PrivateRoute path="/moves/:moveId" exact component={MoveDetails} />}
                     {too && (
                       <PrivateRoute
                         path="/too/customer-moves/:moveOrderId/customer/:customerId"


### PR DESCRIPTION
## Description

We will need a placeholder page created for us to later put components into. This will be used to represent the Move Details view.

**Acceptance Criteria**

A page exists that can be navigated to in order to view move details

The page makes use of the following routing: /moves/[moveID] (reference doc)

Page has the page title heading:

![image](https://user-images.githubusercontent.com/1522549/80547290-b1c25e00-896c-11ea-8f4e-4aa4e97d6b5b.png)


## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Visit `http://officelocal:3000/moves/1` to see page.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2336) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/80547709-c3583580-896d-11ea-95d0-ebc03fc0b84b.png)

