### PR TITLE
MB-3524 Add MoveOrder.NewDutyStation.Address to MTO fetcher

### DIFF
--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -44,7 +44,9 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, sin
 		"MTOShipments.SecondaryPickupAddress",
 		"MTOShipments.MTOAgents",
 		"MoveOrder.ServiceMember",
-		"MoveOrder.Entitlement")
+		"MoveOrder.Entitlement",
+		"MoveOrder.NewDutyStation.Address",
+	)
 
 	if isAvailableToPrime {
 		query = query.Where("available_to_prime_at IS NOT NULL")
@@ -83,7 +85,8 @@ func (f moveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*mo
 		"MTOShipments.SecondaryPickupAddress",
 		"MTOShipments.MTOAgents",
 		"MoveOrder.ServiceMember",
-		"MoveOrder.Entitlement").Find(mto, moveTaskOrderID); err != nil {
+		"MoveOrder.Entitlement",
+		"MoveOrder.NewDutyStation.Address").Find(mto, moveTaskOrderID); err != nil {
 
 		switch err {
 		case sql.ErrNoRows:


### PR DESCRIPTION
## Description

Adds `MoveOrder.NewDutyStation.Address` to the query that fetches all of the MTOs for the Prime API (and possibly elsewhere).

## Setup

Run the server and test with the `fetchMTOUpdates` endpoint in the Prime API that the `destinationDutyStation` field and its address info is not null. 

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3524) for this change.
