### PR TITLE
MB-2893-Update format to be date-time

### DIFF
--- a/docs/adr/0051-swagger-date-formats.md
+++ b/docs/adr/0051-swagger-date-formats.md
@@ -1,0 +1,27 @@
+# Use only Swagger supported formats for dates
+
+In our Swagger yaml files we should only be using date formats that are supported by Swagger.
+
+## Considered Alternatives
+
+* Leave everything as is. Continue to use unsupported date formats, namely, `datetime`
+
+## Decision Outcome
+
+* Chosen Alternative: **Use Swagger supported date formats, `date-time` or `date`, depending on whether we need to store an exact timestamp of the event.**
+
+This option will assure that we are using Swagger supported data types
+
+## Pros and Cons of the Alternatives
+
+### Leave everything as is. Continue to use unsupported date formats, namely `datetime`
+
+* `+` No changes needed to be done.
+* `-` Leads to inconsistent data type usage for what should be similar data.
+* `-` Using a data type format that is not supported by Swagger.
+
+### Use Swagger supported date formats, `date-time` or `date`, depending on whether we need to store an exact timestamp of the event
+
+* `+` Makes correct use of Swagger data types.
+* `+` Maintains consistency in how we format dates in our APIs.
+* `-` Requires changes to yaml files.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -55,6 +55,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0048](0048-frontend-file-org.md) - Use a consistent file structure for front-end code
 - [ADR-0049](0049-etag-for-child-updates.md) - Do not update child records using parent's E-tag
 - [ADR-0050](0050-doc-viewer-fork.md) - Fork & maintain react-file-viewer under @trussworks
+- [ADR-0051](0051-swagger-date-formats.md) - Use only Swagger supported formats for dates
 
 <!-- adrlogstop -->
 

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3107,7 +3107,7 @@ func init() {
         "claimed_at": {
           "description": "when the access code was claimed or used",
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "x-nullable": true,
           "example": "2018-04-12T23:20:50.52Z"
         },
@@ -9330,7 +9330,7 @@ func init() {
         "claimed_at": {
           "description": "when the access code was claimed or used",
           "type": "string",
-          "format": "datetime",
+          "format": "date-time",
           "x-nullable": true,
           "example": "2018-04-12T23:20:50.52Z"
         },

--- a/pkg/gen/internalmessages/access_code.go
+++ b/pkg/gen/internalmessages/access_code.go
@@ -20,7 +20,7 @@ import (
 type AccessCode struct {
 
 	// when the access code was claimed or used
-	// Format: datetime
+	// Format: date-time
 	ClaimedAt *strfmt.DateTime `json:"claimed_at,omitempty"`
 
 	// code
@@ -87,7 +87,7 @@ func (m *AccessCode) validateClaimedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("claimed_at", "body", "datetime", m.ClaimedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("claimed_at", "body", "date-time", m.ClaimedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2492,7 +2492,7 @@ definitions:
         format: date-time
       claimed_at:
         type: string
-        format: datetime
+        format: date-time
         example: 2018-04-12T23:20:50.52Z
         description: when the access code was claimed or used
         x-nullable: true


### PR DESCRIPTION
## Description

Adds an ADR to explain why we want to use Swagger `date-time` and `date` formats, exclusively.

## Reviewer Notes

This previous [PR](https://github.com/transcom/mymove/pull/4221) made a lot of the changes.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2893) for this change