### PR TITLE
MB-4219 Add new prime-api-client command for updating mtoShipment address

### DIFF
--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -112,6 +112,29 @@ func main() {
 	prime.InitUpdateMTOShipmentFlags(updateMTOShipmentCommand.Flags())
 	root.AddCommand(updateMTOShipmentCommand)
 
+	updateMTOShipmentAddressCommand := &cobra.Command{
+		Use:   "update-mto-shipment-address",
+		Short: "Update MTO shipment address",
+		Long: `
+  This command updates an address associated with an MTO shipment.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters, headers and a body for the payload.
+
+  Endpoint path: /mto-shipments/{mtoShipmentID}/addresses/{addressID}
+  The file should contain json as follows:
+  	{
+	  "mtoShipmentID": <uuid string>,
+	  "addressID": <uuid string>,
+      "ifMatch": <eTag>,
+      "body": <MTOShipmentAddress>
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
+		RunE:         prime.UpdateMTOShipmentAddress,
+		SilenceUsage: true,
+	}
+	prime.InitUpdateMTOShipmentAddressFlags(updateMTOShipmentAddressCommand.Flags())
+	root.AddCommand(updateMTOShipmentAddressCommand)
+
 	updatePostCounselingInfo := &cobra.Command{
 		Use:          "update-mto-post-counseling-information",
 		Short:        "update post counseling info",

--- a/cmd/prime-api-client/prime/update_mto_shipment_address.go
+++ b/cmd/prime-api-client/prime/update_mto_shipment_address.go
@@ -1,0 +1,95 @@
+package prime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/transcom/mymove/cmd/prime-api-client/utils"
+
+	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
+)
+
+// InitUpdateMTOShipmentAddressFlags declares which flags are enabled
+func InitUpdateMTOShipmentAddressFlags(flag *pflag.FlagSet) {
+	flag.String(utils.FilenameFlag, "", "Name of the file being passed in")
+	flag.SortFlags = false
+}
+
+func checkUpdateMTOShipmentAddressConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := utils.CheckRootConfig(v)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if v.GetString(utils.FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !utils.ContainsDash(args)) {
+		logger.Fatal(errors.New("update-mto-shipment-address expects a file to be passed in"))
+	}
+
+	return nil
+}
+
+// UpdateMTOShipmentAddress creates a gateway and sends the request to the endpoint
+func UpdateMTOShipmentAddress(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	// Create the logger - remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := utils.ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkUpdateMTOShipmentAddressConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// Decode json from file that was passed into MTOShipment
+	filename := v.GetString(utils.FilenameFlag)
+	var mtoShipmentAddressPayload mtoShipment.UpdateMTOShipmentAddressParams
+	err = utils.DecodeJSONFileToPayload(filename, utils.ContainsDash(args), &mtoShipmentAddressPayload)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	mtoShipmentAddressPayload.SetTimeout(time.Second * 30)
+
+	// Create the client and open the cacStore
+	primeGateway, cacStore, errCreateClient := utils.CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer cacStore.Close()
+	}
+
+	// Make the API Call
+	resp, err := primeGateway.MtoShipment.UpdateMTOShipmentAddress(&mtoShipmentAddressPayload)
+	if err != nil {
+		return utils.HandleGatewayError(err, logger)
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

* Adds `update-mto-shipment-address` command to `prime-api-client`
* Accepts a JSON file with the following:
```  	
{
    "mtoShipmentID": <uuid string>,
    "addressID": <uuid string>,
    "ifMatch": <eTag>,
    "body": { 
      <MTOShipmentAddress>
  	}
```

## Setup

*  Build the `prime-api-client`
`$ rm -rf bin/prime-api-client && make bin/prime-api-client`

* Create json file with a payload, e.g.

```json
{
  "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5",
  "addressID": "08bcdd14-20ee-4440-a85f-89fccf1fd7a2",
  "ifMatch": "MjAyMC0wOS0xNFQyMjo0Nzo0MS41MTI3MzFa",
  "body": {
      "city": <string>,
      "streetAddress1": <string>,
      "state": <string>,
      "postalCode": <string>,
      "country": <string>
  }
}
```
* Run the command

`$ prime-api-client update-mto-shipment-address --filename <filename> --insecure`


* You can add the `--help` flag to get additional context from the client

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4219) for this change
