### PR TITLE
Remove validations requiring pickup and destination address on MTOShipment

### DIFF
--- a/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
@@ -97,9 +97,15 @@ func MTOShipmentModelFromCreate(mtoShipment *primemessages.CreateShipmentPayload
 		MoveTaskOrderID:     uuid.FromStringOrNil(moveTaskOrderID.String()),
 		ShipmentType:        models.MTOShipmentType(mtoShipment.ShipmentType),
 		RequestedPickupDate: &requestedPickupDate,
-		PickupAddress:       AddressModel(mtoShipment.PickupAddress),
-		DestinationAddress:  AddressModel(mtoShipment.DestinationAddress),
 		CustomerRemarks:     mtoShipment.CustomerRemarks,
+	}
+
+	if mtoShipment.PickupAddress != nil {
+		model.PickupAddress = AddressModel(mtoShipment.PickupAddress)
+	}
+
+	if mtoShipment.DestinationAddress != nil {
+		model.DestinationAddress = AddressModel(mtoShipment.DestinationAddress)
 	}
 
 	if mtoShipment.Agents != nil {

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -92,8 +92,6 @@ func (m *MTOShipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		string(MTOShipmentStatusSubmitted),
 	}})
 	vs = append(vs, &validators.UUIDIsPresent{Field: m.MoveTaskOrderID, Name: "MoveTaskOrderID"})
-	vs = append(vs, &validators.UUIDIsPresent{Field: *m.PickupAddressID, Name: "PickupAddressID"})
-	vs = append(vs, &validators.UUIDIsPresent{Field: *m.DestinationAddressID, Name: "DestinationAddressID"})
 	if m.PrimeEstimatedWeight != nil {
 		vs = append(vs, &validators.IntIsGreaterThan{Field: m.PrimeEstimatedWeight.Int(), Compared: -1, Name: "PrimeEstimatedWeight"})
 	}

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -14,17 +14,51 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		// mock weights
 		estimatedWeight := unit.Pound(1000)
 		actualWeight := unit.Pound(980)
-		pickupAddressUUID := uuid.Must(uuid.NewV4())
-		destinationAddressUUID := uuid.Must(uuid.NewV4())
 		validMTOShipment := models.MTOShipment{
 			MoveTaskOrderID:      uuid.Must(uuid.NewV4()),
-			PickupAddressID:      &pickupAddressUUID,
-			DestinationAddressID: &destinationAddressUUID,
 			Status:               models.MTOShipmentStatusApproved,
 			PrimeEstimatedWeight: &estimatedWeight,
 			PrimeActualWeight:    &actualWeight,
 		}
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validMTOShipment, expErrors)
+	})
+
+	suite.T().Run("test empty MTOShipment", func(t *testing.T) {
+		emptyMTOShipment := models.MTOShipment{}
+		expErrors := map[string][]string{
+			"move_task_order_id": {"MoveTaskOrderID can not be blank."},
+			"status":             {"Status is not in the list [APPROVED, REJECTED, SUBMITTED]."},
+		}
+		suite.verifyValidationErrors(&emptyMTOShipment, expErrors)
+	})
+
+	suite.T().Run("test rejected MTOShipment", func(t *testing.T) {
+		rejectionReason := "bad shipment"
+		rejectedMTOShipment := models.MTOShipment{
+			MoveTaskOrderID: uuid.Must(uuid.NewV4()),
+			Status:          models.MTOShipmentStatusRejected,
+			RejectionReason: &rejectionReason,
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&rejectedMTOShipment, expErrors)
+	})
+
+	suite.T().Run("test validation failures", func(t *testing.T) {
+		// mock weights
+		estimatedWeight := unit.Pound(-1000)
+		actualWeight := unit.Pound(-980)
+		invalidMTOShipment := models.MTOShipment{
+			MoveTaskOrderID:      uuid.Must(uuid.NewV4()),
+			Status:               models.MTOShipmentStatusRejected,
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+		}
+		expErrors := map[string][]string{
+			"prime_estimated_weight": {"-1000 is not greater than -1."},
+			"prime_actual_weight":    {"-980 is not greater than -1."},
+			"rejection_reason":       {"RejectionReason can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
 	})
 }


### PR DESCRIPTION
## Description

There was some inconsistency in how pickup and destination address are handled for MTOShipment. The model validation are expecting those fields, but they were nullable in the DB and are both pointers in the model. Since these fields can be empty on creation, this PR removes the validation in the model. Also added some additional model tests to cover some additional cases.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2525) for this change