### PR TITLE
[MB-2654] Make PriceCents nullable/pointer for Payment Service Item

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -508,3 +508,4 @@
 20200423174512_add-status-to-service-item.up.sql
 20200505194253_import_rates_may_2020.up.sql
 20200511185126_make_service_item_param_key_unique.up.sql
+20200515202122_payment_service_item_nullable_price.up.sql

--- a/migrations/app/schema/20200515202122_payment_service_item_nullable_price.up.sql
+++ b/migrations/app/schema/20200515202122_payment_service_item_nullable_price.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE payment_service_items
+    ALTER COLUMN price_cents DROP NOT NULL;
+
+-- Since we don't have pricing yet, any existing records with a price_cents of 0
+-- should really be null instead
+UPDATE payment_service_items
+SET price_cents = NULL
+WHERE price_cents = 0;

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1548,7 +1548,8 @@ func init() {
         "priceCents": {
           "type": "integer",
           "format": "cents",
-          "title": "Price of the service item in cents"
+          "title": "Price of the service item in cents",
+          "x-nullable": true
         },
         "rejectionReason": {
           "type": "string",
@@ -3534,7 +3535,8 @@ func init() {
         "priceCents": {
           "type": "integer",
           "format": "cents",
-          "title": "Price of the service item in cents"
+          "title": "Price of the service item in cents",
+          "x-nullable": true
         },
         "rejectionReason": {
           "type": "string",

--- a/pkg/gen/primemessages/payment_service_item.go
+++ b/pkg/gen/primemessages/payment_service_item.go
@@ -37,7 +37,7 @@ type PaymentServiceItem struct {
 	PaymentServiceItemParams PaymentServiceItemParams `json:"paymentServiceItemParams,omitempty"`
 
 	// Price of the service item in cents
-	PriceCents int64 `json:"priceCents,omitempty"`
+	PriceCents *int64 `json:"priceCents,omitempty"`
 
 	// rejection reason
 	RejectionReason *string `json:"rejectionReason,omitempty"`

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -263,16 +263,21 @@ func PaymentServiceItem(paymentServiceItem *models.PaymentServiceItem) *primemes
 
 	paymentServiceItemParams := PaymentServiceItemParams(&paymentServiceItem.PaymentServiceItemParams)
 
-	return &primemessages.PaymentServiceItem{
+	payload := &primemessages.PaymentServiceItem{
 		ID:                       strfmt.UUID(paymentServiceItem.ID.String()),
 		PaymentRequestID:         strfmt.UUID(paymentServiceItem.PaymentRequestID.String()),
 		MtoServiceItemID:         strfmt.UUID(paymentServiceItem.MTOServiceItemID.String()),
 		Status:                   primemessages.PaymentServiceItemStatus(paymentServiceItem.Status),
-		PriceCents:               int64(paymentServiceItem.PriceCents),
 		RejectionReason:          paymentServiceItem.RejectionReason,
 		PaymentServiceItemParams: *paymentServiceItemParams,
 		ETag:                     etag.GenerateEtag(paymentServiceItem.UpdatedAt),
 	}
+
+	if paymentServiceItem.PriceCents != nil {
+		payload.PriceCents = swag.Int64(int64(*paymentServiceItem.PriceCents))
+	}
+
+	return payload
 }
 
 // PaymentServiceItems payload

--- a/pkg/models/payment_service_item.go
+++ b/pkg/models/payment_service_item.go
@@ -46,7 +46,7 @@ type PaymentServiceItem struct {
 	PaymentRequestID uuid.UUID                `json:"payment_request_id" db:"payment_request_id"`
 	MTOServiceItemID uuid.UUID                `json:"mto_service_item_id" db:"mto_service_item_id"`
 	Status           PaymentServiceItemStatus `json:"status" db:"status"`
-	PriceCents       unit.Cents               `json:"price_cents" db:"price_cents"`
+	PriceCents       *unit.Cents              `json:"price_cents" db:"price_cents"`
 	RejectionReason  *string                  `json:"rejection_reason" db:"rejection_reason"`
 	RequestedAt      time.Time                `json:"requested_at" db:"requested_at"`
 	ApprovedAt       *time.Time               `json:"approved_at" db:"approved_at"`
@@ -72,8 +72,5 @@ func (p *PaymentServiceItem) Validate(tx *pop.Connection) (*validate.Errors, err
 		&validators.UUIDIsPresent{Field: p.MTOServiceItemID, Name: "MTOServiceItemID"},
 		&validators.StringInclusion{Field: p.Status.String(), Name: "Status", List: validPaymentServiceItemStatus},
 		&validators.TimeIsPresent{Field: p.RequestedAt, Name: "RequestedAt"},
-		// TODO: Removing this until we have pricing to populate
-		// &validators.IntIsPresent{Field: p.PriceCents.Int(), Name: "PriceCents"},
-		// &validators.IntIsGreaterThan{Field: p.PriceCents.Int(), Name: "PriceCents", Compared: 0},
 	), nil
 }

--- a/pkg/models/payment_service_item_test.go
+++ b/pkg/models/payment_service_item_test.go
@@ -12,13 +12,15 @@ import (
 )
 
 func (suite *ModelSuite) TestPaymentServiceItemValidation() {
+	cents := unit.Cents(1000)
+
 	suite.T().Run("test valid PaymentServiceItem", func(t *testing.T) {
 		validPaymentServiceItem := models.PaymentServiceItem{
 			PaymentRequestID: uuid.Must(uuid.NewV4()),
 			MTOServiceItemID: uuid.Must(uuid.NewV4()), //MTO Service Item
 			Status:           "REQUESTED",
 			RequestedAt:      time.Now(),
-			PriceCents:       unit.Cents(1000),
+			PriceCents:       &cents,
 		}
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validPaymentServiceItem, expErrors)
@@ -32,8 +34,6 @@ func (suite *ModelSuite) TestPaymentServiceItemValidation() {
 			"m_t_os_ervice_item_id": {"MTOServiceItemID can not be blank."},
 			"status":                {"Status is not in the list [REQUESTED, APPROVED, DENIED, SENT_TO_GEX, PAID]."},
 			"requested_at":          {"RequestedAt can not be blank."},
-			// TODO: Removing this until we have pricing to populate
-			// "price_cents":        {"PriceCents can not be blank.", "0 is not greater than 0."},
 		}
 
 		suite.verifyValidationErrors(&invalidPaymentServiceItem, expErrors)
@@ -45,7 +45,7 @@ func (suite *ModelSuite) TestPaymentServiceItemValidation() {
 			MTOServiceItemID: uuid.Must(uuid.NewV4()), //MTO Service Item
 			Status:           "Sleeping",
 			RequestedAt:      time.Now(),
-			PriceCents:       unit.Cents(1000),
+			PriceCents:       &cents,
 		}
 		expErrors := map[string][]string{
 			"status": {"Status is not in the list [REQUESTED, APPROVED, DENIED, SENT_TO_GEX, PAID]."},

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -15,7 +15,6 @@ import (
 	serviceparamlookups "github.com/transcom/mymove/pkg/payment_request/service_param_value_lookups"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/unit"
 )
 
 type paymentRequestCreator struct {
@@ -232,8 +231,7 @@ func (p *paymentRequestCreator) createPaymentServiceItem(tx *pop.Connection, pay
 	paymentServiceItem.PaymentRequestID = paymentRequest.ID
 	paymentServiceItem.PaymentRequest = *paymentRequest
 	paymentServiceItem.Status = models.PaymentServiceItemStatusRequested
-	// TODO: should PriceCents be a pointer? "0 cents " might be a valid value
-	paymentServiceItem.PriceCents = unit.Cents(0) // TODO: Placeholder until we have pricing ready.
+	// TODO: No pricing yet, so skipping the PriceCents field.
 	paymentServiceItem.RequestedAt = requestedAt
 
 	verrs, err := tx.ValidateAndCreate(paymentServiceItem)

--- a/pkg/testdatagen/make_payment_service_item.go
+++ b/pkg/testdatagen/make_payment_service_item.go
@@ -26,7 +26,6 @@ func MakePaymentServiceItem(db *pop.Connection, assertions Assertions) models.Pa
 		MTOServiceItem:   mtoServiceItem,
 		MTOServiceItemID: mtoServiceItem.ID,
 		Status:           models.PaymentServiceItemStatusRequested,
-		PriceCents:       0,
 		RequestedAt:      time.Now(),
 	}
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1165,6 +1165,7 @@ definitions:
         type: integer
         format: cents
         title: Price of the service item in cents
+        x-nullable: true
       rejectionReason:
         example: documentation was incomplete
         type: string


### PR DESCRIPTION
## Description

This PR converts `PriceCents` (`price_cents` in the DB) for a payment service item to a nullable field (and a pointer in the Go model).  We want to be able to differentiate between the absence of a price and a price of zero.  Any existing payment service item records with a price of zero are assumed to be unpriced (since we haven't integrated pricing yet) and are turned into a null by the migration.

## Reviewer Notes

The returned JSON payload for payment service items does not include the `priceCents` field at all if the price is null.  It will include the price if it's 0 (or any other integer value).  This is in line with how our other JSON payloads work, but if we want `priceCents` to appear even if nil, we can add an `x-omitempty` flag to our swagger definition.

## Setup

1. `make db_dev_e2e_populate`
1. `make server_run`
1. `go run ./cmd/prime-api-client --insecure fetch-mtos | jq` to see the current list of MTOs.  Note that MTO `5d4b25bb-eb04-4c03-9a81-ee0398cb779e` has no payment requests.  However, you should see a service item with ID of `9db1bf43-0964-44ff-8384-3297951f6781`.
1. Using the IDs above, save the following JSON payload as `pr_payload_dev.json`:
    ```json
    {
      "body": {
        "isFinal": false,
        "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
        "serviceItems": [
          {
            "id": "9db1bf43-0964-44ff-8384-3297951f6781"
          }
        ]
      }
    }
    ```
1. `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload_dev.json | jq` to create a payment request.  Note that the return payload does not show `priceCents` at all for the created payment service item (since it's null in the DB because we haven't implemented pricing yet).
1. `go run ./cmd/prime-api-client --insecure fetch-mtos | jq` to fetch MTOs again.  You should see the same behavior in the payload returned here.

If you would like to see the `priceCents` field appear, just change the `payment_service_items` record in the DB to have a 0 (or other value) and run a `fetch-mtos` again.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2654) for this change
