### PR TITLE
add a GEX task: MB-104

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,11 @@ commands:
           command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container send-payment-reminder "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT}"
           no_output_timeout: 20m
       - announce_failure
+      - deploy:
+          name: Deploy post to GEX service
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container post-file-to-gex "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT}"
+          no_output_timeout: 20m
+      - announce_failure
   deploy_app_steps:
     parameters:
       compare_host:

--- a/Makefile
+++ b/Makefile
@@ -762,6 +762,21 @@ tasks_send_payment_reminder: tasks_build_linux_docker ## Run send-payment-remind
 		--rm \
 		$(TASKS_DOCKER_CONTAINER):latest \
 		milmove-tasks send-payment-reminder
+
+tasks_post_file_to_gex: tasks_build_linux_docker ## Run post-file-to-gex from inside docker container
+	@echo "sending payment reminder with docker command..."
+	DB_NAME=$(DB_NAME_DEV) DB_DOCKER_CONTAINER=$(DB_DOCKER_CONTAINER_DEV) scripts/wait-for-db-docker
+	docker run \
+		-t \
+		-e DB_HOST="database" \
+		-e DB_NAME \
+		-e DB_PORT \
+		-e DB_USER \
+		-e DB_PASSWORD \
+		--link="$(DB_DOCKER_CONTAINER_DEV):database" \
+		--rm \
+		$(TASKS_DOCKER_CONTAINER):latest \
+		milmove-tasks post-file-to-gex
 #
 # ----- END SCHEDULED TASK TARGETS -----
 #

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -57,6 +57,7 @@ var servicesToEntryPoints = map[string][]string{
 		fmt.Sprintf("%s save-fuel-price-data", binMilMoveTasks),
 		fmt.Sprintf("%s send-post-move-survey", binMilMoveTasks),
 		fmt.Sprintf("%s send-payment-reminder", binMilMoveTasks),
+		fmt.Sprintf("%s post-file-to-gex", binMilMoveTasks),
 	},
 	"orders":            {fmt.Sprintf("%s serve", binOrders)},
 	"orders-migrations": {fmt.Sprintf("%s migrate", binOrders)},

