### PR TITLE
[MB-2718] Adds Prime Actual Weight to mto shipment payload

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -997,6 +997,10 @@ func init() {
           "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
+        "primeActualWeight": {
+          "type": "integer",
+          "example": 4500
+        },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
@@ -2649,6 +2653,10 @@ func init() {
         "pickupAddress": {
           "x-nullabe": true,
           "$ref": "#/definitions/Address"
+        },
+        "primeActualWeight": {
+          "type": "integer",
+          "example": 4500
         },
         "rejectionReason": {
           "type": "string",

--- a/pkg/gen/supportmessages/m_t_o_shipment.go
+++ b/pkg/gen/supportmessages/m_t_o_shipment.go
@@ -47,6 +47,9 @@ type MTOShipment struct {
 	// pickup address
 	PickupAddress *Address `json:"pickupAddress,omitempty"`
 
+	// prime actual weight
+	PrimeActualWeight int64 `json:"primeActualWeight,omitempty"`
+
 	// rejection reason
 	RejectionReason *string `json:"rejectionReason,omitempty"`
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -335,7 +335,6 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		PickupAddress:            Address(mtoShipment.PickupAddress),
 		Status:                   string(mtoShipment.Status),
 		DestinationAddress:       Address(mtoShipment.DestinationAddress),
-		PrimeActualWeight:        int64(*mtoShipment.PrimeActualWeight),
 		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
 		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
 		CreatedAt:                strfmt.DateTime(mtoShipment.CreatedAt),
@@ -371,6 +370,11 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		payload.PrimeEstimatedWeight = int64(*mtoShipment.PrimeEstimatedWeight)
 		payload.PrimeEstimatedWeightRecordedDate = strfmt.Date(*mtoShipment.PrimeEstimatedWeightRecordedDate)
 	}
+
+	if mtoShipment.PrimeActualWeight != nil {
+		payload.PrimeActualWeight = int64(*mtoShipment.PrimeActualWeight)
+	}
+
 	return payload
 }
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -335,6 +335,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		PickupAddress:            Address(mtoShipment.PickupAddress),
 		Status:                   string(mtoShipment.Status),
 		DestinationAddress:       Address(mtoShipment.DestinationAddress),
+		PrimeActualWeight:        int64(*mtoShipment.PrimeActualWeight),
 		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
 		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
 		CreatedAt:                strfmt.DateTime(mtoShipment.CreatedAt),

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -172,7 +172,10 @@ func Address(address *models.Address) *supportmessages.Address {
 // MTOShipment payload
 func MTOShipment(mtoShipment *models.MTOShipment) *supportmessages.MTOShipment {
 	strfmt.MarshalFormat = strfmt.RFC3339Micro
-
+	var primeActualWeight int64
+	if mtoShipment.PrimeActualWeight != nil {
+		primeActualWeight = int64(*mtoShipment.PrimeActualWeight)
+	}
 	payload := &supportmessages.MTOShipment{
 		ID:                       strfmt.UUID(mtoShipment.ID.String()),
 		MoveTaskOrderID:          strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
@@ -181,7 +184,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *supportmessages.MTOShipment {
 		CustomerRemarks:          mtoShipment.CustomerRemarks,
 		RejectionReason:          mtoShipment.RejectionReason,
 		PickupAddress:            Address(mtoShipment.PickupAddress),
-		PrimeActualWeight:        int64(*mtoShipment.PrimeActualWeight),
+		PrimeActualWeight:        primeActualWeight,
 		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
 		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
 		DestinationAddress:       Address(mtoShipment.DestinationAddress),

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -181,6 +181,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *supportmessages.MTOShipment {
 		CustomerRemarks:          mtoShipment.CustomerRemarks,
 		RejectionReason:          mtoShipment.RejectionReason,
 		PickupAddress:            Address(mtoShipment.PickupAddress),
+		PrimeActualWeight:        int64(*mtoShipment.PrimeActualWeight),
 		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
 		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
 		DestinationAddress:       Address(mtoShipment.DestinationAddress),

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -905,6 +905,9 @@ definitions:
       approvedDate:
         format: date
         type: string
+      primeActualWeight:
+        type: integer
+        example: 4500
       pickupAddress:
         x-nullabe: true
         $ref: '#/definitions/Address'


### PR DESCRIPTION
## Description

Adds Prime Actual Weight to MTO Shipment payload 

## Setup
`make server_run`
Using Postman:
Prime Endpoint: `Get all MTOs` and check if Prime Actual Weight is a property in mto shipment
Support Endpoint: `Get individual MTO` and check if Prime Actual Weight is a property in mto shipment

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2718) for this change
