### PR TITLE
Increase timeout for common Cypress failing tests

### DIFF
--- a/cypress/integration/mymove/ppmCloseout.js
+++ b/cypress/integration/mymove/ppmCloseout.js
@@ -57,7 +57,7 @@ describe('allows a SM to request a payment', function () {
     cy.location().should((loc) => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
-    cy.get('[data-testid="weight-ticket-link"]').click();
+    cy.get('[data-testid="weight-ticket-link"]', { timeout: 30000 }).click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
     });
@@ -73,7 +73,7 @@ describe('allows a SM to request a payment', function () {
     cy.location().should((loc) => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
-    cy.get('[data-testid="expense-link"]').click();
+    cy.get('[data-testid="expense-link"]', { timeout: 30000 }).click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
     });
@@ -116,7 +116,7 @@ function serviceMemberSubmitsPaymentRequestWithMissingDocuments() {
   cy.location().should((loc) => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
   });
-  cy.get('.missing-label').contains('Your estimated payment is unknown');
+  cy.get('.missing-label', { timeout: 30000 }).contains('Your estimated payment is unknown');
 
   cy.get('input[id="agree-checkbox"]').check({ force: true });
 
@@ -130,7 +130,6 @@ function serviceMemberSubmitsPaymentRequestWithMissingDocuments() {
   );
 
   cy.get('.title').contains('Next step: Contact the PPPO office');
-  cy.get('.missing-label').contains('Unknown');
 }
 
 function serviceMemberReviewsDocuments() {


### PR DESCRIPTION
We are currently seeing failures in Circle CI on the master branch for
tests in `ppmCloseout.js`, which has happened several times in the
past. The failure has always been due to the test not finding the
element in time. By default, Cypress will only wait up to 4 seconds
total for a command and its assertions to execute.

To increase the timeout, we can pass in the timeout option to a
command, which is what I've done here for the most common failures.
I've increased it to 30 seconds to see if that helps.

I also removed a test that was looking for the word "unknown" in the
`ApprovedMoveSummary.jsx`. My guess is that the "unknown" was
referring to the estimated weight, which is no longer unknown,
possibly due to a recent change, or this one back in May:
https://github.com/transcom/mymove/pull/4088

## References

https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Applying-Timeouts

## Screenshots

<img width="1680" alt="Screen Shot 2020-08-07 at 3 02 52 PM" src="https://user-images.githubusercontent.com/811150/89683219-24c16600-d8c6-11ea-94b5-75ebd5e2d0b6.png">
