### PR TITLE
MB-4235 Add UpdateMTOAgentHandler

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -502,6 +502,9 @@ func init() {
           },
           "500": {
             "$ref": "#/responses/ServerError"
+          },
+          "501": {
+            "$ref": "#/responses/NotImplemented"
           }
         }
       }
@@ -2104,6 +2107,12 @@ func init() {
         "$ref": "#/definitions/ClientError"
       }
     },
+    "NotImplemented": {
+      "description": "The requested feature is still in development.",
+      "schema": {
+        "$ref": "#/definitions/Error"
+      }
+    },
     "PermissionDenied": {
       "description": "The request was denied.",
       "schema": {
@@ -2747,6 +2756,12 @@ func init() {
           },
           "500": {
             "description": "A server error occurred.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "501": {
+            "description": "The requested feature is still in development.",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -4380,6 +4395,12 @@ func init() {
       "description": "The requested resource wasn't found.",
       "schema": {
         "$ref": "#/definitions/ClientError"
+      }
+    },
+    "NotImplemented": {
+      "description": "The requested feature is still in development.",
+      "schema": {
+        "$ref": "#/definitions/Error"
       }
     },
     "PermissionDenied": {

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
@@ -408,3 +408,47 @@ func (o *UpdateMTOAgentInternalServerError) WriteResponse(rw http.ResponseWriter
 		}
 	}
 }
+
+// UpdateMTOAgentNotImplementedCode is the HTTP code returned for type UpdateMTOAgentNotImplemented
+const UpdateMTOAgentNotImplementedCode int = 501
+
+/*UpdateMTOAgentNotImplemented The requested feature is still in development.
+
+swagger:response updateMTOAgentNotImplemented
+*/
+type UpdateMTOAgentNotImplemented struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *primemessages.Error `json:"body,omitempty"`
+}
+
+// NewUpdateMTOAgentNotImplemented creates UpdateMTOAgentNotImplemented with default headers values
+func NewUpdateMTOAgentNotImplemented() *UpdateMTOAgentNotImplemented {
+
+	return &UpdateMTOAgentNotImplemented{}
+}
+
+// WithPayload adds the payload to the update m t o agent not implemented response
+func (o *UpdateMTOAgentNotImplemented) WithPayload(payload *primemessages.Error) *UpdateMTOAgentNotImplemented {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update m t o agent not implemented response
+func (o *UpdateMTOAgentNotImplemented) SetPayload(payload *primemessages.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateMTOAgentNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(501)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
@@ -78,6 +78,12 @@ func (o *UpdateMTOAgentReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
+	case 501:
+		result := NewUpdateMTOAgentNotImplemented()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
@@ -370,6 +376,39 @@ func (o *UpdateMTOAgentInternalServerError) GetPayload() *primemessages.Error {
 }
 
 func (o *UpdateMTOAgentInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(primemessages.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateMTOAgentNotImplemented creates a UpdateMTOAgentNotImplemented with default headers values
+func NewUpdateMTOAgentNotImplemented() *UpdateMTOAgentNotImplemented {
+	return &UpdateMTOAgentNotImplemented{}
+}
+
+/*UpdateMTOAgentNotImplemented handles this case with default header values.
+
+The requested feature is still in development.
+*/
+type UpdateMTOAgentNotImplemented struct {
+	Payload *primemessages.Error
+}
+
+func (o *UpdateMTOAgentNotImplemented) Error() string {
+	return fmt.Sprintf("[PUT /mto-shipments/{mtoShipmentID}/agents/{agentID}][%d] updateMTOAgentNotImplemented  %+v", 501, o.Payload)
+}
+
+func (o *UpdateMTOAgentNotImplemented) GetPayload() *primemessages.Error {
+	return o.Payload
+}
+
+func (o *UpdateMTOAgentNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(primemessages.Error)
 

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -59,6 +59,9 @@ const InternalServerErrDetail string = "An internal server error has occurred"
 // NotImplementedErrMessage indicates an endpoint has not been implemented
 const NotImplementedErrMessage string = "Not Implemented"
 
+// NotImplementedErrDetail indicates an endpoint has not been implemented
+const NotImplementedErrDetail string = "This feature is in development"
+
 // UnsupportedMediaTypeErrMessage indicates the server does not accept the media type sent
 const UnsupportedMediaTypeErrMessage string = "Unsupported Media Type"
 

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -83,5 +83,10 @@ func NewPrimeAPIHandler(context handlers.HandlerContext) http.Handler {
 		mtoshipment.NewMTOShipmentAddressUpdater(context.DB()),
 	}
 
+	primeAPI.MtoShipmentUpdateMTOAgentHandler = UpdateMTOAgentHandler{
+		context,
+		// TODO add updater
+	}
+
 	return primeAPI.Serve(nil)
 }

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -16,7 +16,6 @@ type UpdateMTOAgentHandler struct {
 
 // Handle updates an address on a shipment
 func (h UpdateMTOAgentHandler) Handle(params mtoshipmentops.UpdateMTOAgentParams) middleware.Responder {
-	msg := handlers.NotImplementedErrMessage
 	return mtoshipmentops.NewUpdateMTOAgentNotImplemented().WithPayload(
-		payloads.InternalServerError(&msg, h.GetTraceID()))
+		payloads.NotImplementedError(nil, h.GetTraceID()))
 }

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -1,0 +1,22 @@
+package primeapi
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+
+	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+)
+
+// UpdateMTOAgentHandler is the handler to update an address
+type UpdateMTOAgentHandler struct {
+	handlers.HandlerContext
+	//MTOAgentUpdater services.MTOAgentUpdater TODO
+}
+
+// Handle updates an address on a shipment
+func (h UpdateMTOAgentHandler) Handle(params mtoshipmentops.UpdateMTOAgentParams) middleware.Responder {
+	msg := handlers.NotImplementedErrMessage
+	return mtoshipmentops.NewUpdateMTOAgentNotImplemented().WithPayload(
+		payloads.InternalServerError(&msg, h.GetTraceID()))
+}

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -1,0 +1,45 @@
+package primeapi
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/transcom/mymove/pkg/etag"
+	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
+	agent := models.MTOAgent{
+		MTOAgentType: models.MTOAgentReleasing,
+	}
+
+	// Create handler
+	handler := UpdateMTOAgentHandler{
+		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+		//mtoshipment.NewMTOAgentUpdater(suite.DB()), TODO
+	}
+
+	suite.T().Run("NotImplemented response", func(t *testing.T) {
+		payload := payloads.MTOAgent(&agent)
+		req := httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s/agents/%s", agent.MTOShipmentID.String(), agent.ID.String()), nil)
+		params := mtoshipmentops.UpdateMTOAgentParams{
+			HTTPRequest:   req,
+			AgentID:       *handlers.FmtUUID(agent.ID),
+			MtoShipmentID: *handlers.FmtUUID(agent.MTOShipmentID),
+			Body:          payload,
+			IfMatch:       etag.GenerateEtag(agent.UpdatedAt),
+		}
+		// Run swagger validations
+		suite.NoError(params.Body.Validate(strfmt.Default))
+
+		// Run handler and check response
+		response := handler.Handle(params)
+		suite.IsType(&mtoshipmentops.UpdateMTOAgentNotImplemented{}, response)
+	})
+}

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -487,6 +487,20 @@ func InternalServerError(detail *string, traceID uuid.UUID) *primemessages.Error
 	return &payload
 }
 
+// NotImplementedError describes errors for endpoints and functions that haven't been fully developed yet.
+// If detail is nil, string defaults to "This feature is in development"
+func NotImplementedError(detail *string, traceID uuid.UUID) *primemessages.Error {
+	payload := primemessages.Error{
+		Title:    handlers.FmtString(handlers.NotImplementedErrMessage),
+		Detail:   handlers.FmtString(handlers.NotImplementedErrDetail),
+		Instance: strfmt.UUID(traceID.String()),
+	}
+	if detail != nil {
+		payload.Detail = detail
+	}
+	return &payload
+}
+
 // ValidationError describes validation errors from the model or properties
 func ValidationError(detail string, instance uuid.UUID, validationErrors *validate.Errors) *primemessages.ValidationError {
 	payload := &primemessages.ValidationError{

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -354,6 +354,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+        '501':
+          $ref: '#/responses/NotImplemented'
   '/mto-service-items':
     post:
       summary: createMTOServiceItem
@@ -1631,6 +1633,10 @@ responses:
       $ref: '#/definitions/ClientError'
   ServerError:
     description: A server error occurred.
+    schema:
+      $ref: '#/definitions/Error'
+  NotImplemented:
+    description: The requested feature is still in development.
     schema:
       $ref: '#/definitions/Error'
   PreconditionFailed:


### PR DESCRIPTION
## Description

This change adds a stub handler for the `updateMTOAgent` endpoint that returns a 501 "Not Implemented" response code. It also adds a small test that verifies the 501 response. 

*Note:* The MTO Agent updater object will be added to this handler in a later ticket.

## Setup

Follow [these instructions](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman) to test the endpoint using Postman (or a similar REST API client).

First, run the server:

```sh
make server_run
```

Grab a bogus UUID or two (such as the nil UUID `00000000-0000-0000-0000-000000000000`) to use in the path. Then you may either make up a fake MTO Agent body to test or send an empty body to verify that you get a 501 "Not Implemented" response when you hit this endpoint. 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4235) for this change.
* [Prime API Documentation](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman)
