### PR TITLE
MB-1583 Implement Service Area Origin Lookup

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -2,6 +2,7 @@ package serviceparamvaluelookups
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/gofrs/uuid"
 
@@ -40,7 +41,7 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 	pickupAddressID := mtoServiceItem.MTOShipment.PickupAddressID
 	if pickupAddressID == nil || *pickupAddressID == uuid.Nil {
 		//check for string of all zeros
-		return "", services.NewNotFoundError(uuid.Nil, "looking for PickupAddressID")
+		return "", fmt.Errorf("could not find pickup address for MTOShipment [%s]", mtoShipmentID)
 	}
 
 	// find the service area by querying for the service area associated with the zip3

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/gofrs/uuid"
 
@@ -47,15 +46,6 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 	// find the service area by querying for the service area associated with the zip3
 	zip := mtoServiceItem.MTOShipment.PickupAddress.PostalCode
 	zip3 := zip[0:3]
-
-	fmt.Println("postalCode in lookup")
-	fmt.Printf("%v", mtoServiceItem.MTOShipment.PickupAddress.PostalCode)
-
-	//query := `
-	//SELECT service_area from re_domestic_service_areas
-	//JOIN re_zip3s on re_zip3s.domestic_service_area_id = re_domestic_service_areas.id
-	//WHERE zip3 = ?
-	//`
 
 	var domesticServiceArea models.ReDomesticServiceArea
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-// ServiceAreaOriginLookup does lookup on actual weight billed
+// ServiceAreaOriginLookup does lookup on pickup address postal code
 type ServiceAreaOriginLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -1,0 +1,50 @@
+package serviceparamvaluelookups
+
+import (
+	"database/sql"
+	"github.com/gofrs/uuid"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// ServiceAreaOrigin does lookup on actual weight billed
+type ServiceAreaOriginLookup struct {
+}
+
+func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+
+	db := *keyData.db
+
+	// Get the MTOServiceItem and associated MTOShipment
+	mtoServiceItemID := keyData.MTOServiceItemID
+	var mtoServiceItem models.MTOServiceItem
+	err := db.Eager("ReService", "MTOShipment").Find(&mtoServiceItem, mtoServiceItemID)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return "", services.NewNotFoundError(mtoServiceItemID, "looking for MTOServiceItemID")
+		default:
+			return "", err
+		}
+	}
+
+	// Make sure there's an MTOShipment since that's nullable
+	mtoShipmentID := mtoServiceItem.MTOShipment.PickupAddress.
+	if mtoShipmentID == nil {
+		return "", services.NewNotFoundError(uuid.Nil, "looking for MTOShipmentID")
+	}
+
+	// Make sure there's an actual weight since that's nullable
+	zip3 := mtoServiceItem.MTOShipment.PickupAddress.PostalCode[0:3]
+
+	query := `
+	SELECT service_area from re_domestic_service_areas
+	JOIN re_zip3s on re_zip3s.domestic_service_area_id = re_domestic_service_areas.id
+	`
+
+	q := db.RawQuery(query).Where("zip3 = ?", zip3)
+	// Select zip3, service_area from re_zip3s
+	// JOIN re_domestic_service_areas rdsa on re_zip3s.domestic_service_area_id = rdsa.id
+
+	return q
+}

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
@@ -1,7 +1,13 @@
 package serviceparamvaluelookups
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/services"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -38,10 +44,51 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceAreaOrigin() {
 	paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
 
 	suite.T().Run("golden path", func(t *testing.T) {
-
 		valueStr, err := paramLookup.ServiceParamValue(key)
-
 		suite.FatalNoError(err)
 		suite.Equal("004", valueStr)
+	})
+
+	suite.T().Run("nil PickupAddress ID", func(t *testing.T) {
+		oldPickupAddressID := mtoServiceItem.MTOShipment.PickupAddressID
+
+		mtoServiceItem.MTOShipment.PickupAddress = nil
+		mtoServiceItem.MTOShipment.PickupAddressID = nil
+		suite.MustSave(&mtoServiceItem.MTOShipment)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf("could not find pickup address for MTOShipment [%s]", mtoServiceItem.MTOShipment.ID)
+		suite.Contains(err.Error(), expected)
+		suite.Equal("", valueStr)
+
+		mtoServiceItem.MTOShipment.PickupAddressID = oldPickupAddressID
+		suite.MustSave(&mtoServiceItem.MTOShipment)
+	})
+
+	suite.T().Run("nil MTOShipment ID", func(t *testing.T) {
+		// Set the MTOShipmentID to nil
+		oldMTOShipmentID := mtoServiceItem.MTOShipmentID
+		mtoServiceItem.MTOShipmentID = nil
+		suite.MustSave(&mtoServiceItem)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		suite.Equal("", valueStr)
+
+		mtoServiceItem.MTOShipmentID = oldMTOShipmentID
+		suite.MustSave(&mtoServiceItem)
+	})
+
+	suite.T().Run("nil MTOServiceItem ID", func(t *testing.T) {
+		// Pass in a non-existent MTOServiceItemID
+		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
+		badParamLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
+
+		valueStr, err := badParamLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, errors.Unwrap(err))
+		suite.Equal("", valueStr)
 	})
 }

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
@@ -1,7 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -11,23 +10,34 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestServiceAreaOrigin() {
 	key := models.ServiceItemParamNameServiceAreaOrigin.String()
 
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{})
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			PostalCode: "35007",
+		},
+	})
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
 			MoveTaskOrder: mtoServiceItem.MoveTaskOrder,
 		})
 
