### PR TITLE
 MB-2591 Price Domestic Linehaul 

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -519,3 +519,4 @@
 20200619120000_remove_cgilmer_cac.up.sql
 20200619202714_import_fake_pricing_data.up.sql
 20200622190818_update-duty-station-address-id.up.sql
+20200624211813_add_contract_to_service_domestic_linehaul.up.sql

--- a/migrations/app/schema/20200624211813_add_contract_to_service_domestic_linehaul.up.sql
+++ b/migrations/app/schema/20200624211813_add_contract_to_service_domestic_linehaul.up.sql
@@ -1,0 +1,2 @@
+INSERT INTO service_params(id, service_id, service_item_param_key_id, created_at, updated_at)
+VALUES ('148aad01-abb2-4cf0-abdb-adf7d6b08f27', (SELECT id FROM re_services WHERE code = 'DLH'), (SELECT id FROM service_item_param_keys where key = 'ContractCode'), now(), now())

--- a/pkg/services/ghc_rate_engine.go
+++ b/pkg/services/ghc_rate_engine.go
@@ -37,13 +37,14 @@ type CounselingServicesPricer interface {
 	ParamsPricer
 }
 
-// Older pricers below (pre-dates payment requests)
-
 // DomesticLinehaulPricer prices domestic linehaul for a GHC move
 //go:generate mockery -name DomesticLinehaulPricer
 type DomesticLinehaulPricer interface {
-	PriceDomesticLinehaul(moveDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, error)
+	Price(contractCode string, requestedPickupDate time.Time, isPeakPeriod bool, distance int, weightBilledActual int, serviceArea string) (unit.Cents, error)
+	ParamsPricer
 }
+
+// Older pricers below (pre-dates payment requests)
 
 // DomesticShorthaulPricer prices the domestic shorthaul for a GHC Move
 //go:generate mockery -name DomesticShorthaulPricer

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
@@ -1,71 +1,98 @@
 package ghcrateengine
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/zap/zapcore"
 
+	"github.com/transcom/mymove/pkg/models"
+
 	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-// NewDomesticLinehaulPricer is the public constructor for a DomesticLinehaulPricer using Pop
