### PR TITLE
[MB-2984] Make at least one service item required for payment requests

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -666,6 +666,7 @@ func init() {
         },
         "serviceItems": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/ServiceItem"
           }
@@ -2706,6 +2707,7 @@ func init() {
         },
         "serviceItems": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/ServiceItem"
           }

--- a/pkg/gen/primemessages/create_payment_request_payload.go
+++ b/pkg/gen/primemessages/create_payment_request_payload.go
@@ -32,6 +32,7 @@ type CreatePaymentRequestPayload struct {
 
 	// service items
 	// Required: true
+	// Min Items: 1
 	ServiceItems []*ServiceItem `json:"serviceItems"`
 }
 
@@ -69,6 +70,12 @@ func (m *CreatePaymentRequestPayload) validateMoveTaskOrderID(formats strfmt.Reg
 func (m *CreatePaymentRequestPayload) validateServiceItems(formats strfmt.Registry) error {
 
 	if err := validate.Required("serviceItems", "body", m.ServiceItems); err != nil {
+		return err
+	}
+
+	iServiceItemsSize := int64(len(m.ServiceItems))
+
+	if err := validate.MinItems("serviceItems", "body", iServiceItemsSize, 1); err != nil {
 		return err
 	}
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -507,16 +507,16 @@ definitions:
     properties:
       isFinal:
         default: false
-
         type: boolean
       moveTaskOrderID:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         format: uuid
         type: string
       serviceItems:
+        type: array
+        minItems: 1
         items:
           $ref: '#/definitions/ServiceItem'
-        type: array
       pointOfContact:
         type: string
         description: Email or id of a contact person for this update.


### PR DESCRIPTION
## Description

Just needed to set minItems on the yaml. No test as this is checked in swagger prior to hitting handler code. 

## Reviewer Notes

Just hit the following endpoint with and without items in serviceItems
`{{baseUrl}}/{{prime}}/payment-requests`

## References
 - [setup postman to make mutual tls api calls · transcom/mymove Wiki](https://github.com/transcom/mymove/wiki/setup-postman-to-make-mutual-tls-api-calls)
 - [[MB-2984] Prime API: CreatePaymentRequest should return an error if no service items were listed - Jira](https://dp3.atlassian.net/browse/MB-2984)


[MB-2984]: https://dp3.atlassian.net/browse/MB-2984