### PR TITLE
Add Ruby script to automate prod deploys

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,284 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+def run(command)
+  abort "command failed (#{$?}): #{command}" unless system command
+end
+
+puts "\n== Installing dependencies =="
+run "gem install bundler --conservative"
+
+require "bundler/inline"
+require "json"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "octokit"
+end
+
+CIRCLE_TOKEN = ENV["CIRCLE_TOKEN"]
+CIRCLE_HEADERS = {
+  "Accept" => "application/json",
+  "Circle-Token" => CIRCLE_TOKEN
+}.freeze
+CIRCLE_PARAMS = {
+  "branch" => "master"
+}.freeze
+CIRCLE_PROJECT_SLUG = "github/transcom/mymove"
+CIRCLE_API_ENDPOINT = "https://circleci.com/api/v2"
+
+GITHUB_TOKEN = ENV["GITHUB_TOKEN"]
+
+class CircleCi
+  def most_recent_successful_pipeline
+    @most_recent_successful_pipeline ||= all_pipelines.find do |pipeline|
+      PipelineWorkflow.new(pipeline_id: pipeline["id"]).success?
+    end
+  end
+
+  def most_recent_on_hold_workflow
+    @most_recent_on_hold_workflow ||= all_pipelines.each do |pipeline|
+      workflow = PipelineWorkflow.new(pipeline_id: pipeline["id"])
+      break workflow if workflow.on_hold?
+    end
+  end
+
+  private
+
+  def all_pipelines
+    @all_pipelines ||= begin
+      request = Faraday.get pipelines_endpoint, CIRCLE_PARAMS, CIRCLE_HEADERS
+      JSON.parse(request.body)["items"]
+    end
+  end
+
+  def pipelines_endpoint
+    "#{CIRCLE_API_ENDPOINT}/project/#{CIRCLE_PROJECT_SLUG}/pipeline"
+  end
+end
+
+class PipelineWorkflow
+  def initialize(pipeline_id:)
+    @pipeline_id = pipeline_id
+  end
+
+  attr_reader :pipeline_id
+
+  def success?
+    status == "success"
+  end
+
+  def on_hold?
+    status == "on_hold"
+  end
+
+  def id
+    attributes["id"]
+  end
+
+  def pipeline_number
+    attributes["pipeline_number"]
+  end
+
+  private
+
+  def status
+    attributes["status"]
+  end
+
+  def attributes
+    @attributes ||= JSON.parse(pipeline_workflows.body)["items"].first
+  end
+
+  def pipeline_workflows
+    Faraday.get(
+      pipeline_workflows_endpoint,
+      CIRCLE_PARAMS,
+      CIRCLE_HEADERS
+    )
+  end
+
+  def pipeline_workflows_endpoint
+    "#{CIRCLE_API_ENDPOINT}/pipeline/#{pipeline_id}/workflow"
+  end
+end
+
+class Pipeline
+  def initialize(pipeline_id:)
+    @pipeline_id = pipeline_id
+  end
+
+  def commit_hash
+    JSON.parse(pipeline_details.body)["vcs"]["revision"]
+  end
+
+  private
+
+  attr_reader :pipeline_id
+
+  def pipeline_details
+    Faraday.get pipeline_endpoint, CIRCLE_PARAMS, CIRCLE_HEADERS
+  end
+
+  def pipeline_endpoint
+    "#{CIRCLE_API_ENDPOINT}/pipeline/#{pipeline_id}"
+  end
+end
+
+class WorkflowJobs
+  def initialize(workflow_id:)
+    @workflow_id = workflow_id
+  end
+
+  def approve_prod_deploy_job
+    answer = prompt_for_deploy_confirmation
+    send_deploy_request if answer == "y"
+  end
+
+  private
+
+  attr_reader :workflow_id
+
+  def prompt_for_deploy_confirmation
+    puts "Are you sure you want to deploy to prod now? [yN]"
+    answer = gets
+    if answer != "y"
+      puts "aborting deploy"
+    else
+      puts "deploying to prod"
+    end
+    answer
+  end
+
+  def send_deploy_request
+    approval_request = Faraday.post prod_deploy_approval_endpoint,
+      {},
+      CIRCLE_HEADERS
+
+    puts "approval request response: #{JSON.parse(approval_request.body)}"
+  end
+
+  def prod_deploy_job_id
+    all_jobs = JSON.parse(jobs.body)["items"]
+    prod_deploy_job = all_jobs.find do |job|
+      job["name"] == "approve_prod_deploy"
+    end
+    prod_deploy_job["id"]
+  end
+
+  def jobs
+    Faraday.get jobs_endpoint, CIRCLE_PARAMS, CIRCLE_HEADERS
+  end
+
+  def jobs_endpoint
+    "#{CIRCLE_API_ENDPOINT}/workflow/#{workflow_id}/job"
+  end
+
+  def prod_deploy_approval_endpoint
+    "#{CIRCLE_API_ENDPOINT}/workflow/#{workflow_id}/approve/#{prod_deploy_job_id}"
+  end
+end
+
+class MyMovePRs
+  def initialize(since_commit:)
+    @since_commit = since_commit
+  end
+
+  def merged_since_last_deploy
+    if search_results.empty?
+      puts "Nothing to deploy. No new PRs since last deploy."
+      return search_results
+    end
+
+    print_pr_titles_and_urls
+
+    search_results
+  end
+
+  private
+
+  attr_reader :since_commit
+
+  def search_results
+    @search_results ||= client.search_issues(query).items
+  end
+
+  def print_pr_titles_and_urls
+    puts "PRs merged since last deploy:"
+    search_results.each do |pr|
+      puts pr.title
+      puts pr.html_url
+      puts "\n"
+    end
+  end
+
+  def query
+    "repo:#{repo} is:pr is:closed base:master merged:>#{(date + 1).iso8601} sort:updated-asc"
+  end
+
+  def date
+    last_deployed_commit.commit.author.date
+  end
+
+  def last_deployed_commit
+    client.commit(repo, since_commit)
+  end
+
+  def repo
+    "transcom/mymove"
+  end
+
+  def client
+    @client ||= Octokit::Client.new(access_token: GITHUB_TOKEN)
+  end
+end
+
+def verify_presence_of_tokens
+  required_tokens = ["CIRCLE_TOKEN", "GITHUB_TOKEN"]
+  status = required_tokens.each_with_object([]) do |token, result|
+    if ENV[token].nil?
+      puts "Please add #{token} to your .envrc.local"
+      result << "failed"
+    else
+      result << "passed"
+    end
+  end
+  status.uniq
+end
+
+def fetch_prs_merged_since_last_deploy
+  most_recent_successful_pipeline = CircleCi.new.most_recent_successful_pipeline
+  pipeline_id = most_recent_successful_pipeline["id"]
+  pipeline_number = most_recent_successful_pipeline["number"]
+  puts "Most recent successful Circle CI pipeline: ##{pipeline_number}\n\n"
+
+  commit_hash_of_last_deployed_pr = Pipeline.new(pipeline_id: pipeline_id).commit_hash
+  puts "commit hash of last deployed PR: #{commit_hash_of_last_deployed_pr}\n\n"
+
+  MyMovePRs.new(since_commit: commit_hash_of_last_deployed_pr).merged_since_last_deploy
+end
+
+def approve_most_recent_on_hold_workflow
+  most_recent_on_hold_workflow = CircleCi.new.most_recent_on_hold_workflow
+  most_recent_on_hold_pipeline_number = most_recent_on_hold_workflow.pipeline_number
+  puts "Most recent on hold Circle CI pipeline: ##{most_recent_on_hold_pipeline_number}\n\n"
+  workflow_id = most_recent_on_hold_workflow.id
+
+  puts "Getting ready to approve the 'approve_prod_deploy' job for pipeline ##{most_recent_on_hold_pipeline_number}"
+  WorkflowJobs.new(workflow_id: workflow_id).approve_prod_deploy_job
+end
+
+def run_script
+  status = verify_presence_of_tokens
+
+  return unless status == ["passed"]
+
+  prs = fetch_prs_merged_since_last_deploy
+
+  return if prs.empty?
+
+  approve_most_recent_on_hold_workflow
+end
+
+run_script


