### PR TITLE
Removes healthcheck since DPS went bye bye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1111,7 +1111,7 @@ jobs:
       - aws_vars_legacy
       - deploy_app_client_tls_steps:
           compare_host: '' # leave blank since we want experimental to be able to roll back
-          health_check_hosts: gex.experimental.move.mil,dps.experimental.move.mil,orders.experimental.move.mil
+          health_check_hosts: gex.experimental.move.mil,orders.experimental.move.mil
           ecr_env: legacy
 
   # `deploy_exp_migrations` deploys migrations to the exp environment
@@ -1154,7 +1154,7 @@ jobs:
       - aws_vars_exp
       - deploy_app_client_tls_steps:
           compare_host: '' # leave blank since we want exp to be able to roll back
-          health_check_hosts: gex.exp.move.mil,dps.exp.move.mil,orders.exp.move.mil
+          health_check_hosts: gex.exp.move.mil,orders.exp.move.mil
           ecr_env: exp
 
   check_circle_against_staging_sha:
@@ -1206,7 +1206,7 @@ jobs:
       - aws_vars_legacy
       - deploy_app_client_tls_steps:
           compare_host: gex.staging.move.mil
-          health_check_hosts: gex.staging.move.mil,dps.staging.move.mil,orders.staging.move.mil
+          health_check_hosts: gex.staging.move.mil,orders.staging.move.mil
           ecr_env: legacy
 
   check_circle_against_stg_sha:
@@ -1258,7 +1258,7 @@ jobs:
       - aws_vars_stg
       - deploy_app_client_tls_steps:
           compare_host: gex.stg.move.mil
-          health_check_hosts: gex.stg.move.mil,dps.stg.move.mil,orders.stg.move.mil
+          health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
           ecr_env: stg
 
   deploy_storybook_dp3:
@@ -1309,7 +1309,7 @@ jobs:
       - aws_vars_prd
       - deploy_app_client_tls_steps:
           compare_host: gex.move.mil
-          health_check_hosts: gex.move.mil,dps.move.mil,orders.move.mil
+          health_check_hosts: gex.move.mil,orders.move.mil
           ecr_env: prd
 
 workflows:


### PR DESCRIPTION
DPS got CNAMED to another entity. But we health check it, which now fails. This removes the health check.