### PR TITLE
Optimize storybook tests when run locally

### DIFF
--- a/docker-compose.storybook.yml
+++ b/docker-compose.storybook.yml
@@ -13,5 +13,7 @@ services:
     image: milmove_storybook
     working_dir: /home/circleci/project
     command: scripts/start-storybook-tests
+    environment:
+      - CHROME_CONCURRENCY
     depends_on:
       - storybook

--- a/docker-compose.storybook.yml
+++ b/docker-compose.storybook.yml
@@ -5,13 +5,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.storybook
+    image: milmove_storybook
     working_dir: /home/circleci/project
     ports:
       - '6006:6006'
   storybook_tests:
-    build:
-      context: .
-      dockerfile: Dockerfile.storybook
+    image: milmove_storybook
     working_dir: /home/circleci/project
     command: scripts/start-storybook-tests
     depends_on:

--- a/docker-compose.storybook_local.yml
+++ b/docker-compose.storybook_local.yml
@@ -4,6 +4,6 @@ services:
   storybook:
     build:
       dockerfile: Dockerfile.storybook_local
+    image: milmove_storybook_local
   storybook_tests:
-    build:
-      dockerfile: Dockerfile.storybook_local
+    image: milmove_storybook_local

--- a/docker-compose.storybook_local.yml
+++ b/docker-compose.storybook_local.yml
@@ -7,3 +7,5 @@ services:
     image: milmove_storybook_local
   storybook_tests:
     image: milmove_storybook_local
+    environment:
+      - CHROME_CONCURRENCY=4

--- a/scripts/start-storybook-tests
+++ b/scripts/start-storybook-tests
@@ -8,6 +8,7 @@ set -eu -o pipefail
 
 retries=0
 timeout="${STORYBOOK_SERVER_TIMEOUT:-80}"
+concurrent="${CHROME_CONCURRENCY:-1}"
 
 # wait for the storybook server to start
 echo "Wait for storybook server to start"
@@ -22,5 +23,5 @@ while [[ "$(curl -s -o /dev/null -w '%{http_code}' http://storybook:6006)" != 20
 done
 
 echo ""
-echo "Running loki tests"
-yarn run loki test --chromeConcurrency 1 --chromeRetries 5 --host storybook --requireReference
+echo "Running loki tests with chromeConcurrency=$concurrent"
+yarn run loki test --chromeConcurrency "$concurrent" --chromeRetries 5 --host storybook --requireReference


### PR DESCRIPTION
## Description

As storybook tests have been added the `make storybook_tests` job has been taking longer and longer. This PR makes a couple of changes to help speed that up locally. First, it reuses the image that is built for the storybook server for the container storybook tests since they are identical. Second, it adds the ability to set the number of concurrent tests and sets it to 4 when running locally. I left this at 1 in CircleCI as there was an issue when running more than one at a time.

## Reviewer Notes

Try running the changes twice, docker caches a lot of stuff on the first build.

## Setup

You can run `make storybook_tests` and time it to see if it's faster than it used to be.

## Code Review Verification Steps

* [X] Request review from a member of a different team.

## References

* [this slack thread](https://ustcdp3.slack.com/archives/CTQQJD3G8/p1592579777001700) explains more about the approach used.
