### PR TITLE
[MB-2812] Added migration to remove is_available_to_prime (zero-down migration)

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -511,3 +511,4 @@
 20200513151500_uploader_refactor_zero_down_alter_tables.up.sql
 20200515202122_payment_service_item_nullable_price.up.sql
 20200527145249_add_mto_available_timestamp.up.sql
+20200602144311_remove_is_available_to_prime.up.sql

--- a/migrations/app/schema/20200602144311_remove_is_available_to_prime.up.sql
+++ b/migrations/app/schema/20200602144311_remove_is_available_to_prime.up.sql
@@ -1,0 +1,11 @@
+-- Zero-down migrations (for a later PR/deployment)
+
+-- This is just meant to catch any older code that may have changed the old
+-- field during the previous deployment.
+UPDATE move_task_orders
+SET available_to_prime_at = updated_at
+WHERE is_available_to_prime = true
+  AND available_to_prime_at IS NULL;
+
+ALTER TABLE move_task_orders
+    DROP COLUMN is_available_to_prime;


### PR DESCRIPTION
## Description

This PR is a follow-up to #4177.  That PR replaced the `is_available_to_prime` boolean with an `available_to_prime_at` timestamp in the `move_task_orders` table.  However, to ensure zero downtime, that migration kept the old `is_available_to_prime` field.  This is the PR to actually remove that field (and migrate any data that may have changed during the previous deployment).

## Setup

- `make db_dev_reset db_dev_migrate` -- to see that the migration works and the `is_available_to_prime` column is gone
- If you want to check the scenario of a record with `is_available_to_prime` that's `true` but doesn't have an `available_to_prime_at`, do the following:
    - Comment out the last migration in `migrations_manifest.txt`
    - Run `make db_dev_e2e_populate`
    - Flip the `is_available_to_prime` flag to true on an MTO that was previously false.
    - Uncomment the migration from the first step and do a `make db_dev_migrate`
    - Verify that `available_to_prime_at` is set for that record now
## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2812) for this change
