### PR TITLE
[MB-2566] ADR about optimistic locking when updating children in an endpoint

### DIFF
--- a/docs/adr/0049-etag-for-child-updates.md
+++ b/docs/adr/0049-etag-for-child-updates.md
@@ -1,0 +1,42 @@
+# Do not update child records using parent's etag
+
+**User Story:** [https://dp3.atlassian.net/browse/MB-2566]
+
+When we have an endpoint that updates a record in the db, it's sometimes desirable to update a child record as well. 
+
+Generally, to update a record, the caller must provide an etag, passed in the header `If-Match` that matches that of the record in the db. 
+
+However the parent and child have two different etags, and the etag is passed in a sole parameter in the header.
+
+Therefore, it's not possible to pass in the child and parent etag cleanly. 
+
+## Considered Alternatives
+
+* Make a new endpoint for child updates so they can be updated separately with the correct etag.
+* Pass a second etag in the body if the child is to be updated.
+* Bubble up a child's updated_at value to the parent, so that the child and parent will have one etag.
+
+## Decision Outcome
+
+We will make a new endpoint for child updates so they can be updated separated with the correct etag.
+
+Currently this is just true for address and agent updates. 
+
+## Pros and Cons of the Alternatives
+
+### Make a new endpoint for child updates
+* `+` The mechanism for optimistic locking stays the same across all endpoints, so it's understandable for the Prime.
+* `+` The `updated_at` value for parent and child record will correctly state the last time that record was updated. 
+* `-` More endpoints to create and maintain.
+
+### Pass a second etag in the body if the child is to be updated
+
+* `-` The mechanism differs when you want to update a child, as the etag is passed in body instead of header. Makes the mechanism inconsistent, harder to reason about and harder to explain to Prime. 
+* `+` Fewer endpoints to maintain
+
+### Bubble up a child's updated_at value to the parent
+
+* `-` Adds complexity because the child may have multiple parents and Prime would not realize that they have unwittingly updated unrelated records. 
+* `-` The mechanism differs from the norm and making exceptions for certain updates, will make it hard to be consistent across the codebase.
+* `+` Fewer endpoints to maintain
+

--- a/docs/adr/0049-etag-for-child-updates.md
+++ b/docs/adr/0049-etag-for-child-updates.md
@@ -1,42 +1,43 @@
-# Do not update child records using parent's etag
+# Do not update child records using parent's E-tag
 
-**User Story:** [https://dp3.atlassian.net/browse/MB-2566]
+**User Story:** [Jira Story](https://dp3.atlassian.net/browse/MB-2566)
 
-When we have an endpoint that updates a record in the db, it's sometimes desirable to update a child record as well. 
+When we have an endpoint that updates a record in the db, it's sometimes desirable to update a child record as well.
 
-Generally, to update a record, the caller must provide an etag, passed in the header `If-Match` that matches that of the record in the db. 
+Generally, to update a record, the caller must provide an E-tag, passed in the header `If-Match` that matches that of the record in the db.
 
-However the parent and child have two different etags, and the etag is passed in a sole parameter in the header.
+However the parent and child have two different E-tags, and the E-tag is passed in a sole parameter in the header.
 
-Therefore, it's not possible to pass in the child and parent etag cleanly. 
+Therefore, it's not possible to pass in the child and parent E-tag cleanly.
 
 ## Considered Alternatives
 
-* Make a new endpoint for child updates so they can be updated separately with the correct etag.
-* Pass a second etag in the body if the child is to be updated.
-* Bubble up a child's updated_at value to the parent, so that the child and parent will have one etag.
+* Make a new endpoint for child updates so they can be updated separately with the correct E-tag.
+* Pass a second E-tag in the body if the child is to be updated.
+* Bubble up a child's updated_at value to the parent, so that the child and parent will have one E-tag.
 
 ## Decision Outcome
 
-We will make a new endpoint for child updates so they can be updated separated with the correct etag.
+We will make a new endpoint for child updates so they can be updated separated with the correct E-tag.
 
-Currently this is just true for address and agent updates. 
+Currently this is just true for address and agent updates.
 
 ## Pros and Cons of the Alternatives
 
 ### Make a new endpoint for child updates
+
 * `+` The mechanism for optimistic locking stays the same across all endpoints, so it's understandable for the Prime.
-* `+` The `updated_at` value for parent and child record will correctly state the last time that record was updated. 
+* `+` The `updated_at` value for parent and child record will correctly state the last time that record was updated.
 * `-` More endpoints to create and maintain.
 
-### Pass a second etag in the body if the child is to be updated
+### Pass a second E-tag in the body if the child is to be updated
 
-* `-` The mechanism differs when you want to update a child, as the etag is passed in body instead of header. Makes the mechanism inconsistent, harder to reason about and harder to explain to Prime. 
+* `-` The mechanism differs when you want to update a child, as the E-tag is passed in body instead of header. Makes the mechanism inconsistent, harder to reason about and harder to explain to Prime.
 * `+` Fewer endpoints to maintain
 
 ### Bubble up a child's updated_at value to the parent
 
-* `-` Adds complexity because the child may have multiple parents and Prime would not realize that they have unwittingly updated unrelated records. 
+* `-` Adds complexity because the child may have multiple parents and Prime would not realize that they have unwittingly updated unrelated records.
 * `-` The mechanism differs from the norm and making exceptions for certain updates, will make it hard to be consistent across the codebase.
 * `+` Fewer endpoints to maintain
 

--- a/docs/adr/0049-etag-for-child-updates.md
+++ b/docs/adr/0049-etag-for-child-updates.md
@@ -18,7 +18,7 @@ Therefore, it's not possible to pass in the child and parent E-tag cleanly.
 
 ## Decision Outcome
 
-We will make a new endpoint for child updates so they can be updated separated with the correct E-tag.
+We will make a new endpoint for child updates so they can be updated separately with the correct E-tag.
 
 Currently this is just true for address and agent updates.
 

--- a/docs/adr/0049-etag-for-child-updates.md
+++ b/docs/adr/0049-etag-for-child-updates.md
@@ -6,7 +6,7 @@ When we have an endpoint that updates a record in the db, it's sometimes desirab
 
 Generally, to update a record, the caller must provide an E-tag, passed in the header `If-Match` that matches that of the record in the db.
 
-However the parent and child have two different E-tags, and the E-tag is passed in a sole parameter in the header.
+However the parent and child have two different E-tags, and only the parent's E-tag is passed in a sole parameter in the header.
 
 Therefore, it's not possible to pass in the child and parent E-tag cleanly.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -53,6 +53,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0046](0046-use-nodenv.md) - Use [nodenv](https://github.com/nodenv/nodenv) to manage Node versions in development
 - [ADR-0047](0047-build-only-pull-requests-in-circleci.md) - Use CircleCI to build only Pull Requests and master
 - [ADR-0048](0048-frontend-file-org.md) - Use a consistent file structure for front-end code
+- [ADR-0049](0049-etag-for-child-updates.md) - Do not update child records using parent's E-tag
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
## Description

Currently in some endpoints like updateMTOShipment, we pass in the etag of the shipment and then update the address. However, this means we are not checking the etag of the address. And there’s only one spot in the header for If-Match.

This ADR decides in this case, it's best to create a separate endpoint for the child, so it can be properly updated with its own etag. 

Slack convo: https://ustcdp3.slack.com/archives/CP6PTUPQF/p1592849994343000
