### PR TITLE
send filename to GEX: MB-3323

### DIFF
--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"crypto/tls"
-	"log"
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/certs"
 	"github.com/transcom/mymove/pkg/cli"
@@ -62,41 +65,42 @@ func initPostFileToGEXFlags(flag *pflag.FlagSet) {
 	flag.SortFlags = false
 }
 
-func quit(logger *log.Logger, flag *pflag.FlagSet, err error) {
-	if err != nil {
-		logger.Println(err.Error())
-	}
-	logger.Println("Usage of send-to-gex:")
-	if flag != nil {
-		flag.PrintDefaults()
-	}
-	os.Exit(1)
+func foramtFilename(filename string) string {
+	dt := time.Now()
+	dtFormatted := fmt.Sprintf("%d%02d%02d_%02d%02d%02d",
+		dt.Year(), dt.Month(), dt.Day(),
+		dt.Hour(), dt.Minute(), dt.Second())
+
+	return fmt.Sprintf("%s_%s_%04d", filename, dtFormatted, 0001)
 }
 
 // go run ./cmd/milmove-tasks post-file-to-gex --edi filepath --transaction-name transactionName --gex-url 'url'
 func postFileToGEX(cmd *cobra.Command, args []string) error {
 	// Create the logger
-	// Remove the prefix and any datetime data
-	logger := log.New(os.Stdout, "", log.LstdFlags)
+	v := viper.New()
+
+	logger, err := logging.Config(v.GetString(cli.LoggingEnvFlag), v.GetBool(cli.VerboseFlag))
+	if err != nil {
+		logger.Fatal("Failed to initialize Zap logging", zap.Error(err))
+	}
 
 	flag := pflag.CommandLine
 	initPostFileToGEXFlags(flag)
-	err := flag.Parse(os.Args[1:])
+	err = flag.Parse(os.Args[1:])
 	if err != nil {
-		quit(logger, flag, err)
+		logger.Fatal("invalid configuration", zap.Error(err))
 	}
 
-	v := viper.New()
 	pflagsErr := v.BindPFlags(flag)
 	if pflagsErr != nil {
-		quit(logger, flag, err)
+		logger.Fatal("invalid configuration", zap.Error(err))
 	}
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
 	checkConfigErr := checkPostFileToGEXConfig(v)
 	if checkConfigErr != nil {
-		quit(logger, flag, checkConfigErr)
+		logger.Fatal("invalid configuration", zap.Error(err))
 	}
 
 	// dbEnv := v.GetString(cli.DbEnvFlag)
@@ -109,18 +113,25 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 
 	certLogger, err := logging.Config("development", true)
 	if err != nil {
-		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+		logger.Fatal("Failed to initialize Zap loggingv", zap.Error(err))
 	}
 	certificates, rootCAs, err := certs.InitDoDEntrustCertificates(v, certLogger)
 	if certificates == nil || rootCAs == nil || err != nil {
-		log.Fatal("Error in getting tls certs", err)
+		logger.Fatal("Error in getting tls certs", zap.Error(err))
 	}
 
 	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs}
 
-	logger.Println("Sending to GEX ...")
+	filename := foramtFilename("filename")
+	urlWithFilename := fmt.Sprintf("%s&fname=%s", v.GetString("gex-url"), filename)
+
+	logger.Info(
+		"Sending to GEX",
+		zap.String("filename", filename),
+		zap.String("url", urlWithFilename))
+
 	resp, err := invoice.NewGexSenderHTTP(
-		v.GetString("gex-url"),
+		urlWithFilename,
 		true,
 		tlsConfig,
 		v.GetString("gex-basic-auth-username"),
@@ -128,14 +139,18 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 	).SendToGex(ediString, v.GetString("transaction-name"))
 
 	if err != nil {
-		log.Fatalf("Gex Sender encountered an error: %v", err)
+		logger.Fatal("Gex Sender encountered an error", zap.Error(err))
 	}
 
 	if resp == nil {
-		log.Fatal("Gex Sender had no response")
+		logger.Fatal("Gex Sender had no response", zap.Error(err))
 	}
 
-	logger.Printf("status code: %v, error: %v \n", resp.StatusCode, err)
+	logger.Info(
+		"Posted to GEX",
+		zap.String("filename", filename),
+		zap.Int("statusCode", resp.StatusCode),
+		zap.Error(err))
 
 	return nil
 }


### PR DESCRIPTION
## Description

We are passing an edi file to GEX, but we are not providing a filename. Update the script to send a filename in form: `filename_YYYYMMDD_HHMMSS_{counter}`

I verified filename was received by GEX via DLA.

I also updated logger to use zap.

## Reviewer Notes

Verify log message when running script to verify the filename:
`Posted to GEX` along w/ a filename and urlstring

## Setup

This command should post a file to GEX. ~~Please don't run this on 7-21-2020 unless you check w/ me first. We'll be testing an e2e run of this and don't want to run into issues since you will actually be posting a file to GEX.~~ 
That time has passed and we ran a successful E2E test 🍕 

cmd run the script:
`go run ./cmd/milmove-tasks post-file-to-gex --gex-url 'https://gexweba.daas.dla.mil/msg_data/submit?channel=TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM'`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3323) for this change
