### PR TITLE
MB-3025 Change to using the moveOrderId for MoveDetails route.

### DIFF
--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -51,9 +51,7 @@ class TOO extends Component {
                   </td>
                   <td onClick={() => this.handleCustomerInfoClick(moveOrderId)}>{moveOrderId}</td>
                   <td>
-                    <a href={`/too/customer-moves/${moveOrderId}/customer/${customerID}`}>
-                      Customer Details Page Skeleton
-                    </a>
+                    <a href={`/too/${moveOrderId}/customer/${customerID}`}>Customer Details Page Skeleton</a>
                   </td>
                 </tr>
               ),

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -209,7 +209,7 @@ export class OfficeWrapper extends Component {
                     )}
                     {too && (
                       <PrivateRoute
-                        path="/moves/:locator"
+                        path="/moves/:moveOrderId"
                         exact
                         component={(props) => (
                           <Suspense fallback={<LoadingPlaceholder />}>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -226,7 +226,7 @@ export class OfficeWrapper extends Component {
                     )}
                     {too && (
                       <PrivateRoute
-                        path="/moves/:moveOrderId/customer/:customerId"
+                        path="/too/:moveOrderId/customer/:customerId"
                         component={(props) => (
                           <Suspense fallback={<LoadingPlaceholder />}>
                             <RenderWithOrWithoutHeader


### PR DESCRIPTION
## Description

Changes the route for the Move Details page in `pages/Office/MoveDetails` so that it uses `moveOrderId` instead of `locator`. This needs to remain as a temporary state until we have sorted out database design dependencies to allow us to ultimately use `locator`. Made it so the customer details skeleton now uses `/too/moveOrderId/...` to be rid of the conflict. This feels okay since the skeleton queue view also starts with that too prefix.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3025) for this change
