### PR TITLE
[MB-3928] Add submitted_at to move

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -551,3 +551,4 @@
 20200827155542_add_db_comments.up.sql
 20200827190454_add_approved_at_rejected_at_timestamps_to_service_items.up.sql
 20200908162414_roci_db_comments.up.sql
+20200910033042_add-move-submitted-at.up.sql

--- a/migrations/app/schema/20200910033042_add-move-submitted-at.up.sql
+++ b/migrations/app/schema/20200910033042_add-move-submitted-at.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE moves
+	ADD COLUMN submitted_at timestamp without time zone;

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4715,6 +4715,11 @@ func init() {
         "status": {
           "$ref": "#/definitions/MoveStatus"
         },
+        "submitted_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time"
@@ -11257,6 +11262,11 @@ func init() {
         },
         "status": {
           "$ref": "#/definitions/MoveStatus"
+        },
+        "submitted_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-nullable": true
         },
         "updated_at": {
           "type": "string",

--- a/pkg/gen/internalmessages/move_payload.go
+++ b/pkg/gen/internalmessages/move_payload.go
@@ -56,6 +56,10 @@ type MovePayload struct {
 	// status
 	Status MoveStatus `json:"status,omitempty"`
 
+	// submitted at
+	// Format: date-time
+	SubmittedAt *strfmt.DateTime `json:"submitted_at,omitempty"`
+
 	// updated at
 	// Required: true
 	// Format: date-time
@@ -99,6 +103,10 @@ func (m *MovePayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSubmittedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -233,6 +241,19 @@ func (m *MovePayload) validateStatus(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("status")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *MovePayload) validateSubmittedAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SubmittedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("submitted_at", "body", "date-time", m.SubmittedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -45,9 +45,14 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 	if move.SelectedMoveType != nil {
 		SelectedMoveType = internalmessages.SelectedMoveType(*move.SelectedMoveType)
 	}
+	var SubmittedAt time.Time
+	if move.SubmittedAt != nil {
+		SubmittedAt = *move.SubmittedAt
+	}
 
 	movePayload := &internalmessages.MovePayload{
 		CreatedAt:               handlers.FmtDateTime(move.CreatedAt),
+		SubmittedAt:             handlers.FmtDateTime(SubmittedAt),
 		SelectedMoveType:        &SelectedMoveType,
 		Locator:                 swag.String(move.Locator),
 		ID:                      handlers.FmtUUID(move.ID),
@@ -58,6 +63,7 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 		ServiceMemberID:         *handlers.FmtUUID(order.ServiceMemberID),
 		Status:                  internalmessages.MoveStatus(move.Status),
 	}
+
 	return movePayload, nil
 }
 

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -214,6 +214,7 @@ func (suite *HandlerSuite) TestSubmitPPMMoveForApprovalHandler() {
 	suite.Assertions.Equal(
 		internalmessages.ReimbursementStatusREQUESTED,
 		*okResponse.Payload.PersonallyProcuredMoves[0].Advance.Status)
+	suite.Assertions.NotNil(okResponse.Payload.SubmittedAt)
 }
 
 func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -69,6 +69,7 @@ type Move struct {
 	Locator                 string                  `json:"locator" db:"locator"`
 	CreatedAt               time.Time               `json:"created_at" db:"created_at"`
 	UpdatedAt               time.Time               `json:"updated_at" db:"updated_at"`
+	SubmittedAt             *time.Time              `json:"submitted_at" db:"submitted_at"`
 	OrdersID                uuid.UUID               `json:"orders_id" db:"orders_id"`
 	Orders                  Order                   `belongs_to:"orders"`
 	SelectedMoveType        *SelectedMoveType       `json:"selected_move_type" db:"selected_move_type"`
@@ -127,8 +128,8 @@ func (m *Move) Submit(submitDate time.Time) error {
 	if m.Status != MoveStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
-
 	m.Status = MoveStatusSUBMITTED
+	m.SubmittedAt = swag.Time(time.Now())
 
 	// Update PPM status too
 	for i := range m.PersonallyProcuredMoves {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -710,6 +710,10 @@ definitions:
       updated_at:
         type: string
         format: date-time
+      submitted_at:
+        type: string
+        format: date-time
+        x-nullable: true
       personally_procured_moves:
         $ref: '#/definitions/IndexPersonallyProcuredMovePayload'
       mto_shipments:


### PR DESCRIPTION
## Description

Adds `submitted_at` to Moves table and payload

## Setup
`make server_run`
`make client_run`
Go through flow to submit a move
Check network tab to see `submitted_at` field on move payload

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3928) for this change

