### PR TITLE
DRAFT UNTIL/UNLESS CI PROVES I'M RIGHT? | fix problematic TOO test

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -57,13 +57,13 @@ describe('TOO user', () => {
       });
 
       // Select additional service items
-      cy.get('label[for="shipmentManagementFee"]').click();
-      cy.get('label[for="counselingFee"]').click();
+      cy.get('label[for="shipmentManagementFee"]').click({ force: true }); // force because off screen on local run
+      cy.get('label[for="counselingFee"]').click({ force: true }); // force because off screen on local run
 
       // Open modal
       const button = cy.contains('Approve selected shipments');
       button.should('be.enabled');
-      button.click();
+      button.click({ force: true }); // force because off screen on local run
 
       cy.get('#approvalConfirmationModal [data-testid="modal"]').then(($modal) => {
         cy.get($modal).should('be.visible');
@@ -78,11 +78,11 @@ describe('TOO user', () => {
       });
 
       // Click approve
-      cy.contains('Approve and send').click();
+      cy.contains('Approve and send').click({ force: true });
       cy.wait(['@patchMTOShipmentStatus', '@patchMTOStatus']);
 
       // Page refresh
-      cy.wait(['@getMoveTaskOrders', '@getMTOShipments', '@getMTOServiceItems']);
+      cy.visit(`/moves/${moveOrderId}/details`); // replace race conditions with actual page refresh
       cy.get('#approvalConfirmationModal [data-testid="modal"]').should('not.be.visible');
       cy.get('#approved-shipments');
       cy.get('#requested-shipments').should('not.exist');


### PR DESCRIPTION
## Description

Ran into this on my cypress-5.0.0 branch-- the same test we saw repeatedly hanging forever in CI was consistently hanging forever locally. While I can't say I am 100% certain I diagnosed the root cause (hi, it's 2am haha), I did see:

- the wait for "page refresh" never finished
- the routes never actually *didn't* load; the cypress logs & server logs all agreed all three requests were sent and returned 200
- if I put a pause on the patch actions, often the actions would return their 200s in that short time between the patch ending and the pause trigger

All of this leads me to believe there is some race condition between the redirect / page refresh triggered by clicking approve and the cypress test runner's ability to grab and spy on the appropriate requests.

So, ¯\_(ツ)_/¯, I threw away the probable race condition and manually reloaded the page before letting the test continue confirming to its heart's content.

Feel free to merge if you like these changes.

## Setup

TBH, I composed this on top of my cypress-5.0.0 branch which is itself on top of my lock-cypress dependencies branch. There are some test runner changes I made in both of those which will help you test these changes.

Or you can rerun the CI jobs to confirm that on successive runs this works?

## References

- #4658 the original home of this lonely commit
- #4623 includes the test runner changes