### PR TITLE
[MB-2875] Fetch All MTOs service object

### DIFF
--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -34,6 +34,7 @@ func NewPrimeAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	primeAPI.MoveTaskOrderFetchMTOUpdatesHandler = FetchMTOUpdatesHandler{
 		context,
+		movetaskorder.NewMoveTaskOrderFetcher(context.DB()),
 	}
 
 	primeAPI.MtoServiceItemCreateMTOServiceItemHandler = CreateMTOServiceItemHandler{

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -1,50 +1,28 @@
 package primeapi
 
 import (
-	"time"
-
 	"github.com/transcom/mymove/pkg/services"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/handlers/primeapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/models"
-
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/internal/payloads"
 )
 
 // FetchMTOUpdatesHandler lists move task orders with the option to filter since a particular date
 type FetchMTOUpdatesHandler struct {
 	handlers.HandlerContext
+	services.MoveTaskOrderFetcher
 }
 
 // Handle fetches all move task orders with the option to filter since a particular date
 func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	var mtos models.MoveTaskOrders
-
-	query := h.DB().Where("available_to_prime_at IS NOT NULL").Eager(
-		"PaymentRequests.PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
-		"MTOServiceItems.ReService",
-		"MTOServiceItems.Dimensions",
-		"MTOServiceItems.CustomerContacts",
-		"MTOShipments.DestinationAddress",
-		"MTOShipments.PickupAddress",
-		"MTOShipments.SecondaryDeliveryAddress",
-		"MTOShipments.SecondaryPickupAddress",
-		"MTOShipments.MTOAgents",
-		"MoveOrder.Customer",
-		"MoveOrder.Entitlement")
-	if params.Since != nil {
-		since := time.Unix(*params.Since, 0)
-		query = query.Where("updated_at > ?", since)
-	}
-
-	err := query.All(&mtos)
+	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(true, params.Since)
 
 	if err != nil {
 		logger.Error("Unable to fetch records:", zap.Error(err))

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -59,7 +59,10 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandler() {
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
-	handler := FetchMTOUpdatesHandler{HandlerContext: context}
+	handler := FetchMTOUpdatesHandler{
+		HandlerContext:       context,
+		MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(suite.DB()),
+	}
 
 	suite.T().Run("with mto service item dimensions", func(t *testing.T) {
 		reServiceDomCrating := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
@@ -188,7 +191,7 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandlerPaymentRequest() {
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
-	handler := FetchMTOUpdatesHandler{HandlerContext: context}
+	handler := FetchMTOUpdatesHandler{HandlerContext: context, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(suite.DB())}
 
 	response := handler.Handle(params)
 
@@ -228,7 +231,7 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandlerMinimal() {
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
-	handler := FetchMTOUpdatesHandler{HandlerContext: context}
+	handler := FetchMTOUpdatesHandler{HandlerContext: context, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(suite.DB())}
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)
@@ -268,7 +271,7 @@ func (suite *HandlerSuite) TestListMoveTaskOrdersHandlerReturnsUpdated() {
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
-	handler := FetchMTOUpdatesHandler{HandlerContext: context}
+	handler := FetchMTOUpdatesHandler{HandlerContext: context, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher(suite.DB())}
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)

--- a/pkg/services/mocks/MoveTaskOrderFetcher.go
+++ b/pkg/services/mocks/MoveTaskOrderFetcher.go
@@ -37,6 +37,29 @@ func (_m *MoveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*
 	return r0, r1
 }
 
+// ListAllMoveTaskOrders provides a mock function with given fields: isAvailableToPrime, since
+func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.MoveTaskOrders, error) {
+	ret := _m.Called(isAvailableToPrime, since)
+
+	var r0 models.MoveTaskOrders
+	if rf, ok := ret.Get(0).(func(bool, *int64) models.MoveTaskOrders); ok {
+		r0 = rf(isAvailableToPrime, since)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(models.MoveTaskOrders)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(bool, *int64) error); ok {
+		r1 = rf(isAvailableToPrime, since)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListMoveTaskOrders provides a mock function with given fields: moveOrderID
 func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.MoveTaskOrder, error) {
 	ret := _m.Called(moveOrderID)

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -20,6 +20,7 @@ type MoveTaskOrderCreator interface {
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*models.MoveTaskOrder, error)
 	ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.MoveTaskOrder, error)
+	ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.MoveTaskOrders, error)
 }
 
 //MoveTaskOrderUpdater is the service object interface for MakeAvailableToPrime

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -29,6 +29,7 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]model
 	return moveTaskOrders, nil
 }
 
+//ListAllMoveTaskOrders retrieves all Move Task Orders that may or may not be available to prime
 func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.MoveTaskOrders, error) {
 	var moveTaskOrders models.MoveTaskOrders
 	var err error

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -2,6 +2,7 @@ package movetaskorder
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
@@ -26,6 +27,59 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]model
 		}
 	}
 	return moveTaskOrders, nil
