### PR TITLE
MB-4228 Hide move on PROD GovCloud

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -553,3 +553,4 @@
 20200908162414_roci_db_comments.up.sql
 20200910033042_add-move-submitted-at.up.sql
 20200911161101_add_fake_contractors_prod.up.sql
+20200914173006_hide_move_on_prod_gov_cloud.up.sql

--- a/migrations/app/secure/20200914173006_hide_move_on_prod_gov_cloud.up.sql
+++ b/migrations/app/secure/20200914173006_hide_move_on_prod_gov_cloud.up.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.


### PR DESCRIPTION
## Description

Hide move used to test on PROD GovCloud.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
// download migrations, prod file should be the only one with code
download-secure-migration 20200914173006_hide_move_on_prod_gov_cloud.up.sql

// run prod migration to make sure nothing is broken, commerical
make run_prod_migrations
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4228) for this change

