### PR TITLE
MB-4188 Add fake contractor to PROD

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -552,3 +552,4 @@
 20200827190454_add_approved_at_rejected_at_timestamps_to_service_items.up.sql
 20200908162414_roci_db_comments.up.sql
 20200910033042_add-move-submitted-at.up.sql
+20200911161101_add_fake_contractors_prod.up.sql

--- a/migrations/app/secure/20200911161101_add_fake_contractors_prod.up.sql
+++ b/migrations/app/secure/20200911161101_add_fake_contractors_prod.up.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.


### PR DESCRIPTION
## Description

We're missing contractor data in PROD. This PR adds fake contractors we're using in other environments.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
// Run this one if you don't have gov cloud access
make run_prod_migrations

// OR gov cloud, if you have access
make run_gov_prod_migrations

// To download migrations
download-secure-migration 20200911161101_add_fake_contractors_prod.up.sql
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4188) for this change