### PR TITLE
MB-978 Update mto_service_items table columns to NOT NULL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1330,56 +1330,56 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - push_milmove_admin_app_exp:
           requires:
             - build_milmove_admin_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - push_app_exp:
           requires:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_exp_migrations:
           requires:
@@ -1393,28 +1393,28 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-978-update-mto-service-items-table-columns
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1330,56 +1330,56 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - push_milmove_admin_app_exp:
           requires:
             - build_milmove_admin_app
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - push_app_exp:
           requires:
             - build_app
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1393,28 +1393,28 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-978-update-mto-service-items-table-columns
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -533,3 +533,4 @@
 20200803200704_create_subscriptions_table.up.sql
 20200804003845_add-draft-status-to-mto-shipments.up.sql
 20200804194318_replace-default-status-on-shipment.up.sql
+20200807222709_update_mto_service_items_columns.up.sql

--- a/migrations/app/schema/20200807222709_update_mto_service_items_columns.up.sql
+++ b/migrations/app/schema/20200807222709_update_mto_service_items_columns.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE mto_service_items
+    ALTER COLUMN move_task_order_id SET NOT NULL,
+    ALTER COLUMN re_service_id SET NOT NULL;


### PR DESCRIPTION
## Description

This PR alters the columns `move_task_order_id`, `re_service_id` to NOT NULL in the `mto_service_items` table. We will never expect these columns to ever be null.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-978) for this change