### PR TITLE
MB-3559 Add event trigger to GHC Payment Request update endpoint

### DIFF
--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"runtime/debug"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"go.uber.org/zap"
@@ -57,6 +59,13 @@ func (suite *BaseHandlerTestSuite) CloseFile(file *runtime.File) {
 // TestNotificationSender returns the notification sender to use in the suite
 func (suite *BaseHandlerTestSuite) TestNotificationSender() notifications.NotificationSender {
 	return suite.notificationSender
+}
+
+// HasWebhookNotification checks that there's a record on the WebhookNotifications table for the object and trace IDs
+func (suite *BaseHandlerTestSuite) HasWebhookNotification(objectID uuid.UUID, traceID uuid.UUID) {
+	notification := &models.WebhookNotification{}
+	err := suite.DB().Where("object_id = $1 AND trace_id = $2", objectID.String(), traceID.String()).First(notification)
+	suite.NoError(err)
 }
 
 // IsNotErrResponse enforces handler does not return an error response


### PR DESCRIPTION
## Description

This PR adds an event trigger after a payment request is successfully updated using the GHC API `updatePaymentRequestStatus` endpoint. This event will add a record to the `webhook_notifications` table if the payment request is attached to a move that is available to the Prime. It also adds tests to this endpoint and the Support API endpoint version to verify that a notification record was created if the object was Prime-available.

## Reviewer Notes

I manually set the `traceID` in the handler for the tests because I was only getting the nil UUID whenever I tried to retrieve it using `GetTraceID()`. If anyone knows of a way to get this value without having to manually set one, let me know! 

## Setup

First you'll need to run your local server and your local client:

```sh
make db_dev_e2e_populate && make server_run
make client_run
```

To test the GHC API using Postman, you'll also need to:

* Navigate to `http://officelocal:3000`. You should see a "Local Sign In" option - click this.
* Choose one of the default office user, TOO, or TIO emails and click "Login".
* Open up your developer tools and grab the following cookies (or enable Postman Interceptor and let that grab the cookies for you):
  * `office_session_token`
  * `masked_gorilla_csrf`
  * `_gorilla_csrf`
* Open Postman and click GHC API `updatePaymentRequestStatus` endpoint. Add the cookie values here by clicking the "Cookies" button on the right side (or, if using Postman Interceptor, make one dummy request using the endpoint and it will populate the cookie values for you).
* Now take the value for the `masked_gorilla_csrf` cookie and add a header called `X-CSRF-Token` and set it to the same value.
* Grab a Prime-available payment request's ID and eTag.
  * You can do this by using the Prime API endpoint `fetchMTOUpdates`, which returns all Prime-available moves and their subobjects. Instructions for testing the Prime API here: https://github.com/transcom/prime_api_deliverable/wiki.
  * You may also use a combination of GHC endpoints to get this info (`listMTOs` then `listPaymentRequests`).
* Fill in the body with a new status, such as "PAID" or "REJECTED", and submit the request!
* If the request was successful, you should see an entry in the log that says that a "Notification was created." You can also look directly in the database to verify that this did indeed happen.

## Code Review Verification Steps

* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3559) for this change.
