### PR TITLE
[MB-2477] Add trace middleware to prime and support api

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -765,6 +765,8 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		primeMux.Use(primeDetectionMiddleware)
 		primeMux.Use(clientCertMiddleware)
 		primeMux.Use(authentication.PrimeAuthorizationMiddleware(logger))
+		primeMux.Use(middleware.Trace(logger, &handlerContext)) // injects trace id into the context
+		primeMux.Use(middleware.ContextLogger("milmove_trace_id", logger))
 		primeMux.Use(middleware.NoCache(logger))
 		primeMux.Use(middleware.RequestLogger(logger))
 		primeMux.Handle(pat.Get("/swagger.yaml"), fileHandler(v.GetString(cli.PrimeSwaggerFlag)))
@@ -784,6 +786,8 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		supportMux.Use(supportDetectionMiddleware)
 		supportMux.Use(clientCertMiddleware)
 		supportMux.Use(authentication.PrimeAuthorizationMiddleware(logger))
+		supportMux.Use(middleware.Trace(logger, &handlerContext)) // injects trace id into the context
+		supportMux.Use(middleware.ContextLogger("milmove_trace_id", logger))
 		supportMux.Use(middleware.NoCache(logger))
 		supportMux.Use(middleware.RequestLogger(logger))
 		supportMux.Handle(pat.Get("/swagger.yaml"), fileHandler(v.GetString(cli.SupportSwaggerFlag)))


### PR DESCRIPTION
## Description

Trace middleware will help us connect error messages sent to to client with logger messages in the server. It's not hooked up on prime or support - hooking it up here. 

## Setup

Send a request using prime api client or postman to a prime endpoint and a support endpoint. Both should have a populated milmove_trace_id in the logger.

```
2020-05-04T23:06:03.980Z	INFO	middleware/request_logger.go:85	Request	{
  "git_branch": "sc-mb-2477-add-trace-middleware",
  "git_commit": "5dc329b3388322aef4de2535cfbc9bad95a82ca0",
  "milmove_trace_id": "5be63436-691a-489d-af17-13be3ee2b220",
  "accepted-language": "",
  "content-length": 489,
  "host": "primelocal:9443",
  "method": "POST",
  "protocol-version": "HTTP/1.1",
  "referer": "",
  "source": "127.0.0.1:56748",
  "url": "/support/v1/move-task-orders",
  ...
}
```
### Related
- [[MB-2477] Add trace middleware to prime - Jira](https://dp3.atlassian.net/browse/MB-2477)

[MB-2477]: https://dp3.atlassian.net/browse/MB-2477