### PR TITLE
MB-3591 Fix MTO shipment updater tests

### DIFF
--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 
@@ -120,9 +121,30 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		MoveTaskOrder: mto,
 		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
+			Status:       models.MTOShipmentStatusSubmitted,
+			ShipmentType: models.MTOShipmentTypeHHGLongHaulDom,
 		},
 	})
+	// Populate the reServices table with codes needed by the
+	// HHG_LONGHAUL_DOMESTIC shipment type
+	reServiceCodes := []models.ReServiceCode{
+		models.ReServiceCodeDLH,
+		models.ReServiceCodeFSC,
+		models.ReServiceCodeDOP,
+		models.ReServiceCodeDDP,
+		models.ReServiceCodeDPK,
+		models.ReServiceCodeDUPK,
+	}
+	for _, serviceCode := range reServiceCodes {
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code:      serviceCode,
+				Name:      "test",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		})
+	}
 
 	requestUser := testdatagen.MakeDefaultUser(suite.DB())
 	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/gofrs/uuid"
+	"time"
 
 	"github.com/go-openapi/strfmt"
-
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
@@ -18,6 +15,7 @@ import (
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/mocks"
@@ -32,9 +30,30 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		MoveTaskOrder: mto,
 		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
+			Status:       models.MTOShipmentStatusSubmitted,
+			ShipmentType: models.MTOShipmentTypeHHGLongHaulDom,
 		},
 	})
+	// Populate the reServices table with codes needed by the
+	// HHG_LONGHAUL_DOMESTIC shipment type
+	reServiceCodes := []models.ReServiceCode{
+		models.ReServiceCodeDLH,
+		models.ReServiceCodeFSC,
+		models.ReServiceCodeDOP,
+		models.ReServiceCodeDDP,
+		models.ReServiceCodeDPK,
+		models.ReServiceCodeDUPK,
+	}
+	for _, serviceCode := range reServiceCodes {
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code:      serviceCode,
+				Name:      "test",
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		})
+	}
 
 	requestUser := testdatagen.MakeDefaultUser(suite.DB())
 	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)


### PR DESCRIPTION
These 2 integration tests that tested updating a shipment's status to
`approved` were using a shipment of type `HHG`, which isn't handled by
the code that performs the update in `mto_shipment_updater`. These
tests were bypassing the code they were attempting to test. In order
to test the updater, one of the supported shipment types must be used,
such as `HHG_LONGHAUL_DOM`. In turn, the ReServices table must be
populated with the appropriate codes for the shipment to be updated.

