### PR TITLE
add cypress runner dep to root pkg as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@testing-library/react-hooks": "^3.4.1",
     "case-sensitive-paths-webpack-plugin": "^2.3.0",
     "cypress": "~4.8.0",
+    "cypress-wait-until": "^1.7.1",
     "danger": "^10.3.0",
     "danger-plugin-jira-issue": "^1.4.1",
     "enzyme": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6157,6 +6157,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-wait-until@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
+  integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
+
 cypress@~4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.8.0.tgz#8fe731db77f39310511d83e81439d06ae3388554"


### PR DESCRIPTION
## Description

Unblock local e2e tests by adding new cypress runner dep to root package.json's devDeps.

## Reviewer Notes

If you `rm -rf node_modules/` (or `mv node_modules/ NOPE_modules/`), can you `yarn; yarn test:e2e` successfully?

## Setup

Lol oops. See reviewer notes. ;p