### PR TITLE
MB-3692 Check for destination address before referencing

### DIFF
--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -285,6 +285,7 @@ func ClearNonUpdateFields(mtoShipment *models.MTOShipment) *primemessages.MTOShi
 func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	primeEstimatedWeight := unit.Pound(500)
 	primeEstimatedWeightDate := testdatagen.DateInsidePeakRateCycle
+	primeActualWeight := unit.Pound(600)
 	move := testdatagen.MakeAvailableMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: move,
@@ -292,6 +293,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			Status: models.MTOShipmentStatusSubmitted,
 		},
 	})
+
 	mtoShipment.PrimeEstimatedWeight = &primeEstimatedWeight
 	mtoShipment.PrimeEstimatedWeightRecordedDate = &primeEstimatedWeightDate
 
@@ -300,6 +302,14 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		Move: mtoNotAvailable,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
+		},
+	})
+
+	minimalMtoShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			Status:              models.MTOShipmentStatusDraft,
+			ScheduledPickupDate: &time.Time{},
 		},
 	})
 
@@ -363,6 +373,26 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentOK)
 		suite.Equal(mtoShipment.ID.String(), okResponse.Payload.ID.String())
+	})
+
+	suite.T().Run("Successful PUT - Update weights on minimal shipment estimated weights", func(t *testing.T) {
+		minimalMtoShipment.PrimeEstimatedWeight = &primeEstimatedWeight
+		minimalMtoShipment.PrimeActualWeight = &primeActualWeight
+
+		req = httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s", minimalMtoShipment.ID.String()), nil)
+		eTag = etag.GenerateEtag(minimalMtoShipment.UpdatedAt)
+		params = mtoshipmentops.UpdateMTOShipmentParams{
+			HTTPRequest:   req,
+			MtoShipmentID: *handlers.FmtUUID(minimalMtoShipment.ID),
+			Body:          ClearNonUpdateFields(&minimalMtoShipment),
+			IfMatch:       eTag,
+		}
+
+		response := handler.Handle(params)
+		suite.IsType(&mtoshipmentops.UpdateMTOShipmentOK{}, response)
+
+		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentOK)
+		suite.Equal(minimalMtoShipment.ID.String(), okResponse.Payload.ID.String())
 	})
 
 	suite.T().Run("PUT failure - Shipment is not part of MTO available to prime", func(t *testing.T) {

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -393,6 +393,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentOK)
 		suite.Equal(minimalMtoShipment.ID.String(), okResponse.Payload.ID.String())
+		suite.Equal(minimalMtoShipment.PrimeActualWeight.Int64(), okResponse.Payload.PrimeActualWeight)
+		suite.Equal(minimalMtoShipment.PrimeEstimatedWeight.Int64(), okResponse.Payload.PrimeEstimatedWeight)
 	})
 
 	suite.T().Run("PUT failure - Shipment is not part of MTO available to prime", func(t *testing.T) {

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -122,7 +122,7 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 	}
 
 	// Updated based on existing fields that may have been updated:
-	if oldShipment.ScheduledPickupDate != nil && oldShipment.PrimeEstimatedWeight != nil && oldShipment.DestinationAddress != nil {
+	if oldShipment.ScheduledPickupDate != nil && oldShipment.PrimeEstimatedWeight != nil && oldShipment.DestinationAddress != nil && oldShipment.PickupAddress != nil {
 
 		requiredDeliveryDate, err := calculateRequiredDeliveryDate(planner, db, *oldShipment.PickupAddress,
 			*oldShipment.DestinationAddress, *oldShipment.ScheduledPickupDate, oldShipment.PrimeEstimatedWeight.Int())

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -84,6 +84,7 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 				verrs.Add("primeEstimatedWeight", err.Error())
 			}
 		}
+
 		oldShipment.PrimeEstimatedWeight = updatedShipment.PrimeEstimatedWeight
 		oldShipment.PrimeEstimatedWeightRecordedDate = &now
 	}
@@ -94,6 +95,7 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 	}
 
 	if updatedShipment.DestinationAddress != nil {
+
 		destinationAddress := updatedShipment.DestinationAddress
 		oldShipment.DestinationAddress = destinationAddress
 	}
@@ -120,9 +122,11 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 	}
 
 	// Updated based on existing fields that may have been updated:
-	if oldShipment.ScheduledPickupDate != nil && oldShipment.PrimeEstimatedWeight != nil {
+	if oldShipment.ScheduledPickupDate != nil && oldShipment.PrimeEstimatedWeight != nil && oldShipment.DestinationAddress != nil {
+
 		requiredDeliveryDate, err := calculateRequiredDeliveryDate(planner, db, *oldShipment.PickupAddress,
 			*oldShipment.DestinationAddress, *oldShipment.ScheduledPickupDate, oldShipment.PrimeEstimatedWeight.Int())
+
 		if err != nil {
 			verrs.Add("requiredDeliveryDate", err.Error())
 		}

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -90,22 +90,19 @@ func MakeMTOShipmentMinimal(db *pop.Connection, assertions Assertions) models.MT
 		moveTaskOrder = MakeMove(db, assertions)
 	}
 	pickupAddress := MakeAddress(db, assertions)
-	destinationAddress := MakeAddress2(db, assertions)
 	shipmentType := models.MTOShipmentTypeHHG
 
 	// mock dates
 	requestedPickupDate := time.Date(GHCTestYear, time.March, 15, 0, 0, 0, 0, time.UTC)
 
 	MTOShipment := models.MTOShipment{
-		MoveTaskOrder:        moveTaskOrder,
-		MoveTaskOrderID:      moveTaskOrder.ID,
-		RequestedPickupDate:  &requestedPickupDate,
-		PickupAddress:        &pickupAddress,
-		PickupAddressID:      &pickupAddress.ID,
-		DestinationAddress:   &destinationAddress,
-		DestinationAddressID: &destinationAddress.ID,
-		ShipmentType:         shipmentType,
-		Status:               "SUBMITTED",
+		MoveTaskOrder:       moveTaskOrder,
+		MoveTaskOrderID:     moveTaskOrder.ID,
+		RequestedPickupDate: &requestedPickupDate,
+		PickupAddress:       &pickupAddress,
+		PickupAddressID:     &pickupAddress.ID,
+		ShipmentType:        shipmentType,
+		Status:              "SUBMITTED",
 	}
 
 	if assertions.MTOShipment.Status == models.MTOShipmentStatusApproved {


### PR DESCRIPTION
## Description

* Fixes bug where attempting to add weights to a shipment without a destination address would return a 500.
* If an estimated weight is updated on an `mtoShipment` and a `scheduledPickupDate` exists, `mto_shipment_updater` calculates a `requiredDeliveryDate`. This calculation requires a `destinationAddress`, which isn't required when creating a shipment. 
* This pr checks that a `destinationAddress` exists before trying to calculate the `requiredDeliveryDate`.
* It also adds a test that would've originally caught this bug.

## Setup

To run tests: `go test ./pkg/handlers/primeapi --testify.m "TestUpdateMTOShipmentHandler" -v`

You can also test manually:

* `make db_dev_e2e_populate`
* Pick an entry in the `mto_shipments` table and delete any estimated weights, plus the destination_address_id and secondary_delivery_address_id.
* Use the `/mto-shipments/:mtoShipmentId` endpoint to update the shipment with a payload similar to the following:

```json
{
    "primeEstimatedWeight": 600,
   "primeActualWeight": 500
}
```

You should receive a 200 and the updated payload. 

## Code Review Verification Steps
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3692) for this change

