### PR TITLE
MB-2442 Connect move details to TOO queue skeleton

### DIFF
--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -10,8 +10,8 @@ class TOO extends Component {
     this.props.getAllMoveOrders();
   }
 
-  handleCustomerInfoClick = (moveOrderId, customerId) => {
-    this.props.history.push(`/too/customer-moves/${moveOrderId}/customer/${customerId}`);
+  handleCustomerInfoClick = (moveOrderId) => {
+    this.props.history.push(`/moves/${moveOrderId}`);
   };
 
   render() {
@@ -39,11 +39,7 @@ class TOO extends Component {
                 originDutyStation,
                 customerID,
               }) => (
-                <tr
-                  data-cy="too-row"
-                  onClick={() => this.handleCustomerInfoClick(moveOrderId, customerID)}
-                  key={moveOrderId}
-                >
+                <tr data-cy="too-row" onClick={() => this.handleCustomerInfoClick(moveOrderId)} key={moveOrderId}>
                   <td>{`${last_name}, ${first_name}`}</td>
                   <td>{confirmation_number}</td>
                   <td>{agency}</td>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -167,6 +167,7 @@ export class OfficeWrapper extends Component {
                     {too && <PrivateRoute path="/too/customer-moves" exact component={TOO} />}
                     {too && <PrivateRoute path="/move/mto/:moveTaskOrderId" exact component={TOOMoveTaskOrder} />}
                     {too && <PrivateRoute path="/moves/:moveId" exact component={MoveDetails} />}
+                    {/*TODO: remove CustomerDetails route when ready*/}
                     {too && (
                       <PrivateRoute
                         path="/too/customer-moves/:moveOrderId/customer/:customerId"


### PR DESCRIPTION
## Description

As a TOO
When I click a move on the queue skeleton page
Then I am directed to the new Moves Details page

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

To test...
- Log in to local office app
- Navigate to `http://officelocal:3000/too/customer-moves`
- Click on any moves
- Should be re-directed to `Move Details` page

## Code Review Verification Steps


* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2442) for this change

## Screenshots

![Apr-29-2020 13-57-33](https://user-images.githubusercontent.com/1522549/80646370-6cac3380-8a21-11ea-9e3e-552b91542e34.gif)