+}
+
+func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.MoveTaskOrders, error) {
+	var moveTaskOrders models.MoveTaskOrders
+	var err error
+	if isAvailableToPrime {
+		query := f.db.Where("available_to_prime_at IS NOT NULL").Eager(
+			"PaymentRequests.PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
+			"MTOServiceItems.ReService",
+			"MTOServiceItems.Dimensions",
+			"MTOServiceItems.CustomerContacts",
+			"MTOShipments.DestinationAddress",
+			"MTOShipments.PickupAddress",
+			"MTOShipments.SecondaryDeliveryAddress",
+			"MTOShipments.SecondaryPickupAddress",
+			"MTOShipments.MTOAgents",
+			"MoveOrder.Customer",
+			"MoveOrder.Entitlement")
+
+		if since != nil {
+			since := time.Unix(*since, 0)
+			query = query.Where("updated_at > ?", since)
+		}
+
+		err = query.All(&moveTaskOrders)
+	} else {
+		query := f.db.Eager(
+			"PaymentRequests.PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
+			"MTOServiceItems.ReService",
+			"MTOServiceItems.Dimensions",
+			"MTOServiceItems.CustomerContacts",
+			"MTOShipments.DestinationAddress",
+			"MTOShipments.PickupAddress",
+			"MTOShipments.SecondaryDeliveryAddress",
+			"MTOShipments.SecondaryPickupAddress",
+			"MTOShipments.MTOAgents",
+			"MoveOrder.Customer",
+			"MoveOrder.Entitlement")
+
+		err = query.All(&moveTaskOrders)
+	}
+
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return models.MoveTaskOrders{}, services.NotFoundError{}
+		default:
+			return models.MoveTaskOrders{}, err
+		}
+	}
+
+	return moveTaskOrders, nil
+
 }
 
 // NewMoveTaskOrderFetcher creates a new struct with the service dependencies

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -1,8 +1,11 @@
 package movetaskorder_test
 
 import (
-	. "github.com/transcom/mymove/pkg/services/move_task_order"
+	"testing"
+	"time"
 
+	"github.com/transcom/mymove/pkg/models"
+	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
@@ -42,4 +45,46 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 	suite.NotNil(expectedMTO.ReferenceID)
 	suite.Nil(expectedMTO.AvailableToPrimeAt)
 	suite.False(expectedMTO.IsCanceled)
+}
+
+func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
+	suite.T().Run("all move task orders", func(t *testing.T) {
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+
+		mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
+
+		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(false, nil)
+		suite.NoError(err)
+
+		mto := moveTaskOrders[0]
+
+		suite.Equal(len(moveTaskOrders), 3)
+		suite.Nil(mto.AvailableToPrimeAt)
+	})
+
+	suite.T().Run("all move task orders that are available to prime", func(t *testing.T) {
+		time1 := time.Now()
+		time2 := time.Now()
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
+			MoveTaskOrder: models.MoveTaskOrder{
+				AvailableToPrimeAt: &time1,
+			},
+		})
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
+			MoveTaskOrder: models.MoveTaskOrder{
+				AvailableToPrimeAt: &time2,
+			},
+		})
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+		testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+
+		mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
+
+		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(true, nil)
+		suite.NoError(err)
+
+		suite.Equal(len(moveTaskOrders), 2)
+	})
 }

--- a/pkg/testdatagen/make_move_task_order.go
+++ b/pkg/testdatagen/make_move_task_order.go
@@ -35,12 +35,13 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 	}
 
 	moveTaskOrder := models.MoveTaskOrder{
-		MoveOrder:    moveOrder,
-		MoveOrderID:  moveOrder.ID,
-		ContractorID: contractorID,
-		ReferenceID:  referenceID,
-		IsCanceled:   false,
-		PPMType:      ppmType,
+		AvailableToPrimeAt: assertions.MoveTaskOrder.AvailableToPrimeAt,
+		MoveOrder:          moveOrder,
+		MoveOrderID:        moveOrder.ID,
+		ContractorID:       contractorID,
+		ReferenceID:        referenceID,
+		IsCanceled:         false,
+		PPMType:            ppmType,
 	}
 
 	// Overwrite values with those from assertions


### PR DESCRIPTION
## Description

Extract querying of all MTOs into service object method for better reuse

## Reviewer Notes
- Wasn't sure of a way only using the eager query once but conditionally adding the Where query if isAvailableToPrime was true, if there even is a way

## Setup
`make server_run`
Use fetch all MTO updates primeapi endpoint

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References
* [Jira story](https://dp3.atlassian.net/browse/MB-2492) for this change