### PR TITLE
MB-3271 cleanup

### DIFF
--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -74,7 +74,7 @@ export class Summary extends Component {
     const showPPMShipmentSummary =
       (isReviewPage && !isEmpty(currentPPM)) ||
       (!isReviewPage && !isEmpty(currentPPM) && currentPPM.status !== 'DRAFT');
-    const showHHGShipmentSummary = !isEmpty(mtoShipment) || (!isEmpty(mtoShipment) && !isReviewPage);
+    const showHHGShipmentSummary = isReviewPage && !isEmpty(mtoShipment);
 
     const showProfileAndOrders = isReviewPage || !isReviewPage;
     return (
@@ -111,11 +111,12 @@ export class Summary extends Component {
           />
         )}
 
-        {showHHGShipmentSummary && <HHGShipmentSummary mtoShipment={mtoShipment} movePath={rootAddressWithMoveId} />}
-
         {showPPMShipmentSummary && (
           <PPMShipmentSummary ppm={currentPPM} movePath={rootAddressWithMoveId} orders={currentOrders} />
         )}
+
+        {showHHGShipmentSummary && <HHGShipmentSummary mtoShipment={mtoShipment} movePath={rootAddressWithMoveId} />}
+
         {moveIsApproved && (
           <div className="approved-edit-warning">
             *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -287,17 +287,3 @@ export const mtoShipmentTypeToFriendlyDisplay = (shipmentType) => {
       return shipmentType;
   }
 };
-
-// Concat service member's full name for display
-export function getFullSMName(serviceMember) {
-  if (!serviceMember) return;
-  return `${serviceMember.first_name} ${serviceMember.middle_name || ''} ${serviceMember.last_name} ${
-    serviceMember.suffix || ''
-  }`;
-}
-
-// Concat agent's full name for display
-export function getFullAgentName(agent) {
-  if (!agent) return;
-  return `${agent.firstName} ${agent.lastName}`;
-}


### PR DESCRIPTION
## Description

Address remaining comments from https://github.com/transcom/mymove/pull/4516

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
