### PR TITLE
[MB-3521] Fix PPM document viewer route

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-form": "^8.3.6",
     "redux-mock-store": "1.5.4",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3",
     "redux-thunk": "^2.2.0",
     "regenerator-runtime": "^0.13.5",

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import Loadable from 'react-loadable';
 import { ConnectedRouter } from 'connected-react-router';
+import { PersistGate } from 'redux-persist/integration/react';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { isOfficeSite, isAdminSite, isSystemAdminSite } from 'shared/constants';
-import { store, history } from 'shared/store';
+import { store, persistor, history } from 'shared/store';
 import { AppContext, defaultOfficeContext, defaultMyMoveContext, defaultAdminContext } from 'shared/AppContext';
 import { detectFlags } from 'shared/featureFlags';
 
@@ -42,11 +43,13 @@ const App = () => {
   if (isOfficeSite)
     return (
       <Provider store={store}>
-        <AppContext.Provider value={officeContext}>
-          <ConnectedRouter history={history}>
-            <Office />
-          </ConnectedRouter>
-        </AppContext.Provider>
+        <PersistGate loading={<LoadingPlaceholder />} persistor={persistor}>
+          <AppContext.Provider value={officeContext}>
+            <ConnectedRouter history={history}>
+              <Office />
+            </ConnectedRouter>
+          </AppContext.Provider>
+        </PersistGate>
       </Provider>
     );
 

--- a/src/constants/userRoles.js
+++ b/src/constants/userRoles.js
@@ -3,4 +3,8 @@ export const roleTypes = {
   PPM: 'ppm_office_users',
   TOO: 'transportation_ordering_officer',
   TIO: 'transportation_invoicing_officer',
+  CUSTOMER: 'customer',
+  CONTRACTING_OFFICER: 'contracting_officer',
 };
+
+export const officeRoles = [roleTypes.PPM, roleTypes.TOO, roleTypes.TIO];

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -24,7 +24,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { QueueHeader } from 'shared/Header/Office';
 import FOUOHeader from 'components/FOUOHeader';
 import { ConnectedSelectApplication } from 'pages/SelectApplication/SelectApplication';
-import { roleTypes, officeRoles } from 'constants/userRoles';
+import { roleTypes } from 'constants/userRoles';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
 import { LocationShape, UserRolesShape } from 'types/index';
@@ -83,8 +83,7 @@ export class OfficeApp extends Component {
       location: { pathname },
     } = this.props;
 
-    let selectedRole = userIsLoggedIn && activeRole;
-    if (!selectedRole) selectedRole = userRoles?.find((r) => officeRoles.indexOf(r.roleType) > -1)?.roleType;
+    const selectedRole = userIsLoggedIn && activeRole;
 
     // TODO - test login page?
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -24,7 +24,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { QueueHeader } from 'shared/Header/Office';
 import FOUOHeader from 'components/FOUOHeader';
 import { ConnectedSelectApplication } from 'pages/SelectApplication/SelectApplication';
-import { roleTypes } from 'constants/userRoles';
+import { roleTypes, officeRoles } from 'constants/userRoles';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
 import { LocationShape, UserRolesShape } from 'types/index';
@@ -83,7 +83,8 @@ export class OfficeApp extends Component {
       location: { pathname },
     } = this.props;
 
-    const selectedRole = userIsLoggedIn && (activeRole || userRoles[0]?.roleType);
+    let selectedRole = userIsLoggedIn && activeRole;
+    if (!selectedRole) selectedRole = userRoles?.find((r) => officeRoles.indexOf(r.roleType) > -1)?.roleType;
 
     // TODO - test login page?
 

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -48,11 +48,17 @@ describe('Office App', () => {
 
   describe('if the user is logged in with multiple roles', () => {
     const multiRoleState = {
+      auth: {
+        activeRole: roleTypes.TOO,
+      },
       user: {
         isLoading: false,
         userInfo: {
           isLoggedIn: true,
           roles: [
+            {
+              roleType: roleTypes.CONTRACTING_OFFICER,
+            },
             {
               roleType: roleTypes.TOO,
             },
@@ -95,6 +101,9 @@ describe('Office App', () => {
     // I FIGURED OUT HOW - need to mock the loadUser (this sets loading back to true and prevents content from rendering)
 
     const loggedInState = {
+      auth: {
+        activeRole: roleTypes.PPM,
+      },
       user: {
         isLoading: false,
         userInfo: {
@@ -109,6 +118,9 @@ describe('Office App', () => {
     };
 
     const loggedOutState = {
+      auth: {
+        activeRole: null,
+      },
       user: {
         isLoading: false,
         userInfo: {
@@ -155,6 +167,9 @@ describe('Office App', () => {
 
     describe('PPM routes', () => {
       const loggedInPPMState = {
+        auth: {
+          activeRole: roleTypes.PPM,
+        },
         user: {
           isLoading: false,
           userInfo: {
@@ -225,6 +240,9 @@ describe('Office App', () => {
 
     describe('TOO routes', () => {
       const loggedInTOOState = {
+        auth: {
+          activeRole: roleTypes.TOO,
+        },
         user: {
           isLoading: false,
           userInfo: {
@@ -289,6 +307,9 @@ describe('Office App', () => {
 
     describe('TIO routes', () => {
       const loggedInTIOState = {
+        auth: {
+          activeRole: roleTypes.TIO,
+        },
         user: {
           isLoading: false,
           userInfo: {

--- a/src/shared/User/LoginButton.jsx
+++ b/src/shared/User/LoginButton.jsx
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import { selectCurrentUser } from 'shared/Data/users';
 import { isDevelopment } from 'shared/constants';
 import { LogoutUser } from 'shared/User/api.js';
+import { logOut } from 'store/auth/actions';
 
 const LoginButton = (props) => {
   if (!props.isLoggedIn) {
@@ -30,9 +31,14 @@ const LoginButton = (props) => {
       </React.Fragment>
     );
   } else {
+    const handleLogOut = () => {
+      props.logOut();
+      LogoutUser();
+    };
+
     return (
       <li className="usa-nav__primary-item">
-        <a className="usa-nav__link" href="#" onClick={LogoutUser}>
+        <a className="usa-nav__link" href="#" onClick={handleLogOut}>
           Sign Out
         </a>
       </li>
@@ -47,4 +53,9 @@ function mapStateToProps(state) {
     showDevlocalButton: get(state, 'isDevelopment', isDevelopment),
   };
 }
-export default connect(mapStateToProps)(LoginButton);
+
+const mapDispatchToProps = {
+  logOut,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LoginButton);

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -1,4 +1,6 @@
 import { createStore, applyMiddleware } from 'redux';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import { appReducer, adminAppReducer } from 'appReducer';
 import { createBrowserHistory } from 'history';
 import { routerMiddleware } from 'connected-react-router';
@@ -32,14 +34,24 @@ export const configureStore = (history, initialState = {}) => {
   }
 
   const composeEnhancers = composeWithDevTools({});
+
+  const persistConfig = {
+    key: 'root',
+    storage,
+    whitelist: ['auth'],
+  };
+
   const rootReducer = appSelector();
-  const store = createStore(rootReducer, initialState, composeEnhancers(applyMiddleware(...middlewares)));
+  const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+  const store = createStore(persistedReducer, initialState, composeEnhancers(applyMiddleware(...middlewares)));
+  const persistor = persistStore(store);
 
   sagaMiddleware.run(rootSaga);
 
-  return store;
+  return { store, persistor };
 };
 
-export const store = configureStore(history);
+export const { store, persistor } = configureStore(history);
 
 export default store;

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -10,3 +10,9 @@ export const LOAD_USER = 'LOAD_USER';
 export const loadUser = () => ({
   type: LOAD_USER,
 });
+
+export const LOG_OUT = 'LOG_OUT';
+
+export const logOut = () => ({
+  type: LOG_OUT,
+});

--- a/src/store/auth/actions.test.js
+++ b/src/store/auth/actions.test.js
@@ -1,4 +1,4 @@
-import { setActiveRole, SET_ACTIVE_ROLE, loadUser, LOAD_USER } from './actions';
+import { setActiveRole, SET_ACTIVE_ROLE, loadUser, LOAD_USER, logOut, LOG_OUT } from './actions';
 
 describe('auth actions', () => {
   it('setActiveRole returns the expected action', () => {
@@ -16,5 +16,13 @@ describe('auth actions', () => {
     };
 
     expect(loadUser()).toEqual(expectedAction);
+  });
+
+  it('logOut returns the expected action', () => {
+    const expectedAction = {
+      type: LOG_OUT,
+    };
+
+    expect(logOut()).toEqual(expectedAction);
   });
 });

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -1,14 +1,29 @@
 import { SET_ACTIVE_ROLE } from './actions';
 
+import { officeRoles } from 'constants/userRoles';
+
 export const initialState = {
   activeRole: null,
 };
 
 const authReducer = (state = initialState, action) => {
   switch (action?.type) {
+    case 'GET_LOGGED_IN_USER_SUCCESS': {
+      if (state.activeRole) return state;
+
+      const {
+        payload: { roles = [] },
+      } = action;
+      const firstOfficeRole = roles?.find((r) => officeRoles.indexOf(r.roleType) > -1)?.roleType;
+
+      return {
+        ...state,
+        activeRole: firstOfficeRole,
+      };
+    }
     case SET_ACTIVE_ROLE: {
       return {
-        ...initialState,
+        ...state,
         activeRole: action.payload,
       };
     }

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -1,4 +1,4 @@
-import { SET_ACTIVE_ROLE } from './actions';
+import { SET_ACTIVE_ROLE, LOG_OUT } from './actions';
 
 import { officeRoles } from 'constants/userRoles';
 
@@ -8,6 +8,10 @@ export const initialState = {
 
 const authReducer = (state = initialState, action) => {
   switch (action?.type) {
+    case LOG_OUT: {
+      return initialState;
+    }
+
     case 'GET_LOGGED_IN_USER_SUCCESS': {
       if (state.activeRole) return state;
 

--- a/src/store/auth/reducer.test.js
+++ b/src/store/auth/reducer.test.js
@@ -30,7 +30,7 @@ describe('authReducer', () => {
       activeRole: 'myRole',
     };
 
-    expect(authReducer(currentState, logOut)).toEqual(initialState);
+    expect(authReducer(currentState, logOut())).toEqual(initialState);
   });
 
   it('handles the GET_LOGGED_IN_USER_SUCCESS action with no activeRole set', () => {

--- a/src/store/auth/reducer.test.js
+++ b/src/store/auth/reducer.test.js
@@ -1,6 +1,8 @@
 import authReducer, { initialState } from './reducer';
 import { setActiveRole } from './actions';
 
+import { roleTypes } from 'constants/userRoles';
+
 describe('authReducer', () => {
   it('returns the initial state by default', () => {
     expect(authReducer(undefined, undefined)).toEqual(initialState);
@@ -20,5 +22,55 @@ describe('authReducer', () => {
       ...initialState,
       activeRole: 'myRole',
     });
+  });
+
+  it('handles the GET_LOGGED_IN_USER_SUCCESS action with no activeRole set', () => {
+    const action = {
+      type: 'GET_LOGGED_IN_USER_SUCCESS',
+      payload: {
+        roles: [
+          {
+            roleType: roleTypes.CUSTOMER,
+          },
+          {
+            roleType: roleTypes.PPM,
+          },
+          {
+            roleType: roleTypes.TOO,
+          },
+        ],
+      },
+    };
+
+    expect(authReducer(initialState, action)).toEqual({
+      ...initialState,
+      activeRole: roleTypes.PPM,
+    });
+  });
+
+  it('handles the GET_LOGGED_IN_USER_SUCCESS action with an activeRole already set', () => {
+    const currentState = {
+      ...initialState,
+      activeRole: roleTypes.TOO,
+    };
+
+    const action = {
+      type: 'GET_LOGGED_IN_USER_SUCCESS',
+      payload: {
+        roles: [
+          {
+            roleType: roleTypes.CUSTOMER,
+          },
+          {
+            roleType: roleTypes.PPM,
+          },
+          {
+            roleType: roleTypes.TOO,
+          },
+        ],
+      },
+    };
+
+    expect(authReducer(currentState, action)).toEqual(currentState);
   });
 });

--- a/src/store/auth/reducer.test.js
+++ b/src/store/auth/reducer.test.js
@@ -1,5 +1,5 @@
 import authReducer, { initialState } from './reducer';
-import { setActiveRole } from './actions';
+import { setActiveRole, logOut } from './actions';
 
 import { roleTypes } from 'constants/userRoles';
 
@@ -22,6 +22,15 @@ describe('authReducer', () => {
       ...initialState,
       activeRole: 'myRole',
     });
+  });
+
+  it('handles the logOut action', () => {
+    const currentState = {
+      ...initialState,
+      activeRole: 'myRole',
+    };
+
+    expect(authReducer(currentState, logOut)).toEqual(initialState);
   });
 
   it('handles the GET_LOGGED_IN_USER_SUCCESS action with no activeRole set', () => {

--- a/src/testUtils.jsx
+++ b/src/testUtils.jsx
@@ -12,7 +12,7 @@ export const MockProviders = ({ children, initialState = {}, initialEntries = []
   const mockStore = configureStore(mockHistory, initialState);
 
   return (
-    <Provider store={mockStore}>
+    <Provider store={mockStore.store}>
       <ConnectedRouter history={mockHistory}>{children}</ConnectedRouter>
     </Provider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -14686,6 +14686,11 @@ redux-mock-store@1.5.4:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-saga@^1.0.0, redux-saga@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.3.tgz#9f3e6aebd3c994bbc0f6901a625f9a42b51d1112"


### PR DESCRIPTION
## Description

This PR fixes the original bug reported, and also adds [redux-persist](https://github.com/rt2zz/redux-persist) to save user role selection across browser windows.

The [original bug](https://dp3.atlassian.net/browse/MB-3521) is that certain users, when logged into the Office app with the PPM role, could not access the PPM version of the document viewer and were shown the TXO interface instead. The root cause turned out to be a combination of things:

- This was only reproducible with users who have multiple roles, with at least one of the non-Office role types (Customer and/or Contracting Officer). This is because when logging in as a user with multiple roles, the Office app defaults to the first role in the array that is returned, and role types are returned by the API in alphabetical order. This resulted in the "active" role being Contracting Officer, which is not handled by the Office app interface. The UX in this case is that at login, the user is presented with a blank page and must select "Change user role" to switch to a PPM/TOO/TIO role in order to view anything.
- The other issue is that the "active" role selected in the "Change user role" page is saved in Redux, which only persists data within a single browser window. Since the document viewer opens in a new window, a user with multiple roles would default back to their "first" role upon opening it. This isn't a current issue for users with PPM & TOO/TIO roles when viewing the PPM document viewer, by virtue of PPM coming first alphabetically.

This PR fixes both of the above issues, by selecting a user's default role from Office roles only, and by persisting the "active" role value across browser windows.

_Additional note:_ this PR adds redux-persist, which can be used to store Redux data in browser local storage. This is a potential avenue for leaking secure data. This PR mitigates risk by both whitelisting what data is stored (currently limited to the `auth` store, which for now only includes the role type a user has), and by clearing that value when the user logs out. Going forward, precaution should be taken when saving more data in Redux Persist to ensure that no PII is stored, and everything is cleared out when a user's session ends.

## Reviewer Notes

To reproduce the bug (not on this branch):
- Log into the Office app as a user with multiple roles, _including non-Office roles_ such as "Customer".
- When you log in, the page will be blank below the milmove header.
- Change to a PPM role by clicking "Change user role" in the top left
- View an existing move, and click on the orders or any document link. It should open in a new window, but display the TXO interface instead of the PPM document viewer.

To reproduce the lack of browser persistence (not on this branch):
- Log into the Office app as a user with multiple _Office roles_ (PPM, TOO, TIO)
- Select a non-default role using the "Change user role" link
- Refresh the page, and note that you see the interface for the default Office role (not the one you had switched to)

## Setup

Test the bug fix:
- Log into the Office app as a user with multiple roles, _including non-Office roles_ such as "Customer".
- When you log in, you should be shown the Office interface for your first Office role (PPM, TOO, or TIO)
- If you select the PPM role using the "Change user role" link, and view a move orders/documents, you should see the expected page open in a new browser window.

Test the redux-persist functionality:
- Log into the Office app as a user with multiple _Office roles_ (PPM, TOO, TIO)
- Select a non-default role using the "Change user role" link
- Refresh the page and verify you still see the interface for the role you switched to.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/backend#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/backend#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3521) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
