### PR TITLE
MB-1595 lookup function for payment service item dom linehaul uuid and price

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cockroachdb/cockroach-go v0.0.0-20200411195601-6f5842749cfc // indirect
 	github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4 // indirect
 	github.com/codegangsta/gin v0.0.0-20171026143024-cafe2ce98974
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.0

--- a/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup.go
@@ -1,0 +1,79 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"database/sql"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// PSILinehaulDomLookup does lookup of uuid of payment service item for dom linehaul
+type PSILinehaulDomLookup struct {
+}
+
+// PSILinehaulDomPriceLookup does lookup of price in cents of payment service item for dom linehaul
+type PSILinehaulDomPriceLookup struct {
+}
+
+func getPaymentServiceItem(keyData *ServiceItemParamKeyData) (models.PaymentServiceItem, error) {
+	db := *keyData.db
+
+	paymentRequestID := keyData.PaymentRequestID
+	mtoServiceItemID := keyData.MTOServiceItemID
+
+	var mtoServiceItem models.MTOServiceItem
+	err := db.Where("id = ?", mtoServiceItemID).First(&mtoServiceItem)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return models.PaymentServiceItem{}, services.NewNotFoundError(mtoServiceItemID, "looking for MTOServiceItemID")
+		default:
+			return models.PaymentServiceItem{}, err
+		}
+	}
+
+	// mtoServiceItemID -> mtoShipmentId + mtoId -> find a service where mtoId==, mtoShipmentId==, and reServiceid==DLH
+	var paymentServiceItemDLH models.PaymentServiceItem
+	err = db.Q().
+		Join("mto_service_items msi", "msi.id = payment_service_items.mto_service_item_id").
+		Join("re_services rs", "rs.id = msi.re_service_id").
+		Where("payment_service_items.status != $1", models.PaymentServiceItemStatusDenied).
+		Where("msi.mto_shipment_id = $2", mtoServiceItem.MTOShipmentID).
+		Where("rs.code = $3", models.ReServiceCodeDLH).
+		Last(&paymentServiceItemDLH) // pop Last orders by created_at
+
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return models.PaymentServiceItem{}, fmt.Errorf("couldn't find PaymentServiceItem for dom linehaul using paymentRequestID: %s and mtoServiceItemID: %s", paymentRequestID, mtoServiceItemID)
+		default:
+			return models.PaymentServiceItem{}, err
+		}
+	}
+
+	return paymentServiceItemDLH, nil
+}
+
+func (r PSILinehaulDomLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	paymentServiceItem, err := getPaymentServiceItem(keyData)
+	if err != nil {
+		return "", err
+	}
+
+	return paymentServiceItem.ID.String(), nil
+}
+
+func (r PSILinehaulDomPriceLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	paymentServiceItem, err := getPaymentServiceItem(keyData)
+	if err != nil {
+		return "", err
+	}
+
+	if paymentServiceItem.PriceCents == nil {
+		return "", fmt.Errorf("found PaymentServiceItem for dom linehaul but it has no price! id found: %s", paymentServiceItem.ID)
+	}
+
+	return paymentServiceItem.PriceCents.String(), nil
+}

