### PR TITLE
MB-3030 - Remove cgilmer CAC access

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -515,3 +515,4 @@
 20200527145249_add_mto_available_timestamp.up.sql
 20200529171253_update_task_order_services_params.up.sql
 20200602144311_remove_is_available_to_prime.up.sql
+20200619120000_remove_cgilmer_cac.up.sql

--- a/migrations/app/schema/20200619120000_remove_cgilmer_cac.up.sql
+++ b/migrations/app/schema/20200619120000_remove_cgilmer_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove cgilmer CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='15697aff85d93a2f04259618b66f09f9976887b3f2ee206395c42e4897aefe61';


### PR DESCRIPTION
## Description

Removes CAC access. The record of who had access for auditing is in both the git repo and the s3 bucket history. While disabling all permissions feels like an ok route to take here its just as easy for someone to re-add those permissions. And the CAC itself is going to be destroyed so removing seems more prudent.

This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes

**NOTE:** This needs to be deployed manually to experimental to apply in that environment.

## Setup

```sh
make db_dev_run db_dev_migrate
```

## Code Review Verification Steps

* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)