### PR TITLE
don't auto download ssw (MB-2706)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
     * [Development Machine Timezone Issues](#development-machine-timezone-issues)
     * [Linters & Pre-commit Hooks](#linters--pre-commit-hooks)
     * [Yarn install markdown-spell (aka mdspell)](#yarn-install-markdown-spell-aka-mdspell)
+  * [PII Best Practices](#pii-best-practices)
+    * [More about content dispositions](#more-about-content-dispositions)
+    * [More about browser settings](#more-about-browser-settings)
 
 Regenerate with "pre-commit run -a markdown-toc"
 
@@ -612,3 +615,19 @@ cd ~/.config/yarn/global
 yarn cache clean
 yarn global add markdown-spellcheck
 ```
+
+### PII Best Practices
+
+Server side: any downloadable content passed to the client should by default have an inline content disposition (like PDFs). You can read more about content disposition headers in [the official Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition "MDN: Content-Disposition Headers").
+
+Client side: before accessing any prod environment, fix your browser settings __or only use Edge when accessing prod data__
+
+#### More about content dispositions
+
+An inline disposition tells the browser to display a file inline if it can. If you instead set an attachment disposition, the browser will download the file even when it is capable of displaying the data itself. If an engineer downloads PII instead of letting their browser display it, this will cause a security incident. So make sure content like PDFs are passed to the client with inline dispositions. You can read more in [the official Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition "MDN: Content-Disposition Headers").
+
+#### More about browser settings
+
+Even if an inline disposition is set, most browsers still allow you to override that behavior and automatically download certain file types.
+
+Since Edge does not download PDFs by default _and that setting cannot be changed_, we strongly recommend using that browser when investigating or debugging production issues. If you must use another browser, ensure you have changed your settings to display PDFs in the browser. In most browsers, you can find the relevant setting by searching "PDF" in the settings menu.

--- a/README.md
+++ b/README.md
@@ -618,9 +618,9 @@ yarn global add markdown-spellcheck
 
 ### PII Best Practices
 
-Server side: any downloadable content passed to the client should by default have an inline content disposition (like PDFs). You can read more about content disposition headers in [the official Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition "MDN: Content-Disposition Headers").
+Server side: any downloadable content passed to the client should by default have an inline content disposition (like PDFs).
 
-Client side: before accessing any prod environment, fix your browser settings __or only use Edge when accessing prod data__
+Client side: before accessing any prod environment, fix your browser settings to display PDFs, not use an external app.
 
 #### More about content dispositions
 
@@ -630,4 +630,4 @@ An inline disposition tells the browser to display a file inline if it can. If y
 
 Even if an inline disposition is set, most browsers still allow you to override that behavior and automatically download certain file types.
 
-Since Edge does not download PDFs by default _and that setting cannot be changed_, we strongly recommend using that browser when investigating or debugging production issues. If you must use another browser, ensure you have changed your settings to display PDFs in the browser. In most browsers, you can find the relevant setting by searching "PDF" in the settings menu.
+Before working with the prod environment, ensure you have changed your settings to display PDFs in the browser. In most browsers, you can find the relevant setting by searching "PDF" in the settings menu.

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -274,7 +274,7 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	}
 
 	payload := ioutil.NopCloser(buf)
-	filename := fmt.Sprintf("attachment; filename=\"%s-%s-ssw-%s.pdf\"", *ssfd.ServiceMember.FirstName, *ssfd.ServiceMember.LastName, time.Now().Format("01-02-2006"))
+	filename := fmt.Sprintf("inline; filename=\"%s-%s-ssw-%s.pdf\"", *ssfd.ServiceMember.FirstName, *ssfd.ServiceMember.LastName, time.Now().Format("01-02-2006"))
 
 	return moveop.NewShowShipmentSummaryWorksheetOK().WithContentDisposition(filename).WithPayload(payload)
 }

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -106,7 +106,7 @@ class PaymentsTable extends Component {
     const userDate = getUserDate();
 
     // eslint-disable-next-line
-    window.open(`/internal/moves/${moveId}/shipment_summary_worksheet/?preparationDate=${userDate}`);
+    window.open(`/internal/moves/${moveId}/shipment_summary_worksheet/?preparationDate=${userDate}`, '_blank');
   };
 
   renderAdvanceAction = () => {

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -218,15 +218,15 @@ class PaymentsTable extends Component {
               <div className="paperwork">
                 <div className="paperwork-step">
                   <div>
-                    <p>Download Shipment Summary Worksheet</p>
-                    <p>Download and complete the worksheet, which is a fill-in PDF form.</p>
+                    <p>Complete the Shipment Summary Worksheet</p>
+                    <p>Open the SSW in a new tab. Download and open the PDF, then fill in any required info.</p>
                   </div>
                   <button
                     className="usa-button"
                     disabled={this.props.disableSSW}
                     onClick={this.downloadShipmentSummary}
                   >
-                    Download Worksheet (PDF)
+                    Open SSW in a New Tab
                   </button>
                 </div>
                 {this.props.disableSSW && (

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -50,6 +50,20 @@ function getUserDate() {
   return new Date().toISOString().split('T')[0];
 }
 
+// Taken from https://mathiasbynens.github.io/rel-noopener/
+// tl;dr-- opening content in target _blank can leave parent window open to malicious code
+// below is a safer way to open content in a new tab
+function safeOpenInNewTab(url) {
+  if (url) {
+    let win = window.open();
+    // win can be null if a pop-up blocker is used
+    if (win) {
+      win.opener = null;
+      win.location = url;
+    }
+  }
+}
+
 class PaymentsTable extends Component {
   state = {
     showPaperwork: false,
@@ -83,15 +97,7 @@ class PaymentsTable extends Component {
           obj: { url },
         },
       } = response;
-      if (url) {
-        // Taken from https://mathiasbynens.github.io/rel-noopener/
-        let win = window.open();
-        // win can be null if a pop-up blocker is used
-        if (win) {
-          win.opener = null;
-          win.location = url;
-        }
-      }
+      safeOpenInNewTab(url);
       this.setState({ disableDownload: false });
     });
   };
@@ -105,8 +111,7 @@ class PaymentsTable extends Component {
     const { moveId } = this.props;
     const userDate = getUserDate();
 
-    // eslint-disable-next-line
-    window.open(`/internal/moves/${moveId}/shipment_summary_worksheet/?preparationDate=${userDate}`, '_blank');
+    safeOpenInNewTab(`/internal/moves/${moveId}/shipment_summary_worksheet/?preparationDate=${userDate}`);
   };
 
   renderAdvanceAction = () => {


### PR DESCRIPTION
## Description

- 22dd88b makes the copy changes recommended in James's comment on the story
- 3625f5a6 fixes the underlying auto download bug (a content disposition header which tells browser to always download the file)
- 1219488c redoes the open in new tab logic in a safer way (fixup 193fc995)
- e7680afe adds some docs re: pii best practices to help prevent other auto-download issues

## Reviewer Notes

@travelar, can you sanity check what I wrote about PII handling in e7680afe?

@gidjin, GH says you've recently touched these files. can you sanity check I didn't stomp anything important? :)

## Setup

Pull the branch locally and use `make server_run` && `make office_client_run` to spin up the relevant services. Log into an office user with an appropriate scenario loaded, and click on the now renamed `Open SSW in a New Tab` button to repro this new behavior. Use any browser you want as long as your browser isn't outsourcing its PDF rendering.

## Code Review Verification Steps

<!--
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI. -->
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge). (ok I didn't try phone views yet)
<!-- * [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores) -->
* [ ] User facing changes have been reviewed by design. <-- yes if James giving me the content counts; no if I should be pulling him to review the screenshot or changed UI
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2706) for this change
* [this GitHub post](https://mathiasbynens.github.io/rel-noopener/) explains more about safe open in new tab logic
* [this MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) discusses content dispositions in greater depth
* [>1yr ago old PR where attachment header was added in the first place](https://github.com/transcom/mymove/pull/1796)

## Screenshots

### new content view

<img width="722" alt="Screen Shot 2020-06-11 at 7 20 45 AM" src="https://user-images.githubusercontent.com/10818509/84379730-29ee8700-ab9b-11ea-8f81-9d0891aadd50.png">

### ssw pdf in new tab

<img width="830" alt="Screen Shot 2020-06-11 at 7 21 00 AM" src="https://user-images.githubusercontent.com/10818509/84379738-2c50e100-ab9b-11ea-9c00-6040f1b358b3.png">
