### PR TITLE
MB-2820 Clean up yaml for service items

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -952,7 +952,8 @@ func init() {
       ],
       "properties": {
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "id": {
           "type": "string",
@@ -972,17 +973,14 @@ func init() {
           "format": "uuid",
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
-        },
         "reServiceName": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
+          "readOnly": true,
           "example": "item was too heavy"
         },
         "status": {
@@ -2970,7 +2968,8 @@ func init() {
       ],
       "properties": {
         "eTag": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "id": {
           "type": "string",
@@ -2990,17 +2989,14 @@ func init() {
           "format": "uuid",
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
-        },
         "reServiceName": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true
         },
         "rejectionReason": {
           "type": "string",
           "x-nullable": true,
+          "readOnly": true,
           "example": "item was too heavy"
         },
         "status": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1024,11 +1024,13 @@ func init() {
           ],
           "properties": {
             "firstAvailableDeliveryDate1": {
+              "description": "First available date that Prime can deliver SIT service item.",
               "type": "string",
               "format": "date",
               "example": "2020-01-20"
             },
             "firstAvailableDeliveryDate2": {
+              "description": "Second available date that Prime can deliver SIT service item.",
               "type": "string",
               "format": "date",
               "example": "2020-01-20"
@@ -1041,10 +1043,12 @@ func init() {
               ]
             },
             "timeMilitary1": {
+              "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate1` + "`" + `.",
               "type": "string",
               "example": "0400Z"
             },
             "timeMilitary2": {
+              "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate2` + "`" + `.",
               "type": "string",
               "example": "0400Z"
             },
@@ -1082,6 +1086,7 @@ func init() {
               ]
             },
             "reason": {
+              "description": "Explanation of why Prime is picking up SIT item.",
               "type": "string",
               "example": "Storage items need to be picked up"
             }
@@ -1190,6 +1195,7 @@ func init() {
           ],
           "properties": {
             "description": {
+              "description": "Further details about the shuttle service.",
               "type": "string",
               "example": "Things to be moved to the place by shuttle."
             },
@@ -1202,6 +1208,7 @@ func init() {
               ]
             },
             "reason": {
+              "description": "Explanation of why a shuttle service is required.",
               "type": "string",
               "example": "Storage items need to be picked up."
             }
@@ -3040,11 +3047,13 @@ func init() {
           ],
           "properties": {
             "firstAvailableDeliveryDate1": {
+              "description": "First available date that Prime can deliver SIT service item.",
               "type": "string",
               "format": "date",
               "example": "2020-01-20"
             },
             "firstAvailableDeliveryDate2": {
+              "description": "Second available date that Prime can deliver SIT service item.",
               "type": "string",
               "format": "date",
               "example": "2020-01-20"
@@ -3057,10 +3066,12 @@ func init() {
               ]
             },
             "timeMilitary1": {
+              "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate1` + "`" + `.",
               "type": "string",
               "example": "0400Z"
             },
             "timeMilitary2": {
+              "description": "Time of delivery corresponding to ` + "`" + `firstAvailableDeliveryDate2` + "`" + `.",
               "type": "string",
               "example": "0400Z"
             },
@@ -3098,6 +3109,7 @@ func init() {
               ]
             },
             "reason": {
+              "description": "Explanation of why Prime is picking up SIT item.",
               "type": "string",
               "example": "Storage items need to be picked up"
             }
@@ -3206,6 +3218,7 @@ func init() {
           ],
           "properties": {
             "description": {
+              "description": "Further details about the shuttle service.",
               "type": "string",
               "example": "Things to be moved to the place by shuttle."
             },
@@ -3218,6 +3231,7 @@ func init() {
               ]
             },
             "reason": {
+              "description": "Explanation of why a shuttle service is required.",
               "type": "string",
               "example": "Storage items need to be picked up."
             }

--- a/pkg/gen/primemessages/m_t_o_service_item.go
+++ b/pkg/gen/primemessages/m_t_o_service_item.go
@@ -25,6 +25,7 @@ type MTOServiceItem interface {
 	runtime.Validatable
 
 	// e tag
+	// Read Only: true
 	ETag() string
 	SetETag(string)
 
@@ -49,16 +50,13 @@ type MTOServiceItem interface {
 	MtoShipmentID() strfmt.UUID
 	SetMtoShipmentID(strfmt.UUID)
 
-	// re service ID
-	// Format: uuid
-	ReServiceID() strfmt.UUID
-	SetReServiceID(strfmt.UUID)
-
 	// re service name
+	// Read Only: true
 	ReServiceName() string
 	SetReServiceName(string)
 
 	// rejection reason
+	// Read Only: true
 	RejectionReason() *string
 	SetRejectionReason(*string)
 
@@ -77,8 +75,6 @@ type mTOServiceItem struct {
 	moveTaskOrderIdField *strfmt.UUID
 
 	mtoShipmentIdField strfmt.UUID
-
-	reServiceIdField strfmt.UUID
 
 	reServiceNameField string
 
@@ -135,16 +131,6 @@ func (m *mTOServiceItem) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this polymorphic type
 func (m *mTOServiceItem) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this polymorphic type
-func (m *mTOServiceItem) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this polymorphic type
-func (m *mTOServiceItem) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this polymorphic type
@@ -286,10 +272,6 @@ func (m *mTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateReServiceID(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -333,19 +315,6 @@ func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *mTOServiceItem) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_basic.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_basic.go
@@ -27,8 +27,6 @@ type MTOServiceItemBasic struct {
 
 	mtoShipmentIdField strfmt.UUID
 
-	reServiceIdField strfmt.UUID
-
 	reServiceNameField string
 
 	rejectionReasonField *string
@@ -88,16 +86,6 @@ func (m *MTOServiceItemBasic) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this subtype
 func (m *MTOServiceItemBasic) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this subtype
-func (m *MTOServiceItemBasic) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this subtype
-func (m *MTOServiceItemBasic) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this subtype
@@ -161,8 +149,6 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -191,8 +177,6 @@ func (m *MTOServiceItemBasic) UnmarshalJSON(raw []byte) error {
 	result.moveTaskOrderIdField = base.MoveTaskOrderID
 
 	result.mtoShipmentIdField = base.MtoShipmentID
-
-	result.reServiceIdField = base.ReServiceID
 
 	result.reServiceNameField = base.ReServiceName
 
@@ -235,8 +219,6 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -253,8 +235,6 @@ func (m MTOServiceItemBasic) MarshalJSON() ([]byte, error) {
 		MoveTaskOrderID: m.MoveTaskOrderID(),
 
 		MtoShipmentID: m.MtoShipmentID(),
-
-		ReServiceID: m.ReServiceID(),
 
 		ReServiceName: m.ReServiceName(),
 
@@ -283,10 +263,6 @@ func (m *MTOServiceItemBasic) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -337,19 +313,6 @@ func (m *MTOServiceItemBasic) validateMtoShipmentID(formats strfmt.Registry) err
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemBasic) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
@@ -33,12 +33,12 @@ type MTOServiceItemDDFSIT struct {
 
 	statusField MTOServiceItemStatus
 
-	// first available delivery date1
+	// First available date that Prime can deliver SIT service item.
 	// Required: true
 	// Format: date
 	FirstAvailableDeliveryDate1 *strfmt.Date `json:"firstAvailableDeliveryDate1"`
 
-	// first available delivery date2
+	// Second available date that Prime can deliver SIT service item.
 	// Required: true
 	// Format: date
 	FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
@@ -47,11 +47,11 @@ type MTOServiceItemDDFSIT struct {
 	// Enum: [DDFSIT]
 	ReServiceCode string `json:"reServiceCode,omitempty"`
 
-	// time military1
+	// Time of delivery corresponding to `firstAvailableDeliveryDate1`.
 	// Required: true
 	TimeMilitary1 *string `json:"timeMilitary1"`
 
-	// time military2
+	// Time of delivery corresponding to `firstAvailableDeliveryDate2`.
 	// Required: true
 	TimeMilitary2 *string `json:"timeMilitary2"`
 
@@ -155,12 +155,12 @@ func (m *MTOServiceItemDDFSIT) SetStatus(val MTOServiceItemStatus) {
 func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 	var data struct {
 
-		// first available delivery date1
+		// First available date that Prime can deliver SIT service item.
 		// Required: true
 		// Format: date
 		FirstAvailableDeliveryDate1 *strfmt.Date `json:"firstAvailableDeliveryDate1"`
 
-		// first available delivery date2
+		// Second available date that Prime can deliver SIT service item.
 		// Required: true
 		// Format: date
 		FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
@@ -169,11 +169,11 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 		// Enum: [DDFSIT]
 		ReServiceCode string `json:"reServiceCode,omitempty"`
 
-		// time military1
+		// Time of delivery corresponding to `firstAvailableDeliveryDate1`.
 		// Required: true
 		TimeMilitary1 *string `json:"timeMilitary1"`
 
-		// time military2
+		// Time of delivery corresponding to `firstAvailableDeliveryDate2`.
 		// Required: true
 		TimeMilitary2 *string `json:"timeMilitary2"`
 
@@ -259,12 +259,12 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 	var err error
 	b1, err = json.Marshal(struct {
 
-		// first available delivery date1
+		// First available date that Prime can deliver SIT service item.
 		// Required: true
 		// Format: date
 		FirstAvailableDeliveryDate1 *strfmt.Date `json:"firstAvailableDeliveryDate1"`
 
-		// first available delivery date2
+		// Second available date that Prime can deliver SIT service item.
 		// Required: true
 		// Format: date
 		FirstAvailableDeliveryDate2 *strfmt.Date `json:"firstAvailableDeliveryDate2"`
@@ -273,11 +273,11 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 		// Enum: [DDFSIT]
 		ReServiceCode string `json:"reServiceCode,omitempty"`
 
-		// time military1
+		// Time of delivery corresponding to `firstAvailableDeliveryDate1`.
 		// Required: true
 		TimeMilitary1 *string `json:"timeMilitary1"`
 
-		// time military2
+		// Time of delivery corresponding to `firstAvailableDeliveryDate2`.
 		// Required: true
 		TimeMilitary2 *string `json:"timeMilitary2"`
 

--- a/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_d_f_s_i_t.go
@@ -27,8 +27,6 @@ type MTOServiceItemDDFSIT struct {
 
 	mtoShipmentIdField strfmt.UUID
 
-	reServiceIdField strfmt.UUID
-
 	reServiceNameField string
 
 	rejectionReasonField *string
@@ -109,16 +107,6 @@ func (m *MTOServiceItemDDFSIT) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this subtype
 func (m *MTOServiceItemDDFSIT) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this subtype
-func (m *MTOServiceItemDDFSIT) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this subtype
-func (m *MTOServiceItemDDFSIT) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this subtype
@@ -213,8 +201,6 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -243,8 +229,6 @@ func (m *MTOServiceItemDDFSIT) UnmarshalJSON(raw []byte) error {
 	result.moveTaskOrderIdField = base.MoveTaskOrderID
 
 	result.mtoShipmentIdField = base.MtoShipmentID
-
-	result.reServiceIdField = base.ReServiceID
 
 	result.reServiceNameField = base.ReServiceName
 
@@ -328,8 +312,6 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -346,8 +328,6 @@ func (m MTOServiceItemDDFSIT) MarshalJSON() ([]byte, error) {
 		MoveTaskOrderID: m.MoveTaskOrderID(),
 
 		MtoShipmentID: m.MtoShipmentID(),
-
-		ReServiceID: m.ReServiceID(),
 
 		ReServiceName: m.ReServiceName(),
 
@@ -376,10 +356,6 @@ func (m *MTOServiceItemDDFSIT) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -450,19 +426,6 @@ func (m *MTOServiceItemDDFSIT) validateMtoShipmentID(formats strfmt.Registry) er
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemDDFSIT) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
@@ -42,7 +42,7 @@ type MTOServiceItemDOFSIT struct {
 	// Enum: [DOFSIT]
 	ReServiceCode string `json:"reServiceCode,omitempty"`
 
-	// reason
+	// Explanation of why Prime is picking up SIT item.
 	// Required: true
 	Reason *string `json:"reason"`
 }
@@ -146,7 +146,7 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 		// Enum: [DOFSIT]
 		ReServiceCode string `json:"reServiceCode,omitempty"`
 
-		// reason
+		// Explanation of why Prime is picking up SIT item.
 		// Required: true
 		Reason *string `json:"reason"`
 	}
@@ -232,7 +232,7 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 		// Enum: [DOFSIT]
 		ReServiceCode string `json:"reServiceCode,omitempty"`
 
-		// reason
+		// Explanation of why Prime is picking up SIT item.
 		// Required: true
 		Reason *string `json:"reason"`
 	}{

--- a/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_d_o_f_s_i_t.go
@@ -27,8 +27,6 @@ type MTOServiceItemDOFSIT struct {
 
 	mtoShipmentIdField strfmt.UUID
 
-	reServiceIdField strfmt.UUID
-
 	reServiceNameField string
 
 	rejectionReasonField *string
@@ -97,16 +95,6 @@ func (m *MTOServiceItemDOFSIT) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this subtype
 func (m *MTOServiceItemDOFSIT) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this subtype
-func (m *MTOServiceItemDOFSIT) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this subtype
-func (m *MTOServiceItemDOFSIT) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this subtype
@@ -183,8 +171,6 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -213,8 +199,6 @@ func (m *MTOServiceItemDOFSIT) UnmarshalJSON(raw []byte) error {
 	result.moveTaskOrderIdField = base.MoveTaskOrderID
 
 	result.mtoShipmentIdField = base.MtoShipmentID
-
-	result.reServiceIdField = base.ReServiceID
 
 	result.reServiceNameField = base.ReServiceName
 
@@ -274,8 +258,6 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -292,8 +274,6 @@ func (m MTOServiceItemDOFSIT) MarshalJSON() ([]byte, error) {
 		MoveTaskOrderID: m.MoveTaskOrderID(),
 
 		MtoShipmentID: m.MtoShipmentID(),
-
-		ReServiceID: m.ReServiceID(),
 
 		ReServiceName: m.ReServiceName(),
 
@@ -322,10 +302,6 @@ func (m *MTOServiceItemDOFSIT) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -384,19 +360,6 @@ func (m *MTOServiceItemDOFSIT) validateMtoShipmentID(formats strfmt.Registry) er
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemDOFSIT) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -27,8 +27,6 @@ type MTOServiceItemDomesticCrating struct {
 
 	mtoShipmentIdField strfmt.UUID
 
-	reServiceIdField strfmt.UUID
-
 	reServiceNameField string
 
 	rejectionReasonField *string
@@ -101,16 +99,6 @@ func (m *MTOServiceItemDomesticCrating) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this subtype
 func (m *MTOServiceItemDomesticCrating) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this subtype
-func (m *MTOServiceItemDomesticCrating) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this subtype
-func (m *MTOServiceItemDomesticCrating) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this subtype
@@ -193,8 +181,6 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -223,8 +209,6 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 	result.moveTaskOrderIdField = base.MoveTaskOrderID
 
 	result.mtoShipmentIdField = base.MtoShipmentID
-
-	result.reServiceIdField = base.ReServiceID
 
 	result.reServiceNameField = base.ReServiceName
 
@@ -292,8 +276,6 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -310,8 +292,6 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 		MoveTaskOrderID: m.MoveTaskOrderID(),
 
 		MtoShipmentID: m.MtoShipmentID(),
-
-		ReServiceID: m.ReServiceID(),
 
 		ReServiceName: m.ReServiceName(),
 
@@ -340,10 +320,6 @@ func (m *MTOServiceItemDomesticCrating) Validate(formats strfmt.Registry) error 
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -406,19 +382,6 @@ func (m *MTOServiceItemDomesticCrating) validateMtoShipmentID(formats strfmt.Reg
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemDomesticCrating) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -27,8 +27,6 @@ type MTOServiceItemShuttle struct {
 
 	mtoShipmentIdField strfmt.UUID
 
-	reServiceIdField strfmt.UUID
-
 	reServiceNameField string
 
 	rejectionReasonField *string
@@ -97,16 +95,6 @@ func (m *MTOServiceItemShuttle) MtoShipmentID() strfmt.UUID {
 // SetMtoShipmentID sets the mto shipment ID of this subtype
 func (m *MTOServiceItemShuttle) SetMtoShipmentID(val strfmt.UUID) {
 	m.mtoShipmentIdField = val
-}
-
-// ReServiceID gets the re service ID of this subtype
-func (m *MTOServiceItemShuttle) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this subtype
-func (m *MTOServiceItemShuttle) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this subtype
@@ -183,8 +171,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -213,8 +199,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	result.moveTaskOrderIdField = base.MoveTaskOrderID
 
 	result.mtoShipmentIdField = base.MtoShipmentID
-
-	result.reServiceIdField = base.ReServiceID
 
 	result.reServiceNameField = base.ReServiceName
 
@@ -274,8 +258,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
-		ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 		ReServiceName string `json:"reServiceName,omitempty"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
@@ -292,8 +274,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		MoveTaskOrderID: m.MoveTaskOrderID(),
 
 		MtoShipmentID: m.MtoShipmentID(),
-
-		ReServiceID: m.ReServiceID(),
 
 		ReServiceName: m.ReServiceName(),
 
@@ -322,10 +302,6 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -384,19 +360,6 @@ func (m *MTOServiceItemShuttle) validateMtoShipmentID(formats strfmt.Registry) e
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemShuttle) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -33,7 +33,7 @@ type MTOServiceItemShuttle struct {
 
 	statusField MTOServiceItemStatus
 
-	// description
+	// Further details about the shuttle service.
 	// Required: true
 	Description *string `json:"description"`
 
@@ -42,7 +42,7 @@ type MTOServiceItemShuttle struct {
 	// Enum: [DOSHUT DDSHUT]
 	ReServiceCode *string `json:"reServiceCode"`
 
-	// reason
+	// Explanation of why a shuttle service is required.
 	// Required: true
 	Reason *string `json:"reason"`
 }
@@ -137,7 +137,7 @@ func (m *MTOServiceItemShuttle) SetStatus(val MTOServiceItemStatus) {
 func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	var data struct {
 
-		// description
+		// Further details about the shuttle service.
 		// Required: true
 		Description *string `json:"description"`
 
@@ -146,7 +146,7 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`
 
-		// reason
+		// Explanation of why a shuttle service is required.
 		// Required: true
 		Reason *string `json:"reason"`
 	}
@@ -223,7 +223,7 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 	var err error
 	b1, err = json.Marshal(struct {
 
-		// description
+		// Further details about the shuttle service.
 		// Required: true
 		Description *string `json:"description"`
 
@@ -232,7 +232,7 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		// Enum: [DOSHUT DDSHUT]
 		ReServiceCode *string `json:"reServiceCode"`
 
-		// reason
+		// Explanation of why a shuttle service is required.
 		// Required: true
 		Reason *string `json:"reason"`
 	}{

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -994,11 +994,6 @@ func init() {
         "rate": {
           "type": "integer"
         },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
-        },
         "reServiceName": {
           "type": "string"
         },
@@ -1414,12 +1409,6 @@ func init() {
         "reServiceCode": {
           "type": "string",
           "readOnly": true
-        },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "readOnly": true,
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "reServiceName": {
           "type": "string",
@@ -2740,11 +2729,6 @@ func init() {
         "rate": {
           "type": "integer"
         },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
-        },
         "reServiceName": {
           "type": "string"
         },
@@ -3160,12 +3144,6 @@ func init() {
         "reServiceCode": {
           "type": "string",
           "readOnly": true
-        },
-        "reServiceID": {
-          "type": "string",
-          "format": "uuid",
-          "readOnly": true,
-          "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "reServiceName": {
           "type": "string",

--- a/pkg/gen/supportmessages/m_t_o_service_item.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item.go
@@ -66,11 +66,6 @@ type MTOServiceItem interface {
 	Rate() int64
 	SetRate(int64)
 
-	// re service ID
-	// Format: uuid
-	ReServiceID() strfmt.UUID
-	SetReServiceID(strfmt.UUID)
-
 	// re service name
 	ReServiceName() string
 	SetReServiceName(string)
@@ -102,8 +97,6 @@ type mTOServiceItem struct {
 	quantityField int64
 
 	rateField int64
-
-	reServiceIdField strfmt.UUID
 
 	reServiceNameField string
 
@@ -200,16 +193,6 @@ func (m *mTOServiceItem) Rate() int64 {
 // SetRate sets the rate of this polymorphic type
 func (m *mTOServiceItem) SetRate(val int64) {
 	m.rateField = val
-}
-
-// ReServiceID gets the re service ID of this polymorphic type
-func (m *mTOServiceItem) ReServiceID() strfmt.UUID {
-	return m.reServiceIdField
-}
-
-// SetReServiceID sets the re service ID of this polymorphic type
-func (m *mTOServiceItem) SetReServiceID(val strfmt.UUID) {
-	m.reServiceIdField = val
 }
 
 // ReServiceName gets the re service name of this polymorphic type
@@ -320,10 +303,6 @@ func (m *mTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateReServiceID(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -416,19 +395,6 @@ func (m *mTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID().String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *mTOServiceItem) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID()) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID().String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
+++ b/pkg/gen/supportmessages/update_m_t_o_service_item_status.go
@@ -59,11 +59,6 @@ type UpdateMTOServiceItemStatus struct {
 	// Read Only: true
 	ReServiceCode string `json:"reServiceCode,omitempty"`
 
-	// re service ID
-	// Read Only: true
-	// Format: uuid
-	ReServiceID strfmt.UUID `json:"reServiceID,omitempty"`
-
 	// re service name
 	// Read Only: true
 	ReServiceName string `json:"reServiceName,omitempty"`
@@ -97,10 +92,6 @@ func (m *UpdateMTOServiceItemStatus) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMtoShipmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReServiceID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -196,19 +187,6 @@ func (m *UpdateMTOServiceItemStatus) validateMtoShipmentID(formats strfmt.Regist
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMTOServiceItemStatus) validateReServiceID(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.ReServiceID) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("reServiceID", "body", "uuid", m.ReServiceID.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -452,7 +452,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	payload.SetID(strfmt.UUID(mtoServiceItem.ID.String()))
 	payload.SetMoveTaskOrderID(handlers.FmtUUID(mtoServiceItem.MoveTaskOrderID))
 	payload.SetMtoShipmentID(strfmt.UUID(shipmentIDStr))
-	payload.SetReServiceID(strfmt.UUID(mtoServiceItem.ReServiceID.String()))
 	payload.SetReServiceName(mtoServiceItem.ReService.Name)
 	payload.SetStatus(primemessages.MTOServiceItemStatus(mtoServiceItem.Status))
 	payload.SetRejectionReason(mtoServiceItem.Reason)

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -504,6 +504,7 @@ definitions:
     properties:
       isFinal:
         default: false
+
         type: boolean
       moveTaskOrderID:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -988,22 +989,21 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
-      reServiceID:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
       reServiceName:
         type: string
+        readOnly: true
       status:
         $ref: '#/definitions/MTOServiceItemStatus'
       rejectionReason:
         example: item was too heavy
         type: string
         x-nullable: true
+        readOnly: true
       modelType: # Base type and sub-types of MTOServiceItem
         $ref: '#/definitions/MTOServiceItemModelType'
       eTag:
         type: string
+        readOnly: true
     required:
       - modelType
       - moveTaskOrderID

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1025,7 +1025,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
-            description: "Service code allowed for this model type."
+            description: Service code allowed for this model type.
             enum:
               - DOFSIT # Domestic Origin First Day SIT
           reason:
@@ -1048,7 +1048,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
-            description: "Service code allowed for this model type."
+            description: Service code allowed for this model type.
             enum:
               - DDFSIT # Domestic Destination First Day SIT
           type:
@@ -1084,7 +1084,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
-            description: "Service codes allowed for this model type."
+            description: Service codes allowed for this model type.
             enum:
               - DOSHUT # Domestic Origin Shuttle Service
               - DDSHUT # Domestic Destination Shuttle Service
@@ -1108,7 +1108,7 @@ definitions:
         properties:
           reServiceCode:
             type: string
-            description: "Service codes allowed for this model type."
+            description: Service codes allowed for this model type.
             enum:
               - DCRT # Domestic Crating
               - DCRTSA # Domestic Crating - Standalone

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1031,6 +1031,7 @@ definitions:
           reason:
             type: string
             example: Storage items need to be picked up
+            description: Explanation of why Prime is picking up SIT item.
           pickupPostalCode:
             type: string
             format: zip
@@ -1055,17 +1056,21 @@ definitions:
           timeMilitary1:
             type: string
             example: 0400Z
+            description: Time of delivery corresponding to `firstAvailableDeliveryDate1`.
           firstAvailableDeliveryDate1:
             format: date
             type: string
             example: 2020-01-20
+            description: First available date that Prime can deliver SIT service item.
           timeMilitary2:
             type: string
             example: 0400Z
+            description: Time of delivery corresponding to `firstAvailableDeliveryDate2`.
           firstAvailableDeliveryDate2:
             format: date
             type: string
             example: 2020-01-20
+            description: Second available date that Prime can deliver SIT service item.
         required:
           - timeMilitary1
           - firstAvailableDeliveryDate1
@@ -1086,9 +1091,11 @@ definitions:
           reason:
             type: string
             example: Storage items need to be picked up.
+            description: Explanation of why a shuttle service is required.
           description:
             type: string
             example: Things to be moved to the place by shuttle.
+            description: Further details about the shuttle service.
         required:
           - reason
           - reServiceCode

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1043,10 +1043,6 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
-      reServiceID:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
       reServiceName:
         type: string
       status:
@@ -1116,11 +1112,6 @@ definitions:
         type: string
         readOnly: true
       mtoShipmentID:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
-        readOnly: true
-      reServiceID:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string


### PR DESCRIPTION
## Description

* Removes unnecessary `reServiceID` for service items from `prime.yaml` and `support.yaml`
* Makes `reServiceName`, `rejectionReason` and `eTag` readOnly in the yaml
* Adds additional descriptions in service item model subtypes

## Setup

`make server_run`
* Use the `createMTOServiceItem` endpoint to verify
* Check updated docs by running `redoc-cli serve swagger/prime.yaml`

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2820) for this change
