### PR TITLE
MB-2720 Use plugin for checking Jira id with dangerjs

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,5 +1,6 @@
 import { includes } from 'lodash';
 import { danger, warn, fail } from 'danger';
+import jiraIssue from 'danger-plugin-jira-issue';
 
 const githubChecks = () => {
   if (danger.github) {
@@ -8,9 +9,11 @@ const githubChecks = () => {
       warn('Please include a description of your PR changes.');
     }
     // PRs should have a Jira ID in the title
-    if (!danger.github.pr.title.match(/^(\[MB-\d+\]|MB-\d+)/)) {
-      warn('Please include the Jira ID at the start of the title with the format MB-123 or \\[MB-123\\]');
-    }
+    jiraIssue({
+      key: 'MB',
+      url: 'https://dp3.atlassian.net/browse',
+      location: 'title',
+    });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@storybook/addons": "^5.3.17",
     "@storybook/react": "^5.3.18",
     "danger": "^10.2.0",
+    "danger-plugin-jira-issue": "^1.4.1",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,6 +5256,11 @@ damerau-levenshtein@^1.0.4:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
   integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
+danger-plugin-jira-issue@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/danger-plugin-jira-issue/-/danger-plugin-jira-issue-1.4.1.tgz#1e2317ae8a291d96dc19762a55cb905681320940"
+  integrity sha512-B/XaW8YigUboK4BH4sMM8GmE0e+Bc6ibAg+Xyf0HFGph4DIawNYOuwKbCh2K1fAyXafott6tGpxFMe9Tc0Aabw==
+
 danger@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/danger/-/danger-10.2.0.tgz#e3500c2003aa85dca029ba695cd04a85afcc34ff"


### PR DESCRIPTION
## Description

I was going to extract this check into a plugin, but found there already was a plugin for it. So this pr removes the custom code and uses the plugin to ensure that Jira story ids are on the PR. If a story id is included Danger will post a comment to the PR linking to the Jira ticket. I was tempted to remove the spot under `References` that is in our PR template for jira id in light of that, but not everyone puts the Jira id in the title correct yet.

## Reviewer Notes

Let me know if you think I should update the PR Template

## Setup

Locally you can run the following to check out the messages. Warning if you do this enough times you will hit the GitHub API limit and have to set a `DANGER_GITHUB_API_TOKEN` of your own to continue, but you have some free calls that should be enough for testing.

```sh
yarn danger pr https://github.com/transcom/mymove/pull/4041
yarn danger pr https://github.com/transcom/mymove/pull/4128
yarn danger pr https://github.com/transcom/mymove/pull/4131
yarn danger pr https://github.com/transcom/mymove/pull/4121
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [MB-2720](https://dp3.atlassian.net/browse/MB-2720) chore for this work