### PR TITLE
Fix Orders test use of mock providers

### DIFF
--- a/src/scenes/Orders/Orders.test.js
+++ b/src/scenes/Orders/Orders.test.js
@@ -1,9 +1,9 @@
-import { configureStore } from 'shared/store';
-import Orders from '../Orders/Orders';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { HashRouter as Router } from 'react-router-dom';
 import { mount } from 'enzyme';
+
+import Orders from '../Orders/Orders';
+
+import { MockProviders } from 'testUtils';
 
 describe('Orders page', () => {
   it('renders', () => {});
@@ -15,11 +15,9 @@ describe('Orders page', () => {
     },
   };
   const wrapper = mount(
-    <Provider store={configureStore(initialState)}>
-      <Router push={jest.fn()}>
-        <Orders pages={[]} pageKey="" updateOrders={jest.fn()} />
-      </Router>
-    </Provider>,
+    <MockProviders initialState={initialState} initialEntries={['/']}>
+      <Orders pages={[]} pageKey="" updateOrders={jest.fn()} />
+    </MockProviders>,
   );
   expect(wrapper.length).toEqual(1);
 });


### PR DESCRIPTION
## Description

[This merge commit](https://github.com/transcom/mymove/commit/351cf01172f3e05769bed6dbe21b8baabbf258b5) broke JS tests on master by [making a change to the signature of the `configureStore` function](https://github.com/transcom/mymove/commit/351cf01172f3e05769bed6dbe21b8baabbf258b5#diff-739fb217e3f211d5fbd6dbf09a7804aaL23), which is used to set up mock Redux & router instances for testing. This PR fixes the test that was broken to use the newer `MockProviders` test utility, which should be more future-proof since it's a component instead of a function.