### PR TITLE
MB-2509 Clean up service items in Support API

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1352,21 +1352,26 @@ func init() {
       "properties": {
         "approvedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "createdAt": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "readOnly": true
         },
         "deletedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "feeType": {
           "type": "string",
@@ -1375,43 +1380,53 @@ func init() {
             "CRATING",
             "TRUCKING",
             "SHUTTLE"
-          ]
+          ],
+          "readOnly": true
         },
         "id": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "moveTaskOrderID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "mtoShipmentID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "quantity": {
-          "type": "integer"
+          "type": "integer",
+          "readOnly": true
         },
         "rate": {
-          "type": "integer"
+          "type": "integer",
+          "readOnly": true
         },
         "reServiceCode": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "reServiceID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "reServiceName": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "rejectedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "rejectionReason": {
           "type": "string",
@@ -1423,15 +1438,18 @@ func init() {
         },
         "submittedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "total": {
           "type": "integer",
-          "format": "cents"
+          "format": "cents",
+          "readOnly": true
         },
         "updatedAt": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "readOnly": true
         }
       }
     },
@@ -3078,21 +3096,26 @@ func init() {
       "properties": {
         "approvedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "createdAt": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "readOnly": true
         },
         "deletedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "feeType": {
           "type": "string",
@@ -3101,43 +3124,53 @@ func init() {
             "CRATING",
             "TRUCKING",
             "SHUTTLE"
-          ]
+          ],
+          "readOnly": true
         },
         "id": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "moveTaskOrderID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "mtoShipmentID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "quantity": {
-          "type": "integer"
+          "type": "integer",
+          "readOnly": true
         },
         "rate": {
-          "type": "integer"
+          "type": "integer",
+          "readOnly": true
         },
         "reServiceCode": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "reServiceID": {
           "type": "string",
           "format": "uuid",
+          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "reServiceName": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "rejectedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "rejectionReason": {
           "type": "string",
@@ -3149,15 +3182,18 @@ func init() {
         },
         "submittedAt": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "readOnly": true
         },
         "total": {
           "type": "integer",
-          "format": "cents"
+          "format": "cents",
+          "readOnly": true
         },
         "updatedAt": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "readOnly": true
         }
       }
     },

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -915,18 +915,6 @@ func init() {
         "mtoShipmentID"
       ],
       "properties": {
-        "approvedAt": {
-          "type": "string",
-          "format": "date"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "deletedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "description": {
           "type": "string"
         },
@@ -974,10 +962,6 @@ func init() {
         "reServiceName": {
           "type": "string"
         },
-        "rejectedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
@@ -986,17 +970,9 @@ func init() {
         "status": {
           "$ref": "#/definitions/MTOServiceItemStatus"
         },
-        "submittedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "total": {
           "type": "integer",
           "format": "cents"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time"
         }
       }
     },
@@ -1350,21 +1326,6 @@ func init() {
         "status"
       ],
       "properties": {
-        "approvedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "readOnly": true
-        },
-        "deletedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "description": {
           "type": "string",
           "readOnly": true
@@ -1423,11 +1384,6 @@ func init() {
           "type": "string",
           "readOnly": true
         },
-        "rejectedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
@@ -1436,19 +1392,9 @@ func init() {
         "status": {
           "$ref": "#/definitions/MTOServiceItemStatus"
         },
-        "submittedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "total": {
           "type": "integer",
           "format": "cents",
-          "readOnly": true
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time",
           "readOnly": true
         }
       }
