### PR TITLE
MB-2811 Add test for updating a minimal mto shipment

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -67,7 +67,6 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 		oldShipment.ActualPickupDate = updatedShipment.ActualPickupDate
 	}
 
-	//scheduledPickupTime := *oldShipment.ScheduledPickupDate
 	if updatedShipment.ScheduledPickupDate != nil {
 		scheduledPickupTime := updatedShipment.ScheduledPickupDate
 		oldShipment.ScheduledPickupDate = scheduledPickupTime

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -386,6 +386,19 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(*updatedMTOShipment.MTOAgents[0].FirstName, newFirstName)
 		suite.Equal(*updatedMTOShipment.MTOAgents[1].LastName, newLastName)
 	})
+
+	suite.T().Run("Successful update to a minimal MTO shipment", func(t *testing.T) {
+
+		oldShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{})
+		eTag := etag.GenerateEtag(oldShipment.UpdatedAt)
+		updatedShipment := models.MTOShipment{
+			ID:                   oldShipment.ID,
+			PrimeEstimatedWeight: &primeEstimatedWeight,
+		}
+		_, err := mtoShipmentUpdater.UpdateMTOShipment(&updatedShipment, eTag)
+		suite.NoError(err)
+
+	})
 }
 
 func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {


### PR DESCRIPTION
## Description

* [MB-2811](https://dp3.atlassian.net/browse/MB-2811) found a nil pointer dereference error in the MTO Shipment Updater, if the `oldShipment` did not have a set scheduledPickupDate.
* @LeDeep's PR #4221 included a fix for this error.
* This PR adds a test to ensure that updating a minimal MTO shipment does not cause any errors.

## Setup

* Relevant code fix can be found in `mto_shipment_updater.go`, line 70-73

```
	if updatedShipment.ScheduledPickupDate != nil {
		scheduledPickupTime := updatedShipment.ScheduledPickupDate
		oldShipment.ScheduledPickupDate = scheduledPickupTime
	}
```

To run the tests:

```
$ go test ./pkg/services/mto_shipment -testify.m TestMTOShipmentUpdater
```

## Code Review Verification Steps
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2811) for this change
