### PR TITLE
MB-2737 Ignore service item params in CreatePaymentRequestPayload

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1708,29 +1708,10 @@ func init() {
     "ServiceItem": {
       "type": "object",
       "properties": {
-        "eTag": {
-          "type": "string"
-        },
         "id": {
           "type": "string",
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
-        },
-        "params": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "example": "Service Item Parameter Name"
-              },
-              "value": {
-                "type": "string",
-                "example": "Service Item Parameter Value"
-              }
-            }
-          }
         }
       }
     },
@@ -3724,29 +3705,10 @@ func init() {
     "ServiceItem": {
       "type": "object",
       "properties": {
-        "eTag": {
-          "type": "string"
-        },
         "id": {
           "type": "string",
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
-        },
-        "params": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string",
-                "example": "Service Item Parameter Name"
-              },
-              "value": {
-                "type": "string",
-                "example": "Service Item Parameter Value"
-              }
-            }
-          }
         }
       }
     },

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1708,10 +1708,30 @@ func init() {
     "ServiceItem": {
       "type": "object",
       "properties": {
+        "eTag": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "example": "Service Item Parameter Name"
+              },
+              "value": {
+                "type": "string",
+                "example": "Service Item Parameter Value"
+              }
+            }
+          },
+          "readOnly": true
         }
       }
     },
@@ -3705,10 +3725,30 @@ func init() {
     "ServiceItem": {
       "type": "object",
       "properties": {
+        "eTag": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "example": "Service Item Parameter Name"
+              },
+              "value": {
+                "type": "string",
+                "example": "Service Item Parameter Value"
+              }
+            }
+          },
+          "readOnly": true
         }
       }
     },

