### PR TITLE
MB-2496 fix storybook tests job and reenable

### DIFF
--- a/scripts/run-storybook-tests
+++ b/scripts/run-storybook-tests
@@ -29,8 +29,7 @@ function run_tests() {
   else
     printf "%sLoki Tests Passed!%s\n" "${GREEN}" "${NOCOLOR}";
   fi
-  # exit "$return_code"
-  exit 0 # temporary fix to allow master builds to pass
+  exit "$return_code"
 }
 
 if [[ -z ${CIRCLECI-} ]]; then

--- a/scripts/start-storybook-tests
+++ b/scripts/start-storybook-tests
@@ -23,4 +23,4 @@ done
 
 echo ""
 echo "Running loki tests"
-yarn run loki test --chromeConcurrency 2 --chromeRetries 5 --host storybook --requireReference
+yarn run loki test --chromeConcurrency 1 --chromeRetries 5 --host storybook --requireReference


### PR DESCRIPTION
## Description

See [this thread](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1588258393012800) for details. But basically there is still a resource constraint issue when running `storybook_tests` in CircleCI vs local. This issue was not appearing on branch builds but was failing very consistently on master. However, a subsequent push to master resolved it. I was able to replicate this locally by setting Docker to have 2 CPUs, 2 GB Memory, and 1 GB swap in docker for mac. This PR reduces concurrency to 1 and enables returning the exit code so that results can be propagated back to CircleCI.

## Setup

Set Docker to have 2 CPUs, 2 GB Memory, and 1 GB swap in docker for mac

```sh
make storybook_tests
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-2496](https://dp3.atlassian.net/browse/MB-2496) for this change
* [this slack thread for background](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1588258393012800)