### PR TITLE
[MB-4223] Creates notification handler for mtoshipment events

### DIFF
--- a/pkg/services/event/event.go
+++ b/pkg/services/event/event.go
@@ -51,6 +51,12 @@ const MTOShipmentCreateEventKey KeyType = "MTOShipment.Create"
 // MTOShipmentUpdateEventKey is a key containing MTOShipment.Update
 const MTOShipmentUpdateEventKey KeyType = "MTOShipment.Update"
 
+// MTOServiceItemCreateEventKey is a key containing MTOServiceItem.Create
+const MTOServiceItemCreateEventKey KeyType = "MTOServiceItem.Create"
+
+// MTOServiceItemUpdateEventKey is a key containing MTOServiceItem.Update
+const MTOServiceItemUpdateEventKey KeyType = "MTOServiceItem.Update"
+
 var eventModels map[KeyType]eventModel = map[KeyType]eventModel{
 	PaymentRequestCreateEventKey: {PaymentRequestCreateEventKey, models.PaymentRequest{}},
 	PaymentRequestUpdateEventKey: {PaymentRequestUpdateEventKey, models.PaymentRequest{}},

--- a/pkg/services/event/event.go
+++ b/pkg/services/event/event.go
@@ -62,6 +62,8 @@ var eventModels map[KeyType]eventModel = map[KeyType]eventModel{
 	PaymentRequestUpdateEventKey: {PaymentRequestUpdateEventKey, models.PaymentRequest{}},
 	MTOShipmentCreateEventKey:    {MTOShipmentCreateEventKey, models.MTOShipment{}},
 	MTOShipmentUpdateEventKey:    {MTOShipmentUpdateEventKey, models.MTOShipment{}},
+	MTOServiceItemCreateEventKey: {MTOServiceItemCreateEventKey, models.MTOServiceItem{}},
+	MTOServiceItemUpdateEventKey: {MTOServiceItemUpdateEventKey, models.MTOServiceItem{}},
 }
 
 // IsCreateEvent returns true if this event is a create event

--- a/pkg/services/event/event.go
+++ b/pkg/services/event/event.go
@@ -45,9 +45,17 @@ const PaymentRequestCreateEventKey KeyType = "PaymentRequest.Create"
 // PaymentRequestUpdateEventKey is a key containing PaymentRequest.Update
 const PaymentRequestUpdateEventKey KeyType = "PaymentRequest.Update"
 
+// MTOShipmentCreateEventKey is a key containing MTOShipment.Create
+const MTOShipmentCreateEventKey KeyType = "MTOShipment.Create"
+
+// MTOShipmentUpdateEventKey is a key containing MTOShipment.Update
+const MTOShipmentUpdateEventKey KeyType = "MTOShipment.Update"
+
 var eventModels map[KeyType]eventModel = map[KeyType]eventModel{
 	PaymentRequestCreateEventKey: {PaymentRequestCreateEventKey, models.PaymentRequest{}},
 	PaymentRequestUpdateEventKey: {PaymentRequestUpdateEventKey, models.PaymentRequest{}},
+	MTOShipmentCreateEventKey:    {MTOShipmentCreateEventKey, models.MTOShipment{}},
+	MTOShipmentUpdateEventKey:    {MTOShipmentUpdateEventKey, models.MTOShipment{}},
 }
 
 // IsCreateEvent returns true if this event is a create event

--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -212,3 +212,42 @@ func (suite *EventServiceSuite) Test_MTOShipmentEventTrigger() {
 
 	})
 }
+
+func (suite *EventServiceSuite) Test_MTOServiceItemEventTrigger() {
+
+	now := time.Now()
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			AvailableToPrimeAt: &now,
+		},
+	})
+
+	mtoServiceItemID := mtoServiceItem.ID
+	mtoID := mtoServiceItem.MoveTaskOrderID
+
+	dummyRequest := http.Request{
+		URL: &url.URL{
+			Path: "",
+		},
+	}
+	logger, _ := zap.NewDevelopment()
+	handler := handlers.NewHandlerContext(suite.DB(), logger)
+
+	// Test successful event passing with Support API
+	suite.T().Run("Success with GHC ServiceItem endpoint", func(t *testing.T) {
+
+		_, err := TriggerEvent(Event{
+			EventKey:        MTOServiceItemCreateEventKey,
+			MtoID:           mtoID,
+			UpdatedObjectID: mtoServiceItemID,
+			Request:         &dummyRequest,
+			EndpointKey:     GhcCreateMTOServiceItemEndpointKey,
+			HandlerContext:  handler,
+			DBConnection:    suite.DB(),
+		})
+		// TODO: Once proper payload is generated this should not return error
+		suite.Error(err)
+		// TODO: Add sandy's webhook notification check
+
+	})
+}

--- a/pkg/services/event/notification.go
+++ b/pkg/services/event/notification.go
@@ -96,6 +96,25 @@ func assembleMTOShipmentPayload(db *pop.Connection, updatedObjectID uuid.UUID) (
 
 }
 
+// assembleMTOServiceItemPayload assembles the MTOServiceItem Payload and returns the JSON in bytes
+func assembleMTOServiceItemPayload(db *pop.Connection, updatedObjectID uuid.UUID) ([]byte, error) {
+	model := models.MTOServiceItem{}
+
+	// Important to be specific about which addl associations to load to reduce DB hits
+	err := db.Find(&model, updatedObjectID.String())
+
+	if err != nil {
+		notFoundError := services.NewNotFoundError(updatedObjectID, "looking for MTOServiceItem")
+		notFoundError.Wrap(err)
+		return nil, notFoundError
+	}
+
+	// TODO: This should convert the model to payload and then return the bytes
+	// Payload should contain customer contacts and dimensions as well
+	return model.ID.Bytes(), nil
+
+}
+
 // assemblePaymentRequestPayload assembles the payload and returns the JSON in bytes
 func assemblePaymentRequestPayload(db *pop.Connection, updatedObjectID uuid.UUID) ([]byte, error) {
 	// ASSEMBLE PAYLOAD
@@ -149,6 +168,8 @@ func objectEventHandler(event *Event, modelBeingUpdated interface{}) (bool, erro
 		payloadArray, err = assemblePaymentRequestPayload(db, event.UpdatedObjectID)
 	case models.MTOShipment:
 		payloadArray, err = assembleMTOShipmentPayload(db, event.UpdatedObjectID)
+	case models.MTOServiceItem:
+		payloadArray, err = assembleMTOServiceItemPayload(db, event.UpdatedObjectID)
 	default:
 		event.logger.Error("event.NotificationEventHandler: Unknown logical object being updated.")
 		err = services.NewEventError(fmt.Sprintf("No notification handler for event %s", event.EventKey), nil)


### PR DESCRIPTION
## Description

Please see tickets [MB-3438](https://dp3.atlassian.net/browse/MB-3438) / [MB-4223](https://dp3.atlassian.net/browse/MB-4223) for full info 

Creates a notification handler for mtoshipment events. 
Note that I combined the paymentRequest and MTOshipment handlers into a default handler and only broke out the assemblePayload function. Originally i had thought we would break out the whole handler, but since that was only needed for future work, I decided it was best to have simpler, less duplicated code today.

Test created but cannot fully pass until successful creation of notification. Currently it passes but expects an error. 

