### PR TITLE
[MB-4260] Create L5 Segment

### DIFF
--- a/pkg/edi/segment/l5.go
+++ b/pkg/edi/segment/l5.go
@@ -1,0 +1,47 @@
+package edisegment
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// L5 represents the L5 EDI segment
+type L5 struct {
+	LadingLineItemNumber   int    `validate:"eq=1"`
+	LadingDescription      string `validate:"eq=DLH"`
+	CommodityCode          string `validate:"required_with=CommodityCodeQualifier,omitempty,gt=0,lt=11"`
+	CommodityCodeQualifier string `validate:"required_with=CommodityCode,omitempty,eq=D"`
+}
+
+// StringArray converts L5 to an array of strings
+func (s *L5) StringArray() []string {
+
+	return []string{
+		"L5",
+		strconv.Itoa(s.LadingLineItemNumber),
+		s.LadingDescription,
+		s.CommodityCode,
+		s.CommodityCodeQualifier,
+		// TODO: will need to fill in the blank fields if using Marks and Numbers to identify shipments
+		"",
+		"",
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the L5 struct
+func (s *L5) Parse(parts []string) error {
+	numElements := len(parts)
+	if numElements != 4 && numElements != 6 {
+		return fmt.Errorf("L5: Wrong number of elements, expected 4 or 6, got %d", numElements)
+	}
+
+	var err error
+	s.LadingLineItemNumber, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return err
+	}
+	s.LadingDescription = parts[1]
+	s.CommodityCode = parts[2]
+	s.CommodityCodeQualifier = parts[3]
+	return nil
+}

--- a/pkg/edi/segment/l5.go
+++ b/pkg/edi/segment/l5.go
@@ -7,7 +7,7 @@ import (
 
 // L5 represents the L5 EDI segment
 type L5 struct {
-	LadingLineItemNumber   int    `validate:"eq=1"`
+	LadingLineItemNumber   int    `validate:"min=1,max=999"`
 	LadingDescription      string `validate:"eq=DLH - Domestic Line Haul"`
 	CommodityCode          string `validate:"required_with=CommodityCodeQualifier,omitempty,gt=0,lt=11"`
 	CommodityCodeQualifier string `validate:"required_with=CommodityCode,omitempty,eq=D"`

--- a/pkg/edi/segment/l5.go
+++ b/pkg/edi/segment/l5.go
@@ -8,7 +8,7 @@ import (
 // L5 represents the L5 EDI segment
 type L5 struct {
 	LadingLineItemNumber   int    `validate:"eq=1"`
-	LadingDescription      string `validate:"eq=DLH"`
+	LadingDescription      string `validate:"eq=DLH - Domestic Line Haul"`
 	CommodityCode          string `validate:"required_with=CommodityCodeQualifier,omitempty,gt=0,lt=11"`
 	CommodityCodeQualifier string `validate:"required_with=CommodityCode,omitempty,eq=D"`
 }
@@ -31,7 +31,7 @@ func (s *L5) StringArray() []string {
 // Parse parses an X12 string that's split into an array into the L5 struct
 func (s *L5) Parse(parts []string) error {
 	numElements := len(parts)
-	if numElements != 4 && numElements != 6 {
+	if numElements != 2 && numElements != 4 && numElements != 6 {
 		return fmt.Errorf("L5: Wrong number of elements, expected 4 or 6, got %d", numElements)
 	}
 

--- a/pkg/edi/segment/l5_test.go
+++ b/pkg/edi/segment/l5_test.go
@@ -1,0 +1,54 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateL5() {
+	validL5 := L5{
+		LadingLineItemNumber:   1,
+		LadingDescription:      "DLH",
+		CommodityCode:          "CCode",
+		CommodityCodeQualifier: "D",
+	}
+
+	suite.T().Run("validate success", func(t *testing.T) {
+		err := suite.validator.Struct(validL5)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure of lading description", func(t *testing.T) {
+		l5 := L5{
+			LadingLineItemNumber: 1,
+			LadingDescription:    "DOP",
+		}
+
+		err := suite.validator.Struct(l5)
+		suite.ValidateError(err, "LadingDescription", "eq")
+		suite.ValidateErrorLen(err, 1)
+	})
+
+	suite.T().Run("validate failure of missing CommodityCodeQualifier", func(t *testing.T) {
+		l5 := L5{
+			LadingLineItemNumber: 1,
+			LadingDescription:    "DLH",
+			CommodityCode:        "CCode",
+		}
+
+		err := suite.validator.Struct(l5)
+		suite.ValidateError(err, "CommodityCodeQualifier", "required_with")
+		suite.ValidateErrorLen(err, 1)
+	})
+
+	suite.T().Run("validate failure of missing CommodityCode ", func(t *testing.T) {
+		l5 := L5{
+			LadingLineItemNumber:   1,
+			LadingDescription:      "DLH",
+			CommodityCodeQualifier: "D",
+		}
+
+		err := suite.validator.Struct(l5)
+		suite.ValidateError(err, "CommodityCode", "required_with")
+		suite.ValidateErrorLen(err, 1)
+	})
+}

--- a/pkg/edi/segment/l5_test.go
+++ b/pkg/edi/segment/l5_test.go
@@ -7,7 +7,7 @@ import (
 func (suite *SegmentSuite) TestValidateL5() {
 	validL5 := L5{
 		LadingLineItemNumber:   1,
-		LadingDescription:      "DLH",
+		LadingDescription:      "DLH - Domestic Line Haul",
 		CommodityCode:          "CCode",
 		CommodityCodeQualifier: "D",
 	}
@@ -31,7 +31,7 @@ func (suite *SegmentSuite) TestValidateL5() {
 	suite.T().Run("validate failure of missing CommodityCodeQualifier", func(t *testing.T) {
 		l5 := L5{
 			LadingLineItemNumber: 1,
-			LadingDescription:    "DLH",
+			LadingDescription:    "DLH - Domestic Line Haul",
 			CommodityCode:        "CCode",
 		}
 
@@ -43,7 +43,7 @@ func (suite *SegmentSuite) TestValidateL5() {
 	suite.T().Run("validate failure of missing CommodityCode ", func(t *testing.T) {
 		l5 := L5{
 			LadingLineItemNumber:   1,
-			LadingDescription:      "DLH",
+			LadingDescription:      "DLH - Domestic Line Haul",
 			CommodityCodeQualifier: "D",
 		}
 


### PR DESCRIPTION
## Description

Garrett and I paired to create this PR that add the L5 segment

## Reviewer Notes

Please check the validations and that it's okay to omit the ProductID and ProductIDQualifier fields described in the [pdf](https://docs.google.com/document/d/1DG6ZvQh48QHSAGALoQmYJWgjY9RfikvVLGGG4Dk74lI/edit) as:
**Optional L506 87 Marks and Numbers – Product ID** X AN 1/48 Marks and numbers used to identify a shipment or parts of a shipment 
• The L506 data element is used to transmit the Product ID of a Line  
Item. If L506 is not included, then the Product ID will be defaulted to  
the first 25 characters of the value contained in the L502 Lading  
Description. 
• Although ANSI allows a maximum of 48 characters for this data  
element, Syncada will capture only the first 25 characters. 

**Optional L507 88 Marks and Numbers Qualifier – Product ID  Qualifier** 
O ID 1/2 

Code specifying the application or source of Marks and Numbers (87) 
Expected, but not limited to: 
SM Shipper Assigned 
• Refer to 004010 Data Element Dictionary for acceptable code values. 
• This data element is required if L506 is submitted. 
• This data element is not mapped to the Syncada application
## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
