### PR TITLE
Kim mb 2172 post counseling info documentation

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -318,7 +318,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/post-counseling-info": {
       "patch": {
-        "description": "Updates move task order's post counseling information",
+        "description": "Updates moveTaskOrder fields ppmType, ppmEstimatedWeight, and pointOfContact.\n",
         "consumes": [
           "application/json"
         ],
@@ -328,7 +328,7 @@ func init() {
         "tags": [
           "moveTaskOrder"
         ],
-        "summary": "Updates move task order's post counseling information",
+        "summary": "Updates a move task order's post-counseling information",
         "operationId": "updateMTOPostCounselingInformation",
         "parameters": [
           {
@@ -339,16 +339,19 @@ func init() {
               "type": "object",
               "properties": {
                 "moveTaskOrderID": {
+                  "description": "ID for the move task order to use.",
                   "type": "string"
                 },
                 "pointOfContact": {
-                  "description": "Email or id of a contact person for this update",
+                  "description": "Email or id of a contact person for this update.",
                   "type": "string"
                 },
                 "ppmEstimatedWeight": {
+                  "description": "The estimated weight determined post counseling.",
                   "type": "integer"
                 },
                 "ppmType": {
+                  "description": "Sets a ppm type to an allowed value.",
                   "type": "string",
                   "enum": [
                     "FULL",
@@ -360,6 +363,7 @@ func init() {
           },
           {
             "type": "string",
+            "description": "Unique value that automatically changes when the request is updated.\nRequired when sending POST or PATCH requests to prevent updating stale data.\nThe same value as the eTag attribute.\n",
             "name": "If-Match",
             "in": "header",
             "required": true
@@ -367,43 +371,43 @@ func init() {
         ],
         "responses": {
           "200": {
-            "description": "Successfully updated move task order post counseling information",
+            "description": "Successfully updated move task order post-counseling information.",
             "schema": {
               "$ref": "#/definitions/MoveTaskOrder"
             }
           },
           "401": {
-            "description": "The request was denied",
+            "description": "The request was denied.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "403": {
-            "description": "The request was denied",
+            "description": "The request was denied.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "404": {
-            "description": "The requested resource wasn't found",
+            "description": "The requested resource wasn't found.",
             "schema": {
               "$ref": "#/responses/NotFound"
             }
           },
           "412": {
-            "description": "precondition failed",
+            "description": "Precondition failed.",
             "schema": {
               "$ref": "#/responses/PreconditionFailed"
             }
           },
           "422": {
-            "description": "The request payload is invalid",
+            "description": "The request payload is invalid.",
             "schema": {
               "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {
-            "description": "A server error occurred",
+            "description": "A server error occurred.",
             "schema": {
               "$ref": "#/responses/ServerError"
             }
@@ -2107,7 +2111,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/post-counseling-info": {
       "patch": {
-        "description": "Updates move task order's post counseling information",
+        "description": "Updates moveTaskOrder fields ppmType, ppmEstimatedWeight, and pointOfContact.\n",
         "consumes": [
           "application/json"
         ],
@@ -2117,7 +2121,7 @@ func init() {
         "tags": [
           "moveTaskOrder"
         ],
-        "summary": "Updates move task order's post counseling information",
+        "summary": "Updates a move task order's post-counseling information",
         "operationId": "updateMTOPostCounselingInformation",
         "parameters": [
           {
@@ -2128,16 +2132,19 @@ func init() {
               "type": "object",
               "properties": {
                 "moveTaskOrderID": {
+                  "description": "ID for the move task order to use.",
                   "type": "string"
                 },
                 "pointOfContact": {
-                  "description": "Email or id of a contact person for this update",
+                  "description": "Email or id of a contact person for this update.",
                   "type": "string"
                 },
                 "ppmEstimatedWeight": {
+                  "description": "The estimated weight determined post counseling.",
                   "type": "integer"
                 },
                 "ppmType": {
+                  "description": "Sets a ppm type to an allowed value.",
                   "type": "string",
                   "enum": [
                     "FULL",
@@ -2149,6 +2156,7 @@ func init() {
           },
           {
             "type": "string",
+            "description": "Unique value that automatically changes when the request is updated.\nRequired when sending POST or PATCH requests to prevent updating stale data.\nThe same value as the eTag attribute.\n",
             "name": "If-Match",
             "in": "header",
             "required": true
@@ -2156,13 +2164,13 @@ func init() {
         ],
         "responses": {
           "200": {
-            "description": "Successfully updated move task order post counseling information",
+            "description": "Successfully updated move task order post-counseling information.",
             "schema": {
               "$ref": "#/definitions/MoveTaskOrder"
             }
           },
           "401": {
-            "description": "The request was denied",
+            "description": "The request was denied.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2171,7 +2179,7 @@ func init() {
             }
           },
           "403": {
-            "description": "The request was denied",
+            "description": "The request was denied.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2180,7 +2188,7 @@ func init() {
             }
           },
           "404": {
-            "description": "The requested resource wasn't found",
+            "description": "The requested resource wasn't found.",
             "schema": {
               "description": "The requested resource wasn't found",
               "schema": {
@@ -2189,7 +2197,7 @@ func init() {
             }
           },
           "412": {
-            "description": "precondition failed",
+            "description": "Precondition failed.",
             "schema": {
               "description": "Precondition failed",
               "schema": {
@@ -2198,13 +2206,13 @@ func init() {
             }
           },
           "422": {
-            "description": "The request payload is invalid",
+            "description": "The request payload is invalid.",
             "schema": {
               "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {
-            "description": "A server error occurred",
+            "description": "A server error occurred.",
             "schema": {
               "description": "A server error occurred",
               "schema": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -377,13 +377,13 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was denied.",
+            "description": "The request was unauthorized.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
           },
           "403": {
-            "description": "The request was denied.",
+            "description": "The client doesn't have permissions to perform the request.",
             "schema": {
               "$ref": "#/responses/PermissionDenied"
             }
@@ -2170,7 +2170,7 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was denied.",
+            "description": "The request was unauthorized.",
             "schema": {
               "description": "The request was denied",
               "schema": {
@@ -2179,7 +2179,7 @@ func init() {
             }
           },
           "403": {
-            "description": "The request was denied.",
+            "description": "The client doesn't have permissions to perform the request.",
             "schema": {
               "description": "The request was denied",
               "schema": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -363,7 +363,7 @@ func init() {
           },
           {
             "type": "string",
-            "description": "Unique value that automatically changes when the request is updated.\nRequired when sending POST or PATCH requests to prevent updating stale data.\nThe same value as the eTag attribute.\n",
+            "description": "Optimistic locking is implemented via the ` + "`" + `If-Match` + "`" + ` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a ` + "`" + `412 Precondition Failed` + "`" + ` error.\n",
             "name": "If-Match",
             "in": "header",
             "required": true
@@ -2156,7 +2156,7 @@ func init() {
           },
           {
             "type": "string",
-            "description": "Unique value that automatically changes when the request is updated.\nRequired when sending POST or PATCH requests to prevent updating stale data.\nThe same value as the eTag attribute.\n",
+            "description": "Optimistic locking is implemented via the ` + "`" + `If-Match` + "`" + ` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a ` + "`" + `412 Precondition Failed` + "`" + ` error.\n",
             "name": "If-Match",
             "in": "header",
             "required": true

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
@@ -36,9 +36,10 @@ func NewUpdateMTOPostCounselingInformation(ctx *middleware.Context, handler Upda
 
 /*UpdateMTOPostCounselingInformation swagger:route PATCH /move-task-orders/{moveTaskOrderID}/post-counseling-info moveTaskOrder updateMTOPostCounselingInformation
 
-Updates move task order's post counseling information
+Updates a move task order's post-counseling information
 
-Updates move task order's post counseling information
+Updates moveTaskOrder fields ppmType, ppmEstimatedWeight, and pointOfContact.
+
 
 */
 type UpdateMTOPostCounselingInformation struct {
@@ -68,16 +69,16 @@ func (o *UpdateMTOPostCounselingInformation) ServeHTTP(rw http.ResponseWriter, r
 // swagger:model UpdateMTOPostCounselingInformationBody
 type UpdateMTOPostCounselingInformationBody struct {
 
-	// move task order ID
+	// ID for the move task order to use.
 	MoveTaskOrderID string `json:"moveTaskOrderID,omitempty"`
 
-	// Email or id of a contact person for this update
+	// Email or id of a contact person for this update.
 	PointOfContact string `json:"pointOfContact,omitempty"`
 
-	// ppm estimated weight
+	// The estimated weight determined post counseling.
 	PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
 
-	// ppm type
+	// Sets a ppm type to an allowed value.
 	// Enum: [FULL PARTIAL]
 	PpmType string `json:"ppmType,omitempty"`
 }

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_parameters.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_parameters.go
@@ -33,7 +33,10 @@ type UpdateMTOPostCounselingInformationParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*
+	/*Unique value that automatically changes when the request is updated.
+	Required when sending POST or PATCH requests to prevent updating stale data.
+	The same value as the eTag attribute.
+
 	  Required: true
 	  In: header
 	*/

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_parameters.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_parameters.go
@@ -33,9 +33,7 @@ type UpdateMTOPostCounselingInformationParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*Unique value that automatically changes when the request is updated.
-	Required when sending POST or PATCH requests to prevent updating stale data.
-	The same value as the eTag attribute.
+	/*Optimistic locking is implemented via the `If-Match` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a `412 Precondition Failed` error.
 
 	  Required: true
 	  In: header

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -16,7 +16,7 @@ import (
 // UpdateMTOPostCounselingInformationOKCode is the HTTP code returned for type UpdateMTOPostCounselingInformationOK
 const UpdateMTOPostCounselingInformationOKCode int = 200
 
-/*UpdateMTOPostCounselingInformationOK Successfully updated move task order post counseling information
+/*UpdateMTOPostCounselingInformationOK Successfully updated move task order post-counseling information.
 
 swagger:response updateMTOPostCounselingInformationOK
 */
@@ -60,7 +60,7 @@ func (o *UpdateMTOPostCounselingInformationOK) WriteResponse(rw http.ResponseWri
 // UpdateMTOPostCounselingInformationUnauthorizedCode is the HTTP code returned for type UpdateMTOPostCounselingInformationUnauthorized
 const UpdateMTOPostCounselingInformationUnauthorizedCode int = 401
 
-/*UpdateMTOPostCounselingInformationUnauthorized The request was denied
+/*UpdateMTOPostCounselingInformationUnauthorized The request was denied.
 
 swagger:response updateMTOPostCounselingInformationUnauthorized
 */
@@ -102,7 +102,7 @@ func (o *UpdateMTOPostCounselingInformationUnauthorized) WriteResponse(rw http.R
 // UpdateMTOPostCounselingInformationForbiddenCode is the HTTP code returned for type UpdateMTOPostCounselingInformationForbidden
 const UpdateMTOPostCounselingInformationForbiddenCode int = 403
 
-/*UpdateMTOPostCounselingInformationForbidden The request was denied
+/*UpdateMTOPostCounselingInformationForbidden The request was denied.
 
 swagger:response updateMTOPostCounselingInformationForbidden
 */
@@ -144,7 +144,7 @@ func (o *UpdateMTOPostCounselingInformationForbidden) WriteResponse(rw http.Resp
 // UpdateMTOPostCounselingInformationNotFoundCode is the HTTP code returned for type UpdateMTOPostCounselingInformationNotFound
 const UpdateMTOPostCounselingInformationNotFoundCode int = 404
 
-/*UpdateMTOPostCounselingInformationNotFound The requested resource wasn't found
+/*UpdateMTOPostCounselingInformationNotFound The requested resource wasn't found.
 
 swagger:response updateMTOPostCounselingInformationNotFound
 */
@@ -186,7 +186,7 @@ func (o *UpdateMTOPostCounselingInformationNotFound) WriteResponse(rw http.Respo
 // UpdateMTOPostCounselingInformationPreconditionFailedCode is the HTTP code returned for type UpdateMTOPostCounselingInformationPreconditionFailed
 const UpdateMTOPostCounselingInformationPreconditionFailedCode int = 412
 
-/*UpdateMTOPostCounselingInformationPreconditionFailed precondition failed
+/*UpdateMTOPostCounselingInformationPreconditionFailed Precondition failed.
 
 swagger:response updateMTOPostCounselingInformationPreconditionFailed
 */
@@ -228,7 +228,7 @@ func (o *UpdateMTOPostCounselingInformationPreconditionFailed) WriteResponse(rw 
 // UpdateMTOPostCounselingInformationUnprocessableEntityCode is the HTTP code returned for type UpdateMTOPostCounselingInformationUnprocessableEntity
 const UpdateMTOPostCounselingInformationUnprocessableEntityCode int = 422
 
-/*UpdateMTOPostCounselingInformationUnprocessableEntity The request payload is invalid
+/*UpdateMTOPostCounselingInformationUnprocessableEntity The request payload is invalid.
 
 swagger:response updateMTOPostCounselingInformationUnprocessableEntity
 */
@@ -272,7 +272,7 @@ func (o *UpdateMTOPostCounselingInformationUnprocessableEntity) WriteResponse(rw
 // UpdateMTOPostCounselingInformationInternalServerErrorCode is the HTTP code returned for type UpdateMTOPostCounselingInformationInternalServerError
 const UpdateMTOPostCounselingInformationInternalServerErrorCode int = 500
 
-/*UpdateMTOPostCounselingInformationInternalServerError A server error occurred
+/*UpdateMTOPostCounselingInformationInternalServerError A server error occurred.
 
 swagger:response updateMTOPostCounselingInformationInternalServerError
 */

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -60,7 +60,7 @@ func (o *UpdateMTOPostCounselingInformationOK) WriteResponse(rw http.ResponseWri
 // UpdateMTOPostCounselingInformationUnauthorizedCode is the HTTP code returned for type UpdateMTOPostCounselingInformationUnauthorized
 const UpdateMTOPostCounselingInformationUnauthorizedCode int = 401
 
-/*UpdateMTOPostCounselingInformationUnauthorized The request was denied.
+/*UpdateMTOPostCounselingInformationUnauthorized The request was unauthorized.
 
 swagger:response updateMTOPostCounselingInformationUnauthorized
 */
@@ -102,7 +102,7 @@ func (o *UpdateMTOPostCounselingInformationUnauthorized) WriteResponse(rw http.R
 // UpdateMTOPostCounselingInformationForbiddenCode is the HTTP code returned for type UpdateMTOPostCounselingInformationForbidden
 const UpdateMTOPostCounselingInformationForbiddenCode int = 403
 
-/*UpdateMTOPostCounselingInformationForbidden The request was denied.
+/*UpdateMTOPostCounselingInformationForbidden The client doesn't have permissions to perform the request.
 
 swagger:response updateMTOPostCounselingInformationForbidden
 */

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -99,9 +99,10 @@ func (a *Client) GetMoveTaskOrderCustomer(params *GetMoveTaskOrderCustomerParams
 }
 
 /*
-UpdateMTOPostCounselingInformation updates move task order s post counseling information
+UpdateMTOPostCounselingInformation updates a move task order s post counseling information
 
-Updates move task order's post counseling information
+Updates moveTaskOrder fields ppmType, ppmEstimatedWeight, and pointOfContact.
+
 */
 func (a *Client) UpdateMTOPostCounselingInformation(params *UpdateMTOPostCounselingInformationParams) (*UpdateMTOPostCounselingInformationOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
@@ -61,7 +61,13 @@ for the update m t o post counseling information operation typically these are w
 */
 type UpdateMTOPostCounselingInformationParams struct {
 
-	/*IfMatch*/
+	/*IfMatch
+	  Unique value that automatically changes when the request is updated.
+	Required when sending POST or PATCH requests to prevent updating stale data.
+	The same value as the eTag attribute.
+
+
+	*/
 	IfMatch string
 	/*Body*/
 	Body UpdateMTOPostCounselingInformationBody

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_parameters.go
@@ -62,9 +62,7 @@ for the update m t o post counseling information operation typically these are w
 type UpdateMTOPostCounselingInformationParams struct {
 
 	/*IfMatch
-	  Unique value that automatically changes when the request is updated.
-	Required when sending POST or PATCH requests to prevent updating stale data.
-	The same value as the eTag attribute.
+	  Optimistic locking is implemented via the `If-Match` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a `412 Precondition Failed` error.
 
 
 	*/

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -83,7 +83,7 @@ func NewUpdateMTOPostCounselingInformationOK() *UpdateMTOPostCounselingInformati
 
 /*UpdateMTOPostCounselingInformationOK handles this case with default header values.
 
-Successfully updated move task order post counseling information
+Successfully updated move task order post-counseling information.
 */
 type UpdateMTOPostCounselingInformationOK struct {
 	Payload *primemessages.MoveTaskOrder
@@ -116,7 +116,7 @@ func NewUpdateMTOPostCounselingInformationUnauthorized() *UpdateMTOPostCounselin
 
 /*UpdateMTOPostCounselingInformationUnauthorized handles this case with default header values.
 
-The request was denied
+The request was denied.
 */
 type UpdateMTOPostCounselingInformationUnauthorized struct {
 	Payload interface{}
@@ -147,7 +147,7 @@ func NewUpdateMTOPostCounselingInformationForbidden() *UpdateMTOPostCounselingIn
 
 /*UpdateMTOPostCounselingInformationForbidden handles this case with default header values.
 
-The request was denied
+The request was denied.
 */
 type UpdateMTOPostCounselingInformationForbidden struct {
 	Payload interface{}
@@ -178,7 +178,7 @@ func NewUpdateMTOPostCounselingInformationNotFound() *UpdateMTOPostCounselingInf
 
 /*UpdateMTOPostCounselingInformationNotFound handles this case with default header values.
 
-The requested resource wasn't found
+The requested resource wasn't found.
 */
 type UpdateMTOPostCounselingInformationNotFound struct {
 	Payload interface{}
@@ -209,7 +209,7 @@ func NewUpdateMTOPostCounselingInformationPreconditionFailed() *UpdateMTOPostCou
 
 /*UpdateMTOPostCounselingInformationPreconditionFailed handles this case with default header values.
 
-precondition failed
+Precondition failed.
 */
 type UpdateMTOPostCounselingInformationPreconditionFailed struct {
 	Payload interface{}
@@ -240,7 +240,7 @@ func NewUpdateMTOPostCounselingInformationUnprocessableEntity() *UpdateMTOPostCo
 
 /*UpdateMTOPostCounselingInformationUnprocessableEntity handles this case with default header values.
 
-The request payload is invalid
+The request payload is invalid.
 */
 type UpdateMTOPostCounselingInformationUnprocessableEntity struct {
 	Payload *primemessages.ValidationError
@@ -273,7 +273,7 @@ func NewUpdateMTOPostCounselingInformationInternalServerError() *UpdateMTOPostCo
 
 /*UpdateMTOPostCounselingInformationInternalServerError handles this case with default header values.
 
-A server error occurred
+A server error occurred.
 */
 type UpdateMTOPostCounselingInformationInternalServerError struct {
 	Payload interface{}
@@ -302,16 +302,16 @@ swagger:model UpdateMTOPostCounselingInformationBody
 */
 type UpdateMTOPostCounselingInformationBody struct {
 
-	// move task order ID
+	// ID for the move task order to use.
 	MoveTaskOrderID string `json:"moveTaskOrderID,omitempty"`
 
-	// Email or id of a contact person for this update
+	// Email or id of a contact person for this update.
 	PointOfContact string `json:"pointOfContact,omitempty"`
 
-	// ppm estimated weight
+	// The estimated weight determined post counseling.
 	PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
 
-	// ppm type
+	// Sets a ppm type to an allowed value.
 	// Enum: [FULL PARTIAL]
 	PpmType string `json:"ppmType,omitempty"`
 }

--- a/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
+++ b/pkg/gen/primeclient/move_task_order/update_m_t_o_post_counseling_information_responses.go
@@ -116,7 +116,7 @@ func NewUpdateMTOPostCounselingInformationUnauthorized() *UpdateMTOPostCounselin
 
 /*UpdateMTOPostCounselingInformationUnauthorized handles this case with default header values.
 
-The request was denied.
+The request was unauthorized.
 */
 type UpdateMTOPostCounselingInformationUnauthorized struct {
 	Payload interface{}
@@ -147,7 +147,7 @@ func NewUpdateMTOPostCounselingInformationForbidden() *UpdateMTOPostCounselingIn
 
 /*UpdateMTOPostCounselingInformationForbidden handles this case with default header values.
 
-The request was denied.
+The client doesn't have permissions to perform the request.
 */
 type UpdateMTOPostCounselingInformationForbidden struct {
 	Payload interface{}

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -103,11 +103,11 @@ paths:
           schema:
             $ref: '#/definitions/MoveTaskOrder'
         '401':
-          description: The request was denied.
+          description: The request was unauthorized.
           schema:
             $ref: '#/responses/PermissionDenied'
         '403':
-          description: The request was denied.
+          description: The client doesn't have permissions to perform the request.
           schema:
             $ref: '#/responses/PermissionDenied'
         '404':

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -90,10 +90,9 @@ paths:
                 description: Email or id of a contact person for this update.
                 type: string
         - in: header
-          description: |
-            Unique value that automatically changes when the request is updated.
-            Required when sending POST or PATCH requests to prevent updating stale data.
-            The same value as the eTag attribute.
+          description: >
+            Optimistic locking is implemented via the `If-Match` header. If the ETag header does not match
+            the value of the resource on the server, the server rejects the change with a `412 Precondition Failed` error.
           name: If-Match
           type: string
           required: true

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -60,6 +60,9 @@ paths:
         required: true
         type: string
     patch:
+      summary: Updates a move task order's post-counseling information
+      description: |
+        Updates moveTaskOrder fields ppmType, ppmEstimatedWeight, and pointOfContact.
       consumes:
         - application/json
       produces:
@@ -72,55 +75,60 @@ paths:
             type: object
             properties:
               moveTaskOrderID:
+                description: ID for the move task order to use.
                 type: string
               ppmType:
+                description: Sets a ppm type to an allowed value.
                 type: string
                 enum:
                   - FULL
                   - PARTIAL
               ppmEstimatedWeight:
+                description: The estimated weight determined post counseling.
                 type: integer
               pointOfContact:
+                description: Email or id of a contact person for this update.
                 type: string
-                description: Email or id of a contact person for this update
         - in: header
+          description: |
+            Unique value that automatically changes when the request is updated.
+            Required when sending POST or PATCH requests to prevent updating stale data.
+            The same value as the eTag attribute.
           name: If-Match
           type: string
           required: true
       responses:
         '200':
-          description: Successfully updated move task order post counseling information
+          description: Successfully updated move task order post-counseling information.
           schema:
             $ref: '#/definitions/MoveTaskOrder'
         '401':
-          description: The request was denied
+          description: The request was denied.
           schema:
             $ref: '#/responses/PermissionDenied'
         '403':
-          description: The request was denied
+          description: The request was denied.
           schema:
             $ref: '#/responses/PermissionDenied'
         '404':
-          description: The requested resource wasn't found
+          description: The requested resource wasn't found.
           schema:
             $ref: '#/responses/NotFound'
         '412':
-          description: precondition failed
+          description: Precondition failed.
           schema:
             $ref: '#/responses/PreconditionFailed'
         '422':
-          description: The request payload is invalid
+          description: The request payload is invalid.
           schema:
             $ref: '#/definitions/ValidationError'
         '500':
-          description: A server error occurred
+          description: A server error occurred.
           schema:
             $ref: '#/responses/ServerError'
       tags:
         - moveTaskOrder
-      description: Updates move task order's post counseling information
       operationId: updateMTOPostCounselingInformation
-      summary: Updates move task order's post counseling information
   '/move-task-orders/{moveTaskOrderID}/customer':
     parameters:
       - description: ID of move order to use


### PR DESCRIPTION
## Description

Updates descriptions in the prime's post-counseling information endpoint

## Setup

To view the generated docs, first install redoc-cli: https://www.npmjs.com/package/redoc-cli.

Run:

`$ cd ~/Projects/mymove`
`$ redoc-cli serve swagger/prime.yaml`

You can now view at localhost:8080

## Code Review Verification Steps


* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2172) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/80653586-61600480-8a2f-11ea-868e-db9f9f12089f.png)
