### PR TITLE
MB-2700 Make moveTaskOrderID required for service items

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -947,7 +947,9 @@ func init() {
       "description": "MTOServiceItem describes a base type of a service item. Polymorphic type. Both Move Task Orders and MTO Shipments will have MTO Service Items.",
       "type": "object",
       "required": [
-        "modelType"
+        "modelType",
+        "mtoShipmentID",
+        "moveTaskOrderID"
       ],
       "properties": {
         "eTag": {
@@ -2963,7 +2965,9 @@ func init() {
       "description": "MTOServiceItem describes a base type of a service item. Polymorphic type. Both Move Task Orders and MTO Shipments will have MTO Service Items.",
       "type": "object",
       "required": [
-        "modelType"
+        "modelType",
+        "mtoShipmentID",
+        "moveTaskOrderID"
       ],
       "properties": {
         "eTag": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -948,7 +948,6 @@ func init() {
       "type": "object",
       "required": [
         "modelType",
-        "mtoShipmentID",
         "moveTaskOrderID"
       ],
       "properties": {
@@ -2966,7 +2965,6 @@ func init() {
       "type": "object",
       "required": [
         "modelType",
-        "mtoShipmentID",
         "moveTaskOrderID"
       ],
       "properties": {

--- a/pkg/gen/primemessages/m_t_o_service_item.go
+++ b/pkg/gen/primemessages/m_t_o_service_item.go
@@ -39,14 +39,16 @@ type MTOServiceItem interface {
 	SetModelType(MTOServiceItemModelType)
 
 	// move task order ID
+	// Required: true
 	// Format: uuid
-	MoveTaskOrderID() strfmt.UUID
-	SetMoveTaskOrderID(strfmt.UUID)
+	MoveTaskOrderID() *strfmt.UUID
+	SetMoveTaskOrderID(*strfmt.UUID)
 
 	// mto shipment ID
+	// Required: true
 	// Format: uuid
-	MtoShipmentID() strfmt.UUID
-	SetMtoShipmentID(strfmt.UUID)
+	MtoShipmentID() *strfmt.UUID
+	SetMtoShipmentID(*strfmt.UUID)
 
 	// re service ID
 	// Format: uuid
@@ -73,9 +75,9 @@ type mTOServiceItem struct {
 
 	modelTypeField MTOServiceItemModelType
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -117,22 +119,22 @@ func (m *mTOServiceItem) SetModelType(val MTOServiceItemModelType) {
 }
 
 // MoveTaskOrderID gets the move task order ID of this polymorphic type
-func (m *mTOServiceItem) MoveTaskOrderID() strfmt.UUID {
+func (m *mTOServiceItem) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this polymorphic type
-func (m *mTOServiceItem) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *mTOServiceItem) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this polymorphic type
-func (m *mTOServiceItem) MtoShipmentID() strfmt.UUID {
+func (m *mTOServiceItem) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this polymorphic type
-func (m *mTOServiceItem) SetMtoShipmentID(val strfmt.UUID) {
+func (m *mTOServiceItem) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -314,8 +316,8 @@ func (m *mTOServiceItem) validateID(formats strfmt.Registry) error {
 
 func (m *mTOServiceItem) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -327,8 +329,8 @@ func (m *mTOServiceItem) validateMoveTaskOrderID(formats strfmt.Registry) error 
 
 func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item.go
+++ b/pkg/gen/primemessages/m_t_o_service_item.go
@@ -45,10 +45,9 @@ type MTOServiceItem interface {
 	SetMoveTaskOrderID(*strfmt.UUID)
 
 	// mto shipment ID
-	// Required: true
 	// Format: uuid
-	MtoShipmentID() *strfmt.UUID
-	SetMtoShipmentID(*strfmt.UUID)
+	MtoShipmentID() strfmt.UUID
+	SetMtoShipmentID(strfmt.UUID)
 
 	// re service ID
 	// Format: uuid
@@ -77,7 +76,7 @@ type mTOServiceItem struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -129,12 +128,12 @@ func (m *mTOServiceItem) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this polymorphic type
-func (m *mTOServiceItem) MtoShipmentID() *strfmt.UUID {
+func (m *mTOServiceItem) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this polymorphic type
-func (m *mTOServiceItem) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *mTOServiceItem) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -329,8 +328,8 @@ func (m *mTOServiceItem) validateMoveTaskOrderID(formats strfmt.Registry) error 
 
 func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_basic.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_basic.go
@@ -25,7 +25,7 @@ type MTOServiceItemBasic struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -81,12 +81,12 @@ func (m *MTOServiceItemBasic) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemBasic) MtoShipmentID() *strfmt.UUID {
+func (m *MTOServiceItemBasic) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemBasic) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *MTOServiceItemBasic) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -159,7 +159,7 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -233,7 +233,7 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -332,8 +332,8 @@ func (m *MTOServiceItemBasic) validateMoveTaskOrderID(formats strfmt.Registry) e
 
 func (m *MTOServiceItemBasic) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_basic.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_basic.go
@@ -23,9 +23,9 @@ type MTOServiceItemBasic struct {
 
 	idField strfmt.UUID
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -71,22 +71,22 @@ func (m *MTOServiceItemBasic) SetModelType(val MTOServiceItemModelType) {
 }
 
 // MoveTaskOrderID gets the move task order ID of this subtype
-func (m *MTOServiceItemBasic) MoveTaskOrderID() strfmt.UUID {
+func (m *MTOServiceItemBasic) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this subtype
-func (m *MTOServiceItemBasic) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *MTOServiceItemBasic) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemBasic) MtoShipmentID() strfmt.UUID {
+func (m *MTOServiceItemBasic) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemBasic) SetMtoShipmentID(val strfmt.UUID) {
+func (m *MTOServiceItemBasic) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -157,9 +157,9 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -231,9 +231,9 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -319,8 +319,8 @@ func (m *MTOServiceItemBasic) validateID(formats strfmt.Registry) error {
 
 func (m *MTOServiceItemBasic) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -332,8 +332,8 @@ func (m *MTOServiceItemBasic) validateMoveTaskOrderID(formats strfmt.Registry) e
 
 func (m *MTOServiceItemBasic) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
@@ -23,9 +23,9 @@ type MTOServiceItemDDFSIT struct {
 
 	idField strfmt.UUID
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -92,22 +92,22 @@ func (m *MTOServiceItemDDFSIT) SetModelType(val MTOServiceItemModelType) {
 }
 
 // MoveTaskOrderID gets the move task order ID of this subtype
-func (m *MTOServiceItemDDFSIT) MoveTaskOrderID() strfmt.UUID {
+func (m *MTOServiceItemDDFSIT) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this subtype
-func (m *MTOServiceItemDDFSIT) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *MTOServiceItemDDFSIT) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDDFSIT) MtoShipmentID() strfmt.UUID {
+func (m *MTOServiceItemDDFSIT) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDDFSIT) SetMtoShipmentID(val strfmt.UUID) {
+func (m *MTOServiceItemDDFSIT) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -209,9 +209,9 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -324,9 +324,9 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -432,8 +432,8 @@ func (m *MTOServiceItemDDFSIT) validateID(formats strfmt.Registry) error {
 
 func (m *MTOServiceItemDDFSIT) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -445,8 +445,8 @@ func (m *MTOServiceItemDDFSIT) validateMoveTaskOrderID(formats strfmt.Registry) 
 
 func (m *MTOServiceItemDDFSIT) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
@@ -25,7 +25,7 @@ type MTOServiceItemDDFSIT struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -102,12 +102,12 @@ func (m *MTOServiceItemDDFSIT) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDDFSIT) MtoShipmentID() *strfmt.UUID {
+func (m *MTOServiceItemDDFSIT) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDDFSIT) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *MTOServiceItemDDFSIT) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -211,7 +211,7 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -326,7 +326,7 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -445,8 +445,8 @@ func (m *MTOServiceItemDDFSIT) validateMoveTaskOrderID(formats strfmt.Registry) 
 
 func (m *MTOServiceItemDDFSIT) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
@@ -25,7 +25,7 @@ type MTOServiceItemDOFSIT struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -90,12 +90,12 @@ func (m *MTOServiceItemDOFSIT) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDOFSIT) MtoShipmentID() *strfmt.UUID {
+func (m *MTOServiceItemDOFSIT) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDOFSIT) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *MTOServiceItemDOFSIT) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -181,7 +181,7 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -272,7 +272,7 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -379,8 +379,8 @@ func (m *MTOServiceItemDOFSIT) validateMoveTaskOrderID(formats strfmt.Registry) 
 
 func (m *MTOServiceItemDOFSIT) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
@@ -23,9 +23,9 @@ type MTOServiceItemDOFSIT struct {
 
 	idField strfmt.UUID
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -80,22 +80,22 @@ func (m *MTOServiceItemDOFSIT) SetModelType(val MTOServiceItemModelType) {
 }
 
 // MoveTaskOrderID gets the move task order ID of this subtype
-func (m *MTOServiceItemDOFSIT) MoveTaskOrderID() strfmt.UUID {
+func (m *MTOServiceItemDOFSIT) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this subtype
-func (m *MTOServiceItemDOFSIT) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *MTOServiceItemDOFSIT) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDOFSIT) MtoShipmentID() strfmt.UUID {
+func (m *MTOServiceItemDOFSIT) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDOFSIT) SetMtoShipmentID(val strfmt.UUID) {
+func (m *MTOServiceItemDOFSIT) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -179,9 +179,9 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -270,9 +270,9 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -366,8 +366,8 @@ func (m *MTOServiceItemDOFSIT) validateID(formats strfmt.Registry) error {
 
 func (m *MTOServiceItemDOFSIT) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -379,8 +379,8 @@ func (m *MTOServiceItemDOFSIT) validateMoveTaskOrderID(formats strfmt.Registry) 
 
 func (m *MTOServiceItemDOFSIT) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -23,9 +23,9 @@ type MTOServiceItemDomesticCrating struct {
 
 	idField strfmt.UUID
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -84,22 +84,22 @@ func (m *MTOServiceItemDomesticCrating) SetModelType(val MTOServiceItemModelType
 }
 
 // MoveTaskOrderID gets the move task order ID of this subtype
-func (m *MTOServiceItemDomesticCrating) MoveTaskOrderID() strfmt.UUID {
+func (m *MTOServiceItemDomesticCrating) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this subtype
-func (m *MTOServiceItemDomesticCrating) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *MTOServiceItemDomesticCrating) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDomesticCrating) MtoShipmentID() strfmt.UUID {
+func (m *MTOServiceItemDomesticCrating) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDomesticCrating) SetMtoShipmentID(val strfmt.UUID) {
+func (m *MTOServiceItemDomesticCrating) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -189,9 +189,9 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -288,9 +288,9 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -388,8 +388,8 @@ func (m *MTOServiceItemDomesticCrating) validateID(formats strfmt.Registry) erro
 
 func (m *MTOServiceItemDomesticCrating) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -401,8 +401,8 @@ func (m *MTOServiceItemDomesticCrating) validateMoveTaskOrderID(formats strfmt.R
 
 func (m *MTOServiceItemDomesticCrating) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -25,7 +25,7 @@ type MTOServiceItemDomesticCrating struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -94,12 +94,12 @@ func (m *MTOServiceItemDomesticCrating) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemDomesticCrating) MtoShipmentID() *strfmt.UUID {
+func (m *MTOServiceItemDomesticCrating) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemDomesticCrating) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *MTOServiceItemDomesticCrating) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -191,7 +191,7 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -290,7 +290,7 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -401,8 +401,8 @@ func (m *MTOServiceItemDomesticCrating) validateMoveTaskOrderID(formats strfmt.R
 
 func (m *MTOServiceItemDomesticCrating) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -23,9 +23,9 @@ type MTOServiceItemShuttle struct {
 
 	idField strfmt.UUID
 
-	moveTaskOrderIdField strfmt.UUID
+	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField strfmt.UUID
+	mtoShipmentIdField *strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -80,22 +80,22 @@ func (m *MTOServiceItemShuttle) SetModelType(val MTOServiceItemModelType) {
 }
 
 // MoveTaskOrderID gets the move task order ID of this subtype
-func (m *MTOServiceItemShuttle) MoveTaskOrderID() strfmt.UUID {
+func (m *MTOServiceItemShuttle) MoveTaskOrderID() *strfmt.UUID {
 	return m.moveTaskOrderIdField
 }
 
 // SetMoveTaskOrderID sets the move task order ID of this subtype
-func (m *MTOServiceItemShuttle) SetMoveTaskOrderID(val strfmt.UUID) {
+func (m *MTOServiceItemShuttle) SetMoveTaskOrderID(val *strfmt.UUID) {
 	m.moveTaskOrderIdField = val
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemShuttle) MtoShipmentID() strfmt.UUID {
+func (m *MTOServiceItemShuttle) MtoShipmentID() *strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemShuttle) SetMtoShipmentID(val strfmt.UUID) {
+func (m *MTOServiceItemShuttle) SetMtoShipmentID(val *strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -179,9 +179,9 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -270,9 +270,9 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		ModelType MTOServiceItemModelType `json:"modelType"`
 
-		MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
+		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
+		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -366,8 +366,8 @@ func (m *MTOServiceItemShuttle) validateID(formats strfmt.Registry) error {
 
 func (m *MTOServiceItemShuttle) validateMoveTaskOrderID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MoveTaskOrderID()) { // not required
-		return nil
+	if err := validate.Required("moveTaskOrderID", "body", m.MoveTaskOrderID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("moveTaskOrderID", "body", "uuid", m.MoveTaskOrderID().String(), formats); err != nil {
@@ -379,8 +379,8 @@ func (m *MTOServiceItemShuttle) validateMoveTaskOrderID(formats strfmt.Registry)
 
 func (m *MTOServiceItemShuttle) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.MtoShipmentID()) { // not required
-		return nil
+	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
+		return err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -25,7 +25,7 @@ type MTOServiceItemShuttle struct {
 
 	moveTaskOrderIdField *strfmt.UUID
 
-	mtoShipmentIdField *strfmt.UUID
+	mtoShipmentIdField strfmt.UUID
 
 	reServiceIdField strfmt.UUID
 
@@ -90,12 +90,12 @@ func (m *MTOServiceItemShuttle) SetMoveTaskOrderID(val *strfmt.UUID) {
 }
 
 // MtoShipmentID gets the mto shipment ID of this subtype
-func (m *MTOServiceItemShuttle) MtoShipmentID() *strfmt.UUID {
+func (m *MTOServiceItemShuttle) MtoShipmentID() strfmt.UUID {
 	return m.mtoShipmentIdField
 }
 
 // SetMtoShipmentID sets the mto shipment ID of this subtype
-func (m *MTOServiceItemShuttle) SetMtoShipmentID(val *strfmt.UUID) {
+func (m *MTOServiceItemShuttle) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
 }
 
@@ -181,7 +181,7 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -272,7 +272,7 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
@@ -379,8 +379,8 @@ func (m *MTOServiceItemShuttle) validateMoveTaskOrderID(formats strfmt.Registry)
 
 func (m *MTOServiceItemShuttle) validateMtoShipmentID(formats strfmt.Registry) error {
 
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID()); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID()) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -445,14 +445,10 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	}
 
 	// set all relevant fields that apply to all service items
-	var shipmentIDStr string
-	if mtoServiceItem.MTOShipmentID != nil {
-		shipmentIDStr = mtoServiceItem.MTOShipmentID.String()
-	}
 
 	payload.SetID(strfmt.UUID(mtoServiceItem.ID.String()))
-	payload.SetMoveTaskOrderID(strfmt.UUID(mtoServiceItem.MoveTaskOrderID.String()))
-	payload.SetMtoShipmentID(strfmt.UUID(shipmentIDStr))
+	payload.SetMoveTaskOrderID(handlers.FmtUUID(mtoServiceItem.MoveTaskOrderID))
+	payload.SetMtoShipmentID(handlers.FmtUUIDPtr(mtoServiceItem.MTOShipmentID))
 	payload.SetReServiceID(strfmt.UUID(mtoServiceItem.ReServiceID.String()))
 	payload.SetReServiceName(mtoServiceItem.ReService.Name)
 	payload.SetStatus(primemessages.MTOServiceItemStatus(mtoServiceItem.Status))

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -445,10 +445,14 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	}
 
 	// set all relevant fields that apply to all service items
+	var shipmentIDStr string
+	if mtoServiceItem.MTOShipmentID != nil {
+		shipmentIDStr = mtoServiceItem.MTOShipmentID.String()
+	}
 
 	payload.SetID(strfmt.UUID(mtoServiceItem.ID.String()))
 	payload.SetMoveTaskOrderID(handlers.FmtUUID(mtoServiceItem.MoveTaskOrderID))
-	payload.SetMtoShipmentID(handlers.FmtUUIDPtr(mtoServiceItem.MTOShipmentID))
+	payload.SetMtoShipmentID(strfmt.UUID(shipmentIDStr))
 	payload.SetReServiceID(strfmt.UUID(mtoServiceItem.ReServiceID.String()))
 	payload.SetReServiceName(mtoServiceItem.ReService.Name)
 	payload.SetStatus(primemessages.MTOServiceItemStatus(mtoServiceItem.Status))

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/strfmt"
-
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 
 	"github.com/gobuffalo/validate"
@@ -136,8 +134,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		}
 
 		body := payloads.MTOServiceItem(&mtoServiceItem)
-		body.SetMoveTaskOrderID(strfmt.UUID(mtoShipment.MoveTaskOrderID.String()))
-		body.SetMtoShipmentID(strfmt.UUID(mtoShipment2.ID.String()))
+		body.SetMoveTaskOrderID(handlers.FmtUUID(mtoShipment.MoveTaskOrderID))
+		body.SetMtoShipmentID(handlers.FmtUUID(mtoShipment2.ID))
 
 		newParams := mtoserviceitemops.CreateMTOServiceItemParams{
 			HTTPRequest: req,

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -3,11 +3,13 @@ package primeapi
 import (
 	"errors"
 	"net/http/httptest"
-	"testing"
-	"time"
 
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
 	"github.com/gobuffalo/validate"
 
 	"github.com/stretchr/testify/mock"
@@ -135,7 +137,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 
 		body := payloads.MTOServiceItem(&mtoServiceItem)
 		body.SetMoveTaskOrderID(handlers.FmtUUID(mtoShipment.MoveTaskOrderID))
-		body.SetMtoShipmentID(handlers.FmtUUID(mtoShipment2.ID))
+		body.SetMtoShipmentID(strfmt.UUID(mtoShipment2.ID.String()))
 
 		newParams := mtoserviceitemops.CreateMTOServiceItemParams{
 			HTTPRequest: req,

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1005,7 +1005,6 @@ definitions:
         type: string
     required:
       - modelType
-      - mtoShipmentID
       - moveTaskOrderID
   MTOServiceItemBasic:
     description: Describes a basic service item subtype of a MTOServiceItem.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1005,6 +1005,8 @@ definitions:
         type: string
     required:
       - modelType
+      - mtoShipmentID
+      - moveTaskOrderID
   MTOServiceItemBasic:
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:


### PR DESCRIPTION
## Description

* This PR updates `prime.yaml` and affected code to make `moveTaskOrderID` required for `CreateMTOServiceItem`. 

* The parent ids for `CreateMTOShipment` and `CreateMTOServiceItem` were previously removed from the path and added to the body payload for each. [MB-2700](https://dp3.atlassian.net/browse/MB-2700) is to make sure these fields are marked as required for the payload.
* `CreateMTOShipment` already has `moveTaskOrderID` marked as required and returns the proper validation error if omitted, so no action was needed for that AC.


## Reviewer Notes

> One question that came up in conversations with @shimonacarvalho and @sandy-wright was, "Do 

> we want these fields to always be required for the `MTOServiceItem` definition? Is this definition used elsewhere?"
> 
> Besides the `CreateMTOServiceItem` endpoint, the `MTOServiceItem` definition is referenced in `CreateShipmentPayload`, which is used in `CreateMTOShipment`. Here is where I need help:
> 
> * **CreateMTOShipment** - create a new MTO shipment, which requires a `moveTaskOrderID`, and returns an `mtoShipmentID`
> * **CreateMTOServiceItem** - create a new service item, which requires an `mtoShipmentID`, and that shipment's `moveTaskOrderID`.
> 
> Is it correct to assume you cannot create a service item unless you have an existing mtoShipment to link? Or should the client be able to pass in mto service items during the creation of an mtoShipment?

> Our [current documentation](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/master/swagger/prime.yaml#operation/createMTOShipment) makes it seem like the latter, stating the mtoShipment can be passed "An array of optional accessorial service item codes."

> Let's discuss and clarify the expected flow! 🙏 

### Update to above questions
* Service items can be created without an associated shipment, e.g. Counseling Fee, so `mtoShipmentID` should not be required on the definition.
* But `mtoShipmentID` is required for the Prime using the createMTOServiceItem endpoint, because they will be using this endpoint to create accessorial service items which will have both `mtoShipmentID` and `moveTaskOrderID`.
  * This means it's ok to call out they are required values in the prime.yaml description of the endpoint; just not in the definition.
* `moveTaskOrderID` *can* be required for creating service items.
  * Currently in the support-create-mto endpoint, it appears as though you can create an mto with service items, but this is incorrect and will be fixed in a future story.

## Setup

### Test Endpoint
`make db_dev_e2e_populate && make server_run`
* Test CreateMTOServiceItem endpoint and verify validation error if no `moveTaskOrderID` is passed.

### Check Documentation
In a separate tab, run:
`redoc-cli server swagger/prime.yaml`

* Verify in documentation for createMTOServiceItem that `moveTaskOrderID` is marked as required.

### Run Tests
`make db_test_e2e_populate`
`go test ./pkg/handlers/primeapi/ -testify.m TestCreateMTOServiceItemHandler`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References
* [Jira story](https://dp3.atlassian.net/browse/MB-2700) for this change
