### PR TITLE
Fix broken links from LICENSE.md -> LICENSE.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,11 @@ Code formatting conventions are defined in the `.editorconfig` file which uses t
 
 ## Legalese
 
-Before submitting a pull request to this repository for the first time, you'll need to sign a [Developer Certificate of Origin](https://developercertificate.org) (DCO). To read and agree to the DCO, you'll add your name and email address to [CONTRIBUTORS.md](https://github.com/transcom/mymove/blob/master/CONTRIBUTORS.md). At a high level, this tells us that you have the right to submit the work you're contributing in your pull request and says that you consent to us treating the contribution in a way consistent with the license associated with this software (as described in [LICENSE.md](https://github.com/transcom/mymove/blob/master/LICENSE.md)) and its documentation ("Project").
+Before submitting a pull request to this repository for the first time, you'll need to sign a [Developer Certificate of Origin](https://developercertificate.org) (DCO). To read and agree to the DCO, you'll add your name and email address to [CONTRIBUTORS.md](https://github.com/transcom/mymove/blob/master/CONTRIBUTORS.md). At a high level, this tells us that you have the right to submit the work you're contributing in your pull request and says that you consent to us treating the contribution in a way consistent with the license associated with this software (as described in [LICENSE.txt](https://github.com/transcom/mymove/blob/master/LICENSE.txt)) and its documentation ("Project").
 
 You may submit contributions anonymously or under a pseudonym if you'd like, but we need to be able to reach you at the email address you provide when agreeing to the DCO. Contributions you make to this public Department of Defense repository are completely voluntary. When you submit a pull request, you're offering your contribution without expectation of payment and you expressly waive any future pay claims against the U.S. Federal Government related to your contribution.
 
 [contributors]: https://github.com/transcom/move.mil/blob/master/CONTRIBUTORS.md
 [issues]: https://github.com/transcom/move.mil/issues
-[license]: https://github.com/transcom/move.mil/blob/master/LICENSE.md
+[license]: https://github.com/transcom/move.mil/blob/master/LICENSE.txt
 [pulls]: https://github.com/transcom/move.mil/pulls

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,4 +13,4 @@
 
 If you're a U.S. Federal Government employee and use a `*.mil` or `*.gov` email address to agree to the DCO, we interpret your signed DCO to mean that the contribution was created in whole or in part by you as part of your job with the U.S. Federal Government and that your contribution is not subject to copyright protections.
 
-[license]: https://github.com/transcom/mymove/blob/master/LICENSE.md
+[license]: https://github.com/transcom/mymove/blob/master/LICENSE.txt

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-**By adding your name, email address, and copyright date below, you understand and agree to the terms of the [Developer's Certificate of Origin](https://developercertificate.org) (DCO) version 1.1, and you are submitting all contributions you make to this Project pursuant to the terms described in [LICENSE.md][license].**
+**By adding your name, email address, and copyright date below, you understand and agree to the terms of the [Developer's Certificate of Origin](https://developercertificate.org) (DCO) version 1.1, and you are submitting all contributions you make to this Project pursuant to the terms described in [LICENSE.txt][license].**
 
 ## Signed-off-by
 

--- a/pkg/gen/adminapi/doc.go
+++ b/pkg/gen/adminapi/doc.go
@@ -10,7 +10,7 @@ The API for move.mil admin actions.
     Host: localhost
     BasePath: /admin/v1
     Version: 1.0.0
-    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.txt
 
     Consumes:
     - application/json

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -30,7 +30,7 @@ func init() {
     "title": "move.mil Admin API",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "1.0.0"
   },
@@ -2115,7 +2115,7 @@ func init() {
     "title": "move.mil Admin API",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "1.0.0"
   },

--- a/pkg/gen/dpsapi/doc.go
+++ b/pkg/gen/dpsapi/doc.go
@@ -10,7 +10,7 @@ MyMove API for DPS
     Host: localhost
     BasePath: /dps/v0
     Version: 0.1.0
-    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.txt
 
     Consumes:
     - application/json

--- a/pkg/gen/dpsapi/embedded_spec.go
+++ b/pkg/gen/dpsapi/embedded_spec.go
@@ -30,7 +30,7 @@ func init() {
     "title": "MyMove DPS API",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "0.1.0"
   },
@@ -157,7 +157,7 @@ func init() {
     "title": "MyMove DPS API",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "0.1.0"
   },

--- a/pkg/gen/ordersapi/doc.go
+++ b/pkg/gen/ordersapi/doc.go
@@ -10,7 +10,7 @@ API to submit, amend, and cancel orders for move.mil.
     Host: localhost
     BasePath: /orders/v1
     Version: 1.0.0
-    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.txt
 
     Consumes:
     - application/json

--- a/pkg/gen/ordersapi/embedded_spec.go
+++ b/pkg/gen/ordersapi/embedded_spec.go
@@ -24,7 +24,7 @@ func init() {
     "title": "move.mil Orders Gateway",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "1.0.0"
   },
@@ -699,7 +699,7 @@ func init() {
     "title": "move.mil Orders Gateway",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "1.0.0"
   },

--- a/pkg/gen/restapi/doc.go
+++ b/pkg/gen/restapi/doc.go
@@ -10,7 +10,7 @@ The public API for my.move.mil. This is a work in-progress, and is not a final p
     Host: localhost
     BasePath: /api/v1
     Version: 0.0.1
-    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.md
+    License: MIT https://github.com/transcom/mymove/blob/master/LICENSE.txt
 
     Consumes:
     - application/json

--- a/pkg/gen/restapi/embedded_spec.go
+++ b/pkg/gen/restapi/embedded_spec.go
@@ -30,7 +30,7 @@ func init() {
     "title": "my.move.mil",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "0.0.1"
   },
@@ -113,7 +113,7 @@ func init() {
     "title": "my.move.mil",
     "license": {
       "name": "MIT",
-      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.md"
+      "url": "https://github.com/transcom/mymove/blob/master/LICENSE.txt"
     },
     "version": "0.0.1"
   },

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -5,7 +5,7 @@ info:
   title: move.mil Admin API
   license:
     name: MIT
-    url: https://github.com/transcom/mymove/blob/master/LICENSE.md
+    url: https://github.com/transcom/mymove/blob/master/LICENSE.txt
 basePath: /admin/v1
 consumes:
   - application/json

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -5,7 +5,7 @@ info:
   title: my.move.mil
   license:
     name: MIT
-    url: https://github.com/transcom/mymove/blob/master/LICENSE.md
+    url: https://github.com/transcom/mymove/blob/master/LICENSE.txt
 basePath: /api/v1
 consumes:
   - application/json

--- a/swagger/dps.yaml
+++ b/swagger/dps.yaml
@@ -5,7 +5,7 @@ info:
   title: MyMove DPS API
   license:
     name: MIT
-    url: https://github.com/transcom/mymove/blob/master/LICENSE.md
+    url: https://github.com/transcom/mymove/blob/master/LICENSE.txt
 basePath: /dps/v0
 produces:
   - application/json

--- a/swagger/orders.yaml
+++ b/swagger/orders.yaml
@@ -5,7 +5,7 @@ info:
   title: move.mil Orders Gateway
   license:
     name: MIT
-    url: 'https://github.com/transcom/mymove/blob/master/LICENSE.md'
+    url: 'https://github.com/transcom/mymove/blob/master/LICENSE.txt'
 basePath: /orders/v1
 paths:
   '/edipis/{edipi}/orders':


### PR DESCRIPTION
## Description

mymove links to `LICENSE.md` in various places, but that file does not exist: instead, it is named `LICENSE.txt`. This pull request fixes the broken links.

## Reviewer Notes

Since this is a documentation change I have not performed the various code review verification steps. If those steps are mandatory, please help. It looks complicated :-)

## Setup

N/A

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* N/A

## Screenshots

N/A
