### PR TITLE
MB-2523 Add CreatedAt and UpdatedAt to MTOAgent model

### DIFF
--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -196,12 +196,14 @@ func MTOAgent(mtoAgent *models.MTOAgent) *primemessages.MTOAgent {
 
 	return &primemessages.MTOAgent{
 		AgentType:     primemessages.MTOAgentType(mtoAgent.MTOAgentType),
-		Email:         mtoAgent.Email,
 		FirstName:     mtoAgent.FirstName,
-		ID:            strfmt.UUID(mtoAgent.ID.String()),
 		LastName:      mtoAgent.LastName,
-		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
 		Phone:         mtoAgent.Phone,
+		Email:         mtoAgent.Email,
+		ID:            strfmt.UUID(mtoAgent.ID.String()),
+		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
+		CreatedAt:     strfmt.Date(mtoAgent.CreatedAt),
+		UpdatedAt:     strfmt.Date(mtoAgent.UpdatedAt),
 	}
 }
 


### PR DESCRIPTION
## Description

Adds the fields CreatedAt and UpdatedAt to the model to payload function for MTO Agents so that the data for those fields is populated.

## Reviewer Notes

This can be tested with any Prime API endpoint that pulls back MTO Agents data - an easy one to test with is `prime-api-client --insecure fetch-mtos` in the CLI for the API. More details/instructions here: https://github.com/transcom/prime_api_deliverable/wiki/API-Endpoints

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2523) for this change
