### PR TITLE
MB-4186 Fix bug for checking verrs in ResponseForVErrors

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -208,7 +208,7 @@ func responseForBaseError(logger Logger, err error) middleware.Responder {
 // ResponseForVErrors checks for validation errors
 func ResponseForVErrors(logger Logger, verrs *validate.Errors, err error) middleware.Responder {
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
-	if verrs.HasAny() {
+	if verrs != nil && verrs.HasAny() {
 		skipLogger.Error("Encountered validation error", zap.Any("Validation errors", verrs.String()))
 		return NewValidationErrorsResponse(verrs)
 	}


### PR DESCRIPTION
## Description

This fixes a bug in ResponseForVErrors() where variable `verrs.HasErrors()` errors out when `verrs` is nil. We're now checking if `verrs` is nil before calling the function. 

## Reviewer Notes
- This fix should now bubble up the errors we're expecting when there is an error and no validation error.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4186) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/92822486-106b0000-f381-11ea-80ba-ba70eef95298.png)
