### PR TITLE
MB-2668 Use MoveOrder ID for Move Details Page

### DIFF
--- a/src/pages/TOO/moveDetails.jsx
+++ b/src/pages/TOO/moveDetails.jsx
@@ -3,28 +3,22 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import '../../index.scss';
 import '../../ghc_index.scss';
-// import OrdersTable from '../../components/Office/OrdersTable';
 import { get } from 'lodash';
-import { getMoveByLocator, selectMoveByLocator } from '../../shared/Entities/modules/moves';
-import { loadOrders, selectOrdersForMove } from '../../shared/Entities/modules/orders';
+import { getMoveOrder, selectMoveOrder } from '../../shared/Entities/modules/moveTaskOrders';
+import { loadOrders } from '../../shared/Entities/modules/orders';
 import OrdersTable from '../../components/Office/OrdersTable';
-
-// import OrdersTable from "../../components/Office/OrdersTable";
 
 class MoveDetails extends Component {
   componentDidMount() {
     // eslint-disable-next-line react/destructuring-assignment,react/prop-types
-    const { locator } = this.props.match.params;
+    const { moveOrderId } = this.props.match.params;
     // eslint-disable-next-line react/prop-types,react/destructuring-assignment
-    this.props.getMoveByLocator(locator).then(({ response: { body: move } }) => {
-      // eslint-disable-next-line react/prop-types,react/destructuring-assignment
-      this.props.loadOrders(move.orders_id);
-    });
+    this.props.getMoveOrder(moveOrderId);
   }
 
   render() {
     // eslint-disable-next-line react/prop-types
-    const { orders } = this.props;
+    const { moveOrder } = this.props;
     return (
       <div className="grid-container-desktop-lg" data-cy="too-move-details">
         <h1>Move details</h1>
@@ -32,23 +26,25 @@ class MoveDetails extends Component {
           <OrdersTable
             ordersInfo={{
               // eslint-disable-next-line react/prop-types
-              newDutyStation: get(orders.new_duty_station, 'name'),
+              newDutyStation: get(moveOrder.destinationDutyStation, 'name'),
               // eslint-disable-next-line react/prop-types
-              issuedDate: orders.issue_date,
+              currentDutyStation: get(moveOrder.originDutyStation, 'name'),
               // eslint-disable-next-line react/prop-types
-              reportByDate: orders.report_by_date,
+              issuedDate: moveOrder.date_issued,
               // eslint-disable-next-line react/prop-types
-              departmentIndicator: orders.department_indicator,
+              reportByDate: moveOrder.report_by_date,
               // eslint-disable-next-line react/prop-types
-              ordersNumber: orders.orders_number,
+              departmentIndicator: moveOrder.department_indicator,
               // eslint-disable-next-line react/prop-types
-              ordersType: orders.orders_type,
+              ordersNumber: moveOrder.order_number,
               // eslint-disable-next-line react/prop-types
-              ordersTypeDetail: orders.orders_type_detail,
+              ordersType: moveOrder.order_type,
               // eslint-disable-next-line react/prop-types
-              tacMDC: orders.tac,
+              ordersTypeDetail: moveOrder.order_type_detail,
               // eslint-disable-next-line react/prop-types
-              sacSDN: orders.sacSDN,
+              tacMDC: moveOrder.tac,
+              // eslint-disable-next-line react/prop-types
+              sacSDN: moveOrder.sacSDN,
             }}
           />
         </div>
@@ -58,20 +54,15 @@ class MoveDetails extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { locator } = ownProps.match.params;
-  const move = selectMoveByLocator(state, locator);
-  let moveId;
-  if (move) {
-    moveId = move.id;
-  }
+  const { moveOrderId } = ownProps.match.params;
+
   return {
-    move,
-    orders: selectOrdersForMove(state, moveId),
+    moveOrder: selectMoveOrder(state, moveOrderId),
   };
 };
 
 const mapDispatchToProps = {
-  getMoveByLocator,
+  getMoveOrder,
   loadOrders,
 };
 

--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -10,8 +10,8 @@ class TOO extends Component {
     this.props.getAllMoveOrders();
   }
 
-  handleCustomerInfoClick = (locator) => {
-    this.props.history.push(`/moves/${locator}`);
+  handleCustomerInfoClick = (moveOrderId) => {
+    this.props.history.push(`/moves/${moveOrderId}`);
   };
 
   render() {
@@ -38,12 +38,9 @@ class TOO extends Component {
                 agency,
                 originDutyStation,
                 customerID,
+                moveTaskOrderId,
               }) => (
-                <tr
-                  data-cy="too-row"
-                  onClick={() => this.handleCustomerInfoClick(confirmation_number)}
-                  key={moveOrderId}
-                >
+                <tr data-cy="too-row" onClick={() => this.handleCustomerInfoClick(moveOrderId)} key={moveOrderId}>
                   <td>{`${last_name}, ${first_name}`}</td>
                   <td>{confirmation_number}</td>
                   <td>{agency}</td>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -168,7 +168,7 @@ export class OfficeWrapper extends Component {
                   <Switch>
                     {too && <PrivateRoute path="/too/customer-moves" exact component={TOO} />}
                     {too && <PrivateRoute path="/move/mto/:moveTaskOrderId" exact component={TOOMoveTaskOrder} />}
-                    {too && <PrivateRoute path="/moves/:locator" exact component={MoveDetails} />}
+                    {too && <PrivateRoute path="/moves/:moveOrderId" exact component={MoveDetails} />}
                     {/*TODO: remove CustomerDetails route when ready*/}
                     {too && (
                       <PrivateRoute


### PR DESCRIPTION
## Description

Sets us up to use the MoveOrderID temporarily for the MoveDetails view in the TOO application. This state is meant to keep us moving while we work in parallel to solve for some DB schema constraints.

## Setup

```sh
make db_dev_e2e_populate
```

If you click on a move under `http://officelocal:3000/too/customer-moves/` you should be greeted with a page that has an Orders Table and a url similar to this one: `http://officelocal:3000/moves/9c7513d9-996f-4fee-b413-2d0b08776d47`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2668) for this change
