### PR TITLE
MB-3235 Fix error response formatting in support.yaml

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -114,16 +114,10 @@ func init() {
             "$ref": "#/responses/InvalidRequest"
           },
           "401": {
-            "description": "The request was unauthorized.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "404": {
             "$ref": "#/responses/NotFound"
@@ -159,16 +153,10 @@ func init() {
             "$ref": "#/responses/InvalidRequest"
           },
           "401": {
-            "description": "The request was unauthorized.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "404": {
             "$ref": "#/responses/NotFound"
@@ -339,25 +327,16 @@ func init() {
             "$ref": "#/responses/InvalidRequest"
           },
           "401": {
-            "description": "The request was unauthorized.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "404": {
             "$ref": "#/responses/NotFound"
           },
           "409": {
-            "description": "Conflict error due to trying to change the status of shipment that is not currently \"SUBMITTED\".",
-            "schema": {
-              "$ref": "#/responses/Conflict"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "412": {
             "$ref": "#/responses/PreconditionFailed"
@@ -423,16 +402,10 @@ func init() {
             "$ref": "#/responses/InvalidRequest"
           },
           "401": {
-            "description": "The request was unauthorized.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "404": {
             "$ref": "#/responses/NotFound"
@@ -501,25 +474,16 @@ func init() {
             "$ref": "#/responses/InvalidRequest"
           },
           "401": {
-            "description": "The request was unauthorized.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
+            "$ref": "#/responses/PermissionDenied"
           },
           "404": {
             "$ref": "#/responses/NotFound"
           },
           "409": {
-            "description": "Conflict error due to trying to change the status of service item that is not currently \"SUBMITTED\".",
-            "schema": {
-              "$ref": "#/responses/Conflict"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "412": {
             "$ref": "#/responses/PreconditionFailed"
@@ -1725,21 +1689,15 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was unauthorized.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "404": {
@@ -1788,21 +1746,15 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was unauthorized.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "404": {
@@ -2019,21 +1971,15 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was unauthorized.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "404": {
@@ -2043,12 +1989,9 @@ func init() {
             }
           },
           "409": {
-            "description": "Conflict error due to trying to change the status of shipment that is not currently \"SUBMITTED\".",
+            "description": "There was a conflict with the request.",
             "schema": {
-              "description": "There was a conflict with the request.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "412": {
@@ -2127,21 +2070,15 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was unauthorized.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "404": {
@@ -2226,21 +2163,15 @@ func init() {
             }
           },
           "401": {
-            "description": "The request was unauthorized.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "403": {
-            "description": "The client doesn't have permissions to perform the request.",
+            "description": "The request was denied.",
             "schema": {
-              "description": "The request was denied.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "404": {
@@ -2250,12 +2181,9 @@ func init() {
             }
           },
           "409": {
-            "description": "Conflict error due to trying to change the status of service item that is not currently \"SUBMITTED\".",
+            "description": "There was a conflict with the request.",
             "schema": {
-              "description": "There was a conflict with the request.",
-              "schema": {
-                "$ref": "#/definitions/ClientError"
-              }
+              "$ref": "#/definitions/ClientError"
             }
           },
           "412": {

--- a/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/create_move_task_order_responses.go
@@ -104,7 +104,7 @@ func (o *CreateMoveTaskOrderBadRequest) WriteResponse(rw http.ResponseWriter, pr
 // CreateMoveTaskOrderUnauthorizedCode is the HTTP code returned for type CreateMoveTaskOrderUnauthorized
 const CreateMoveTaskOrderUnauthorizedCode int = 401
 
-/*CreateMoveTaskOrderUnauthorized The request was unauthorized.
+/*CreateMoveTaskOrderUnauthorized The request was denied.
 
 swagger:response createMoveTaskOrderUnauthorized
 */
@@ -113,7 +113,7 @@ type CreateMoveTaskOrderUnauthorized struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewCreateMoveTaskOrderUnauthorized creates CreateMoveTaskOrderUnauthorized with default headers values
@@ -123,13 +123,13 @@ func NewCreateMoveTaskOrderUnauthorized() *CreateMoveTaskOrderUnauthorized {
 }
 
 // WithPayload adds the payload to the create move task order unauthorized response
-func (o *CreateMoveTaskOrderUnauthorized) WithPayload(payload interface{}) *CreateMoveTaskOrderUnauthorized {
+func (o *CreateMoveTaskOrderUnauthorized) WithPayload(payload *supportmessages.ClientError) *CreateMoveTaskOrderUnauthorized {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the create move task order unauthorized response
-func (o *CreateMoveTaskOrderUnauthorized) SetPayload(payload interface{}) {
+func (o *CreateMoveTaskOrderUnauthorized) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -137,16 +137,18 @@ func (o *CreateMoveTaskOrderUnauthorized) SetPayload(payload interface{}) {
 func (o *CreateMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(401)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
 // CreateMoveTaskOrderForbiddenCode is the HTTP code returned for type CreateMoveTaskOrderForbidden
 const CreateMoveTaskOrderForbiddenCode int = 403
 
-/*CreateMoveTaskOrderForbidden The client doesn't have permissions to perform the request.
+/*CreateMoveTaskOrderForbidden The request was denied.
 
 swagger:response createMoveTaskOrderForbidden
 */
@@ -155,7 +157,7 @@ type CreateMoveTaskOrderForbidden struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewCreateMoveTaskOrderForbidden creates CreateMoveTaskOrderForbidden with default headers values
@@ -165,13 +167,13 @@ func NewCreateMoveTaskOrderForbidden() *CreateMoveTaskOrderForbidden {
 }
 
 // WithPayload adds the payload to the create move task order forbidden response
-func (o *CreateMoveTaskOrderForbidden) WithPayload(payload interface{}) *CreateMoveTaskOrderForbidden {
+func (o *CreateMoveTaskOrderForbidden) WithPayload(payload *supportmessages.ClientError) *CreateMoveTaskOrderForbidden {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the create move task order forbidden response
-func (o *CreateMoveTaskOrderForbidden) SetPayload(payload interface{}) {
+func (o *CreateMoveTaskOrderForbidden) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -179,9 +181,11 @@ func (o *CreateMoveTaskOrderForbidden) SetPayload(payload interface{}) {
 func (o *CreateMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order_responses.go
@@ -104,7 +104,7 @@ func (o *GetMoveTaskOrderBadRequest) WriteResponse(rw http.ResponseWriter, produ
 // GetMoveTaskOrderUnauthorizedCode is the HTTP code returned for type GetMoveTaskOrderUnauthorized
 const GetMoveTaskOrderUnauthorizedCode int = 401
 
-/*GetMoveTaskOrderUnauthorized The request was unauthorized.
+/*GetMoveTaskOrderUnauthorized The request was denied.
 
 swagger:response getMoveTaskOrderUnauthorized
 */
@@ -113,7 +113,7 @@ type GetMoveTaskOrderUnauthorized struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewGetMoveTaskOrderUnauthorized creates GetMoveTaskOrderUnauthorized with default headers values
@@ -123,13 +123,13 @@ func NewGetMoveTaskOrderUnauthorized() *GetMoveTaskOrderUnauthorized {
 }
 
 // WithPayload adds the payload to the get move task order unauthorized response
-func (o *GetMoveTaskOrderUnauthorized) WithPayload(payload interface{}) *GetMoveTaskOrderUnauthorized {
+func (o *GetMoveTaskOrderUnauthorized) WithPayload(payload *supportmessages.ClientError) *GetMoveTaskOrderUnauthorized {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get move task order unauthorized response
-func (o *GetMoveTaskOrderUnauthorized) SetPayload(payload interface{}) {
+func (o *GetMoveTaskOrderUnauthorized) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -137,16 +137,18 @@ func (o *GetMoveTaskOrderUnauthorized) SetPayload(payload interface{}) {
 func (o *GetMoveTaskOrderUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(401)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
 // GetMoveTaskOrderForbiddenCode is the HTTP code returned for type GetMoveTaskOrderForbidden
 const GetMoveTaskOrderForbiddenCode int = 403
 
-/*GetMoveTaskOrderForbidden The client doesn't have permissions to perform the request.
+/*GetMoveTaskOrderForbidden The request was denied.
 
 swagger:response getMoveTaskOrderForbidden
 */
@@ -155,7 +157,7 @@ type GetMoveTaskOrderForbidden struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewGetMoveTaskOrderForbidden creates GetMoveTaskOrderForbidden with default headers values
@@ -165,13 +167,13 @@ func NewGetMoveTaskOrderForbidden() *GetMoveTaskOrderForbidden {
 }
 
 // WithPayload adds the payload to the get move task order forbidden response
-func (o *GetMoveTaskOrderForbidden) WithPayload(payload interface{}) *GetMoveTaskOrderForbidden {
+func (o *GetMoveTaskOrderForbidden) WithPayload(payload *supportmessages.ClientError) *GetMoveTaskOrderForbidden {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get move task order forbidden response
-func (o *GetMoveTaskOrderForbidden) SetPayload(payload interface{}) {
+func (o *GetMoveTaskOrderForbidden) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -179,9 +181,11 @@ func (o *GetMoveTaskOrderForbidden) SetPayload(payload interface{}) {
 func (o *GetMoveTaskOrderForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/mto_service_item/update_m_t_o_service_item_status_responses.go
@@ -104,7 +104,7 @@ func (o *UpdateMTOServiceItemStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdateMTOServiceItemStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOServiceItemStatusUnauthorized
 const UpdateMTOServiceItemStatusUnauthorizedCode int = 401
 
-/*UpdateMTOServiceItemStatusUnauthorized The request was unauthorized.
+/*UpdateMTOServiceItemStatusUnauthorized The request was denied.
 
 swagger:response updateMTOServiceItemStatusUnauthorized
 */
@@ -113,7 +113,7 @@ type UpdateMTOServiceItemStatusUnauthorized struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOServiceItemStatusUnauthorized creates UpdateMTOServiceItemStatusUnauthorized with default headers values
@@ -123,13 +123,13 @@ func NewUpdateMTOServiceItemStatusUnauthorized() *UpdateMTOServiceItemStatusUnau
 }
 
 // WithPayload adds the payload to the update m t o service item status unauthorized response
-func (o *UpdateMTOServiceItemStatusUnauthorized) WithPayload(payload interface{}) *UpdateMTOServiceItemStatusUnauthorized {
+func (o *UpdateMTOServiceItemStatusUnauthorized) WithPayload(payload *supportmessages.ClientError) *UpdateMTOServiceItemStatusUnauthorized {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o service item status unauthorized response
-func (o *UpdateMTOServiceItemStatusUnauthorized) SetPayload(payload interface{}) {
+func (o *UpdateMTOServiceItemStatusUnauthorized) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -137,16 +137,18 @@ func (o *UpdateMTOServiceItemStatusUnauthorized) SetPayload(payload interface{})
 func (o *UpdateMTOServiceItemStatusUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(401)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
 // UpdateMTOServiceItemStatusForbiddenCode is the HTTP code returned for type UpdateMTOServiceItemStatusForbidden
 const UpdateMTOServiceItemStatusForbiddenCode int = 403
 
-/*UpdateMTOServiceItemStatusForbidden The client doesn't have permissions to perform the request.
+/*UpdateMTOServiceItemStatusForbidden The request was denied.
 
 swagger:response updateMTOServiceItemStatusForbidden
 */
@@ -155,7 +157,7 @@ type UpdateMTOServiceItemStatusForbidden struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOServiceItemStatusForbidden creates UpdateMTOServiceItemStatusForbidden with default headers values
@@ -165,13 +167,13 @@ func NewUpdateMTOServiceItemStatusForbidden() *UpdateMTOServiceItemStatusForbidd
 }
 
 // WithPayload adds the payload to the update m t o service item status forbidden response
-func (o *UpdateMTOServiceItemStatusForbidden) WithPayload(payload interface{}) *UpdateMTOServiceItemStatusForbidden {
+func (o *UpdateMTOServiceItemStatusForbidden) WithPayload(payload *supportmessages.ClientError) *UpdateMTOServiceItemStatusForbidden {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o service item status forbidden response
-func (o *UpdateMTOServiceItemStatusForbidden) SetPayload(payload interface{}) {
+func (o *UpdateMTOServiceItemStatusForbidden) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -179,9 +181,11 @@ func (o *UpdateMTOServiceItemStatusForbidden) SetPayload(payload interface{}) {
 func (o *UpdateMTOServiceItemStatusForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -232,7 +236,7 @@ func (o *UpdateMTOServiceItemStatusNotFound) WriteResponse(rw http.ResponseWrite
 // UpdateMTOServiceItemStatusConflictCode is the HTTP code returned for type UpdateMTOServiceItemStatusConflict
 const UpdateMTOServiceItemStatusConflictCode int = 409
 
-/*UpdateMTOServiceItemStatusConflict Conflict error due to trying to change the status of service item that is not currently "SUBMITTED".
+/*UpdateMTOServiceItemStatusConflict There was a conflict with the request.
 
 swagger:response updateMTOServiceItemStatusConflict
 */
@@ -241,7 +245,7 @@ type UpdateMTOServiceItemStatusConflict struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOServiceItemStatusConflict creates UpdateMTOServiceItemStatusConflict with default headers values
@@ -251,13 +255,13 @@ func NewUpdateMTOServiceItemStatusConflict() *UpdateMTOServiceItemStatusConflict
 }
 
 // WithPayload adds the payload to the update m t o service item status conflict response
-func (o *UpdateMTOServiceItemStatusConflict) WithPayload(payload interface{}) *UpdateMTOServiceItemStatusConflict {
+func (o *UpdateMTOServiceItemStatusConflict) WithPayload(payload *supportmessages.ClientError) *UpdateMTOServiceItemStatusConflict {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o service item status conflict response
-func (o *UpdateMTOServiceItemStatusConflict) SetPayload(payload interface{}) {
+func (o *UpdateMTOServiceItemStatusConflict) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -265,9 +269,11 @@ func (o *UpdateMTOServiceItemStatusConflict) SetPayload(payload interface{}) {
 func (o *UpdateMTOServiceItemStatusConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(409)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -104,7 +104,7 @@ func (o *UpdateMTOShipmentStatusBadRequest) WriteResponse(rw http.ResponseWriter
 // UpdateMTOShipmentStatusUnauthorizedCode is the HTTP code returned for type UpdateMTOShipmentStatusUnauthorized
 const UpdateMTOShipmentStatusUnauthorizedCode int = 401
 
-/*UpdateMTOShipmentStatusUnauthorized The request was unauthorized.
+/*UpdateMTOShipmentStatusUnauthorized The request was denied.
 
 swagger:response updateMTOShipmentStatusUnauthorized
 */
@@ -113,7 +113,7 @@ type UpdateMTOShipmentStatusUnauthorized struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOShipmentStatusUnauthorized creates UpdateMTOShipmentStatusUnauthorized with default headers values
@@ -123,13 +123,13 @@ func NewUpdateMTOShipmentStatusUnauthorized() *UpdateMTOShipmentStatusUnauthoriz
 }
 
 // WithPayload adds the payload to the update m t o shipment status unauthorized response
-func (o *UpdateMTOShipmentStatusUnauthorized) WithPayload(payload interface{}) *UpdateMTOShipmentStatusUnauthorized {
+func (o *UpdateMTOShipmentStatusUnauthorized) WithPayload(payload *supportmessages.ClientError) *UpdateMTOShipmentStatusUnauthorized {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o shipment status unauthorized response
-func (o *UpdateMTOShipmentStatusUnauthorized) SetPayload(payload interface{}) {
+func (o *UpdateMTOShipmentStatusUnauthorized) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -137,16 +137,18 @@ func (o *UpdateMTOShipmentStatusUnauthorized) SetPayload(payload interface{}) {
 func (o *UpdateMTOShipmentStatusUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(401)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
 // UpdateMTOShipmentStatusForbiddenCode is the HTTP code returned for type UpdateMTOShipmentStatusForbidden
 const UpdateMTOShipmentStatusForbiddenCode int = 403
 
-/*UpdateMTOShipmentStatusForbidden The client doesn't have permissions to perform the request.
+/*UpdateMTOShipmentStatusForbidden The request was denied.
 
 swagger:response updateMTOShipmentStatusForbidden
 */
@@ -155,7 +157,7 @@ type UpdateMTOShipmentStatusForbidden struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOShipmentStatusForbidden creates UpdateMTOShipmentStatusForbidden with default headers values
@@ -165,13 +167,13 @@ func NewUpdateMTOShipmentStatusForbidden() *UpdateMTOShipmentStatusForbidden {
 }
 
 // WithPayload adds the payload to the update m t o shipment status forbidden response
-func (o *UpdateMTOShipmentStatusForbidden) WithPayload(payload interface{}) *UpdateMTOShipmentStatusForbidden {
+func (o *UpdateMTOShipmentStatusForbidden) WithPayload(payload *supportmessages.ClientError) *UpdateMTOShipmentStatusForbidden {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o shipment status forbidden response
-func (o *UpdateMTOShipmentStatusForbidden) SetPayload(payload interface{}) {
+func (o *UpdateMTOShipmentStatusForbidden) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -179,9 +181,11 @@ func (o *UpdateMTOShipmentStatusForbidden) SetPayload(payload interface{}) {
 func (o *UpdateMTOShipmentStatusForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -232,7 +236,7 @@ func (o *UpdateMTOShipmentStatusNotFound) WriteResponse(rw http.ResponseWriter, 
 // UpdateMTOShipmentStatusConflictCode is the HTTP code returned for type UpdateMTOShipmentStatusConflict
 const UpdateMTOShipmentStatusConflictCode int = 409
 
-/*UpdateMTOShipmentStatusConflict Conflict error due to trying to change the status of shipment that is not currently "SUBMITTED".
+/*UpdateMTOShipmentStatusConflict There was a conflict with the request.
 
 swagger:response updateMTOShipmentStatusConflict
 */
@@ -241,7 +245,7 @@ type UpdateMTOShipmentStatusConflict struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdateMTOShipmentStatusConflict creates UpdateMTOShipmentStatusConflict with default headers values
@@ -251,13 +255,13 @@ func NewUpdateMTOShipmentStatusConflict() *UpdateMTOShipmentStatusConflict {
 }
 
 // WithPayload adds the payload to the update m t o shipment status conflict response
-func (o *UpdateMTOShipmentStatusConflict) WithPayload(payload interface{}) *UpdateMTOShipmentStatusConflict {
+func (o *UpdateMTOShipmentStatusConflict) WithPayload(payload *supportmessages.ClientError) *UpdateMTOShipmentStatusConflict {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o shipment status conflict response
-func (o *UpdateMTOShipmentStatusConflict) SetPayload(payload interface{}) {
+func (o *UpdateMTOShipmentStatusConflict) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -265,9 +269,11 @@ func (o *UpdateMTOShipmentStatusConflict) SetPayload(payload interface{}) {
 func (o *UpdateMTOShipmentStatusConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(409)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/supportapi/supportoperations/payment_requests/update_payment_request_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_requests/update_payment_request_status_responses.go
@@ -104,7 +104,7 @@ func (o *UpdatePaymentRequestStatusBadRequest) WriteResponse(rw http.ResponseWri
 // UpdatePaymentRequestStatusUnauthorizedCode is the HTTP code returned for type UpdatePaymentRequestStatusUnauthorized
 const UpdatePaymentRequestStatusUnauthorizedCode int = 401
 
-/*UpdatePaymentRequestStatusUnauthorized The request was unauthorized.
+/*UpdatePaymentRequestStatusUnauthorized The request was denied.
 
 swagger:response updatePaymentRequestStatusUnauthorized
 */
@@ -113,7 +113,7 @@ type UpdatePaymentRequestStatusUnauthorized struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdatePaymentRequestStatusUnauthorized creates UpdatePaymentRequestStatusUnauthorized with default headers values
@@ -123,13 +123,13 @@ func NewUpdatePaymentRequestStatusUnauthorized() *UpdatePaymentRequestStatusUnau
 }
 
 // WithPayload adds the payload to the update payment request status unauthorized response
-func (o *UpdatePaymentRequestStatusUnauthorized) WithPayload(payload interface{}) *UpdatePaymentRequestStatusUnauthorized {
+func (o *UpdatePaymentRequestStatusUnauthorized) WithPayload(payload *supportmessages.ClientError) *UpdatePaymentRequestStatusUnauthorized {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update payment request status unauthorized response
-func (o *UpdatePaymentRequestStatusUnauthorized) SetPayload(payload interface{}) {
+func (o *UpdatePaymentRequestStatusUnauthorized) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -137,16 +137,18 @@ func (o *UpdatePaymentRequestStatusUnauthorized) SetPayload(payload interface{})
 func (o *UpdatePaymentRequestStatusUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(401)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
 // UpdatePaymentRequestStatusForbiddenCode is the HTTP code returned for type UpdatePaymentRequestStatusForbidden
 const UpdatePaymentRequestStatusForbiddenCode int = 403
 
-/*UpdatePaymentRequestStatusForbidden The client doesn't have permissions to perform the request.
+/*UpdatePaymentRequestStatusForbidden The request was denied.
 
 swagger:response updatePaymentRequestStatusForbidden
 */
@@ -155,7 +157,7 @@ type UpdatePaymentRequestStatusForbidden struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
 }
 
 // NewUpdatePaymentRequestStatusForbidden creates UpdatePaymentRequestStatusForbidden with default headers values
@@ -165,13 +167,13 @@ func NewUpdatePaymentRequestStatusForbidden() *UpdatePaymentRequestStatusForbidd
 }
 
 // WithPayload adds the payload to the update payment request status forbidden response
-func (o *UpdatePaymentRequestStatusForbidden) WithPayload(payload interface{}) *UpdatePaymentRequestStatusForbidden {
+func (o *UpdatePaymentRequestStatusForbidden) WithPayload(payload *supportmessages.ClientError) *UpdatePaymentRequestStatusForbidden {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update payment request status forbidden response
-func (o *UpdatePaymentRequestStatusForbidden) SetPayload(payload interface{}) {
+func (o *UpdatePaymentRequestStatusForbidden) SetPayload(payload *supportmessages.ClientError) {
 	o.Payload = payload
 }
 
@@ -179,9 +181,11 @@ func (o *UpdatePaymentRequestStatusForbidden) SetPayload(payload interface{}) {
 func (o *UpdatePaymentRequestStatusForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/supportclient/move_task_order/create_move_task_order_responses.go
+++ b/pkg/gen/supportclient/move_task_order/create_move_task_order_responses.go
@@ -145,24 +145,26 @@ func NewCreateMoveTaskOrderUnauthorized() *CreateMoveTaskOrderUnauthorized {
 
 /*CreateMoveTaskOrderUnauthorized handles this case with default header values.
 
-The request was unauthorized.
+The request was denied.
 */
 type CreateMoveTaskOrderUnauthorized struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *CreateMoveTaskOrderUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /move-task-orders][%d] createMoveTaskOrderUnauthorized  %+v", 401, o.Payload)
 }
 
-func (o *CreateMoveTaskOrderUnauthorized) GetPayload() interface{} {
+func (o *CreateMoveTaskOrderUnauthorized) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *CreateMoveTaskOrderUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -176,24 +178,26 @@ func NewCreateMoveTaskOrderForbidden() *CreateMoveTaskOrderForbidden {
 
 /*CreateMoveTaskOrderForbidden handles this case with default header values.
 
-The client doesn't have permissions to perform the request.
+The request was denied.
 */
 type CreateMoveTaskOrderForbidden struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *CreateMoveTaskOrderForbidden) Error() string {
 	return fmt.Sprintf("[POST /move-task-orders][%d] createMoveTaskOrderForbidden  %+v", 403, o.Payload)
 }
 
-func (o *CreateMoveTaskOrderForbidden) GetPayload() interface{} {
+func (o *CreateMoveTaskOrderForbidden) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *CreateMoveTaskOrderForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/pkg/gen/supportclient/move_task_order/get_move_task_order_responses.go
+++ b/pkg/gen/supportclient/move_task_order/get_move_task_order_responses.go
@@ -139,24 +139,26 @@ func NewGetMoveTaskOrderUnauthorized() *GetMoveTaskOrderUnauthorized {
 
 /*GetMoveTaskOrderUnauthorized handles this case with default header values.
 
-The request was unauthorized.
+The request was denied.
 */
 type GetMoveTaskOrderUnauthorized struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *GetMoveTaskOrderUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /move-task-orders/{moveTaskOrderID}][%d] getMoveTaskOrderUnauthorized  %+v", 401, o.Payload)
 }
 
-func (o *GetMoveTaskOrderUnauthorized) GetPayload() interface{} {
+func (o *GetMoveTaskOrderUnauthorized) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *GetMoveTaskOrderUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -170,24 +172,26 @@ func NewGetMoveTaskOrderForbidden() *GetMoveTaskOrderForbidden {
 
 /*GetMoveTaskOrderForbidden handles this case with default header values.
 
-The client doesn't have permissions to perform the request.
+The request was denied.
 */
 type GetMoveTaskOrderForbidden struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *GetMoveTaskOrderForbidden) Error() string {
 	return fmt.Sprintf("[GET /move-task-orders/{moveTaskOrderID}][%d] getMoveTaskOrderForbidden  %+v", 403, o.Payload)
 }
 
-func (o *GetMoveTaskOrderForbidden) GetPayload() interface{} {
+func (o *GetMoveTaskOrderForbidden) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *GetMoveTaskOrderForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_responses.go
+++ b/pkg/gen/supportclient/mto_service_item/update_m_t_o_service_item_status_responses.go
@@ -157,24 +157,26 @@ func NewUpdateMTOServiceItemStatusUnauthorized() *UpdateMTOServiceItemStatusUnau
 
 /*UpdateMTOServiceItemStatusUnauthorized handles this case with default header values.
 
-The request was unauthorized.
+The request was denied.
 */
 type UpdateMTOServiceItemStatusUnauthorized struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOServiceItemStatusUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /service-items/{mtoServiceItemID}/status][%d] updateMTOServiceItemStatusUnauthorized  %+v", 401, o.Payload)
 }
 
-func (o *UpdateMTOServiceItemStatusUnauthorized) GetPayload() interface{} {
+func (o *UpdateMTOServiceItemStatusUnauthorized) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOServiceItemStatusUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -188,24 +190,26 @@ func NewUpdateMTOServiceItemStatusForbidden() *UpdateMTOServiceItemStatusForbidd
 
 /*UpdateMTOServiceItemStatusForbidden handles this case with default header values.
 
-The client doesn't have permissions to perform the request.
+The request was denied.
 */
 type UpdateMTOServiceItemStatusForbidden struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOServiceItemStatusForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /service-items/{mtoServiceItemID}/status][%d] updateMTOServiceItemStatusForbidden  %+v", 403, o.Payload)
 }
 
-func (o *UpdateMTOServiceItemStatusForbidden) GetPayload() interface{} {
+func (o *UpdateMTOServiceItemStatusForbidden) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOServiceItemStatusForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -252,24 +256,26 @@ func NewUpdateMTOServiceItemStatusConflict() *UpdateMTOServiceItemStatusConflict
 
 /*UpdateMTOServiceItemStatusConflict handles this case with default header values.
 
-Conflict error due to trying to change the status of service item that is not currently "SUBMITTED".
+There was a conflict with the request.
 */
 type UpdateMTOServiceItemStatusConflict struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOServiceItemStatusConflict) Error() string {
 	return fmt.Sprintf("[PATCH /service-items/{mtoServiceItemID}/status][%d] updateMTOServiceItemStatusConflict  %+v", 409, o.Payload)
 }
 
-func (o *UpdateMTOServiceItemStatusConflict) GetPayload() interface{} {
+func (o *UpdateMTOServiceItemStatusConflict) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOServiceItemStatusConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_responses.go
+++ b/pkg/gen/supportclient/mto_shipment/update_m_t_o_shipment_status_responses.go
@@ -157,24 +157,26 @@ func NewUpdateMTOShipmentStatusUnauthorized() *UpdateMTOShipmentStatusUnauthoriz
 
 /*UpdateMTOShipmentStatusUnauthorized handles this case with default header values.
 
-The request was unauthorized.
+The request was denied.
 */
 type UpdateMTOShipmentStatusUnauthorized struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOShipmentStatusUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /mto-shipments/{mtoShipmentID}/status][%d] updateMTOShipmentStatusUnauthorized  %+v", 401, o.Payload)
 }
 
-func (o *UpdateMTOShipmentStatusUnauthorized) GetPayload() interface{} {
+func (o *UpdateMTOShipmentStatusUnauthorized) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOShipmentStatusUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -188,24 +190,26 @@ func NewUpdateMTOShipmentStatusForbidden() *UpdateMTOShipmentStatusForbidden {
 
 /*UpdateMTOShipmentStatusForbidden handles this case with default header values.
 
-The client doesn't have permissions to perform the request.
+The request was denied.
 */
 type UpdateMTOShipmentStatusForbidden struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOShipmentStatusForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /mto-shipments/{mtoShipmentID}/status][%d] updateMTOShipmentStatusForbidden  %+v", 403, o.Payload)
 }
 
-func (o *UpdateMTOShipmentStatusForbidden) GetPayload() interface{} {
+func (o *UpdateMTOShipmentStatusForbidden) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOShipmentStatusForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -252,24 +256,26 @@ func NewUpdateMTOShipmentStatusConflict() *UpdateMTOShipmentStatusConflict {
 
 /*UpdateMTOShipmentStatusConflict handles this case with default header values.
 
-Conflict error due to trying to change the status of shipment that is not currently "SUBMITTED".
+There was a conflict with the request.
 */
 type UpdateMTOShipmentStatusConflict struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdateMTOShipmentStatusConflict) Error() string {
 	return fmt.Sprintf("[PATCH /mto-shipments/{mtoShipmentID}/status][%d] updateMTOShipmentStatusConflict  %+v", 409, o.Payload)
 }
 
-func (o *UpdateMTOShipmentStatusConflict) GetPayload() interface{} {
+func (o *UpdateMTOShipmentStatusConflict) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdateMTOShipmentStatusConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/pkg/gen/supportclient/payment_requests/update_payment_request_status_responses.go
+++ b/pkg/gen/supportclient/payment_requests/update_payment_request_status_responses.go
@@ -151,24 +151,26 @@ func NewUpdatePaymentRequestStatusUnauthorized() *UpdatePaymentRequestStatusUnau
 
 /*UpdatePaymentRequestStatusUnauthorized handles this case with default header values.
 
-The request was unauthorized.
+The request was denied.
 */
 type UpdatePaymentRequestStatusUnauthorized struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdatePaymentRequestStatusUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /payment-requests/{paymentRequestID}/status][%d] updatePaymentRequestStatusUnauthorized  %+v", 401, o.Payload)
 }
 
-func (o *UpdatePaymentRequestStatusUnauthorized) GetPayload() interface{} {
+func (o *UpdatePaymentRequestStatusUnauthorized) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdatePaymentRequestStatusUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -182,24 +184,26 @@ func NewUpdatePaymentRequestStatusForbidden() *UpdatePaymentRequestStatusForbidd
 
 /*UpdatePaymentRequestStatusForbidden handles this case with default header values.
 
-The client doesn't have permissions to perform the request.
+The request was denied.
 */
 type UpdatePaymentRequestStatusForbidden struct {
-	Payload interface{}
+	Payload *supportmessages.ClientError
 }
 
 func (o *UpdatePaymentRequestStatusForbidden) Error() string {
 	return fmt.Sprintf("[PATCH /payment-requests/{paymentRequestID}/status][%d] updatePaymentRequestStatusForbidden  %+v", 403, o.Payload)
 }
 
-func (o *UpdatePaymentRequestStatusForbidden) GetPayload() interface{} {
+func (o *UpdatePaymentRequestStatusForbidden) GetPayload() *supportmessages.ClientError {
 	return o.Payload
 }
 
 func (o *UpdatePaymentRequestStatusForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(supportmessages.ClientError)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -85,13 +85,9 @@ paths:
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was unauthorized.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '403':
-          description: The client doesn't have permissions to perform the request.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '422':
@@ -125,13 +121,9 @@ paths:
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was unauthorized.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '403':
-          description: The client doesn't have permissions to perform the request.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '500':
@@ -258,13 +250,9 @@ paths:
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was unauthorized.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '403':
-          description: The client doesn't have permissions to perform the request.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '412':
@@ -314,19 +302,13 @@ paths:
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was unauthorized.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '403':
-          description: The client doesn't have permissions to perform the request.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '409':
-          description: Conflict error due to trying to change the status of service item that is not currently "SUBMITTED".
-          schema:
-            $ref: '#/responses/Conflict'
+          $ref: '#/responses/Conflict'
         '412':
           $ref: '#/responses/PreconditionFailed'
         '422':
@@ -377,19 +359,13 @@ paths:
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':
-          description: The request was unauthorized.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '403':
-          description: The client doesn't have permissions to perform the request.
-          schema:
-            $ref: '#/responses/PermissionDenied'
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '409':
-          description: Conflict error due to trying to change the status of shipment that is not currently "SUBMITTED".
-          schema:
-            $ref: '#/responses/Conflict'
+          $ref: '#/responses/Conflict'
         '412':
           $ref: '#/responses/PreconditionFailed'
         '422':


### PR DESCRIPTION
## Description

* It is invalid to have a response code defined with a schema attribute pointing at a response. 
* This PR removes the `schema` and `description` keys and instead points `$ref` to the response.
* Note: This work has already been completed for `prime.yaml`

## Reviewer's Notes

* You can validate the yaml using https://apitools.dev/swagger-parser/online/


## Code Review Verification Steps
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3235) for this change