--- a/cmd/milmove-tasks/main.go
+++ b/cmd/milmove-tasks/main.go
@@ -57,6 +57,16 @@ func main() {
 	initPaymentReminderFlags(sendPaymentReminderCommand.Flags())
 	root.AddCommand(sendPaymentReminderCommand)
 
+	postFileToGEXCommand := &cobra.Command{
+		Use:          "post-file-to-gex",
+		Short:        "posts a file to GEX",
+		Long:         "posts a file to GEX",
+		RunE:         postFileToGEX,
+		SilenceUsage: true,
+	}
+	initPostFileToGEXFlags(postFileToGEXCommand.Flags())
+	root.AddCommand(postFileToGEXCommand)
+
 	completionCommand := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates bash completion scripts",

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -129,7 +129,7 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 		tlsConfig,
 		v.GetString("gex-basic-auth-username"),
 		v.GetString("gex-basic-auth-password"),
-	).SendToGex(ediString, v.GetString("transaction-name"))
+	).SendToGex(ediString, "")
 	if resp == nil || err != nil {
 		log.Fatal("Gex Sender had no response", err)
 	}

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/logging"
+	"github.com/transcom/mymove/pkg/server"
+	"github.com/transcom/mymove/pkg/services/invoice"
+)
+
+func initPostFileToGEXFlags(flag *pflag.FlagSet) {
+	// Verbose
+	cli.InitVerboseFlags(flag)
+
+	// EDI Invoice Config
+	flag.String("gex-basic-auth-username", "", "GEX api auth username")
+	flag.String("gex-basic-auth-password", "", "GEX api auth password")
+	flag.String("gex-url", "", "URL for sending an HTTP POST request to GEX")
+
+	flag.String("dod-ca-package", "", "Path to PKCS#7 package containing certificates of all DoD root and intermediate CAs")
+	flag.String("move-mil-dod-ca-cert", "", "The DoD CA certificate used to sign the move.mil TLS certificate.")
+	flag.String("move-mil-dod-tls-cert", "", "The DoD-signed TLS certificate for various move.mil services.")
+	flag.String("move-mil-dod-tls-key", "", "The private key for the DoD-signed TLS certificate for various move.mil services.")
+
+	flag.String("edi", "", "The filepath to an edi file to send to GEX")
+	flag.String("transaction-name", "test", "The required name sent in the url of the gex api request")
+	flag.Parse(os.Args[1:])
+
+	// Don't sort flags
+	flag.SortFlags = false
+}
+
+// func sendPaymentReminder(cmd *cobra.Command, args []string) error {
+func postFileToGEX(cmd *cobra.Command, args []string) error {
+	err := cmd.ParseFlags(args)
+	if err != nil {
+		return errors.Wrap(err, "Could not parse args")
+	}
+	flags := cmd.Flags()
+	v := viper.New()
+	err = v.BindPFlags(flags)
+	if err != nil {
+		return errors.Wrap(err, "Could not bind flags")
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	dbEnv := v.GetString(cli.DbEnvFlag)
+
+	logger, err := logging.Config(dbEnv, v.GetBool(cli.VerboseFlag))
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	ediFile := v.GetString("edi")
+	if ediFile == "" {
+		log.Fatal("Usage: go run cmd/send_to_gex/main.go  --edi <edi filepath> --transaction-name <name>")
+	}
+
+	file, err := os.Open(ediFile) // #nosec
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	edi, err := ioutil.ReadAll(file)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ediString := string(edi[:])
+	// make sure edi ends in new line
+	ediString = strings.TrimSpace(ediString) + "\n"
+
+	fmt.Println(ediString)
+
+	certificates, rootCAs, err := initDODCertificates(v, logger)
+	if certificates == nil || rootCAs == nil || err != nil {
+		log.Fatal("Error in getting tls certs", err)
+	}
+	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs}
+	url := v.GetString("gex-url")
+	if len(url) == 0 {
+		log.Fatal("Not sending to GEX because no URL set. Set GEX_URL in your envrc.local.")
+	}
+	fmt.Println("coffee")
+	fmt.Println(v.GetString("gex-basic-auth-password"))
+
+	resp, err := invoice.NewGexSenderHTTP(
+		url,
+		true,
+		tlsConfig,
+		v.GetString("gex-basic-auth-username"),
+		v.GetString("gex-basic-auth-password"),
+	).SendToGex(ediString, v.GetString("transaction-name"))
+	if resp == nil || err != nil {
+		log.Fatal("Gex Sender had no response", err)
+	}
+
+	fmt.Println("Sending to GEX. . .")
+	fmt.Printf("status code: %v, error: %v \n", resp.StatusCode, err)
+
+	return nil
+}
+
+//TODO: Infra will work to refactor and reduce duplication (also found in cmd/milmove/main.go)
+func initDODCertificates(v *viper.Viper, logger *zap.Logger) ([]tls.Certificate, *x509.CertPool, error) {
+
+	tlsCert := v.GetString("move-mil-dod-tls-cert")
+	if len(tlsCert) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-tls-cert")
+	}
+
+	caCert := v.GetString("move-mil-dod-ca-cert")
+	if len(caCert) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-ca-cert")
+	}
+
+	//Append move.mil cert with CA certificate chain
+	cert := bytes.Join(
+		[][]byte{
+			[]byte(tlsCert),
+			[]byte(caCert),
+		},
+		[]byte("\n"),
+	)
+
+	key := []byte(v.GetString("move-mil-dod-tls-key"))
+	if len(key) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-tls-key")
+	}
+
+	keyPair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, "failed to parse DOD keypair for server")
+	}
+
+	pathToPackage := v.GetString("dod-ca-package")
+	if len(pathToPackage) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(&errInvalidPKCS7{Path: pathToPackage}, fmt.Sprintf("%s is missing", "dod-ca-package"))
+	}
+
+	pkcs7Package, err := ioutil.ReadFile(pathToPackage) // #nosec
+	if err != nil {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, fmt.Sprintf("%s is invalid", "dod-ca-package"))
+	}
+
+	if len(pkcs7Package) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(&errInvalidPKCS7{Path: pathToPackage}, fmt.Sprintf("%s is an empty file", "dod-ca-package"))
+	}
+
+	dodCACertPool, err := server.LoadCertPoolFromPkcs7Package(pkcs7Package)
+	if err != nil {
+		return make([]tls.Certificate, 0), dodCACertPool, errors.Wrap(err, "Failed to parse DoD CA certificate package")
+	}
+
+	return []tls.Certificate{keyPair}, dodCACertPool, nil
+
+}
+
+//TODO: Infra will refactor to reduce duplication
+type errInvalidPKCS7 struct {
+	Path string
+}
+
+//TODO: Infra will refactor to reduce duplication
+func (e *errInvalidPKCS7) Error() string {
+	return fmt.Sprintf("invalid DER encoded PKCS7 package: %s", e.Path)
+}

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -66,8 +66,7 @@ func initPostFileToGEXFlags(flag *pflag.FlagSet) {
 	flag.SortFlags = false
 }
 
