### PR TITLE
Update check-aws-vault-version to look for aws-vault 5.4

### DIFF
--- a/scripts/check-aws-vault-version
+++ b/scripts/check-aws-vault-version
@@ -5,7 +5,7 @@ set -eu -o pipefail
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-VERSION="v5.3"
+VERSION="v5.4"
 
 VAULT_VERSION=$(type -p aws-vault && aws-vault --version)
 


### PR DESCRIPTION
## Description

Homebrew now installs `aws-valut` version 5.4.x so updating the `scripts/check-aws-vault-version` to check for that version instead of 5.3.x