### PR TITLE
MB-3334 Add serviceItemCodes for MS and CS to Send To Prime in skeleton

### DIFF
--- a/src/scenes/Office/TOO/customerDetails.jsx
+++ b/src/scenes/Office/TOO/customerDetails.jsx
@@ -269,7 +269,9 @@ class CustomerDetails extends Component {
             </table>
 
             <div>
-              <button onClick={() => this.props.updateMoveTaskOrderStatus(moveTaskOrder.id, moveTaskOrder.eTag)}>
+              <button
+                onClick={() => this.props.updateMoveTaskOrderStatus(moveTaskOrder.id, moveTaskOrder.eTag, ['MS', 'CS'])}
+              >
                 Send to Prime
               </button>
             </div>


### PR DESCRIPTION
## Description

Send to Prime function in the TOO skeleton broken after changes to the GHC API in [this PR](https://github.com/transcom/mymove/pull/4366) This PR adds the missing serviceItemCodes to the call to repair the button. In a future PR I'd like to add a cypress test to verify the functionality of this skeleton to avoid this in the future as suggested by @tinyels but I want to unblock our team as quickly as I can.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Then walk through creating a new MTO https://github.com/transcom/mymove/wiki/Acceptance-Testing-Payment-Requests

You should not see the error screenshotted below.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.

## References

* [this slack thread](https://ustcdp3.slack.com/archives/CP4979J0G/p1594829681044300) explains more about the approach used.

## Screenshots

Error Before:

<img width="1525" alt="Screen Shot 2020-07-16 at 12 15 25 PM" src="https://user-images.githubusercontent.com/940173/87698759-c67ee880-c748-11ea-9d0a-d04b51d8e8c1.png">