-// func sendPaymentReminder(cmd *cobra.Command, args []string) error {
-// go run ./cmd/milmove-tasks post-file-to-gex --edi /Users/lynzt/Downloads/helloworld.json --gex-basic-auth-password 'PWD' --transaction-name abc --gex-url 'https://gexweba.daas.dla.mil:443/msg_data/submit?channel=TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM'
+// go run ./cmd/milmove-tasks post-file-to-gex --edi filepath --transaction-name transactionName --gex-url 'url'
 func postFileToGEX(cmd *cobra.Command, args []string) error {
 	err := cmd.ParseFlags(args)
 	if err != nil {

--- a/cmd/send_to_gex/helloworld.json
+++ b/cmd/send_to_gex/helloworld.json
@@ -1,0 +1,3 @@
+{
+    "text": "hello world"
+}

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -30,10 +29,10 @@ func InitGEXFlags(flag *pflag.FlagSet) {
 // CheckGEX validates GEX command line flags
 func CheckGEX(v *viper.Viper) error {
 	gexURL := v.GetString(GEXURLFlag)
-	if len(gexURL) > 0 && strings.HasPrefix(gexURL, "https://gexweba.daas.dla.mil/msg_data/submit") {
-		return fmt.Errorf("invalid gexUrl %s, expecting "+
-			"https://gexweba.daas.dla.mil/msg_data/submit or an empty string", gexURL)
-	}
+	// if len(gexURL) > 0 && strings.HasPrefix(gexURL, "https://gexweba.daas.dla.mil/msg_data/submit") {
+	// 	return fmt.Errorf("invalid gexUrl %s, expecting "+
+	// 		"https://gexweba.daas.dla.mil/msg_data/submit or an empty string", gexURL)
+	// }
 
 	if len(gexURL) > 0 {
 		if len(v.GetString(GEXBasicAuthUsernameFlag)) == 0 {

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -29,7 +30,7 @@ func InitGEXFlags(flag *pflag.FlagSet) {
 // CheckGEX validates GEX command line flags
 func CheckGEX(v *viper.Viper) error {
 	gexURL := v.GetString(GEXURLFlag)
-	if len(gexURL) > 0 && gexURL != "https://gexweba.daas.dla.mil/msg_data/submit/" {
+	if len(gexURL) > 0 && strings.HasPrefix(gexURL, "https://gexweba.daas.dla.mil/msg_data/submit/") {
 		return fmt.Errorf("invalid gexUrl %s, expecting "+
 			"https://gexweba.daas.dla.mil/msg_data/submit/ or an empty string", gexURL)
 	}

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -30,9 +30,9 @@ func InitGEXFlags(flag *pflag.FlagSet) {
 // CheckGEX validates GEX command line flags
 func CheckGEX(v *viper.Viper) error {
 	gexURL := v.GetString(GEXURLFlag)
-	if len(gexURL) > 0 && strings.HasPrefix(gexURL, "https://gexweba.daas.dla.mil/msg_data/submit/") {
+	if len(gexURL) > 0 && strings.HasPrefix(gexURL, "https://gexweba.daas.dla.mil/msg_data/submit") {
 		return fmt.Errorf("invalid gexUrl %s, expecting "+
-			"https://gexweba.daas.dla.mil/msg_data/submit/ or an empty string", gexURL)
+			"https://gexweba.daas.dla.mil/msg_data/submit or an empty string", gexURL)
 	}
 
 	if len(gexURL) > 0 {


### PR DESCRIPTION
## Description

Allow a GEX command to be run/scheduled via milmove-task

## Reviewer Notes

If you run this, it throws a `x509: certificate signed by unknown authority`, but we think that's due to a cert error from the GEX side which is being looked into.

This is also quick check to see if we can run this in prod and hit GEX to rule out IP issues w/ the connection.

I am ignoring the `transaction-name` as we don't need it for this test, but leaving it in the code as we will use it in the future.

## Setup

to run: `go run ./cmd/milmove-tasks post-file-to-gex --edi ./cmd/send_to_gex/helloworld.json --transaction-name 'transactionName' --gex-url 'gexURL'`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-104) for this change
* [this article](tbd) explains more about the approach used.
