### PR TITLE
Update ServiceAreaOriginLookup to take ContractCode into account

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+
 )
 
 // ServiceAreaOriginLookup does lookup on pickup address postal code
@@ -29,7 +30,7 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 		default:
 			return "", err
 		}
-	}
+	} 
 
 	// Make sure there's an MTOShipment since that's nullable
 	mtoShipmentID := mtoServiceItem.MTOShipmentID
@@ -51,7 +52,9 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 	var domesticServiceArea models.ReDomesticServiceArea
 
 	query := db.Q().Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
-		Where("zip3 = ?", zip3)
+		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
+		Where("re_zip3s.zip3 = ?", zip3).
+		Where("re_contracts.code = ?", "TRUSS_TEST")
 
 	err = query.First(&domesticServiceArea)
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -52,7 +52,8 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 
 	var domesticServiceArea models.ReDomesticServiceArea
 
-	query := db.Q().Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
+	query := db.Q().
+		Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
 		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
 		Where("re_zip3s.zip3 = ?", zip3).
 		/*

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -57,12 +57,14 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
 		Where("re_zip3s.zip3 = ?", zip3).
 		/*
-			DefaultContractCode, TRUSS_TEST is temporarily being used here because:
-			MTO and mtoServiceItem are not linked or associated with the contract record
-			MTO currently has a contractor_id but not a contract_id. 
+			DefaultContractCode = TRUSS_TEST is temporarily being used here because the contract
+			code is not currently accessible. This is caused by:
+				- mtoServiceItem is not linked or associated with a contract record
+				- MTO currently has a contractor_id but not a contract_id
+			In order for this lookup's query to have accesss to a contract code there must be a contract_code field created on either the mtoServiceItem or the MTO models
 			If it'll will be possible for a MTO to contain service items that are associated with different contracts
-			It would be ideal for the mtoServiceItem records to contain a contract code that can then passed
-			to this query. Otherwise the MTO could contain the contract_id or contract_code
+			then it would be ideal for the mtoServiceItem records to contain a contract code that can then be passed
+			to this query. Otherwise the contract_code field could be added to the MTO.
 		*/
 		Where("re_contracts.code = ?", ghcrateengine.DefaultContractCode)
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-
 )
 
 // ServiceAreaOriginLookup does lookup on pickup address postal code
@@ -31,7 +30,7 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 		default:
 			return "", err
 		}
-	} 
+	}
 
 	// Make sure there's an MTOShipment since that's nullable
 	mtoShipmentID := mtoServiceItem.MTOShipmentID

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -55,6 +55,14 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 	query := db.Q().Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
 		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
 		Where("re_zip3s.zip3 = ?", zip3).
+		/*
+			DefaultContractCode, TRUSS_TEST is temporarily being used here because:
+			MTO and mtoServiceItem are not linked or associated with the contract record
+			MTO currently has a contractor_id but not a contract_id. 
+			If it'll will be possible for a MTO to contain service items that are associated with different contracts
+			It would be ideal for the mtoServiceItem records to contain a contract code that can then passed
+			to this query. Otherwise the MTO could contain the contract_id or contract_code
+		*/
 		Where("re_contracts.code = ?", ghcrateengine.DefaultContractCode)
 
 	err = query.First(&domesticServiceArea)

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 
 )
 
@@ -54,7 +55,7 @@ func (r ServiceAreaOriginLookup) lookup(keyData *ServiceItemParamKeyData) (strin
 	query := db.Q().Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
 		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
 		Where("re_zip3s.zip3 = ?", zip3).
-		Where("re_contracts.code = ?", "TRUSS_TEST")
+		Where("re_contracts.code = ?", ghcrateengine.DefaultContractCode)
 
 	err = query.First(&domesticServiceArea)
 

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -96,7 +96,7 @@ var cal = dates.NewUSCalendar()
 var NextValidMoveDate = dates.NextValidMoveDate(time.Now(), cal)
 
 // DefaultContractCode is the default contract code for testing
-const DefaultContractCode = "TEST"
+const DefaultContractCode = "TRUSS_TEST"
 
 // DefaultContractName name used for contractor in testing
 const DefaultContractName = "Default contractor name for test"


### PR DESCRIPTION
## Description

This PR adds a condition to the ServiceAreaOriginLookup to account for the `contract_code`. It passes in the `defaultContractCode` which has been hardcoded to `TRUSS_TEST`

## Reviewer Notes
In addition to testing locally with the sql query below please let me know if there's another approach for verifying this ticket

## Setup

```sh
select * from re_domestic_service_areas
join re_zip3s on re_zip3s.domestic_service_area_id = re_domestic_service_areas.id
join re_contracts on re_contracts.id = re_domestic_service_areas.contract_id
where re_zip3s.zip3 = '176'
and re_contracts.code = 'TRUSS_TEST';
```


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3043) for this change