@@ -2659,18 +2605,6 @@ func init() {
         "mtoShipmentID"
       ],
       "properties": {
-        "approvedAt": {
-          "type": "string",
-          "format": "date"
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "deletedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "description": {
           "type": "string"
         },
@@ -2718,10 +2652,6 @@ func init() {
         "reServiceName": {
           "type": "string"
         },
-        "rejectedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
@@ -2730,17 +2660,9 @@ func init() {
         "status": {
           "$ref": "#/definitions/MTOServiceItemStatus"
         },
-        "submittedAt": {
-          "type": "string",
-          "format": "date"
-        },
         "total": {
           "type": "integer",
           "format": "cents"
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time"
         }
       }
     },
@@ -3094,21 +3016,6 @@ func init() {
         "status"
       ],
       "properties": {
-        "approvedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "readOnly": true
-        },
-        "deletedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "description": {
           "type": "string",
           "readOnly": true
@@ -3167,11 +3074,6 @@ func init() {
           "type": "string",
           "readOnly": true
         },
-        "rejectedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
@@ -3180,19 +3082,9 @@ func init() {
         "status": {
           "$ref": "#/definitions/MTOServiceItemStatus"
         },
-        "submittedAt": {
-          "type": "string",
-          "format": "date",
-          "readOnly": true
-        },
         "total": {
           "type": "integer",
           "format": "cents",
-          "readOnly": true
-        },
-        "updatedAt": {
-          "type": "string",
-          "format": "date-time",
           "readOnly": true
         }
       }

--- a/pkg/gen/supportmessages/m_t_o_service_item.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item.go
@@ -19,18 +19,6 @@ import (
 // swagger:model MTOServiceItem
 type MTOServiceItem struct {
 
-	// approved at
-	// Format: date
-	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
-
-	// created at
-	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
-
-	// deleted at
-	// Format: date
-	DeletedAt strfmt.Date `json:"deletedAt,omitempty"`
-
 	// description
 	Description string `json:"description,omitempty"`
 
@@ -75,43 +63,19 @@ type MTOServiceItem struct {
 	// Required: true
 	ReServiceName *string `json:"reServiceName"`
 
-	// rejected at
-	// Format: date
-	RejectedAt strfmt.Date `json:"rejectedAt,omitempty"`
-
 	// rejection reason
 	RejectionReason *string `json:"rejectionReason,omitempty"`
 
 	// status
 	Status MTOServiceItemStatus `json:"status,omitempty"`
 
-	// submitted at
-	// Format: date
-	SubmittedAt strfmt.Date `json:"submittedAt,omitempty"`
-
 	// total
 	Total int64 `json:"total,omitempty"`
-
-	// updated at
-	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this m t o service item
 func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 	var res []error
-
-	if err := m.validateApprovedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateCreatedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateDeletedAt(formats); err != nil {
-		res = append(res, err)
-	}
 
 	if err := m.validateFeeType(formats); err != nil {
 		res = append(res, err)
@@ -141,64 +105,13 @@ func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateStatus(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSubmittedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateUpdatedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *MTOServiceItem) validateApprovedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ApprovedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("approvedAt", "body", "date", m.ApprovedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateCreatedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.CreatedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateDeletedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.DeletedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("deletedAt", "body", "date", m.DeletedAt.String(), formats); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -321,19 +234,6 @@ func (m *MTOServiceItem) validateReServiceName(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *MTOServiceItem) validateRejectedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.RejectedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("rejectedAt", "body", "date", m.RejectedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *MTOServiceItem) validateStatus(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.Status) { // not required
@@ -344,32 +244,6 @@ func (m *MTOServiceItem) validateStatus(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("status")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateSubmittedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.SubmittedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("submittedAt", "body", "date", m.SubmittedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateUpdatedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.UpdatedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
+++ b/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
@@ -20,56 +20,71 @@ import (
 type UpdateMTOServiceItemStatus struct {
 
 	// approved at
+	// Read Only: true
 	// Format: date
 	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
 
 	// created at
+	// Read Only: true
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// deleted at
+	// Read Only: true
 	// Format: date
 	DeletedAt strfmt.Date `json:"deletedAt,omitempty"`
 
 	// description
+	// Read Only: true
 	Description string `json:"description,omitempty"`
 
 	// e tag
+	// Read Only: true
 	ETag string `json:"eTag,omitempty"`
 
 	// fee type
+	// Read Only: true
 	// Enum: [COUNSELING CRATING TRUCKING SHUTTLE]
 	FeeType string `json:"feeType,omitempty"`
 
 	// id
+	// Read Only: true
 	// Format: uuid
 	ID strfmt.UUID `json:"id,omitempty"`
 
 	// move task order ID
+	// Read Only: true
 	// Format: uuid
 	MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
 
 	// mto shipment ID
+	// Read Only: true
 	// Format: uuid
 	MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 	// quantity
+	// Read Only: true
 	Quantity int64 `json:"quantity,omitempty"`
 
 	// rate
+	// Read Only: true
 	Rate int64 `json:"rate,omitempty"`
 
 	// re service code
+	// Read Only: true
 	ReServiceCode string `json:"reServiceCode,omitempty"`
 
 	// re service ID
+	// Read Only: true
 	// Format: uuid
 	ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
 
 	// re service name
+	// Read Only: true
 	ReServiceName string `json:"reServiceName,omitempty"`
 
 	// rejected at
+	// Read Only: true
 	// Format: date
 	RejectedAt strfmt.Date `json:"rejectedAt,omitempty"`
 
@@ -81,13 +96,16 @@ type UpdateMTOServiceItemStatus struct {
 	Status MTOServiceItemStatus `json:"status"`
 
 	// submitted at
+	// Read Only: true
 	// Format: date
 	SubmittedAt strfmt.Date `json:"submittedAt,omitempty"`
 
 	// total
+	// Read Only: true
 	Total int64 `json:"total,omitempty"`
 
 	// updated at
+	// Read Only: true
 	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }

--- a/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
+++ b/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
@@ -19,21 +19,6 @@ import (
 // swagger:model UpdateMTOServiceItemStatus
 type UpdateMTOServiceItemStatus struct {
 
-	// approved at
-	// Read Only: true
-	// Format: date
-	ApprovedAt strfmt.Date `json:"approvedAt,omitempty"`
-
-	// created at
-	// Read Only: true
-	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
-
-	// deleted at
-	// Read Only: true
-	// Format: date
-	DeletedAt strfmt.Date `json:"deletedAt,omitempty"`
-
 	// description
 	// Read Only: true
 	Description string `json:"description,omitempty"`
@@ -83,11 +68,6 @@ type UpdateMTOServiceItemStatus struct {
 	// Read Only: true
 	ReServiceName string `json:"reServiceName,omitempty"`
 
-	// rejected at
-	// Read Only: true
-	// Format: date
-	RejectedAt strfmt.Date `json:"rejectedAt,omitempty"`
-
 	// rejection reason
 	RejectionReason *string `json:"rejectionReason,omitempty"`
 
@@ -95,36 +75,14 @@ type UpdateMTOServiceItemStatus struct {
 	// Required: true
 	Status MTOServiceItemStatus `json:"status"`
 
-	// submitted at
-	// Read Only: true
-	// Format: date
-	SubmittedAt strfmt.Date `json:"submittedAt,omitempty"`
-
 	// total
 	// Read Only: true
 	Total int64 `json:"total,omitempty"`
-
-	// updated at
-	// Read Only: true
-	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this update m t o service item status
 func (m *UpdateMTOServiceItemStatus) Validate(formats strfmt.Registry) error {
 	var res []error
-
-	if err := m.validateApprovedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateCreatedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateDeletedAt(formats); err != nil {
-		res = append(res, err)
-	}
 
 	if err := m.validateFeeType(formats); err != nil {
 		res = append(res, err)
@@ -146,64 +104,13 @@ func (m *UpdateMTOServiceItemStatus) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateRejectedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateStatus(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSubmittedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateUpdatedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateApprovedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ApprovedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("approvedAt", "body", "date", m.ApprovedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateCreatedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.CreatedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateDeletedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.DeletedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("deletedAt", "body", "date", m.DeletedAt.String(), formats); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -308,51 +215,12 @@ func (m *UpdateMTOServiceItemStatus) validateReServiceID(formats strfmt.Registry
 	return nil
 }
 
-func (m *UpdateMTOServiceItemStatus) validateRejectedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.RejectedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("rejectedAt", "body", "date", m.RejectedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *UpdateMTOServiceItemStatus) validateStatus(formats strfmt.Registry) error {
 
 	if err := m.Status.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("status")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateSubmittedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.SubmittedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("submittedAt", "body", "date", m.SubmittedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateUpdatedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.UpdatedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -1,8 +1,6 @@
 package payloads
 
 import (
-	"time"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate"
@@ -216,11 +214,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) *supportmessages.Upda
 		MtoShipmentID:   strfmt.UUID(mtoServiceItem.MTOShipmentID.String()),
 		Status:          supportmessages.MTOServiceItemStatus(mtoServiceItem.Status),
 		RejectionReason: mtoServiceItem.Reason,
-	}
-
-	if mtoServiceItem.Status == "REJECTED" {
-		currentTime := time.Now()
-		payload.RejectedAt = strfmt.Date(currentTime)
 	}
 
 	return payload

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"time"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate"
@@ -214,6 +216,11 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) *supportmessages.Upda
 		MtoShipmentID:   strfmt.UUID(mtoServiceItem.MTOShipmentID.String()),
 		Status:          supportmessages.MTOServiceItemStatus(mtoServiceItem.Status),
 		RejectionReason: mtoServiceItem.Reason,
+	}
+
+	if mtoServiceItem.Status == "REJECTED" {
+		currentTime := time.Now()
+		payload.RejectedAt = strfmt.Date(currentTime)
 	}
 
 	return payload

--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -38,7 +38,8 @@ func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemops.Updat
 
 		switch e := err.(type) {
 		case services.NotFoundError:
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusNotFound()
+			payload := payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID())
+			return mtoserviceitemops.NewUpdateMTOServiceItemStatusNotFound().WithPayload(payload)
 		case services.InvalidInputError:
 			payload := payloads.ValidationError("The information you provided is invalid", h.GetTraceID(), e.ValidationErrors)
 			return mtoserviceitemops.NewUpdateMTOServiceItemStatusUnprocessableEntity().WithPayload(payload)

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -35,11 +35,11 @@ func (p *mtoServiceItemUpdater) UpdateMTOServiceItemStatus(mtoServiceItemID uuid
 	err := p.builder.FetchOne(&mtoServiceItem, queryFilters)
 
 	if err != nil {
-		return nil, services.NewNotFoundError(mtoServiceItem.ID, "MTOServiceItemID")
+		return nil, services.NewNotFoundError(mtoServiceItemID, "MTOServiceItemID")
 	}
 
 	if mtoServiceItem.Status != models.MTOServiceItemStatusSubmitted || (status != models.MTOServiceItemStatusApproved && status != models.MTOServiceItemStatusRejected) {
-		return nil, services.NewConflictError(mtoServiceItem.ID, "MTOServiceItemID")
+		return nil, services.NewConflictError(mtoServiceItemID, "MTOServiceItemID")
 	}
 
 	mtoServiceItem.Status = status
@@ -47,7 +47,7 @@ func (p *mtoServiceItemUpdater) UpdateMTOServiceItemStatus(mtoServiceItemID uuid
 
 	if status == models.MTOServiceItemStatusRejected {
 		if reason == nil {
-			return nil, services.NewConflictError(mtoServiceItem.ID, "Rejecting an MTO Service item requires a rejection reason")
+			return nil, services.NewConflictError(mtoServiceItemID, "Rejecting an MTO Service item requires a rejection reason")
 		}
 		mtoServiceItem.Reason = reason
 	} else if status == models.MTOServiceItemStatusApproved {

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1097,29 +1097,38 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+        readOnly: true
       mtoShipmentID:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+        readOnly: true
       reServiceID:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+        readOnly: true
       reServiceCode:
         type: string
+        readOnly: true
       reServiceName:
         type: string
+        readOnly: true
       approvedAt:
         format: date
         type: string
+        readOnly: true
       createdAt:
         format: date-time
         type: string
+        readOnly: true
       deletedAt:
         format: date
         type: string
+        readOnly: true
       description:
         type: string
+        readOnly: true
       feeType:
         enum:
           - COUNSELING
@@ -1127,14 +1136,18 @@ definitions:
           - TRUCKING
           - SHUTTLE
         type: string
+        readOnly: true
       id:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+        readOnly: true
       quantity:
         type: integer
+        readOnly: true
       rate:
         type: integer
+        readOnly: true
       rejectionReason:
         example: item was too heavy
         type: string
@@ -1142,19 +1155,24 @@ definitions:
       rejectedAt:
         format: date
         type: string
+        readOnly: true
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
       submittedAt:
         format: date
         type: string
+        readOnly: true
       total:
         format: cents
         type: integer
+        readOnly: true
       updatedAt:
         format: date-time
         type: string
+        readOnly: true
       eTag:
         type: string
+        readOnly: true
     required:
       - status
     type: object

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1013,15 +1013,6 @@ definitions:
         type: string
       reServiceName:
         type: string
-      approvedAt:
-        format: date
-        type: string
-      createdAt:
-        format: date-time
-        type: string
-      deletedAt:
-        format: date
-        type: string
       description:
         type: string
       feeType:
@@ -1043,20 +1034,11 @@ definitions:
         example: item was too heavy
         type: string
         x-nullable: true
-      rejectedAt:
-        format: date
-        type: string
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
-      submittedAt:
-        format: date
-        type: string
       total:
         format: cents
         type: integer
-      updatedAt:
-        format: date-time
-        type: string
       eTag:
         type: string
     required:
@@ -1114,18 +1096,6 @@ definitions:
       reServiceName:
         type: string
         readOnly: true
-      approvedAt:
-        format: date
-        type: string
-        readOnly: true
-      createdAt:
-        format: date-time
-        type: string
-        readOnly: true
-      deletedAt:
-        format: date
-        type: string
-        readOnly: true
       description:
         type: string
         readOnly: true
@@ -1152,23 +1122,11 @@ definitions:
         example: item was too heavy
         type: string
         x-nullable: true
-      rejectedAt:
-        format: date
-        type: string
-        readOnly: true
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
-      submittedAt:
-        format: date
-        type: string
-        readOnly: true
       total:
         format: cents
         type: integer
-        readOnly: true
-      updatedAt:
-        format: date-time
-        type: string
         readOnly: true
       eTag:
         type: string


### PR DESCRIPTION
## Description

* Only `status` and `rejectionReason` can be updated via `UpdateMTOServiceItemStatus`. This PR makes all other fields `readOnly` so it's less confusing to the user and the fields do not appear  in the docs request payload.

* Many date-time fields for `MTOServiceItem` are not used or stored in the database. There is future work planned around these, so for now consensus was to remove them from `support.yaml`.

* Same hold applies to `createdAt` and `updatedAt` -- unsure if we want to include these in the payload. Pop automatically creates these in the db, so an easy revert if we decide to use them in the API response.

* Added title, error, instance patter for returning `404` from `UpdateMTOServiceItemStatus`. 


## Setup

```sh
make db_dev_e2e_populate && make server_run
```

### readOnly fields
```
redoc-cli serve swagger/support.yaml
```

* Observe `updateMTOServiceItemStatus` section and confirm only `status` and `rejectionReason` appear in the request body schema.
* Test `support/v1/service-items/:mtoServiceItemID/status` and confirm it's working and returns the expected payload.

### 404 Testing
* Submit a request with a faulty uuid to `support/v1/service-items/:mtoServiceItemID/status` and observe the 404 error returned. It should look similar to the following: 

```
{
    "detail": "id: 00000000-0000-0000-0000-000000000000 not found MTOServiceItemID",
    "instance": "17330d5c-3d36-4272-af8a-a41417169f9b",
    "title": "Not Found Error"
}

```

## Code Review Verification Steps
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2509) for this change
