### PR TITLE
MB-1579 Lookup Zip for PickupAddress

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -54,6 +54,7 @@ func ServiceParamLookupInitialize(
 	s.lookups[models.ServiceItemParamNameWeightBilledActual.String()] = WeightBilledActualLookup{}
 	s.lookups[models.ServiceItemParamNameWeightEstimated.String()] = WeightEstimatedLookup{}
 	s.lookups[models.ServiceItemParamNameWeightActual.String()] = WeightActualLookup{}
+	s.lookups[models.ServiceItemParamNameZipPickupAddress.String()] = ZipPickupAddressLookup{}
 
 	return &s
 }

--- a/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup.go
@@ -1,0 +1,50 @@
+package serviceparamvaluelookups
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// ZipPickupAddressLookup does lookup on the postal code for the pickup address
+type ZipPickupAddressLookup struct {
+}
+
+func (r ZipPickupAddressLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	db := *keyData.db
+
+	// Get the MTOServiceItem and associated MTOShipment
+	mtoServiceItemID := keyData.MTOServiceItemID
+	var mtoServiceItem models.MTOServiceItem
+	err := db.Eager("MTOShipment", "MTOShipment.PickupAddress").Find(&mtoServiceItem, mtoServiceItemID)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return "", services.NewNotFoundError(mtoServiceItemID, "looking for MTOServiceItemID")
+		default:
+			return "", err
+		}
+	}
+
+	// Make sure there's an MTOShipment since that's nullable
+	mtoShipmentID := mtoServiceItem.MTOShipmentID
+	if mtoShipmentID == nil {
+		return "", services.NewNotFoundError(uuid.Nil, "looking for MTOShipmentID")
+	}
+
+	// Make sure there's a pickup address zip code since pickupAddress is nullable
+	pickupAddress := mtoServiceItem.MTOShipment.PickupAddress
+
+	if pickupAddress == nil {
+		return "", fmt.Errorf("could not find pickup address for MTOShipment [%s]", mtoShipmentID)
+	}
+
+	zipPickupAddress := pickupAddress.PostalCode
+
+	value := fmt.Sprintf("%s", zipPickupAddress)
+	return value, nil
+}

--- a/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup_test.go
@@ -1,0 +1,78 @@
+package serviceparamvaluelookups
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestZipPickupAddressLookup() {
+	key := models.ServiceItemParamNameZipPickupAddress.String()
+
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{})
+
+	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+		testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
+			},
+		})
+
+	paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
+
+	suite.T().Run("zip code for the pickup address is present on MTO Shipment", func(t *testing.T) {
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal("90210", valueStr)
+	})
+
+	suite.T().Run("nil Pickup Address", func(t *testing.T) {
+		oldPickupAddressID := mtoServiceItem.MTOShipment.PickupAddressID
+
+		mtoServiceItem.MTOShipment.PickupAddress = nil
+		mtoServiceItem.MTOShipment.PickupAddressID = nil
+		suite.MustSave(&mtoServiceItem.MTOShipment)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf("could not find pickup address for MTOShipment [%s]", mtoServiceItem.MTOShipment.ID)
+		suite.Contains(err.Error(), expected)
+		suite.Equal("", valueStr)
+
+		mtoServiceItem.MTOShipment.PickupAddressID = oldPickupAddressID
+		suite.MustSave(&mtoServiceItem.MTOShipment)
+	})
+
+	suite.T().Run("nil MTOShipmentID", func(t *testing.T) {
+		// Set the MTOShipmentID to nil
+		oldMTOShipmentID := mtoServiceItem.MTOShipmentID
+		mtoServiceItem.MTOShipmentID = nil
+		suite.MustSave(&mtoServiceItem)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		suite.Equal("", valueStr)
+
+		mtoServiceItem.MTOShipmentID = oldMTOShipmentID
+		suite.MustSave(&mtoServiceItem)
+	})
+
+	suite.T().Run("bogus MTOServiceItemID", func(t *testing.T) {
+		// Pass in a non-existent MTOServiceItemID
+		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
+		badParamLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
+
+		valueStr, err := badParamLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		suite.Equal("", valueStr)
+	})
+
+}


### PR DESCRIPTION
## Description

add the functionality to look up the zip pickup address service item param when a payment request is made.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup
1. First run `make db_dev_e2e_populate` to ensure your database is setup with the E2E data.
1. Next, save this example JSON payload (which references E2E UUIDs) to a file called `pr_payload_dev.json`:
    ```json
    {
      "isFinal": false,
      "moveTaskOrderID": "da3f34cc-fb94-4e0b-1c90-ba3333cb7791",
      "serviceItems": [
        {
          "id": "3624d82f-fa87-47f5-a09a-2d5639e45c02"
        }
      ]
    }
    ```
 
1. Ensure your server is running: `make server_run`
1. Run this command to fetch the "available to prime" MTOs and look at the payment request state for the `moveTaskOrderID` above in the returned JSON: `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload.json | jq`
1. Look at the `payment_service_item_params` table and you should not see any records.
1. Now let's create a payment request using our payload above.  There are two different ways to do this:
    - With the `--filename` flag: `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload_dev.json | jq`
    - From stdin: `go run ./cmd/prime-api-client --insecure create-payment-request - < pr_payload_dev.json | jq`
1. Fetch the MTOs again and verify the payment request(s) you created are there: `go run ./cmd/prime-api-client --insecure fetch-mtos | jq`
1. Look at the `payment_service_item_params` table and verify that there are now params that include `ZipPickupAddress ` and that the value is the zip code for the pickup address `mto_shipment`.
1. This query will also show you the key/value param pairs for an MTO service item id:
    ```sql
    select key, value from payment_service_item_params
    inner join payment_service_items psi on payment_service_item_params.payment_service_item_id = psi.id
    inner join service_item_param_keys sipk on payment_service_item_params.service_item_param_key_id = sipk.id
    where mto_service_item_id = '3624d82f-fa87-47f5-a09a-2d5639e45c02';
    ```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
