### PR TITLE
[MB-2855] Remove reference to the schema diagram since it has been removed from…

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -19,4 +19,4 @@ Loading is accomplished in a few steps:
 
 1. Reset the DB on your branch or master with `make db_dev_reset && make db_dev_migrate`
 2. Open SQLEditor and go to (File -> Import From Database).  Entering the `dev_db` connection information. ![settings](SQLEditor_import.png)
-3. After the data has been imported save the file as [dp3.sqs](https://github.com/transcom/mymove/blob/master/docs/schema/dp3.sqs) so you can refer to it.
+3. After the data has been imported save the file as dp3.sqs so you can refer to it.


### PR DESCRIPTION
… the repo

## Description

Removes the dead link in the database schema docs pointing to a diagram that is no longer checked in. 

## Reviewer Notes

## Setup

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2855) for this change

## Screenshots