--- a/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup_test.go
@@ -1,0 +1,231 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ServiceParamValueLookupsSuite) setupPSILinehaulTestData(priceCents *unit.Cents, status *models.PaymentServiceItemStatus) (models.PaymentServiceItem, models.PaymentServiceItem) {
+	code := models.ReServiceCodeDLH
+	var localPriceCents unit.Cents
+	if priceCents == nil {
+		localPriceCents = unit.Cents(102400)
+	} else {
+		localPriceCents = *priceCents
+	}
+
+	var localStatus models.PaymentServiceItemStatus
+	if status == nil {
+		localStatus = models.PaymentServiceItemStatusRequested
+	} else {
+		localStatus = *status
+	}
+	psiLinehaulDomDLH := testdatagen.MakePaymentServiceItem(suite.DB(),
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &localPriceCents,
+				Status:     localStatus,
+			},
+			ReService: models.ReService{
+				Code: code,
+				Name: string(code),
+			},
+		},
+	)
+
+	code = models.ReServiceCodeFSC
+	psiLinehaulDomFSC := testdatagen.MakePaymentServiceItem(suite.DB(),
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: nil,
+			},
+			MTOServiceItem: models.MTOServiceItem{
+				MTOShipmentID: psiLinehaulDomDLH.MTOServiceItem.MTOShipmentID,
+			},
+			ReService: models.ReService{
+				Code: code,
+				Name: string(code),
+			},
+		},
+	)
+
+	return psiLinehaulDomFSC, psiLinehaulDomDLH
+}
+
+func (suite *ServiceParamValueLookupsSuite) TestPSILinehaulDomLookup() {
+	key := models.ServiceItemParamNamePSILinehaulDom.String()
+
+	suite.T().Run("Domestic Linehaul Price has been calculated", func(t *testing.T) {
+
+		psiLinehaulDom, expectedPSILinehaulDom := suite.setupPSILinehaulTestData(nil, nil)
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal(expectedPSILinehaulDom.ID.String(), valueStr)
+	})
+
+	suite.T().Run("Domestic Linehaul Price has been calculated twice use latest", func(t *testing.T) {
+		psiLinehaulDom, psiLinehaulDomDLH := suite.setupPSILinehaulTestData(nil, nil)
+
+		priceCents := unit.Cents(204800)
+		psiLinehaulDomSecond := testdatagen.MakePaymentServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: &priceCents,
+				},
+				MTOServiceItem: models.MTOServiceItem{
+					MTOShipmentID: psiLinehaulDomDLH.MTOServiceItem.MTOShipmentID,
+				},
+				ReService: models.ReService{
+					ID: psiLinehaulDomDLH.MTOServiceItem.ReServiceID,
+				},
+			},
+		)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal(psiLinehaulDomSecond.ID.String(), valueStr)
+	})
+
+	suite.T().Run("Domestic Linehaul Price has been calculated and Denied", func(t *testing.T) {
+		price := unit.Cents(102400)
+		status := models.PaymentServiceItemStatusDenied
+		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(&price, &status)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomLookup with error couldn't find PaymentServiceItem for dom linehaul using paymentRequestID: %s and mtoServiceItemID: %s", psiLinehaulDom.PaymentRequestID, psiLinehaulDom.MTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+
+	suite.T().Run("Invalid MTO Service ID", func(t *testing.T) {
+		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(nil, nil)
+
+		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomLookup with error id: %s not found looking for MTOServiceItemID", invalidMTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+
+	suite.T().Run("Domestic Linehaul Price has NOT been calculated", func(t *testing.T) {
+		code := models.ReServiceCodeFSC
+		psiLinehaulDomFSC := testdatagen.MakePaymentServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: nil,
+				},
+				ReService: models.ReService{
+					Code: code,
+					Name: string(code),
+				},
+			},
+		)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDomFSC.MTOServiceItemID, psiLinehaulDomFSC.PaymentRequestID, psiLinehaulDomFSC.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomLookup with error couldn't find PaymentServiceItem for dom linehaul using paymentRequestID: %s and mtoServiceItemID: %s", psiLinehaulDomFSC.PaymentRequestID, psiLinehaulDomFSC.MTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+}
+
+func (suite *ServiceParamValueLookupsSuite) TestPSILinehaulDomPriceLookup() {
+	key := models.ServiceItemParamNamePSILinehaulDomPrice.String()
+
+	suite.T().Run("Domestic Linehaul Price has been calculated", func(t *testing.T) {
+
+		psiLinehaulDom, expectedPSILinehaulDom := suite.setupPSILinehaulTestData(nil, nil)
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal(expectedPSILinehaulDom.PriceCents.String(), valueStr)
+	})
+
+	suite.T().Run("Domestic Linehaul Price has been calculated twice use latest", func(t *testing.T) {
+		psiLinehaulDom, psiLinehaulDomDLH := suite.setupPSILinehaulTestData(nil, nil)
+
+		priceCents := unit.Cents(204800)
+		psiLinehaulDomSecond := testdatagen.MakePaymentServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: &priceCents,
+				},
+				MTOServiceItem: models.MTOServiceItem{
+					MTOShipmentID: psiLinehaulDomDLH.MTOServiceItem.MTOShipmentID,
+				},
+				ReService: models.ReService{
+					ID: psiLinehaulDomDLH.MTOServiceItem.ReServiceID,
+				},
+			},
+		)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		valueStr, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+		suite.Equal(psiLinehaulDomSecond.PriceCents.String(), valueStr)
+	})
+
+	suite.T().Run("Domestic Linehaul Price has been calculated and Denied", func(t *testing.T) {
+		price := unit.Cents(102400)
+		status := models.PaymentServiceItemStatusDenied
+		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(&price, &status)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomPriceLookup with error couldn't find PaymentServiceItem for dom linehaul using paymentRequestID: %s and mtoServiceItemID: %s", psiLinehaulDom.PaymentRequestID, psiLinehaulDom.MTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+
+	suite.T().Run("Invalid MTO Service ID", func(t *testing.T) {
+		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(nil, nil)
+
+		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, invalidMTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomPriceLookup with error id: %s not found looking for MTOServiceItemID", invalidMTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+
+	suite.T().Run("Domestic Linehaul Price has NOT been calculated", func(t *testing.T) {
+		code := models.ReServiceCodeFSC
+		psiLinehaulDomFSC := testdatagen.MakePaymentServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: nil,
+				},
+				ReService: models.ReService{
+					Code: code,
+					Name: string(code),
+				},
+			},
+		)
+
+		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDomFSC.MTOServiceItemID, psiLinehaulDomFSC.PaymentRequestID, psiLinehaulDomFSC.PaymentRequest.MoveTaskOrderID)
+
+		_, err := paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		expected := fmt.Sprintf(" failed ServiceParamValue PSI_LinehaulDomPriceLookup with error couldn't find PaymentServiceItem for dom linehaul using paymentRequestID: %s and mtoServiceItemID: %s", psiLinehaulDomFSC.PaymentRequestID, psiLinehaulDomFSC.MTOServiceItemID)
+		suite.Equal(expected, err.Error())
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -60,6 +60,8 @@ func ServiceParamLookupInitialize(
 	s.lookups[models.ServiceItemParamNameServiceAreaOrigin.String()] = ServiceAreaOriginLookup{}
 	s.lookups[models.ServiceItemParamNameServiceAreaDest.String()] = ServiceAreaDestLookup{}
 	s.lookups[models.ServiceItemParamNameContractCode.String()] = ContractCodeLookup{}
+	s.lookups[models.ServiceItemParamNamePSILinehaulDom.String()] = PSILinehaulDomLookup{}
+	s.lookups[models.ServiceItemParamNamePSILinehaulDomPrice.String()] = PSILinehaulDomPriceLookup{}
 
 	return &s
 }


### PR DESCRIPTION
## Description

As part of the Pricing Fuel Surcharge service item we need to provide lookups for all the service item params required. This PR provides the lookup functions for `PSI_LonghaulDom` and `PSI_LonghaulDomPrice`, which return the UUID for the Payment Service Item for Domestic Longhaul and the price respectively.

## Reviewer Notes

It would be great to pay extra attention to the logic of the query that looks up the DLH payment service item?

This PR is affected by the work for [MB-2982](https://dp3.atlassian.net/browse/MB-2982), there is a chance that the lookup will fail if it is performed before the linehaul price is calculated. The aforementioned PR will guarantee that this does not happen. However, before that is done you should know that you may have to create a payment request to price linehaul first then a second that has fuel surcharge.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Find or create an MTO shipment with DLH and FSC as a service items. Steps are detailed [in the Acceptance Testing Payment Requests wiki](https://github.com/transcom/mymove/wiki/Acceptance-Testing-Payment-Requests)

2 ways to create payment requests for this story:

1. Create a payment request with both DLH and FSC listed as service items
2. Create two payment requests one with DLH and the other with FSC as a service item.

NOTE if you create a payment request with FSC only or FSC is listed first it will fail unless there was another payment request with DLH priced.

You should see a similar result to the below with payment service item params `PSI_LinehaulDom` and `PSI_LinehaulDomPrice`.

```json
 {
      "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMi45OTM1MzRa",
      "id": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
      "mtoServiceItemID": "72dff2b2-7a71-487c-a0f7-b7053b55ad4f",
      "paymentRequestID": "dc272706-ba65-4bfb-9c8a-f2d0cce1d154",
      "paymentServiceItemParams": [
        {
          "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMy4wNDQ0MjFa",
          "id": "328918f8-4db6-4cef-ba09-37b629fe5dac",
          "key": "PSI_LinehaulDom",
          "origin": "SYSTEM",
          "paymentServiceItemID": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
          "type": "PaymentServiceItemUUID",
          "value": "1f0e5a6c-df09-4755-a1a6-326a167f2268"
        },
        {
          "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMy4wNTc0MTVa",
          "id": "93218ecb-5ca5-4fe8-b912-bec57f0a9b4e",
          "key": "PSI_LinehaulDomPrice",
          "origin": "SYSTEM",
          "paymentServiceItemID": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
          "type": "DECIMAL",
          "value": "12231303"
        },
        {
          "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMy4wNjI3NjVa",
          "id": "4080d1c8-76f3-41c2-8e3f-2a837e492a06",
          "key": "PSI_LinehaulShort",
          "origin": "SYSTEM",
          "paymentServiceItemID": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
          "type": "PaymentServiceItemUUID",
          "value": "NOT IMPLEMENTED"
        },
        {
          "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMy4wNjc1MjZa",
          "id": "358f3631-16d1-4de5-819e-e748150767b0",
          "key": "PSI_LinehaulShortPrice",
          "origin": "SYSTEM",
          "paymentServiceItemID": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
          "type": "DECIMAL",
          "value": "NOT IMPLEMENTED"
        },
        {
          "eTag": "MjAyMC0wNy0xN1QwMjoyNTowMy4wNzE5Nlo=",
          "id": "7fb79cb7-f1f6-4e57-ab23-e1cd6e904c29",
          "key": "EIAFuelPrice",
          "origin": "SYSTEM",
          "paymentServiceItemID": "7d83ca2a-4f4e-4caa-b922-9dac7c0f14bb",
          "type": "DECIMAL",
          "value": "NOT IMPLEMENTED"
        }
      ],
      "status": "REQUESTED"
    }
```

### 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](MB-1595) for this change
* [this story is related MB-2982](https://dp3.atlassian.net/browse/MB-2982)