### PR TITLE
Create flag to disable pages for demo

### DIFF
--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -139,7 +139,7 @@ const pages = {
     description: 'Backup contacts',
   },
   '/service-member/:serviceMemberId/move-landing': {
-    isInFlow: () => myFirstRodeo && inGhcFlow && !removeForDemo,
+    isInFlow: (props) => myFirstRodeo(props) && inGhcFlow(props) && !removeForDemo(props),
     isComplete: always,
     render: (key, pages) => () => {
       return (
@@ -184,7 +184,7 @@ const pages = {
     },
   },
   '/moves/:moveId/moving-info': {
-    isInFlow: () => inHhgFlow && !removeForDemo,
+    isInFlow: (props) => inHhgFlow(props) && !removeForDemo(props),
     isComplete: always,
     render: (key, pages) => () => {
       return (

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -71,6 +71,7 @@ const notMyFirstRodeo = (props) => props.lastMoveIsCanceled;
 const hasPPM = ({ selectedMoveType }) => selectedMoveType !== null && selectedMoveType === SHIPMENT_OPTIONS.PPM;
 const inHhgFlow = (props) => props.context.flags.hhgFlow;
 const inGhcFlow = (props) => props.context.flags.ghcFlow;
+const removeForDemo = (props) => props.context.flags.disableForDemo;
 const isCurrentMoveSubmitted = ({ move }) => {
   return get(move, 'status', 'DRAFT') === 'SUBMITTED';
 };
@@ -138,7 +139,7 @@ const pages = {
     description: 'Backup contacts',
   },
   '/service-member/:serviceMemberId/move-landing': {
-    isInFlow: myFirstRodeo && inGhcFlow,
+    isInFlow: () => myFirstRodeo && inGhcFlow && !removeForDemo,
     isComplete: always,
     render: (key, pages) => () => {
       return (
@@ -183,7 +184,7 @@ const pages = {
     },
   },
   '/moves/:moveId/moving-info': {
-    isInFlow: inHhgFlow,
+    isInFlow: () => inHhgFlow && !removeForDemo,
     isComplete: always,
     render: (key, pages) => () => {
       return (

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -11,12 +11,14 @@ const ppmContext = {
 const hhgContext = {
   flags: {
     hhgFlow: true,
+    disableForDemo: false,
   },
 };
 const ghcContext = {
   flags: {
     ghcFlow: true,
     hhgFlow: false,
+    disableForDemo: false,
   },
 };
 

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -17,16 +17,32 @@ const defaultFlags = {
   allOrdersTypes: false,
   hhgFlow: false,
   ghcFlow: false,
+  disableForDemo: false,
 };
 
 const environmentFlags = {
-  development: Object.assign({}, defaultFlags, { allOrdersTypes: true, hhgFlow: true, ghcFlow: true }),
+  development: Object.assign({}, defaultFlags, {
+    allOrdersTypes: true,
+    hhgFlow: true,
+    ghcFlow: true,
+    disableForDemo: false,
+  }),
 
   test: Object.assign({}, defaultFlags),
 
-  experimental: Object.assign({}, defaultFlags, { allOrdersTypes: true, hhgFlow: true, ghcFlow: true }),
+  experimental: Object.assign({}, defaultFlags, {
+    allOrdersTypes: true,
+    hhgFlow: true,
+    ghcFlow: true,
+    disableForDemo: false,
+  }),
 
-  staging: Object.assign({}, defaultFlags, { allOrdersTypes: true, hhgFlow: true, ghcFlow: true }),
+  staging: Object.assign({}, defaultFlags, {
+    allOrdersTypes: true,
+    hhgFlow: true,
+    ghcFlow: true,
+    disableForDemo: true,
+  }),
 
   production: Object.assign({}, defaultFlags, {
     sitPanel: false,

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -25,7 +25,6 @@ const environmentFlags = {
     allOrdersTypes: true,
     hhgFlow: true,
     ghcFlow: true,
-    disableForDemo: false,
   }),
 
   test: Object.assign({}, defaultFlags),
@@ -34,7 +33,6 @@ const environmentFlags = {
     allOrdersTypes: true,
     hhgFlow: true,
     ghcFlow: true,
-    disableForDemo: false,
   }),
 
   staging: Object.assign({}, defaultFlags, {


### PR DESCRIPTION
## Description

This removes the dummy landing page and the dummy move info page on staging.  It does not remove those pages for other environments

## Reviewer Notes

using 'disable' creates a double negative situation, so not sure it's too confusing.  but saying 'showForDemo" seemed strange since we are showing everything else for the demo, even without the flag. . .open to feedback.  

## Setup

Locally, the flag is set to false (we are not disabling the page locally).  To check locally, set flag with `?flag:disableForDemo=true`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3487) for this change

