### PR TITLE
Add a target for pulling the default DB postgres image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,10 @@ redis_reset: redis_destroy redis_run ## Reset Redis
 # ----- START DB_DEV TARGETS -----
 #
 
+.PHONY: db_pull
+db_pull: ## Pull db image
+	docker pull $(DB_DOCKER_CONTAINER_IMAGE)
+
 .PHONY: db_dev_destroy
 db_dev_destroy: ## Destroy Dev DB
 ifndef CIRCLECI


### PR DESCRIPTION
## Description

We added a target to pull the docker image for Redis recently and it feels like a nice pattern to do for the DB too. These targets make it easier to remember how to get the latest docker images.