--- a/pkg/gen/primemessages/service_item.go
+++ b/pkg/gen/primemessages/service_item.go
@@ -6,8 +6,6 @@ package primemessages
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"strconv"
-
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -19,15 +17,9 @@ import (
 // swagger:model ServiceItem
 type ServiceItem struct {
 
-	// e tag
-	ETag string `json:"eTag,omitempty"`
-
 	// id
 	// Format: uuid
 	ID strfmt.UUID `json:"id,omitempty"`
-
-	// params
-	Params []*ServiceItemParamsItems0 `json:"params"`
 }
 
 // Validate validates this service item
@@ -35,10 +27,6 @@ func (m *ServiceItem) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateParams(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -61,31 +49,6 @@ func (m *ServiceItem) validateID(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ServiceItem) validateParams(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.Params) { // not required
-		return nil
-	}
-
-	for i := 0; i < len(m.Params); i++ {
-		if swag.IsZero(m.Params[i]) { // not required
-			continue
-		}
-
-		if m.Params[i] != nil {
-			if err := m.Params[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("params" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
-	}
-
-	return nil
-}
-
 // MarshalBinary interface implementation
 func (m *ServiceItem) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -97,40 +60,6 @@ func (m *ServiceItem) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *ServiceItem) UnmarshalBinary(b []byte) error {
 	var res ServiceItem
-	if err := swag.ReadJSON(b, &res); err != nil {
-		return err
-	}
-	*m = res
-	return nil
-}
-
-// ServiceItemParamsItems0 service item params items0
-// swagger:model ServiceItemParamsItems0
-type ServiceItemParamsItems0 struct {
-
-	// key
-	Key string `json:"key,omitempty"`
-
-	// value
-	Value string `json:"value,omitempty"`
-}
-
-// Validate validates this service item params items0
-func (m *ServiceItemParamsItems0) Validate(formats strfmt.Registry) error {
-	return nil
-}
-
-// MarshalBinary interface implementation
-func (m *ServiceItemParamsItems0) MarshalBinary() ([]byte, error) {
-	if m == nil {
-		return nil, nil
-	}
-	return swag.WriteJSON(m)
-}
-
-// UnmarshalBinary interface implementation
-func (m *ServiceItemParamsItems0) UnmarshalBinary(b []byte) error {
-	var res ServiceItemParamsItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/gen/primemessages/service_item.go
+++ b/pkg/gen/primemessages/service_item.go
@@ -6,6 +6,8 @@ package primemessages
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"strconv"
+
 	strfmt "github.com/go-openapi/strfmt"
 
 	"github.com/go-openapi/errors"
@@ -17,9 +19,16 @@ import (
 // swagger:model ServiceItem
 type ServiceItem struct {
 
+	// e tag
+	ETag string `json:"eTag,omitempty"`
+
 	// id
 	// Format: uuid
 	ID strfmt.UUID `json:"id,omitempty"`
+
+	// params
+	// Read Only: true
+	Params []*ServiceItemParamsItems0 `json:"params"`
 }
 
 // Validate validates this service item
@@ -27,6 +36,10 @@ func (m *ServiceItem) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateParams(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -49,6 +62,31 @@ func (m *ServiceItem) validateID(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ServiceItem) validateParams(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Params) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Params); i++ {
+		if swag.IsZero(m.Params[i]) { // not required
+			continue
+		}
+
+		if m.Params[i] != nil {
+			if err := m.Params[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("params" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *ServiceItem) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -60,6 +98,40 @@ func (m *ServiceItem) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *ServiceItem) UnmarshalBinary(b []byte) error {
 	var res ServiceItem
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// ServiceItemParamsItems0 service item params items0
+// swagger:model ServiceItemParamsItems0
+type ServiceItemParamsItems0 struct {
+
+	// key
+	Key string `json:"key,omitempty"`
+
+	// value
+	Value string `json:"value,omitempty"`
+}
+
+// Validate validates this service item params items0
+func (m *ServiceItemParamsItems0) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *ServiceItemParamsItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *ServiceItemParamsItems0) UnmarshalBinary(b []byte) error {
+	var res ServiceItemParamsItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -132,26 +132,8 @@ func (h CreatePaymentRequestHandler) buildPaymentServiceItems(payload *primemess
 			MTOServiceItemID: mtoServiceItemID,
 		}
 
-		paymentServiceItem.PaymentServiceItemParams = h.buildPaymentServiceItemParams(payloadServiceItem)
-
 		paymentServiceItems = append(paymentServiceItems, paymentServiceItem)
 	}
 
 	return paymentServiceItems, verrs, nil
-}
-
-func (h CreatePaymentRequestHandler) buildPaymentServiceItemParams(payloadMTOServiceItem *primemessages.ServiceItem) models.PaymentServiceItemParams {
-	var paymentServiceItemParams models.PaymentServiceItemParams
-
-	for _, payloadServiceItemParam := range payloadMTOServiceItem.Params {
-		paymentServiceItemParam := models.PaymentServiceItemParam{
-			// ID and PaymentServiceItemID to be filled in when payment request is created
-			IncomingKey: payloadServiceItemParam.Key,
-			Value:       payloadServiceItemParam.Value,
-		}
-
-		paymentServiceItemParams = append(paymentServiceItemParams, paymentServiceItemParam)
-	}
-
-	return paymentServiceItemParams
 }

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -134,8 +134,30 @@ func (h CreatePaymentRequestHandler) buildPaymentServiceItems(payload *primemess
 			MTOServiceItemID: mtoServiceItemID,
 		}
 
+		paymentServiceItem.PaymentServiceItemParams = h.buildPaymentServiceItemParams(payloadServiceItem)
+
 		paymentServiceItems = append(paymentServiceItems, paymentServiceItem)
 	}
 
 	return paymentServiceItems, verrs, nil
+}
+
+
+func (h CreatePaymentRequestHandler) buildPaymentServiceItemParams(payloadMTOServiceItem *primemessages.ServiceItem) models.PaymentServiceItemParams {
+	var paymentServiceItemParams models.PaymentServiceItemParams
+
+	/************
+	   ServiceItem.params is set to readOnly = true currently in prime.yaml. Therefore we are only checking if
+	   there were params sent. If there were params in via the create payment request then we will error out.
+
+	   Currently not expecting the prime to provide any params. This might change we continue adding service items
+	   for billing and will have to adjust which service items allow incoming params at that time.
+	 ***********/
+
+	if len(payloadMTOServiceItem.Params) > 0 {
+		// TODO return error
+		// if not in this function it can also be done up top
+
+	}
+
 }

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -129,23 +129,21 @@ func (h CreatePaymentRequestHandler) buildPaymentServiceItems(payload *primemess
 			return nil, verrs, fmt.Errorf("could not convert service item ID [%v] to UUID: %w", payloadServiceItem.ID, err)
 		}
 
-		/*
-			var reService models.ReService
-			err = h.DB().Q().Join("mto_service_items", "mto_service_items.re_service_id = re_services.id").
-				Where("mto_service_items.id = ?", mtoServiceItemID).
-				First(&reService)
-			if err != nil {
-				return nil, verrs, fmt.Errorf("could not find RE (rate engine) service item for MTO Service Items with UUID %s with error: %w", mtoServiceItemID, err)
-			}
-		*/
+		// Find the ReService model that maps to to the MTOServiceItem
+		var reService models.ReService
+		err = h.DB().Q().Join("mto_service_items", "mto_service_items.re_service_id = re_services.id").
+			Where("mto_service_items.id = ?", mtoServiceItemID).
+			First(&reService)
+		if err != nil {
+			return nil, verrs, fmt.Errorf("could not find RE (rate engine) service item for MTO Service Item with UUID %s with error: %w", mtoServiceItemID, err)
+		}
 
 		paymentServiceItem := models.PaymentServiceItem{
 			// The rest of the model will be filled in when the payment request is created
 			MTOServiceItemID: mtoServiceItemID,
 		}
 
-		//paymentServiceItem.PaymentServiceItemParams, err = h.buildPaymentServiceItemParams(payloadServiceItem, reService)
-		paymentServiceItem.PaymentServiceItemParams, err = h.buildPaymentServiceItemParams(payloadServiceItem)
+		paymentServiceItem.PaymentServiceItemParams, err = h.buildPaymentServiceItemParams(payloadServiceItem, reService)
 		if err != nil {
 			return nil, verrs, err
 		}
@@ -156,19 +154,18 @@ func (h CreatePaymentRequestHandler) buildPaymentServiceItems(payload *primemess
 	return paymentServiceItems, verrs, nil
 }
 
-func (h CreatePaymentRequestHandler) buildPaymentServiceItemParams(payloadMTOServiceItem *primemessages.ServiceItem) (models.PaymentServiceItemParams, error) {
+func (h CreatePaymentRequestHandler) buildPaymentServiceItemParams(payloadMTOServiceItem *primemessages.ServiceItem, reService models.ReService) (models.PaymentServiceItemParams, error) {
 	/************
 	  ServiceItem.params is set to readOnly = true currently in prime.yaml. Therefore we are only checking if
 	  there were params sent. If there were params in via the create payment request then we will error out.
 
-	  Currently not expecting the prime to provide any params. This might change we continue adding service items
-	  for billing and will have to adjust which service items allow incoming params at that time.
+	  Currently not expecting the prime to provide any params. This might change as we continue adding service items
+	  for billing and then we'll have to adjust which service items allow incoming params at that time.
 	***********/
 
 	if len(payloadMTOServiceItem.Params) > 0 {
 		// if not in this function it can also be done up top
-		//return models.PaymentServiceItemParams{}, fmt.Errorf("updating service item params not allowed for service item [%s] with MTO Service UUID: %s", reService.Name, payloadMTOServiceItem.ID)
-		return models.PaymentServiceItemParams{}, fmt.Errorf("updating service item params not allowed with MTO Service UUID: %s", payloadMTOServiceItem.ID)
+		return models.PaymentServiceItemParams{}, fmt.Errorf("updating service item params not allowed for service item [%s] with MTO Service UUID: %s", reService.Name, payloadMTOServiceItem.ID)
 
 	}
 

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -67,6 +67,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 	// in from the API. These paymentRequest.PaymentServiceItems will be used as a temp holder to process the incoming API data
 	verrs := validate.NewErrors()
 	paymentRequest.PaymentServiceItems, verrs, err = h.buildPaymentServiceItems(payload)
+
 	if err != nil || verrs.HasAny() {
 
 		logger.Error("could not build service items", zap.Error(err))
@@ -114,6 +115,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 }
 
 func (h CreatePaymentRequestHandler) buildPaymentServiceItems(payload *primemessages.CreatePaymentRequestPayload) (models.PaymentServiceItems, *validate.Errors, error) {
+
 	var paymentServiceItems models.PaymentServiceItems
 	verrs := validate.NewErrors()
 	for _, payloadServiceItem := range payload.ServiceItems {

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -125,7 +125,9 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			},
 		}
 		response := handler.Handle(params)
+		typedResponse := response.(*paymentrequestop.CreatePaymentRequestCreated)
 
+		suite.Equal(len(typedResponse.Payload.PaymentServiceItems), 0)
 		suite.IsType(&paymentrequestop.CreatePaymentRequestCreated{}, response)
 	})
 

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -63,25 +63,25 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "1234",
-							},
-							{
-								Key:   "pickup",
-								Value: "2019-12-16",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "1234",
+						//	},
+						//	{
+						//		Key:   "pickup",
+						//		Value: "2019-12-16",
+						//	},
+						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "5678",
+						//	},
+						//},
 					},
 				},
 				PointOfContact: "user@prime.com",
@@ -203,12 +203,12 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: badFormatID,
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "5678",
+						//	},
+						//},
 					},
 				},
 			},
