### PR TITLE
MB-3443 Remove firstAvailableDelivery examples

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1039,14 +1039,12 @@ func init() {
             "firstAvailableDeliveryDate1": {
               "description": "First available date that Prime can deliver SIT service item.",
               "type": "string",
-              "format": "date",
-              "example": "2020-01-20"
+              "format": "date"
             },
             "firstAvailableDeliveryDate2": {
               "description": "Second available date that Prime can deliver SIT service item.",
               "type": "string",
-              "format": "date",
-              "example": "2020-01-20"
+              "format": "date"
             },
             "reServiceCode": {
               "description": "Service code allowed for this model type.",
@@ -3107,14 +3105,12 @@ func init() {
             "firstAvailableDeliveryDate1": {
               "description": "First available date that Prime can deliver SIT service item.",
               "type": "string",
-              "format": "date",
-              "example": "2020-01-20"
+              "format": "date"
             },
             "firstAvailableDeliveryDate2": {
               "description": "Second available date that Prime can deliver SIT service item.",
               "type": "string",
-              "format": "date",
-              "example": "2020-01-20"
+              "format": "date"
             },
             "reServiceCode": {
               "description": "Service code allowed for this model type.",

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1083,7 +1083,6 @@ definitions:
           firstAvailableDeliveryDate1:
             format: date
             type: string
-            example: "2020-01-20"
             description: First available date that Prime can deliver SIT service item.
           timeMilitary2:
             type: string
@@ -1093,7 +1092,6 @@ definitions:
           firstAvailableDeliveryDate2:
             format: date
             type: string
-            example: "2020-01-20"
             description: Second available date that Prime can deliver SIT service item.
         required:
           - reServiceCode

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1083,7 +1083,7 @@ definitions:
           firstAvailableDeliveryDate1:
             format: date
             type: string
-            example: 2020-01-20
+            example: "2020-01-20"
             description: First available date that Prime can deliver SIT service item.
           timeMilitary2:
             type: string
@@ -1093,7 +1093,7 @@ definitions:
           firstAvailableDeliveryDate2:
             format: date
             type: string
-            example: 2020-01-20
+            example: "2020-01-20"
             description: Second available date that Prime can deliver SIT service item.
         required:
           - reServiceCode


### PR DESCRIPTION
## Description

This PR updates the example value for `firstAvailableDeliveryDate1` and `firstAvailableDeliveryDate2` in the Prime API. The Redocly documentation was showing a date-time value instead of date, and this change makes it so now the sample payload is correct.

## Setup

Check out the sample payload here: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/sw-mb-3443-update-redoc-example/swagger/prime.yaml#operation/createMTOServiceItem

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3443) for this change
