### PR TITLE
Replaces broken docs links with new wiki links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,14 +16,14 @@ echo "Code goes here"
 
 ## Code Review Verification Steps
 
-* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
+* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
 * [ ] The requirements listed in
- [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
+ [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
  have been satisfied.
 * Any new migrations/schema changes:
-  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
+  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
   * [ ] Have been communicated to #dp3-engineering
-  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
+  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
 * [ ] There are no aXe warnings for UI.
 * [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
 * [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)


### PR DESCRIPTION
## Description

* We migrated our docs to the wiki, but the PR template still has the old links.
* Replaces broken docs links in the `Code Review Verification` section with updated links to the wiki pages.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.