### PR TITLE
MB-3422 Increase the storybook_tests circleCI test container size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,8 +562,8 @@ jobs:
 
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
-    parallelism: 3
-    executor: mymove_medium_plus
+    parallelism: 5
+    executor: mymove_large
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,7 @@ jobs:
 
   # `storybook_tests` builds the storybook application container and pushes to the container repository
   storybook_tests:
-    executor: mymove_medium
+    executor: mymove_medium_plus
     steps:
       - checkout
       - setup_remote_docker:
@@ -720,7 +720,11 @@ jobs:
       - restore_cache:
           keys:
             - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - run: make storybook_tests
+      - run:
+          name: make storybook_tests
+          command: make storybook_tests
+          environment:
+            CHROME_CONCURRENCY: 3
       - run: make storybook_build
       - persist_to_workspace:
           root: /home/circleci/transcom/mymove/


### PR DESCRIPTION
## Description

### storybook_tests

As more and more storybook stories are added as part of the ongoing development of new components and UI for MilMove this job is requiring more resources than before. This PR updates it from a `medium` to a `medium_plus` container giving it 6Gb of ram instead of 4Gb. The PR also increases concurrency to 2 instead of 1.

### integration_tests

This job takes a long time, so increasing this from a `medium_plus` to a `large` and increasing the parallelism from 3 to 5, this seems to marginally improve the run time. This may or may not be worth keeping.

## Reviewer Notes

Should we keep the increase on integration tests?

## Setup

Look at the build job for `storybook_tests` and `integration_tests` for this PR

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3422) for this change