### PR TITLE
Replaced deprecated UUID library references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/gobuffalo/nulls v0.4.0 // indirect
 	github.com/gobuffalo/packr v1.30.1
 	github.com/gobuffalo/pop v4.13.1+incompatible
-	github.com/gobuffalo/uuid v2.0.5+incompatible
 	github.com/gobuffalo/validate v2.0.4+incompatible
 	github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576
 	github.com/gofrs/flock v0.7.1

--- a/pkg/handlers/ghcapi/payment_service_items.go
+++ b/pkg/handlers/ghcapi/payment_service_items.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-openapi/swag"
 
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"

--- a/pkg/handlers/ghcapi/payment_service_items_test.go
+++ b/pkg/handlers/ghcapi/payment_service_items_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-openapi/swag"
 
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -2,7 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )


### PR DESCRIPTION
## Description

I noticed a few references to `github.com/gobuffalo/uuid` that crept back into the code.  That library is [deprecated](https://github.com/gobuffalo/uuid) and we should use `github.com/gofrs/uuid` instead.

## Setup

`make server_test`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
