### PR TITLE
MB-3691 Refactor create/update address for updating mto shipment

### DIFF
--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -417,45 +417,48 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	})
 
 	//TODO: when the address bug (MB-3691) gets fixed, this test should pass
-	//suite.T().Run("PATCH failure - 422 -- invalid input", func(t *testing.T) {
-	//	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
-	//	fetcher := fetch.NewFetcher(builder)
-	//	updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
-	//	handler := UpdateMTOShipmentHandler{
-	//		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-	//		updater,
-	//	}
-	//
-	//	oldShipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
-	//	oldShipment.RequestedPickupDate = nil
-	//
-	//	req := httptest.NewRequest("PATCH", "/mto-shipments/"+oldShipment.ID.String(), nil)
-	//	req = suite.AuthenticateRequest(req, serviceMember)
-	//	// invalid zip
-	//	payloadDestinationAddress := &internalmessages.Address{
-	//		City:           swag.String("Stumptown"),
-	//		Country:        swag.String("USA"),
-	//		ID:             "6e07a670-a072-4014-be9f-4926c1389f9a",
-	//		State:          swag.String("CA"),
-	//		StreetAddress1: swag.String("321 Main St."),
-	//		PostalCode: 	swag.String("123"),
-	//	}
-	//
-	//	payload := internalmessages.UpdateShipment{
-	//		DestinationAddress:   payloadDestinationAddress,
-	//	}
-	//	eTag := etag.GenerateEtag(oldShipment.UpdatedAt)
-	//	params := mtoshipmentops.UpdateMTOShipmentParams{
-	//		HTTPRequest:   req,
-	//		MtoShipmentID: *handlers.FmtUUID(oldShipment.ID),
-	//		Body:          &payload,
-	//		IfMatch:       eTag,
-	//	}
-	//
-	//	response := handler.Handle(params)
-	//
-	//	suite.IsType(&mtoshipmentops.UpdateMTOShipmentUnprocessableEntity{}, response)
-	//})
+	// Update: This test is not passing due swagger validation failing and no server-side validation
+	// happening. These changes weren't covered in MB-3691, so we'll need to do addt'l
+	// work to fix. Since we have refactoring slated for addresses, we can do then.
+	// suite.T().Run("PATCH failure - 422 -- invalid input", func(t *testing.T) {
+	// 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	// 	fetcher := fetch.NewFetcher(builder)
+	// 	updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
+	// 	handler := UpdateMTOShipmentHandler{
+	// 		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+	// 		updater,
+	// 	}
+
+	// 	oldShipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
+	// 	oldShipment.RequestedPickupDate = nil
+
+	// 	req := httptest.NewRequest("PATCH", "/mto-shipments/"+oldShipment.ID.String(), nil)
+	// 	req = suite.AuthenticateRequest(req, serviceMember)
+	// 	// invalid zip
+	// 	payloadDestinationAddress := &internalmessages.Address{
+	// 		City:           swag.String("Stumptown"),
+	// 		Country:        swag.String("USA"),
+	// 		ID:             "6e07a670-a072-4014-be9f-4926c1389f9a",
+	// 		State:          swag.String("CA"),
+	// 		StreetAddress1: swag.String("321 Main St."),
+	// 		PostalCode:     swag.String("123"),
+	// 	}
+
+	// 	payload := internalmessages.UpdateShipment{
+	// 		DestinationAddress: payloadDestinationAddress,
+	// 	}
+	// 	eTag := etag.GenerateEtag(oldShipment.UpdatedAt)
+	// 	params := mtoshipmentops.UpdateMTOShipmentParams{
+	// 		HTTPRequest:   req,
+	// 		MtoShipmentID: *handlers.FmtUUID(oldShipment.ID),
+	// 		Body:          &payload,
+	// 		IfMatch:       eTag,
+	// 	}
+
+	// 	response := handler.Handle(params)
+	// 	suite.IsType(&mtoshipmentops.UpdateMTOShipmentUnprocessableEntity{}, response)
+
+	// })
 
 	suite.T().Run("PATCH failure - 500", func(t *testing.T) {
 		mockUpdater := mocks.MTOShipmentUpdater{}

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -330,7 +330,8 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(dbShipment *models.MTOShipment
 		if err := tx.RawQuery(updateMTOShipmentQuery, params...).Exec(); err != nil {
 			return err
 		}
-		// Is there any reason we can't remover the above query and just use Update?
+		// #TODO: Is there any reason we can't remove updateMTOShipmentQuery and use tx.Update?
+		//
 		// if err := tx.Update(newShipment); err != nil {
 		// 	return err
 		// }

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -153,13 +153,13 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		primeEstimatedWeightRecordedDate := time.Date(2019, time.March, 12, 0, 0, 0, 0, time.UTC)
 		customerRemarks := "I have a grandfather clock"
 		updatedShipment := models.MTOShipment{
-			ID:                   oldShipment.ID,
-			DestinationAddress:   &newDestinationAddress,
-			DestinationAddressID: &newDestinationAddress.ID,
-			PickupAddress:        &newPickupAddress,
-			PickupAddressID:      &newPickupAddress.ID,
-			//SecondaryPickupAddress:     &secondaryPickupAddress,
-			//SecondaryDeliveryAddress:   &secondaryDeliveryAddress,
+			ID:                               oldShipment.ID,
+			DestinationAddress:               &newDestinationAddress,
+			DestinationAddressID:             &newDestinationAddress.ID,
+			PickupAddress:                    &newPickupAddress,
+			PickupAddressID:                  &newPickupAddress.ID,
+			SecondaryPickupAddress:           &secondaryPickupAddress,
+			SecondaryDeliveryAddress:         &secondaryDeliveryAddress,
 			RequestedPickupDate:              &requestedPickupDate,
 			ScheduledPickupDate:              &scheduledPickupDate,
 			RequestedDeliveryDate:            &requestedDeliveryDate,
@@ -174,7 +174,6 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		newShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&updatedShipment, eTag)
-
 		suite.NoError(err)
 		suite.True(requestedPickupDate.Equal(*newShipment.RequestedPickupDate))
 		suite.True(scheduledPickupDate.Equal(*newShipment.ScheduledPickupDate))
@@ -187,12 +186,10 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(primeActualWeight, *newShipment.PrimeActualWeight)
 		suite.Equal(customerRemarks, *newShipment.CustomerRemarks)
 		suite.Equal(models.MTOShipmentStatusSubmitted, newShipment.Status)
-		// TODO: uncomment below when address bug is fixed MB-
-		//suite.Equal(newDestinationAddress, *newShipment.DestinationAddress)
-		//suite.Equal(newPickupAddress, *newShipment.PickupAddress)
-		// TODO: uncomment below when able to create if doesn't exist
-		//suite.Equal(secondaryPickupAddress, *newShipment.SecondaryPickupAddress)
-		//suite.Equal(secondaryDeliveryAddress, *newShipment.SecondaryDeliveryAddress)
+		suite.Equal(newDestinationAddress.ID, *newShipment.DestinationAddressID)
+		suite.Equal(newPickupAddress.ID, *newShipment.PickupAddressID)
+		suite.Equal(secondaryPickupAddress.ID, *newShipment.SecondaryPickupAddressID)
+		suite.Equal(secondaryDeliveryAddress.ID, *newShipment.SecondaryDeliveryAddressID)
 
 	})
 

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -43,6 +43,29 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	secondaryDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
 	primeActualWeight := unit.Pound(1234)
 	primeEstimatedWeight := unit.Pound(1234)
+	newDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			StreetAddress1: "987 Other Avenue",
+			StreetAddress2: swag.String("P.O. Box 1234"),
+			StreetAddress3: swag.String("c/o Another Person"),
+			City:           "Des Moines",
+			State:          "IA",
+			PostalCode:     "50309",
+			Country:        swag.String("US"),
+		},
+	})
+
+	newPickupAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			StreetAddress1: "987 Over There Avenue",
+			StreetAddress2: swag.String("P.O. Box 1234"),
+			StreetAddress3: swag.String("c/o Another Person"),
+			City:           "Houston",
+			State:          "TX",
+			PostalCode:     "77083",
+			Country:        swag.String("US"),
+		},
+	})
 
 	mtoShipment := models.MTOShipment{
 		ID:                         oldMTOShipment.ID,
@@ -117,36 +140,46 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Nil(updatedMTOShipment.PrimeEstimatedWeight)
 	})
 
