### PR TITLE
[MB-2550] Change prime-api-client command names to match their operationId

### DIFF
--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -64,8 +64,8 @@ func main() {
 	initRootFlags(root.PersistentFlags())
 
 	fetchMTOsCommand := &cobra.Command{
-		Use:          "fetch-mtos",
-		Short:        "fetch mtos",
+		Use:          "fetch-mto-updates",
+		Short:        "Fetch all MTOs available to prime",
 		Long:         "fetch move task orders",
 		RunE:         fetchMTOs,
 		SilenceUsage: true,
@@ -74,7 +74,7 @@ func main() {
 	root.AddCommand(fetchMTOsCommand)
 
 	createMTOCommand := &cobra.Command{
-		Use:   "support-create-mto",
+		Use:   "support-create-move-task-order",
 		Short: "Create a MoveTaskOrder",
 		Long: `
   This command creates a MoveTaskOrder object.
@@ -134,9 +134,9 @@ func main() {
 	root.AddCommand(updateMTOShipmentCommand)
 
 	updatePostCounselingInfo := &cobra.Command{
-		Use:          "update-post-counseling-info",
+		Use:          "update-mto-post-counseling-information",
 		Short:        "update post counseling info",
-		Long:         "update post counseling info such as discovering that customer has a PPM",
+		Long:         "Update post counseling info such as discovering that customer has a PPM",
 		RunE:         updatePostCounselingInfo,
 		SilenceUsage: true,
 	}
@@ -164,7 +164,7 @@ func main() {
 	root.AddCommand(createMTOServiceItemCommand)
 
 	makeAvailableToPrimeCommand := &cobra.Command{
-		Use:   "support-make-mto-available-to-prime",
+		Use:   "support-update-move-task-order-status",
 		Short: "Make mto available to prime",
 		Long: `
   This command makes an MTO available for prime consumption.
@@ -209,7 +209,7 @@ func main() {
 	root.AddCommand(updatePaymentRequestStatusCommand)
 
 	getMoveTaskOrder := &cobra.Command{
-		Use:   "support-get-mto",
+		Use:   "support-get-move-task-order",
 		Short: "Get an individual mto",
 		Long: `
   This command gets a single move task order by ID
@@ -272,7 +272,7 @@ func main() {
 	root.AddCommand(createPaymentRequestCommand)
 
 	createPaymentRequestUploadCommand := &cobra.Command{
-		Use:          "create-payment-request-upload",
+		Use:          "create-upload",
 		Short:        "Create payment request upload",
 		Long:         "Create payment request upload for a payment request",
 		RunE:         createPaymentRequestUpload,

--- a/scripts/run-e2e-mtls-test-docker
+++ b/scripts/run-e2e-mtls-test-docker
@@ -134,7 +134,7 @@ function prime_api_client () {
 
 #Integration test for Prime API
 #Return mtos from the fetch-mto endpoint where is_available_for_prime is true
-mtos=$(prime_api_client fetch-mtos)
+mtos=$(prime_api_client fetch-mto-updates)
 #Returns mtoShipments from the fetch-mto response, needed to return etag below
 mtoShipments=$(echo "$mtos" | jq '.[0] | .mtoShipments')
 echo "$mtoShipments"


### PR DESCRIPTION
## Description

Rename prime-api-client command names to match operation names in respective yaml files to be more consistent

## Reviewer Notes
- I can change the documentation in the wiki once we agree on the changes. I have a feeling we will want to rename some of the operation names to be a little clearer because some are pretty verbose. Also there's some inconsistency on using abbreviations (ex. Sometimes using MTO vs using move-task-order). Let me know what y'all think!
 
## Setup
`rm bin/prime-api-client`
`make bin/prime-api-client`
`prime-api-client fetch-mto-updates --insecure | jq`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2550) for this change
