### PR TITLE
MB-3552: Removing prd safeties from upload-secure-migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -839,7 +839,8 @@ tasks_post_file_to_gex: tasks_build_linux_docker ## Run post-file-to-gex from in
 #
 
 .PHONY: run_prod_migrations
-run_prod_migrations: run_com_prod_migrations run_gov_prod_migrations
+run_prod_migrations: run_com_prod_migrations
+	# run_gov_prod_migrations
 
 .PHONY: run_com_prod_migrations
 run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Prod migrations against Deployed Migrations DB
@@ -862,7 +863,8 @@ run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovClou
  	bin/milmove migrate
 
 .PHONY: run_staging_migrations
-run_staging_migrations: run_com_staging_migrations run_gov_staging_migrations
+run_staging_migrations: run_com_staging_migrations i
+  # run_gov_staging_migrations
 
 .PHONY: run_com_staging_migrations
 run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Staging migrations against Deployed Migrations DB
@@ -885,7 +887,8 @@ run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovC
 	bin/milmove migrate
 
 .PHONY: run_experimental_migrations
-run_experimental_migrations: run_com_experimental_migrations run_gov_experimental_migrations
+run_experimental_migrations: run_com_experimental_migrations
+	# run_gov_experimental_migrations
 
 .PHONY: run_com_experimental_migrations
 run_com_experimental_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Experimental migrations against Deployed Migrations DB

--- a/Makefile
+++ b/Makefile
@@ -855,7 +855,7 @@ run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commerc
 .PHONY: run_gov_prod_migrations
 run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Prod migrations against Deployed Migrations DB
 	@echo "Migrating the prod-migrations database with prod migrations..."
- 	MIGRATION_PATH="s3://transcom-gov-milmove-prd-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
+	MIGRATION_PATH="s3://transcom-gov-milmove-prd-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
  	DB_HOST=localhost \
  	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
  	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \

--- a/Makefile
+++ b/Makefile
@@ -863,7 +863,7 @@ run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovClou
  	bin/milmove migrate
 
 .PHONY: run_staging_migrations
-run_staging_migrations: run_com_staging_migrations i
+run_staging_migrations: run_com_staging_migrations
   # run_gov_staging_migrations
 
 .PHONY: run_com_staging_migrations

--- a/Makefile
+++ b/Makefile
@@ -838,9 +838,8 @@ tasks_post_file_to_gex: tasks_build_linux_docker ## Run post-file-to-gex from in
 # ----- START Deployed MIGRATION TARGETS -----
 #
 
-.PHONY: run_prod_migrations ## Currently: Run Commercial Prod migrations against Deployed Migrations DB
-run_prod_migrations: run_com_prod_migrations
-	# run_gov_prod_migrations
+.PHONY: run_prod_migrations
+run_prod_migrations: run_com_prod_migrations run_gov_prod_migrations
 
 .PHONY: run_com_prod_migrations
 run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Prod migrations against Deployed Migrations DB
@@ -852,20 +851,18 @@ run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commerc
 	DB_DEBUG=0 \
 	bin/milmove migrate
 
-# This will be added once GovCloud prod env is up
-# .PHONY: run_gov_prod_migrations
-# run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Prod migrations against Deployed Migrations DB
-# 	@echo "Migrating the prod-migrations database with prod migrations..."
-# 	MIGRATION_PATH="s3://transcom-gov-milmove-prd-app/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-# 	DB_HOST=localhost \
-# 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-# 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-# 	DB_DEBUG=0 \
-# 	bin/milmove migrate
+.PHONY: run_gov_prod_migrations
+run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Prod migrations against Deployed Migrations DB
+	@echo "Migrating the prod-migrations database with prod migrations..."
+ 	MIGRATION_PATH="s3://transcom-gov-milmove-prd-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
+ 	DB_HOST=localhost \
+ 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
+ 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+ 	DB_DEBUG=0 \
+ 	bin/milmove migrate
 
 .PHONY: run_staging_migrations
-run_staging_migrations: run_com_staging_migrations ## Currently: Run Commercial Staging migrations against Deployed Migrations DB in commercial
-	# run_gov_staging_migrations
+run_staging_migrations: run_com_staging_migrations run_gov_staging_migrations
 
 .PHONY: run_com_staging_migrations
 run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Staging migrations against Deployed Migrations DB
@@ -887,9 +884,8 @@ run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovC
 	DB_DEBUG=0 \
 	bin/milmove migrate
 
-.PHONY: run_experimental_migrations ## Currently: Run Commercial Experimental migrations against Deployed Migrations DB
-run_experimental_migrations: run_com_experimental_migrations
-# run_gov_experimental_migrations
+.PHONY: run_experimental_migrations
+run_experimental_migrations: run_com_experimental_migrations run_gov_experimental_migrations
 
 .PHONY: run_com_experimental_migrations
 run_com_experimental_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Experimental migrations against Deployed Migrations DB

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -136,7 +136,7 @@ migrations.
 | --- | --- |
 | `download-secure-migration` |  A script to download secure migrations from all environments |
 | `generate-secure-migration` |  A script to help manage the creation of secure migrations |
-| `upload-secure-migration` | A script to upload secure migrations to all environments in commercial AWS and to experimental and staging environments in GovCloud |
+| `upload-secure-migration` | A script to upload secure migrations to all environments in both commercial and GovCloud AWS |
 
 ### Database Scripts
 

