### PR TITLE
MB-3658 - Remove move-landing (aka home) page until it is functional

### DIFF
--- a/cypress/integration/mymove/hhg.js
+++ b/cypress/integration/mymove/hhg.js
@@ -79,9 +79,6 @@ function customerFillsInProfileInformation(reloadAfterEveryPage) {
   cy.get('input[name="name"]').type('Douglas Glass');
   cy.get('input[name="email"]').type('doug@glass.net');
   cy.nextPage();
-
-  cy.get('h2').contains('Welcome Jane');
-  cy.nextPage();
 }
 
 function customerFillsOutOrdersInformation() {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -19,7 +19,6 @@ import DutyStation from 'scenes/ServiceMembers/DutyStation';
 
 import UploadOrders from 'scenes/Orders/UploadOrders';
 
-import MoveLanding from 'pages/MyMove/MoveLanding';
 import SelectMoveType from 'pages/MyMove/SelectMoveType';
 import ConusOrNot from 'pages/MyMove/ConusOrNot';
 import MovingInfo from 'pages/MyMove/MovingInfo';
@@ -135,17 +134,6 @@ const pages = {
     },
     render: (key, pages) => ({ match }) => <BackupContact pages={pages} pageKey={key} match={match} />,
     description: 'Backup contacts',
-  },
-  '/service-member/:serviceMemberId/move-landing': {
-    isInFlow: (props) => myFirstRodeo(props) && inGhcFlow(props),
-    isComplete: always,
-    render: (key, pages) => () => {
-      return (
-        <WizardPage handleSubmit={no_op} pageList={pages} pageKey={key}>
-          <MoveLanding />
-        </WizardPage>
-      );
-    },
   },
   '/profile-review': {
     isInFlow: notMyFirstRodeo,

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -105,7 +105,6 @@ describe('when getting the routes for the current workflow', () => {
             '/service-member/:serviceMemberId/residence-address',
             '/service-member/:serviceMemberId/backup-mailing-address',
             '/service-member/:serviceMemberId/backup-contacts',
-            '/service-member/:serviceMemberId/move-landing',
             '/orders/',
             '/orders/upload',
             '/moves/:moveId/moving-info',


### PR DESCRIPTION
## Description

Context:
https://ustcdp3.slack.com/archives/CTNTFJSBA/p1598622833201000

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
