### PR TITLE
standardize health check log line

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -690,7 +690,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 		// Always show DB unless key set to "false"
 		if !ok || (ok && showDB[0] != "false") {
-			logger.Info("Health check connecting to DB")
+			logger.Info("Health check connecting to the DB")
 			dbErr := dbConnection.RawQuery("SELECT 1;").Exec()
 			if dbErr != nil {
 				logger.Error("Failed database health check", zap.Error(dbErr))

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -690,7 +690,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 		// Always show DB unless key set to "false"
 		if !ok || (ok && showDB[0] != "false") {
-			logger.Info("connecting to the DB for health check")
+			logger.Info("Health check connecting to DB")
 			dbErr := dbConnection.RawQuery("SELECT 1;").Exec()
 			if dbErr != nil {
 				logger.Error("Failed database health check", zap.Error(dbErr))


### PR DESCRIPTION
## Description

Make searching logs easier by standardizing the health check `Info` log line... Similar to the redis info: https://github.com/transcom/mymove/blob/9a658ca7f8e6ec0d4f3067997f66f2b4e4100d18/cmd/milmove/serve.go#L326


