### PR TITLE
MB-3658 Put moving-info behind ghc instead of hhg flag

### DIFF
--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -173,7 +173,7 @@ const pages = {
     description: 'Upload your orders',
   },
   '/moves/:moveId/moving-info': {
-    isInFlow: (props) => inHhgFlow(props),
+    isInFlow: (props) => inGhcFlow(props),
     isComplete: always,
     render: (key, pages) => () => {
       return (

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -108,6 +108,7 @@ describe('when getting the routes for the current workflow', () => {
             '/service-member/:serviceMemberId/move-landing',
             '/orders/',
             '/orders/upload',
+            '/moves/:moveId/moving-info',
             '/moves/:moveId/select-type',
 
             '/moves/:moveId/review',
@@ -158,7 +159,6 @@ describe('when getting the routes for the current workflow', () => {
           '/service-member/:serviceMemberId/backup-contacts',
           '/orders/',
           '/orders/upload',
-          '/moves/:moveId/moving-info',
           '/moves/:moveId/select-type',
           '/moves/:moveId/hhg-start',
           '/moves/:moveId/review',


### PR DESCRIPTION
## Description

In my[ last PR](https://github.com/transcom/mymove/pull/4679) to remove the disableForDemo flag, I should have put the moving-info page behind the GHC flag, according to the ticket instructions (linked below).

This PR does that and updates the tests accordingly.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=MB&modal=detail&selectedIssue=MB-3658) for this change

