### PR TITLE
Fix checks around session config settings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -152,9 +152,6 @@ require MOVE_MIL_DOD_TLS_CERT "See 'chamber read app-devlocal move_mil_dod_tls_c
 require MOVE_MIL_DOD_TLS_KEY "See 'chamber read app-devlocal move_mil_dod_tls_key'"
 export MOVE_MIL_DOD_CA_CERT
 
-# Set a long inactivity timeout for local sessions
-export SESSION_IDLE_TIMEOUT_IN_MINUTES=30
-
 # Use UTC timezone
 export TZ="UTC"
 

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -530,8 +530,8 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	useSecureCookie := !isDevOrTest
 	redisEnabled := v.GetBool(cli.RedisEnabledFlag)
 	sessionStore := redisstore.New(redisPool)
-	idleTimeout := v.GetDuration(cli.SessionIdleTimeoutInMinutesFlag) * time.Minute
-	lifetime := v.GetDuration(cli.SessionLifetimeInHoursFlag) * time.Hour
+	idleTimeout := time.Duration(v.GetInt(cli.SessionIdleTimeoutInMinutesFlag)) * time.Minute
+	lifetime := time.Duration(v.GetInt(cli.SessionLifetimeInHoursFlag)) * time.Hour
 	sessionManagers := auth.SetupSessionManagers(redisEnabled, sessionStore, useSecureCookie, idleTimeout, lifetime)
 	milSession := sessionManagers[0]
 	adminSession := sessionManagers[1]

--- a/pkg/cli/session.go
+++ b/pkg/cli/session.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -13,17 +11,12 @@ const (
 	SessionIdleTimeoutInMinutesFlag string = "session-idle-timeout-in-minutes"
 	// SessionLifetimeInHoursFlag sets the session's absolute expiry in hours
 	SessionLifetimeInHoursFlag string = "session-lifetime-in-hours"
-
-	// SessionIdleTimeoutInMinutes is the default idle timeout in minutes
-	SessionIdleTimeoutInMinutes int = 30
-	// SessionLifetimeInHours is the default session lifetime in hours
-	SessionLifetimeInHours int = 24
 )
 
 // InitSessionFlags initializes SessionFlags command line flags
 func InitSessionFlags(flag *pflag.FlagSet) {
-	flag.Duration(SessionIdleTimeoutInMinutesFlag, (time.Duration(SessionIdleTimeoutInMinutes) * time.Minute), "Session idle timeout in minutes")
-	flag.Duration(SessionLifetimeInHoursFlag, (time.Duration(SessionLifetimeInHours) * time.Hour), "Session absolute expiry in hours")
+	flag.Int(SessionIdleTimeoutInMinutesFlag, 15, "Session idle timeout in minutes")
+	flag.Int(SessionLifetimeInHoursFlag, 24, "Session absolute expiry in hours")
 }
 
 // CheckSession validates session command line flags
