### PR TITLE
[MB-3015] Fix duplicate nesting of Change Role UI

### DIFF
--- a/src/containers/PrivateRoute.jsx
+++ b/src/containers/PrivateRoute.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { selectCurrentUser, selectGetCurrentUserIsLoading } from 'shared/Data/users';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { UserRolesShape } from 'types/user';
 
 export function userIsAuthorized(userRoles, requiredRoles) {
   // Return true if no roles are required
@@ -17,7 +19,7 @@ export function userIsAuthorized(userRoles, requiredRoles) {
 }
 
 const PrivateRoute = (props) => {
-  const { loginIsLoading, userIsLoggedIn, requiredRoles, userRoles, hideSwitcher, ...routeProps } = props;
+  const { loginIsLoading, userIsLoggedIn, requiredRoles, userRoles, ...routeProps } = props;
 
   if (loginIsLoading) return <LoadingPlaceholder />;
 
@@ -30,10 +32,23 @@ const PrivateRoute = (props) => {
   )
     return <Redirect to="/" />;
 
+  // eslint-disable-next-line react/jsx-props-no-spreading
   return <Route {...routeProps} />;
 };
 
 PrivateRoute.displayName = 'PrivateRoute';
+
+PrivateRoute.propTypes = {
+  loginIsLoading: PropTypes.bool.isRequired,
+  userIsLoggedIn: PropTypes.bool.isRequired,
+  requiredRoles: PropTypes.arrayOf(PropTypes.string),
+  userRoles: UserRolesShape,
+};
+
+PrivateRoute.defaultProps = {
+  requiredRoles: [],
+  userRoles: [],
+};
 
 const mapStateToProps = (state) => ({
   loginIsLoading: selectGetCurrentUserIsLoading(state),

--- a/src/containers/PrivateRoute.jsx
+++ b/src/containers/PrivateRoute.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import { selectCurrentUser, selectGetCurrentUserIsLoading } from 'shared/Data/users';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { UserRolesShape } from 'types/user';
+import { UserRolesShape } from 'types/index';
 
 export function userIsAuthorized(userRoles, requiredRoles) {
   // Return true if no roles are required
@@ -39,13 +39,15 @@ const PrivateRoute = (props) => {
 PrivateRoute.displayName = 'PrivateRoute';
 
 PrivateRoute.propTypes = {
-  loginIsLoading: PropTypes.bool.isRequired,
-  userIsLoggedIn: PropTypes.bool.isRequired,
+  loginIsLoading: PropTypes.bool,
+  userIsLoggedIn: PropTypes.bool,
   requiredRoles: PropTypes.arrayOf(PropTypes.string),
   userRoles: UserRolesShape,
 };
 
 PrivateRoute.defaultProps = {
+  loginIsLoading: true,
+  userIsLoggedIn: false,
   requiredRoles: [],
   userRoles: [],
 };

--- a/src/containers/PrivateRoute.test.jsx
+++ b/src/containers/PrivateRoute.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { MockProviders } from 'testUtils';
 import PrivateRoute, { userIsAuthorized } from './PrivateRoute';
+
+import { MockProviders } from 'testUtils';
 import { roleTypes } from 'constants/userRoles';
 
 describe('userIsAuthorized function', () => {

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router';
 import { NavLink, Switch } from 'react-router-dom';
 import { Tag } from '@trussworks/react-uswds';
 
-import PrivateRoute from 'shared/User/PrivateRoute';
+import PrivateRoute from 'containers/PrivateRoute';
 import { roleTypes } from 'constants/userRoles';
 import TabNav from 'components/TabNav';
 import { MatchShape } from 'types/router';
@@ -55,7 +55,6 @@ const TXOMoveInfo = ({
               exact
               component={MoveDetails}
               requiredRoles={[roleTypes.TOO]}
-              hideSwitcher
             />
           )}
           {too && (
@@ -64,7 +63,6 @@ const TXOMoveInfo = ({
               exact
               component={TOOMoveTaskOrder}
               requiredRoles={[roleTypes.TOO]}
-              hideSwitcher
             />
           )}
           {tio && (
@@ -73,7 +71,6 @@ const TXOMoveInfo = ({
               exact
               component={PaymentRequestShow}
               requiredRoles={[roleTypes.TIO]}
-              hideSwitcher
             />
           )}
           {tio && (
@@ -82,7 +79,6 @@ const TXOMoveInfo = ({
               exact
               component={MoveHistory}
               requiredRoles={[roleTypes.TIO]}
-              hideSwitcher
             />
           )}
         </Switch>

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -16,7 +16,7 @@ import {
 } from 'shared/Swagger/ducks';
 // Shared layout components
 import ConnectedLogoutOnInactivity from 'shared/User/LogoutOnInactivity';
-import PrivateRoute from 'shared/User/PrivateRoute';
+import PrivateRoute from 'containers/PrivateRoute';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { QueueHeader } from 'shared/Header/Office';
 import FOUOHeader from 'components/FOUOHeader';

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -24,7 +24,7 @@ import { ConnectedSelectApplication } from 'pages/SelectApplication/SelectApplic
 import { roleTypes } from 'constants/userRoles';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
-import { LocationShape } from 'types/router';
+import { LocationShape, UserRolesShape } from 'types/index';
 
 // Lazy load these dependencies (they correspond to unique routes & only need to be loaded when that URL is accessed)
 const SignIn = lazy(() => import('shared/User/SignIn'));
@@ -188,11 +188,7 @@ OfficeWrapper.propTypes = {
   }),
   location: LocationShape,
   userIsLoggedIn: PropTypes.bool,
-  userRoles: PropTypes.arrayOf(
-    PropTypes.shape({
-      roleType: PropTypes.string,
-    }),
-  ),
+  userRoles: UserRolesShape,
 };
 
 OfficeWrapper.defaultProps = {

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Switch, withRouter, matchPath } from 'react-router-dom';
+import { Route, Switch, withRouter, matchPath, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -27,6 +27,7 @@ import { withContext } from 'shared/AppContext';
 import { LocationShape } from 'types/router';
 
 // Lazy load these dependencies (they correspond to unique routes & only need to be loaded when that URL is accessed)
+const SignIn = lazy(() => import('shared/User/SignIn'));
 const ConnectedOfficeHome = lazy(() => import('pages/OfficeHome'));
 // PPM pages (TODO move into src/pages)
 const MoveInfo = lazy(() => import('scenes/Office/MoveInfo'));
@@ -76,6 +77,7 @@ export class OfficeWrapper extends Component {
     const { hasError, error, info } = this.state;
     const {
       userIsLoggedIn,
+      userRoles,
       context: {
         flags: { too, tio },
       },
@@ -98,9 +100,18 @@ export class OfficeWrapper extends Component {
           exact: true,
         }));
 
+    const displayChangeRole =
+      userIsLoggedIn &&
+      userRoles?.length > 1 &&
+      !matchPath(pathname, {
+        path: '/select-application',
+        exact: true,
+      });
+
     return (
       <div className="site">
         <FOUOHeader />
+        {displayChangeRole && <Link to="/select-application">Change user role</Link>}
         {!hideHeader && <QueueHeader />}
         <main role="main" className="site__content">
           <ConnectedLogoutOnInactivity />
@@ -110,6 +121,9 @@ export class OfficeWrapper extends Component {
           <Suspense fallback={<LoadingPlaceholder />}>
             {!hasError && (
               <Switch>
+                {/* no auth */}
+                <Route path="/sign-in" component={SignIn} />
+
                 {/* ROOT */}
                 <PrivateRoute exact path="/" component={ConnectedOfficeHome} />
                 <PrivateRoute exact path="/select-application" component={ConnectedSelectApplication} />
@@ -174,6 +188,11 @@ OfficeWrapper.propTypes = {
   }),
   location: LocationShape,
   userIsLoggedIn: PropTypes.bool,
+  userRoles: PropTypes.arrayOf(
+    PropTypes.shape({
+      roleType: PropTypes.string,
+    }),
+  ),
 };
 
 OfficeWrapper.defaultProps = {
@@ -185,6 +204,7 @@ OfficeWrapper.defaultProps = {
   },
   location: { pathname: '' },
   userIsLoggedIn: false,
+  userRoles: [],
 };
 
 const mapStateToProps = (state) => {
@@ -192,6 +212,7 @@ const mapStateToProps = (state) => {
   return {
     swaggerError: state.swaggerInternal.hasErrored,
     userIsLoggedIn: user.isLoggedIn,
+    userRoles: user.roles,
   };
 };
 

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -91,6 +91,7 @@ describe('ConnectedOffice', () => {
   describe('routing', () => {
     // TODO - expects should look for actual component content instead of the route path
     // Might have to add testing-library for this because something about enzyme + Suspense + routes are not rendering content
+    // I FIGURED OUT HOW - need to mock the getCurrentUserInfo (this sets loading back to true and prevents content from rendering)
 
     const loggedInState = {
       user: {

--- a/src/pages/OfficeHome/OfficeHome.jsx
+++ b/src/pages/OfficeHome/OfficeHome.jsx
@@ -3,6 +3,7 @@ import React, { lazy } from 'react';
 import PropTypes from 'prop-types';
 
 import { roleTypes } from 'constants/userRoles';
+import { UserRolesShape } from 'types/index';
 
 const Queues = lazy(() => import('scenes/Office/Queues'));
 const TOO = lazy(() => import('scenes/Office/TOO/too'));
@@ -29,11 +30,7 @@ OfficeHome.displayName = 'OfficeHome';
 
 OfficeHome.propTypes = {
   activeRole: PropTypes.string,
-  userRoles: PropTypes.arrayOf(
-    PropTypes.shape({
-      roleType: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  userRoles: UserRolesShape.isRequired,
 };
 
 OfficeHome.defaultProps = {

--- a/src/pages/SelectApplication/SelectApplication.jsx
+++ b/src/pages/SelectApplication/SelectApplication.jsx
@@ -8,6 +8,7 @@ import { Button, GridContainer } from '@trussworks/react-uswds';
 import { selectCurrentUser } from 'shared/Data/users';
 import { setActiveRole as setActiveRoleAction } from 'store/auth/actions';
 import { roleTypes } from 'constants/userRoles';
+import { UserRolesShape } from 'types/index';
 
 const SelectApplication = ({ userRoles, setActiveRole, activeRole }) => {
   const history = useHistory();
@@ -44,11 +45,7 @@ const SelectApplication = ({ userRoles, setActiveRole, activeRole }) => {
 SelectApplication.propTypes = {
   activeRole: PropTypes.string,
   setActiveRole: PropTypes.func.isRequired,
-  userRoles: PropTypes.arrayOf(
-    PropTypes.shape({
-      roleType: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  userRoles: UserRolesShape.isRequired,
 };
 
 SelectApplication.defaultProps = {

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -13,7 +13,7 @@ import { loadMove, loadMoveLabel } from 'shared/Entities/modules/moves';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import { loadServiceMember, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
-import PrivateRoute from 'shared/User/PrivateRoute';
+import PrivateRoute from 'containers/PrivateRoute';
 import { Switch, Redirect } from 'react-router-dom';
 
 import DocumentUploadViewer from 'shared/DocumentViewer/DocumentUploadViewer';

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -16,7 +16,7 @@ import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import moment from 'moment';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import PrivateRoute from 'shared/User/PrivateRoute';
+import PrivateRoute from 'containers/PrivateRoute';
 import Alert from 'shared/Alert'; // eslint-disable-line
 import ToolTip from 'shared/ToolTip';
 import ComboButton from 'shared/ComboButton';

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { selectCurrentUser, selectGetCurrentUserIsLoading } from 'shared/Data/users';
-import SignIn from './SignIn';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { Redirect, Link } from 'react-router-dom';
 
 export function userIsAuthorized(userRoles, requiredRoles) {
   // Return true if no roles are required
@@ -18,39 +16,24 @@ export function userIsAuthorized(userRoles, requiredRoles) {
   return !!userRoles?.find((r) => requiredRoles.indexOf(r) > -1);
 }
 
-const PrivateRouteContainer = (props) => {
-  const { loginIsLoading, userIsLoggedIn, path, requiredRoles, userRoles, hideSwitcher, ...routeProps } = props;
+const PrivateRoute = (props) => {
+  const { loginIsLoading, userIsLoggedIn, requiredRoles, userRoles, hideSwitcher, ...routeProps } = props;
 
+  if (loginIsLoading) return <LoadingPlaceholder />;
+
+  if (!userIsLoggedIn) return <Redirect to="/sign-in" />;
   if (
-    userIsLoggedIn &&
-    userIsAuthorized(
-      userRoles.map((role) => role.roleType),
+    !userIsAuthorized(
+      userRoles.map((r) => r.roleType),
       requiredRoles,
     )
-  ) {
-    // User is logged in & authorized to view the requested URL
-    // If user has multiple roles, add a link to let them select which role they are using
-    // TODO improve this UI
-
-    const displaySelectApplication =
-      !hideSwitcher && userRoles?.length > 1 && routeProps.location?.pathname !== '/select-application';
-    return displaySelectApplication ? (
-      <>
-        <Link to="/select-application">Change user role</Link>
-        <Route path={path} {...routeProps} />
-      </>
-    ) : (
-      <Route path={path} {...routeProps} />
-    );
-  } else if (userIsLoggedIn)
-    // User is logged in but not authorized to view the requested URL, redirect home
+  )
     return <Redirect to="/" />;
-  else if (loginIsLoading)
-    // User is still loading
-    return <LoadingPlaceholder />;
-  // User is not logged in, go to Sign In page
-  else return <Route path={path} component={SignIn} />; // TODO - change this to a redirect
+
+  return <Route {...routeProps} />;
 };
+
+PrivateRoute.displayName = 'PrivateRoute';
 
 const mapStateToProps = (state) => ({
   loginIsLoading: selectGetCurrentUserIsLoading(state),
@@ -58,6 +41,6 @@ const mapStateToProps = (state) => ({
   userRoles: selectCurrentUser(state).roles,
 });
 
-const PrivateRoute = connect(mapStateToProps)(PrivateRouteContainer);
+const ConnectedPrivateRoute = connect(mapStateToProps)(PrivateRoute);
 
-export default PrivateRoute;
+export default ConnectedPrivateRoute;

--- a/src/shared/User/PrivateRoute.test.jsx
+++ b/src/shared/User/PrivateRoute.test.jsx
@@ -29,7 +29,9 @@ describe('userIsAuthorized function', () => {
   });
 });
 
-describe('PrivateRouteContainer', () => {
+describe('ConnectedPrivateRoute', () => {
+  const MyPrivateComponent = () => <div>My page</div>;
+
   describe('if the user is still loading', () => {
     it('renders the loading placeholder', () => {
       const wrapper = mount(
@@ -62,7 +64,7 @@ describe('PrivateRouteContainer', () => {
           }}
           initialEntries={['/']}
         >
-          <PrivateRoute render={() => <div>My page</div>} requiredRoles={[roleTypes.TOO]} />
+          <PrivateRoute path="/" component={MyPrivateComponent} />
         </MockProviders>,
       );
 
@@ -72,8 +74,11 @@ describe('PrivateRouteContainer', () => {
       it('does not render the requested component', () => {
         expect(wrapper.contains(<div>My page</div>)).toEqual(false);
       });
-      it('displays the Sign In link', () => {
-        expect(wrapper.containsMatchingElement(<a href="/auth/login-gov">Sign in</a>)).toEqual(true);
+
+      it('redirects to the sign in URL', () => {
+        const redirect = wrapper.find('Redirect');
+        expect(redirect).toHaveLength(1);
+        expect(redirect.prop('to')).toEqual('/sign-in');
       });
     });
 
@@ -96,7 +101,7 @@ describe('PrivateRouteContainer', () => {
             }}
             initialEntries={['/']}
           >
-            <PrivateRoute render={() => <div>My page</div>} requiredRoles={[roleTypes.TOO]} />
+            <PrivateRoute component={MyPrivateComponent} requiredRoles={[roleTypes.TOO]} />
           </MockProviders>,
         );
 
@@ -131,7 +136,7 @@ describe('PrivateRouteContainer', () => {
             }}
             initialEntries={['/']}
           >
-            <PrivateRoute render={() => <div>My page</div>} requiredRoles={[roleTypes.PPM]} />
+            <PrivateRoute component={MyPrivateComponent} requiredRoles={[roleTypes.PPM]} />
           </MockProviders>,
         );
         it('does not render the loading placeholder', () => {
@@ -139,89 +144,6 @@ describe('PrivateRouteContainer', () => {
         });
         it('renders the requested component', () => {
           expect(wrapper.contains(<div>My page</div>)).toEqual(true);
-        });
-      });
-
-      describe('and is authorized with multiple roles', () => {
-        describe('on a page that isn’t the Select Application page', () => {
-          const wrapper = mount(
-            <MockProviders
-              initialState={{
-                user: {
-                  isLoading: false,
-                  userInfo: {
-                    isLoggedIn: true,
-                    roles: [
-                      {
-                        roleType: roleTypes.TOO,
-                      },
-                      {
-                        roleType: roleTypes.TIO,
-                      },
-                    ],
-                  },
-                },
-              }}
-              initialEntries={['/']}
-            >
-              <PrivateRoute
-                render={() => <div>My page</div>}
-                requiredRoles={[roleTypes.TOO]}
-                path="/my-page"
-                location={{ pathname: '/my-page' }}
-              />
-            </MockProviders>,
-          );
-
-          it('does not render the loading placeholder', () => {
-            expect(wrapper.find('[data-name="loading-placeholder"]')).toHaveLength(0);
-          });
-          it('renders the requested component', () => {
-            expect(wrapper.contains(<div>My page</div>)).toEqual(true);
-          });
-          it('renders the Select Application link', () => {
-            expect(wrapper.containsMatchingElement(<a href="/select-application">Change user role</a>)).toEqual(true);
-          });
-        });
-
-        describe('on the Select Application page', () => {
-          const wrapper = mount(
-            <MockProviders
-              initialState={{
-                user: {
-                  isLoading: false,
-                  userInfo: {
-                    isLoggedIn: true,
-                    roles: [
-                      {
-                        roleType: roleTypes.TOO,
-                      },
-                      {
-                        roleType: roleTypes.TIO,
-                      },
-                    ],
-                  },
-                },
-              }}
-              initialEntries={['/select-application']}
-            >
-              <PrivateRoute
-                render={() => <div>My page</div>}
-                requiredRoles={[roleTypes.TOO]}
-                path="/select-application"
-                location={{ pathname: '/select-application' }}
-              />
-            </MockProviders>,
-          );
-          it('does not render the loading placeholder', () => {
-            expect(wrapper.find('[data-name="loading-placeholder"]')).toHaveLength(0);
-          });
-          it('renders the requested component', () => {
-            expect(wrapper.contains(<div>My page</div>)).toEqual(true);
-          });
-          it('does not render the Select Application link', () => {
-            expect(wrapper.containsMatchingElement(<a href="/select-application">Change user role</a>)).toEqual(false);
-          });
         });
       });
     });

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,0 +1,13 @@
+export { UserRoleShape, UserRolesShape } from './user';
+export { AddressShape } from './address';
+export { DutyStationShape } from './dutyStation';
+export { DropdownArrayOf } from './form';
+export {
+  DestinationDutyStationShape,
+  OriginDutyStationShape,
+  EntitlementShape,
+  MoveOrderShape,
+  CustomerShape,
+  MTOShipmentShape,
+} from './moveOrder';
+export { MatchShape, LocationShape } from './router';

--- a/src/types/user.js
+++ b/src/types/user.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+import PropTypes from 'prop-types';
+
+export const UserRoleShape = PropTypes.shape({
+  roleType: PropTypes.string,
+});
+
+export const UserRolesShape = PropTypes.arrayOf(UserRoleShape);

--- a/src/types/user.js
+++ b/src/types/user.js
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 
 export const UserRoleShape = PropTypes.shape({
-  roleType: PropTypes.string,
+  roleType: PropTypes.string.isRequired,
 });
 
 export const UserRolesShape = PropTypes.arrayOf(UserRoleShape);


### PR DESCRIPTION
## Description
Fixes MB-3015 by extracting the "Change user role" link from `<PrivateRoute>` and putting it in the Office index instead (which currently serves to render the layout for all Office pages). Other changes are:
- moved `PrivateRoute` into the new component structure
- removed the `hideSwitcher` prop which had been added as a temporary workaround
- modified `PrivateRoute` so that if the user is not logged in, it actually redirects them to a `/sign-in` path (instead of rendering the `SignIn` component at the attempted path)

## Setup / Test Cases

#### User with multiple roles
1. Log into the Office app as a user with multiple roles
1. Verify you can still click on "Change user role" in the top left to change which role you're acting as
1. Verify the "Change user role" link appears _above_ the office.move.mil header
1. Verify when you navigate to one of the TOO Move Details pages, there is only one instance of the "Change user role" link

#### User with one role
1. Log into the Office app as a user with only one role, and verify you do not see the "Change user role" link at all.

#### Not logged in
1. Try to access an Office app URL without being logged in, and verify you are redirected to the Sign In page.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3015) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/2723066/86051359-e4dfa700-ba1a-11ea-909a-450bd24999c5.png)