@@ -248,25 +248,25 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "1234",
-							},
-							{
-								Key:   "pickup",
-								Value: "2019-12-16",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "1234",
+						//	},
+						//	{
+						//		Key:   "pickup",
+						//		Value: "2019-12-16",
+						//	},
+						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "5678",
+						//	},
+						//},
 					},
 				},
 				PointOfContact: "user@prime.com",
@@ -302,25 +302,9 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "1234",
-							},
-							{
-								Key:   "pickup",
-								Value: "2019-12-16",
-							},
-						},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
 					},
 				},
 				PointOfContact: "user@prime.com",
@@ -346,25 +330,19 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "1234",
-							},
-							{
-								Key:   "pickup",
-								Value: "2019-12-16",
-							},
-						},
+						//Params: []*primemessages.ServiceItemParamsItems0{
+						//	{
+						//		Key:   "weight",
+						//		Value: "1234",
+						//	},
+						//	{
+						//		Key:   "pickup",
+						//		Value: "2019-12-16",
+						//	},
+						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
 					},
 				},
 			},

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -54,8 +54,18 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		serviceItemID1, _ := uuid.FromString("1b7b134a-7c44-45f2-9114-bb0831cc5db3")
+		testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				ID: serviceItemID1,
+			},
+		})
 		serviceItemID2, _ := uuid.FromString("119f0a05-34d7-4d86-9745-009c0707b4c2")
