### PR TITLE
[MB-3000] Fix issue with leading zeros being lost when migrating data

### DIFF
--- a/pkg/migrate/Exec_test.go
+++ b/pkg/migrate/Exec_test.go
@@ -70,6 +70,48 @@ func (suite *MigrateSuite) TestExecWithCopyFromStdinMultipleSQL() {
 	suite.NoError(errTransaction)
 }
 
+func (suite *MigrateSuite) TestExecWithCopyFromStdinTypes() {
+
+	// Load the fixture with the sql example
+	f, err := os.Open("./fixtures/copyFromStdinTypes.sql")
+	suite.NoError(err)
+
+	errTransaction := suite.DB().Transaction(func(tx *pop.Connection) error {
+		wait := 10 * time.Millisecond
+		innerErr := Exec(f, tx, wait)
+		suite.NoError(innerErr)
+		return innerErr
+	})
+	suite.NoError(errTransaction)
+
+	// Verify we didn't lose anything when inserting into database
+	// (some fields were previously converted from string to float/int as part of the exec)
+
+	// String
+	var contract models.ReContract
+	err = suite.DB().Find(&contract, "8ef44ca4-c589-4c39-93d8-3410a762ec6c")
+	suite.NoError(err)
+	suite.Equal("Pricing", contract.Code)
+
+	// Float
+	var contractYear models.ReContractYear
+	err = suite.DB().Find(&contractYear, "9ca0c8d2-3b14-4a49-9709-1f710383642f")
+	suite.NoError(err)
+	suite.InDelta(1.01970, contractYear.Escalation, 0.0001)
+
+	// Integer (but should store as string due to leading zeros)
+	var domesticServiceArea models.ReDomesticServiceArea
+	err = suite.DB().Find(&domesticServiceArea, "ea949687-431e-4c00-bbe7-646158471d4e")
+	suite.NoError(err)
+	suite.Equal("004", domesticServiceArea.ServiceArea)
+
+	// null/nil
+	var zip3 models.ReZip3
+	err = suite.DB().Find(&zip3, "7eee5a4f-c457-49eb-bd6a-216fb00ab43c")
+	suite.NoError(err)
+	suite.Nil(zip3.RateAreaID)
+}
+
 func (suite *MigrateSuite) TestExecWithLoopSQL() {
 
 	// Load the fixture with the sql example

--- a/pkg/migrate/fixtures/copyFromStdinTypes.sql
+++ b/pkg/migrate/fixtures/copyFromStdinTypes.sql
@@ -1,0 +1,15 @@
+COPY public.re_contracts (id, code, name, created_at, updated_at) FROM stdin;
+8ef44ca4-c589-4c39-93d8-3410a762ec6c	Pricing	Pricing	2020-06-15 19:07:59.702658	2020-06-15 19:07:59.702661
+\.
+
+COPY public.re_contract_years (id, contract_id, name, start_date, end_date, escalation, escalation_compounded, created_at, updated_at) FROM stdin;
+9ca0c8d2-3b14-4a49-9709-1f710383642f	8ef44ca4-c589-4c39-93d8-3410a762ec6c	Base Period Year 3	2021-06-01	2022-05-31	1.01970	1.04071	2020-06-15 19:07:59.713313	2020-06-15 19:07:59.713314
+\.
+
+COPY public.re_domestic_service_areas (id, service_area, services_schedule, sit_pd_schedule, created_at, updated_at, contract_id) FROM stdin;
+ea949687-431e-4c00-bbe7-646158471d4e	004	2	2	2020-06-15 19:08:03.986359	2020-06-15 19:08:03.98636	8ef44ca4-c589-4c39-93d8-3410a762ec6c
+\.
+
+COPY public.re_zip3s (id, zip3, domestic_service_area_id, created_at, updated_at, contract_id, rate_area_id, has_multiple_rate_areas, base_point_city, state) FROM stdin;
+7eee5a4f-c457-49eb-bd6a-216fb00ab43c	321	ea949687-431e-4c00-bbe7-646158471d4e	2020-06-15 19:08:03.267183	2020-06-15 19:08:06.52456	8ef44ca4-c589-4c39-93d8-3410a762ec6c	\N	t	Crescent City	FL
+\.

--- a/pkg/migrate/lineToValues.go
+++ b/pkg/migrate/lineToValues.go
@@ -1,7 +1,6 @@
 package migrate
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -11,10 +10,6 @@ func lineToValues(line string) []interface{} {
 	for _, s := range parts {
 		if s == "\\N" {
 			values = append(values, nil)
-		} else if n, err := strconv.Atoi(s); err == nil {
-			values = append(values, int64(n))
-		} else if f, err := strconv.ParseFloat(s, 64); err == nil {
-			values = append(values, f)
 		} else {
 			values = append(values, s)
 		}


### PR DESCRIPTION
## Description

When doing a COPY (like we do in big data loads), our custom migrator seems to lose leading zeros when importing zip3/zip5 values (e.g. "010") and service areas ("004"), even though we're storing those as varchar fields in the database.  Those values aren't integers; they just happen to be codes that are only composed of digits.

It turns out that we are converting any value that *could* be an integer to an integer, even when it may not be appropriate like with zips (thus losing the leading zeros).  It doesn't appear that we have to do any integer/float conversion for the data to COPY correctly.  This PR removes those conversions and adds appropriate tests.

## Setup

- `make server_test`
- You could pull the SQL fixture in this PR into a migration and see if the integer/float fields copy correctly
- You can also follow the instructions in the `pricing-import` script to get a migration with zip3 and service area values that originally triggered this bug (also see #4255)

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3000) for this change
