### PR TITLE
Fixing a bad dependency in the deploy_migrations_exp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1544,7 +1544,7 @@ workflows:
             - push_app_exp
             - build_tools
             - push_tasks_exp
-            - push_migrations_legacy
+            - push_migrations_exp
           filters:
             branches:
               only: placeholder_branch_name


### PR DESCRIPTION
## Description

Moncef was having an issue pushing to experimental in https://github.com/transcom/mymove/pull/4533 and it looks like it is due to a bad dependency I had in the `deploy_migrations_exp` job in CircleCI. This should fix that dependency.