### PR TITLE
 MB-2482 Remove OrderType and OrderTypeDetail from MoveOrder payload

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1103,19 +1103,6 @@ func init() {
           "x-nullable": true,
           "example": "030-00362"
         },
-        "orderType": {
-          "type": "string",
-          "enum": [
-            "GHC",
-            "NTS"
-          ],
-          "x-nullable": true,
-          "example": "GHC"
-        },
-        "orderTypeDetail": {
-          "type": "string",
-          "x-nullable": true
-        },
         "originDutyStation": {
           "$ref": "#/definitions/DutyStation"
         },
@@ -2778,19 +2765,6 @@ func init() {
           "type": "string",
           "x-nullable": true,
           "example": "030-00362"
-        },
-        "orderType": {
-          "type": "string",
-          "enum": [
-            "GHC",
-            "NTS"
-          ],
-          "x-nullable": true,
-          "example": "GHC"
-        },
-        "orderTypeDetail": {
-          "type": "string",
-          "x-nullable": true
         },
         "originDutyStation": {
           "$ref": "#/definitions/DutyStation"

--- a/pkg/gen/supportmessages/move_order.go
+++ b/pkg/gen/supportmessages/move_order.go
@@ -6,8 +6,6 @@ package supportmessages
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"encoding/json"
-
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -61,13 +59,6 @@ type MoveOrder struct {
 	// ID of the military orders associated with this move.
 	OrderNumber *string `json:"orderNumber,omitempty"`
 
-	// order type
-	// Enum: [GHC NTS]
-	OrderType *string `json:"orderType,omitempty"`
-
-	// order type detail
-	OrderTypeDetail *string `json:"orderTypeDetail,omitempty"`
-
 	// origin duty station
 	OriginDutyStation *DutyStation `json:"originDutyStation,omitempty"`
 
@@ -115,10 +106,6 @@ func (m *MoveOrder) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateOrderType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -240,49 +227,6 @@ func (m *MoveOrder) validateID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("id", "body", "uuid", m.ID.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-var moveOrderTypeOrderTypePropEnum []interface{}
-
-func init() {
-	var res []string
-	if err := json.Unmarshal([]byte(`["GHC","NTS"]`), &res); err != nil {
-		panic(err)
-	}
-	for _, v := range res {
-		moveOrderTypeOrderTypePropEnum = append(moveOrderTypeOrderTypePropEnum, v)
-	}
-}
-
-const (
-
-	// MoveOrderOrderTypeGHC captures enum value "GHC"
-	MoveOrderOrderTypeGHC string = "GHC"
-
-	// MoveOrderOrderTypeNTS captures enum value "NTS"
-	MoveOrderOrderTypeNTS string = "NTS"
-)
-
-// prop value enum
-func (m *MoveOrder) validateOrderTypeEnum(path, location string, value string) error {
-	if err := validate.Enum(path, location, value, moveOrderTypeOrderTypePropEnum); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *MoveOrder) validateOrderType(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.OrderType) { // not required
-		return nil
-	}
-
-	// value enum
-	if err := m.validateOrderTypeEnum("orderType", "body", *m.OrderType); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -79,11 +79,9 @@ func MoveOrder(moveOrder *models.MoveOrder) *supportmessages.MoveOrder {
 		Entitlement:            Entitlement(moveOrder.Entitlement),
 		Customer:               Customer(moveOrder.Customer),
 		OrderNumber:            moveOrder.OrderNumber,
-		OrderTypeDetail:        moveOrder.OrderTypeDetail,
 		ID:                     strfmt.UUID(moveOrder.ID.String()),
 		OriginDutyStation:      originDutyStation,
 		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),
-		OrderType:              moveOrder.OrderType,
 	}
 
 	if moveOrder.ReportByDate != nil {

--- a/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
@@ -36,13 +36,11 @@ func MoveOrderModel(moveOrderPayload *supportmessages.MoveOrder) *models.MoveOrd
 		return nil
 	}
 	model := &models.MoveOrder{
-		ID:              uuid.FromStringOrNil(moveOrderPayload.ID.String()),
-		Grade:           &moveOrderPayload.Rank,
-		OrderNumber:     moveOrderPayload.OrderNumber,
-		OrderType:       moveOrderPayload.OrderType,
-		OrderTypeDetail: moveOrderPayload.OrderTypeDetail,
-		Customer:        CustomerModel(moveOrderPayload.Customer),
-		Entitlement:     EntitlementModel(moveOrderPayload.Entitlement),
+		ID:          uuid.FromStringOrNil(moveOrderPayload.ID.String()),
+		Grade:       &moveOrderPayload.Rank,
+		OrderNumber: moveOrderPayload.OrderNumber,
+		Customer:    CustomerModel(moveOrderPayload.Customer),
+		Entitlement: EntitlementModel(moveOrderPayload.Entitlement),
 	}
 
 	customerID := uuid.FromStringOrNil(moveOrderPayload.CustomerID.String())

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -683,16 +683,6 @@ definitions:
         type: string
         x-nullable: true
         example: '030-00362'
-      orderType:
-        example: GHC
-        type: string
-        enum:
-          - GHC
-          - NTS
-        x-nullable: true
-      orderTypeDetail:
-        type: string
-        x-nullable: true
       dateIssued:
         description: The date the orders were issued.
         type: string


### PR DESCRIPTION
## Description

This PR removes the `orderType` and `orderTypeDetail` fields from the `MoveOrder` payload in the Support API. 

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2482) for this change