### PR TITLE
[quick review] fix typo before demo

### DIFF
--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -120,7 +120,7 @@ class Home extends Component {
     }
     return (
       <p>
-        You&apos;re moving from <strong>{orders.new_duty_station.name}</strong> from{' '}
+        You&apos;re moving to <strong>{orders.new_duty_station.name}</strong> from{' '}
         <strong>{serviceMember.current_station.name}.</strong> Report by{' '}
         <strong>{moment(orders.report_by_date).format('DD MMM YYYY')}.</strong>
         <br />


### PR DESCRIPTION
## Description

Quick fix for typo on `/home-2`, which currently reads like person is moving "from ABC from DEF" rather than "to ABC from DEF" as I assume it should.

<img width="395" alt="Screen Shot 2020-08-31 at 11 41 27 PM" src="https://user-images.githubusercontent.com/10818509/91810932-96e64b80-ebe3-11ea-9a74-048191e7b0e6.png">

## Reviewer Notes

if you approve this change, __please merge it when you do__. I suspect I will not be online before the merge freeze at 8am pacific, and the whole point of this was to fix the typo in time for the demo. 🙂