### PR TITLE
MB-3398 Add static uuid to the creation of a Document test record

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -391,6 +391,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			MoveDocumentType:         "WEIGHT_TICKET",
 		},
 		Document: models.Document{
+			ID:              uuid.FromStringOrNil("c26421b0-e4c3-446b-88f3-493bb25c1756"),
 			ServiceMemberID: ppm3.Move.Orders.ServiceMember.ID,
 			ServiceMember:   ppm3.Move.Orders.ServiceMember,
 		},


### PR DESCRIPTION
## Description

This adds a static UUID to the creation of a documents test record so that Load Testing has something concrete to reference when creating an MTO.

## Setup

Reset and apply migrations to your DB:

```sh
make db_dev_reset && make db_dev_migrate
```

Then populate the DB with new fake test data:

```sh
make db_dev_e2e_populate
```

Now check in the `documents` table in your DB that a record with UUID `'c26421b0-e4c3-446b-88f3-493bb25c1756'` exists. You may also use the `createMoveTaskOrder` endpoint in the Support API to try and create a new MTO with the `uploadedOrdersID` field set to `"c26421b0-e4c3-446b-88f3-493bb25c1756"`.

OPTIONAL: Check out [this branch](https://github.com/transcom/milmove_load_testing/pull/27) in `milmove_load_testing` and check that `make load_test_prime` works with mostly 2xx response codes in all endpoints. 

## References

* Dependent load testing PR: https://github.com/transcom/milmove_load_testing/pull/27