### PR TITLE
MB-3569 Treat HHG and HHG_LONGHAUL_DOM the same

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -543,7 +543,7 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 		// More info in MB-1140: https://dp3.atlassian.net/browse/MB-1140
 		var serviceItemsToCreate models.MTOServiceItems
 		switch shipment.ShipmentType {
-		case models.MTOShipmentTypeHHGLongHaulDom:
+		case models.MTOShipmentTypeHHG, models.MTOShipmentTypeHHGLongHaulDom:
 			//Need to create: Dom Linehaul, Fuel Surcharge, Dom Origin Price, Dom Destination Price, Dom Packing, and Dom Unpacking.
 			reServiceCodes := []models.ReServiceCode{
 				models.ReServiceCodeDLH,


### PR DESCRIPTION
## Description

Currently, when a customer goes through onboarding and selects HHG, we
create an MTO Shipment with a shipment_type of `HHG`. However, in our
`mto_shipment_updater`, which is what creates service items when the
TOO approves the shipment, we don't handle the case where the shipment
type is just plain `HHG`.

This is blocking other teams, namely John Gedeon, from testing their
work that relies on service items being created. To work around that,
they have created a `convert.go` file that adds complexity and looks
up current moves that were created via onboarding, and adds longhaul
and shorthaul shipments to it, simply to be able to approve them via
the TOO interface and therefore have service items created.

The `convert.go` file has been a source of confusion during our DB
consolidation efforts, and we can get rid of it by duplicating the
current logic in the switch statement in `mto_shipment_updater` for
both `HHG` and `HHG_LONGHAUL_DOMESTIC` shipment types until we
decide whether or not there is a different between `HHG` and other
shipment types, and if we should default to `HHG_LONGHAUL_DOMESTIC`
instead of `HHG`.

## Reviewer Notes

Verify that service items are created after a TOO approves an HHG shipment

1. Sign in as a service member and go through the whole onboarding follow, selecting an HHG move
2. Sign in as a TOO and click on the move that was just created
3. Approve the move
4. Verify that service items were created

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3569) for this change
