### PR TITLE
[MB-2781] Updated createServiceItem endpoint to make options clearer for Prime

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1024,7 +1024,11 @@ func init() {
               "example": "2020-01-20"
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "description": "Service code allowed for this model type.",
+              "type": "string",
+              "enum": [
+                "DDFSIT"
+              ]
             },
             "timeMilitary1": {
               "type": "string",
@@ -1061,7 +1065,11 @@ func init() {
               "example": 90210
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "description": "Service code allowed for this model type.",
+              "type": "string",
+              "enum": [
+                "DOFSIT"
+              ]
             },
             "reason": {
               "type": "string",
@@ -1134,6 +1142,7 @@ func init() {
               "$ref": "#/definitions/MTOServiceItemDimension"
             },
             "reServiceCode": {
+              "description": "Service codes allowed for this model type.",
               "type": "string",
               "enum": [
                 "DCRT",
@@ -1146,7 +1155,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.",
+      "description": "Describes all model sub-types for a MTOServiceItem model. Prime can only request the following service codes for which they will use the corresponding modelType\n  * DOFSIT - MTOServiceItemDOFSIT\n  * DDFSIT - MTOServiceItemDDFSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -1175,6 +1184,7 @@ func init() {
               "example": "Things to be moved to the place by shuttle."
             },
             "reServiceCode": {
+              "description": "Service codes allowed for this model type.",
               "type": "string",
               "enum": [
                 "DOSHUT",
@@ -1629,6 +1639,7 @@ func init() {
       }
     },
     "ReServiceCode": {
+      "description": "This is the full list of service items that can be found on a shipment. Not all service items\nmay be requested by the Prime, but may be returned in a response.\n\nDocumentation of all the service items will be provided.\n",
       "type": "string",
       "enum": [
         "CS",
@@ -3015,7 +3026,11 @@ func init() {
               "example": "2020-01-20"
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "description": "Service code allowed for this model type.",
+              "type": "string",
+              "enum": [
+                "DDFSIT"
+              ]
             },
             "timeMilitary1": {
               "type": "string",
@@ -3052,7 +3067,11 @@ func init() {
               "example": 90210
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "description": "Service code allowed for this model type.",
+              "type": "string",
+              "enum": [
+                "DOFSIT"
+              ]
             },
             "reason": {
               "type": "string",
@@ -3125,6 +3144,7 @@ func init() {
               "$ref": "#/definitions/MTOServiceItemDimension"
             },
             "reServiceCode": {
+              "description": "Service codes allowed for this model type.",
               "type": "string",
               "enum": [
                 "DCRT",
@@ -3137,7 +3157,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.",
+      "description": "Describes all model sub-types for a MTOServiceItem model. Prime can only request the following service codes for which they will use the corresponding modelType\n  * DOFSIT - MTOServiceItemDOFSIT\n  * DDFSIT - MTOServiceItemDDFSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -3166,6 +3186,7 @@ func init() {
               "example": "Things to be moved to the place by shuttle."
             },
             "reServiceCode": {
+              "description": "Service codes allowed for this model type.",
               "type": "string",
               "enum": [
                 "DOSHUT",
@@ -3620,6 +3641,7 @@ func init() {
       }
     },
     "ReServiceCode": {
+      "description": "This is the full list of service items that can be found on a shipment. Not all service items\nmay be requested by the Prime, but may be returned in a response.\n\nDocumentation of all the service items will be provided.\n",
       "type": "string",
       "enum": [
         "CS",

--- a/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
@@ -45,8 +45,9 @@ type MTOServiceItemDDFSIT struct {
 	// Format: date
 	FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
 
-	// re service code
-	ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+	// Service code allowed for this model type.
+	// Enum: [DDFSIT]
+	ReServiceCode string `json:"reServiceCode,omitempty"`
 
 	// time military1
 	// Required: true
@@ -176,8 +177,9 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 		// Format: date
 		FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
 
-		// re service code
-		ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+		// Service code allowed for this model type.
+		// Enum: [DDFSIT]
+		ReServiceCode string `json:"reServiceCode,omitempty"`
 
 		// time military1
 		// Required: true
@@ -283,8 +285,9 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 		// Format: date
 		FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
 
-		// re service code
-		ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+		// Service code allowed for this model type.
+		// Enum: [DDFSIT]
+		ReServiceCode string `json:"reServiceCode,omitempty"`
 
 		// time military1
 		// Required: true
@@ -508,16 +511,34 @@ func (m *MTOServiceItemDDFSIT) validateFirstAvailableDeliveryDate2(formats strfm
 	return nil
 }
 
+var mTOServiceItemDDFSITTypeReServiceCodePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["DDFSIT"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		mTOServiceItemDDFSITTypeReServiceCodePropEnum = append(mTOServiceItemDDFSITTypeReServiceCodePropEnum, v)
+	}
+}
+
+// property enum
+func (m *MTOServiceItemDDFSIT) validateReServiceCodeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, mTOServiceItemDDFSITTypeReServiceCodePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *MTOServiceItemDDFSIT) validateReServiceCode(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.ReServiceCode) { // not required
 		return nil
 	}
 
-	if err := m.ReServiceCode.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("reServiceCode")
-		}
+	// value enum
+	if err := m.validateReServiceCodeEnum("reServiceCode", "body", m.ReServiceCode); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
@@ -40,8 +40,9 @@ type MTOServiceItemDOFSIT struct {
 	// Pattern: ^(\d{5}([\-]\d{4})?)$
 	PickupPostalCode *string `json:"pickupPostalCode"`
 
-	// re service code
-	ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+	// Service code allowed for this model type.
+	// Enum: [DOFSIT]
+	ReServiceCode string `json:"reServiceCode,omitempty"`
 
 	// reason
 	// Required: true
@@ -153,8 +154,9 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 		// Pattern: ^(\d{5}([\-]\d{4})?)$
 		PickupPostalCode *string `json:"pickupPostalCode"`
 
-		// re service code
-		ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+		// Service code allowed for this model type.
+		// Enum: [DOFSIT]
+		ReServiceCode string `json:"reServiceCode,omitempty"`
 
 		// reason
 		// Required: true
@@ -242,8 +244,9 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 		// Pattern: ^(\d{5}([\-]\d{4})?)$
 		PickupPostalCode *string `json:"pickupPostalCode"`
 
-		// re service code
-		ReServiceCode ReServiceCode `json:"reServiceCode,omitempty"`
+		// Service code allowed for this model type.
+		// Enum: [DOFSIT]
+		ReServiceCode string `json:"reServiceCode,omitempty"`
 
 		// reason
 		// Required: true
@@ -429,16 +432,34 @@ func (m *MTOServiceItemDOFSIT) validatePickupPostalCode(formats strfmt.Registry)
 	return nil
 }
 
+var mTOServiceItemDOFSITTypeReServiceCodePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["DOFSIT"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		mTOServiceItemDOFSITTypeReServiceCodePropEnum = append(mTOServiceItemDOFSITTypeReServiceCodePropEnum, v)
+	}
+}
+
+// property enum
+func (m *MTOServiceItemDOFSIT) validateReServiceCodeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, mTOServiceItemDOFSITTypeReServiceCodePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *MTOServiceItemDOFSIT) validateReServiceCode(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.ReServiceCode) { // not required
 		return nil
 	}
 
-	if err := m.ReServiceCode.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("reServiceCode")
-		}
+	// value enum
+	if err := m.validateReServiceCodeEnum("reServiceCode", "body", m.ReServiceCode); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -47,7 +47,7 @@ type MTOServiceItemDomesticCrating struct {
 	// Required: true
 	Item *MTOServiceItemDimension `json:"item"`
 
-	// re service code
+	// Service codes allowed for this model type.
 	// Required: true
 	// Enum: [DCRT DCRTSA DUCRT]
 	ReServiceCode *string `json:"reServiceCode"`
@@ -167,7 +167,7 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 		// Required: true
 		Item *MTOServiceItemDimension `json:"item"`
 
-		// re service code
+		// Service codes allowed for this model type.
 		// Required: true
 		// Enum: [DCRT DCRTSA DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
@@ -263,7 +263,7 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 		// Required: true
 		Item *MTOServiceItemDimension `json:"item"`
 
-		// re service code
+		// Service codes allowed for this model type.
 		// Required: true
 		// Enum: [DCRT DCRTSA DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`

--- a/pkg/gen/primemessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_model_type.go
@@ -14,7 +14,12 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// MTOServiceItemModelType Describes all model sub-types for a MTOServiceItem model.
+// MTOServiceItemModelType Describes all model sub-types for a MTOServiceItem model. Prime can only request the following service codes for which they will use the corresponding modelType
+//   * DOFSIT - MTOServiceItemDOFSIT
+//   * DDFSIT - MTOServiceItemDDFSIT
+//   * DOSHUT, DDSHUT - MTOServiceItemShuttle
+//   * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+//
 // swagger:model MTOServiceItemModelType
 type MTOServiceItemModelType string
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -39,7 +39,7 @@ type MTOServiceItemShuttle struct {
 	// Required: true
 	Description *string `json:"description"`
 
-	// re service code
+	// Service codes allowed for this model type.
 	// Required: true
 	// Enum: [DOSHUT DDSHUT]
 	ReServiceCode *string `json:"reServiceCode"`
@@ -153,7 +153,7 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		// Required: true
 		Description *string `json:"description"`
 
-		// re service code
+		// Service codes allowed for this model type.
 		// Required: true
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`
@@ -243,7 +243,7 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		// Required: true
 		Description *string `json:"description"`
 
-		// re service code
+		// Service codes allowed for this model type.
 		// Required: true
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`

--- a/pkg/gen/primemessages/re_service_code.go
+++ b/pkg/gen/primemessages/re_service_code.go
@@ -14,7 +14,11 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// ReServiceCode re service code
+// ReServiceCode This is the full list of service items that can be found on a shipment. Not all service items
+// may be requested by the Prime, but may be returned in a response.
+//
+// Documentation of all the service items will be provided.
+//
 // swagger:model ReServiceCode
 type ReServiceCode string
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -396,7 +396,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	switch mtoServiceItem.ReService.Code {
 	case models.ReServiceCodeDOFSIT:
 		payload = &primemessages.MTOServiceItemDOFSIT{
-			ReServiceCode:    primemessages.ReServiceCode(mtoServiceItem.ReService.Code),
+			ReServiceCode:    string(mtoServiceItem.ReService.Code),
 			PickupPostalCode: mtoServiceItem.PickupPostalCode,
 			Reason:           mtoServiceItem.Reason,
 		}
@@ -404,7 +404,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 		firstContact := getCustomerContact(mtoServiceItem.CustomerContacts, models.CustomerContactTypeFirst)
 		secondContact := getCustomerContact(mtoServiceItem.CustomerContacts, models.CustomerContactTypeSecond)
 		payload = &primemessages.MTOServiceItemDDFSIT{
-			ReServiceCode:               primemessages.ReServiceCode(mtoServiceItem.ReService.Code),
+			ReServiceCode:               string(mtoServiceItem.ReService.Code),
 			TimeMilitary1:               handlers.FmtString(firstContact.TimeMilitary),
 			FirstAvailableDeliveryDate1: handlers.FmtDate(firstContact.FirstAvailableDeliveryDate),
 			TimeMilitary2:               handlers.FmtString(secondContact.TimeMilitary),

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -941,7 +941,13 @@ definitions:
       - APPROVED
       - REJECTED
   MTOServiceItemModelType:
-    description: Describes all model sub-types for a MTOServiceItem model.
+    description: >
+      Describes all model sub-types for a MTOServiceItem model.
+      Prime can only request the following service codes for which they will use the corresponding modelType
+        * DOFSIT - MTOServiceItemDOFSIT
+        * DDFSIT - MTOServiceItemDDFSIT
+        * DOSHUT, DDSHUT - MTOServiceItemShuttle
+        * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
     type: string
     enum:
       - MTOServiceItemBasic
@@ -1008,7 +1014,10 @@ definitions:
       - type: object
         properties:
           reServiceCode:
-            $ref: '#/definitions/ReServiceCode'
+            type: string
+            description: "Service code allowed for this model type."
+            enum:
+              - DOFSIT # Domestic Origin First Day SIT
           reason:
             type: string
             example: Storage items need to be picked up
@@ -1027,7 +1036,10 @@ definitions:
       - type: object
         properties:
           reServiceCode:
-            $ref: '#/definitions/ReServiceCode'
+            type: string
+            description: "Service code allowed for this model type."
+            enum:
+              - DDFSIT # Domestic Destination First Day SIT
           type:
             $ref: '#/definitions/CustomerContactType'
           timeMilitary1:
@@ -1057,6 +1069,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
+            description: "Service codes allowed for this model type."
             enum:
               - DOSHUT # Domestic Origin Shuttle Service
               - DDSHUT # Domestic Destination Shuttle Service
@@ -1078,6 +1091,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
+            description: "Service codes allowed for this model type."
             enum:
               - DCRT # Domestic Crating
               - DCRTSA # Domestic Crating - Standalone
@@ -1238,6 +1252,11 @@ definitions:
     type: object
   ReServiceCode:
     type: string
+    description: |
+      This is the full list of service items that can be found on a shipment. Not all service items
+      may be requested by the Prime, but may be returned in a response.
+
+      Documentation of all the service items will be provided.
     enum:
       - CS
       - DBHF


### PR DESCRIPTION
## Description

Cleaned up the list of enums for the serviceItems to only include the allowed items in each `modelType`. 

Unfortunately can NOT clean up the list for `ServiceItemBasic` because the same definition is used in other locations that can and do return a variety of service types. 

I also tried making a separate definition for `ServiceItem` that points only to the `modelTypes` that are allowed for the prime to create, and due to the polymorphism, that does not work. 

So instead I have added to the documentation the list of currently enabled `serviceCodes` and the `modelType` to use in that case. 

## Reviewer Notes

YOu can check it out in Redoc - here's the link to the version in this branch
https://raw.githubusercontent.com/transcom/mymove/sc-mb-2781-add-service-item-cleanup/swagger/prime.yaml



