### PR TITLE
MB-3505 Drop customers table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -528,3 +528,4 @@
 20200715153454_add_contract_code_param_to_ddp.up.sql
 20200715202720_add_contract_code_param_to_dop.up.sql
 20200716142734_add_and_update_priority_to_re_service.up.sql
+20200730151934_drop_customers.up.sql

--- a/migrations/app/schema/20200730151934_drop_customers.up.sql
+++ b/migrations/app/schema/20200730151934_drop_customers.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE customers;


### PR DESCRIPTION
**Description**

When we consolidated the `service_members` and `customers` tables, we
left the customers table behind to make sure everything was still
working properly. This has now been verified and we can safely remove
the customers table from the database.

