### PR TITLE
[MB-2664] Consistent client server errors for Prime API

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -480,7 +480,8 @@ func init() {
           "example": "USA"
         },
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "id": {
           "type": "string",
@@ -674,7 +675,10 @@ func init() {
     "CreateShipmentPayload": {
       "type": "object",
       "required": [
-        "moveTaskOrderID"
+        "moveTaskOrderID",
+        "pickupAddress",
+        "destinationAddress",
+        "shipmentType"
       ],
       "properties": {
         "agents": {
@@ -2510,7 +2514,8 @@ func init() {
           "example": "USA"
         },
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "id": {
           "type": "string",
@@ -2704,7 +2709,10 @@ func init() {
     "CreateShipmentPayload": {
       "type": "object",
       "required": [
-        "moveTaskOrderID"
+        "moveTaskOrderID",
+        "pickupAddress",
+        "destinationAddress",
+        "shipmentType"
       ],
       "properties": {
         "agents": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -214,6 +214,9 @@ func init() {
           "404": {
             "$ref": "#/responses/NotFound"
           },
+          "409": {
+            "$ref": "#/responses/Conflict"
+          },
           "422": {
             "$ref": "#/responses/UnprocessableEntity"
           },
@@ -1883,6 +1886,12 @@ func init() {
     }
   },
   "responses": {
+    "Conflict": {
+      "description": "The request could not be processed because of conflict in the current state of the resource.",
+      "schema": {
+        "$ref": "#/definitions/ClientError"
+      }
+    },
     "InvalidRequest": {
       "description": "The request payload is invalid.",
       "schema": {
@@ -2159,6 +2168,12 @@ func init() {
           },
           "404": {
             "description": "The requested resource wasn't found.",
+            "schema": {
+              "$ref": "#/definitions/ClientError"
+            }
+          },
+          "409": {
+            "description": "The request could not be processed because of conflict in the current state of the resource.",
             "schema": {
               "$ref": "#/definitions/ClientError"
             }
@@ -3901,6 +3916,12 @@ func init() {
     }
   },
   "responses": {
+    "Conflict": {
+      "description": "The request could not be processed because of conflict in the current state of the resource.",
+      "schema": {
+        "$ref": "#/definitions/ClientError"
+      }
+    },
     "InvalidRequest": {
       "description": "The request payload is invalid.",
       "schema": {

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item_responses.go
@@ -233,6 +233,50 @@ func (o *CreateMTOServiceItemNotFound) WriteResponse(rw http.ResponseWriter, pro
 	}
 }
 
+// CreateMTOServiceItemConflictCode is the HTTP code returned for type CreateMTOServiceItemConflict
+const CreateMTOServiceItemConflictCode int = 409
+
+/*CreateMTOServiceItemConflict The request could not be processed because of conflict in the current state of the resource.
+
+swagger:response createMTOServiceItemConflict
+*/
+type CreateMTOServiceItemConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *primemessages.ClientError `json:"body,omitempty"`
+}
+
+// NewCreateMTOServiceItemConflict creates CreateMTOServiceItemConflict with default headers values
+func NewCreateMTOServiceItemConflict() *CreateMTOServiceItemConflict {
+
+	return &CreateMTOServiceItemConflict{}
+}
+
+// WithPayload adds the payload to the create m t o service item conflict response
+func (o *CreateMTOServiceItemConflict) WithPayload(payload *primemessages.ClientError) *CreateMTOServiceItemConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create m t o service item conflict response
+func (o *CreateMTOServiceItemConflict) SetPayload(payload *primemessages.ClientError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *CreateMTOServiceItemConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // CreateMTOServiceItemUnprocessableEntityCode is the HTTP code returned for type CreateMTOServiceItemUnprocessableEntity
 const CreateMTOServiceItemUnprocessableEntityCode int = 422
 

--- a/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeclient/mto_service_item/create_m_t_o_service_item_responses.go
@@ -54,6 +54,12 @@ func (o *CreateMTOServiceItemReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return nil, result
+	case 409:
+		result := NewCreateMTOServiceItemConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewCreateMTOServiceItemUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -226,6 +232,39 @@ func (o *CreateMTOServiceItemNotFound) GetPayload() *primemessages.ClientError {
 }
 
 func (o *CreateMTOServiceItemNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(primemessages.ClientError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateMTOServiceItemConflict creates a CreateMTOServiceItemConflict with default headers values
+func NewCreateMTOServiceItemConflict() *CreateMTOServiceItemConflict {
+	return &CreateMTOServiceItemConflict{}
+}
+
+/*CreateMTOServiceItemConflict handles this case with default header values.
+
+The request could not be processed because of conflict in the current state of the resource.
+*/
+type CreateMTOServiceItemConflict struct {
+	Payload *primemessages.ClientError
+}
+
+func (o *CreateMTOServiceItemConflict) Error() string {
+	return fmt.Sprintf("[POST /mto-service-items][%d] createMTOServiceItemConflict  %+v", 409, o.Payload)
+}
+
+func (o *CreateMTOServiceItemConflict) GetPayload() *primemessages.ClientError {
+	return o.Payload
+}
+
+func (o *CreateMTOServiceItemConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(primemessages.ClientError)
 

--- a/pkg/gen/primemessages/address.go
+++ b/pkg/gen/primemessages/address.go
@@ -27,6 +27,7 @@ type Address struct {
 	Country *string `json:"country,omitempty"`
 
 	// e tag
+	// Read Only: true
 	ETag string `json:"eTag,omitempty"`
 
 	// id

--- a/pkg/gen/primemessages/create_shipment_payload.go
+++ b/pkg/gen/primemessages/create_shipment_payload.go
@@ -30,7 +30,8 @@ type CreateShipmentPayload struct {
 	CustomerRemarks *string `json:"customerRemarks,omitempty"`
 
 	// destination address
-	DestinationAddress *Address `json:"destinationAddress,omitempty"`
+	// Required: true
+	DestinationAddress *Address `json:"destinationAddress"`
 
 	// move task order ID
 	// Required: true
@@ -40,7 +41,8 @@ type CreateShipmentPayload struct {
 	mtoServiceItemsField []MTOServiceItem
 
 	// pickup address
-	PickupAddress *Address `json:"pickupAddress,omitempty"`
+	// Required: true
+	PickupAddress *Address `json:"pickupAddress"`
 
 	// Email or id of a contact person for this update
 	PointOfContact string `json:"pointOfContact,omitempty"`
@@ -50,7 +52,8 @@ type CreateShipmentPayload struct {
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
 	// shipment type
-	ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
+	// Required: true
+	ShipmentType MTOShipmentType `json:"shipmentType"`
 }
 
 // MtoServiceItems gets the mto service items of this base type
@@ -70,19 +73,19 @@ func (m *CreateShipmentPayload) UnmarshalJSON(raw []byte) error {
 
 		CustomerRemarks *string `json:"customerRemarks,omitempty"`
 
-		DestinationAddress *Address `json:"destinationAddress,omitempty"`
+		DestinationAddress *Address `json:"destinationAddress"`
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
 		MtoServiceItems json.RawMessage `json:"mtoServiceItems"`
 
-		PickupAddress *Address `json:"pickupAddress,omitempty"`
+		PickupAddress *Address `json:"pickupAddress"`
 
 		PointOfContact string `json:"pointOfContact,omitempty"`
 
 		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
-		ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
+		ShipmentType MTOShipmentType `json:"shipmentType"`
 	}
 	buf := bytes.NewBuffer(raw)
 	dec := json.NewDecoder(buf)
@@ -144,17 +147,17 @@ func (m CreateShipmentPayload) MarshalJSON() ([]byte, error) {
 
 		CustomerRemarks *string `json:"customerRemarks,omitempty"`
 
-		DestinationAddress *Address `json:"destinationAddress,omitempty"`
+		DestinationAddress *Address `json:"destinationAddress"`
 
 		MoveTaskOrderID *strfmt.UUID `json:"moveTaskOrderID"`
 
-		PickupAddress *Address `json:"pickupAddress,omitempty"`
+		PickupAddress *Address `json:"pickupAddress"`
 
 		PointOfContact string `json:"pointOfContact,omitempty"`
 
 		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
-		ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
+		ShipmentType MTOShipmentType `json:"shipmentType"`
 	}{
 
 		Agents: m.Agents,
@@ -247,8 +250,8 @@ func (m *CreateShipmentPayload) validateAgents(formats strfmt.Registry) error {
 
 func (m *CreateShipmentPayload) validateDestinationAddress(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.DestinationAddress) { // not required
-		return nil
+	if err := validate.Required("destinationAddress", "body", m.DestinationAddress); err != nil {
+		return err
 	}
 
 	if m.DestinationAddress != nil {
@@ -298,8 +301,8 @@ func (m *CreateShipmentPayload) validateMtoServiceItems(formats strfmt.Registry)
 
 func (m *CreateShipmentPayload) validatePickupAddress(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.PickupAddress) { // not required
-		return nil
+	if err := validate.Required("pickupAddress", "body", m.PickupAddress); err != nil {
+		return err
 	}
 
 	if m.PickupAddress != nil {
@@ -328,10 +331,6 @@ func (m *CreateShipmentPayload) validateRequestedPickupDate(formats strfmt.Regis
 }
 
 func (m *CreateShipmentPayload) validateShipmentType(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ShipmentType) { // not required
-		return nil
-	}
 
 	if err := m.ShipmentType.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -25,7 +25,7 @@ func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesPa
 	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(true, params.Since)
 
 	if err != nil {
-		logger.Error("Unable to fetch records:", zap.Error(err))
+		logger.Error("Unexpected error while fetching records:", zap.Error(err))
 		return movetaskorderops.NewFetchMTOUpdatesInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 	}
 

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -92,7 +92,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 
 	})
 
-	suite.T().Run("POST failure - 412", func(t *testing.T) {
+	suite.T().Run("POST failure - 422 Unprocessable Entity Error", func(t *testing.T) {
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
@@ -107,6 +107,23 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 
 		response := handler.Handle(params)
 		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemUnprocessableEntity{}, response)
+	})
+
+	suite.T().Run("POST failure - 409 Conflict Error", func(t *testing.T) {
+		mockCreator := mocks.MTOServiceItemCreator{}
+		handler := CreateMTOServiceItemHandler{
+			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			&mockCreator,
+		}
+		// ConflictError should generate a Conflict response
+		err := services.ConflictError{}
+
+		mockCreator.On("CreateMTOServiceItem",
+			mock.Anything,
+		).Return(nil, nil, err)
+
+		response := handler.Handle(params)
+		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemConflict{}, response)
 	})
 
 	suite.T().Run("POST failure - 404", func(t *testing.T) {

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -92,12 +92,13 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 
 	})
 
-	suite.T().Run("POST failure - 400", func(t *testing.T) {
+	suite.T().Run("POST failure - 412", func(t *testing.T) {
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			&mockCreator,
 		}
+		// InvalidInputError should generate an UnprocessableEntity response
 		err := services.InvalidInputError{}
 
 		mockCreator.On("CreateMTOServiceItem",
@@ -105,7 +106,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		).Return(nil, nil, err)
 
 		response := handler.Handle(params)
-		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemBadRequest{}, response)
+		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemUnprocessableEntity{}, response)
 	})
 
 	suite.T().Run("POST failure - 404", func(t *testing.T) {

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -164,7 +164,13 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 
 	mtoAvailableToPrime, err := h.mtoShipmentUpdater.MTOAvailableToPrime(mtoShipmentID)
 	if err != nil {
-		return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
+		logger.Error("primeapi.UpdateMTOShipmentHandler error - MTO is not available to prime", zap.Error(err))
+		switch e := err.(type) {
+		case services.NotFoundError:
+			return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, e.Error(), h.GetTraceID()))
+		default:
+			return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+		}
 	}
 
 	if mtoAvailableToPrime {

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -128,7 +128,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 		response := handler.Handle(badParams)
 
-		suite.IsType(&mtoshipmentops.CreateMTOShipmentBadRequest{}, response)
+		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
 	})
 
 	suite.T().Run("POST failure - 404 -- not found", func(t *testing.T) {

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -58,12 +58,7 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, sin
 	err = query.All(&moveTaskOrders)
 
 	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			return models.MoveTaskOrders{}, services.NotFoundError{}
-		default:
-			return models.MoveTaskOrders{}, err
-		}
+		return models.MoveTaskOrders{}, services.NewQueryError("MoveTaskOrder", err, "Unexpected error while querying db.")
 	}
 
 	return moveTaskOrders, nil

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -68,7 +68,7 @@ func (o *moveTaskOrderUpdater) UpdatePostCounselingInfo(moveTaskOrderID uuid.UUI
 	err := o.builder.FetchOne(&moveTaskOrder, queryFilters)
 
 	if err != nil {
-		return nil, services.NewNotFoundError(moveTaskOrder.ID, "")
+		return nil, services.NewNotFoundError(moveTaskOrderID, "while looking for moveTaskOrder.")
 	}
 
 	estimatedWeight := unit.Pound(body.PpmEstimatedWeight)

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -37,7 +37,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	// check if MTO exists
 	err = o.builder.FetchOne(&moveTaskOrder, queryFilters)
 	if err != nil {
-		return nil, nil, services.NewNotFoundError(moveTaskOrderID, fmt.Sprintf("MoveTaskOrderID: %s", err))
+		return nil, nil, services.NewNotFoundError(moveTaskOrderID, "in MoveTaskOrders")
 	}
 
 	// TODO: Once customer onboarding is built, we can revisit to figure out which service items goes under each type of shipment
@@ -54,7 +54,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	err = o.builder.FetchOne(&mtoShipment, queryFilters)
 	if err != nil {
 		return nil, nil, services.NewNotFoundError(mtoShipmentID,
-			fmt.Sprintf("MTOShipmentID with MoveTaskOrderID (%s): %s", moveTaskOrderID.String(), err))
+			fmt.Sprintf("in MTOShipments associated with MoveTaskOrderID %s", moveTaskOrderID.String()))
 	}
 
 	// find the re service code id
@@ -65,7 +65,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	}
 	err = o.builder.FetchOne(&reService, queryFilters)
 	if err != nil {
-		return nil, nil, services.NewNotFoundError(uuid.Nil, fmt.Sprintf("failed to find service item code: %s; %s", reServiceCode, err))
+		return nil, nil, services.NewNotFoundError(uuid.Nil, fmt.Sprintf(". Failed to find service item code: %s", reServiceCode))
 	}
 
 	// set re service for service item
@@ -73,8 +73,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	serviceItem.Status = models.MTOServiceItemStatusSubmitted
 	if serviceItem.ReService.Code == models.ReServiceCodeDOSHUT || serviceItem.ReService.Code == models.ReServiceCodeDDSHUT {
 		if mtoShipment.PrimeEstimatedWeight == nil {
-			return nil, nil, services.NewInvalidInputError(mtoShipmentID, nil, nil,
-				fmt.Sprintf("MTOShipment with id: %s is missing the estimated weight required for this service item", mtoShipmentID))
+			return nil, verrs, services.NewConflictError(reService.ID, "Cannot create service item. MTOShipment associated with this service item must have a valid PrimeEstimatedWeight.")
 		}
 	}
 
@@ -112,8 +111,10 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		return nil
 	})
 
-	if verrs != nil || err != nil {
-		return nil, verrs, err
+	if verrs != nil && verrs.HasAny() {
+		return nil, verrs, nil
+	} else if err != nil {
+		return nil, verrs, services.NewQueryError("unknown", err, "")
 	}
 
 	return serviceItem, nil, nil

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -482,6 +482,7 @@ definitions:
         default: USA
       eTag:
         type: string
+        readOnly: true
     required:
       - streetAddress1
       - city
@@ -552,6 +553,9 @@ definitions:
           $ref: '#/definitions/MTOServiceItem'
     required:
       - moveTaskOrderID
+      - pickupAddress
+      - destinationAddress
+      - shipmentType
   Customer:
     type: object
     properties:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -249,6 +249,8 @@ paths:
           $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
+        '409':
+          $ref: '#/responses/Conflict'
         '422':
           $ref: '#/responses/UnprocessableEntity'
         '500':
@@ -1441,6 +1443,10 @@ responses:
       $ref: '#/definitions/ClientError'
   NotFound:
     description: The requested resource wasn't found.
+    schema:
+      $ref: '#/definitions/ClientError'
+  Conflict:
+    description: "The request could not be processed because of conflict in the current state of the resource."
     schema:
       $ref: '#/definitions/ClientError'
   PermissionDenied:


### PR DESCRIPTION
## Description

Trying to make the errors consistent. This is a tedious process so broke the tickets up. In this ticket I did createMTOShipment, updateMTOShipment, createMTOServiceItem and updateMTOPostCounseling.
Separate ticket created for support api and for paymentrequest related items, because we probably need to talk to a-team first. 

Went with this strategy... 

For correctness, we want server errors only to be returned when it is really an unexpected error on the server and not an error that the client can correct. 

If we can read and understand the request, it’s likely the error is one of the following
- Unprocessable Entity - these are validation errors, missing values, invalid values
- Conflict Error - we cannot process the request due to the current state of the server (for e.g.. we cannot change this value once this date is past)
- Not Found error - we cannot find an object related to completing the request.

The above are ALL 4xx errors. Note that Bad request isn’t one of them. Typically we should never need to return Bad Request because it implies we were unable to read the request. Since the request is first parsed by swagger, swagger will return bad request. And the handler never gets called unless the request was able to be correctly read and parsed.

If we can read and understand the request, AND there’s nothing wrong with the request BUT it still fails, we can return an Internal Server Error. In the service object, we can generate a queryError which then returns an InternalServer error response. 
- The logger should print the pq error
- The response should NOT contain the pq error, but should not be a nil payload. It should have a default internal server error title/message/instance

## Reviewer Notes

Try to generate errors with the endpoints that were fixed. Ideally we should get useful responses not 500 errors. 


## References

* [MB-2664 Make server errors consistent for the Prime APIs - Jira](https://dp3.atlassian.net/browse/MB-2664)


[MB-2664]: https://dp3.atlassian.net/browse/MB-2664