-	testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{})
+	domesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+		ReDomesticServiceArea: models.ReDomesticServiceArea{
+			ServiceArea: "004",
+		},
+	})
+
+	testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+		ReZip3: models.ReZip3{
+			Contract:            domesticServiceArea.Contract,
+			DomesticServiceArea: domesticServiceArea,
+			Zip3:                "350",
+		},
+	})
 
 	paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
 
 	suite.T().Run("golden path", func(t *testing.T) {
-		mtoServiceItem.MTOShipment.PickupAddress.PostalCode = "35007"
-		suite.MustSave(&mtoServiceItem.MTOShipment)
-
-		fmt.Println("postalCode in test")
-		fmt.Printf("%v", mtoServiceItem.MTOShipment.PickupAddress.PostalCode)
 
 		valueStr, err := paramLookup.ServiceParamValue(key)
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
@@ -24,7 +24,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceAreaOrigin() {
 
 	suite.T().Run("golden path", func(t *testing.T) {
 		mtoServiceItem.MTOShipment.PickupAddress.PostalCode = "35007"
-		suite.MustSave(&mtoServiceItem)
+		suite.MustSave(&mtoServiceItem.MTOShipment)
 
 		fmt.Println("postalCode in test")
 		fmt.Printf("%v", mtoServiceItem.MTOShipment.PickupAddress.PostalCode)

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup_test.go
@@ -1,0 +1,37 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestServiceAreaOrigin() {
+	key := models.ServiceItemParamNameServiceAreaOrigin.String()
+
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{})
+
+	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+		testdatagen.Assertions{
+			MoveTaskOrder: mtoServiceItem.MoveTaskOrder,
+		})
+
+	testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{})
+
+	paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID)
+
+	suite.T().Run("golden path", func(t *testing.T) {
+		mtoServiceItem.MTOShipment.PickupAddress.PostalCode = "35007"
+		suite.MustSave(&mtoServiceItem)
+
+		fmt.Println("postalCode in test")
+		fmt.Printf("%v", mtoServiceItem.MTOShipment.PickupAddress.PostalCode)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+
+		suite.FatalNoError(err)
+		suite.Equal("004", valueStr)
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -64,6 +64,7 @@ func ServiceParamLookupInitialize(
 	s.lookups[models.ServiceItemParamNameZipPickupAddress.String()] = ZipPickupAddressLookup{}
 	s.lookups[models.ServiceItemParamNameZipDestAddress.String()] = ZipDestAddressLookup{}
 	s.lookups[models.ServiceItemParamNameMTOAvailableToPrimeAt.String()] = MTOAvailableToPrimeAtLookup{}
+	s.lookups[models.ServiceItemParamNameServiceAreaOrigin.String()] = ServiceAreaOriginLookup{}
 
 	return &s
 }

--- a/pkg/testdatagen/make_re_domestic_service_area.go
+++ b/pkg/testdatagen/make_re_domestic_service_area.go
@@ -15,6 +15,7 @@ func MakeReDomesticServiceArea(db *pop.Connection, assertions Assertions) models
 
 	reDomesticServiceArea := models.ReDomesticServiceArea{
 		ContractID:       reContract.ID,
+		Contract:         reContract,
 		ServiceArea:      "004",
 		ServicesSchedule: 2,
 		SITPDSchedule:    2,

--- a/pkg/testdatagen/make_zip3.go
+++ b/pkg/testdatagen/make_zip3.go
@@ -1,0 +1,40 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeReZip3 creates a single ReZip3
+func MakeReZip3(db *pop.Connection, assertions Assertions) models.ReZip3 {
+	reContract := assertions.ReZip3.Contract
+	if isZeroUUID(reContract.ID) {
+		reContract = MakeReContract(db, assertions)
+	}
+
+	domesticServiceArea := assertions.ReZip3.DomesticServiceArea
+	if isZeroUUID(domesticServiceArea.ID) {
+		domesticServiceArea = MakeReDomesticServiceArea(db, assertions)
+	}
+
+	reZip3 := models.ReZip3{
+		DomesticServiceAreaID: domesticServiceArea.ID,
+		ContractID:            reContract.ID,
+		Zip3:                  "350",
+		BasePointCity:         "Memphis",
+		State:                 "TN",
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&reZip3, assertions.ReZip3)
+
+	mustCreate(db, &reZip3)
+
+	return reZip3
+}
+
+// MakeDefaultReZip3 makes a single ReZip3 with default values
+func MakeDefaultReZip3(db *pop.Connection) models.ReZip3 {
+	return MakeReZip3(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -68,6 +68,7 @@ type Assertions struct {
 	ReDomesticServiceArea                    models.ReDomesticServiceArea
 	Reimbursement                            models.Reimbursement
 	ReService                                models.ReService
+	ReZip3                                   models.ReZip3
 	ServiceItemParamKey                      models.ServiceItemParamKey
 	ServiceParam                             models.ServiceParam
 	SignedCertification                      models.SignedCertification


### PR DESCRIPTION
## Description
Add functionality to lookup the ServiceAreaOrigin Service Item Param when a  payment request is made. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup
- First run `make db_dev_e2e_populate` to ensure your database is setup with the E2E data.
- Next, save this example JSON payload to a file called `pr_payload.json`


```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "76055c99-0990-410c-a7c9-69373b0b53eb"
      }
    ]
  }
}
```

-  Ensure your server is running: `make server_run`

- Create a payment request using that payload: `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload.json | jq`

- Look at the DB and verify that the appropriate records appear in the payment_service_item_params table.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
z