### PR TITLE
MB-2464 [JM] api test proof of service upload

### DIFF
--- a/cmd/prime-api-client/create_payment_request_upload.go
+++ b/cmd/prime-api-client/create_payment_request_upload.go
@@ -35,6 +35,11 @@ func checkCreatePaymentRequestUploadConfig(v *viper.Viper, args []string, logger
 		return errors.New("create-payment-request-upload expects a file to be passed in")
 	}
 
+	// Get the paymentRequestID to use for the upload file
+	if v.GetString(PaymentRequestID) == "" && (len(args) < 1 || len(args) > 0) {
+		return errors.New("create-payment-request-upload expects a PaymentRequestID to be passed in")
+	}
+
 	return nil
 }
 
@@ -68,16 +73,11 @@ func createPaymentRequestUpload(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	// Decode json from file that was passed into create-payment-request-upload
+	// Get the filename for the upload file to upload with command create-payment-request-upload
 	filename := v.GetString(FilenameFlag)
-	if filename == "" {
-		return fmt.Errorf("failed to open filename: %s", filename)
-	}
 
+	// Get the paymentRequestID to use for the upload file
 	paymentRequestID := v.GetString(PaymentRequestID)
-	if paymentRequestID == "" {
-		return fmt.Errorf("paymentRequestID required: %s", paymentRequestID)
-	}
 
 	file, fileErr := os.Open(filepath.Clean(filename))
 	defer file.Close()

--- a/cmd/prime-api-client/create_payment_request_upload.go
+++ b/cmd/prime-api-client/create_payment_request_upload.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	//"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,27 +9,23 @@ import (
 	"path/filepath"
 	"time"
 
-	//"unsafe"
-
-	//"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/pkg/gen/primeclient/uploads"
-	//"github.com/transcom/mymove/pkg/gen/primemessages"
 )
 
