### PR TITLE
Fix propType spelling from post_code to postal_code

### DIFF
--- a/src/components/Customer/HHGDetailsForm.jsx
+++ b/src/components/Customer/HHGDetailsForm.jsx
@@ -273,7 +273,7 @@ HHGDetailsForm.propTypes = {
   newDutyStationAddress: shape({
     city: string.isRequired,
     state: string.isRequired,
-    post_code: string.isRequired,
+    postal_code: string.isRequired,
   }).isRequired,
   moveTaskOrderID: string.isRequired,
   createMTOShipment: func.isRequired,


### PR DESCRIPTION
## Description

The propType should be postal_code not post_code.

Having post_code throws an error: 

<img width="982" alt="Screen Shot 2020-08-03 at 3 33 22 PM" src="https://user-images.githubusercontent.com/3099491/89227177-caad6180-d5a2-11ea-804a-46231695ae3a.png">
