### PR TITLE
Add serialize-javascript to resolutions so version with security advisory is not used

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "yup": "^0.29.1"
   },
   "resolutions": {
-    "kind-of": "^6.0.2"
+    "kind-of": "^6.0.2",
+    "serialize-javascript": "^3.1.0"
   },
   "name": "client",
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15251,22 +15251,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
-serialize-javascript@^3.1.0:
+serialize-javascript@^2.1.2, serialize-javascript@^3.1.0, serialize-javascript@^4.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
 


### PR DESCRIPTION
## Description

A new security advisory for `serialize-javascript` was released today. This PR ensures we do not pull in the insecure versions as part of other module dependencies. See https://www.npmjs.com/advisories/1548

## Reviewer Notes

Something requires version 2.1.2 so this forces it to use a whole major release newer, and forces one down from 4.0.0 to 3.1.0. Some scrutiny on that would be good.

## Setup

There should be no High level warnings for production dependencies, and the server should run as normal. 

```sh
yarn audit --groups dependencies --level high
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [this advisory](https://www.npmjs.com/advisories/1548)