### PR TITLE
MB-4104: Making workspace persistence more selective

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ commands:
           command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
       - persist_to_workspace:
           root: bin
-          paths: sha/
+          paths: sha/ECR_DIGEST_<< parameters.repo >>_<< parameters.ecr_env >>
 
   server_tests_step:
     parameters:


### PR DESCRIPTION
## Description

There was an issue where the `push_image` jobs for prod were re-persisting a bunch of files previous jobs had, and this confused CircleCI evidently. This should fix that issue.