### PR TITLE
MB-2392: Splitting build/push steps in Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ commands:
           command: |
             bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             shopt -s extglob
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ commands:
           name: 'Record ECR Image Digest'
           command: |
             mkdir -p /home/circleci/transcom/mymove/bin/sha
+            echo "aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>"
             echo $(aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
             cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,12 +263,13 @@ commands:
       repo:
         type: string
     steps:
+      - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: /home/circleci/transcom/mymove/bin
       - run:
           name: 'Retrieve docker image from workspace'
           command: |
-            docker load -i /tmp/workspace/images/<< parameters.image_name >>
+            docker load -i /home/circleci/transcom/mymove/bin/images/<< parameters.image_name >>
       - run:
           name: 'Tag and push docker image'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,43 +292,6 @@ commands:
           root: bin
           paths: sha/
 
-
-  build_tag_push:
-    parameters:
-      dockerfile:
-        type: string
-      tag:
-        type: string
-      repo:
-        type: string
-      working_dir:
-        type: string
-    steps:
-      - run:
-          name: 'Build, tag, and push docker image << parameters.tag >> from Dockerfile << parameters.dockerfile >>'
-          working_directory: << parameters.working_dir >>
-          command: |
-            docker build -f << parameters.dockerfile >> -t << parameters.tag >> .
-            aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
-            docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
-            shopt -s extglob
-            docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
-      - run:
-          name: Record ECR Image Digest
-          command: |
-            mkdir -p /home/circleci/transcom/mymove/bin/sha
-            echo $(aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
-            cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
-      - run:
-          name: 'Describe image scan findings'
-          command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
-      - persist_to_workspace:
-          root: bin
-          paths:
-            - sha/
-
   server_tests_step:
     parameters:
       application:
@@ -1220,7 +1183,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1232,7 +1195,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1240,7 +1203,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1248,7 +1211,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1295,28 +1258,28 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: cblkwell-MB-2392-update-circleci-for-exp-env
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cblkwell-MB-2392-update-circleci-for-exp-env
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cblkwell-MB-2392-update-circleci-for-exp-env
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cblkwell-MB-2392-update-circleci-for-exp-env
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
           name: 'Tag and push docker image'
           command: |
             aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
-            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
+            docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             shopt -s extglob
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ commands:
       - run:
           name: 'Tag and push docker image'
           command: |
-            bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
+            aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             shopt -s extglob
@@ -282,7 +282,6 @@ commands:
           name: 'Record ECR Image Digest'
           command: |
             mkdir -p /home/circleci/transcom/mymove/bin/sha
-            echo "aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>"
             echo $(aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
             cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,19 +249,9 @@ commands:
             docker build -f << parameters.dockerfile>> -t << parameters.image_name >>:<< parameters.tag >> .
             mkdir -p /home/circleci/transcom/mymove/bin/images
             docker save -o /home/circleci/transcom/mymove/bin/images/<< parameters.image_name >> << parameters.image_name >>:<< parameters.tag >>
-      - run:
-          name: 'Record ECR Image Digest'
-          command: |
-            mkdir -p /home/circleci/transcom/mymove/bin/sha
-            echo $(aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
-            cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
-      - run:
-          name: 'Describe image scan findings'
-          command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
       - persist_to_workspace:
           root: bin
           paths:
-            - sha/
             - images/<< parameters.image_name >>
 
   push_image:
@@ -288,6 +278,19 @@ commands:
             shopt -s extglob
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
             docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//+([^A-Za-z0-9-.])/-}
+      - run:
+          name: 'Record ECR Image Digest'
+          command: |
+            mkdir -p /home/circleci/transcom/mymove/bin/sha
+            echo $(aws ecr describe-images --repository-name << parameters.repo >> --image-ids imageTag=git-${CIRCLE_SHA1} | jq ".imageDetails[0] .imageDigest" -r) > /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
+            cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_<< parameters.repo >>
+      - run:
+          name: 'Describe image scan findings'
+          command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
+      - persist_to_workspace:
+          root: bin
+          paths: sha/
+
 
   build_tag_push:
     parameters:
@@ -583,6 +586,7 @@ jobs:
   acceptance_tests:
     executor: mymove_medium
     steps:
+      - aws_vars_legacy
       - checkout
       - restore_cache:
           keys:
@@ -612,7 +616,6 @@ jobs:
             MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
-      - aws_vars_legacy
       - run:
           name: Run Experimental acceptance tests
           command: make acceptance_test
@@ -649,8 +652,8 @@ jobs:
     parallelism: 5
     executor: mymove_large
     steps:
-      - checkout
       - aws_vars_legacy
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: false
       - restore_cache:
@@ -683,8 +686,8 @@ jobs:
   integration_tests_mtls:
     executor: mymove_medium_plus
     steps:
-      - checkout
       - aws_vars_legacy
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: false
       - restore_cache:
@@ -766,11 +769,10 @@ jobs:
             - prime-api-client #for running Prime API integration tests
       - announce_failure
 
-  # `build_app` builds the application container and pushes to the container repository
+  # `build_app` builds the application container
   build_app:
     executor: mymove_medium_plus
     steps:
-      - aws_vars_legacy
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
@@ -787,11 +789,24 @@ jobs:
       - run: make bin/rds-ca-us-gov-west-1-2017-root.pem
       - run: make client_build
       - run: make server_build
-      - build_tag_push:
+      - build_image:
           dockerfile: Dockerfile
-          tag: ppp:web-dev
-          repo: app
+          image_name: ppp
+          tag: web-dev
           working_dir: ~/transcom/mymove
+      - announce_failure
+
+  # `push_app_legacy` pushes the app container to the legacy container repository
+  push_app_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          image_name: ppp
+          tag: web-dev
+          repo: app
       - announce_failure
 
   # `storybook_tests` builds the storybook application container and pushes to the container repository
@@ -828,29 +843,40 @@ jobs:
           destination: reference
       - announce_failure
 
-  # `build_migrations` builds the migrations container and pushes to the container repository
+  # `build_migrations` builds the migrations container
   build_migrations:
     executor: mymove_medium
     steps:
-      - aws_vars_legacy
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
       - run: make bin/rds-ca-2019-root.pem
       - run: make bin/rds-ca-us-gov-west-1-2017-root.pem
       - run: make server_build
-      - build_tag_push:
+      - build_image:
           dockerfile: Dockerfile.migrations
-          tag: ppp-migrations:dev
-          repo: app-migrations
+          image_name: ppp-migrations
+          tag: dev
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `build_django_app` builds the django app container and pushes to container repository
+  # `push_migrations` pushes the migrations container to the legacy container repository
+  push_migrations_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          image_name: ppp-migrations
+          tag: dev
+          repo: app-migrations
+      - announce_failure
+
+  # `build_django_app` builds the django app container
   build_milmove_admin_app:
     executor: mymove_and_postgres_medium
     steps:
-      - aws_vars_legacy
       - checkout
       - restore_cache:
           keys:
@@ -909,23 +935,39 @@ jobs:
             LOGIN_GOV_JWK_SET_FILENAME: keyset.jwk
       - setup_remote_docker:
           docker_layer_caching: false
-      - build_tag_push:
+      - build_image:
           dockerfile: Dockerfile.prod
-          tag: engadmin:dev
-          repo: app-engadmin
+          image_name: engadmin
+          tag: dev
           working_dir: ~/transcom/milmove_admin/app
-      - build_tag_push:
+      - build_image:
           dockerfile: Dockerfile
-          tag: engadmin-nginx:dev
-          repo: app-engadmin-nginx
+          image_name: engadmin-nginx
+          tag: dev
           working_dir: ~/transcom/milmove_admin/nginx
       - announce_failure
 
-  # `build_tasks` builds the tasks containers and pushes them to the container repository
+  # `push_milmove_admin_app_legacy` pushes the django admin container to the legacy container repository
+  push_milmove_admin_app_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          image_name: engadmin
+          tag: dev
+          repo: app-engadmin
+      - push_image:
+          image_name: engadmin-nginx
+          tag: dev
+          repo: app-engadmin-nginx
+      - announce_failure
+
+  # `build_tasks` builds the tasks containers
   build_tasks:
     executor: mymove_medium
     steps:
-      - aws_vars_legacy
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
@@ -937,11 +979,24 @@ jobs:
       - run: rm -f pkg/assets/assets.go && make pkg/assets/assets.go
       - run: make server_generate
       - run: rm -f bin/milmove-tasks && make bin/milmove-tasks
-      - build_tag_push:
+      - build_image:
           dockerfile: Dockerfile.tasks
-          tag: tasks:dev
-          repo: app-tasks
+          image_name: tasks
+          tag: dev
           working_dir: ~/transcom/mymove
+      - announce_failure
+
+  # `push_tasks_legacy` pushes the tasks containers to the legacy container repository
+  push_tasks_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          image_name: tasks
+          tag: dev
+          repo: app-tasks
       - announce_failure
 
   # `deploy_experimental_migrations` deploys migrations to the experimental environment
@@ -1131,6 +1186,10 @@ workflows:
           requires:
             - pre_deps_golang
 
+      - push_milmove_admin_app_legacy:
+          requires:
+            - build_milmove_admin_app
+
       - check_generated_code:
           requires:
             - pre_deps_golang
@@ -1154,25 +1213,25 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - check_generated_code
-            - build_app
-            - build_migrations
+            - push_app_legacy
+            - push_migrations_legacy
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - integration_tests_mtls:
           requires:
             - pre_deps_golang
             - check_generated_code
-            - build_app
-            - build_migrations
+            - push_app_legacy
+            - push_migrations_legacy
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - client_test:
           requires:
@@ -1180,7 +1239,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - server_test:
           requires:
@@ -1188,7 +1247,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - build_app:
           requires:
@@ -1196,6 +1255,10 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - acceptance_tests # don't bother building and pushing the application if it won't even start properly
+
+      - push_app_legacy:
+          requires:
+            - build_app
 
       - build_tools:
           requires:
@@ -1207,9 +1270,17 @@ workflows:
             - anti_virus
             - pre_deps_golang
 
+      - push_migrations_legacy:
+          requires:
+            - build_migrations
+
       - build_tasks:
           requires:
             - build_tools
+
+      - push_tasks_legacy:
+          requires:
+            - build_tasks
 
       - deploy_experimental_migrations:
           requires:
@@ -1217,44 +1288,44 @@ workflows:
             - client_test
             - server_test
             - acceptance_tests
-            - build_app
+            - push_app_legacy
             - build_tools
-            - build_tasks
-            - build_migrations
+            - push_tasks_legacy
+            - push_migrations_legacy
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cblkwell-MB-2392-update-circleci-for-exp-env
 
       - check_circle_against_staging_sha:
           requires:
             - pre_test
             - client_test
             - server_test
-            - build_app
+            - push_app_legacy
             - build_tools
-            - build_migrations
-            - build_tasks
+            - push_migrations_legacy
+            - push_tasks_legacy
             - acceptance_tests
             - integration_tests
             - integration_tests_mtls


### PR DESCRIPTION
## Description

This splits the build_tag_push step into a build and push step, with the build step triggering once, and the push step being run once for each account (right now, just the legacy account). I've run this successfully against the experimental environment (see https://app.circleci.com/pipelines/github/transcom/mymove/19478/workflows/b87dd881-48bf-4cc0-93e0-4a0727d77fb4) so I'm pretty sure this component works now.

This doesn't deploy to the new exp environment yet -- I wanted to merge this change in so that if there are any other changes people can incorporate this into their branch.