### PR TITLE
[MB-2436] Fix malformed errors sent to prime api client

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -617,10 +617,10 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
-	site.Use(middleware.Recovery(logger))
-	site.Use(middleware.SecurityHeaders(logger))
 	site.Use(middleware.Trace(logger, &handlerContext)) // injects trace id into the context
 	site.Use(middleware.ContextLogger("milmove_trace_id", logger))
+	site.Use(middleware.Recovery(logger))
+	site.Use(middleware.SecurityHeaders(logger))
 
 	if maxBodySize := v.GetInt64(cli.MaxBodySizeFlag); maxBodySize > 0 {
 		site.Use(middleware.LimitBodySize(maxBodySize, logger))

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -862,7 +862,17 @@ func init() {
         "message"
       ],
       "properties": {
+        "detail": {
+          "type": "string"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uuid"
+        },
         "message": {
+          "type": "string"
+        },
+        "title": {
           "type": "string"
         }
       }
@@ -2853,7 +2863,17 @@ func init() {
         "message"
       ],
       "properties": {
+        "detail": {
+          "type": "string"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uuid"
+        },
         "message": {
+          "type": "string"
+        },
+        "title": {
           "type": "string"
         }
       }

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -859,7 +859,8 @@ func init() {
     "Error": {
       "type": "object",
       "required": [
-        "message"
+        "title",
+        "detail"
       ],
       "properties": {
         "detail": {
@@ -868,9 +869,6 @@ func init() {
         "instance": {
           "type": "string",
           "format": "uuid"
-        },
-        "message": {
-          "type": "string"
         },
         "title": {
           "type": "string"
@@ -2860,7 +2858,8 @@ func init() {
     "Error": {
       "type": "object",
       "required": [
-        "message"
+        "title",
+        "detail"
       ],
       "properties": {
         "detail": {
@@ -2869,9 +2868,6 @@ func init() {
         "instance": {
           "type": "string",
           "format": "uuid"
-        },
-        "message": {
-          "type": "string"
         },
         "title": {
           "type": "string"

--- a/pkg/gen/primemessages/error.go
+++ b/pkg/gen/primemessages/error.go
@@ -18,35 +18,46 @@ import (
 type Error struct {
 
 	// detail
-	Detail string `json:"detail,omitempty"`
+	// Required: true
+	Detail *string `json:"detail"`
 
 	// instance
 	// Format: uuid
 	Instance strfmt.UUID `json:"instance,omitempty"`
 
-	// message
-	// Required: true
-	Message *string `json:"message"`
-
 	// title
-	Title string `json:"title,omitempty"`
+	// Required: true
+	Title *string `json:"title"`
 }
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDetail(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateInstance(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateMessage(formats); err != nil {
+	if err := m.validateTitle(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Error) validateDetail(formats strfmt.Registry) error {
+
+	if err := validate.Required("detail", "body", m.Detail); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -63,9 +74,9 @@ func (m *Error) validateInstance(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Error) validateMessage(formats strfmt.Registry) error {
+func (m *Error) validateTitle(formats strfmt.Registry) error {
 
-	if err := validate.Required("message", "body", m.Message); err != nil {
+	if err := validate.Required("title", "body", m.Title); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/error.go
+++ b/pkg/gen/primemessages/error.go
@@ -17,14 +17,28 @@ import (
 // swagger:model Error
 type Error struct {
 
+	// detail
+	Detail string `json:"detail,omitempty"`
+
+	// instance
+	// Format: uuid
+	Instance strfmt.UUID `json:"instance,omitempty"`
+
 	// message
 	// Required: true
 	Message *string `json:"message"`
+
+	// title
+	Title string `json:"title,omitempty"`
 }
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.validateInstance(formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.validateMessage(formats); err != nil {
 		res = append(res, err)
@@ -33,6 +47,19 @@ func (m *Error) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Error) validateInstance(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Instance) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("instance", "body", "uuid", m.Instance.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -782,10 +782,18 @@ func init() {
     "Error": {
       "type": "object",
       "required": [
-        "message"
+        "title",
+        "detail"
       ],
       "properties": {
-        "message": {
+        "detail": {
+          "type": "string"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "title": {
           "type": "string"
         }
       }
@@ -2439,10 +2447,18 @@ func init() {
     "Error": {
       "type": "object",
       "required": [
-        "message"
+        "title",
+        "detail"
       ],
       "properties": {
-        "message": {
+        "detail": {
+          "type": "string"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "title": {
           "type": "string"
         }
       }

--- a/pkg/gen/supportmessages/error.go
+++ b/pkg/gen/supportmessages/error.go
@@ -17,16 +17,32 @@ import (
 // swagger:model Error
 type Error struct {
 
-	// message
+	// detail
 	// Required: true
-	Message *string `json:"message"`
+	Detail *string `json:"detail"`
+
+	// instance
+	// Format: uuid
+	Instance strfmt.UUID `json:"instance,omitempty"`
+
+	// title
+	// Required: true
+	Title *string `json:"title"`
 }
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateMessage(formats); err != nil {
+	if err := m.validateDetail(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateInstance(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTitle(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -36,9 +52,31 @@ func (m *Error) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Error) validateMessage(formats strfmt.Registry) error {
+func (m *Error) validateDetail(formats strfmt.Registry) error {
 
-	if err := validate.Required("message", "body", m.Message); err != nil {
+	if err := validate.Required("detail", "body", m.Detail); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Error) validateInstance(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Instance) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("instance", "body", "uuid", m.Instance.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Error) validateTitle(formats strfmt.Registry) error {
+
+	if err := validate.Required("title", "body", m.Title); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -24,6 +24,8 @@ import (
 	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
 )
 
+// The following are strings to be used in the title field of errors sent to the client
+
 // SQLErrMessage represents string value to represent generic sql error to avoid leaking implementation details
 const SQLErrMessage string = "Unhandled SQL error encountered"
 
@@ -50,6 +52,9 @@ const MethodNotAllowedErrMessage string = "Method Not Allowed"
 
 // InternalServerErrMessage indicates that there was an internal server error
 const InternalServerErrMessage string = "Internal Server Error"
+
+// InternalServerErrDetail provides a default detail string
+const InternalServerErrDetail string = "An internal server error has occurred"
 
 // NotImplementedErrMessage indicates an endpoint has not been implemented
 const NotImplementedErrMessage string = "Not Implemented"

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -471,6 +471,19 @@ func MTOServiceItems(mtoServiceItems *models.MTOServiceItems) *[]primemessages.M
 	return &payload
 }
 
+// InternalServerError describes errors in a standard structure to be returned in the payload
+func InternalServerError(detail string, instance uuid.UUID) *primemessages.Error {
+	payload := primemessages.Error{
+		Title:    handlers.InternalServerErrMessage,
+		Detail:   "An unexpected server error occurred.",
+		Instance: strfmt.UUID(instance.String()),
+	}
+	if detail != "" {
+		payload.Detail = detail
+	}
+	return &payload
+}
+
 // ValidationError describes validation errors from the model or properties
 func ValidationError(detail string, instance uuid.UUID, validationErrors *validate.Errors) *primemessages.ValidationError {
 	payload := &primemessages.ValidationError{

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -471,14 +471,15 @@ func MTOServiceItems(mtoServiceItems *models.MTOServiceItems) *[]primemessages.M
 	return &payload
 }
 
-// InternalServerError describes errors in a standard structure to be returned in the payload
-func InternalServerError(detail string, instance uuid.UUID) *primemessages.Error {
+// InternalServerError describes errors in a standard structure to be returned in the payload.
+// If detail is nil, string defaults to "An internal server error has occurred."
+func InternalServerError(detail *string, traceID uuid.UUID) *primemessages.Error {
 	payload := primemessages.Error{
-		Title:    handlers.InternalServerErrMessage,
-		Detail:   "An unexpected server error occurred.",
-		Instance: strfmt.UUID(instance.String()),
+		Title:    handlers.FmtString(handlers.InternalServerErrMessage),
+		Detail:   handlers.FmtString(handlers.InternalServerErrDetail),
+		Instance: strfmt.UUID(traceID.String()),
 	}
-	if detail != "" {
+	if detail != nil {
 		payload.Detail = detail
 	}
 	return &payload

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -84,7 +84,7 @@ func (h UpdateMTOPostCounselingInformationHandler) Handle(params movetaskorderop
 			return movetaskorderops.NewUpdateMTOPostCounselingInformationUnprocessableEntity().WithPayload(
 				payloads.ValidationError(err.Error(), h.GetTraceID(), e.ValidationErrors))
 		default:
-			return movetaskorderops.NewUpdateMTOPostCounselingInformationInternalServerError()
+			return movetaskorderops.NewUpdateMTOPostCounselingInformationInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 		}
 	}
 	mtoPayload := payloads.MoveTaskOrder(mto)

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -48,7 +48,7 @@ func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesPa
 
 	if err != nil {
 		logger.Error("Unable to fetch records:", zap.Error(err))
-		return movetaskorderops.NewFetchMTOUpdatesInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+		return movetaskorderops.NewFetchMTOUpdatesInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 	}
 
 	payload := payloads.MoveTaskOrders(&mtos)

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -48,7 +48,7 @@ func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesPa
 
 	if err != nil {
 		logger.Error("Unable to fetch records:", zap.Error(err))
-		return movetaskorderops.NewFetchMTOUpdatesInternalServerError()
+		return movetaskorderops.NewFetchMTOUpdatesInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 	}
 
 	payload := payloads.MoveTaskOrders(&mtos)

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -69,7 +69,7 @@ func (h CreateMTOServiceItemHandler) Handle(params mtoserviceitemops.CreateMTOSe
 		case services.InvalidInputError:
 			return mtoserviceitemops.NewCreateMTOServiceItemBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceID()))
 		default:
-			return mtoserviceitemops.NewCreateMTOServiceItemInternalServerError().WithPayload(&primemessages.Error{Message: handlers.FmtString(err.Error())})
+			return mtoserviceitemops.NewCreateMTOServiceItemInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 		}
 	}
 	mtoServiceItemPayload := payloads.MTOServiceItem(mtoServiceItem)

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -69,7 +69,7 @@ func (h CreateMTOServiceItemHandler) Handle(params mtoserviceitemops.CreateMTOSe
 		case services.InvalidInputError:
 			return mtoserviceitemops.NewCreateMTOServiceItemBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceID()))
 		default:
-			return mtoserviceitemops.NewCreateMTOServiceItemInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+			return mtoserviceitemops.NewCreateMTOServiceItemInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 		}
 	}
 	mtoServiceItemPayload := payloads.MTOServiceItem(mtoServiceItem)

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -86,6 +86,10 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 
 		response := handler.Handle(params)
 		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemInternalServerError{}, response)
+
+		errResponse := response.(*mtoserviceitemops.CreateMTOServiceItemInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong")
+
 	})
 
 	suite.T().Run("POST failure - 400", func(t *testing.T) {

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -55,7 +55,7 @@ func (h CreateMTOShipmentHandler) Handle(params mtoshipmentops.CreateMTOShipment
 			return mtoshipmentops.NewCreateMTOShipmentNotFound()
 		}
 		logger.Error("Error creating mto shipment: ", zap.Error(err))
-		return mtoshipmentops.NewCreateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+		return mtoshipmentops.NewCreateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 	}
 
 	returnPayload := payloads.MTOShipment(mtoShipment)
@@ -186,11 +186,11 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 			case services.PreconditionFailedError:
 				return mtoshipmentops.NewUpdateMTOShipmentPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
 			default:
-				return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+				return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 			}
 		}
 		mtoShipmentPayload := payloads.MTOShipment(mtoShipment)
 		return mtoshipmentops.NewUpdateMTOShipmentOK().WithPayload(mtoShipmentPayload)
 	}
-	return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+	return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 }

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -55,7 +55,7 @@ func (h CreateMTOShipmentHandler) Handle(params mtoshipmentops.CreateMTOShipment
 			return mtoshipmentops.NewCreateMTOShipmentNotFound()
 		}
 		logger.Error("Error creating mto shipment: ", zap.Error(err))
-		return mtoshipmentops.NewCreateMTOShipmentInternalServerError()
+		return mtoshipmentops.NewCreateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 	}
 
 	returnPayload := payloads.MTOShipment(mtoShipment)
@@ -186,11 +186,11 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 			case services.PreconditionFailedError:
 				return mtoshipmentops.NewUpdateMTOShipmentPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
 			default:
-				return mtoshipmentops.NewUpdateMTOShipmentInternalServerError()
+				return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 			}
 		}
 		mtoShipmentPayload := payloads.MTOShipment(mtoShipment)
 		return mtoshipmentops.NewUpdateMTOShipmentOK().WithPayload(mtoShipmentPayload)
 	}
-	return mtoshipmentops.NewUpdateMTOShipmentInternalServerError()
+	return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 }

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -106,6 +106,10 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		response := handler.Handle(badParams)
 
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentInternalServerError{}, response)
+
+		errResponse := response.(*mtoshipmentops.CreateMTOShipmentInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong")
+
 	})
 
 	suite.T().Run("POST failure - 404 -- not found", func(t *testing.T) {
@@ -269,6 +273,10 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		response := mockHandler.Handle(params)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentInternalServerError{}, response)
+
+		errResponse := response.(*mtoshipmentops.UpdateMTOShipmentInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong")
+
 	})
 
 	suite.T().Run("PUT failure - 404", func(t *testing.T) {

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -105,7 +105,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 		}
 		logger.Error("Payment Request",
 			zap.Any("payload", payload))
-		return paymentrequestop.NewCreatePaymentRequestInternalServerError()
+		return paymentrequestop.NewCreatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
 	}
 
 	returnPayload := payloads.PaymentRequest(createdPaymentRequest)

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -105,7 +105,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 		}
 		logger.Error("Payment Request",
 			zap.Any("payload", payload))
-		return paymentrequestop.NewCreatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError("", h.GetTraceID()))
+		return paymentrequestop.NewCreatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 	}
 
 	returnPayload := payloads.PaymentRequest(createdPaymentRequest)

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -146,6 +146,10 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 
 		response := handler.Handle(params)
 		suite.IsType(&paymentrequestop.CreatePaymentRequestInternalServerError{}, response)
+
+		errResponse := response.(*paymentrequestop.CreatePaymentRequestInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong") // check body (body was written before panic)
+
 	})
 
 	suite.T().Run("failed create payment request -- invalid MTO ID format", func(t *testing.T) {

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -268,6 +268,20 @@ func PaymentRequest(pr *models.PaymentRequest) *supportmessages.PaymentRequest {
 	}
 }
 
+// InternalServerError describes errors in a standard structure to be returned in the payload.
+// If detail is nil, string defaults to "An internal server error has occurred."
+func InternalServerError(detail *string, traceID uuid.UUID) *supportmessages.Error {
+	payload := supportmessages.Error{
+		Title:    handlers.FmtString(handlers.InternalServerErrMessage),
+		Detail:   handlers.FmtString(handlers.InternalServerErrDetail),
+		Instance: strfmt.UUID(traceID.String()),
+	}
+	if detail != nil {
+		payload.Detail = detail
+	}
+	return &payload
+}
+
 // ValidationError payload describes validation errors from the model or properties
 func ValidationError(detail string, instance uuid.UUID, validationErrors *validate.Errors) *supportmessages.ValidationError {
 	payload := &supportmessages.ValidationError{

--- a/pkg/handlers/supportapi/move_task_order.go
+++ b/pkg/handlers/supportapi/move_task_order.go
@@ -45,7 +45,7 @@ func (h MakeMoveTaskOrderAvailableHandlerFunc) Handle(params movetaskorderops.Ma
 			return movetaskorderops.NewMakeMoveTaskOrderAvailablePreconditionFailed().WithPayload(
 				payloads.ClientError(handlers.PreconditionErrMessage, *handlers.FmtString(err.Error()), h.GetTraceID()))
 		default:
-			return movetaskorderops.NewMakeMoveTaskOrderAvailableInternalServerError().WithPayload(&supportmessages.Error{Message: handlers.FmtString(err.Error())})
+			return movetaskorderops.NewMakeMoveTaskOrderAvailableInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 
@@ -76,7 +76,7 @@ func (h GetMoveTaskOrderHandlerFunc) Handle(params movetaskorderops.GetMoveTaskO
 			return movetaskorderops.NewCreateMoveTaskOrderUnprocessableEntity().WithPayload(
 				payloads.ValidationError(err.Error(), h.GetTraceID(), typedErr.ValidationErrors))
 		default:
-			return movetaskorderops.NewGetMoveTaskOrderInternalServerError().WithPayload(&supportmessages.Error{Message: handlers.FmtString(err.Error())})
+			return movetaskorderops.NewGetMoveTaskOrderInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 	moveTaskOrderPayload := payloads.MoveTaskOrder(mto)
@@ -109,7 +109,7 @@ func (h CreateMoveTaskOrderHandler) Handle(params movetaskorderops.CreateMoveTas
 			return movetaskorderops.NewCreateMoveTaskOrderBadRequest().WithPayload(
 				payloads.ClientError(handlers.SQLErrMessage, *handlers.FmtString(err.Error()), h.GetTraceID()))
 		default:
-			return movetaskorderops.NewCreateMoveTaskOrderInternalServerError().WithPayload(&supportmessages.Error{Message: handlers.FmtString(err.Error())})
+			return movetaskorderops.NewCreateMoveTaskOrderInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 	moveTaskOrderPayload := payloads.MoveTaskOrder(moveTaskOrder)

--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -54,7 +54,7 @@ func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemops.Updat
 			}
 			return mtoserviceitemops.NewUpdateMTOServiceItemStatusConflict().WithPayload(payload)
 		default:
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusInternalServerError()
+			return mtoserviceitemops.NewUpdateMTOServiceItemStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 

--- a/pkg/handlers/supportapi/mto_shipment.go
+++ b/pkg/handlers/supportapi/mto_shipment.go
@@ -48,7 +48,7 @@ func (h UpdateMTOShipmentStatusHandlerFunc) Handle(params mtoshipmentops.UpdateM
 		case mtoshipment.ConflictStatusError:
 			return mtoshipmentops.NewUpdateMTOShipmentStatusConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceID()))
 		default:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusInternalServerError()
+			return mtoshipmentops.NewUpdateMTOShipmentStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -75,6 +75,10 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		response := mockHandler.Handle(params)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusInternalServerError{}, response)
+
+		errResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong")
+
 	})
 
 	suite.T().Run("Patch failure - 404", func(t *testing.T) {

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -31,7 +31,7 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 
 	if err != nil {
 		logger.Error(fmt.Sprintf("Error parsing payment request id: %s", params.PaymentRequestID.String()), zap.Error(err))
-		return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError()
+		return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 	}
 
 	// Let's fetch the existing payment request using the PaymentRequestFetcher service object
@@ -115,7 +115,7 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 			return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
 		default:
 			logger.Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
-			return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError()
+			return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))
 		}
 	}
 

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -79,7 +79,10 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 		response := handler.Handle(params)
 
-		suite.IsType(paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError(), response)
+		suite.IsType(&paymentrequestop.UpdatePaymentRequestStatusInternalServerError{}, response)
+
+		errResponse := response.(*paymentrequestop.UpdatePaymentRequestStatusInternalServerError)
+		suite.Equal(handlers.InternalServerErrMessage, string(*errResponse.Payload.Title), "Payload title is wrong")
 
 	})
 

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -19,7 +19,6 @@ func Recovery(logger Logger) func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if obj := recover(); obj != nil {
-					fmt.Println("\n\nwe got to recovery")
 
 					// Log the error and optionally the stacktrace
 					fields := []zap.Field{

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -1,11 +1,15 @@
 package middleware
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"runtime/debug"
 
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 // Recovery recovers from a panic within a handler.
@@ -15,9 +19,15 @@ func Recovery(logger Logger) func(inner http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if obj := recover(); obj != nil {
-					w.WriteHeader(http.StatusInternalServerError) // don't write error to body, since body might have already been written.
+					fmt.Println("\n\nwe got to recovery")
+
+					// Log the error and optionally the stacktrace
 					fields := []zap.Field{
 						zap.String("url", fmt.Sprint(r.URL)),
+					}
+					traceID := trace.FromContext(r.Context())
+					if traceID != "" {
+						fields = append(fields, zap.String("milmove_trace_id", traceID))
 					}
 					if err, ok := obj.(error); ok {
 						fields = append(fields, zap.Error(err))
@@ -26,6 +36,16 @@ func Recovery(logger Logger) func(inner http.Handler) http.Handler {
 						fields = append(fields, zap.String("stacktrace", fmt.Sprintf("%s", debug.Stack())))
 					}
 					logger.Error("http request panic", fields...)
+
+					// Create a formatted server error
+					jsonBody, _ := json.Marshal(struct {
+						Title    string `json:"title"`
+						Instance string `json:"instance"`
+						Detail   string `json:"detail"`
+					}{handlers.InternalServerErrMessage, traceID, "An unexpected server error has occurred."})
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write(jsonBody)
 				}
 			}()
 			inner.ServeHTTP(w, r)

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/transcom/mymove/pkg/handlers"
 )
 
 // TestRecoveryPanic tests the recovery middleware with a handler that returns as normal.
@@ -14,6 +17,12 @@ func (suite *testSuite) TestRecoveryNormal() {
 	suite.Equal(http.StatusOK, rr.Code, errStatusCode) // check status code
 }
 
+type recoveryError struct {
+	Title    string
+	Detail   string
+	Instance string
+}
+
 // TestRecoveryPanic tests the recovery middleware with a handler that panics.
 func (suite *testSuite) TestRecoveryPanic() {
 	mw := Recovery(suite.logger)
@@ -21,6 +30,10 @@ func (suite *testSuite) TestRecoveryPanic() {
 	suite.do(mw, suite.panic, rr, httptest.NewRequest("GET", testURL, nil))
 	suite.Equal(http.StatusInternalServerError, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.NoError(err)                     // check that you could read full body
-	suite.Equal("", string(body), errBody) // check body (body was written before panic)
+	suite.NoError(err) // check that you could read full body
+	var response recoveryError
+	err = json.Unmarshal(body, &response)
+	suite.Nil(err)
+	suite.Equal(handlers.InternalServerErrMessage, string(response.Title), errBody) // check body (body was written before panic)
+
 }

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -34,6 +34,6 @@ func (suite *testSuite) TestRecoveryPanic() {
 	var response recoveryError
 	err = json.Unmarshal(body, &response)
 	suite.Nil(err)
-	suite.Equal(handlers.InternalServerErrMessage, string(response.Title), errBody) // check body (body was written before panic)
+	suite.Equal(handlers.InternalServerErrMessage, string(response.Title), errBody)
 
 }

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -650,6 +650,13 @@ definitions:
     properties:
       message:
         type: string
+      title:
+        type: string
+      detail:
+        type: string
+      instance:
+        type: string
+        format: uuid
     required:
       - message
     type: object

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -648,8 +648,6 @@ definitions:
     type: object
   Error:
     properties:
-      message:
-        type: string
       title:
         type: string
       detail:
@@ -658,7 +656,8 @@ definitions:
         type: string
         format: uuid
     required:
-      - message
+      - title
+      - detail
     type: object
   MoveOrder:
     required:

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -621,10 +621,16 @@ definitions:
     type: object
   Error:
     properties:
-      message:
+      title:
         type: string
+      detail:
+        type: string
+      instance:
+        type: string
+        format: uuid
     required:
-      - message
+      - title
+      - detail
     type: object
   MoveOrder:
     properties:


### PR DESCRIPTION
## Description

When using prime api client we used to get a lot of unmarshalling errors due to the response not containing valid json. This PR is meant to cleanup some of these cases. In the course of searching for these I found that if we have a panic we also return a null, when we could return a well formed error with trace id, to help debug the error with logs. 

So this ticket does 2 things
- Changes recoveryLogger to include a well formed response with traceID (this only gets returned on a panic)
- Changes prime and support InternalServerError format to match the prescribed title/detail/instance.

**AC from JIRA**
Find every instance in prime and support handlers where we are returning a string instead of json, and return message in json. Involves looking at every single handler and every error we return.

## Setup

It's a bit hard to test since you need an internal server error to happen. One known one right now is if you try to update a shipment that has no current scheduledPickupDate, you should get a server error. You will want to see a response like this...
```
{
  "Payload": {
    "detail": "An unexpected server error has occurred.",
    "instance": "68d8784f-9f85-4443-9fe1-f6f2fd90c413",
    "title": "Internal Server Error"
  }
}
```

## References

* [MB-2436 Fix unmarshalling errors in Prime API client - Jira](https://dp3.atlassian.net/browse/MB-2436) for this change
* [handle backend errors · transcom/mymove Wiki](https://github.com/transcom/mymove/wiki/handle-backend-errors) explains more about the approach used.


[MB-2436]: https://dp3.atlassian.net/browse/MB-2436