### PR TITLE
[MB-4015] Clear Cookies in Office auth tests

### DIFF
--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -32,6 +32,10 @@ describe('Office authorization', () => {
     cy.prepareOfficeApp();
   });
 
+  beforeEach(() => {
+    cy.clearAllCookies();
+  });
+
   it('redirects TOO to TOO homepage', () => {
     cy.signInAsNewTOOUser();
     cy.contains('All Customer Moves');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,6 +48,13 @@ Cypress.Commands.add('persistSessionCookies', () => {
   Cypress.Cookies.preserveOnce('masked_gorilla_csrf', 'office_session_token', '_gorilla_csrf');
 });
 
+// Use this for issue where Cypress is not clearing cookies between tests
+// Delete ALL cookies across domains (milmove, office)
+// https://github.com/cypress-io/cypress/issues/781
+Cypress.Commands.add('clearAllCookies', () => {
+  cy.clearCookies({ domain: null });
+});
+
 // Reloads the page but makes an attempt to wait for the loading screen to disappear
 Cypress.Commands.add('patientReload', () => {
   cy.reload();


### PR DESCRIPTION
## Description

This test has been failing in CI frequently as of late:

![Office authorization -- redirects TIO to TIO homepage (failed)](https://user-images.githubusercontent.com/2723066/92281631-98549400-eec1-11ea-93e8-208196cf5125.png)

I believe the underlying cause is that [Cypress is not reliably clearing cookies in between tests](https://github.com/cypress-io/cypress/issues/781) (which results in the scenario displayed in the screenshot) -- possibly because of [leftover XHR requests completing that set cookies](https://github.com/cypress-io/cypress/issues/781#issuecomment-587500218) or possibly because we often change the base URL during tests (due to testing both the customer & office apps at the same time), which I think messes with Cypress's Cookies API which by default only interacts with cookies from the base URL domain.

Cypress has a current proposal for [revamped Session API](https://github.com/cypress-io/cypress/issues/8301) which I'm hopeful will provide utilities for better handling our test cases that span multiple users/roles. In the meantime this fix adds an aggressive clear all cookies (across all domains) command to use when we're experiencing relevant failures.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4015) for this change