-	suite.T().Run("Successful update to a minimal MTO shipment", func(t *testing.T) {
+	suite.T().Run("Successful update to all address fields", func(t *testing.T) {
+		// Ensure we can update every address field on the shipment
+		// Create an mtoShipment to update that has every address populated
+		oldMTOShipment3 := testdatagen.MakeDefaultMTOShipment(suite.DB())
 
+		eTag := etag.GenerateEtag(oldMTOShipment3.UpdatedAt)
+
+		updatedShipment := &models.MTOShipment{
+			ID:                         oldMTOShipment3.ID,
+			DestinationAddress:         &newDestinationAddress,
+			DestinationAddressID:       &newDestinationAddress.ID,
+			PickupAddress:              &newPickupAddress,
+			PickupAddressID:            &newPickupAddress.ID,
+			SecondaryPickupAddress:     &secondaryPickupAddress,
+			SecondaryPickupAddressID:   &secondaryDeliveryAddress.ID,
+			SecondaryDeliveryAddress:   &secondaryDeliveryAddress,
+			SecondaryDeliveryAddressID: &secondaryDeliveryAddress.ID,
+		}
+
+		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipment(updatedShipment, eTag)
+		suite.NoError(err)
+		suite.Equal(newDestinationAddress.ID, *updatedShipment.DestinationAddressID)
+		suite.Equal(newPickupAddress.ID, *updatedShipment.PickupAddressID)
+		suite.Equal(secondaryPickupAddress.ID, *updatedShipment.SecondaryPickupAddressID)
+		suite.Equal(secondaryDeliveryAddress.ID, *updatedShipment.SecondaryDeliveryAddressID)
+
+	})
+
+	suite.T().Run("Successful update to a minimal MTO shipment", func(t *testing.T) {
+		// Minimal MTO Shipment has only pickup address created by default
+		// Part of this test ensures that if an address doesn't exist on a shipment,
+		// the updater can successfully create it.
 		oldShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				Status: models.MTOShipmentStatusDraft,
 			},
 		})
+
 		eTag := etag.GenerateEtag(oldShipment.UpdatedAt)
-		newDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "987 Other Avenue",
-				StreetAddress2: swag.String("P.O. Box 1234"),
-				StreetAddress3: swag.String("c/o Another Person"),
-				City:           "Des Moines",
-				State:          "IA",
-				PostalCode:     "50309",
-				Country:        swag.String("US"),
-			},
-		})
-		newPickupAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{
-			Address: models.Address{
-				StreetAddress1: "987 Over There Avenue",
-				StreetAddress2: swag.String("P.O. Box 1234"),
-				StreetAddress3: swag.String("c/o Another Person"),
-				City:           "Houston",
-				State:          "TX",
-				PostalCode:     "77083",
-				Country:        swag.String("US"),
-			},
-		})
+
 		requestedPickupDate := time.Date(2019, time.March, 15, 0, 0, 0, 0, time.UTC)
 		scheduledPickupDate := time.Date(2019, time.March, 17, 0, 0, 0, 0, time.UTC)
 		requestedDeliveryDate := time.Date(2019, time.March, 30, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Description

Originally MB-3691 was a bug to address the destinationAddress not properly updating with the UpdateMTOShipment endpoint. This couldn't be replicated, but additional improvements were made instead based on parallel work by pamplemousse:

* When updating an address field, it changes from using `RawQuery` to using `Save` in the transaction: 
  * This will update the entry if it exists, or create it if it doesn't.
* There wasn't any known justification for using `RawQuery` instead, so this code simplifies the transaction and ensures the address gets created/updated correctly.

## Reviewer Notes

* The address updating will be split out into its own separate endpoint in [MB-3729](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=MB&modal=detail&selectedIssue=MB-3729)

* The commented-out test was written by Pamplemousse and expected to work with this bugfix, but there are unrelated validation issues happening. We plan to address them in MB-3729 + the new endpoint work.

## Setup

```bash

$ make db_test_e2e_populate
$ make server_run

// To run the tests
$ go test ./pkg/services/mto_shipment --testify.m "TestMTOShipmentUpdater" -v

```

You can also hit the endpoint manually with different variations and make sure the addresses update correctly.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3691) for this change
