### PR TITLE
Add check in developer prereqs to make sure nodenv init was run

### DIFF
--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -33,6 +33,19 @@ function has() {
     fi
 }
 
+function has_path() {
+  local match=$1
+  local install_direction=$2
+  case $PATH in
+    *${match}*)
+      echo "${match} was found in path";;
+    *)
+      echo -e "${YELLOW}WARNING: PATH did not contain ${match}, fix by running: ${install_direction}${NC}"
+      prereqs_found=false
+    ;;
+  esac
+}
+
 has aws "brew install awscli"
 has bash "brew install bash"
 has chamber "brew install chamber"
@@ -44,6 +57,7 @@ has pre-commit "brew install pre-commit"
 has shellcheck "brew install shellcheck"
 has psql "brew install postgresql"
 has nodenv "brew install nodenv"
+has_path ".nodenv/shims" "nodenv init"
 has node "nodenv local 12.16.3"
 
 # not on CircleCI


### PR DESCRIPTION
## Description

During developer setup it's possible to install nodenv and the right node version declared in .node_version but still run into errors if not completing Step 2 of the [nodenv setup](https://github.com/nodenv/nodenv#homebrew-on-macos).  This requires running `nodenv init`, which requires you to append the command `eval "$(nodenv init -)"` at the end of your ~/.zshrc or ~/.bashrc file.

I've added an extra command to check that `.nodenv/shims` is present in the $PATH environment variable to detect if nodenv init has been run previously.

## Reviewer Notes

Do we need to test with fish shell?

## Setup

Assuming you already have nodenv installed, you can test the script by first commenting out the line in your .zshrc file and restart your terminal or by refreshing with `source ~/.zshrc`

Test that the warning displays when it's no longer in your path:
```
make prereqs
```

Follow the directions from:
```
nodenv init
```
Restart your terminal or source your .zshrc file and test that the warning is no longer displayed:
```
make prereqs
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

## Screenshots

![Screen Shot 2020-07-22 at 2 51 50 PM](https://user-images.githubusercontent.com/52669884/88217035-f12ade80-cc2b-11ea-87f1-2aa60532a30a.png)

