### PR TITLE
add storybook deployment to storybook.dp3.us - MB-3431

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1452,6 +1452,13 @@ jobs:
       - deploy_app_storybook:
           s3_bucket: storybook.move.mil
 
+  deploy_exp_storybook_dp3:
+    executor: mymove_small
+    steps:
+      - aws_vars_legacy
+      - deploy_app_storybook:
+          s3_bucket: storybook.dp3.us
+
   # `deploy_prd_migrations` deploys migrations to the milmove-prd environment
   deploy_prd_migrations:
     executor: mymove_small
@@ -1709,6 +1716,13 @@ workflows:
           filters:
             branches:
               only: placeholder_branch_name
+
+      - deploy_exp_storybook_dp3:
+          requires:
+            - storybook_tests
+          filters:
+            branches:
+              only: rd-MB-3431
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1458,14 +1458,14 @@ jobs:
   deploy_prod_storybook:
     executor: mymove_small
     steps:
-      - aws_vars_transcom_com_dev
+      - aws_vars_legacy
       - deploy_app_storybook:
           s3_bucket: storybook.move.mil
 
   deploy_exp_storybook_dp3:
     executor: mymove_small
     steps:
-      - aws_vars_legacy
+      - aws_vars_transcom_com_dev
       - deploy_app_storybook:
           s3_bucket: storybook.dp3.us
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1879,11 +1879,11 @@ workflows:
               only: master
 
       - deploy_storybook_dp3:
-          requires:
-            - storybook_tests
+#          requires:
+#            - storybook_tests
           filters:
             branches:
-              only: master
+              only: rd-MB-3431
 
       - storybook_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1879,8 +1879,8 @@ workflows:
               only: master
 
       - deploy_storybook_dp3:
-#          requires:
-#            - storybook_tests
+          requires:
+            - storybook_tests
           filters:
             branches:
               only: rd-MB-3431

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run:
           name: 'Setting up AWS environment variables for prd env'
           command: |
-            echo "export AWS_DEFAULT_REGION=$DEV_REGION" >> $BASH_ENV
+            echo "export AWS_DEFAULT_REGION=$COM_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_KEY" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run:
           name: 'Setting up AWS environment variables for prd env'
           command: |
-            echo "export AWS_DEFAULT_REGION=$LEGACY_REGION" >> $BASH_ENV
+            echo "export AWS_DEFAULT_REGION=$DEV_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_KEY" >> $BASH_ENV
@@ -1462,7 +1462,7 @@ jobs:
       - deploy_app_storybook:
           s3_bucket: storybook.move.mil
 
-  deploy_prod_storybook_dp3:
+  deploy_storybook_dp3:
     executor: mymove_small
     steps:
       - aws_vars_transcom_com_dev
@@ -1878,7 +1878,7 @@ workflows:
             branches:
               only: master
 
-      - deploy_prod_storybook_dp3:
+      - deploy_storybook_dp3:
           requires:
             - storybook_tests
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1462,7 +1462,7 @@ jobs:
       - deploy_app_storybook:
           s3_bucket: storybook.move.mil
 
-  deploy_exp_storybook_dp3:
+  deploy_prod_storybook_dp3:
     executor: mymove_small
     steps:
       - aws_vars_transcom_com_dev
@@ -1727,13 +1727,6 @@ workflows:
             branches:
               only: placeholder_branch_name
 
-      - deploy_exp_storybook_dp3:
-          requires:
-            - storybook_tests
-          filters:
-            branches:
-              only: rd-MB-3431
-
       - check_circle_against_staging_sha:
           requires:
             - pre_test
@@ -1884,6 +1877,13 @@ workflows:
           filters:
             branches:
               only: master
+
+      - deploy_prod_storybook_dp3:
+          requires:
+            - storybook_tests
+          filters:
+            branches:
+              only: rd-MB-3431
 
       - storybook_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,16 @@ commands:
             echo "export AWS_ACCESS_KEY_ID=$PRD_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$PRD_SECRET_ACCESS_KEY" >> $BASH_ENV
             source $BASH_ENV
+  aws_vars_transcom_com_dev:
+    steps:
+      - run:
+          name: 'Setting up AWS environment variables for prd env'
+          command: |
+            echo "export AWS_DEFAULT_REGION=$LEGACY_REGION" >> $BASH_ENV
+            echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_KEY" >> $BASH_ENV
+            source $BASH_ENV
   announce_failure:
     parameters:
     steps:
@@ -1448,7 +1458,7 @@ jobs:
   deploy_prod_storybook:
     executor: mymove_small
     steps:
-      - aws_vars_legacy
+      - aws_vars_transcom_com_dev
       - deploy_app_storybook:
           s3_bucket: storybook.move.mil
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1883,7 +1883,7 @@ workflows:
             - storybook_tests
           filters:
             branches:
-              only: rd-MB-3431
+              only: master
 
       - storybook_tests:
           requires:


### PR DESCRIPTION
## Description

This PR adds [storybook.dp3.us](https://storybook.dp3.us) to the master branch deploy. For now both storybook.move.mil and storybook.dp3.us are available. Over the next few weeks we will sunset storybook.move.mil and start using storybook.dp3.us

## Reviewer Notes

See [last build](https://app.circleci.com/pipelines/github/transcom/mymove/20533/workflows/5e173006-ea44-418b-9932-7ee7db562252/jobs/317481) and deploy for a proof of concept, in this build the branch was filtered on my branch so storybook deployed successfully. 


## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3431?atlOrigin=eyJpIjoiMzYwYzRiODgzY2ZmNDQyN2FlOGM0MDEyNDQzYzU2ZWEiLCJwIjoiaiJ9) for this change
