### PR TITLE
[MB-2434] Improve param handling in prime api client

### DIFF
--- a/cmd/prime-api-client/create_move_task_order.go
+++ b/cmd/prime-api-client/create_move_task_order.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -77,19 +76,7 @@ func createMTO(cmd *cobra.Command, args []string) error {
 	// Make the API Call
 	resp, err := gateway.MoveTaskOrder.CreateMoveTaskOrder(&createMTOParams)
 	if err != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	// Get the successful response payload and convert to json for output

--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -150,13 +151,21 @@ func createMTOServiceItem(cmd *cobra.Command, args []string) error {
 	}
 	params.SetTimeout(time.Second * 30)
 
-	resp, errCreateMTOServiceItem := primeGateway.MtoServiceItem.CreateMTOServiceItem(&params)
-	if errCreateMTOServiceItem != nil {
-		// If the response cannot be parsed as JSON you may see an error like
-		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-		// Likely this is because the API doesn't return JSON response for BadRequest OR
-		// The response type is not being set to text
-		logger.Fatal(errCreateMTOServiceItem.Error())
+	resp, err := primeGateway.MtoServiceItem.CreateMTOServiceItem(&params)
+	if err != nil {
+		// If you see an error like "unknown error (status 422)", it means
+		// we hit a completely unhandled error that we should handle.
+		// We should be enabling said error in the endpoint in swagger.
+		// 422 for example is an Unprocessable Entity and is returned by the swagger
+		// validation before it even hits the handler.
+		if _, ok := err.(*openapi.APIError); ok {
+			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
+			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
+		}
+		// If it is a handled error, we should be able to pull out the payload here
+		data, _ := json.Marshal(err)
+		fmt.Printf("%s", data)
+		return nil
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -153,19 +152,7 @@ func createMTOServiceItem(cmd *cobra.Command, args []string) error {
 
 	resp, err := primeGateway.MtoServiceItem.CreateMTOServiceItem(&params)
 	if err != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/create_payment_request.go
+++ b/cmd/prime-api-client/create_payment_request.go
@@ -1,21 +1,19 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
 
+	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/pkg/gen/primeclient/payment_requests"
-	"github.com/transcom/mymove/pkg/gen/primemessages"
 )
 
 // initCreatePaymentRequestFlags initializes flags.
@@ -58,6 +56,15 @@ func createPaymentRequest(cmd *cobra.Command, args []string) error {
 		logger.Fatal(err)
 	}
 
+	// Decode json from file that was passed in
+	filename := v.GetString(FilenameFlag)
+	var paymentRequestParams payment_requests.CreatePaymentRequestParams
+	err = decodeJSONFileToPayload(filename, containsDash(args), &paymentRequestParams)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	paymentRequestParams.SetTimeout(time.Second * 30)
+
 	// cac and api gateway
 	primeGateway, cacStore, errCreateClient := CreatePrimeClient(v)
 	if errCreateClient != nil {
@@ -69,40 +76,21 @@ func createPaymentRequest(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	// Decode json from file that was passed into create-payment-request
-	filename := v.GetString(FilenameFlag)
-	var reader *bufio.Reader
-	if filename != "" {
-		file, fileErr := os.Open(filepath.Clean(filename))
-		if fileErr != nil {
-			logger.Fatal(fileErr)
-		}
-		reader = bufio.NewReader(file)
-	}
-
-	if len(args) > 0 && containsDash(args) {
-		reader = bufio.NewReader(os.Stdin)
-	}
-
-	jsonDecoder := json.NewDecoder(reader)
-	var paymentRequest primemessages.CreatePaymentRequestPayload
-	err = jsonDecoder.Decode(&paymentRequest)
-	if err != nil {
-		return fmt.Errorf("decoding data failed: %w", err)
-	}
-
-	params := payment_requests.CreatePaymentRequestParams{
-		Body: &paymentRequest,
-	}
-	params.SetTimeout(time.Second * 30)
-
-	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&params)
+	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&paymentRequestParams)
 	if errCreatePaymentRequest != nil {
-		// If the response cannot be parsed as JSON you may see an error like
-		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-		// Likely this is because the API doesn't return JSON response for BadRequest OR
-		// The response type is not being set to text
-		logger.Fatal(errCreatePaymentRequest.Error())
+		// If you see an error like "unknown error (status 422)", it means
+		// we hit a completely unhandled error that we should handle.
+		// We should be enabling said error in the endpoint in swagger.
+		// 422 for example is an Unprocessable Entity and is returned by the swagger
+		// validation before it even hits the handler.
+		if _, ok := err.(*openapi.APIError); ok {
+			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
+			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
+		}
+		// If it is a handled error, we should be able to pull out the payload here
+		data, _ := json.Marshal(err)
+		fmt.Printf("%s", data)
+		return nil
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/create_payment_request.go
+++ b/cmd/prime-api-client/create_payment_request.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -78,19 +77,7 @@ func createPaymentRequest(cmd *cobra.Command, args []string) error {
 
 	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&paymentRequestParams)
 	if errCreatePaymentRequest != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/create_payment_request.go
+++ b/cmd/prime-api-client/create_payment_request.go
@@ -75,8 +75,8 @@ func createPaymentRequest(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&paymentRequestParams)
-	if errCreatePaymentRequest != nil {
+	resp, err := primeGateway.PaymentRequests.CreatePaymentRequest(&paymentRequestParams)
+	if err != nil {
 		return handleGatewayError(err, logger)
 	}
 

--- a/cmd/prime-api-client/fetch_mtos.go
+++ b/cmd/prime-api-client/fetch_mtos.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -57,13 +58,21 @@ func fetchMTOs(cmd *cobra.Command, args []string) error {
 
 	var params mto.FetchMTOUpdatesParams
 	params.SetTimeout(time.Second * 30)
-	resp, errFetchMTOUpdates := primeGateway.MoveTaskOrder.FetchMTOUpdates(&params)
-	if errFetchMTOUpdates != nil {
-		// If the response cannot be parsed as JSON you may see an error like
-		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-		// Likely this is because the API doesn't return JSON response for BadRequest OR
-		// The response type is not being set to text
-		logger.Fatal(errFetchMTOUpdates.Error())
+	resp, err := primeGateway.MoveTaskOrder.FetchMTOUpdates(&params)
+	if err != nil {
+		// If you see an error like "unknown error (status 422)", it means
+		// we hit a completely unhandled error that we should handle.
+		// We should be enabling said error in the endpoint in swagger.
+		// 422 for example is an Unprocessable Entity and is returned by the swagger
+		// validation before it even hits the handler.
+		if _, ok := err.(*openapi.APIError); ok {
+			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
+			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
+		}
+		// If it is a handled error, we should be able to pull out the payload here
+		data, _ := json.Marshal(err)
+		fmt.Printf("%s", data)
+		return nil
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/fetch_mtos.go
+++ b/cmd/prime-api-client/fetch_mtos.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -60,19 +59,7 @@ func fetchMTOs(cmd *cobra.Command, args []string) error {
 	params.SetTimeout(time.Second * 30)
 	resp, err := primeGateway.MoveTaskOrder.FetchMTOUpdates(&params)
 	if err != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/get_mto.go
+++ b/cmd/prime-api-client/get_mto.go
@@ -73,8 +73,8 @@ func getMTO(cmd *cobra.Command, args []string) error {
 	}
 	getMTOParams.SetTimeout(time.Second * 30)
 
-	resp, errGetMTO := supportGateway.MoveTaskOrder.GetMoveTaskOrder(&getMTOParams)
-	if errGetMTO != nil {
+	resp, err := supportGateway.MoveTaskOrder.GetMoveTaskOrder(&getMTOParams)
+	if err != nil {
 		return handleGatewayError(err, logger)
 	}
 

--- a/cmd/prime-api-client/get_mto.go
+++ b/cmd/prime-api-client/get_mto.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -76,19 +75,7 @@ func getMTO(cmd *cobra.Command, args []string) error {
 
 	resp, errGetMTO := supportGateway.MoveTaskOrder.GetMoveTaskOrder(&getMTOParams)
 	if errGetMTO != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -74,9 +74,18 @@ func main() {
 	root.AddCommand(fetchMTOsCommand)
 
 	createMTOCommand := &cobra.Command{
-		Use:          "support-create-mto",
-		Short:        "fetch mtos",
-		Long:         "fetch move task orders",
+		Use:   "support-create-mto",
+		Short: "Create a MoveTaskOrder",
+		Long: `
+  This command creates a MoveTaskOrder object.
+  It requires the caller to pass in a file using the --filename param.
+
+  Endpoint path: /move-task-orders
+  The file should contain json as follows:
+    {
+      "body": <MoveTaskOrder>
+    }
+  Please see API documentation for full details on the MoveTaskOrder definition.`,
 		RunE:         createMTO,
 		SilenceUsage: true,
 	}
@@ -84,9 +93,22 @@ func main() {
 	root.AddCommand(createMTOCommand)
 
 	updateMTOShipmentCommand := &cobra.Command{
-		Use:          "update-mto-shipment",
-		Short:        "update mto shipment",
-		Long:         "update move task order shipment",
+		Use:   "update-mto-shipment",
+		Short: "update mto shipment",
+		Long: `
+  This command updates an MTO shipment.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters, headers and a body for the payload.
+
+  Endpoint path: move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}
+  The file should contain json as follows:
+  	{
+      "moveTaskOrderID": <uuid string>,
+      "mtoShipmentID": <uuid string>,
+      "ifMatch": <eTag>,
+      "body": <MTOShipment>
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         updateMTOShipment,
 		SilenceUsage: true,
 	}
@@ -104,9 +126,22 @@ func main() {
 	root.AddCommand(updatePostCounselingInfo)
 
 	createMTOServiceItemCommand := &cobra.Command{
-		Use:          "create-mto-service-item",
-		Short:        "Create mto service item",
-		Long:         "Create move task order service item for move task order and/or shipment",
+		Use:   "create-mto-service-item",
+		Short: "Create mto service item",
+		Long: `
+  This command creates an MTO service item on an MTO shipment.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters and headers and a body for the payload.
+
+  Endpoint path: /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items
+  The file should contain json as follows:
+  	{
+  	"moveTaskOrderID": <uuid string>,
+  	"mtoShipmentID": <uuid string>,
+  	"ifMatch": <eTag>,
+  	"body": <MTOServiceItem>
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         createMTOServiceItem,
 		SilenceUsage: true,
 	}
@@ -114,9 +149,20 @@ func main() {
 	root.AddCommand(createMTOServiceItemCommand)
 
 	makeAvailableToPrimeCommand := &cobra.Command{
-		Use:          "support-make-mto-available-to-prime",
-		Short:        "Make mto available to prime",
-		Long:         "Makes an mto available to the prime for prime-api consumption",
+		Use:   "support-make-mto-available-to-prime",
+		Short: "Make mto available to prime",
+		Long: `
+  This command makes an MTO available for prime consumption.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters and headers.
+
+  Endpoint path: /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items
+  The file should contain json as follows:
+  	{
+  	"moveTaskOrderID": <uuid string>,
+  	"ifMatch": <eTag>,
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         updateMTOStatus,
 		SilenceUsage: true,
 	}
@@ -134,9 +180,18 @@ func main() {
 	root.AddCommand(updatePaymentRequestStatusCommand)
 
 	getMoveTaskOrder := &cobra.Command{
-		Use:          "support-get-mto",
-		Short:        "Get an individual mto",
-		Long:         "Get an individual mto's information",
+		Use:   "support-get-mto",
+		Short: "Get an individual mto",
+		Long: `
+  This command gets a single move task order by ID
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters and headers.
+  Endpoint path: /move-task-orders/{moveTaskOrderID}
+  The file should contain json as follows:
+  	{
+  	"moveTaskOrderID": <uuid string>,
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         getMTO,
 		SilenceUsage: true,
 	}
@@ -154,9 +209,18 @@ func main() {
 	root.AddCommand(updateMTOServiceItemStatus)
 
 	createPaymentRequestCommand := &cobra.Command{
-		Use:          "create-payment-request",
-		Short:        "Create payment request",
-		Long:         "Create payment request for a move task order",
+		Use:   "create-payment-request",
+		Short: "Create payment request",
+		Long: `
+  This command gets a single move task order by ID
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain a body defining the PaymentRequest object.
+  Endpoint path: /payment-requests
+  The file should contain json as follows:
+  	{
+  	"body": <PaymentRequest>,
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         createPaymentRequest,
 		SilenceUsage: true,
 	}

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -153,10 +153,11 @@ func main() {
 		Short: "Make mto available to prime",
 		Long: `
   This command makes an MTO available for prime consumption.
+  This is a support endpoint and is not available in production.
   It requires the caller to pass in a file using the --filename arg.
   The file should contain path parameters and headers.
 
-  Endpoint path: /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items
+  Endpoint path: /move-task-orders/{moveTaskOrderID}/status
   The file should contain json as follows:
   	{
   	"moveTaskOrderID": <uuid string>,
@@ -170,9 +171,22 @@ func main() {
 	root.AddCommand(makeAvailableToPrimeCommand)
 
 	updatePaymentRequestStatusCommand := &cobra.Command{
-		Use:          "support-update-payment-request-status",
-		Short:        "Update payment request status for prime",
-		Long:         "Allows prime to update payment request status in non-prod envs",
+		Use:   "support-update-payment-request-status",
+		Short: "Update payment request status for prime",
+		Long: `
+  This command allows prime to update payment request status.
+  This is a support endpoint and is not available in production.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters and headers.
+
+  Endpoint path: /payment-requests/{paymentRequestID}/status
+  The file should contain json as follows:
+    {
+      "paymentRequestID": <uuid string>,
+      "ifMatch": <etag>,
+      "body" : <paymentRequestStatus>
+    }
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         updatePaymentRequestStatus,
 		SilenceUsage: true,
 	}
@@ -184,8 +198,10 @@ func main() {
 		Short: "Get an individual mto",
 		Long: `
   This command gets a single move task order by ID
+  This is a support endpoint and is not available in production.
   It requires the caller to pass in a file using the --filename arg.
   The file should contain path parameters and headers.
+
   Endpoint path: /move-task-orders/{moveTaskOrderID}
   The file should contain json as follows:
   	{
@@ -199,9 +215,22 @@ func main() {
 	root.AddCommand(getMoveTaskOrder)
 
 	updateMTOServiceItemStatus := &cobra.Command{
-		Use:          "support-update-mto-service-item-status",
-		Short:        "Update service item status",
-		Long:         "Approve or reject a service item",
+		Use:   "support-update-mto-service-item-status",
+		Short: "Update service item status",
+		Long: `
+  This command allows prime to update the MTO service item status.
+  This is a support endpoint and is not available in production.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain a body defining the request body.
+
+  Endpoint path: service-items/{mtoServiceItemID}/status
+    {
+      "mtoServiceItemID": <uuid string>,
+      "ifMatch": <etag>,
+      "body": {
+        "status": "APPROVED"
+    }
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         updateMTOServiceItemStatus,
 		SilenceUsage: true,
 	}
@@ -228,9 +257,22 @@ func main() {
 	root.AddCommand(createPaymentRequestCommand)
 
 	patchMTOShipmentStatusCommand := &cobra.Command{
-		Use:          "support-patch-mto-shipment-status",
-		Short:        "Update MTO shipment status for prime",
-		Long:         "Allows prime to update MTO shipment status in non-prod envs",
+		Use:   "support-patch-mto-shipment-status",
+		Short: "Update MTO shipment status for prime",
+		Long: `
+  This command allows prime to update the MTO shipment status.
+  This is a support endpoint and is not available in production.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain a body defining the request body.
+
+  Endpoint path: /mto-shipments/{mtoShipmentID}/status
+  The file should contain json as follows:
+    {
+      "mtoShipmentID": <uuid string>,
+      "ifMatch": <etag>,
+      "body": <MtoShipmentRequestStatus>,
+    }
+  Please see API documentation for full details on the endpoint definition.`,
 		RunE:         patchMTOShipmentStatus,
 		SilenceUsage: true,
 	}

--- a/cmd/prime-api-client/make_mto_available_to_prime.go
+++ b/cmd/prime-api-client/make_mto_available_to_prime.go
@@ -72,8 +72,8 @@ func updateMTOStatus(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	resp, errUpdateMTOStatus := supportGateway.MoveTaskOrder.UpdateMoveTaskOrderStatus(&updateMTOParams)
-	if errUpdateMTOStatus != nil {
+	resp, err := supportGateway.MoveTaskOrder.UpdateMoveTaskOrderStatus(&updateMTOParams)
+	if err != nil {
 		return handleGatewayError(err, logger)
 	}
 

--- a/cmd/prime-api-client/make_mto_available_to_prime.go
+++ b/cmd/prime-api-client/make_mto_available_to_prime.go
@@ -1,21 +1,19 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
 
+	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	mto "github.com/transcom/mymove/pkg/gen/supportclient/move_task_order"
-	"github.com/transcom/mymove/pkg/gen/supportmessages"
 )
 
 func initUpdateMTOStatusFlags(flag *pflag.FlagSet) {
@@ -60,6 +58,16 @@ func updateMTOStatus(cmd *cobra.Command, args []string) error {
 		logger.Fatal(err)
 	}
 
+	// Decode json from file that was passed into MTOShipment
+	filename := v.GetString(FilenameFlag)
+	var updateMTOParams mto.UpdateMoveTaskOrderStatusParams
+	err = decodeJSONFileToPayload(filename, containsDash(args), &updateMTOParams)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	updateMTOParams.SetTimeout(time.Second * 30)
+
+	// Create the client and open the cacStore
 	supportGateway, cacStore, errCreateClient := CreateSupportClient(v)
 	if errCreateClient != nil {
 		return errCreateClient
@@ -70,42 +78,21 @@ func updateMTOStatus(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	// Decode json from file that was passed into MTOShipment
-	filename := v.GetString(FilenameFlag)
-	var reader *bufio.Reader
-	if filename != "" {
-		file, fileErr := os.Open(filepath.Clean(filename))
-		if fileErr != nil {
-			logger.Fatal(fileErr)
-		}
-		reader = bufio.NewReader(file)
-	}
-
-	if len(args) > 0 && containsDash(args) {
-		reader = bufio.NewReader(os.Stdin)
-	}
-
-	jsonDecoder := json.NewDecoder(reader)
-	var moveTaskOrder supportmessages.MoveTaskOrder
-	err = jsonDecoder.Decode(&moveTaskOrder)
-	if err != nil {
-		return fmt.Errorf("decoding data failed: %w", err)
-	}
-
-	params := mto.UpdateMoveTaskOrderStatusParams{
-		MoveTaskOrderID: moveTaskOrder.ID.String(),
-		IfMatch:         v.GetString(ETagFlag),
-	}
-
-	params.SetTimeout(time.Second * 30)
-
-	resp, errUpdateMTOStatus := supportGateway.MoveTaskOrder.UpdateMoveTaskOrderStatus(&params)
+	resp, errUpdateMTOStatus := supportGateway.MoveTaskOrder.UpdateMoveTaskOrderStatus(&updateMTOParams)
 	if errUpdateMTOStatus != nil {
-		// If the response cannot be parsed as JSON you may see an error like
-		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-		// Likely this is because the API doesn't return JSON response for BadRequest OR
-		// The response type is not being set to text
-		logger.Fatal(errUpdateMTOStatus.Error())
+		// If you see an error like "unknown error (status 422)", it means
+		// we hit a completely unhandled error that we should handle.
+		// We should be enabling said error in the endpoint in swagger.
+		// 422 for example is an Unprocessable Entity and is returned by the swagger
+		// validation before it even hits the handler.
+		if _, ok := err.(*openapi.APIError); ok {
+			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
+			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
+		}
+		// If it is a handled error, we should be able to pull out the payload here
+		data, _ := json.Marshal(errUpdateMTOStatus)
+		fmt.Printf("%s", data)
+		return nil
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/patch_mto_shipment_status.go
+++ b/cmd/prime-api-client/patch_mto_shipment_status.go
@@ -71,8 +71,8 @@ func patchMTOShipmentStatus(cmd *cobra.Command, args []string) error {
 		defer cacStore.Close()
 	}
 
-	resp, errPatchMTOShipmentStatus := supportGateway.MtoShipment.PatchMTOShipmentStatus(&patchMTOShipmentParams)
-	if errPatchMTOShipmentStatus != nil {
+	resp, err := supportGateway.MtoShipment.PatchMTOShipmentStatus(&patchMTOShipmentParams)
+	if err != nil {
 		return handleGatewayError(err, logger)
 	}
 

--- a/cmd/prime-api-client/patch_mto_shipment_status.go
+++ b/cmd/prime-api-client/patch_mto_shipment_status.go
@@ -1,16 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"time"
-
-	"github.com/transcom/mymove/pkg/gen/supportmessages"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -21,7 +17,6 @@ import (
 
 func initPatchMTOShipmentStatusFlags(flag *pflag.FlagSet) {
 	flag.String(FilenameFlag, "", "Name of the file being passed in")
-	flag.String(ETagFlag, "", "ETag for the mto shipment being updated")
 
 	flag.SortFlags = false
 }
@@ -30,10 +25,6 @@ func checkPatchMTOShipmentStatusConfig(v *viper.Viper, args []string, logger *lo
 	err := CheckRootConfig(v)
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	if v.GetString(ETagFlag) == "" {
-		logger.Fatal(errors.New("support-patch-mto-shipment-status expects an etag"))
 	}
 
 	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {
@@ -61,58 +52,28 @@ func patchMTOShipmentStatus(cmd *cobra.Command, args []string) error {
 		logger.Fatal(err)
 	}
 
+	// Decode json from file that was passed in
+	filename := v.GetString(FilenameFlag)
+	var patchMTOShipmentParams mtoShipment.PatchMTOShipmentStatusParams
+	err = decodeJSONFileToPayload(filename, containsDash(args), &patchMTOShipmentParams)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	patchMTOShipmentParams.SetTimeout(time.Second * 30)
+
+	// Create the client and open the cacStore
 	supportGateway, cacStore, errCreateClient := CreateSupportClient(v)
 	if errCreateClient != nil {
 		return errCreateClient
 	}
-
 	// Defer closing the store until after the API call has completed
 	if cacStore != nil {
 		defer cacStore.Close()
 	}
 
-	// Decode json from file that was passed into MTOShipment
-	filename := v.GetString(FilenameFlag)
-
-	var reader *bufio.Reader
-	if filename != "" {
-		file, fileErr := os.Open(filepath.Clean(filename))
-		if fileErr != nil {
-			logger.Fatal(fileErr)
-		}
-		reader = bufio.NewReader(file)
-	}
-
-	if len(args) > 0 && containsDash(args) {
-		reader = bufio.NewReader(os.Stdin)
-	}
-
-	jsonDecoder := json.NewDecoder(reader)
-	var shipment supportmessages.MTOShipment
-
-	err = jsonDecoder.Decode(&shipment)
-
-	if err != nil {
-		return fmt.Errorf("decoding data failed: %w", err)
-	}
-
-	params := mtoShipment.PatchMTOShipmentStatusParams{
-		MtoShipmentID: shipment.ID,
-		IfMatch:       v.GetString(ETagFlag),
-		Body: &supportmessages.PatchMTOShipmentStatus{
-			Status:          shipment.Status,
-			RejectionReason: shipment.RejectionReason},
-	}
-
-	params.SetTimeout(time.Second * 30)
-
-	resp, errPatchMTOShipmentStatus := supportGateway.MtoShipment.PatchMTOShipmentStatus(&params)
+	resp, errPatchMTOShipmentStatus := supportGateway.MtoShipment.PatchMTOShipmentStatus(&patchMTOShipmentParams)
 	if errPatchMTOShipmentStatus != nil {
-		// If the response cannot be parsed as JSON you may see an error like
-		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
-		// Likely this is because the API doesn't return JSON response for BadRequest OR
-		// The response type is not being set to text
-		logger.Fatal(errPatchMTOShipmentStatus.Error())
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/shared.go
+++ b/cmd/prime-api-client/shared.go
@@ -1,5 +1,14 @@
 package main
 
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 const (
 	// FilenameFlag is the name of the file being passed in
 	FilenameFlag string = "filename"
@@ -14,4 +23,31 @@ func containsDash(args []string) bool {
 		}
 	}
 	return false
+}
+
+// decodeJSONFileToPayload takes a filename, or if not available
+func decodeJSONFileToPayload(filename string, isStdin bool, payload interface{}) error {
+	var reader *bufio.Reader
+	if filename != "" {
+		file, err := os.Open(filepath.Clean(filename))
+		if err != nil {
+			return fmt.Errorf("File open failed: %w", err)
+		}
+		reader = bufio.NewReader(file)
+	} else if isStdin { // Uses std in if "-"" is provided instead
+		reader = bufio.NewReader(os.Stdin)
+	} else {
+		return errors.New("no file input was found")
+	}
+
+	jsonDecoder := json.NewDecoder(reader)
+	jsonDecoder.DisallowUnknownFields()
+
+	// Read the json into the mto payload
+	err := jsonDecoder.Decode(payload)
+	if err != nil {
+		return fmt.Errorf("File decode failed: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/prime-api-client/shared.go
+++ b/cmd/prime-api-client/shared.go
@@ -5,8 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+
+	openapi "github.com/go-openapi/runtime"
 )
 
 const (
@@ -25,7 +29,11 @@ func containsDash(args []string) bool {
 	return false
 }
 
-// decodeJSONFileToPayload takes a filename, or if not available
+// decodeJSONFileToPayload takes a filename, or stdin and decodes the file into
+// the supplied json payload.
+// If the filename is not supplied, the isStdin bool should be set to true to use stdin.
+// If the file contains parameters that do not exist in the payload struct, it will fail with an error
+// Otherwise it will populate the payload
 func decodeJSONFileToPayload(filename string, isStdin bool, payload interface{}) error {
 	var reader *bufio.Reader
 	if filename != "" {
@@ -49,5 +57,26 @@ func decodeJSONFileToPayload(filename string, isStdin bool, payload interface{})
 		return fmt.Errorf("File decode failed: %w", err)
 	}
 
+	return nil
+}
+
+// handleGatewayError handles errors returned by the gateway
+func handleGatewayError(err error, logger *log.Logger) error {
+	if _, ok := err.(*openapi.APIError); ok {
+		// If you see an error like "unknown error (status 422)", it means
+		// we hit a completely unhandled error that we should handle.
+		// We should be enabling said error in the endpoint in swagger.
+		// 422 for example is an Unprocessable Entity and is returned by the swagger
+		// validation before it even hits the handler.
+		apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
+		logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
+
+	} else if typedErr, ok := err.(*url.Error); ok {
+		// If the server is not running you are likely to see a connection
+		logger.Fatal(fmt.Sprintf("%s operation to %s failed : %s", typedErr.Op, typedErr.URL, typedErr.Err.Error()))
+	}
+	// If it is a handled error, we should be able to pull out the payload here
+	data, _ := json.Marshal(err)
+	fmt.Printf("%s", data)
 	return nil
 }

--- a/cmd/prime-api-client/shared.go
+++ b/cmd/prime-api-client/shared.go
@@ -72,8 +72,9 @@ func handleGatewayError(err error, logger *log.Logger) error {
 		logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
 
 	} else if typedErr, ok := err.(*url.Error); ok {
-		// If the server is not running you are likely to see a connection
-		logger.Fatal(fmt.Sprintf("%s operation to %s failed : %s", typedErr.Op, typedErr.URL, typedErr.Err.Error()))
+		// If the server is not running you are likely to see a connection error
+		// This catches the error and prints a useful message.
+		logger.Fatal(fmt.Sprintf("%s operation to %s failed, check if server is running : %s", typedErr.Op, typedErr.URL, typedErr.Err.Error()))
 	}
 	// If it is a handled error, we should be able to pull out the payload here
 	data, _ := json.Marshal(err)

--- a/cmd/prime-api-client/update_mto_service_item_status.go
+++ b/cmd/prime-api-client/update_mto_service_item_status.go
@@ -20,7 +20,6 @@ import (
 
 func initUpdateMTOServiceItemStatusFlags(flag *pflag.FlagSet) {
 	flag.String(FilenameFlag, "", "Name of the file being passed in")
-	flag.String(ETagFlag, "", "ETag for the mto service item being updated")
 
 	flag.SortFlags = false
 }
@@ -29,10 +28,6 @@ func checkUpdateMTOServiceItemStatusConfig(v *viper.Viper, args []string, logger
 	err := CheckRootConfig(v)
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	if v.GetString(ETagFlag) == "" {
-		logger.Fatal(errors.New("support-update-mto-service-item-status expects an etag"))
 	}
 
 	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {

--- a/cmd/prime-api-client/update_mto_shipment.go
+++ b/cmd/prime-api-client/update_mto_shipment.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	openapi "github.com/go-openapi/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -74,19 +73,7 @@ func updateMTOShipment(cmd *cobra.Command, args []string) error {
 	// Make the API Call
 	resp, err := primeGateway.MtoShipment.UpdateMTOShipment(&shipmentPayload)
 	if err != nil {
-		// If you see an error like "unknown error (status 422)", it means
-		// we hit a completely unhandled error that we should handle.
-		// We should be enabling said error in the endpoint in swagger.
-		// 422 for example is an Unprocessable Entity and is returned by the swagger
-		// validation before it even hits the handler.
-		if _, ok := err.(*openapi.APIError); ok {
-			apiErr := err.(*openapi.APIError).Response.(openapi.ClientResponse)
-			logger.Fatal(fmt.Sprintf("%s: %s", err, apiErr.Message()))
-		}
-		// If it is a handled error, we should be able to pull out the payload here
-		data, _ := json.Marshal(err)
-		fmt.Printf("%s", data)
-		return nil
+		return handleGatewayError(err, logger)
 	}
 
 	payload := resp.GetPayload()

--- a/cmd/prime-api-client/update_post_counseling_info.go
+++ b/cmd/prime-api-client/update_post_counseling_info.go
@@ -19,7 +19,6 @@ import (
 
 func initUpdatePostCounselingInfoFlags(flag *pflag.FlagSet) {
 	flag.String(FilenameFlag, "", "Name of the file being passed in")
-	flag.String(ETagFlag, "", "ETag for the mto shipment being updated")
 
 	flag.SortFlags = false
 }
@@ -28,10 +27,6 @@ func checkUpdatePostCounselingInfoConfig(v *viper.Viper, args []string, logger *
 	err := CheckRootConfig(v)
 	if err != nil {
 		logger.Fatal(err)
-	}
-
-	if v.GetString(ETagFlag) == "" {
-		logger.Fatal(errors.New("update-post-counseling-info expects an etag"))
 	}
 
 	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -96,7 +96,6 @@ func MoveOrder(moveOrder *models.MoveOrder) *primemessages.MoveOrder {
 	if moveOrder.Grade != nil && moveOrder.Entitlement != nil {
 		moveOrder.Entitlement.SetWeightAllotment(*moveOrder.Grade)
 	}
-	reportByDate := strfmt.Date(*moveOrder.ReportByDate)
 	entitlements := Entitlement(moveOrder.Entitlement)
 	payload := primemessages.MoveOrder{
 		CustomerID:             strfmt.UUID(moveOrder.CustomerID.String()),
@@ -109,8 +108,10 @@ func MoveOrder(moveOrder *models.MoveOrder) *primemessages.MoveOrder {
 		LinesOfAccounting:      moveOrder.LinesOfAccounting,
 		Rank:                   moveOrder.Grade,
 		ConfirmationNumber:     moveOrder.ConfirmationNumber,
-		ReportByDate:           reportByDate,
 		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),
+	}
+	if moveOrder.ReportByDate != nil {
+		payload.ReportByDate = strfmt.Date(*moveOrder.ReportByDate)
 	}
 	return &payload
 }

--- a/pkg/testdatagen/testdata/update_mto_shipment.json
+++ b/pkg/testdatagen/testdata/update_mto_shipment.json
@@ -1,13 +1,15 @@
 {
-  "ID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
-  "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
-  "agents": [
-    {
-      "agentType": "RECEIVING_AGENT",
-      "email": "updatedagentemail@test.email.com",
-      "firstName": "Super",
-      "id": "d73cc488-d5a1-4c9c-bea3-8b02d9bd0dea",
-      "lastName": "Agent"
-    }
-  ]
+  "body": {
+    "ID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
+    "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
+    "agents": [
+      {
+        "agentType": "RECEIVING_AGENT",
+        "email": "updatedagentemail@test.email.com",
+        "firstName": "Super",
+        "id": "d73cc488-d5a1-4c9c-bea3-8b02d9bd0dea",
+        "lastName": "Agent"
+      }
+    ]
+  }
 }

--- a/scripts/run-e2e-mtls-test-docker
+++ b/scripts/run-e2e-mtls-test-docker
@@ -137,10 +137,26 @@ function prime_api_client () {
 mtos=$(prime_api_client fetch-mtos)
 #Returns mtoShipments from the fetch-mto response, needed to return etag below
 mtoShipments=$(echo "$mtos" | jq '.[0] | .mtoShipments')
-#Returns etag for the first mtoShipment, needed to run update-mto-shipment below
-etag=$(echo "$mtoShipments" | jq '.[0] | .eTag' |  tr -d '"')
-#Tests update-shipment endpoint
-prime_api_client update-mto-shipment --etag "${etag}" --filename ./pkg/testdatagen/testdata/update_mto_shipment.json
+echo "$mtoShipments"
+
+#TODO Decide what the goal of this test is. If it is simply to check that the
+#     Prime API is up and running, the above functions as a health check
+#     Adding more API calls makes this test more fragile without checking the
+#     output anyway.
+
+#Get etag for the first mtoShipment, needed to run update-mto-shipment below
+#etag=$(echo "$mtoShipments" | jq '.[0] | .eTag' |  tr -d '"')
+#Get ids from the received data
+#mto_id=$(echo "$mtos" | jq '.[0] | .id' |  tr -d '"')
+#mto_shipment_id=$(echo "$mtoShipments" | jq '.[0] | .id' |  tr -d '"')
+
+#Get body for update-mto-shipment request
+#params=$(cat ./pkg/testdatagen/testdata/update_mto_shipment.json)
+#Add ids and etag to the params
+#params=$(echo $params | jq \
+#  --arg etag $etag --arg mto_id $mto_id --arg mto_shipment_id $mto_shipment_id \
+#  '. + {ifMatch: $etag} + {mtoShipmentID: $mto_shipment_id} + {moveTaskOrderID: $mto_id}')
+
 
 #
 # INTEGRATION TESTS END


### PR DESCRIPTION
## Description

Two big changes propagated across all endpoints, except create-mto-service-item which I didn't want to mess with as Donald has some complex json decode happening there. 

### Improved  path and header param separation from body
The body of the payload is now separated from the headers and path params. So what we send is essentially. 
```
{
    "pathParam1": <value>,
    "pathParam1": <value>,
    "header1": <value>,
    "body": {
        "bodyParam1": <value>,
        "bodyParam2": <value>
    }
}
```
Note this means we no longer have etag as a command line flag! 

### Improved Error Handling 
In an attempt to have fewer unmarshaling errors, we detect a couple of errors now and can get a descriptive error if 
* the server is not up
* the server is up responded with a json payload

Still no great errors if the server responded with just a text message but at least we display an empty json instead of an error and rerunning with -v should display the message. We should really not have the server send text instead of json. 

### Improved Usage Info
I updated the long version of the help info for each command so that the user will understand how to put together the file. 

## Reviewer Notes

I actually had to remove code from the circleCI test. Now that we are passing params in a file that needs to be created on the fly, the current setup doesn't work. I will create another ticket to address that, currently the circleCI WILL test basic prime api health - aka is it up, is it responding.

## Setup

Try some commands 
https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client

## References

* [[MB-2434] Change the way prime-api-client works so that the ids in paths are passed in file but not in body - Jira](https://dp3.atlassian.net/browse/MB-2434)



[MB-2434]: https://dp3.atlassian.net/browse/MB-2434