### PR TITLE
MB-3504 Remove GHC and NTS from OrdersType

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -5160,9 +5160,7 @@ func init() {
       "enum": [
         "PERMANENT_CHANGE_OF_STATION",
         "RETIREMENT",
-        "SEPARATION",
-        "GHC",
-        "NTS"
+        "SEPARATION"
       ],
       "x-display-value": {
         "GHC": "GHC",
@@ -11763,9 +11761,7 @@ func init() {
       "enum": [
         "PERMANENT_CHANGE_OF_STATION",
         "RETIREMENT",
-        "SEPARATION",
-        "GHC",
-        "NTS"
+        "SEPARATION"
       ],
       "x-display-value": {
         "GHC": "GHC",

--- a/pkg/gen/internalmessages/orders_type.go
+++ b/pkg/gen/internalmessages/orders_type.go
@@ -28,12 +28,6 @@ const (
 
 	// OrdersTypeSEPARATION captures enum value "SEPARATION"
 	OrdersTypeSEPARATION OrdersType = "SEPARATION"
-
-	// OrdersTypeGHC captures enum value "GHC"
-	OrdersTypeGHC OrdersType = "GHC"
-
-	// OrdersTypeNTS captures enum value "NTS"
-	OrdersTypeNTS OrdersType = "NTS"
 )
 
 // for schema
@@ -41,7 +35,7 @@ var ordersTypeEnum []interface{}
 
 func init() {
 	var res []OrdersType
-	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","RETIREMENT","SEPARATION","GHC","NTS"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PERMANENT_CHANGE_OF_STATION","RETIREMENT","SEPARATION"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2056,8 +2056,6 @@ definitions:
       - PERMANENT_CHANGE_OF_STATION
       - RETIREMENT
       - SEPARATION
-      - GHC
-      - NTS
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station (PCS)
       RETIREMENT: Retirement


### PR DESCRIPTION
## Description

When we consolidated the `orders` and `move_orders` tables, we noticed
that the `move_orders` table had an enum column called `OrderType`
with two possible values: GHC and NTS. To preserve this existing
functionality, we added "GHC" and "NTS" to the list of enums defined
under `OrdersType` in the `internal.yaml` Swagger file.

It has now come to our attention that "GHC" and "NTS" are not valid
options for `OrdersType` and should be removed.

## Code Review Verification Steps

When going through customer onboarding, when you reach the "Tell us about your move orders" dropdown for "Orders type", there should not be any options for `GHC` or `NTS`

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3504) for this change

## Screenshots

<img width="637" alt="Screen Shot 2020-07-30 at 11 03 50 AM" src="https://user-images.githubusercontent.com/811150/88939359-6f066f80-d254-11ea-8453-dd9391093e1d.png">

