### PR TITLE
Prime API Documentation: Update YAML Descriptions for "Payment Requests" Endpoint

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -422,7 +422,7 @@ func init() {
     },
     "/payment-requests": {
       "post": {
-        "description": "Creates a payment request",
+        "description": "Creates a new instance of a paymentRequest.\nA newly created payment request is assigned the status ` + "`" + `PENDING` + "`" + `.\nA move task order can have multiple payment requests, and\na final payment request can be marked using boolean ` + "`" + `isFinal` + "`" + `.\n",
         "consumes": [
           "application/json"
         ],
@@ -445,46 +445,43 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "successfully created instance of payment request",
+            "description": "Successfully created a paymentRequest object.",
             "schema": {
               "$ref": "#/definitions/PaymentRequest"
             }
           },
           "400": {
-            "description": "the payment request payload is invalid",
+            "description": "Request payload is invalid.",
             "schema": {
               "$ref": "#/responses/InvalidRequest"
             }
           },
           "401": {
-            "description": "must be authenticated to use this endpoint",
+            "description": "The request was denied.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "403": {
-            "description": "not authorized to create a payment request",
+            "description": "The request was denied.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "404": {
-            "description": "The requested resource wasn't found",
+            "description": "The requested resource wasn't found.",
             "schema": {
               "$ref": "#/responses/NotFound"
             }
           },
           "422": {
-            "description": "validation error",
+            "description": "Invalid values in request payload.",
             "schema": {
               "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {
-            "description": "A server error occurred",
-            "schema": {
-              "$ref": "#/responses/ServerError"
-            }
+            "$ref": "#/responses/ServerError"
           }
         }
       }
