### PR TITLE
switch to make_env_migrations defaulting to govcloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,7 +644,7 @@ jobs:
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
       - run:
-          name: Run Experimental acceptance tests
+          name: Run exp acceptance tests
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
@@ -653,12 +653,12 @@ jobs:
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
             ENV: test
-            ENVIRONMENT: experimental
+            ENVIRONMENT: exp
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
-            TEST_ACC_ENV: experimental
+            TEST_ACC_ENV: exp
       - run:
-          name: Run Staging acceptance tests
+          name: Run stg acceptance tests
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
@@ -667,10 +667,10 @@ jobs:
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
             ENV: test
-            ENVIRONMENT: staging
+            ENVIRONMENT: stg
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
-            TEST_ACC_ENV: staging
+            TEST_ACC_ENV: stg
       - run: echo "Prod acceptance tests are prohibited in CircleCI"
       - announce_failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
           name: 'Setting up AWS environment variables for exp env'
           command: |
             echo "export AWS_DEFAULT_REGION=$EXP_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$EXP_REGION >> $$BASH_ENV"
+            echo "export DB_REGION=$EXP_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$EXP_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$EXP_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$EXP_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -94,7 +94,7 @@ commands:
           name: 'Setting up AWS environment variables for stg env'
           command: |
             echo "export AWS_DEFAULT_REGION=$STG_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$STG_REGION >> $$BASH_ENV"
+            echo "export DB_REGION=$STG_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$STG_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$STG_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$STG_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -105,7 +105,7 @@ commands:
           name: 'Setting up AWS environment variables for prd env'
           command: |
             echo "export AWS_DEFAULT_REGION=$PRD_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$PRD_REGION >> $$BASH_ENV"
+            echo "export DB_REGION=$PRD_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$PRD_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$PRD_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$PRD_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -113,7 +113,7 @@ commands:
   aws_vars_transcom_com_dev:
     steps:
       - run:
-          name: 'Setting up AWS environment variables for prd env'
+          name: 'Setting up AWS environment variables for com dev env'
           command: |
             echo "export AWS_DEFAULT_REGION=$COM_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ commands:
           name: 'Setting up AWS environment variables for legacy env'
           command: |
             echo "export AWS_DEFAULT_REGION=$LEGACY_REGION" >> $BASH_ENV
+            echo "export AWS_DB_REGION=$LEGACY_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$LEGACY_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$LEGACY_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$LEGACY_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -82,6 +83,7 @@ commands:
           name: 'Setting up AWS environment variables for exp env'
           command: |
             echo "export AWS_DEFAULT_REGION=$EXP_REGION" >> $BASH_ENV
+            echo "export DB_REGION=$EXP_REGION >> $$BASH_ENV"
             echo "export AWS_ACCOUNT_ID=$EXP_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$EXP_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$EXP_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -92,6 +94,7 @@ commands:
           name: 'Setting up AWS environment variables for stg env'
           command: |
             echo "export AWS_DEFAULT_REGION=$STG_REGION" >> $BASH_ENV
+            echo "export DB_REGION=$STG_REGION >> $$BASH_ENV"
             echo "export AWS_ACCOUNT_ID=$STG_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$STG_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$STG_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -102,6 +105,7 @@ commands:
           name: 'Setting up AWS environment variables for prd env'
           command: |
             echo "export AWS_DEFAULT_REGION=$PRD_REGION" >> $BASH_ENV
+            echo "export DB_REGION=$PRD_REGION >> $$BASH_ENV"
             echo "export AWS_ACCOUNT_ID=$PRD_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$PRD_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$PRD_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -648,7 +652,6 @@ jobs:
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
-            DB_REGION: us-west-2
             DB_RETRY_INTERVAL: 5s
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
@@ -663,7 +666,6 @@ jobs:
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
-            DB_REGION: us-west-2
             DB_RETRY_INTERVAL: 5s
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,7 +613,6 @@ jobs:
   acceptance_tests:
     executor: mymove_medium
     steps:
-      - aws_vars_legacy
       - checkout
       - restore_cache:
           keys:
@@ -643,6 +642,7 @@ jobs:
             MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
+      - aws_vars_exp
       - run:
           name: Run exp acceptance tests
           command: make acceptance_test
@@ -657,6 +657,7 @@ jobs:
             NO_TLS_ENABLED: true
             PWD: /home/circleci/transcom/mymove
             TEST_ACC_ENV: exp
+      - aws_vars_stg
       - run:
           name: Run stg acceptance tests
           command: make acceptance_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ commands:
           name: 'Setting up AWS environment variables for legacy env'
           command: |
             echo "export AWS_DEFAULT_REGION=$LEGACY_REGION" >> $BASH_ENV