-		// TODO should be using MakeMTOServiceItem to create MTO Service Items, causing failures
+		testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				ID: serviceItemID2,
+			},
+		})
+
 		params := paymentrequestop.CreatePaymentRequestParams{
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -55,6 +55,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 
 		serviceItemID1, _ := uuid.FromString("1b7b134a-7c44-45f2-9114-bb0831cc5db3")
 		serviceItemID2, _ := uuid.FromString("119f0a05-34d7-4d86-9745-009c0707b4c2")
+		// TODO should be using MakeMTOServiceItem to create MTO Service Items, causing failures
 		params := paymentrequestop.CreatePaymentRequestParams{
 			HTTPRequest: req,
 			Body: &primemessages.CreatePaymentRequestPayload{
@@ -118,12 +119,6 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						Params: []*primemessages.ServiceItemParamsItems0{
-							{
-								Key:   "weight",
-								Value: "5678",
-							},
-						},
 					},
 				},
 				PointOfContact: "user@prime.com",

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -63,25 +63,9 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "1234",
-						//	},
-						//	{
-						//		Key:   "pickup",
-						//		Value: "2019-12-16",
-						//	},
-						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "5678",
-						//	},
-						//},
 					},
 				},
 				PointOfContact: "user@prime.com",
@@ -203,12 +187,6 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: badFormatID,
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "5678",
-						//	},
-						//},
 					},
 				},
 			},