@@ -745,6 +742,10 @@ func init() {
     },
     "CreatePaymentRequestPayload": {
       "type": "object",
+      "required": [
+        "moveTaskOrderID",
+        "serviceItems"
+      ],
       "properties": {
         "isFinal": {
           "type": "boolean",
@@ -1698,6 +1699,7 @@ func init() {
       }
     },
     "ValidationError": {
+      "description": "Invalid values in request payload.",
       "required": [
         "invalidFields"
       ],
@@ -2226,7 +2228,7 @@ func init() {
     },
     "/payment-requests": {
       "post": {
-        "description": "Creates a payment request",
+        "description": "Creates a new instance of a paymentRequest.\nA newly created payment request is assigned the status ` + "`" + `PENDING` + "`" + `.\nA move task order can have multiple payment requests, and\na final payment request can be marked using boolean ` + "`" + `isFinal` + "`" + `.\n",
         "consumes": [
           "application/json"
         ],
@@ -2249,13 +2251,13 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "successfully created instance of payment request",
+            "description": "Successfully created a paymentRequest object.",
             "schema": {
               "$ref": "#/definitions/PaymentRequest"
             }
           },
           "400": {
-            "description": "the payment request payload is invalid",
+            "description": "Request payload is invalid.",
             "schema": {
               "description": "The request payload is invalid",
               "schema": {
@@ -2264,7 +2266,7 @@ func init() {
             }
           },
           "401": {
-            "description": "must be authenticated to use this endpoint",
+            "description": "The request was denied.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2273,7 +2275,7 @@ func init() {
             }
           },
           "403": {
-            "description": "not authorized to create a payment request",
+            "description": "The request was denied.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2282,7 +2284,7 @@ func init() {
             }
           },
           "404": {
-            "description": "The requested resource wasn't found",
+            "description": "The requested resource wasn't found.",
             "schema": {
               "description": "The requested resource wasn't found",
               "schema": {
@@ -2291,7 +2293,7 @@ func init() {
             }
           },
           "422": {
-            "description": "validation error",
+            "description": "Invalid values in request payload.",
             "schema": {
               "$ref": "#/definitions/ValidationError"
             }
@@ -2299,10 +2301,7 @@ func init() {
           "500": {
             "description": "A server error occurred",
             "schema": {
-              "description": "A server error occurred",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
+              "$ref": "#/definitions/Error"
             }
           }
         }
@@ -2579,6 +2578,10 @@ func init() {
     },
     "CreatePaymentRequestPayload": {
       "type": "object",
+      "required": [
+        "moveTaskOrderID",
+        "serviceItems"
+      ],
       "properties": {
         "isFinal": {
           "type": "boolean",
@@ -3532,6 +3535,7 @@ func init() {
       }
     },
     "ValidationError": {
+      "description": "Invalid values in request payload.",
       "required": [
         "invalidFields"
       ],

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -457,13 +457,13 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was denied.",
+            "description": "The request was unauthorized.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "403": {
-            "description": "The request was denied.",
+            "description": "The client doesn't have permissions to perform the request.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
@@ -2266,7 +2266,7 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was denied.",
+            "description": "The request was unauthorized.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2275,7 +2275,7 @@ func init() {
             }
           },
           "403": {
-            "description": "The request was denied.",
+            "description": "The client doesn't have permissions to perform the request.",
             "schema": {
               "description": "The request was denied",
               "schema": {

--- a/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request.go
+++ b/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request.go
@@ -33,7 +33,11 @@ func NewCreatePaymentRequest(ctx *middleware.Context, handler CreatePaymentReque
 
 Creates a payment request
 
-Creates a payment request
+Creates a new instance of a paymentRequest.
+A newly created payment request is assigned the status `PENDING`.
+A move task order can have multiple payment requests, and
+a final payment request can be marked using boolean `isFinal`.
+
 
 */
 type CreatePaymentRequest struct {

--- a/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request_responses.go
+++ b/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request_responses.go
@@ -16,7 +16,7 @@ import (
 // CreatePaymentRequestCreatedCode is the HTTP code returned for type CreatePaymentRequestCreated
 const CreatePaymentRequestCreatedCode int = 201
 
-/*CreatePaymentRequestCreated successfully created instance of payment request
+/*CreatePaymentRequestCreated Successfully created a paymentRequest object.
 
 swagger:response createPaymentRequestCreated
 */
@@ -60,7 +60,7 @@ func (o *CreatePaymentRequestCreated) WriteResponse(rw http.ResponseWriter, prod
 // CreatePaymentRequestBadRequestCode is the HTTP code returned for type CreatePaymentRequestBadRequest
 const CreatePaymentRequestBadRequestCode int = 400
 
-/*CreatePaymentRequestBadRequest the payment request payload is invalid
+/*CreatePaymentRequestBadRequest Request payload is invalid.
 
 swagger:response createPaymentRequestBadRequest
 */
@@ -102,7 +102,7 @@ func (o *CreatePaymentRequestBadRequest) WriteResponse(rw http.ResponseWriter, p
 // CreatePaymentRequestUnauthorizedCode is the HTTP code returned for type CreatePaymentRequestUnauthorized
 const CreatePaymentRequestUnauthorizedCode int = 401
 
-/*CreatePaymentRequestUnauthorized must be authenticated to use this endpoint
+/*CreatePaymentRequestUnauthorized The request was denied.
 
 swagger:response createPaymentRequestUnauthorized
 */
@@ -144,7 +144,7 @@ func (o *CreatePaymentRequestUnauthorized) WriteResponse(rw http.ResponseWriter,
 // CreatePaymentRequestForbiddenCode is the HTTP code returned for type CreatePaymentRequestForbidden
 const CreatePaymentRequestForbiddenCode int = 403
 
-/*CreatePaymentRequestForbidden not authorized to create a payment request
+/*CreatePaymentRequestForbidden The request was denied.
 
 swagger:response createPaymentRequestForbidden
 */
@@ -186,7 +186,7 @@ func (o *CreatePaymentRequestForbidden) WriteResponse(rw http.ResponseWriter, pr
 // CreatePaymentRequestNotFoundCode is the HTTP code returned for type CreatePaymentRequestNotFound
 const CreatePaymentRequestNotFoundCode int = 404
 
-/*CreatePaymentRequestNotFound The requested resource wasn't found
+/*CreatePaymentRequestNotFound The requested resource wasn't found.
 
 swagger:response createPaymentRequestNotFound
 */
@@ -228,7 +228,7 @@ func (o *CreatePaymentRequestNotFound) WriteResponse(rw http.ResponseWriter, pro
 // CreatePaymentRequestUnprocessableEntityCode is the HTTP code returned for type CreatePaymentRequestUnprocessableEntity
 const CreatePaymentRequestUnprocessableEntityCode int = 422
 
-/*CreatePaymentRequestUnprocessableEntity validation error
+/*CreatePaymentRequestUnprocessableEntity Invalid values in request payload.
 
 swagger:response createPaymentRequestUnprocessableEntity
 */
@@ -281,7 +281,7 @@ type CreatePaymentRequestInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *primemessages.Error `json:"body,omitempty"`
 }
 
 // NewCreatePaymentRequestInternalServerError creates CreatePaymentRequestInternalServerError with default headers values
@@ -291,13 +291,13 @@ func NewCreatePaymentRequestInternalServerError() *CreatePaymentRequestInternalS
 }
 
 // WithPayload adds the payload to the create payment request internal server error response
-func (o *CreatePaymentRequestInternalServerError) WithPayload(payload interface{}) *CreatePaymentRequestInternalServerError {
+func (o *CreatePaymentRequestInternalServerError) WithPayload(payload *primemessages.Error) *CreatePaymentRequestInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the create payment request internal server error response
-func (o *CreatePaymentRequestInternalServerError) SetPayload(payload interface{}) {
+func (o *CreatePaymentRequestInternalServerError) SetPayload(payload *primemessages.Error) {
 	o.Payload = payload
 }
 
@@ -305,8 +305,10 @@ func (o *CreatePaymentRequestInternalServerError) SetPayload(payload interface{}
 func (o *CreatePaymentRequestInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request_responses.go
+++ b/pkg/gen/primeapi/primeoperations/payment_requests/create_payment_request_responses.go
@@ -102,7 +102,7 @@ func (o *CreatePaymentRequestBadRequest) WriteResponse(rw http.ResponseWriter, p
 // CreatePaymentRequestUnauthorizedCode is the HTTP code returned for type CreatePaymentRequestUnauthorized
 const CreatePaymentRequestUnauthorizedCode int = 401
 
-/*CreatePaymentRequestUnauthorized The request was denied.
+/*CreatePaymentRequestUnauthorized The request was unauthorized.
 
 swagger:response createPaymentRequestUnauthorized
 */
@@ -144,7 +144,7 @@ func (o *CreatePaymentRequestUnauthorized) WriteResponse(rw http.ResponseWriter,
 // CreatePaymentRequestForbiddenCode is the HTTP code returned for type CreatePaymentRequestForbidden
 const CreatePaymentRequestForbiddenCode int = 403
 
-/*CreatePaymentRequestForbidden The request was denied.
+/*CreatePaymentRequestForbidden The client doesn't have permissions to perform the request.
 
 swagger:response createPaymentRequestForbidden
 */

--- a/pkg/gen/primeclient/payment_requests/create_payment_request_responses.go
+++ b/pkg/gen/primeclient/payment_requests/create_payment_request_responses.go
@@ -79,7 +79,7 @@ func NewCreatePaymentRequestCreated() *CreatePaymentRequestCreated {
 
 /*CreatePaymentRequestCreated handles this case with default header values.
 
-successfully created instance of payment request
+Successfully created a paymentRequest object.
 */
 type CreatePaymentRequestCreated struct {
 	Payload *primemessages.PaymentRequest
@@ -112,7 +112,7 @@ func NewCreatePaymentRequestBadRequest() *CreatePaymentRequestBadRequest {
 
 /*CreatePaymentRequestBadRequest handles this case with default header values.
 
-the payment request payload is invalid
+Request payload is invalid.
 */
 type CreatePaymentRequestBadRequest struct {
 	Payload interface{}
@@ -143,7 +143,7 @@ func NewCreatePaymentRequestUnauthorized() *CreatePaymentRequestUnauthorized {
 
 /*CreatePaymentRequestUnauthorized handles this case with default header values.
 
-must be authenticated to use this endpoint
+The request was denied.
 */
 type CreatePaymentRequestUnauthorized struct {
 	Payload interface{}
@@ -174,7 +174,7 @@ func NewCreatePaymentRequestForbidden() *CreatePaymentRequestForbidden {
 
 /*CreatePaymentRequestForbidden handles this case with default header values.
 
-not authorized to create a payment request
+The request was denied.
 */
 type CreatePaymentRequestForbidden struct {
 	Payload interface{}
@@ -205,7 +205,7 @@ func NewCreatePaymentRequestNotFound() *CreatePaymentRequestNotFound {
 
 /*CreatePaymentRequestNotFound handles this case with default header values.
 
-The requested resource wasn't found
+The requested resource wasn't found.
 */
 type CreatePaymentRequestNotFound struct {
 	Payload interface{}
@@ -236,7 +236,7 @@ func NewCreatePaymentRequestUnprocessableEntity() *CreatePaymentRequestUnprocess
 
 /*CreatePaymentRequestUnprocessableEntity handles this case with default header values.
 
-validation error
+Invalid values in request payload.
 */
 type CreatePaymentRequestUnprocessableEntity struct {
 	Payload *primemessages.ValidationError
@@ -272,21 +272,23 @@ func NewCreatePaymentRequestInternalServerError() *CreatePaymentRequestInternalS
 A server error occurred
 */
 type CreatePaymentRequestInternalServerError struct {
-	Payload interface{}
+	Payload *primemessages.Error
 }
 
 func (o *CreatePaymentRequestInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /payment-requests][%d] createPaymentRequestInternalServerError  %+v", 500, o.Payload)
 }
 
-func (o *CreatePaymentRequestInternalServerError) GetPayload() interface{} {
+func (o *CreatePaymentRequestInternalServerError) GetPayload() *primemessages.Error {
 	return o.Payload
 }
 
 func (o *CreatePaymentRequestInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(primemessages.Error)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/pkg/gen/primeclient/payment_requests/create_payment_request_responses.go
+++ b/pkg/gen/primeclient/payment_requests/create_payment_request_responses.go
@@ -143,7 +143,7 @@ func NewCreatePaymentRequestUnauthorized() *CreatePaymentRequestUnauthorized {
 
 /*CreatePaymentRequestUnauthorized handles this case with default header values.
 
-The request was denied.
+The request was unauthorized.
 */
 type CreatePaymentRequestUnauthorized struct {
 	Payload interface{}
@@ -174,7 +174,7 @@ func NewCreatePaymentRequestForbidden() *CreatePaymentRequestForbidden {
 
 /*CreatePaymentRequestForbidden handles this case with default header values.
 
-The request was denied.
+The client doesn't have permissions to perform the request.
 */
 type CreatePaymentRequestForbidden struct {
 	Payload interface{}

--- a/pkg/gen/primeclient/payment_requests/payment_requests_client.go
+++ b/pkg/gen/primeclient/payment_requests/payment_requests_client.go
@@ -29,7 +29,11 @@ type Client struct {
 /*
 CreatePaymentRequest creates a payment request
 
-Creates a payment request
+Creates a new instance of a paymentRequest.
+A newly created payment request is assigned the status `PENDING`.
+A move task order can have multiple payment requests, and
+a final payment request can be marked using boolean `isFinal`.
+
 */
 func (a *Client) CreatePaymentRequest(params *CreatePaymentRequestParams) (*CreatePaymentRequestCreated, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primemessages/create_payment_request_payload.go
+++ b/pkg/gen/primemessages/create_payment_request_payload.go
@@ -23,13 +23,15 @@ type CreatePaymentRequestPayload struct {
 	IsFinal *bool `json:"isFinal,omitempty"`
 
 	// move task order ID
+	// Required: true
 	// Format: uuid
-	MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+	MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
 	// Email or id of a contact person for this update
 	PointOfContact string `json:"pointOfContact,omitempty"`
 
 	// service items
+	// Required: true
 	ServiceItems []*ServiceItem `json:"serviceItems"`
 }
 
@@ -53,8 +55,8 @@ func (m *CreatePaymentRequestPayload) Validate(formats strfmt.Registry) error {
 
 func (m *CreatePaymentRequestPayload) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID.String(), formats); err != nil {
@@ -66,8 +68,8 @@ func (m *CreatePaymentRequestPayload) validateMoveTaskOrderID(formats strfmt.Reg
 
 func (m *CreatePaymentRequestPayload) validateServiceItems(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.ServiceItems) { // not required
-		return nil
+	if err := validate.Required("serviceItems", "body", m.ServiceItems); err != nil {
+		return err
 	}
 
 	for i := 0; i < len(m.ServiceItems); i++ {

--- a/pkg/gen/primemessages/validation_error.go
+++ b/pkg/gen/primemessages/validation_error.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// ValidationError validation error
+// ValidationError Invalid values in request payload.
 // swagger:model ValidationError
 type ValidationError struct {
 	ClientError

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -38,7 +38,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "post": {
-        "description": "Creates an instance of moveTaskOrder.\nCurrent this will also create a number of nested objects but not all.\nIt will currently create\n* MoveTaskOrder\n* MoveOrder\n* Customer\n* User\n* Entitlement\n\nIt will not create addresses or duty stations.\nThis is a support endpoint and will not be available in production.\n",
+        "description": "Creates an instance of moveTaskOrder.\nCurrently this will also create a number of nested objects but not all.\nIt will currently create\n* MoveTaskOrder\n* MoveOrder\n* Customer\n* User\n* Entitlement\n\nIt will not create addresses or duty stations.\nThis is a support endpoint and will not be available in production.\n",
         "consumes": [
           "application/json"
         ],
@@ -1652,7 +1652,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "post": {
-        "description": "Creates an instance of moveTaskOrder.\nCurrent this will also create a number of nested objects but not all.\nIt will currently create\n* MoveTaskOrder\n* MoveOrder\n* Customer\n* User\n* Entitlement\n\nIt will not create addresses or duty stations.\nThis is a support endpoint and will not be available in production.\n",
+        "description": "Creates an instance of moveTaskOrder.\nCurrently this will also create a number of nested objects but not all.\nIt will currently create\n* MoveTaskOrder\n* MoveOrder\n* Customer\n* User\n* Entitlement\n\nIt will not create addresses or duty stations.\nThis is a support endpoint and will not be available in production.\n",
         "consumes": [
           "application/json"
         ],

--- a/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order.go
@@ -34,7 +34,7 @@ func NewCreateMoveTaskOrder(ctx *middleware.Context, handler CreateMoveTaskOrder
 Creates a move task order
 
 Creates an instance of moveTaskOrder.
-Current this will also create a number of nested objects but not all.
+Currently this will also create a number of nested objects but not all.
 It will currently create
 * MoveTaskOrder
 * MoveOrder

--- a/pkg/gen/supportclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/supportclient/move_task_order/move_task_order_client.go
@@ -30,7 +30,7 @@ type Client struct {
 CreateMoveTaskOrder creates a move task order
 
 Creates an instance of moveTaskOrder.
-Current this will also create a number of nested objects but not all.
+Currently this will also create a number of nested objects but not all.
 It will currently create
 * MoveTaskOrder
 * MoveOrder

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -59,7 +59,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
@@ -139,7 +139,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				PointOfContact:  "user@prime.com",
 			},
 		}
@@ -167,7 +167,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: badFormatID,
+				MoveTaskOrderID: &badFormatID,
 			},
 		}
 
@@ -194,7 +194,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				PointOfContact:  "user@prime.com",
 				ServiceItems: []*primemessages.ServiceItem{
 					{
@@ -240,7 +240,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
@@ -294,7 +294,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
@@ -337,7 +337,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
 				IsFinal:         swag.Bool(false),
-				MoveTaskOrderID: *handlers.FmtUUID(moveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(moveTaskOrderID),
 				PointOfContact:  "user@prime.com",
 				ServiceItems: []*primemessages.ServiceItem{
 					{

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -295,11 +295,11 @@ paths:
           schema:
             $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was denied.
+          description: The request was unauthorized.
           schema:
             $ref: '#/responses/PermissionDenied'
         '403':
-          description: The request was denied.
+          description: The client doesn't have permissions to perform the request.
           schema:
             $ref: '#/responses/PermissionDenied'
         '404':

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -270,6 +270,12 @@ paths:
             $ref: '#/responses/ServerError'
   /payment-requests:
     post:
+      summary: Creates a payment request
+      description: |
+        Creates a new instance of a paymentRequest.
+        A newly created payment request is assigned the status `PENDING`.
+        A move task order can have multiple payment requests, and
+        a final payment request can be marked using boolean `isFinal`.
       consumes:
         - application/json
       produces:
@@ -281,38 +287,34 @@ paths:
             $ref: '#/definitions/CreatePaymentRequestPayload'
       responses:
         '201':
-          description: successfully created instance of payment request
+          description: Successfully created a paymentRequest object.
           schema:
             $ref: '#/definitions/PaymentRequest'
         '400':
-          description: the payment request payload is invalid
+          description: Request payload is invalid.
           schema:
             $ref: '#/responses/InvalidRequest'
         '401':
-          description: must be authenticated to use this endpoint
+          description: The request was denied.
           schema:
             $ref: '#/responses/PermissionDenied'
         '403':
-          description: not authorized to create a payment request
+          description: The request was denied.
           schema:
             $ref: '#/responses/PermissionDenied'
         '404':
-          description: The requested resource wasn't found
+          description: The requested resource wasn't found.
           schema:
             $ref: '#/responses/NotFound'
         '422':
-          description: validation error
+          description: Invalid values in request payload.
           schema:
             $ref: '#/definitions/ValidationError'
         '500':
-          description: A server error occurred
-          schema:
-            $ref: '#/responses/ServerError'
+          $ref: '#/responses/ServerError'
       tags:
         - paymentRequests
-      description: Creates a payment request
       operationId: createPaymentRequest
-      summary: Creates a payment request
   /payment-requests/{paymentRequestID}/uploads:
     post:
       summary: Create a new upload for a payment request
@@ -541,6 +543,9 @@ definitions:
       pointOfContact:
         type: string
         description: Email or id of a contact person for this update
+    required:
+      - moveTaskOrderID
+      - serviceItems
   Customer:
     type: object
     properties:
@@ -1224,6 +1229,7 @@ definitions:
         type: string
     type: object
   ValidationError:
+    description: Invalid values in request payload.
     allOf:
       - $ref: '#/definitions/ClientError'
       - type: object

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -17,7 +17,7 @@ paths:
       summary: Creates a move task order
       description: |
         Creates an instance of moveTaskOrder.
-        Current this will also create a number of nested objects but not all.
+        Currently this will also create a number of nested objects but not all.
         It will currently create
         * MoveTaskOrder
         * MoveOrder


### PR DESCRIPTION
## Description

Revises description and summary for create payment request
Makes moveTaskOrderID and serviceItems required in the `CreatePaymentRequestPayload` definition

## Reviewer Notes

I tried removing the descriptions in the responses of the endpoint so that it defaults to the descriptions in the responses section of the yaml.  However, this caused the expected payload type to change from an interface{} to a specific Error type (in the generated code), which broke some existing code.  The descriptions will need to be removed later when ClientError ([see issue here](https://ustcdp3.slack.com/archives/CP497TGAU/p1588188149064100)) is applied to the yaml responses.

## Setup

To view the generated docs, first install redoc-cli: https://www.npmjs.com/package/redoc-cli.

Run:

`$ cd ~/Projects/mymove`
`$ redoc-cli serve swagger/prime.yaml`

You can now view at localhost:8080

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2174) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/80646651-fcea7880-8a21-11ea-8de4-a8305e76676c.png)
