### PR TITLE
[MB-3686] Handle PaymentRequestIndex if no payment requests

### DIFF
--- a/src/pages/Office/PaymentRequestIndex/PaymentRequestIndex.jsx
+++ b/src/pages/Office/PaymentRequestIndex/PaymentRequestIndex.jsx
@@ -8,13 +8,15 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { PAYMENT_REQUESTS } from 'constants/queryKeys';
 
 const PaymentRequestIndex = () => {
-  const { isLoading, isError, data, error } = useQuery(PAYMENT_REQUESTS, getPaymentRequestList);
+  const { isLoading, isError, data: { paymentRequests } = {}, error } = useQuery(
+    PAYMENT_REQUESTS,
+    getPaymentRequestList,
+  );
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong error={error} />;
 
-  const { paymentRequests } = data;
-  const paymentRequestsArr = Object.values(paymentRequests);
+  const paymentRequestsArr = paymentRequests ? Object.values(paymentRequests) : [];
 
   return (
     <>

--- a/src/pages/Office/PaymentRequestIndex/PaymentRequestIndex.test.jsx
+++ b/src/pages/Office/PaymentRequestIndex/PaymentRequestIndex.test.jsx
@@ -22,6 +22,8 @@ const mockGetPaymentRequestListSuccess = jest.fn(() =>
   }),
 );
 
+const mockGetPaymentRequestListEmpty = jest.fn(() => Promise.resolve({}));
+
 describe('PaymentRequestIndex', () => {
   describe('loading state', () => {
     it('shows the loader', () => {
@@ -40,6 +42,24 @@ describe('PaymentRequestIndex', () => {
 
     it('renders without errors', async () => {
       await cache.prefetchQuery(PAYMENT_REQUESTS, mockGetPaymentRequestListSuccess);
+
+      const wrapper = mount(
+        <ReactQueryCacheProvider queryCache={cache}>
+          <MockProviders initialEntries={['/']}>
+            <PaymentRequestIndex />
+          </MockProviders>
+        </ReactQueryCacheProvider>,
+      );
+
+      expect(wrapper.find('[data-testid="PaymentRequestIndex"]').exists()).toBe(true);
+    });
+  });
+
+  describe('with no payment requests', () => {
+    const cache = makeQueryCache();
+
+    it('renders without errors', async () => {
+      await cache.prefetchQuery(PAYMENT_REQUESTS, mockGetPaymentRequestListEmpty);
 
       const wrapper = mount(
         <ReactQueryCacheProvider queryCache={cache}>


### PR DESCRIPTION
## Description

There's an existing bug where the PaymentRequestIndex page shows a JS error if there are no payment requests in the database. This PR fixes that bug & adds a corresponding test case.

## Reviewer Notes

- This does not implement a UI for empty payment requests. IMO that can be done when the UI for this page is worked on.

## Setup

- Reset your database (`make db_dev_reset; make db_dev_migrate`) so all data is cleared
- Start the application (`make server_run; make client_run`) and navigate to the Office app (http://officelocal:3000/)
- Go to Local Sign In -> Create a New TIO office User
- Verify the Payment Requests index page loads, and does not show an error.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3686) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/2723066/90556402-7edfe800-e15e-11ea-86ed-38ab5d5b1380.png)
