### PR TITLE
MB-3551 update scripts and directions to include staging env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -863,7 +863,7 @@ run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commerc
 # 	bin/milmove migrate
 
 .PHONY: run_staging_migrations
-run_staging_migrations: run_com_staging_migrations ## Currently: Run Commercial Staging migrations against Deployed Migrations DB
+run_staging_migrations: run_com_staging_migrations ## Currently: Run Commercial Staging migrations against Deployed Migrations DB in commercial
 	# run_gov_staging_migrations
 
 .PHONY: run_com_staging_migrations
@@ -876,16 +876,15 @@ run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Comm
 	DB_DEBUG=0 \
 	bin/milmove migrate
 
-# This will be added once GovCloud staging env is up
-# .PHONY: run_gov_staging_migrations ## Run GovCloud Staging migrations against Deployed Migrations DB
-# run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Staging migrations against Deployed Migrations DB
-# 	@echo "Migrating the staging-migrations database with staging migrations..."
-# 	MIGRATION_PATH="s3://transcom-gov-milmove-stg-app/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-# 	DB_HOST=localhost \
-# 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-# 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-# 	DB_DEBUG=0 \
-# 	bin/milmove migrate
+.PHONY: run_gov_staging_migrations ## Run GovCloud Staging migrations against Deployed Migrations DB
+run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Staging migrations against Deployed Migrations DB in commercial
+	@echo "Migrating the staging-migrations database with staging migrations..."
+	MIGRATION_PATH="s3://transcom-gov-milmove-stg-app/secure-migrations;file://migrations/$(APPLICATION)/schema" \
+	DB_HOST=localhost \
+	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
+	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+	DB_DEBUG=0 \
+	bin/milmove migrate
 
 .PHONY: run_experimental_migrations ## Currently: Run Commercial Experimental migrations against Deployed Migrations DB
 run_experimental_migrations: run_com_experimental_migrations

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -136,7 +136,7 @@ migrations.
 | --- | --- |
 | `download-secure-migration` |  A script to download secure migrations from all environments |
 | `generate-secure-migration` |  A script to help manage the creation of secure migrations |
-| `upload-secure-migration` | A script to upload secure migrations to all environments in commercial AWS and experimental in GovCloud |
+| `upload-secure-migration` | A script to upload secure migrations to all environments in commercial AWS and to experimental and staging environments in GovCloud |
 
 ### Database Scripts
 

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -101,8 +101,8 @@ fi
           stg_govenv="stg"
           readonly aws_gov_stg_account="${aws_gov_bucket_prefix}${stg_govenv}"
           readonly aws_gov_stg_bucket_name="${aws_gov_stg_account}${aws_gov_bucket_suffix}"
-          # DISABLE_AWS_VAULT_WRAPPER=1 AWS_PROFILE=${aws_gov_id_account} AWS_REGION=${aws_gov_region} aws-vault exec ${aws_gov_stg_account} -- ${aws_command} s3 ls ${aws_gov_stg_bucket_name} > /dev/null
-          # echo "confirmed: you have access to ${aws_gov_stg_bucket_name} bucket via account ${aws_gov_id_account}"
+          DISABLE_AWS_VAULT_WRAPPER=1 AWS_PROFILE=${aws_gov_id_account} AWS_REGION=${aws_gov_region} aws-vault exec ${aws_gov_stg_account} -- ${aws_command} s3 ls ${aws_gov_stg_bucket_name} > /dev/null
+          echo "confirmed: you have access to ${aws_gov_stg_bucket_name} bucket via account ${aws_gov_id_account}"
         elif [[ $environment == "prod" ]]; then
           prd_govenv="prd"
           readonly aws_gov_prd_account="${aws_gov_bucket_prefix}${prd_govenv}"
@@ -136,7 +136,7 @@ echo
 # Upload secure migration
 #
 
-proceed "Are you ready to upload your new migration? Currently only works in Commercial environments (experimental, staging, prod) and GovCloud experimental environment."
+proceed "Are you ready to upload your new migration? Currently only works in Commercial environments (experimental, staging, prod) and GovCloud experimental and staging environments."
 
 # This will currently only work for commercial AWS envs and GovCloud experimental.
   for environment in "${environments[@]}"; do
@@ -163,13 +163,13 @@ proceed "Are you ready to upload your new migration? Currently only works in Com
             "s3://${aws_gov_exp_bucket_name}/${aws_path_prefix}/"
           echo "confirmed: you ran a secure migration to ${aws_gov_exp_bucket_name} via ${aws_gov_id_account}"
         elif [[ $environment == "staging" ]]; then
-          #  DISABLE_AWS_VAULT_WRAPPER=1 \
-          #    AWS_PROFILE=${aws_gov_id_account} \
-          #    AWS_REGION=${aws_gov_region} \
-          #    aws-vault exec ${aws_gov_stg_account} -- ${aws_command} s3 cp --sse AES256 \
-          #    "$production_migration_file" \
-          #    "s3://${aws_gov_stg_bucket_name}/${aws_path_prefix}/"
-          echo "you cannot run a secure migration to ${aws_gov_stg_bucket_name} via ${aws_gov_id_account}"
+           DISABLE_AWS_VAULT_WRAPPER=1 \
+             AWS_PROFILE=${aws_gov_id_account} \
+             AWS_REGION=${aws_gov_region} \
+             aws-vault exec ${aws_gov_stg_account} -- ${aws_command} s3 cp --sse AES256 \
+             "$production_migration_file" \
+             "s3://${aws_gov_stg_bucket_name}/${aws_path_prefix}/"
+          echo "confirmed: you ran a secure migration to ${aws_gov_stg_bucket_name} via ${aws_gov_id_account}"
         elif [[ $environment == "prod" ]]; then
           #  DISABLE_AWS_VAULT_WRAPPER=1 \
           #    AWS_PROFILE=${aws_gov_id_account} \


### PR DESCRIPTION
## Description

https://dp3.atlassian.net/browse/MB-3551
This PR adds in the ability to upload secure migrations to STAGING govcloud env using the upload-secure-migration script.
It is follow up work to https://github.com/transcom/mymove/pull/4525/files

## Setup

Use this guide: https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations to test. You will only be able to test as an engineer once you have GovCloud access. This works both when running for  individual environments and for all three at once (except prod GovCloud, which still is not up).

Add any steps or code to run in this section to help others prepare to run your code:

```sh
generate-secure-migration name-of-file
upload-secure-migration name-of-file
```

## Code Review Verification Steps


  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