### PR DESCRIPTION
**Why**:
The current deploy process followed twice a day by the folks who are
on call is manual and tedious. It requires following these steps:

1. Visit the Circle CI website to view the most recent pipelines for
the master branch
2. Click on the most recent successful pipeline
3. Copy the git commit hash
4. Look up the date for the commit hash via the command line
5. Visit the GitHub website to view pull requests for mymove
6. Filter PRs using this query:
`is:closed base:master merged:>2020-05-04T17:33:46-00:00 sort:updated-asc`
where the date is the one from step 4, but with one second added to
it, and converted to ISO 8601 format that GitHub needs.These first 6
steps are how we can obtain all PRs that have been merged to master
since the last one that was deployed to production.
7. Copy the title of each PR into a new Slack post and share it in
the #prod-support channel
8. Go back to the CircleCI pipelines, and click on the most recent
"ON_HOLD" pipeline.
9. Scroll horizontally until you see the "approve_prod_deploy" job,
and click on it, then type in "approve_prod_deploy" to approve it.

These steps are time-consuming and error-prone. With this script, the
process is reduced from several minutes to a few seconds. If there
aren't any new merged PRs since the last deploy, it will let you know.
If there are PRs to deploy, it will first prompt you to make sure you
really want to deploy. This helps avoid accidental deploys.

For troubleshooting and comparison with the CircleCI website, the
script will output the pipeline number for the most recent successful
and on hold pipelines, and the commit hash for the last deployed PR.
For easy copy and pasting into Slack, it will output the title and URL
for each PR that is about to be deployed.

## Setup

1. Go to https://app.circleci.com/settings/user/tokens
2. Create a new token and save it somewhere safe, like in 1Password. I named mine "mymove-deploy"
3. Go to https://github.com/settings/tokens
4. Click on "Generate new token", and give it only the `repo` permissions, and save it in 1Password
5. Run `docker run -it --rm=true -v $PWD:/app -w /app ruby:2.7-slim bash`
6. Inside Docker, run `export CIRCLE_TOKEN=your_circle_token`
7. Inside Docker, run `export GITHUB_TOKEN=your_github_token`
8. Run `scripts/deploy`