### PR TITLE
MB-2874 Add link to Customer Move Details skeleton

### DIFF
--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -26,6 +26,8 @@ class TOO extends Component {
               <th>Confirmation #</th>
               <th>Agency</th>
               <th>Origin Duty Station</th>
+              <th>MoveOrderID</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -47,6 +49,7 @@ class TOO extends Component {
                   <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>
                     {originDutyStation && originDutyStation.name}
                   </td>
+                  <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>{moveOrderId}</td>
                   <td>
                     <a href={`/too/customer-moves/${moveOrderId}/customer/${customerID}`}>
                       Customer Details Page Skeleton

--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -40,11 +40,18 @@ class TOO extends Component {
                 customerID,
                 moveTaskOrderId,
               }) => (
-                <tr data-cy="too-row" onClick={() => this.handleCustomerInfoClick(moveOrderId)} key={moveOrderId}>
-                  <td>{`${last_name}, ${first_name}`}</td>
-                  <td>{confirmation_number}</td>
-                  <td>{agency}</td>
-                  <td>{originDutyStation && originDutyStation.name}</td>
+                <tr data-cy="too-row" key={moveOrderId}>
+                  <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>{`${last_name}, ${first_name}`}</td>
+                  <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>{confirmation_number}</td>
+                  <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>{agency}</td>
+                  <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>
+                    {originDutyStation && originDutyStation.name}
+                  </td>
+                  <td>
+                    <a href={`/too/customer-moves/${moveOrderId}/customer/${customerID}`}>
+                      Customer Details Page Skeleton
+                    </a>
+                  </td>
                 </tr>
               ),
             )}


### PR DESCRIPTION
## Description

To help facilitate acceptance on payment requests, this PR adds a link to the customer move details page skeleton that allows us to approve shipments and send them to the prime API in staging. See [this thread](https://ustcdp3.slack.com/archives/CP4979J0G/p1591901608051400) for more details.

## Reviewer Notes

I debated making the link to the new move details page also to the right of the screen instead of just clicking, but didn't want to break anyone's flow.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Login to the office app http://officelocal:3000

visit the customer moves list http://officelocal:3000/too/customer-moves

Click on the details for one of the listed moves. 

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira MB-2874](https://dp3.atlassian.net/browse/MB-2874) for this change
* [this slack thread](https://ustcdp3.slack.com/archives/CP4979J0G/p1591901608051400) explains more about the approach used.