### PR TITLE
MB-2665 Prime API: Add error payloads to Create Upload endpoint

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -444,6 +444,9 @@ func init() {
           "404": {
             "$ref": "#/responses/NotFound"
           },
+          "422": {
+            "$ref": "#/responses/UnprocessableEntity"
+          },
           "500": {
             "$ref": "#/responses/ServerError"
           }
@@ -2438,6 +2441,12 @@ func init() {
             "description": "The requested resource wasn't found.",
             "schema": {
               "$ref": "#/definitions/ClientError"
+            }
+          },
+          "422": {
+            "description": "The payload was unprocessable.",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {

--- a/pkg/gen/primeapi/primeoperations/uploads/create_upload_responses.go
+++ b/pkg/gen/primeapi/primeoperations/uploads/create_upload_responses.go
@@ -233,6 +233,50 @@ func (o *CreateUploadNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
+// CreateUploadUnprocessableEntityCode is the HTTP code returned for type CreateUploadUnprocessableEntity
+const CreateUploadUnprocessableEntityCode int = 422
+
+/*CreateUploadUnprocessableEntity The payload was unprocessable.
+
+swagger:response createUploadUnprocessableEntity
+*/
+type CreateUploadUnprocessableEntity struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *primemessages.ValidationError `json:"body,omitempty"`
+}
+
+// NewCreateUploadUnprocessableEntity creates CreateUploadUnprocessableEntity with default headers values
+func NewCreateUploadUnprocessableEntity() *CreateUploadUnprocessableEntity {
+
+	return &CreateUploadUnprocessableEntity{}
+}
+
+// WithPayload adds the payload to the create upload unprocessable entity response
+func (o *CreateUploadUnprocessableEntity) WithPayload(payload *primemessages.ValidationError) *CreateUploadUnprocessableEntity {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create upload unprocessable entity response
+func (o *CreateUploadUnprocessableEntity) SetPayload(payload *primemessages.ValidationError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *CreateUploadUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(422)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // CreateUploadInternalServerErrorCode is the HTTP code returned for type CreateUploadInternalServerError
 const CreateUploadInternalServerErrorCode int = 500
 

--- a/pkg/gen/primeclient/uploads/create_upload_responses.go
+++ b/pkg/gen/primeclient/uploads/create_upload_responses.go
@@ -54,6 +54,12 @@ func (o *CreateUploadReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 422:
+		result := NewCreateUploadUnprocessableEntity()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewCreateUploadInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -222,6 +228,39 @@ func (o *CreateUploadNotFound) GetPayload() *primemessages.ClientError {
 func (o *CreateUploadNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(primemessages.ClientError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateUploadUnprocessableEntity creates a CreateUploadUnprocessableEntity with default headers values
+func NewCreateUploadUnprocessableEntity() *CreateUploadUnprocessableEntity {
+	return &CreateUploadUnprocessableEntity{}
+}
+
+/*CreateUploadUnprocessableEntity handles this case with default header values.
+
+The payload was unprocessable.
+*/
+type CreateUploadUnprocessableEntity struct {
+	Payload *primemessages.ValidationError
+}
+
+func (o *CreateUploadUnprocessableEntity) Error() string {
+	return fmt.Sprintf("[POST /payment-requests/{paymentRequestID}/uploads][%d] createUploadUnprocessableEntity  %+v", 422, o.Payload)
+}
+
+func (o *CreateUploadUnprocessableEntity) GetPayload() *primemessages.ValidationError {
+	return o.Payload
+}
+
+func (o *CreateUploadUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(primemessages.ValidationError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -4,6 +4,9 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 
+	"github.com/transcom/mymove/pkg/handlers/primeapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/services"
+
 	"github.com/gofrs/uuid"
 
 	"go.uber.org/zap"
@@ -36,31 +39,45 @@ type CreateUploadHandler struct {
 // Handle creates uploads
 func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middleware.Responder {
 	_, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// TODO https://dp3.atlassian.net/browse/MB-1969
-	var contractorID uuid.UUID // TODO not populated. Do not know how get from MTO to Contractor ID
+
+	var contractorID uuid.UUID
 	contractor, err := models.FetchGHCPrimeTestContractor(h.DB())
 	if err != nil {
 		logger.Error("error getting TEST GHC Prime Contractor", zap.Error(err))
-		return uploadop.NewCreateUploadBadRequest()
+		// Setting a custom message so we don't reveal the SQL error:
+		return uploadop.NewCreateUploadBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage,
+			"Unable to get the TEST GHC Prime Contractor.", h.GetTraceID()))
 	}
 	if contractor != nil {
 		contractorID = contractor.ID
 	} else {
 		logger.Error("error with TEST GHC Prime Contractor value is nil")
-		return uploadop.NewCreateUploadBadRequest()
+		// Same message as before (same base issue):
+		return uploadop.NewCreateUploadBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage,
+			"Unable to get the TEST GHC Prime Contractor.", h.GetTraceID()))
 	}
 
 	paymentRequestID, err := uuid.FromString(params.PaymentRequestID)
 	if err != nil {
 		logger.Error("error creating uuid from string", zap.Error(err))
-		return uploadop.NewCreateUploadBadRequest()
+		return uploadop.NewCreateUploadUnprocessableEntity().WithPayload(payloads.ValidationError(
+			"The payment request ID must be a valid UUID.", h.GetTraceID(), nil))
 	}
 
 	uploadCreator := paymentrequest.NewPaymentRequestUploadCreator(h.DB(), logger, h.FileStorer())
 	createdUpload, err := uploadCreator.CreateUpload(params.File, paymentRequestID, contractorID)
 	if err != nil {
-		logger.Error("cannot create payment request upload", zap.Error(err))
-		return uploadop.NewCreateUploadBadRequest()
+		logger.Error("primeapi.CreateUploadHandler error", zap.Error(err))
+		switch e := err.(type) {
+		case *services.BadDataError:
+			return uploadop.NewCreateUploadBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceID()))
+		case services.NotFoundError:
+			return uploadop.NewCreateUploadNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
+		case services.InvalidInputError:
+			return uploadop.NewCreateUploadUnprocessableEntity().WithPayload(payloads.ValidationError(err.Error(), h.GetTraceID(), e.ValidationErrors))
+		default:
+			return uploadop.NewCreateUploadInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+		}
 	}
 
 	returnPayload := payloadForPaymentRequestUploadModel(*createdUpload)

--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -77,19 +77,19 @@ func (p *paymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRe
 		}
 		verrs, err := tx.ValidateAndCreate(&proofOfServiceDoc)
 		if err != nil {
-			return fmt.Errorf("failure creating proof of service doc: %w", err)
+			return fmt.Errorf("failure creating proof of service doc: %w", err) // server err
 		}
 		if verrs.HasAny() {
-			return fmt.Errorf("validation error creating proof of service doc: %w", verrs)
+			return services.NewInvalidCreateInputError(verrs, "validation error with creating proof of service doc")
 		}
 
 		posID := &proofOfServiceDoc.ID
 		primeUpload, verrs, err := newUploader.CreatePrimeUploadForDocument(posID, contractorID, uploader.File{File: aFile}, uploader.AllowedTypesPaymentRequest)
 		if verrs.HasAny() {
-			return fmt.Errorf("validation error creating payment request primeUpload: %w", verrs)
+			return services.NewInvalidCreateInputError(verrs, "validation error with creating payment request")
 		}
 		if err != nil {
-			return fmt.Errorf("failure creating payment request primeUpload: %w", err)
+			return fmt.Errorf("failure creating payment request primeUpload: %w", err) // server err
 		}
 		upload = &primeUpload.Upload
 		return nil

--- a/pkg/uploader/prime_uploader.go
+++ b/pkg/uploader/prime_uploader.go
@@ -28,6 +28,9 @@ type PrimeUploader struct {
 func NewPrimeUploader(db *pop.Connection, logger Logger, storer storage.FileStorer, fileSizeLimit ByteSize) (*PrimeUploader, error) {
 	uploader, err := NewUploader(db, logger, storer, fileSizeLimit, models.UploadTypePRIME)
 	if err != nil {
+		if err == ErrFileSizeLimitExceedsMax {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not create uploader.PrimeUploader for PrimeUpload: %w", err)
 	}
 	return &PrimeUploader{

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -329,6 +329,8 @@ paths:
           $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
+        '422':
+          $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
 definitions:


### PR DESCRIPTION
## Description

Adds consistently formatted error payloads to the errors from the Create Upload endpoint. Moves to the format of returning service errors (ex. `services.NotFoundError`) from the service object so that the handler can return the correct response code and error payload.

## Setup

You'll need to populate your test DB with data and run your server to test. Full instructions for how to set up the Prime API for testing can be found here: https://github.com/transcom/prime_api_deliverable/wiki

### With Postman

- Navigate to the `createUpload` endpoint under `payment-requests`
- Put "00000000-0000-0000-0000-0c0b9272e208" as the payment request ID
- Navigate to the Body tab
- Select "form-data" as the option and select "File" from the drop down in the "file" cell in the "Key" column
- Choose a PDF to test with
- Submit
- You should get a 404 response in the ClientError format
- Try again with the payment request ID "a2c34dba-015f-4f96-a38b-0c0b9272e208" and you should get a 200 😄 

### With `prime-api-client`

Recreate the binary if needed. Then use the following command:

```sh
prime-api-client --insecure create-upload --paymentRequestID <non-existent ID like 00000000-0000-0000-0000-0c0b9272e208> --filename <path to test PDF file>
```

You should get a 404 ClientError response. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2665) for this change
