### PR TITLE
MB-2554 Add in FOUO component to display in all pages for office app

### DIFF
--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -16,6 +16,7 @@ import PrivateRoute from 'shared/User/PrivateRoute';
 import { isProduction } from 'shared/constants';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import QueueHeader from 'shared/Header/Office';
+import FOUOHeader from 'components/FOUOHeader';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import './office.scss';
@@ -79,6 +80,7 @@ export class OfficeWrapper extends Component {
     return (
       <ConnectedRouter history={history}>
         <div className="Office site">
+          <FOUOHeader />
           <Suspense fallback={<LoadingPlaceholder />}>{!userIsLoggedIn && <QueueHeader />}</Suspense>
           <ConditionalWrap
             condition={!userIsLoggedIn}


### PR DESCRIPTION
## Description

As an authorized TOO/TIO
When I login to …
I am able to see the Unclassified / FOUO banner at the top of every page (above the standard header)

**Acceptance Criteria**

- The FOUO banner appears site wide above the standard header in the TOO/TIO interface. 
- The banner will show up in all pages for the Office app.

## Reviewer Notes

This work should also cover https://dp3.atlassian.net/browse/MB-2547

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Navigate to http://officelocal:3000/moves/1

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2554) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/1522549/82257244-8946d780-990c-11ea-9d19-0de4b3d5c784.png)
