### PR TITLE
remove un-needed setPendingPpmWeight

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -7,7 +7,6 @@ import { formatCents } from 'shared/formatters';
 import { change } from 'redux-form';
 
 // Types
-export const SET_PENDING_PPM_WEIGHT = 'SET_PENDING_PPM_WEIGHT';
 const CLEAR_SIT_ESTIMATE = 'CLEAR_SIT_ESTIMATE';
 export const CREATE_OR_UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes('CREATE_OR_UPDATE_PPM');
 export const GET_PPM = ReduxHelpers.generateAsyncActionTypes('GET_PPM');
@@ -164,10 +163,6 @@ export function ppmReducer(state = initialState, action) {
         sitReimbursement: get(activePpm, 'estimated_storage_reimbursement', null),
         hasLoadSuccess: true,
         hasLoadError: false,
-      });
-    case SET_PENDING_PPM_WEIGHT:
-      return Object.assign({}, state, {
-        pendingPpmWeight: action.payload,
       });
     case CREATE_OR_UPDATE_PPM.start:
       return Object.assign({}, state, {


### PR DESCRIPTION
## Description

Missed deleting references to `setPendingPpmWeight` when removing the function in https://github.com/transcom/mymove/pull/3896.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-292) for this change
