### PR TITLE
MB-2611 Create a prime api client call for Create MTO shipment

### DIFF
--- a/cmd/prime-api-client/create_mto_shipment.go
+++ b/cmd/prime-api-client/create_mto_shipment.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
+)
+
+func initCreateMTOShipmentFlags(flag *pflag.FlagSet) {
+	flag.String(FilenameFlag, "", "Name of the file being passed in")
+	flag.SortFlags = false
+}
+
+func checkCreateMTOShipmentConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := CheckRootConfig(v)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {
+		logger.Fatal(errors.New("create-mto-shipment expects a file to be passed in"))
+	}
+
+	return nil
+}
+
+func createMTOShipment(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	// Create the logger - remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkCreateMTOShipmentConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// Decode json from file that was passed into MTOShipment
+	filename := v.GetString(FilenameFlag)
+	var shipmentPayload mtoShipment.CreateMTOShipmentParams
+	err = decodeJSONFileToPayload(filename, containsDash(args), &shipmentPayload)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	shipmentPayload.SetTimeout(time.Second * 30)
+
+	// Create the client and open the cacStore
+	primeGateway, cacStore, errCreateClient := CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer cacStore.Close()
+	}
+
+	// Make the API Call
+	resp, err := primeGateway.MtoShipment.CreateMTOShipment(&shipmentPayload)
+	if err != nil {
+		return handleGatewayError(err, logger)
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -92,6 +92,26 @@ func main() {
 	initCreateMTOFlags(createMTOCommand.Flags())
 	root.AddCommand(createMTOCommand)
 
+	createMTOShipmentCommand := &cobra.Command{
+		Use:   "create-mto-shipment",
+		Short: "Create MTO shipment",
+		Long: `
+	This command creates a MTO shipment.
+	It requires the caller to pass in a file using the --filename arg.
+	The file should contain a body defining the MTOShipment object.
+	Endpoint path: move-task-orders/{moveTaskOrderID}/mto-shipments
+	The file should contain json as follows:
+		{
+			"moveTaskOrderID": <uuid string>
+			"body": <MTOShipment>,
+		}
+	Please see API documentation for full details on the endpoint definition.`,
+		RunE:         createMTOShipment,
+		SilenceUsage: true,
+	}
+	initCreateMTOShipmentFlags(createMTOShipmentCommand.Flags())
+	root.AddCommand(createMTOShipmentCommand)
+
 	updateMTOShipmentCommand := &cobra.Command{
 		Use:   "update-mto-shipment",
 		Short: "Update MTO shipment",


### PR DESCRIPTION
## Description

add call for `CreateMTOShipment` to Prime API Client so that the `move-task-orders/{moveTaskOrderId}/mto-shipments` endpoint can be tested in staging

## Setup

```
make db_dev_reset db_dev_e2e_populate
rm bin/prime-api-client && make bin/prime-api-client 
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=26&projectKey=MB&modal=detail&selectedIssue=MB-2611&sprint=96)

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
