### PR TITLE
MB-3280 Return a 403 instead of a 500 when we fail to match the cookie state …

### DIFF
--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -558,7 +558,7 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stateCookie, err := r.Cookie(StateCookieName(session))
 	if err != nil {
 		h.logger.Error("Getting login.gov state cookie", zap.Error(err))
-		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+		http.Error(w, http.StatusText(403), http.StatusForbidden)
 		return
 	}
 


### PR DESCRIPTION
…with login.gov

## Description

It seems we've been hitting this condition and it has been setting off pager duty alarms. It looks like this situation warrants a 403 instead of a 500, since the 403 is a more specific and applicable response.

## Setup

When you get your server and client running and navigate to `http://milmovelocal:3000/auth/login-gov/callback` you should get this result:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/4325613/87572769-a6402280-c691-11ea-8c81-164253c5c1a5.png">

Instead of this one:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/4325613/87572813-b7892f00-c691-11ea-83c5-a8fffe550acb.png">


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3280) for this change