### PR TITLE
remove storybook deployment step for storybook.move.mil - MB-3431

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1305,13 +1305,6 @@ jobs:
           health_check_hosts: gex.move.mil,dps.move.mil,orders.move.mil
           ecr_env: legacy
 
-  deploy_prod_storybook:
-    executor: mymove_small
-    steps:
-      - aws_vars_legacy
-      - deploy_app_storybook:
-          s3_bucket: storybook.move.mil
-
   deploy_storybook_dp3:
     executor: mymove_small
     steps:
@@ -1702,13 +1695,6 @@ workflows:
       - deploy_prod_app_client_tls:
           requires:
             - deploy_prod_migrations
-          filters:
-            branches:
-              only: master
-
-      - deploy_prod_storybook:
-          requires:
-            - storybook_tests
           filters:
             branches:
               only: master


### PR DESCRIPTION
## Description

This PR removes storybook deploy step for storybook.move.mil so it stops getting latest storybook copy. The buckets content that holds files for storybook.move.mil will be replaced by a single html re-directing to storybook new home @ [storybook.dp3.us](https://storybook.dp3.us)

Contents of stand-in html file:

```
<!doctype html>

<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Storybook has moved</title>
</head>

<body>
	<h1>Hi there, storybook has a new home and can be found at <a href="https://storybook.dp3.us">storybook.dp3.us</a>.</h1>
</body>
</html>
``` 


## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3431?atlOrigin=eyJpIjoiMDU3ZDYzNzY5N2NlNGI2Zjk5ZDNhOTdjZjE5OGQ3NTQiLCJwIjoiaiJ9) for this change

## Screenshots

Storybook.move.mil will look like this shortly:

![image](https://user-images.githubusercontent.com/5003421/92150431-670a9400-eded-11ea-973b-77aa3918a10c.png)

