### PR TITLE
MB-2790 Fix date format inconsistency for createdAt and updatedAt

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,7 @@
+{
+  "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
+  "ifMatch": "MjAyMC0wNi0xMFQyMDoxNjowMS4xMDQ4Mjda",
+  "body": {
+    "scheduledPickupDate": "2018-03-19"
+  }
+}

--- a/data.json
+++ b/data.json
@@ -1,7 +1,0 @@
-{
-  "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
-  "ifMatch": "MjAyMC0wNi0xMFQyMDoxNjowMS4xMDQ4Mjda",
-  "body": {
-    "scheduledPickupDate": "2018-03-19"
-  }
-}

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1188,7 +1188,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string",
@@ -1212,7 +1212,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "userId": {
           "type": "string",
@@ -1300,7 +1300,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "id": {
@@ -1317,7 +1317,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Updated at"
         }
       }
@@ -1438,7 +1438,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string"
@@ -1491,7 +1491,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string",
@@ -1529,7 +1529,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -1640,7 +1640,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "email": {
@@ -1666,7 +1666,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Updated at"
         }
       }
@@ -1688,10 +1688,8 @@ func init() {
       ],
       "properties": {
         "createdAt": {
-          "description": "when the role was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -1707,10 +1705,8 @@ func init() {
           "example": "customer"
         },
         "updatedAt": {
-          "description": "when the role was updated",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         }
       }
     },
