### PR TITLE
draft adr for on-call schedule

### DIFF
--- a/docs/adr/0048-on-call-schedule-scaling.md
+++ b/docs/adr/0048-on-call-schedule-scaling.md
@@ -1,0 +1,55 @@
+# Milmove has an on-call schedule that scales
+
+As the Milmove team has grown, we need to address several concerns with our on-call schedule:
+
+- The schedule is very long and people cannot anticipate/plan for when they will be on-call.
+- Team members are often on-cal at the same time.
+- The long gaps between times on-call mean that people aren’t able to learn the skills needed or discern patterns of failures.
+
+## Considered Alternatives
+
+- Each team has an on-call rotation
+- Schedule is organized to minimize impact on teams, by round robin.
+- Schedule is organized to ensure individuals are on-call a few times without large gaps
+
+## Decision Outcome
+
+- Chosen Alternative: _[alternative 1]_
+- _[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force force | ... | comes out best (see below)]_
+- _[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]_ <!-- optional -->
+
+## Pros and Cons of the Alternatives
+
+### Each team has an on-call rotation
+
+- `+` as teams get ownership of areas of the application, they could be alerted for those specific sub-systems
+- `+` Only one person on a team would be on-call at a given time
+- `+` People would be on-call more often
+- `+` Consistent impact of on-call would improve teams planning
+- `+` The on-call team member can address bugs and other non-feature work when not handling issues
+- `-` At present, it is not clear which team should get alerted for an issue
+- `-` People would be on-call every 4 weeks
+- `-`More people on-call means less people focused on feature work
+- `-` Not sure we really need 4 people on-call when there is low usage of the system at the moment. (But may make sense when we go live)
+- `-` Not sure if the lead should be on-call or not.
+
+### Schedule is organized to minimize impact on teams, by round robin
+
+Primary: a 1, b 1, c 1, d 1, a 2, b 2, c 2, d 2, a 3, b 3, c 3, d 3, a 4, b 4, c 4, d 4
+
+Secondary: b 1, c 1, d 1, a 2, b 2, c 2, d 2, a 3, b 3, c 3, d 3, a 4, b 4, c 4, d 4, a 1
+
+Tertiary: leads
+
+- `+` Only one person on a team would be on-call at a given time
+- `+` Teams could consistently plan for impact of on-call rotation
+- `-` On-call every 16 weeks, so still hard for individuals to predict their schedules
+- `-`As teams focus on specific part of the project, the on-call person is less likely to have the context for issue at hand.
+- `-`As soon as someone needs to swap, the impact to teams changes. (This could be mitigated by trying to keep swaps within a team.)
+
+### Schedule is organized to ensure individuals are on-call a few times without large gaps
+
+- `+` Only one person on a team would be on-call at a given time
+- `+` People would be on-call a few times in a 8 week period, followed by an 8 week period they aren’t on-call
+- `-` The complexity here is far greater than any benefit.
+- `-`As soon as someone needs to swap, the main benefit of this plan is diminished

--- a/docs/adr/0048-on-call-schedule-scaling.md
+++ b/docs/adr/0048-on-call-schedule-scaling.md
@@ -3,7 +3,7 @@
 As the Milmove team has grown, we need to address several concerns with our on-call schedule:
 
 - The schedule is very long and people cannot anticipate/plan for when they will be on-call.
-- Team members are often on-cal at the same time.
+- Team members are often on-call at the same time.
 - The long gaps between times on-call mean that people aren’t able to learn the skills needed or discern patterns of failures.
 
 ## Considered Alternatives

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -51,6 +51,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0044](0044-params-styling.md) - Use camelCase for API params
 - [ADR-0045](0045-nesting-swagger-paths.md) - Nesting Swagger paths in the Prime API with multiple IDs
 - [ADR-0046](0046-use-nodenv.md) - Use [nodenv](https://github.com/nodenv/nodenv) to manage Node versions in development
+- [ADR-0048](0048-on-call-schedule-scaling.md) - Milmove has an on-call schedule that scales
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
The team leads have an action item from the on-call retro to make the the on-call schedule less opaque. This adr addresses this and a few other concerns with how it is scheduled now.

I'm inclined to split on-call so each team has their own schedule, but still need to work out the consequences of that and thing we need to do to make that happen and be effective.