-func NewDomesticLinehaulPricer(db *pop.Connection, logger Logger, contractCode string) services.DomesticLinehaulPricer {
+type domesticLinehaulPricer struct {
+	db *pop.Connection
+}
+
+// NewDomesticLinehaulPricer creates a new pricer for domestic linehaul services
+func NewDomesticLinehaulPricer(db *pop.Connection) services.DomesticLinehaulPricer {
 	return &domesticLinehaulPricer{
-		db:           db,
-		logger:       logger,
-		contractCode: contractCode,
+		db: db,
 	}
 }
 
-// domesticLinehaulPricer is a service object to price domestic linehaul
-type domesticLinehaulPricer struct {
-	db           *pop.Connection
-	logger       Logger
-	contractCode string
+// Price determines the price for a domestic linehaul
+func (p domesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, isPeakPeriod bool, distance int, weightBilledActual int, serviceArea string) (unit.Cents, error) {
+	priceAndEscalation, err := fetchDomesticLinehaulPrice(p.db, contractCode, requestedPickupDate, isPeakPeriod, distance, weightBilledActual, serviceArea)
+	if err != nil {
+		return unit.Cents(0), fmt.Errorf("could not fetch domestic linehaul rate: %w", err)
+	}
+
+	weightPounds := unit.Pound(weightBilledActual)
+	distanceMiles := unit.Miles(distance)
+	baseTotalPrice := weightPounds.ToCWTFloat64() * distanceMiles.Float64() * priceAndEscalation.PriceMillicents.Float64()
+	escalatedTotalPrice := priceAndEscalation.EscalationCompounded * baseTotalPrice
+
+	totalPriceMillicents := unit.Millicents(escalatedTotalPrice)
+	totalPriceCents := totalPriceMillicents.ToCents()
+
+	return totalPriceCents, nil
+
 }
 
-// priceAndEscalation is used to hold data returned by the database query
-type milliCentPriceAndEscalation struct {
-	PriceMillicents      unit.Millicents `db:"price_millicents"`
-	EscalationCompounded float64         `db:"escalation_compounded"`
+// PriceUsingParams determines the price for a domestic linehaul given PaymentServiceItemParams
+func (p domesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, error) {
+	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
+	if err != nil {
+		return unit.Cents(0), err
+	}
+
+	requestedPickupDate, err := getParamTime(params, models.ServiceItemParamNameRequestedPickupDate)
+	if err != nil {
+		return unit.Cents(0), err
+	}
+
+	distanceZip3, err := getParamInt(params, models.ServiceItemParamNameDistanceZip3)
+	if err != nil {
+		return unit.Cents(0), err
+	}
+
+	weightBilledActual, err := getParamInt(params, models.ServiceItemParamNameWeightBilledActual)
+	if err != nil {
+		return unit.Cents(0), err
+	}
+
+	serviceAreaOrigin, err := getParamString(params, models.ServiceItemParamNameServiceAreaOrigin)
+	if err != nil {
+		return unit.Cents(0), err
+	}
+
+	isPeakPeriod := IsPeakPeriod(requestedPickupDate)
+
+	return p.Price(contractCode, requestedPickupDate, isPeakPeriod, distanceZip3, weightBilledActual, serviceAreaOrigin)
 }
 
-func (p milliCentPriceAndEscalation) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
-	encoder.AddInt("PriceMillicents", p.PriceMillicents.Int())
-	encoder.AddFloat64("EscalationCompounded", p.EscalationCompounded)
-	return nil
-}
-
-// PriceDomesticLinehaul produces the price in cents for the linehaul charge for the given move parameters
-func (p domesticLinehaulPricer) PriceDomesticLinehaul(moveDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, error) {
+func fetchDomesticLinehaulPrice(db *pop.Connection, contractCode string, requestedPickupDate time.Time, isPeakPeriod bool, distance int, weight int, serviceArea string) (milliCentPriceAndEscalation, error) {
 	// Validate parameters
-	if moveDate.IsZero() {
-		return 0, errors.New("MoveDate is required")
+	if requestedPickupDate.IsZero() {
+		return milliCentPriceAndEscalation{}, errors.New("MoveDate is required")
 	}
 	if distance <= 0 {
-		return 0, errors.New("Distance must be greater than 0")
+		return milliCentPriceAndEscalation{}, errors.New("Distance must be greater than 0")
 	}
 	if weight <= 0 {
-		return 0, errors.New("Weight must be greater than 0")
+		return milliCentPriceAndEscalation{}, errors.New("Weight must be greater than 0")
 	}
 	if len(serviceArea) == 0 {
-		return 0, errors.New("ServiceArea is required")
+		return milliCentPriceAndEscalation{}, errors.New("ServiceArea is required")
 	}
 
-	// Minimum weight is 500 pounds
-	effectiveWeight := weight
-	if weight < minDomesticWeight {
-		effectiveWeight = minDomesticWeight
-	}
-
-	isPeakPeriod := IsPeakPeriod(moveDate)
-
-	var pe milliCentPriceAndEscalation
+	var mpe milliCentPriceAndEscalation
 	query :=
 		`select price_millicents, escalation_compounded
          from re_domestic_linehaul_prices dlp
@@ -78,38 +105,30 @@ func (p domesticLinehaulPricer) PriceDomesticLinehaul(moveDate time.Time, distan
          and $4 between dlp.weight_lower and dlp.weight_upper
          and $5 between dlp.miles_lower and dlp.miles_upper
          and dsa.service_area = $6;`
-	err := p.db.RawQuery(
+	err := db.RawQuery(
 		query,
-		p.contractCode,
-		moveDate,
+		contractCode,
+		requestedPickupDate,
 		isPeakPeriod,
-		effectiveWeight,
+		weight,
 		distance,
-		serviceArea).First(&pe)
+		serviceArea).First(&mpe)
 	if err != nil {
-		return 0, errors.Wrap(err, "Lookup of domestic linehaul rate failed")
+		return mpe, errors.Wrap(err, "Lookup of domestic linehaul rate failed")
 	}
 
-	baseTotalPrice := effectiveWeight.ToCWTFloat64() * distance.Float64() * pe.PriceMillicents.Float64()
-	escalatedTotalPrice := pe.EscalationCompounded * baseTotalPrice
+	return mpe, nil
 
-	// TODO: Round or truncate?
-	totalPriceMillicents := unit.Millicents(escalatedTotalPrice)
-	totalPriceCents := totalPriceMillicents.ToCents()
+}
 
-	p.logger.Info("Base domestic linehaul calculated",
-		zap.String("contractCode", p.contractCode),
-		zap.Time("moveDate", moveDate),
-		zap.Int("distance", distance.Int()),
-		zap.Int("weight", weight.Int()),
-		zap.String("serviceArea", serviceArea),
-		zap.Bool("isPeakPeriod", isPeakPeriod),
-		zap.Int("effectiveWeight", effectiveWeight.Int()),
-		zap.Object("priceAndEscalation", pe),
-		zap.Float64("baseTotalPrice", baseTotalPrice),
-		zap.Float64("escalatedTotalPrice", escalatedTotalPrice),
-		zap.Int("totalPriceCents", totalPriceCents.Int()),
-	)
+// priceAndEscalation is used to hold data returned by the database query
+type milliCentPriceAndEscalation struct {
+	PriceMillicents      unit.Millicents `db:"price_millicents"`
+	EscalationCompounded float64         `db:"escalation_compounded"`
+}
 
-	return totalPriceCents, err
+func (p milliCentPriceAndEscalation) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddInt("PriceMillicents", p.PriceMillicents.Int())
+	encoder.AddFloat64("EscalationCompounded", p.EscalationCompounded)
+	return nil
 }

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
@@ -15,6 +15,11 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+const (
+	dlhPricerMinimumWeight   = 500
+	dlhPricerMinimumDistance = 0
+)
+
 type domesticLinehaulPricer struct {
 	db *pop.Connection
 }
@@ -82,11 +87,11 @@ func fetchDomesticLinehaulPrice(db *pop.Connection, contractCode string, request
 	if requestedPickupDate.IsZero() {
 		return milliCentPriceAndEscalation{}, errors.New("MoveDate is required")
 	}
-	if distance <= 0 {
-		return milliCentPriceAndEscalation{}, errors.New("Distance must be greater than 0")
+	if distance <= dlhPricerMinimumDistance {
+		return milliCentPriceAndEscalation{}, fmt.Errorf("distance must be greater than %d", dlhPricerMinimumDistance)
 	}
-	if weight <= 0 {
-		return milliCentPriceAndEscalation{}, errors.New("Weight must be greater than 0")
+	if weight <= dlhPricerMinimumWeight {
+		return milliCentPriceAndEscalation{}, fmt.Errorf("weight must be greater than %d", dlhPricerMinimumWeight)
 	}
 	if len(serviceArea) == 0 {
 		return milliCentPriceAndEscalation{}, errors.New("ServiceArea is required")

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
@@ -1,6 +1,7 @@
 package ghcrateengine
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,74 +14,64 @@ const (
 	dlhTestServiceArea = "004"
 	dlhTestDistance    = unit.Miles(1200)
 	dlhTestWeight      = unit.Pound(4000)
+	dlhPriceCents      = unit.Cents(249770)
 )
+
+var dlhRequestedPickupDate = time.Date(testdatagen.TestYear, time.June, 5, 7, 33, 11, 456, time.UTC)
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 	suite.setupDomesticLinehaulData()
-	domesticLinehaulPricer := NewDomesticLinehaulPricer(suite.DB(), suite.logger, testdatagen.DefaultContractCode)
+	paymentServiceItem := suite.setupDomesticLinehaulServiceItem()
+	linehaulServicePricer := NewDomesticLinehaulPricer(suite.DB())
 
-	suite.T().Run("success within peak period", func(t *testing.T) {
-		totalPrice, err := domesticLinehaulPricer.PriceDomesticLinehaul(
-			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
-			dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
-
+	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+		priceCents, err := linehaulServicePricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
-		suite.Equal(249770, totalPrice.Int())
+		suite.Equal(dlhPriceCents, priceCents)
 	})
 
-	suite.T().Run("success within non-peak period", func(t *testing.T) {
-		nonPeakDate := peakStart.addDate(0, -1)
-		totalPrice, err := domesticLinehaulPricer.PriceDomesticLinehaul(
-			time.Date(testdatagen.TestYear, nonPeakDate.month, nonPeakDate.day, 0, 0, 0, 0, time.UTC),
-			dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
-
+	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+		priceCents, err := linehaulServicePricer.Price(testdatagen.DefaultContractCode, dlhRequestedPickupDate, true, int(dlhTestDistance), int(dlhTestWeight), dlhTestServiceArea)
+		//contractCode, requestedPickupDate, isPeakPeriod, distanceZip3, weightBilledActual, serviceAreaOrigin
 		suite.NoError(err)
-		suite.Equal(224793, totalPrice.Int())
+		suite.Equal(dlhPriceCents, priceCents)
 	})
 
-	suite.T().Run("weight below minimum", func(t *testing.T) {
-		totalPrice, err := domesticLinehaulPricer.PriceDomesticLinehaul(
-			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
-			dlhTestDistance, minDomesticWeight/2, dlhTestServiceArea)
-
-		suite.NoError(err)
-		suite.Equal(31221, totalPrice.Int())
+	suite.T().Run("sending PaymentServiceItemParams without expected param", func(t *testing.T) {
+		_, err := linehaulServicePricer.PriceUsingParams(models.PaymentServiceItemParams{})
+		suite.Error(err)
 	})
 
-	suite.T().Run("date outside of valid contract year", func(t *testing.T) {
-		_, err := domesticLinehaulPricer.PriceDomesticLinehaul(
-			time.Date(testdatagen.TestYear-1, time.January, 1, 0, 0, 0, 0, time.UTC),
-			dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
-
+	suite.T().Run("not finding a rate record", func(t *testing.T) {
+		_, err := linehaulServicePricer.Price("BOGUS", dlhRequestedPickupDate, true, int(dlhTestDistance), int(dlhTestWeight), dlhTestServiceArea)
 		suite.Error(err)
 	})
 
 	suite.T().Run("validation errors", func(t *testing.T) {
-		moveDate := time.Date(testdatagen.TestYear, time.July, 4, 0, 0, 0, 0, time.UTC)
-
 		// No move date
-		_, err := domesticLinehaulPricer.PriceDomesticLinehaul(time.Time{}, dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
+		_, err := linehaulServicePricer.Price("BOGUS", time.Time{}, true, int(dlhTestDistance), int(dlhTestWeight), dlhTestServiceArea)
 		suite.Error(err)
-		suite.Equal("MoveDate is required", err.Error())
+		suite.Equal("could not fetch domestic linehaul rate: MoveDate is required", err.Error())
 
 		// No distance
-		_, err = domesticLinehaulPricer.PriceDomesticLinehaul(moveDate, 0, dlhTestWeight, dlhTestServiceArea)
+		_, err = linehaulServicePricer.Price(testdatagen.DefaultContractCode, dlhRequestedPickupDate, true, 0, int(dlhTestWeight), dlhTestServiceArea)
 		suite.Error(err)
-		suite.Equal("Distance must be greater than 0", err.Error())
+		suite.Equal("could not fetch domestic linehaul rate: Distance must be greater than 0", err.Error())
 
 		// No weight
-		_, err = domesticLinehaulPricer.PriceDomesticLinehaul(moveDate, dlhTestDistance, 0, dlhTestServiceArea)
+		_, err = linehaulServicePricer.Price(testdatagen.DefaultContractCode, dlhRequestedPickupDate, true, int(dlhTestDistance), 0, dlhTestServiceArea)
 		suite.Error(err)
-		suite.Equal("Weight must be greater than 0", err.Error())
+		suite.Equal("could not fetch domestic linehaul rate: Weight must be greater than 0", err.Error())
 
 		// No service area
-		_, err = domesticLinehaulPricer.PriceDomesticLinehaul(moveDate, dlhTestDistance, dlhTestWeight, "")
+		_, err = linehaulServicePricer.Price(testdatagen.DefaultContractCode, dlhRequestedPickupDate, true, int(dlhTestDistance), int(dlhTestWeight), "")
 		suite.Error(err)
-		suite.Equal("ServiceArea is required", err.Error())
+		suite.Equal("could not fetch domestic linehaul rate: ServiceArea is required", err.Error())
 	})
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulData() {
+
 	contractYear := testdatagen.MakeReContractYear(suite.DB(),
 		testdatagen.Assertions{
 			ReContractYear: models.ReContractYear{
@@ -111,8 +102,57 @@ func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulData() {
 	linehaulPricePeak.PriceMillicents = 5000 // 0.050
 	suite.MustSave(&linehaulPricePeak)
 
-	linehaulPriceNonPeak := baseLinehaulPrice
-	linehaulPriceNonPeak.IsPeakPeriod = false
-	linehaulPriceNonPeak.PriceMillicents = 4500 // 0.045
-	suite.MustSave(&linehaulPriceNonPeak)
+}
+
+func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulServiceItem() models.PaymentServiceItem {
+	return suite.setupPaymentServiceItemWithParams(
+		models.ReServiceCodeDLH,
+		[]createParams{
+			{
+				models.ServiceItemParamNameContractCode,
+				models.ServiceItemParamTypeString,
+				testdatagen.DefaultContractCode,
+			},
+			{
+				models.ServiceItemParamNameRequestedPickupDate,
+				models.ServiceItemParamTypeTimestamp,
+				dlhRequestedPickupDate.Format(TimestampParamFormat),
+			},
+			{
+				models.ServiceItemParamNameDistanceZip3,
+				models.ServiceItemParamTypeInteger,
+				fmt.Sprintf("%d", int(dlhTestDistance)),
+			},
+			{
+				models.ServiceItemParamNameZipPickupAddress,
+				models.ServiceItemParamTypeString,
+				"90210",
+			},
+			{
+				models.ServiceItemParamNameZipDestAddress,
+				models.ServiceItemParamTypeString,
+				"94535",
+			},
+			{
+				models.ServiceItemParamNameWeightBilledActual,
+				models.ServiceItemParamTypeInteger,
+				fmt.Sprintf("%d", int(dlhTestWeight)),
+			},
+			{
+				models.ServiceItemParamNameWeightActual,
+				models.ServiceItemParamTypeInteger,
+				"1400",
+			},
+			{
+				models.ServiceItemParamNameWeightEstimated,
+				models.ServiceItemParamTypeInteger,
+				"1400",
+			},
+			{
+				models.ServiceItemParamNameServiceAreaOrigin,
+				models.ServiceItemParamTypeString,
+				dlhTestServiceArea,
+			},
+		},
+	)
 }

--- a/pkg/services/ghcrateengine/param_convert.go
+++ b/pkg/services/ghcrateengine/param_convert.go
@@ -2,6 +2,7 @@ package ghcrateengine
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -12,6 +13,25 @@ const (
 	DateParamFormat      = "2006-01-02"
 	TimestampParamFormat = time.RFC3339
 )
+
+func getParamInt(params models.PaymentServiceItemParams, name models.ServiceItemParamName) (int, error) {
+	paymentServiceItemParam := getPaymentServiceItemParam(params, name)
+	if paymentServiceItemParam == nil {
+		return 0, fmt.Errorf("could not find param with key %s", name)
+	}
+
+	paramType := paymentServiceItemParam.ServiceItemParamKey.Type
+	if paramType != models.ServiceItemParamTypeInteger {
+		return 0, fmt.Errorf("trying to convert %s to a int, but param is of type %s", name, paramType)
+	}
+
+	value, err := strconv.Atoi(paymentServiceItemParam.Value)
+	if err != nil {
+		return 0, fmt.Errorf("could not convert value %s to a int: %w", paymentServiceItemParam.Value, err)
+	}
+
+	return value, nil
+}
 
 func getParamString(params models.PaymentServiceItemParams, name models.ServiceItemParamName) (string, error) {
 	paymentServiceItemParam := getPaymentServiceItemParam(params, name)

--- a/pkg/services/ghcrateengine/service_item_pricer.go
+++ b/pkg/services/ghcrateengine/service_item_pricer.go
@@ -43,6 +43,8 @@ func (p serviceItemPricer) getPricer(serviceCode models.ReServiceCode) (services
 		return NewManagementServicesPricer(p.db), nil
 	case models.ReServiceCodeCS:
 		return NewCounselingServicesPricer(p.db), nil
+	case models.ReServiceCodeDLH:
+		return NewDomesticLinehaulPricer(p.db), nil
 	default:
 		// TODO: We may want a different error type here after all pricers have been implemented
 		return nil, services.NewNotImplementedError(fmt.Sprintf("pricer not found for code %s", serviceCode))

--- a/pkg/services/ghcrateengine/service_item_pricer_test.go
+++ b/pkg/services/ghcrateengine/service_item_pricer_test.go
@@ -61,6 +61,7 @@ func (suite *GHCRateEngineServiceSuite) TestGetPricer() {
 	}{
 		{models.ReServiceCodeMS, &managementServicesPricer{}},
 		{models.ReServiceCodeCS, &counselingServicesPricer{}},
+		{models.ReServiceCodeDLH, &domesticLinehaulPricer{}},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/services/mocks/DomesticLinehaulPricer.go
+++ b/pkg/services/mocks/DomesticLinehaulPricer.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+	models "github.com/transcom/mymove/pkg/models"
 
 	time "time"
 
@@ -15,20 +16,41 @@ type DomesticLinehaulPricer struct {
 	mock.Mock
 }
 
-// PriceDomesticLinehaul provides a mock function with given fields: moveDate, distance, weight, serviceArea
-func (_m *DomesticLinehaulPricer) PriceDomesticLinehaul(moveDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, error) {
-	ret := _m.Called(moveDate, distance, weight, serviceArea)
+// Price provides a mock function with given fields: contractCode, requestedPickupDate, isPeakPeriod, distance, weightBilledActual, serviceArea
+func (_m *DomesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, isPeakPeriod bool, distance int, weightBilledActual int, serviceArea string) (unit.Cents, error) {
+	ret := _m.Called(contractCode, requestedPickupDate, isPeakPeriod, distance, weightBilledActual, serviceArea)
 
 	var r0 unit.Cents
-	if rf, ok := ret.Get(0).(func(time.Time, unit.Miles, unit.Pound, string) unit.Cents); ok {
-		r0 = rf(moveDate, distance, weight, serviceArea)
+	if rf, ok := ret.Get(0).(func(string, time.Time, bool, int, int, string) unit.Cents); ok {
+		r0 = rf(contractCode, requestedPickupDate, isPeakPeriod, distance, weightBilledActual, serviceArea)
 	} else {
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(time.Time, unit.Miles, unit.Pound, string) error); ok {
-		r1 = rf(moveDate, distance, weight, serviceArea)
+	if rf, ok := ret.Get(1).(func(string, time.Time, bool, int, int, string) error); ok {
+		r1 = rf(contractCode, requestedPickupDate, isPeakPeriod, distance, weightBilledActual, serviceArea)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PriceUsingParams provides a mock function with given fields: params
+func (_m *DomesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, error) {
+	ret := _m.Called(params)
+
+	var r0 unit.Cents
+	if rf, ok := ret.Get(0).(func(models.PaymentServiceItemParams) unit.Cents); ok {
+		r0 = rf(params)
+	} else {
+		r0 = ret.Get(0).(unit.Cents)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) error); ok {
+		r1 = rf(params)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -9,6 +9,9 @@ import (
 // TestYear is the default year for testing.
 var TestYear = 2018
 
+// GHCTestYear is the default for GHC rate engine testing
+var GHCTestYear = 2020
+
 // DefaultZip3 is the default zip3 for testing
 var DefaultZip3 = "902"
 

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -34,8 +34,8 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	actualWeight := unit.Pound(980)
 
 	// mock dates
-	scheduledPickupDate := time.Date(TestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
-	requestedPickupDate := time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
+	scheduledPickupDate := time.Date(GHCTestYear, time.March, 16, 0, 0, 0, 0, time.UTC)
+	requestedPickupDate := time.Date(GHCTestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
 
 	MTOShipment := models.MTOShipment{
 		MoveTaskOrder:            moveTaskOrder,
@@ -56,12 +56,12 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	}
 
 	if assertions.MTOShipment.Status == models.MTOShipmentStatusApproved {
-		approvedDate := time.Date(TestYear, time.March, 20, 0, 0, 0, 0, time.UTC)
+		approvedDate := time.Date(GHCTestYear, time.March, 20, 0, 0, 0, 0, time.UTC)
 		MTOShipment.ApprovedDate = &approvedDate
 	}
 
 	if assertions.MTOShipment.ScheduledPickupDate != nil {
-		requiredDeliveryDate := time.Date(TestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
+		requiredDeliveryDate := time.Date(GHCTestYear, time.April, 15, 0, 0, 0, 0, time.UTC)
 		MTOShipment.RequiredDeliveryDate = &requiredDeliveryDate
 	}
 
@@ -85,7 +85,7 @@ func MakeMTOShipmentMinimal(db *pop.Connection, assertions Assertions) models.MT
 	shipmentType := models.MTOShipmentTypeHHG
 
 	// mock dates
-	requestedPickupDate := time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
+	requestedPickupDate := time.Date(GHCTestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
 
 	MTOShipment := models.MTOShipment{
 		MoveTaskOrder:        moveTaskOrder,
@@ -100,7 +100,7 @@ func MakeMTOShipmentMinimal(db *pop.Connection, assertions Assertions) models.MT
 	}
 
 	if assertions.MTOShipment.Status == models.MTOShipmentStatusApproved {
-		approvedDate := time.Date(TestYear, time.March, 20, 0, 0, 0, 0, time.UTC)
+		approvedDate := time.Date(GHCTestYear, time.March, 20, 0, 0, 0, 0, time.UTC)
 		MTOShipment.ApprovedDate = &approvedDate
 	}
 

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -949,8 +949,14 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		},
 	})
 
+	estimatedWeight := unit.Pound(1400)
+	actualWeight := unit.Pound(2000)
 	MTOShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		MTOShipment:   models.MTOShipment{ID: uuid.FromStringOrNil("475579d5-aaa4-4755-8c43-c510381ff9b5")},
+		MTOShipment: models.MTOShipment{
+			ID:                   uuid.FromStringOrNil("475579d5-aaa4-4755-8c43-c510381ff9b5"),
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+		},
 		MoveTaskOrder: mto,
 	})
 


### PR DESCRIPTION
## Description

Price linehaul service item.

The prime will request a payment request including service item Domestic Linehaul. The milmove system will receive the request, gather the params needed to price the service item. Create a payment request and price the payment request using the params previously gathered and return back the information (via a payment request) to the caller.


## Reviewer Notes

Similar PR was done to price Task Order Services. https://github.com/transcom/mymove/pull/4250 

## Setup

Testing information are in the steps below, but additional information to perform testing is in
* https://github.com/transcom/mymove/wiki/Acceptance-Testing-Payment-Requests  
* https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)


## Formula for Dom Linehaul

Dom Linehaul Price Millicent  * distance * cwtWeight * escalationCompounded


## Verifying unit test calculations used in unit test if you are wanting to check the pricecents used for assertions. 

function `TestPriceDomesticLinehaul`
```
	dlhPriceCents      = unit.Cents(249770)
```
from file https://github.com/transcom/mymove/blob/d32e1dd618d06056ded679d061a9f02f2d91ad2b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go#L17

```
//baseTotalPrice := weightPounds.ToCWTFloat64() * distanceMiles.Float64() * priceAndEscalation.PriceMillicents.Float64()
240000000 = 40.00 * 1200.00 * 5000.00

//escalatedTotalPrice := priceAndEscalation.EscalationCompounded * baseTotalPrice
249770400.00 = 1.040710 * 240000000.00 = 

// to cents
249770.4 = 249770400.00  / 1000
```

## Steps to run in dev with `prime-api-client`

### Run 
```
make db_dev_reset db_dev_e2e_populate && rm bin/prime-api-client && make bin/prime-api-client
make server_run
```

### Using paylaod below create file `pr_create_dev.json`

```json
{                                                                                                                                                                            
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
    "serviceItems": [
      {   
        "id": "9db1bf43-0964-44ff-8384-3297951f6781"
      }   
    ]   
  }
}
```

### Create a payment request. 

```sh
prime-api-client --insecure create-payment-request --filename pr_create_dev.json | jq
```

### View the results coming back from the payment request. 
Review the 9 params needed to price linehaul.

### Optionally, you can run `fetch-mto-updates` to pull the MTOs and view the same payment request info there. 

```sh
prime-api-client --insecure fetch-mto-updates | jq 'map(select(.id == "5d4b25bb-eb04-4c03-9a81-ee0398cb779e")) | .[0]'
```

### To verify the calculations, find the rate in your local dev database.

```sql
select price_millicents, escalation_compounded
from re_domestic_linehaul_prices dlp
         inner join re_contracts c on dlp.contract_id = c.id
         inner join re_contract_years cy on c.id = cy.contract_id
         inner join re_domestic_service_areas dsa on dlp.domestic_service_area_id = dsa.id
where c.code = 'TRUSS_TEST'
  and '2020-03-15 00:00:00 UTC' between cy.start_date and cy.end_date
  and dlp.is_peak_period = false
  and '1540' between dlp.weight_lower and dlp.weight_upper
  and '373' between dlp.miles_lower and dlp.miles_upper
  and dsa.service_area = '056';
```

### Verify the calculations from using e2e data with `prime-api-client` to create a payment-request. 

```
//baseTotalPrice := weightPounds.ToCWTFloat64() * distanceMiles.Float64() * priceAndEscalation.PriceMillicents.Float64()
1366545180 = (1540/100.0) * 373.0 * 237900

//escalatedTotalPrice := priceAndEscalation.EscalationCompounded * baseTotalPrice
1366545180.00 = 1.00 * 1366545180.00 = 

// to cents
1366545.18 = 1366545180.0 / 1000
```


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2591) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