-            echo "export AWS_DB_REGION=$LEGACY_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$LEGACY_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$LEGACY_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$LEGACY_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -83,7 +82,6 @@ commands:
           name: 'Setting up AWS environment variables for exp env'
           command: |
             echo "export AWS_DEFAULT_REGION=$EXP_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$EXP_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$EXP_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$EXP_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$EXP_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -94,7 +92,6 @@ commands:
           name: 'Setting up AWS environment variables for stg env'
           command: |
             echo "export AWS_DEFAULT_REGION=$STG_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$STG_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$STG_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$STG_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$STG_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -105,7 +102,6 @@ commands:
           name: 'Setting up AWS environment variables for prd env'
           command: |
             echo "export AWS_DEFAULT_REGION=$PRD_REGION" >> $BASH_ENV
-            echo "export DB_REGION=$PRD_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$PRD_ACCOUNT_ID" >> $BASH_ENV
             echo "export AWS_ACCESS_KEY_ID=$PRD_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$PRD_SECRET_ACCESS_KEY" >> $BASH_ENV
@@ -652,6 +648,7 @@ jobs:
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
+            DB_REGION: us-gov-west-1
             DB_RETRY_INTERVAL: 5s
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
@@ -666,6 +663,7 @@ jobs:
           command: make acceptance_test
           environment:
             CHAMBER_RETRIES: 20
+            DB_REGION: us-gov-west-1
             DB_RETRY_INTERVAL: 5s
             DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/.envrc