-// initCreateProofOfServiceUploadFlags initializes flags.
-func initCreateProofOfServiceUploadFlags(flag *pflag.FlagSet) {
-	flag.String(FilenameFlag, "", "Path to the file with the create-payment-request-upload JSON payload")
+// initCreatePaymentRequestUploadFlags initializes flags.
+func initCreatePaymentRequestUploadFlags(flag *pflag.FlagSet) {
+	flag.String(FilenameFlag, "", "Path to the upload file for create-payment-request-upload payload")
 	flag.String(PaymentRequestID, "", "Payment Request ID to upload the proof of service document to")
 
 	flag.SortFlags = false
 }
 
-// checkCreateProofOfServiceUploadConfig checks the args.
-func checkCreateProofOfServiceUploadConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+// checkCreatePaymentRequestUploadConfig checks the args.
+func checkCreatePaymentRequestUploadConfig(v *viper.Viper, args []string, logger *log.Logger) error {
 	err := CheckRootConfig(v)
 	if err != nil {
 		return err
@@ -43,33 +38,8 @@ func checkCreateProofOfServiceUploadConfig(v *viper.Viper, args []string, logger
 	return nil
 }
 
-/*
-func intToByteArray(num int64) []byte {
-	size := int(unsafe.Sizeof(num))
-	arr := make([]byte, size)
-	for i := 0; i < size; i++ {
-		byt := *(*uint8)(unsafe.Pointer(uintptr(unsafe.Pointer(&num)) + uintptr(i)))
-		arr[i] = byt
-	}
-	return arr
-}
-
-func bytesToFile(filename string, data []byte) (afero.File, error) {
-	var fs = afero.NewMemMapFs()
-	uploadFile, err := fs.Create(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create afero file %w", err)
-	}
-
-	uploadFile.Write(data)
-	uploadFile.Sync()
-
-	return uploadFile, nil
-}
-*/
-
-// createProofOfServiceUpload creates the payment request for an MTO
-func createProofOfServiceUpload(cmd *cobra.Command, args []string) error {
+// createPaymentRequestUpload creates the payment request for an MTO
+func createPaymentRequestUpload(cmd *cobra.Command, args []string) error {
 	v := viper.New()
 
 	// Create the logger
@@ -82,7 +52,7 @@ func createProofOfServiceUpload(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check the config before talking to the CAC
-	err := checkCreateProofOfServiceUploadConfig(v, args, logger)
+	err := checkCreatePaymentRequestUploadConfig(v, args, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -98,37 +68,7 @@ func createProofOfServiceUpload(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	/*
-		// Decode json from file that was passed into proof-of-service-upload
-		filename := v.GetString(FilenameFlag)
-		var reader *bufio.Reader
-		if filename != "" {
-			file, fileErr := os.Open(filepath.Clean(filename))
-			if fileErr != nil {
-				logger.Fatal(fileErr)
-			}
-			reader = bufio.NewReader(file)
-		}
-
-		if len(args) > 0 && containsDash(args) {
-			reader = bufio.NewReader(os.Stdin)
-		}
-
-		jsonDecoder := json.NewDecoder(reader)
-		var upload primemessages.Upload
-		err = jsonDecoder.Decode(&upload)
-		if err != nil {
-			return fmt.Errorf("decoding data failed: %w", err)
-		}
-
-		data := intToByteArray(*upload.Bytes)
-		file, err := bytesToFile(*upload.Filename, data)
-		if err != nil {
-			return fmt.Errorf("failed to create file from Byte: %w", err)
-		}
-	*/
-
-	// Decode json from file that was passed into proof-of-service-upload
+	// Decode json from file that was passed into create-payment-request-upload
 	filename := v.GetString(FilenameFlag)
 	if filename == "" {
 		return fmt.Errorf("failed to open filename: %s", filename)

--- a/cmd/prime-api-client/create_proof_of_service_upload.go
+++ b/cmd/prime-api-client/create_proof_of_service_upload.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	//"unsafe"
 
@@ -148,6 +149,7 @@ func createProofOfServiceUpload(cmd *cobra.Command, args []string) error {
 		File:             file,
 		PaymentRequestID: paymentRequestID,
 	}
+	params.SetTimeout(time.Second * 30)
 
 	resp, errCreatePaymentRequestUpload := primeGateway.Uploads.CreateUpload(&params)
 	if errCreatePaymentRequestUpload != nil {

--- a/cmd/prime-api-client/create_proof_of_service_upload.go
+++ b/cmd/prime-api-client/create_proof_of_service_upload.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/transcom/mymove/pkg/gen/primeclient/uploads"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
+)
+
+// initCreateProofOfServiceUploadFlags initializes flags.
+func initCreateProofOfServiceUploadFlags(flag *pflag.FlagSet) {
+	flag.String(FilenameFlag, "", "Path to the file with the proof of service upload JSON payload")
+
+	flag.SortFlags = false
+}
+
+// checkCreateProofOfServiceUploadConfig checks the args.
+func checkCreateProofOfServiceUploadConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := CheckRootConfig(v)
+	if err != nil {
+		return err
+	}
+
+	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {
+		return errors.New("proof-of-service-upload expects a file to be passed in")
+	}
+
+	return nil
+}
+
+func createAferoFile(filename string, bytes []int) (afero.file, error) {
+	var fs = afero.NewMemMapFs()
+
+	/*
+	file, err := os.Open(filename)
+	if err != nil {
+		//suite.logger.Fatal("Error opening local file", zap.Error(err))
+	}
+	*/
+
+
+	//suite.NotNil(fs)
+	uploadFile, err := fs.Create(filename)
+	if err != nil {
+		//suite.logger.Fatal("Error creating afero file", zap.Error(err))
+	}
+
+	uploadFile.Write(bytes)
+
+	io.ByteWriter(uploadFile, bytes)
+	if err != nil {
+		//suite.logger.Fatal("Error copying to afero file", zap.Error(err))
+	}
+
+	return outputFile, nil
+}
+
+// createProofOfServiceUpload creates the payment request for an MTO
+func createProofOfServiceUpload(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	// Create the logger
+	// Remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkCreateProofOfServiceUploadConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// cac and api gateway
+	primeGateway, cacStore, errCreateClient := CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer cacStore.Close()
+	}
+
+	// Decode json from file that was passed into proof-of-service-upload
+	filename := v.GetString(FilenameFlag)
+	var reader *bufio.Reader
+	if filename != "" {
+		file, fileErr := os.Open(filepath.Clean(filename))
+		if fileErr != nil {
+			logger.Fatal(fileErr)
+		}
+		reader = bufio.NewReader(file)
+	}
+
+	if len(args) > 0 && containsDash(args) {
+		reader = bufio.NewReader(os.Stdin)
+	}
+
+	jsonDecoder := json.NewDecoder(reader)
+	var proofOfServiceDocs primemessages.ProofOfServiceDocs
+	err = jsonDecoder.Decode(&proofOfServiceDocs)
+	if err != nil {
+		return fmt.Errorf("decoding data failed: %w", err)
+	}
+
+	for posDoc, _ := range proofOfServiceDocs.Uploads {
+		outputFile, err := suite.helperNewTempFile()
+		suite.Nil(err)
+		defer outputFile.Close()
+
+		written, err := io.Copy(outputFile, download)
+		suite.Nil(err)
+		suite.NotEqual(0, written)
+
+		info, err := outputFile.Stat()
+		suite.Equal(fixtureFileInfo.Size(), info.Size())
+	}
+
+	params := uploads.CreateUploadParams{
+		File: proofOfServiceDocs.Uploads[0].Bytes
+		Body: &proofOfServiceDocs,
+	}
+	params.SetTimeout(time.Second * 30)
+
+	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&params)
+	if errCreatePaymentRequest != nil {
+		// If the response cannot be parsed as JSON you may see an error like
+		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
+		// Likely this is because the API doesn't return JSON response for BadRequest OR
+		// The response type is not being set to text
+		logger.Fatal(errCreatePaymentRequest.Error())
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -133,6 +133,16 @@ func main() {
 	initCreatePaymentRequestFlags(createPaymentRequestCommand.Flags())
 	root.AddCommand(createPaymentRequestCommand)
 
+	createPaymentRequestUploadCommand := &cobra.Command{
+		Use:          "create-payment-request-upload",
+		Short:        "Create payment request upload",
+		Long:         "Create payment request upload for a payment request",
+		RunE:         createProofOfServiceUpload,
+		SilenceUsage: true,
+	}
+	initCreateProofOfServiceUploadFlags(createPaymentRequestUploadCommand.Flags())
+	root.AddCommand(createPaymentRequestUploadCommand)
+
 	patchMTOShipmentStatusCommand := &cobra.Command{
 		Use:          "support-patch-mto-shipment-status",
 		Short:        "Update MTO shipment status for prime",

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -137,10 +137,10 @@ func main() {
 		Use:          "create-payment-request-upload",
 		Short:        "Create payment request upload",
 		Long:         "Create payment request upload for a payment request",
-		RunE:         createProofOfServiceUpload,
+		RunE:         createPaymentRequestUpload,
 		SilenceUsage: true,
 	}
-	initCreateProofOfServiceUploadFlags(createPaymentRequestUploadCommand.Flags())
+	initCreatePaymentRequestUploadFlags(createPaymentRequestUploadCommand.Flags())
 	root.AddCommand(createPaymentRequestUploadCommand)
 
 	patchMTOShipmentStatusCommand := &cobra.Command{

--- a/cmd/prime-api-client/shared.go
+++ b/cmd/prime-api-client/shared.go
@@ -5,6 +5,8 @@ const (
 	FilenameFlag string = "filename"
 	// ETagFlag is the etag for the mto shipment being updated
 	ETagFlag string = "etag"
+	// PaymentRequestID is the ID of payment request to use
+	PaymentRequestID string = "paymentRequestID"
 )
 
 func containsDash(args []string) bool {

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -1,18 +1,18 @@
 package primeapi
 
 import (
-	"go.uber.org/zap"
-
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+
 	"github.com/gofrs/uuid"
 
+	"go.uber.org/zap"
+
 	uploadop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/uploads"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 )
 
 func payloadForPaymentRequestUploadModel(u models.Upload) *primemessages.Upload {
@@ -20,6 +20,8 @@ func payloadForPaymentRequestUploadModel(u models.Upload) *primemessages.Upload 
 		Bytes:       &u.Bytes,
 		ContentType: &u.ContentType,
 		Filename:    &u.Filename,
+		CreatedAt:   (*strfmt.DateTime)(&u.CreatedAt),
+		UpdatedAt:   (*strfmt.DateTime)(&u.UpdatedAt),
 	}
 }
 


### PR DESCRIPTION
## Description

Added new endpoint to `prime-api-client` to create an upload. 

Bypassing using `json` because I'm not sure how to write a json file to represent a file. Decided to go a different route and just use flags to pull in the `paymentRequestID` and the `filename` to be uploaded which is not a `json` file like with other endpoints. 



## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup
```
make db_dev_reset db_dev_e2e_populate
rm bin/prime-api-client && make bin/prime-api-client 
```

To run the upload command you follow the sequence:
1. Fetch MTOs, to find the MTO ID that you will be working with (and also to find the service items IDs if you are adding those to the payment request)
2. Create a payment request and then use the payment request ID that is returned
3. Create a payment request upload

(Copying heavily from PR #3932 in the setup section)
### Testing Dev

1. First run `make db_dev_e2e_populate` to ensure your database is setup with the E2E data.
2. Next, save this example JSON payload (which references E2E UUIDs) to a file called `pr_payload_dev.json`:
```
{
    "isFinal": false,
    "moveTaskOrderID": "da3f34cc-fb94-4e0b-1c90-ba3333cb7791",
    "serviceItems": [
        {
            "id": "8a625314-1922-4987-93c5-a62c0d13f053",
            "params": [
                {
                    "key": "WeightEstimated",
                    "value": "3254"
                },
                {
                    "key": "RequestedPickupDate",
                    "value": "2020-04-20"
                }
            ]
        }
    ]
}
```
3. Ensure your server is running: `make server_run`
4. Run this command to fetch the "available to prime" MTOs (there's just one of those in E2E data at this time) and notice that there are no payment requests for it yet in the returned JSON: `go run ./cmd/prime-api-client --insecure fetch-mtos | jq`
5. Now let's create a payment request using our payload above.  There are two different ways to do this:
    - With the `--filename` flag: `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload_dev.json | jq`
    - From stdin: `go run ./cmd/prime-api-client --insecure create-payment-request - < pr_payload_dev.json | jq`
6. Fetch the MTOs again and verify the payment request(s) you created are there: `go run ./cmd/prime-api-client --insecure fetch-mtos | jq`
7. Create an upload for the payment request using the payment request ID
`go run ./cmd/prime-api-client --insecure create-payment-request-upload --paymentRequestID "fe3bfc25-0c94-4783-80f8-132c73f4cea1" --filename "/Users/jacquelinemckinney/Documents/mymove/pcs orders/dd1614_pcs.pdf" | jq`

### Testing Experimental (optional)

**NOTE: You must have a CAC to do this part!**

1. Make a copy of the JSON payload above and save it to `pr_payload_exp.json`
2. See what "available to prime" MTOs are out there (you will prompted for your CAC PIN): `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 fetch-mtos | jq`
3. Edit the `pr_payload_exp.json` file and replace the two UUIDs in it with a `moveTaskOrderID` value and `mtoServiceItems` ID value from the output of step 2. 
4. Create the payment request: `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 create-payment-request --filename pr_payload_exp.json | jq`
5. Fetch the MTOs again and verify the payment request(s) you created are there: `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 fetch-mtos | jq`
6. Create an upload for the payment request using the payment request ID
`go run ./cmd/prime-api-client  --cac --hostname api.experimental.move.mil --port 443 create-payment-request-upload --paymentRequestID "fe3bfc25-0c94-4783-80f8-132c73f4cea1" --filename "/Users/jacquelinemckinney/Documents/mymove/pcs orders/dd1614_pcs.pdf" | jq`
7. Verify file is in AWS S3 bucket by going to the S3 website or by running AWS CLI, if running AWS CLI to check run the following: `aws s3 ls --recursive s3://transcom-ppp-app-experimental-us-west-2/app/app/payment-request-uploads`
8. Once verified to remove file run: 
`$ aws s3 rm s3://transcom-ppp-app-experimental-us-west-2/app/app/payment-request-uploads/mto-5d4b25bb-eb04-4c03-9a81-ee0398cb779e/payment-request-80ff7576-b3f9-4812-85bd-6bc14f02d862/timestamp-2020-05-04 20:52:50.236046446 +0000 UTC m=+830.171653999` (can't do recursive remove based on user when not in local dev)

### Testing Staging (follow steps for experimental)

**Testing in the staging environment should be similar, but uses `api.staging.move.mil` instead.
transcom-ppp-app-staging-us-west-2**

Verify file is in AWS S3 bucket by going to the S3 website or by running AWS CLI, if running AWS CLI to check run the following: `aws s3 ls --recursive s3://transcom-ppp-app-staging-us-west-2/app/app/payment-request-uploads`

Once verified to remove file run: 
`$ aws s3 rm  s3://transcom-ppp-app-staging-us-west-2/app/app/payment-request-uploads/mto-5d4b25bb-eb04-4c03-9a81-ee0398cb779e/payment-request-80ff7576-b3f9-4812-85bd-6bc14f02d862/timestamp-2020-05-04 20:52:50.236046446 +0000 UTC m=+830.171653999`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2464) for this change


## Screenshots
n/a