### PR TITLE
[MB-4208] Adds testdatagen function for MTOAgent.

### DIFF
--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -30,13 +30,14 @@ func (suite *ModelSuite) TestMTOAgentValidation() {
 	})
 }
 
-func (suite *ModelSuite) TestMTOAgentTestdataGen() {
+func (suite *ModelSuite) Test_MTOAgentTestdataGen() {
 	//test with no assertions
 	MTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{})
 	suite.Equal(MTOAgent.FirstName, swag.String("Jason"))
 	suite.Equal(MTOAgent.LastName, swag.String("Ash"))
 	suite.Equal(MTOAgent.Email, swag.String("jason.ash@gmail.com"))
 	suite.Equal(MTOAgent.Phone, swag.String("2025559301"))
+	suite.Equal(MTOAgent.MTOAgentType, models.MTOAgentReleasing)
 	// test with assertions
 	someFirstName := "Some other agent name"
 	otherMTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -33,9 +33,9 @@ func (suite *ModelSuite) TestMTOAgentValidation() {
 func (suite *ModelSuite) TestMTOAgentTestdataGen() {
 	//test with no assertions
 	MTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{})
-	suite.Equal(MTOAgent.FirstName, swag.String("Agent First Name"))
-	suite.Equal(MTOAgent.LastName, swag.String("Agent Last Name"))
-	suite.Equal(MTOAgent.Email, swag.String("agent.email@ghc.gov"))
+	suite.Equal(MTOAgent.FirstName, swag.String("Jason"))
+	suite.Equal(MTOAgent.LastName, swag.String("Ash"))
+	suite.Equal(MTOAgent.Email, swag.String("jason.ash@gmail.com"))
 	suite.Equal(MTOAgent.Phone, swag.String("2025559301"))
 	// test with assertions
 	someFirstName := "Some other agent name"

--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -3,6 +3,8 @@ package models_test
 import (
 	"testing"
 
+	"github.com/transcom/mymove/pkg/testdatagen"
+
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
@@ -26,4 +28,21 @@ func (suite *ModelSuite) TestMTOAgentValidation() {
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validMTOAgent, expErrors)
 	})
+}
+
+func (suite *ModelSuite) TestMTOAgentTestdataGen() {
+	//test with no assertions
+	MTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{})
+	suite.Equal(MTOAgent.FirstName, swag.String("Agent First Name"))
+	suite.Equal(MTOAgent.LastName, swag.String("Agent Last Name"))
+	suite.Equal(MTOAgent.Email, swag.String("agent.email@ghc.gov"))
+	suite.Equal(MTOAgent.Phone, swag.String("2025559301"))
+	// test with assertions
+	someFirstName := "Some other agent name"
+	otherMTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
+		MTOAgent: models.MTOAgent{
+			FirstName: &someFirstName,
+		},
+	})
+	suite.Equal(otherMTOAgent.FirstName, swag.String("Some other agent name"))
 }

--- a/pkg/testdatagen/make_mto_agent.go
+++ b/pkg/testdatagen/make_mto_agent.go
@@ -17,9 +17,9 @@ func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 		mtoShipmentID = mtoShipment.ID
 	}
 
-	firstName := "Agent First Name"
-	lastName := "Agent Last Name"
-	email := "agent.email@ghc.gov"
+	firstName := "Jason"
+	lastName := "Ash"
+	email := "jason.ash@gmail.com"
 	phone := "2025559301"
 
 	mtoAgentType := models.MTOAgentReleasing

--- a/pkg/testdatagen/make_mto_agent.go
+++ b/pkg/testdatagen/make_mto_agent.go
@@ -10,7 +10,7 @@ import (
 // MakeMTOAgent creates a single MTOAgent and associated MTOShipment
 func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 	var mtoShipmentID uuid.UUID
-	mtoShipment := assertions.MTOAgent.MTOShipment
+	mtoShipment := assertions.MTOShipment
 
 	if isZeroUUID(assertions.MTOAgent.MTOShipmentID) {
 		mtoShipment = MakeMTOShipment(db, assertions)
@@ -22,11 +22,6 @@ func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 	email := "jason.ash@gmail.com"
 	phone := "2025559301"
 
-	mtoAgentType := models.MTOAgentReleasing
-	if string(assertions.MTOAgent.MTOAgentType) != "" {
-		mtoAgentType = assertions.MTOAgent.MTOAgentType
-	}
-
 	MTOAgent := models.MTOAgent{
 		MTOShipment:   mtoShipment,
 		MTOShipmentID: mtoShipmentID,
@@ -34,7 +29,7 @@ func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 		LastName:      &lastName,
 		Email:         &email,
 		Phone:         &phone,
-		MTOAgentType:  mtoAgentType,
+		MTOAgentType:  models.MTOAgentReleasing,
 	}
 
 	mergeModels(&MTOAgent, assertions.MTOAgent)


### PR DESCRIPTION
## Description

Adds testdatagen functions for `MTOAgent` -  `MakeMTOAgent` and `MakeDefaultMTOAgent`. 

## Reviewer Notes

Inline comments. 

## Setup

Run new unit test to ensure nothing breaks.
```
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
mylaptop ~ %: go test ./pkg/models --testify.m "TestMTOAgentTestdataGen" -v 
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story MB-4208](https://dp3.atlassian.net/browse/MB-4208) for this change
