### PR TITLE
[MB-4262] Create Way to Handle to Build Payment Service Item Lines Depending on the Type of Service Item

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -364,7 +364,7 @@ func (g GHCPaymentRequestInvoiceGenerator) fetchPaymentServiceItemParam(serviceI
 	return paymentServiceItemParam, nil
 }
 
-func (g GHCPaymentRequestInvoiceGenerator) getDefaultPaymentParamsForServiceItem(serviceItem models.PaymentServiceItem) (weightFloat float64, distanceFloat float64, err error) {
+func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (weightFloat float64, distanceFloat float64, err error) {
 	// TODO: update to have a case statement as different service items may or may not have weight
 	// and the distance key can differ (zip3 v zip5, and distances for SIT)
 	weight, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNameWeightBilledActual)
@@ -405,16 +405,15 @@ func (g GHCPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 			// https://dp3.atlassian.net/browse/MB-3718
 			ReferenceIdentification: serviceItem.ID.String(),
 		}
-
 		// TODO: add another n9 for SIT
-		// TODO: add a L5 segment/definition
 
+		// Determine the correct params to use based off of the particular service item
 		switch serviceItem.MTOServiceItem.ReService {
 		default:
 			var err error
-			weightFloat, distanceFloat, err = g.getDefaultPaymentParamsForServiceItem(serviceItem)
+			weightFloat, distanceFloat, err = g.getPaymentParamsForDefaultServiceItems(serviceItem)
 			if err != nil {
-				return segments, fmt.Errorf("Could not parse weight for PaymentServiceItem %w", err)
+				return segments, fmt.Errorf("Could not parse weight or distance for PaymentServiceItem %w", err)
 			}
 
 		}
@@ -428,6 +427,7 @@ func (g GHCPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 			WeightUnitCode:         "L",
 		}
 
+		// TODO: add a L5 segment/definition
 		segments = append(segments, &hlSegment, &n9Segment, &l0Segment)
 	}
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -364,14 +364,14 @@ func (g GHCPaymentRequestInvoiceGenerator) fetchPaymentServiceItemParam(serviceI
 	return paymentServiceItemParam, nil
 }
 
-func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (weightFloat float64, distanceFloat float64, err error) {
+func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (paramWeightFloat float64, paramDistanceFloat float64, err error) {
 	// TODO: update to have a case statement as different service items may or may not have weight
 	// and the distance key can differ (zip3 v zip5, and distances for SIT)
 	weight, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNameWeightBilledActual)
 	if err != nil {
 		return 0, 0, err
 	}
-	weightFloat2, err := strconv.ParseFloat(weight.Value, 64)
+	weightFloat, err := strconv.ParseFloat(weight.Value, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Could not parse weight for PaymentServiceItem %s: %w", serviceItem.ID, err)
 	}
@@ -379,11 +379,11 @@ func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItem
 	if err != nil {
 		return 0, 0, err
 	}
-	distanceFloat2, err := strconv.ParseFloat(distance.Value, 64)
+	distanceFloat, err := strconv.ParseFloat(distance.Value, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Could not parse Distance Zip3 for PaymentServiceItem %s: %w", serviceItem.ID, err)
 	}
-	return weightFloat2, distanceFloat2, nil
+	return weightFloat, distanceFloat, nil
 }
 
 func (g GHCPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(paymentServiceItems models.PaymentServiceItems) ([]edisegment.Segment, error) {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -364,7 +364,7 @@ func (g GHCPaymentRequestInvoiceGenerator) fetchPaymentServiceItemParam(serviceI
 	return paymentServiceItemParam, nil
 }
 
-func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (paramWeightFloat float64, paramDistanceFloat float64, err error) {
+func (g GHCPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (float64, float64, error) {
 	// TODO: update to have a case statement as different service items may or may not have weight
 	// and the distance key can differ (zip3 v zip5, and distances for SIT)
 	weight, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNameWeightBilledActual)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -387,6 +387,7 @@ func (g GHCPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 		// TODO: add another n9 for SIT
 		// TODO: add a L5 segment/definition
 
+		// abstract out to create default case
 		var weight models.PaymentServiceItemParam
 		// TODO: update to have a case statement as different service items may or may not have weight
 		// and the distance key can differ (zip3 v zip5, and distances for SIT)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -416,19 +416,20 @@ func (g GHCPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				return segments, fmt.Errorf("Could not parse weight or distance for PaymentServiceItem %w", err)
 			}
 
+			l0Segment := edisegment.L0{
+				LadingLineItemNumber:   hierarchicalIDNumber,
+				BilledRatedAsQuantity:  distanceFloat,
+				BilledRatedAsQualifier: "DM",
+				Weight:                 weightFloat,
+				WeightQualifier:        "B",
+				WeightUnitCode:         "L",
+			}
+
+			// TODO: add a L5 segment/definition
+			segments = append(segments, &hlSegment, &n9Segment, &l0Segment)
+
 		}
 
-		l0Segment := edisegment.L0{
-			LadingLineItemNumber:   hierarchicalIDNumber,
-			BilledRatedAsQuantity:  distanceFloat,
-			BilledRatedAsQualifier: "DM",
-			Weight:                 weightFloat,
-			WeightQualifier:        "B",
-			WeightUnitCode:         "L",
-		}
-
-		// TODO: add a L5 segment/definition
-		segments = append(segments, &hlSegment, &n9Segment, &l0Segment)
 	}
 
 	return segments, nil


### PR DESCRIPTION
## Description

This PR is for a subtask to create the switch statement and function needed so that the generate EDI code can generate payment service item related lines depending on a particular service item.

This PR created the code to setup the switch statement so that subsequent payment service types can be added in. It created a default case that works for Domestic Linehaul and likely other service item types. Future work is happening with 
MB-4261 and MB-4260 to create boilerplate for segments that are needed to complete linehaul and other service items. 

To test this story follow the steps below and ensure that the L0 line is still be generated as expected

## Setup & Review

1. Run your server `make server_run`.
2. Create a payment request with a Domestic Linehaul service item. Create a file called `create_payment_request.json` in the project root and paste in the JSON payload provided below:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      },
    ]
  }
}
```

2. Use the Prime API Client to create the payment request and return the payment request number by running the command below:

```sh
prime-api-client --insecure create-payment-request --filename  create_payment_request.json| jq '.paymentRequestNumber'
```
3. Use the CLI utility to generate the EDI858 and view it in your terminal. Remember to pass the payment request number of the payment request you just created.

```sh
go run ./cmd/generate-payment-request-edi/ --payment-request-number [$paymentRequestNumber]
```

4. Check that the output matches this sample expected output:

```txt
ISA*00*0084182369*00*_   _*ZZ*GOVDPIBS*12*8004171844*20200911*1523*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*20200911*1523*100001251*X*004010
ST*858*0001
BX*00*J*PP*4659-6176*TRUS**4
N9*CN*4659-6176-1**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*86*2020-09-11*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
N1*SF*dbzwwCCg6o*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
HL*1**|
N9*PO*38a8822e-2bd9-464a-ac81-df83ccf5341d**
L0*1*373.000*DM*1349.000*B******L
SE*18*0001
GE*1*100001251
IEA*1*100001272
```


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [JIRA Subtask MB-4262](https://dp3.atlassian.net/browse/MB-4262)