--- a/scripts/generate-secure-migration
+++ b/scripts/generate-secure-migration
@@ -74,7 +74,7 @@ Next:
     3. If everything looks good, upload the migration to S3 with this utility:
        scripts/upload-secure-migration \\
           ${prod_migration_name}
-    4. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. Currently this only works for commercial AWS prod.
+    4. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will upload to both the commercial and GovCloud environments.
     5. Open a pull request for this change; when it is accepted, your migration will run on staging.
 EOM
 

--- a/scripts/generate-secure-migration
+++ b/scripts/generate-secure-migration
@@ -74,7 +74,7 @@ Next:
     3. If everything looks good, upload the migration to S3 with this utility:
        scripts/upload-secure-migration \\
           ${prod_migration_name}
-    4. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will upload to both the commercial and GovCloud environments.
+    4. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will check against the commercial environment only at the moment.
     5. Open a pull request for this change; when it is accepted, your migration will run on staging.
 EOM
 

--- a/scripts/pricing-import
+++ b/scripts/pricing-import
@@ -123,7 +123,7 @@ Next:
     2. If everything looks good, upload the migration to S3 with this utility:
        scripts/upload-secure-migration \\
           ${prod_migration_name}
-    3. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. Currently this only works for commercial AWS prod.
+    3. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will check against both the commercial and GovCloud environments.
     4. Open a pull request for this change; when it is accepted, your migration will run on staging.
     5. Delete local test and production migrations
 EOM

--- a/scripts/pricing-import
+++ b/scripts/pricing-import
@@ -123,7 +123,7 @@ Next:
     2. If everything looks good, upload the migration to S3 with this utility:
        scripts/upload-secure-migration \\
           ${prod_migration_name}
-    3. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will check against both the commercial and GovCloud environments.
+    3. Run make run_prod_migrations to verify that the upload worked and that the migration can be applied successfully. This will check against the commercial environment at the moment.
     4. Open a pull request for this change; when it is accepted, your migration will run on staging.
     5. Delete local test and production migrations
 EOM

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -136,7 +136,7 @@ echo
 # Upload secure migration
 #
 
-proceed "Are you ready to upload your new migration? Currently only works in Commercial environments (experimental, staging, prod) and GovCloud experimental and staging environments."
+proceed "Are you ready to upload your new migration? This will upload to all commercial environments (experimental, staging, prod) and GovCloud environments (exp, stg, prd)."
 
 # This will currently only work for commercial AWS envs and GovCloud experimental.
   for environment in "${environments[@]}"; do

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -107,8 +107,8 @@ fi
           prd_govenv="prd"
           readonly aws_gov_prd_account="${aws_gov_bucket_prefix}${prd_govenv}"
           readonly aws_gov_prd_bucket_name="${aws_gov_prd_account}${aws_gov_bucket_suffix}"
-          # DISABLE_AWS_VAULT_WRAPPER=1 AWS_PROFILE=${aws_gov_id_account} AWS_REGION=${aws_gov_region} aws-vault exec ${aws_gov_prd_account} -- ${aws_command} s3 ls ${aws_gov_prd_bucket_name} > /dev/null
-          # echo "confirmed: you have access to ${aws_gov_prd_bucket_name} bucket via account ${aws_gov_id_account}"
+          DISABLE_AWS_VAULT_WRAPPER=1 AWS_PROFILE=${aws_gov_id_account} AWS_REGION=${aws_gov_region} aws-vault exec ${aws_gov_prd_account} -- ${aws_command} s3 ls ${aws_gov_prd_bucket_name} > /dev/null
+          echo "confirmed: you have access to ${aws_gov_prd_bucket_name} bucket via account ${aws_gov_id_account}"
         fi
       fi
     done
@@ -171,13 +171,13 @@ proceed "Are you ready to upload your new migration? Currently only works in Com
              "s3://${aws_gov_stg_bucket_name}/${aws_path_prefix}/"
           echo "confirmed: you ran a secure migration to ${aws_gov_stg_bucket_name} via ${aws_gov_id_account}"
         elif [[ $environment == "prod" ]]; then
-          #  DISABLE_AWS_VAULT_WRAPPER=1 \
-          #    AWS_PROFILE=${aws_gov_id_account} \
-          #    AWS_REGION=${aws_gov_region} \
-          #    aws-vault exec ${aws_gov_prd_account} -- ${aws_command} s3 cp --sse AES256 \
-          #    "$production_migration_file" \
-          #    "s3://${aws_gov_prd_bucket_name}/${aws_path_prefix}/"
-          echo "you cannot run a secure migration to ${aws_gov_prd_bucket_name} via ${aws_gov_id_account}"
+           DISABLE_AWS_VAULT_WRAPPER=1 \
+             AWS_PROFILE=${aws_gov_id_account} \
+             AWS_REGION=${aws_gov_region} \
+             aws-vault exec ${aws_gov_prd_account} -- ${aws_command} s3 cp --sse AES256 \
+             "$production_migration_file" \
+             "s3://${aws_gov_prd_bucket_name}/${aws_path_prefix}/"
+          echo "confirmed: you ran a secure migration to ${aws_gov_prd_bucket_name} via ${aws_gov_id_account}"
         fi
       fi
     done


### PR DESCRIPTION
## Description

This switches on the functionality for uploading migrations into the bucket for the prd environment. I've added the appropriate permissions for engineers in the GovCloud `prd` account and tested to make sure they can do an `ls` of the bucket and `cp` the files appropriately. I am not sure if we want to merge this immediately, but this should close the loop and make it possible to move forward with `prd`.
