### PR TITLE
MB-2441 Connect shipment display component to move details page

### DIFF
--- a/src/components/Office/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames/bind';
 import { SHIPMENT_TYPE } from 'shared/constants';
 import * as PropTypes from 'prop-types';
 import styles from 'components/Office/ShipmentDisplay.module.scss';
+import { formatDate } from 'shared/dates';
 import { ReactComponent as ChevronDown } from '../../shared/icon/chevron-down.svg';
 import ShipmentContainer from './ShipmentContainer';
 
@@ -43,7 +44,7 @@ const ShipmentDisplay = ({ shipmentType, checkboxId, displayInfo }) => {
             <tr>
               <td />
               <td className={`${cx('shipment-display__label')}`}>Requested move date</td>
-              <td>{displayInfo.requestedMoveDate}</td>
+              <td>{formatDate(displayInfo.requestedMoveDate, 'DD MMM YYYY')}</td>
               <td />
             </tr>
             <tr>

--- a/src/components/Office/shipmentContainer.module.scss
+++ b/src/components/Office/shipmentContainer.module.scss
@@ -1,5 +1,4 @@
 @import '../../shared/styles/basics';
-@import '../../shared/styles/mixins';
 
 .shipment-container {
     @include u-padding-top(0);

--- a/src/pages/TOO/moveDetails.jsx
+++ b/src/pages/TOO/moveDetails.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import '../../index.scss';
-import '../../ghc_index.scss';
-import { get } from 'lodash';
-import RequestedShipments from 'components/Office/RequestedShipments';
 
+import 'pages/TOO/too.scss';
+
+import { get } from 'lodash';
 import { getMTOShipments, selectMTOShipments } from 'shared/Entities/modules/mtoShipments';
+import RequestedShipments from 'components/Office/RequestedShipments';
 import ShipmentDisplay from 'components/Office/ShipmentDisplay';
 
 import { getMoveOrder, getAllMoveTaskOrders, selectMoveOrder } from '../../shared/Entities/modules/moveTaskOrders';

--- a/src/pages/TOO/moveDetails.jsx
+++ b/src/pages/TOO/moveDetails.jsx
@@ -4,25 +4,48 @@ import { connect } from 'react-redux';
 import '../../index.scss';
 import '../../ghc_index.scss';
 import { get } from 'lodash';
-import { getMoveOrder, selectMoveOrder } from '../../shared/Entities/modules/moveTaskOrders';
+import RequestedShipments from 'components/Office/RequestedShipments';
+
+import { getMTOShipments, selectMTOShipments } from 'shared/Entities/modules/mtoShipments';
+import ShipmentDisplay from 'components/Office/ShipmentDisplay';
+
+import { getMoveOrder, getAllMoveTaskOrders, selectMoveOrder } from '../../shared/Entities/modules/moveTaskOrders';
 import { loadOrders } from '../../shared/Entities/modules/orders';
 import OrdersTable from '../../components/Office/OrdersTable';
 
 class MoveDetails extends Component {
   componentDidMount() {
-    // eslint-disable-next-line react/destructuring-assignment,react/prop-types
+    /* eslint-disable */
     const { moveOrderId } = this.props.match.params;
-    // eslint-disable-next-line react/prop-types,react/destructuring-assignment
-    this.props.getMoveOrder(moveOrderId);
+    this.props.getMoveOrder(moveOrderId).then(({ response: { body: moveOrder } }) => {
+      this.props.getAllMoveTaskOrders(moveOrder.id).then(({ response: { body: moveTaskOrder } }) => {
+        moveTaskOrder.forEach((item) => this.props.getMTOShipments(item.id));
+      });
+    });
   }
 
   render() {
     // eslint-disable-next-line react/prop-types
-    const { moveOrder } = this.props;
+    const { moveOrder, mtoShipments } = this.props;
     return (
       <div className="grid-container-desktop-lg" data-cy="too-move-details">
         <h1>Move details</h1>
         <div className="container">
+          <RequestedShipments>
+            {mtoShipments &&
+              mtoShipments.map((shipment) => (
+                <ShipmentDisplay
+                  key={shipment.id}
+                  shipmentType={shipment.shipmentType}
+                  displayInfo={{
+                    heading: shipment.shipmentType,
+                    requestedMoveDate: shipment.requestedPickupDate,
+                    currentAddress: shipment.pickupAddress,
+                    destinationAddress: shipment.destinationAddress,
+                  }}
+                />
+              ))}
+          </RequestedShipments>
           <OrdersTable
             ordersInfo={{
               // eslint-disable-next-line react/prop-types
@@ -58,12 +81,15 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     moveOrder: selectMoveOrder(state, moveOrderId),
+    mtoShipments: selectMTOShipments(state, moveOrderId),
   };
 };
 
 const mapDispatchToProps = {
   getMoveOrder,
   loadOrders,
+  getAllMoveTaskOrders,
+  getMTOShipments,
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(MoveDetails));

--- a/src/pages/TOO/moveDetails.test.jsx
+++ b/src/pages/TOO/moveDetails.test.jsx
@@ -30,4 +30,7 @@ describe('MoveDetails', () => {
     expect(wrapper.find({ 'data-cy': 'tacMDC' }).exists()).toBe(true);
     expect(wrapper.find({ 'data-cy': 'sacSDN' }).exists()).toBe(true);
   });
+  it('renders the Requested Shipments', () => {
+    expect(wrapper.find({ 'data-cy': 'requested-shipments' }).exists()).toBe(true);
+  });
 });

--- a/src/pages/TOO/too.scss
+++ b/src/pages/TOO/too.scss
@@ -1,0 +1,2 @@
+@import '../../index.scss';
+@import '../../ghc_index.scss';

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -11,6 +11,7 @@ const allowedDateFormats = [
   'D-MMM-YYYY',
   'MMM-D-YYYY',
   'DD-MMM-YY',
+  'DD MMM YYYY',
 ];
 
 export function parseDate(str, _format, locale = 'en') {


### PR DESCRIPTION
## Description

Connecting the shipment display component from [this PR](https://github.com/transcom/mymove/pull/4065) to the move details page.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

To test:
1. Log in to office app
2. Navigate to http://officelocal:3000/too/customer-moves
3. Click on any customer moves

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2441) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/82616050-e34fd300-9b80-11ea-8935-bb61d292217d.png)