@@ -41,12 +34,10 @@ func CheckSession(v *viper.Viper) error {
 
 // ValidateSessionTimeout validates session idle timeout
 func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
-	timeout := v.GetDuration(flagname) * time.Minute
-	var minTimeout time.Duration = 15 * time.Minute
-	var maxTimeout time.Duration = 60 * time.Minute
+	timeout := v.GetInt(flagname)
 
-	if timeout <= minTimeout || timeout >= maxTimeout {
-		return errors.Errorf("%s must be an integer between 15 and 60, got %s", SessionIdleTimeoutInMinutesFlag, timeout)
+	if timeout < 15 || timeout > 60 {
+		return errors.Errorf("%s must be an integer between 15 and 60, got %d", SessionIdleTimeoutInMinutesFlag, timeout)
 	}
 
 	return nil
@@ -54,16 +45,10 @@ func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
 
 // ValidateSessionLifetime validates session lifetime
 func ValidateSessionLifetime(v *viper.Viper, flagname string) error {
-	lifetime := v.GetDuration(flagname) * time.Hour
-	var minLifetime time.Duration = 1 * time.Hour
-	var minLifetimeDeployed time.Duration = 12 * time.Hour
+	lifetime := v.GetInt(flagname)
 
-	if lifetime < minLifetimeDeployed {
-		return errors.Errorf("%s must be at least 12 hours in production, got %s", SessionLifetimeInHoursFlag, lifetime)
-	}
-
-	if lifetime < minLifetime {
-		return errors.Errorf("%s must be at least 1, got %s", SessionLifetimeInHoursFlag, lifetime)
+	if lifetime < 12 {
+		return errors.Errorf("%s must be at least 12 hours, got %d", SessionLifetimeInHoursFlag, lifetime)
 	}
 
 	return nil

--- a/pkg/cli/session.go
+++ b/pkg/cli/session.go
@@ -15,7 +15,7 @@ const (
 	SessionLifetimeInHoursFlag string = "session-lifetime-in-hours"
 
 	// SessionIdleTimeoutInMinutes is the default idle timeout in minutes
-	SessionIdleTimeoutInMinutes int = 15
+	SessionIdleTimeoutInMinutes int = 30
 	// SessionLifetimeInHours is the default session lifetime in hours
 	SessionLifetimeInHours int = 24
 )
@@ -41,13 +41,12 @@ func CheckSession(v *viper.Viper) error {
 
 // ValidateSessionTimeout validates session idle timeout
 func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
-	environment := v.GetString(EnvironmentFlag)
 	timeout := v.GetDuration(flagname) * time.Minute
 	var minTimeout time.Duration = 15 * time.Minute
 	var maxTimeout time.Duration = 60 * time.Minute
 
-	if (environment != EnvironmentDevelopment) && (timeout < minTimeout || timeout > maxTimeout) {
-		return errors.Errorf("%s must be an integer between 15 and 60", SessionIdleTimeoutInMinutesFlag)
+	if timeout <= minTimeout || timeout >= maxTimeout {
+		return errors.Errorf("%s must be an integer between 15 and 60, got %s", SessionIdleTimeoutInMinutesFlag, timeout)
 	}
 
 	return nil
@@ -55,17 +54,16 @@ func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
 
 // ValidateSessionLifetime validates session lifetime
 func ValidateSessionLifetime(v *viper.Viper, flagname string) error {
-	environment := v.GetString(EnvironmentFlag)
 	lifetime := v.GetDuration(flagname) * time.Hour
 	var minLifetime time.Duration = 1 * time.Hour
 	var minLifetimeDeployed time.Duration = 12 * time.Hour
 
-	if (environment != EnvironmentDevelopment) && (lifetime < minLifetimeDeployed) {
-		return errors.Errorf("%s must be at least 12 hours in production", SessionLifetimeInHoursFlag)
+	if lifetime < minLifetimeDeployed {
+		return errors.Errorf("%s must be at least 12 hours in production, got %s", SessionLifetimeInHoursFlag, lifetime)
 	}
 
 	if lifetime < minLifetime {
-		return errors.Errorf("%s must be at least 1", SessionLifetimeInHoursFlag)
+		return errors.Errorf("%s must be at least 1, got %s", SessionLifetimeInHoursFlag, lifetime)
 	}
 
 	return nil

--- a/pkg/cli/session.go
+++ b/pkg/cli/session.go
@@ -42,9 +42,11 @@ func CheckSession(v *viper.Viper) error {
 // ValidateSessionTimeout validates session idle timeout
 func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
 	environment := v.GetString(EnvironmentFlag)
-	timeout := v.GetDuration(flagname)
+	timeout := v.GetDuration(flagname) * time.Minute
+	var minTimeout time.Duration = 15 * time.Minute
+	var maxTimeout time.Duration = 60 * time.Minute
 
-	if environment == EnvironmentProd && (timeout < 15 || timeout > 60) {
+	if (environment != EnvironmentDevelopment) && (timeout < minTimeout || timeout > maxTimeout) {
 		return errors.Errorf("%s must be an integer between 15 and 60", SessionIdleTimeoutInMinutesFlag)
 	}
 
@@ -54,13 +56,15 @@ func ValidateSessionTimeout(v *viper.Viper, flagname string) error {
 // ValidateSessionLifetime validates session lifetime
 func ValidateSessionLifetime(v *viper.Viper, flagname string) error {
 	environment := v.GetString(EnvironmentFlag)
-	lifetime := v.GetDuration(flagname)
+	lifetime := v.GetDuration(flagname) * time.Hour
+	var minLifetime time.Duration = 1 * time.Hour
+	var minLifetimeDeployed time.Duration = 12 * time.Hour
 
-	if environment == EnvironmentProd && lifetime < 12 {
+	if (environment != EnvironmentDevelopment) && (lifetime < minLifetimeDeployed) {
 		return errors.Errorf("%s must be at least 12 hours in production", SessionLifetimeInHoursFlag)
 	}
 
-	if lifetime < 1 {
+	if lifetime < minLifetime {
 		return errors.Errorf("%s must be at least 1", SessionLifetimeInHoursFlag)
 	}
 


### PR DESCRIPTION
When checking if the session idle timeout and lifetime are within our
limits, we were not comparing the same time units. Furthermore, this
check was only happening in prod, so we missed this bug in staging.

This fixes the checks so that they compare the same time units, and
allows the checks to run in all deployed environments.

