### PR TITLE
View more than 25 SM in the local SM list when using local sign in

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -62,7 +62,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, h.landingURL(session), http.StatusTemporaryRedirect)
 		return
 	}
-	limit := 25
+	limit := 100
 	identities, err := models.FetchAppUserIdentities(h.db, session.ApplicationName, limit)
 	if err != nil {
 		h.logger.Error("Could not load list of users", zap.Error(err))


### PR DESCRIPTION
## Description

We don't see all the SM users and hard/impossible to create a new MM user and have the ability to logout and login using the newly created user.

Increase the number of SM users returned in the list when using `local sign in`.

This also affects the office users list, but I don't see that as a problem...

## Screenshots
The current list of SM users:
<img width="571" alt="Screen Shot 2020-07-30 at 11 30 58 AM" src="https://user-images.githubusercontent.com/3099491/88949549-0241a400-d259-11ea-97e8-9dd941f6e050.png">

The new list:
<img width="513" alt="Screen Shot 2020-07-30 at 11 26 12 AM" src="https://user-images.githubusercontent.com/3099491/88949570-0a014880-d259-11ea-9fcd-0c5e7ac413f0.png">

