### PR TITLE
MB-3556 Keep testdatagen functions organized

### DIFF
--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -3,12 +3,6 @@ package primeapi
 import (
 	"log"
 	"testing"
-	"time"
-
-	"github.com/gobuffalo/pop"
-
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 
@@ -49,15 +43,4 @@ func TestHandlerSuite(t *testing.T) {
 
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()
-}
-
-// MakeAvailableMoveTaskOrder returns a default MTO with AvailableToPrimeAt set. Shared throughout this test package.
-func MakeAvailableMoveTaskOrder(db *pop.Connection) models.Move {
-	now := time.Now()
-	mto := testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-	})
-	return mto
 }

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -9,8 +9,6 @@ import (
 
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 
-	"github.com/go-openapi/swag"
-
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -41,11 +39,7 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandler() {
 	// unavailable MTO
 	testdatagen.MakeDefaultMove(suite.DB())
 
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: moveTaskOrder,
@@ -173,11 +167,7 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandler() {
 }
 
 func (suite *HandlerSuite) TestFetchMTOUpdatesHandlerPaymentRequest() {
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	// This should create all the other associated records we need.
 	paymentServiceItemParam := testdatagen.MakePaymentServiceItemParam(suite.DB(), testdatagen.Assertions{
@@ -217,11 +207,7 @@ func (suite *HandlerSuite) TestFetchMTOUpdatesHandlerPaymentRequest() {
 func (suite *HandlerSuite) TestFetchMTOUpdatesHandlerMinimal() {
 	// Creates a move task order with one minimal shipment and no payment requests
 	// or service items
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 		Move: moveTaskOrder,
@@ -249,18 +235,10 @@ func (suite *HandlerSuite) TestListMoveTaskOrdersHandlerReturnsUpdated() {
 	now := time.Now()
 	lastFetch := now.Add(-time.Second)
 
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-	})
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	// this MTO should not be returned
-	olderMoveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-	})
+	olderMoveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	// Pop will overwrite UpdatedAt when saving a model, so use SQL to set it in the past
 	suite.NoError(suite.DB().RawQuery("UPDATE moves SET updated_at=? WHERE id=?",

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
-	mto := MakeAvailableMoveTaskOrder(suite.DB())
+	mto := testdatagen.MakeAvailableMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 	})
@@ -176,7 +176,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 	})
 
 	suite.T().Run("POST failure - 404 - Integration - ShipmentID not linked by MoveTaskOrderID", func(t *testing.T) {
-		mto2 := MakeAvailableMoveTaskOrder(suite.DB())
+		mto2 := testdatagen.MakeAvailableMove(suite.DB())
 		mtoShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto2,
 		})
@@ -250,7 +250,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 }
 
 func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
-	mto := MakeAvailableMoveTaskOrder(suite.DB())
+	mto := testdatagen.MakeAvailableMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 	})
@@ -386,7 +386,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 }
 
 func (suite *HandlerSuite) TestCreateMTOServiceItemDDFSITHandler() {
-	mto := MakeAvailableMoveTaskOrder(suite.DB())
+	mto := testdatagen.MakeAvailableMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 	})

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
-	mto := MakeAvailableMoveTaskOrder(suite.DB())
+	mto := testdatagen.MakeAvailableMove(suite.DB())
 	pickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
 	destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
@@ -285,13 +285,9 @@ func ClearNonUpdateFields(mtoShipment *models.MTOShipment) *primemessages.MTOShi
 func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	primeEstimatedWeight := unit.Pound(500)
 	primeEstimatedWeightDate := testdatagen.DateInsidePeakRateCycle
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+	move := testdatagen.MakeAvailableMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
+		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},
@@ -444,7 +440,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	})
 
 	mtoShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
+		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -32,11 +32,7 @@ func (suite *HandlerSuite) TestListMTOsHandler() {
 	// unavailable MTO
 	testdatagen.MakeDefaultMove(suite.DB())
 
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
 
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: moveTaskOrder,

--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -6,19 +6,11 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 
-	"time"
-
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
-	now := time.Now()
-	availableMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-	})
+	availableMTO := testdatagen.MakeAvailableMove(suite.DB())
 	notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 	mtoChecker := NewMoveTaskOrderChecker(suite.DB())
 

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -67,25 +67,11 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 	})
 
 	suite.T().Run("all move task orders that are available to prime and using since", func(t *testing.T) {
-		time1 := time.Now()
-		time2 := time.Now()
-		time3 := time.Now()
-		testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-			Move: models.Move{
-				AvailableToPrimeAt: &time1,
-			},
-		})
-		testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-			Move: models.Move{
-				AvailableToPrimeAt: &time2,
-			},
-		})
+		now := time.Now()
 
-		oldMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-			Move: models.Move{
-				AvailableToPrimeAt: &time3,
-			},
-		})
+		testdatagen.MakeAvailableMove(suite.DB())
+		testdatagen.MakeAvailableMove(suite.DB())
+		oldMTO := testdatagen.MakeAvailableMove(suite.DB())
 		testdatagen.MakeDefaultMove(suite.DB())
 		testdatagen.MakeDefaultMove(suite.DB())
 
@@ -97,8 +83,8 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 		// Put 1 Move updatedAt in the past
 		suite.NoError(suite.DB().RawQuery("UPDATE moves SET updated_at=? WHERE id=?",
-			time3.Add(-2*time.Second), oldMTO.ID).Exec())
-		since := time3.Unix()
+			now.Add(-2*time.Second), oldMTO.ID).Exec())
+		since := now.Unix()
 		mtosWithSince, err := mtoFetcher.ListAllMoveTaskOrders(true, &since)
 		suite.NoError(err)
 		suite.Equal(len(mtosWithSince), 2)

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -1,6 +1,8 @@
 package testdatagen
 
 import (
+	"time"
+
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
@@ -101,6 +103,18 @@ func MakeMoveWithoutMoveType(db *pop.Connection, assertions Assertions) models.M
 
 	mustCreate(db, &move)
 
+	return move
+}
+
+// MakeAvailableMove makes a Move that is available to the prime at
+// the time of its creation
+func MakeAvailableMove(db *pop.Connection) models.Move {
+	now := time.Now()
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			AvailableToPrimeAt: &now,
+		},
+	})
 	return move
 }
 


### PR DESCRIPTION
## Description

During our work to consolidate Moves and MTOs, we noticed this
`MakeAvailableMoveTaskOrder` function that fit better inside the
`testdatagen` package. This PR moves that function into the
`make_move.go` file and renames it to `MakeAvailableMove` since we
no longer have a Move Task Orders table.