+++ b/.envrc
@@ -47,7 +47,7 @@ check_required_variables() {
 #############################
 
 export AWS_VAULT_KEYCHAIN_NAME=login
-export AWS_PROFILE=transcom-ppp
+# export AWS_PROFILE=transcom-ppp
 
 #############################
 # Load Secrets from Chamber #
@@ -171,12 +171,12 @@ export TZ="UTC"
 # Your AWS credentials should be setup in the transcom-ppp profile using
 # aws-vault. They will be detected and used by the app automatically.
 export AWS_S3_BUCKET_NAME="transcom-ppp-app-devlocal-us-west-2"
-export AWS_S3_REGION="us-west-2"
+# export AWS_S3_REGION="us-west-2"
 # Setting these regions interacts poorly when using multiple AWS accounts
-export AWS_DEFAULT_REGION="us-west-2"
+# export AWS_DEFAULT_REGION="us-west-2"
 export AWS_S3_KEY_NAMESPACE=$USER
 export AWS_SES_DOMAIN="devlocal.dp3.us"
-export AWS_SES_REGION="us-west-2"
+# export AWS_SES_REGION="us-west-2"
 
 # To use cdn links like assets.devlocal.move.mil/xx/user/ for local builds,
 # you'll need to add the following to your .envrc.local:

--- a/Makefile
+++ b/Makefile
@@ -841,28 +841,30 @@ tasks_post_file_to_gex: tasks_build_linux_docker ## Run post-file-to-gex from in
 .PHONY: run_prod_migrations
 run_prod_migrations: run_gov_prod_migrations
 
-.PHONY: run_com_prod_migrations
-run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Prod migrations against Deployed Migrations DB
-	@echo "Migrating the prod-migrations database with prod migrations..."
-	MIGRATION_PATH="s3://transcom-ppp-app-prod-us-west-2/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-	DB_HOST=localhost \
-	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-	DB_DEBUG=0 \
-	bin/milmove migrate
-
 .PHONY: run_gov_prod_migrations
 run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Prod migrations against Deployed Migrations DB
 	@echo "Migrating the prod-migrations database with prod migrations..."
+	AWS_PROFILE="transcom-gov-milmove-prd"
 	MIGRATION_PATH="s3://transcom-gov-milmove-prd-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
  	DB_HOST=localhost \
  	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
  	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
  	DB_DEBUG=0 \
- 	bin/milmove migrate
+ 	aws-vault exec transcom-gov-milmove-prd -- bin/milmove migrate
 
 .PHONY: run_staging_migrations
 run_staging_migrations: run_gov_staging_migrations
+
+.PHONY: run_gov_staging_migrations ## Run GovCloud Staging migrations against Deployed Migrations DB
+run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Staging migrations against Deployed Migrations DB in commercial
+	@echo "Migrating the staging-migrations database with staging migrations..."
+	AWS_PROFILE="transcom-gov-milmove-stg"
+	MIGRATION_PATH="s3://transcom-gov-milmove-stg-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
+	DB_HOST=localhost \
+	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
+	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+	DB_DEBUG=0 \
+	aws-vault exec transcom-gov-milmove-stg -- bin/milmove migrate
 
 .PHONY: run_com_staging_migrations
 run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Staging migrations against Deployed Migrations DB
@@ -874,38 +876,19 @@ run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Comm
 	DB_DEBUG=0 \
 	bin/milmove migrate
 
-.PHONY: run_gov_staging_migrations ## Run GovCloud Staging migrations against Deployed Migrations DB
-run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Staging migrations against Deployed Migrations DB in commercial
-	@echo "Migrating the staging-migrations database with staging migrations..."
-	MIGRATION_PATH="s3://transcom-gov-milmove-stg-app/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-	DB_HOST=localhost \
-	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-	DB_DEBUG=0 \
-	bin/milmove migrate
-
 .PHONY: run_experimental_migrations
 run_experimental_migrations: run_gov_experimental_migrations
-
-.PHONY: run_com_experimental_migrations
-run_com_experimental_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Experimental migrations against Deployed Migrations DB
-	@echo "Migrating the experimental-migrations database with experimental migrations..."
-	MIGRATION_PATH="s3://transcom-ppp-app-experimental-us-west-2/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-	DB_HOST=localhost \
-	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-	DB_DEBUG=0 \
-	bin/milmove migrate
 
 .PHONY: run_gov_experimental_migrations
 run_gov_experimental_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud Experimental migrations against Deployed Migrations DB
 	@echo "Migrating the experimental-migrations database with experimental migrations..."
-	MIGRATION_PATH="s3://transcom-gov-milmove-exp-app/secure-migrations;file://migrations/$(APPLICATION)/schema" \
+	AWS_PROFILE="transcom-gov-milmove-exp"
+	MIGRATION_PATH="s3://transcom-gov-milmove-exp-app-us-gov-west-1/secure-migrations;file://migrations/$(APPLICATION)/schema" \
 	DB_HOST=localhost \
 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
 	DB_DEBUG=0 \
-	bin/milmove migrate
+	aws-vault exec transcom-gov-milmove-exp -- bin/milmove migrate
 
 #
 # ----- END PROD_MIGRATION TARGETS -----

--- a/Makefile
+++ b/Makefile
@@ -866,16 +866,6 @@ run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovC
 	DB_DEBUG=0 \
 	aws-vault exec transcom-gov-milmove-stg -- bin/milmove migrate
 
-.PHONY: run_com_staging_migrations
-run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Staging migrations against Deployed Migrations DB
-	@echo "Migrating the staging-migrations database with staging migrations..."
-	MIGRATION_PATH="s3://transcom-ppp-app-staging-us-west-2/secure-migrations;file://migrations/$(APPLICATION)/schema" \
-	DB_HOST=localhost \
-	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
-	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
-	DB_DEBUG=0 \
-	bin/milmove migrate
-
 .PHONY: run_experimental_migrations
 run_experimental_migrations: run_gov_experimental_migrations
 

--- a/Makefile
+++ b/Makefile
@@ -839,8 +839,7 @@ tasks_post_file_to_gex: tasks_build_linux_docker ## Run post-file-to-gex from in
 #
 
 .PHONY: run_prod_migrations
-run_prod_migrations: run_com_prod_migrations
-	# run_gov_prod_migrations
+run_prod_migrations: run_gov_prod_migrations
 
 .PHONY: run_com_prod_migrations
 run_com_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Prod migrations against Deployed Migrations DB
@@ -863,8 +862,7 @@ run_gov_prod_migrations: bin/milmove db_deployed_migrations_reset ## Run GovClou
  	bin/milmove migrate
 
 .PHONY: run_staging_migrations
-run_staging_migrations: run_com_staging_migrations
-  # run_gov_staging_migrations
+run_staging_migrations: run_gov_staging_migrations
 
 .PHONY: run_com_staging_migrations
 run_com_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Staging migrations against Deployed Migrations DB
@@ -887,8 +885,7 @@ run_gov_staging_migrations: bin/milmove db_deployed_migrations_reset ## Run GovC
 	bin/milmove migrate
 
 .PHONY: run_experimental_migrations
-run_experimental_migrations: run_com_experimental_migrations
-	# run_gov_experimental_migrations
+run_experimental_migrations: run_gov_experimental_migrations
 
 .PHONY: run_com_experimental_migrations
 run_com_experimental_migrations: bin/milmove db_deployed_migrations_reset ## Run Commercial Experimental migrations against Deployed Migrations DB


### PR DESCRIPTION
## Description

This PR changes the make command destination for migrations to default to gov rather than commercial cloud. The commercial commands still remain.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make run_experimental_migrations
make run_staging_migrations
make run_prod_migrations
```

## Code Review Verification Steps


* [ ] Request review from a member of a different team.