@@ -248,25 +226,9 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "1234",
-						//	},
-						//	{
-						//		Key:   "pickup",
-						//		Value: "2019-12-16",
-						//	},
-						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "5678",
-						//	},
-						//},
 					},
 				},
 				PointOfContact: "user@prime.com",
@@ -330,16 +292,6 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				ServiceItems: []*primemessages.ServiceItem{
 					{
 						ID: *handlers.FmtUUID(serviceItemID1),
-						//Params: []*primemessages.ServiceItemParamsItems0{
-						//	{
-						//		Key:   "weight",
-						//		Value: "1234",
-						//	},
-						//	{
-						//		Key:   "pickup",
-						//		Value: "2019-12-16",
-						//	},
-						//},
 					},
 					{
 						ID: *handlers.FmtUUID(serviceItemID2),

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -61,7 +61,6 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 		// These incoming payment service items have not been created in the database yet
 		var newPaymentServiceItems models.PaymentServiceItems
 		for _, paymentServiceItem := range paymentRequestArg.PaymentServiceItems {
-
 			var mtoServiceItem models.MTOServiceItem
 
 			// Gather message information for logging
@@ -84,6 +83,7 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 
 			// store param Key:Value pairs coming from the create payment request payload, sent by the user when requesting payment
 			incomingMTOServiceItemParams := make(map[string]string)
+
 			// Create a payment service item parameter for each of the incoming payment service item params
 			var newPaymentServiceItemParams models.PaymentServiceItemParams
 			for _, paymentServiceItemParam := range paymentServiceItem.PaymentServiceItemParams {

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -84,7 +84,6 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 
 			// store param Key:Value pairs coming from the create payment request payload, sent by the user when requesting payment
 			incomingMTOServiceItemParams := make(map[string]string)
-
 			// Create a payment service item parameter for each of the incoming payment service item params
 			var newPaymentServiceItemParams models.PaymentServiceItemParams
 			for _, paymentServiceItemParam := range paymentServiceItem.PaymentServiceItemParams {
@@ -114,6 +113,7 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 
 			// Retrieve all of the params needed to price this service item
 			paymentHelper := paymentrequesthelper.RequestPaymentHelper{DB: tx}
+
 			reServiceParams, err := paymentHelper.FetchServiceParamList(paymentServiceItem.MTOServiceItemID)
 			if err != nil {
 				errMessage := "Failed to retrieve service item param list for " + errMessageString

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1244,19 +1244,6 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      params:
-        type: array
-        items:
-          properties:
-            key:
-              type: string
-              example: Service Item Parameter Name
-            value:
-              type: string
-              example: Service Item Parameter Value
-          type: object
-      eTag:
-        type: string
     type: object
   ReServiceCode:
     type: string

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1244,6 +1244,20 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      params:
+        type: array
+        readOnly: true
+        items:
+          properties:
+            key:
+              type: string
+              example: Service Item Parameter Name
+            value:
+              type: string
+              example: Service Item Parameter Value
+          type: object
+      eTag:
+        type: string
     type: object
   ReServiceCode:
     type: string


### PR DESCRIPTION
## Description

The Prime may attempt to send Service Item Params through the Create Payment Request payload, but we want the source of truth to be the MTO. This PR achieves ignoring the input of service item params by converting this part of the payload to readOnly, and removing the handler function that assigns serviceItemParams to serviceItems. At this time there can be a CreatePaymentRequest success when serviceItemParams are passed, without throwing an error. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

- `make db_dev_e2e_populate`
- `make server_run`
- Make a `pr_payload.json` file containing the following (which references E2E data) **running with this payload should produce an error, to make it successful, then remove the params part of the payload**:
```
  {
    "body": {
      "isFinal": false,
      "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
      "serviceItems": [
        {
          "id": "76055c99-0990-410c-a7c9-69373b0b53eb",
          "params": [
            {
             "key": "weightActual",
              "value": "1111"
            }
          ]
        }
      ]
    }
  }
```
- `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload.json | jq`
- Verify parameters and that the payment request is created without the service item params passed in through the payment request payload (in this case weightActual).  


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=26&modal=detail&selectedIssue=MB-2737)

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
