### PR TITLE
MB-1571 Add weight estimated lookup function

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -52,6 +52,7 @@ func ServiceParamLookupInitialize(
 	s.lookups[models.ServiceItemParamNameDistanceZip5.String()] = DistanceZip5Lookup{}
 	s.lookups[models.ServiceItemParamNameDistanceZip3.String()] = DistanceZip3Lookup{}
 	s.lookups[models.ServiceItemParamNameWeightBilledActual.String()] = WeightBilledActualLookup{}
+	s.lookups[models.ServiceItemParamNameWeightEstimated.String()] = WeightEstimatedLookup{}
 
 	return &s
 }

--- a/pkg/payment_request/service_param_value_lookups/weight_billed_actual_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_actual_lookup_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-func (suite *ServiceParamValueLookupsSuite) setupTest(estimatedWeight unit.Pound, actualWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithWeight(estimatedWeight unit.Pound, actualWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
 			ReService: models.ReService{
@@ -43,7 +43,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 	key := "WeightBilledActual"
 
 	suite.T().Run("estimated and actual are the same", func(t *testing.T) {
-		_, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
 		suite.Equal("1234", valueStr)
@@ -51,7 +51,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("estimated is greater than actual", func(t *testing.T) {
 		// Set the actual weight to less than estimated weight
-		_, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(1024), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(1024), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
 		suite.Equal("1024", valueStr)
@@ -59,7 +59,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("actual is exactly 110% of estimated weight", func(t *testing.T) {
 		// Set the actual weight to exactly 110% of estimated weight
-		_, _, paramLookup := suite.setupTest(unit.Pound(100), unit.Pound(110), models.ReServiceCodeNSTH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(100), unit.Pound(110), models.ReServiceCodeNSTH, models.MTOShipmentTypeHHG)
 
 		valueStr, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
@@ -68,7 +68,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("actual is 120% of estimated weight", func(t *testing.T) {
 		// Set the actual weight to about 120% of estimated weight
-		_, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(1481), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(1481), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 
 		valueStr, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
@@ -77,7 +77,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("rounds to the nearest whole pound", func(t *testing.T) {
 		// Set the weights so that a fraction of a pound is returned
-		_, _, paramLookup := suite.setupTest(unit.Pound(1235), unit.Pound(1482), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1235), unit.Pound(1482), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 
 		valueStr, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
@@ -136,7 +136,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 	for _, data := range serviceCodesWithMinimum {
 		suite.T().Run(fmt.Sprintf("actual below minimum service code %s", data.code), func(t *testing.T) {
 			// Set the actual weight to below minimum
-			_, _, paramLookup := suite.setupTest(unit.Pound(1234), data.actualWeight, data.code, data.shipmentType)
+			_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), data.actualWeight, data.code, data.shipmentType)
 
 			valueStr, err := paramLookup.ServiceParamValue(key)
 			suite.FatalNoError(err)
@@ -146,7 +146,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("nil PrimeActualWeight", func(t *testing.T) {
 		// Set the actual weight to nil
-		mtoServiceItem, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoServiceItem, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		mtoShipment := mtoServiceItem.MTOShipment
 		mtoShipment.PrimeActualWeight = nil
 		suite.MustSave(&mtoShipment)
@@ -160,7 +160,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("nil PrimeEstimatedWeight", func(t *testing.T) {
 		// Set the estimated weight to nil
-		mtoServiceItem, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoServiceItem, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		mtoShipment := mtoServiceItem.MTOShipment
 		mtoShipment.PrimeEstimatedWeight = nil
 		suite.MustSave(&mtoShipment)
@@ -174,7 +174,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("nil MTOShipmentID", func(t *testing.T) {
 		// Set the MTOShipmentID to nil
-		mtoServiceItem, _, paramLookup := suite.setupTest(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoServiceItem, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		mtoServiceItem.MTOShipmentID = nil
 		suite.MustSave(&mtoServiceItem)
 
@@ -188,7 +188,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightBilledActualLookup() {
 
 	suite.T().Run("bogus MTOServiceItemID", func(t *testing.T) {
 		// Pass in a non-existent MTOServiceItemID
-		_, paymentRequest, _ := suite.setupTest(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, paymentRequest, _ := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
 		badParamLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
 

--- a/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup.go
@@ -1,0 +1,48 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"github.com/gofrs/uuid"
+
+	"database/sql"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// WeightEstimatedLookup does lookup on actual weight billed
+type WeightEstimatedLookup struct {
+}
+
+func (r WeightEstimatedLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	db := *keyData.db
+
+	// Get the MTOServiceItem and associated MTOShipment
+	mtoServiceItemID := keyData.MTOServiceItemID
+	var mtoServiceItem models.MTOServiceItem
+	err := db.Eager("ReService", "MTOShipment").Find(&mtoServiceItem, mtoServiceItemID)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return "", services.NewNotFoundError(mtoServiceItemID, "looking for MTOServiceItemID")
+		default:
+			return "", err
+		}
+	}
+
+	// Make sure there's an MTOShipment since that's nullable
+	mtoShipmentID := mtoServiceItem.MTOShipmentID
+	if mtoShipmentID == nil {
+		return "", services.NewNotFoundError(uuid.Nil, "looking for MTOShipmentID")
+	}
+
+	estimatedWeight := mtoServiceItem.MTOShipment.PrimeEstimatedWeight
+	if estimatedWeight == nil {
+		// TODO: Do we need a different error -- is this a "normal" scenario?
+		return "", fmt.Errorf("could not find estimated weight for MTOShipmentID [%s]", mtoShipmentID)
+	}
+
+	value := fmt.Sprintf("%d", int(*estimatedWeight))
+	return value, nil
+}

--- a/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup_test.go
@@ -1,0 +1,66 @@
+package serviceparamvaluelookups
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestWeightEstimatedLookup() {
+	key := "WeightEstimated"
+
+	suite.T().Run("estimated weight is present on MTO Shipment", func(t *testing.T) {
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal("1234", valueStr)
+	})
+
+	suite.T().Run("nil PrimeEstimatedWeight", func(t *testing.T) {
+		// Set the estimated weight to nil
+		mtoServiceItem, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoShipment := mtoServiceItem.MTOShipment
+		mtoShipment.PrimeEstimatedWeight = nil
+		suite.MustSave(&mtoShipment)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf("could not find estimated weight for MTOShipmentID [%s]", mtoShipment.ID)
+		suite.Contains(err.Error(), expected)
+		suite.Equal("", valueStr)
+	})
+
+	suite.T().Run("nil MTOShipmentID", func(t *testing.T) {
+		// Set the MTOShipmentID to nil
+		mtoServiceItem, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoServiceItem.MTOShipmentID = nil
+		suite.MustSave(&mtoServiceItem)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		expected := fmt.Sprintf("looking for MTOShipmentID")
+		suite.Contains(err.Error(), expected)
+		suite.Equal("", valueStr)
+	})
+
+	suite.T().Run("bogus MTOServiceItemID", func(t *testing.T) {
+		// Pass in a non-existent MTOServiceItemID
+		_, paymentRequest, _ := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
+		badParamLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
+
+		valueStr, err := badParamLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		expected := fmt.Sprintf("looking for MTOServiceItemID")
+		suite.Contains(err.Error(), expected)
+		suite.Equal("", valueStr)
+	})
+}

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -10,21 +10,29 @@ import (
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 	// Create some records we'll need to link to
 	moveTaskOrder := testdatagen.MakeDefaultMoveTaskOrder(suite.DB())
+	estimatedWeight := unit.Pound(2048)
 	mtoServiceItem1 := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 		MoveTaskOrder: moveTaskOrder,
 		ReService: models.ReService{
 			Code: "DLH",
+		},
+		MTOShipment: models.MTOShipment{
+			PrimeEstimatedWeight: &estimatedWeight,
 		},
 	})
 	mtoServiceItem2 := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 		MoveTaskOrder: moveTaskOrder,
 		ReService: models.ReService{
 			Code: "DOP",
+		},
+		MTOShipment: models.MTOShipment{
+			PrimeEstimatedWeight: &estimatedWeight,
 		},
 	})
 	serviceItemParamKey1 := testdatagen.MakeServiceItemParamKey(suite.DB(), testdatagen.Assertions{

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -32,6 +32,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 
 	// mock weights
 	actualWeight := unit.Pound(980)
+	estimatedWeight := unit.Pound(1024)
 
 	// mock dates
 	scheduledPickupDate := time.Date(TestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
@@ -48,6 +49,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 		DestinationAddress:       &destinationAddress,
 		DestinationAddressID:     &destinationAddress.ID,
 		PrimeActualWeight:        &actualWeight,
+		PrimeEstimatedWeight:     &estimatedWeight,
 		SecondaryPickupAddress:   &secondaryPickupAddress,
 		SecondaryDeliveryAddress: &secondaryDeliveryAddress,
 		ShipmentType:             shipmentType,

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -32,7 +32,6 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 
 	// mock weights
 	actualWeight := unit.Pound(980)
-	estimatedWeight := unit.Pound(1024)
 
 	// mock dates
 	scheduledPickupDate := time.Date(TestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
@@ -49,7 +48,6 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 		DestinationAddress:       &destinationAddress,
 		DestinationAddressID:     &destinationAddress.ID,
 		PrimeActualWeight:        &actualWeight,
-		PrimeEstimatedWeight:     &estimatedWeight,
 		SecondaryPickupAddress:   &secondaryPickupAddress,
 		SecondaryDeliveryAddress: &secondaryDeliveryAddress,
 		ShipmentType:             shipmentType,


### PR DESCRIPTION
## Description

This story is part of the [Price Domestic Linehaul](https://dp3.atlassian.net/browse/MB-2572) epic and adds the function to lookup function for the `WeightEstimated` value for the shipment based on the MTOShipment's `PrimeEstimatedWeight` value. 

## Reviewer Notes

None

## Setup

The samples below are based on the e2e data

Run `make db_dev_e2e_populate`

Then get the eTag for the `MTOShipments`

```sh
prime-api-client --insecure fetch-mto-updates | jq 'map(select(.id == "5d4b25bb-eb04-4c03-9a81-ee0398cb779e")) | .[0] | .mtoShipments | .[0] | .eTag'
```

Use the eTag from the above command in the `ifMatch` value of the following payload to set Estimated Weight and Actual Weight on the MTOShipment object. Save this in `pr_update_mto_dev.json`

```json
{
  "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
  "ifMatch": "MjAyMC0wNS0yMVQwMDowODo1MS4zNzc0NTla",
  "body": {
    "primeEstimatedWeight": 1000,
    "primeActualWeight": 3000
  }
}
```

Update the MTOShipment

```sh
prime-api-client --insecure update-mto-shipment --filename pr_update_mto_dev.json | jq
```

Create a payment request json file

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
    "serviceItems": [
      {
        "id": "d886431c-c357-46b7-a084-a0c85dd496d3"
      }
    ]
  }
}
```

Create the payment request

```sh
prime-api-client --insecure create-payment-request --filename pr_payload_dev.json | jq
```

Check the output of the create command and verify that the `WeightEstimated` service item param is added with the correct value. 

```json
{
  "eTag": "MjAyMC0wNS0yMVQwMDoyMTo1NC45MDI3ODJa",
  "id": "a4b76a60-6b67-4774-9982-9d957a4445d8",
  "isFinal": false,
  "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
  "paymentRequestNumber": "1219-5215-2",
  "paymentServiceItems": [
    {
      "eTag": "MjAyMC0wNS0yMVQwMDoyMTo1NC45MTE0NTha",
      "id": "199a8750-5c92-4904-a158-36e94f5428db",
      "mtoServiceItemID": "d886431c-c357-46b7-a084-a0c85dd496d3",
      "paymentRequestID": "a4b76a60-6b67-4774-9982-9d957a4445d8",
      "paymentServiceItemParams": [
        {
          "eTag": "MjAyMC0wNS0yMVQwMDoyMTo1NC45Njg4MjJa",
          "id": "e2533f97-c729-4757-a4e5-c21f072580bf",
          "key": "WeightBilledActual",
          "origin": "SYSTEM",
          "paymentServiceItemID": "199a8750-5c92-4904-a158-36e94f5428db",
          "type": "INTEGER",
          "value": "1100"
        },
        {
          "eTag": "MjAyMC0wNS0yMVQwMDoyMTo1NC45NzI3ODNa",
          "id": "bfa19388-b423-4b89-ae3a-cca91bf9e5ed",
          "key": "WeightActual",
          "origin": "PRIME",
          "paymentServiceItemID": "199a8750-5c92-4904-a158-36e94f5428db",
          "type": "INTEGER",
          "value": "NOT IMPLEMENTED"
        },
        {
          "eTag": "MjAyMC0wNS0yMVQwMDoyMTo1NC45NzU0ODJa",
          "id": "5c16cecf-04a7-44e5-a7de-3420b78e3efd",
          "key": "WeightEstimated",
          "origin": "PRIME",
          "paymentServiceItemID": "199a8750-5c92-4904-a158-36e94f5428db",
          "type": "INTEGER",
          "value": "1000"
        },
        ...
      ],
      "status": "REQUESTED"
    }
  ],
  "status": "PENDING"
}
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-1571](https://dp3.atlassian.net/browse/MB-1571) for this change
* [this slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1589993036003800) explains more about the approach used.