@@ -1875,7 +1871,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "filename": {
@@ -3143,7 +3139,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string",
@@ -3167,7 +3163,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "userId": {
           "type": "string",
@@ -3255,7 +3251,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "id": {
@@ -3272,7 +3268,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Updated at"
         }
       }
@@ -3394,7 +3390,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string"
@@ -3447,7 +3443,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "email": {
           "type": "string",
@@ -3485,7 +3481,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -3596,7 +3592,7 @@ func init() {
       "properties": {
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "email": {
@@ -3622,7 +3618,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Updated at"
         }
       }
@@ -3644,10 +3640,8 @@ func init() {
       ],
       "properties": {
         "createdAt": {
-          "description": "when the role was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -3663,10 +3657,8 @@ func init() {
           "example": "customer"
         },
         "updatedAt": {
-          "description": "when the role was updated",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         }
       }
     },
@@ -3831,7 +3823,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "title": "Created at"
         },
         "filename": {

--- a/pkg/gen/adminmessages/admin_user.go
+++ b/pkg/gen/adminmessages/admin_user.go
@@ -23,7 +23,7 @@ type AdminUser struct {
 
 	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// email
@@ -51,7 +51,7 @@ type AdminUser struct {
 
 	// updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 
 	// user Id
@@ -121,7 +121,7 @@ func (m *AdminUser) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -191,7 +191,7 @@ func (m *AdminUser) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/electronic_order.go
+++ b/pkg/gen/adminmessages/electronic_order.go
@@ -19,7 +19,7 @@ type ElectronicOrder struct {
 
 	// Created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// id
@@ -37,7 +37,7 @@ type ElectronicOrder struct {
 
 	// Updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 }
 
@@ -77,7 +77,7 @@ func (m *ElectronicOrder) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -124,7 +124,7 @@ func (m *ElectronicOrder) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/notification.go
+++ b/pkg/gen/adminmessages/notification.go
@@ -21,7 +21,7 @@ type Notification struct {
 
 	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// email
@@ -88,7 +88,7 @@ func (m *Notification) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/office_user.go
+++ b/pkg/gen/adminmessages/office_user.go
@@ -25,7 +25,7 @@ type OfficeUser struct {
 
 	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// email
@@ -66,7 +66,7 @@ type OfficeUser struct {
 
 	// updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 }
 
@@ -139,7 +139,7 @@ func (m *OfficeUser) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -256,7 +256,7 @@ func (m *OfficeUser) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/organization.go
+++ b/pkg/gen/adminmessages/organization.go
@@ -19,7 +19,7 @@ type Organization struct {
 
 	// Created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// email
@@ -41,7 +41,7 @@ type Organization struct {
 
 	// Updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 }
 
@@ -85,7 +85,7 @@ func (m *Organization) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (m *Organization) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/role.go
+++ b/pkg/gen/adminmessages/role.go
@@ -17,9 +17,9 @@ import (
 // swagger:model Role
 type Role struct {
 
-	// when the role was created
+	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// id
@@ -35,9 +35,9 @@ type Role struct {
 	// Required: true
 	RoleType *string `json:"roleType"`
 
-	// when the role was updated
+	// updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 }
 
@@ -77,7 +77,7 @@ func (m *Role) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func (m *Role) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/upload.go
+++ b/pkg/gen/adminmessages/upload.go
@@ -24,7 +24,7 @@ type Upload struct {
 	ContentType string `json:"contentType,omitempty"`
 
 	// Created at
-	// Format: datetime
+	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// filename
@@ -104,7 +104,7 @@ func (m *Upload) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1968,7 +1968,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -2006,7 +2006,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -2035,7 +2035,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -2111,7 +2111,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -2151,7 +2151,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "customerRemarks": {
           "type": "string",
@@ -2217,7 +2217,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -2350,7 +2350,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "destinationAddress": {
           "$ref": "#/definitions/Address"
@@ -2398,7 +2398,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -4900,7 +4900,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -4938,7 +4938,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -4967,7 +4967,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -5043,7 +5043,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -5083,7 +5083,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "customerRemarks": {
           "type": "string",
@@ -5149,7 +5149,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -5282,7 +5282,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "destinationAddress": {
           "$ref": "#/definitions/Address"
@@ -5330,7 +5330,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },

--- a/pkg/gen/ghcmessages/m_t_o_agent.go
+++ b/pkg/gen/ghcmessages/m_t_o_agent.go
@@ -24,8 +24,8 @@ type MTOAgent struct {
 	AgentType string `json:"agentType,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// e tag
 	ETag string `json:"eTag,omitempty"`
@@ -54,8 +54,8 @@ type MTOAgent struct {
 	Phone *string `json:"phone,omitempty"`
 
 	// updated at
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this m t o agent
@@ -145,7 +145,7 @@ func (m *MTOAgent) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (m *MTOAgent) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/m_t_o_service_item.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item.go
@@ -24,8 +24,8 @@ type MTOServiceItem struct {
 	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// deleted at
 	// Format: date
@@ -98,7 +98,7 @@ type MTOServiceItem struct {
 	Total int64 `json:"total,omitempty"`
 
 	// updated at
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -195,7 +195,7 @@ func (m *MTOServiceItem) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -400,7 +400,7 @@ func (m *MTOServiceItem) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/m_t_o_shipment.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment.go
@@ -24,7 +24,7 @@ type MTOShipment struct {
 	ApprovedDate strfmt.Date `json:"approvedDate,omitempty"`
 
 	// created at
-	// Format: datetime
+	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// customer remarks
@@ -73,7 +73,7 @@ type MTOShipment struct {
 	Status string `json:"status,omitempty"`
 
 	// updated at
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -154,7 +154,7 @@ func (m *MTOShipment) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -337,7 +337,7 @@ func (m *MTOShipment) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/move_task_order.go
+++ b/pkg/gen/ghcmessages/move_task_order.go
@@ -22,8 +22,8 @@ type MoveTaskOrder struct {
 	AvailableToPrimeAt *strfmt.DateTime `json:"availableToPrimeAt,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// destination address
 	DestinationAddress *Address `json:"destinationAddress,omitempty"`
@@ -64,8 +64,8 @@ type MoveTaskOrder struct {
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
 	// updated at
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this move task order
@@ -141,7 +141,7 @@ func (m *MoveTaskOrder) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -273,7 +273,7 @@ func (m *MoveTaskOrder) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3106,10 +3106,8 @@ func init() {
           "example": "CODE456"
         },
         "created_at": {
-          "description": "when the access code was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -5498,10 +5496,8 @@ func init() {
       ],
       "properties": {
         "createdAt": {
-          "description": "when the role was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -5513,10 +5509,8 @@ func init() {
           "example": "customer"
         },
         "updatedAt": {
-          "description": "when the role was updated",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         }
       }
     },
@@ -9321,10 +9315,8 @@ func init() {
           "example": "CODE456"
         },
         "created_at": {
-          "description": "when the access code was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -11723,10 +11715,8 @@ func init() {
       ],
       "properties": {
         "createdAt": {
-          "description": "when the role was created",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         },
         "id": {
           "type": "string",
@@ -11738,10 +11728,8 @@ func init() {
           "example": "customer"
         },
         "updatedAt": {
-          "description": "when the role was updated",
           "type": "string",
-          "format": "datetime",
-          "example": "2018-04-12T23:20:50.52Z"
+          "format": "date-time"
         }
       }
     },

--- a/pkg/gen/internalmessages/access_code.go
+++ b/pkg/gen/internalmessages/access_code.go
@@ -27,9 +27,9 @@ type AccessCode struct {
 	// Required: true
 	Code *string `json:"code"`
 
-	// when the access code was created
+	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"created_at"`
 
 	// id
@@ -109,7 +109,7 @@ func (m *AccessCode) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("created_at", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("created_at", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/internalmessages/role.go
+++ b/pkg/gen/internalmessages/role.go
@@ -17,9 +17,9 @@ import (
 // swagger:model Role
 type Role struct {
 
-	// when the role was created
+	// created at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt *strfmt.DateTime `json:"createdAt"`
 
 	// id
@@ -31,9 +31,9 @@ type Role struct {
 	// Required: true
 	RoleType *string `json:"roleType"`
 
-	// when the role was updated
+	// updated at
 	// Required: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt"`
 }
 
@@ -69,7 +69,7 @@ func (m *Role) validateCreatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func (m *Role) validateUpdatedAt(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -875,7 +875,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date",
+          "format": "date-time",
           "readOnly": true
         },
         "email": {
@@ -912,7 +912,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date",
+          "format": "date-time",
           "readOnly": true
         }
       }
@@ -1215,7 +1215,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "readOnly": true
         },
         "customerRemarks": {
@@ -1307,7 +1307,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "readOnly": true
         }
       }
@@ -1402,7 +1402,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -1452,7 +1452,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -2866,7 +2866,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date",
+          "format": "date-time",
           "readOnly": true
         },
         "email": {
@@ -2903,7 +2903,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date",
+          "format": "date-time",
           "readOnly": true
         }
       }
@@ -3206,7 +3206,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "readOnly": true
         },
         "customerRemarks": {
@@ -3298,7 +3298,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "readOnly": true
         }
       }
@@ -3393,7 +3393,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -3443,7 +3443,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },

--- a/pkg/gen/primemessages/m_t_o_agent.go
+++ b/pkg/gen/primemessages/m_t_o_agent.go
@@ -22,8 +22,8 @@ type MTOAgent struct {
 
 	// created at
 	// Read Only: true
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// email
 	// Pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
@@ -51,8 +51,8 @@ type MTOAgent struct {
 
 	// updated at
 	// Read Only: true
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this m t o agent
@@ -115,7 +115,7 @@ func (m *MTOAgent) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -180,7 +180,7 @@ func (m *MTOAgent) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -33,7 +33,7 @@ type MTOShipment struct {
 
 	// created at
 	// Read Only: true
-	// Format: datetime
+	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// customer remarks
@@ -112,7 +112,7 @@ type MTOShipment struct {
 
 	// updated at
 	// Read Only: true
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -246,7 +246,7 @@ func (m *MTOShipment) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -484,7 +484,7 @@ func (m *MTOShipment) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -28,8 +28,8 @@ type MoveTaskOrder struct {
 	AvailableToPrimeAt *strfmt.DateTime `json:"availableToPrimeAt,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// e tag
 	ETag string `json:"eTag,omitempty"`
@@ -69,8 +69,8 @@ type MoveTaskOrder struct {
 	ReferenceID string `json:"referenceId,omitempty"`
 
 	// updated at
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // MtoServiceItems gets the mto service items of this base type
@@ -88,7 +88,7 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	var data struct {
 		AvailableToPrimeAt *strfmt.DateTime `json:"availableToPrimeAt,omitempty"`
 
-		CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+		CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 		ETag string `json:"eTag,omitempty"`
 
@@ -112,7 +112,7 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 
 		ReferenceID string `json:"referenceId,omitempty"`
 
-		UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+		UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -183,7 +183,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 	b1, err = json.Marshal(struct {
 		AvailableToPrimeAt *strfmt.DateTime `json:"availableToPrimeAt,omitempty"`
 
-		CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+		CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 		ETag string `json:"eTag,omitempty"`
 
@@ -205,7 +205,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		ReferenceID string `json:"referenceId,omitempty"`
 
-		UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+		UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 	}{
 
 		AvailableToPrimeAt: m.AvailableToPrimeAt,
@@ -321,7 +321,7 @@ func (m *MoveTaskOrder) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -473,7 +473,7 @@ func (m *MoveTaskOrder) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -802,7 +802,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -840,7 +840,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -867,7 +867,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -942,7 +942,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -969,7 +969,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "customerRemarks": {
           "type": "string",
@@ -1039,7 +1039,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -1145,7 +1145,7 @@ func init() {
         "createdAt": {
           "description": "Date the MoveTaskOrder was created on.",
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "description": "Uniquely identifies the state of the MoveTaskOrder object (but not the nested objects)\n\nIt will change everytime the object is updated. Client should store the value.\nUpdates to this MoveTaskOrder will require that this eTag be passed in with the If-Match header.\n",
@@ -1208,7 +1208,7 @@ func init() {
         "updatedAt": {
           "description": "Date on which this MoveTaskOrder was last updated.",
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -1302,7 +1302,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -1377,7 +1377,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -2459,7 +2459,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "type": "string"
@@ -2497,7 +2497,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -2524,7 +2524,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -2599,7 +2599,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -2626,7 +2626,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         },
         "customerRemarks": {
           "type": "string",
@@ -2696,7 +2696,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },
@@ -2802,7 +2802,7 @@ func init() {
         "createdAt": {
           "description": "Date the MoveTaskOrder was created on.",
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "eTag": {
           "description": "Uniquely identifies the state of the MoveTaskOrder object (but not the nested objects)\n\nIt will change everytime the object is updated. Client should store the value.\nUpdates to this MoveTaskOrder will require that this eTag be passed in with the If-Match header.\n",
@@ -2865,7 +2865,7 @@ func init() {
         "updatedAt": {
           "description": "Date on which this MoveTaskOrder was last updated.",
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         }
       }
     },
@@ -2959,7 +2959,7 @@ func init() {
         },
         "createdAt": {
           "type": "string",
-          "format": "date"
+          "format": "date-time"
         },
         "deletedAt": {
           "type": "string",
@@ -3034,7 +3034,7 @@ func init() {
         },
         "updatedAt": {
           "type": "string",
-          "format": "datetime"
+          "format": "date-time"
         }
       }
     },

--- a/pkg/gen/supportmessages/m_t_o_agent.go
+++ b/pkg/gen/supportmessages/m_t_o_agent.go
@@ -24,8 +24,8 @@ type MTOAgent struct {
 	AgentType string `json:"agentType,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// e tag
 	ETag string `json:"eTag,omitempty"`
@@ -54,8 +54,8 @@ type MTOAgent struct {
 	Phone *string `json:"phone,omitempty"`
 
 	// updated at
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this m t o agent
@@ -145,7 +145,7 @@ func (m *MTOAgent) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (m *MTOAgent) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/m_t_o_service_item.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item.go
@@ -24,8 +24,8 @@ type MTOServiceItem struct {
 	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// deleted at
 	// Format: date
@@ -93,7 +93,7 @@ type MTOServiceItem struct {
 	Total int64 `json:"total,omitempty"`
 
 	// updated at
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -182,7 +182,7 @@ func (m *MTOServiceItem) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -369,7 +369,7 @@ func (m *MTOServiceItem) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/m_t_o_shipment.go
+++ b/pkg/gen/supportmessages/m_t_o_shipment.go
@@ -24,7 +24,7 @@ type MTOShipment struct {
 	ApprovedDate strfmt.Date `json:"approvedDate,omitempty"`
 
 	// created at
-	// Format: datetime
+	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// customer remarks
@@ -76,7 +76,7 @@ type MTOShipment struct {
 	Status string `json:"status,omitempty"`
 
 	// updated at
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -157,7 +157,7 @@ func (m *MTOShipment) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -340,7 +340,7 @@ func (m *MTOShipment) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -33,8 +33,8 @@ type MoveTaskOrder struct {
 	ContractorID strfmt.UUID `json:"contractorID,omitempty"`
 
 	// Date the MoveTaskOrder was created on.
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// Uniquely identifies the state of the MoveTaskOrder object (but not the nested objects)
 	//
@@ -83,8 +83,8 @@ type MoveTaskOrder struct {
 	ReferenceID string `json:"referenceId,omitempty"`
 
 	// Date on which this MoveTaskOrder was last updated.
-	// Format: date
-	UpdatedAt strfmt.Date `json:"updatedAt,omitempty"`
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this move task order
@@ -173,7 +173,7 @@ func (m *MoveTaskOrder) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -330,7 +330,7 @@ func (m *MoveTaskOrder) validateUpdatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "date", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
+++ b/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
@@ -24,8 +24,8 @@ type UpdateMTOServiceItemStatus struct {
 	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
 
 	// created at
-	// Format: date
-	CreatedAt strfmt.Date `json:"createdAt,omitempty"`
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// deleted at
 	// Format: date
@@ -88,7 +88,7 @@ type UpdateMTOServiceItemStatus struct {
 	Total int64 `json:"total,omitempty"`
 
 	// updated at
-	// Format: datetime
+	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
@@ -169,7 +169,7 @@ func (m *UpdateMTOServiceItemStatus) validateCreatedAt(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.FormatOf("createdAt", "body", "date", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
 		return err
 	}
 
@@ -334,7 +334,7 @@ func (m *UpdateMTOServiceItemStatus) validateUpdatedAt(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.FormatOf("updatedAt", "body", "datetime", m.UpdatedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -35,12 +35,12 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *ghcmessages.MoveTaskOrd
 
 	payload := &ghcmessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
-		CreatedAt:          strfmt.Date(moveTaskOrder.CreatedAt),
+		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         &moveTaskOrder.IsCanceled,
 		MoveOrderID:        strfmt.UUID(moveTaskOrder.MoveOrderID.String()),
 		ReferenceID:        moveTaskOrder.ReferenceID,
-		UpdatedAt:          strfmt.Date(moveTaskOrder.UpdatedAt),
+		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 	return payload
@@ -236,8 +236,8 @@ func MTOAgent(mtoAgent *models.MTOAgent) *ghcmessages.MTOAgent {
 	payload := &ghcmessages.MTOAgent{
 		ID:            strfmt.UUID(mtoAgent.ID.String()),
 		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
-		CreatedAt:     strfmt.Date(mtoAgent.CreatedAt),
-		UpdatedAt:     strfmt.Date(mtoAgent.UpdatedAt),
+		CreatedAt:     strfmt.DateTime(mtoAgent.CreatedAt),
+		UpdatedAt:     strfmt.DateTime(mtoAgent.UpdatedAt),
 		FirstName:     mtoAgent.FirstName,
 		LastName:      mtoAgent.LastName,
 		AgentType:     string(mtoAgent.MTOAgentType),

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -22,7 +22,7 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *primemessages.MoveTaskO
 	mtoShipments := MTOShipments(&moveTaskOrder.MTOShipments)
 	payload := &primemessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
-		CreatedAt:          strfmt.Date(moveTaskOrder.CreatedAt),
+		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         &moveTaskOrder.IsCanceled,
 		MoveOrderID:        strfmt.UUID(moveTaskOrder.MoveOrderID.String()),
@@ -30,7 +30,7 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *primemessages.MoveTaskO
 		ReferenceID:        moveTaskOrder.ReferenceID,
 		PaymentRequests:    *paymentRequests,
 		MtoShipments:       *mtoShipments,
-		UpdatedAt:          strfmt.Date(moveTaskOrder.UpdatedAt),
+		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 
@@ -201,8 +201,8 @@ func MTOAgent(mtoAgent *models.MTOAgent) *primemessages.MTOAgent {
 		Email:         mtoAgent.Email,
 		ID:            strfmt.UUID(mtoAgent.ID.String()),
 		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
-		CreatedAt:     strfmt.Date(mtoAgent.CreatedAt),
-		UpdatedAt:     strfmt.Date(mtoAgent.UpdatedAt),
+		CreatedAt:     strfmt.DateTime(mtoAgent.CreatedAt),
+		UpdatedAt:     strfmt.DateTime(mtoAgent.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -20,14 +20,14 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *supportmessages.MoveTas
 	mtoShipments := MTOShipments(&moveTaskOrder.MTOShipments)
 	payload := &supportmessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
-		CreatedAt:          strfmt.Date(moveTaskOrder.CreatedAt),
+		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         &moveTaskOrder.IsCanceled,
 		MoveOrder:          MoveOrder(&moveTaskOrder.MoveOrder),
 		ReferenceID:        moveTaskOrder.ReferenceID,
 		ContractorID:       strfmt.UUID(moveTaskOrder.ContractorID.String()),
 		MtoShipments:       *mtoShipments,
-		UpdatedAt:          strfmt.Date(moveTaskOrder.UpdatedAt),
+		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 	}
 
@@ -234,8 +234,8 @@ func MTOAgent(mtoAgent *models.MTOAgent) *supportmessages.MTOAgent {
 	payload := &supportmessages.MTOAgent{
 		ID:            strfmt.UUID(mtoAgent.ID.String()),
 		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
-		CreatedAt:     strfmt.Date(mtoAgent.CreatedAt),
-		UpdatedAt:     strfmt.Date(mtoAgent.UpdatedAt),
+		CreatedAt:     strfmt.DateTime(mtoAgent.CreatedAt),
+		UpdatedAt:     strfmt.DateTime(mtoAgent.UpdatedAt),
 		FirstName:     mtoAgent.FirstName,
 		LastName:      mtoAgent.LastName,
 		AgentType:     string(mtoAgent.MTOAgentType),

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -67,10 +67,10 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 		oldShipment.ActualPickupDate = updatedShipment.ActualPickupDate
 	}
 
-	scheduledPickupTime := *oldShipment.ScheduledPickupDate
+	//scheduledPickupTime := *oldShipment.ScheduledPickupDate
 	if updatedShipment.ScheduledPickupDate != nil {
-		scheduledPickupTime = *updatedShipment.ScheduledPickupDate
-		oldShipment.ScheduledPickupDate = &scheduledPickupTime
+		scheduledPickupTime := updatedShipment.ScheduledPickupDate
+		oldShipment.ScheduledPickupDate = scheduledPickupTime
 	}
 
 	if updatedShipment.PrimeEstimatedWeight != nil {
@@ -79,7 +79,7 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 		}
 		now := time.Now()
 		if oldShipment.ApprovedDate != nil {
-			err := validatePrimeEstimatedWeightRecordedDate(now, scheduledPickupTime, *oldShipment.ApprovedDate)
+			err := validatePrimeEstimatedWeightRecordedDate(now, *oldShipment.ScheduledPickupDate, *oldShipment.ApprovedDate)
 			if err != nil {
 				verrs.Add("primeEstimatedWeight", "the time period for updating the estimated weight for a shipment has expired, please contact the TOO directly to request updates to this shipment’s estimated weight")
 				verrs.Add("primeEstimatedWeight", err.Error())

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -74,14 +74,10 @@ definitions:
         example: Transportation Ordering Officer
       createdAt:
         type: string
-        format: datetime
-        example: 2018-04-12T23:20:50.52Z
-        description: when the role was created
+        format: date-time
       updatedAt:
         type: string
-        format: datetime
-        example: 2018-04-12T23:20:50.52Z
-        description: when the role was updated
+        format: date-time
     required:
       - id
       - roleType
@@ -120,10 +116,10 @@ definitions:
           $ref: '#/definitions/Role'
       createdAt:
         type: string
-        format: datetime
+        format: date-time
       updatedAt:
         type: string
-        format: datetime
+        format: date-time
     required:
       - id
       - firstName
@@ -165,10 +161,10 @@ definitions:
         type: boolean
       createdAt:
         type: string
-        format: datetime
+        format: date-time
       updatedAt:
         type: string
-        format: datetime
+        format: date-time
     required:
       - id
       - firstName
@@ -562,11 +558,11 @@ definitions:
         title: Orders Number
       createdAt:
         type: string
-        format: datetime
+        format: date-time
         title: Created at
       updatedAt:
         type: string
-        format: datetime
+        format: date-time
         title: Updated at
   ElectronicOrders:
     type: array
@@ -599,11 +595,11 @@ definitions:
         x-nullable: true
       createdAt:
         type: string
-        format: datetime
+        format: date-time
         title: Created at
       updatedAt:
         type: string
-        format: datetime
+        format: date-time
         title: Updated at
   Organizations:
     type: array
@@ -639,7 +635,7 @@ definitions:
     properties:
       createdAt:
         type: string
-        format: datetime
+        format: date-time
         title: Created at
       filename:
         type: string
@@ -727,7 +723,7 @@ definitions:
           - MOVE_PAYMENT_REMINDER_EMAIL
       createdAt:
         type: string
-        format: datetime
+        format: date-time
   Notifications:
     type: array
     items:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1484,7 +1484,7 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       moveOrderID:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -1501,7 +1501,7 @@ definitions:
         type: boolean
         x-nullable: true
       updatedAt:
-        format: date
+        format: date-time
         type: string
       destinationAddress:
         $ref: '#/definitions/Address'
@@ -1547,10 +1547,10 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       updatedAt:
-        format: date
+        format: date-time
         type: string
       firstName:
         type: string
@@ -1646,10 +1646,10 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: datetime
+        format: date-time
         type: string
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
       scheduledPickupDate:
         format: date
@@ -1738,7 +1738,7 @@ definitions:
         format: date
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       deletedAt:
         format: date
@@ -1776,7 +1776,7 @@ definitions:
         format: cents
         type: integer
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
       eTag:
         type: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2485,9 +2485,7 @@ definitions:
           - PPM
       created_at:
         type: string
-        format: datetime
-        example: 2018-04-12T23:20:50.52Z
-        description: when the access code was created
+        format: date-time
       claimed_at:
         type: string
         format: datetime
@@ -2511,14 +2509,10 @@ definitions:
         example: customer
       createdAt:
         type: string
-        format: datetime
-        example: 2018-04-12T23:20:50.52Z
-        description: when the role was created
+        format: date-time
       updatedAt:
         type: string
-        format: datetime
-        example: 2018-04-12T23:20:50.52Z
-        description: when the role was updated
+        format: date-time
     required:
       - id
       - roleType

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -704,7 +704,7 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       moveOrderID:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -723,7 +723,7 @@ definitions:
         type: boolean
         x-nullable: true
       updatedAt:
-        format: date
+        format: date-time
         type: string
       paymentRequests:
         $ref: '#/definitions/PaymentRequests'
@@ -763,11 +763,11 @@ definitions:
         type: string
         readOnly: true
       createdAt:
-        format: date
+        format: date-time
         type: string
         readOnly: true
       updatedAt:
-        format: date
+        format: date-time
         type: string
         readOnly: true
       firstName:
@@ -802,11 +802,11 @@ definitions:
         type: string
         readOnly: true
       createdAt:
-        format: datetime
+        format: date-time
         type: string
         readOnly: true
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
         readOnly: true
       approvedDate:

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -705,7 +705,7 @@ definitions:
         readOnly: true
         description: ID of the MoveTaskOrder object.
       createdAt:
-        format: date
+        format: date-time
         type: string
         description: Date the MoveTaskOrder was created on.
       moveOrderID:
@@ -744,7 +744,7 @@ definitions:
           ID associated with the contractor, in this case Prime
         example: 5db13bb4-6d29-4bdb-bc81-262f4513ecf6
       updatedAt:
-        format: date
+        format: date-time
         type: string
         description: Date on which this MoveTaskOrder was last updated.
       paymentRequests:
@@ -798,10 +798,10 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       updatedAt:
-        format: date
+        format: date-time
         type: string
       firstName:
         type: string
@@ -891,10 +891,10 @@ definitions:
         format: uuid
         type: string
       createdAt:
-        format: datetime
+        format: date-time
         type: string
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
       scheduledPickupDate:
         format: date
@@ -979,7 +979,7 @@ definitions:
         format: date
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       deletedAt:
         format: date
@@ -1017,7 +1017,7 @@ definitions:
         format: cents
         type: integer
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
       eTag:
         type: string
@@ -1075,7 +1075,7 @@ definitions:
         format: date
         type: string
       createdAt:
-        format: date
+        format: date-time
         type: string
       deletedAt:
         format: date
@@ -1113,7 +1113,7 @@ definitions:
         format: cents
         type: integer
       updatedAt:
-        format: datetime
+        format: date-time
         type: string
       eTag:
         type: string


### PR DESCRIPTION
## Description

We're currently using several different date formats in our yaml files for `createdAt` and `updatedAt`. These include `date`, `datetime`, and `date-time`. The swagger docs provide `date` and `date-time` as supported formats.

This PR fixes the inconsistency and uses `date-time` as the format. 

## Reviewer Notes

I plan to write up a separate ticket to see if we should be using `date-time` for all date fields. If that is the case then would be good to have an ADR that makes this clear.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2790) for this change