### PR TITLE
Yaml linting fixes for prime and support yaml, no effective code change

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -83,7 +83,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/post-counseling-info": {
       "patch": {
-        "description": "Updates move task order after the counseling stage. Allows update of fields ppmType and ppmEstimatedWeight.",
+        "description": "### Functionality\nThis endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.\n\nPPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).\n",
         "consumes": [
           "application/json"
         ],
@@ -190,7 +190,6 @@ func init() {
             "name": "body",
             "in": "body",
             "schema": {
-              "description": "This may be a MTOServiceItemBasic, MTOServiceItemDOFSIT or etc.",
               "$ref": "#/definitions/MTOServiceItem"
             }
           }
@@ -346,7 +345,7 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}/addresses/{addressID}": {
       "put": {
-        "description": "### Functionality\nThis endpoint is used to **update** the addresses on an MTO Shipment. The address details completely replace the original, except for the UUID.\nTherefore a complete address should be sent in the request.\n\nThis endpoint **cannot create** an address.\nTo create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.\n\n### Errors:\nThe address must be associated with the mtoShipment passed in the url.\nIn other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.\nIf it is not, caller will receive a **Conflict** Error.\n\nThe mtoShipment should be associated with an MTO that is available to prime.\nIf the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.\n",
+        "description": "### Functionality\nThis endpoint is used to **update** the addresses on an MTO Shipment. The address details completely replace the original, except for the UUID.\nTherefore a complete address should be sent in the request.\n\nThis endpoint **cannot create** an address.\nTo create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.\n\n### Errors\nThe address must be associated with the mtoShipment passed in the url.\nIn other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.\nIf it is not, caller will receive a **Conflict** Error.\n\nThe mtoShipment should be associated with an MTO that is available to prime.\nIf the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.\n",
         "consumes": [
           "application/json"
         ],
@@ -565,7 +564,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/uploads": {
       "post": {
-        "description": "Uploads represent a single digital file, such as a JPEG, PNG, or PDF.",
+        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
         "consumes": [
           "multipart/form-data"
         ],
@@ -1254,7 +1253,7 @@ func init() {
               "type": "string",
               "format": "zip",
               "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
-              "example": 90210
+              "example": "90210"
             },
             "reServiceCode": {
               "description": "Service code allowed for this model type.",
@@ -1810,7 +1809,7 @@ func init() {
         },
         "value": {
           "type": "string",
-          "example": 3025
+          "example": "3025"
         }
       }
     },
@@ -2128,7 +2127,24 @@ func init() {
         "$ref": "#/definitions/ValidationError"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "moveTaskOrder"
+    },
+    {
+      "name": "mtoShipment"
+    },
+    {
+      "name": "paymentRequests"
+    },
+    {
+      "name": "uploads"
+    },
+    {
+      "name": "mtoServiceItem"
+    }
+  ]
 }`))
 	FlatSwaggerJSON = json.RawMessage([]byte(`{
   "schemes": [
@@ -2211,7 +2227,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/post-counseling-info": {
       "patch": {
-        "description": "Updates move task order after the counseling stage. Allows update of fields ppmType and ppmEstimatedWeight.",
+        "description": "### Functionality\nThis endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.\n\nPPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).\n",
         "consumes": [
           "application/json"
         ],
@@ -2336,7 +2352,6 @@ func init() {
             "name": "body",
             "in": "body",
             "schema": {
-              "description": "This may be a MTOServiceItemBasic, MTOServiceItemDOFSIT or etc.",
               "$ref": "#/definitions/MTOServiceItem"
             }
           }
@@ -2546,7 +2561,7 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}/addresses/{addressID}": {
       "put": {
-        "description": "### Functionality\nThis endpoint is used to **update** the addresses on an MTO Shipment. The address details completely replace the original, except for the UUID.\nTherefore a complete address should be sent in the request.\n\nThis endpoint **cannot create** an address.\nTo create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.\n\n### Errors:\nThe address must be associated with the mtoShipment passed in the url.\nIn other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.\nIf it is not, caller will receive a **Conflict** Error.\n\nThe mtoShipment should be associated with an MTO that is available to prime.\nIf the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.\n",
+        "description": "### Functionality\nThis endpoint is used to **update** the addresses on an MTO Shipment. The address details completely replace the original, except for the UUID.\nTherefore a complete address should be sent in the request.\n\nThis endpoint **cannot create** an address.\nTo create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.\n\n### Errors\nThe address must be associated with the mtoShipment passed in the url.\nIn other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.\nIf it is not, caller will receive a **Conflict** Error.\n\nThe mtoShipment should be associated with an MTO that is available to prime.\nIf the caller requests an update to an address, and the shipment is not on an available MTO, the caller will receive a **NotFound** Error.\n",
         "consumes": [
           "application/json"
         ],
@@ -2825,7 +2840,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/uploads": {
       "post": {
-        "description": "Uploads represent a single digital file, such as a JPEG, PNG, or PDF.",
+        "description": "### Functionality\nThis endpoint **uploads** a Proof of Service document for a PaymentRequest.\n\nThe PaymentRequest should already exist.\n\nPaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.\n",
         "consumes": [
           "multipart/form-data"
         ],
@@ -3532,7 +3547,7 @@ func init() {
               "type": "string",
               "format": "zip",
               "pattern": "^(\\d{5}([\\-]\\d{4})?)$",
-              "example": 90210
+              "example": "90210"
             },
             "reServiceCode": {
               "description": "Service code allowed for this model type.",
@@ -4088,7 +4103,7 @@ func init() {
         },
         "value": {
           "type": "string",
-          "example": 3025
+          "example": "3025"
         }
       }
     },
@@ -4406,6 +4421,23 @@ func init() {
         "$ref": "#/definitions/ValidationError"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "moveTaskOrder"
+    },
+    {
+      "name": "mtoShipment"
+    },
+    {
+      "name": "paymentRequests"
+    },
+    {
+      "name": "uploads"
+    },
+    {
+      "name": "mtoServiceItem"
+    }
+  ]
 }`))
 }

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
@@ -38,7 +38,11 @@ func NewUpdateMTOPostCounselingInformation(ctx *middleware.Context, handler Upda
 
 updateMTOPostCounselingInformation
 
-Updates move task order after the counseling stage. Allows update of fields ppmType and ppmEstimatedWeight.
+### Functionality
+This endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.
+
+PPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).
+
 
 */
 type UpdateMTOPostCounselingInformation struct {

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment_address.go
@@ -40,7 +40,7 @@ Therefore a complete address should be sent in the request.
 This endpoint **cannot create** an address.
 To create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.
 
-### Errors:
+### Errors
 The address must be associated with the mtoShipment passed in the url.
 In other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.
 If it is not, caller will receive a **Conflict** Error.

--- a/pkg/gen/primeapi/primeoperations/uploads/create_upload.go
+++ b/pkg/gen/primeapi/primeoperations/uploads/create_upload.go
@@ -33,7 +33,13 @@ func NewCreateUpload(ctx *middleware.Context, handler CreateUploadHandler) *Crea
 
 createUpload
 
-Uploads represent a single digital file, such as a JPEG, PNG, or PDF.
+### Functionality
+This endpoint **uploads** a Proof of Service document for a PaymentRequest.
+
+The PaymentRequest should already exist.
+
+PaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.
+
 
 */
 type CreateUpload struct {

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -66,7 +66,11 @@ func (a *Client) FetchMTOUpdates(params *FetchMTOUpdatesParams) (*FetchMTOUpdate
 /*
 UpdateMTOPostCounselingInformation updates m t o post counseling information
 
-Updates move task order after the counseling stage. Allows update of fields ppmType and ppmEstimatedWeight.
+### Functionality
+This endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.
+
+PPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).
+
 */
 func (a *Client) UpdateMTOPostCounselingInformation(params *UpdateMTOPostCounselingInformationParams) (*UpdateMTOPostCounselingInformationOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
@@ -179,7 +179,7 @@ Therefore a complete address should be sent in the request.
 This endpoint **cannot create** an address.
 To create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.
 
-### Errors:
+### Errors
 The address must be associated with the mtoShipment passed in the url.
 In other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.
 If it is not, caller will receive a **Conflict** Error.

--- a/pkg/gen/primeclient/uploads/uploads_client.go
+++ b/pkg/gen/primeclient/uploads/uploads_client.go
@@ -29,7 +29,13 @@ type Client struct {
 /*
 CreateUpload creates upload
 
-Uploads represent a single digital file, such as a JPEG, PNG, or PDF.
+### Functionality
+This endpoint **uploads** a Proof of Service document for a PaymentRequest.
+
+The PaymentRequest should already exist.
+
+PaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.
+
 */
 func (a *Client) CreateUpload(params *CreateUploadParams) (*CreateUploadCreated, error) {
 	// TODO: Validate the params before sending

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -38,7 +38,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move task orders. Provides all move task orders regardless of whether or not they have been made available to prime.\n",
+        "description": "### Functionality\nThis endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.\n\nIt will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.\n",
         "produces": [
           "application/json"
         ],
@@ -133,7 +133,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}": {
       "get": {
-        "description": "Gets an individual move task order by ID. \u003cbr /\u003e\n\u003cbr /\u003e\nThis is a support endpoint and will not be available in production.\n",
+        "description": "### Functionality\nThis endpoint gets an individual MoveTaskOrder by ID.\n\nIt will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.\n\nThis is a support endpoint and is not available in production.\n",
         "produces": [
           "application/json"
         ],
@@ -241,7 +241,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/payment-requests": {
       "get": {
-        "description": "Gets all payment requests for a given move task order\n",
+        "description": "### Functionality\n\nThis endpoint lists all PaymentRequests associated with a given MoveTaskOrder.\n\nThis is a support endpoint and is not available in production.\n",
         "produces": [
           "application/json"
         ],
@@ -362,7 +362,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/status": {
       "patch": {
-        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `. \u003cbr /\u003e\n\u003cbr /\u003e\nThis is a support endpoint and will not be available in production.\n",
+        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
         "consumes": [
           "application/json"
         ],
@@ -804,7 +804,6 @@ func init() {
           "title": "Agency customer is affilated with"
         },
         "currentAddress": {
-          "x-nullable": true,
           "$ref": "#/definitions/Address"
         },
         "dodID": {
@@ -1140,7 +1139,6 @@ func init() {
           "example": "handle with care"
         },
         "destinationAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "eTag": {
@@ -1158,7 +1156,6 @@ func init() {
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "pickupAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "primeActualWeight": {
@@ -1179,11 +1176,9 @@ func init() {
           "format": "date"
         },
         "secondaryDeliveryAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "secondaryPickupAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "shipmentType": {
@@ -1260,8 +1255,7 @@ func init() {
         "issueDate": {
           "description": "The date the orders were issued.",
           "type": "string",
-          "format": "date",
-          "example": "2020-01-01"
+          "format": "date"
         },
         "orderNumber": {
           "description": "ID of the military orders associated with this move.",
@@ -1289,8 +1283,7 @@ func init() {
         "reportByDate": {
           "description": "Date that the service member must report to the new DutyStation by.",
           "type": "string",
-          "format": "date",
-          "example": "2020-01-01"
+          "format": "date"
         },
         "status": {
           "$ref": "#/definitions/OrdersStatus"
@@ -1313,8 +1306,8 @@ func init() {
       }
     },
     "MoveStatus": {
+      "description": "Current status of this MoveTaskOrder",
       "type": "string",
-      "title": "Move status",
       "enum": [
         "DRAFT",
         "SUBMITTED",
@@ -1375,7 +1368,6 @@ func init() {
           "example": "ABC123"
         },
         "moveOrder": {
-          "description": "MoveOrder associated with this MoveTaskOrder.",
           "$ref": "#/definitions/MoveOrder"
         },
         "moveOrderID": {
@@ -1417,7 +1409,6 @@ func init() {
           "example": "1001-3456"
         },
         "status": {
-          "description": "move status",
           "$ref": "#/definitions/MoveStatus"
         },
         "updatedAt": {
@@ -1791,7 +1782,24 @@ func init() {
         "$ref": "#/definitions/ValidationError"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "moveTaskOrder"
+    },
+    {
+      "name": "paymentRequests"
+    },
+    {
+      "name": "mtoServiceItem"
+    },
+    {
+      "name": "mtoShipment"
+    },
+    {
+      "name": "webhook"
+    }
+  ]
 }`))
 	FlatSwaggerJSON = json.RawMessage([]byte(`{
   "schemes": [
@@ -1814,7 +1822,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move task orders. Provides all move task orders regardless of whether or not they have been made available to prime.\n",
+        "description": "### Functionality\nThis endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.\n\nIt will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.\n",
         "produces": [
           "application/json"
         ],
@@ -1942,7 +1950,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}": {
       "get": {
-        "description": "Gets an individual move task order by ID. \u003cbr /\u003e\n\u003cbr /\u003e\nThis is a support endpoint and will not be available in production.\n",
+        "description": "### Functionality\nThis endpoint gets an individual MoveTaskOrder by ID.\n\nIt will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.\n\nThis is a support endpoint and is not available in production.\n",
         "produces": [
           "application/json"
         ],
@@ -2086,7 +2094,7 @@ func init() {
     },
     "/move-task-orders/{moveTaskOrderID}/payment-requests": {
       "get": {
-        "description": "Gets all payment requests for a given move task order\n",
+        "description": "### Functionality\n\nThis endpoint lists all PaymentRequests associated with a given MoveTaskOrder.\n\nThis is a support endpoint and is not available in production.\n",
         "produces": [
           "application/json"
         ],
@@ -2246,7 +2254,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/status": {
       "patch": {
-        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `. \u003cbr /\u003e\n\u003cbr /\u003e\nThis is a support endpoint and will not be available in production.\n",
+        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
         "consumes": [
           "application/json"
         ],
@@ -2733,7 +2741,6 @@ func init() {
           "title": "Agency customer is affilated with"
         },
         "currentAddress": {
-          "x-nullable": true,
           "$ref": "#/definitions/Address"
         },
         "dodID": {
@@ -3069,7 +3076,6 @@ func init() {
           "example": "handle with care"
         },
         "destinationAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "eTag": {
@@ -3087,7 +3093,6 @@ func init() {
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "pickupAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "primeActualWeight": {
@@ -3108,11 +3113,9 @@ func init() {
           "format": "date"
         },
         "secondaryDeliveryAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "secondaryPickupAddress": {
-          "x-nullabe": true,
           "$ref": "#/definitions/Address"
         },
         "shipmentType": {
@@ -3189,8 +3192,7 @@ func init() {
         "issueDate": {
           "description": "The date the orders were issued.",
           "type": "string",
-          "format": "date",
-          "example": "2020-01-01"
+          "format": "date"
         },
         "orderNumber": {
           "description": "ID of the military orders associated with this move.",
@@ -3218,8 +3220,7 @@ func init() {
         "reportByDate": {
           "description": "Date that the service member must report to the new DutyStation by.",
           "type": "string",
-          "format": "date",
-          "example": "2020-01-01"
+          "format": "date"
         },
         "status": {
           "$ref": "#/definitions/OrdersStatus"
@@ -3242,8 +3243,8 @@ func init() {
       }
     },
     "MoveStatus": {
+      "description": "Current status of this MoveTaskOrder",
       "type": "string",
-      "title": "Move status",
       "enum": [
         "DRAFT",
         "SUBMITTED",
@@ -3304,7 +3305,6 @@ func init() {
           "example": "ABC123"
         },
         "moveOrder": {
-          "description": "MoveOrder associated with this MoveTaskOrder.",
           "$ref": "#/definitions/MoveOrder"
         },
         "moveOrderID": {
@@ -3346,7 +3346,6 @@ func init() {
           "example": "1001-3456"
         },
         "status": {
-          "description": "move status",
           "$ref": "#/definitions/MoveStatus"
         },
         "updatedAt": {
@@ -3720,6 +3719,23 @@ func init() {
         "$ref": "#/definitions/ValidationError"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "moveTaskOrder"
+    },
+    {
+      "name": "paymentRequests"
+    },
+    {
+      "name": "mtoServiceItem"
+    },
+    {
+      "name": "mtoShipment"
+    },
+    {
+      "name": "webhook"
+    }
+  ]
 }`))
 }

--- a/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/get_move_task_order.go
@@ -33,9 +33,12 @@ func NewGetMoveTaskOrder(ctx *middleware.Context, handler GetMoveTaskOrderHandle
 
 getMoveTaskOrder
 
-Gets an individual move task order by ID. <br />
-<br />
-This is a support endpoint and will not be available in production.
+### Functionality
+This endpoint gets an individual MoveTaskOrder by ID.
+
+It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
+This is a support endpoint and is not available in production.
 
 
 */

--- a/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os.go
+++ b/pkg/gen/supportapi/supportoperations/move_task_order/list_m_t_os.go
@@ -33,7 +33,10 @@ func NewListMTOs(ctx *middleware.Context, handler ListMTOsHandler) *ListMTOs {
 
 listMTOs
 
-Gets all move task orders. Provides all move task orders regardless of whether or not they have been made available to prime.
+### Functionality
+This endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.
+
+It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
 
 
 */

--- a/pkg/gen/supportapi/supportoperations/payment_requests/list_m_t_o_payment_requests.go
+++ b/pkg/gen/supportapi/supportoperations/payment_requests/list_m_t_o_payment_requests.go
@@ -33,7 +33,11 @@ func NewListMTOPaymentRequests(ctx *middleware.Context, handler ListMTOPaymentRe
 
 listMTOPaymentRequests
 
-Gets all payment requests for a given move task order
+### Functionality
+
+This endpoint lists all PaymentRequests associated with a given MoveTaskOrder.
+
+This is a support endpoint and is not available in production.
 
 
 */

--- a/pkg/gen/supportapi/supportoperations/payment_requests/update_payment_request_status.go
+++ b/pkg/gen/supportapi/supportoperations/payment_requests/update_payment_request_status.go
@@ -34,9 +34,10 @@ func NewUpdatePaymentRequestStatus(ctx *middleware.Context, handler UpdatePaymen
 updatePaymentRequestStatus
 
 Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.
-A status of REVIEWED can optionally have a `rejectionReason`. <br />
-<br />
-This is a support endpoint and will not be available in production.
+
+A status of REVIEWED can optionally have a `rejectionReason`.
+
+This is a support endpoint and is not available in production.
 
 
 */

--- a/pkg/gen/supportclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/supportclient/move_task_order/move_task_order_client.go
@@ -78,9 +78,12 @@ func (a *Client) CreateMoveTaskOrder(params *CreateMoveTaskOrderParams) (*Create
 /*
 GetMoveTaskOrder gets move task order
 
-Gets an individual move task order by ID. <br />
-<br />
-This is a support endpoint and will not be available in production.
+### Functionality
+This endpoint gets an individual MoveTaskOrder by ID.
+
+It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
+This is a support endpoint and is not available in production.
 
 */
 func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams) (*GetMoveTaskOrderOK, error) {
@@ -117,7 +120,10 @@ func (a *Client) GetMoveTaskOrder(params *GetMoveTaskOrderParams) (*GetMoveTaskO
 /*
 ListMTOs lists m t os
 
-Gets all move task orders. Provides all move task orders regardless of whether or not they have been made available to prime.
+### Functionality
+This endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.
+
+It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
 
 */
 func (a *Client) ListMTOs(params *ListMTOsParams) (*ListMTOsOK, error) {

--- a/pkg/gen/supportclient/payment_requests/payment_requests_client.go
+++ b/pkg/gen/supportclient/payment_requests/payment_requests_client.go
@@ -29,7 +29,11 @@ type Client struct {
 /*
 ListMTOPaymentRequests lists m t o payment requests
 
-Gets all payment requests for a given move task order
+### Functionality
+
+This endpoint lists all PaymentRequests associated with a given MoveTaskOrder.
+
+This is a support endpoint and is not available in production.
 
 */
 func (a *Client) ListMTOPaymentRequests(params *ListMTOPaymentRequestsParams) (*ListMTOPaymentRequestsOK, error) {
@@ -67,9 +71,10 @@ func (a *Client) ListMTOPaymentRequests(params *ListMTOPaymentRequestsParams) (*
 UpdatePaymentRequestStatus updates payment request status
 
 Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.
-A status of REVIEWED can optionally have a `rejectionReason`. <br />
-<br />
-This is a support endpoint and will not be available in production.
+
+A status of REVIEWED can optionally have a `rejectionReason`.
+
+This is a support endpoint and is not available in production.
 
 */
 func (a *Client) UpdatePaymentRequestStatus(params *UpdatePaymentRequestStatusParams) (*UpdatePaymentRequestStatusOK, error) {

--- a/pkg/gen/supportmessages/move_status.go
+++ b/pkg/gen/supportmessages/move_status.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// MoveStatus Move status
+// MoveStatus Current status of this MoveTaskOrder
 // swagger:model MoveStatus
 type MoveStatus string
 

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -59,7 +59,7 @@ type MoveTaskOrder struct {
 	// Unique 6-character code the customer can use to refer to their move
 	Locator string `json:"locator,omitempty"`
 
-	// MoveOrder associated with this MoveTaskOrder.
+	// move order
 	// Required: true
 	MoveOrder *MoveOrder `json:"moveOrder"`
 
@@ -89,7 +89,7 @@ type MoveTaskOrder struct {
 	//
 	ReferenceID string `json:"referenceId,omitempty"`
 
-	// move status
+	// status
 	Status MoveStatus `json:"status,omitempty"`
 
 	// Date on which this MoveTaskOrder was last updated.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -15,6 +15,12 @@ info:
 basePath: /prime/v1
 schemes:
   - http
+tags:
+  - name: moveTaskOrder
+  - name: mtoShipment
+  - name: paymentRequests
+  - name: uploads
+  - name: mtoServiceItem
 paths:
   /move-task-orders:
     get:
@@ -57,7 +63,12 @@ paths:
         type: string
     patch:
       summary: updateMTOPostCounselingInformation
-      description: Updates move task order after the counseling stage. Allows update of fields ppmType and ppmEstimatedWeight.
+      description: |
+        ### Functionality
+        This endpoint **updates** the MoveTaskOrder after the Prime has completed Counseling.
+
+        PPM related information is updated here. Most other fields will be found on the specific MTOShipment and updated using [updateMTOShipment](#operation/updateMTOShipment).
+
       operationId: updateMTOPostCounselingInformation
       consumes:
         - application/json
@@ -227,7 +238,7 @@ paths:
         This endpoint **cannot create** an address.
         To create an address on an MTO shipment, the caller must use [updateMTOShipment](#operation/updateMTOShipment) as the parent shipment has to be updated with the appropriate link to the address.
 
-        ### Errors:
+        ### Errors
         The address must be associated with the mtoShipment passed in the url.
         In other words, it should be listed as pickupAddress, destinationAddress, secondaryPickupAddress or secondaryDeliveryAddress on the mtoShipment provided.
         If it is not, caller will receive a **Conflict** Error.
@@ -374,7 +385,6 @@ paths:
         - in: body
           name: body
           schema:
-            description: This may be a MTOServiceItemBasic, MTOServiceItemDOFSIT or etc.
             $ref: '#/definitions/MTOServiceItem'
       responses:
         '200':
@@ -441,7 +451,14 @@ paths:
   /payment-requests/{paymentRequestID}/uploads:
     post:
       summary: createUpload
-      description: Uploads represent a single digital file, such as a JPEG, PNG, or PDF.
+      description: |
+        ### Functionality
+        This endpoint **uploads** a Proof of Service document for a PaymentRequest.
+
+        The PaymentRequest should already exist.
+
+        PaymentRequests are created with the [createPaymentRequest](#operation/createPaymentRequest) endpoint.
+
       operationId: createUpload
       tags:
         - uploads
@@ -1196,7 +1213,7 @@ definitions:
           pickupPostalCode:
             type: string
             format: zip
-            example: 90210
+            example: "90210"
             pattern: '^(\d{5}([\-]\d{4})?)$'
         required:
           - reServiceCode
@@ -1316,7 +1333,7 @@ definitions:
       status:
         $ref: '#/definitions/PaymentRequestStatus'
       paymentRequestNumber:
-        example: 1234-5678-1
+        example: "1234-5678-1"
         readOnly: true
         type: string
       proofOfServiceDocs:
@@ -1399,7 +1416,7 @@ definitions:
       key:
         $ref: '#/definitions/ServiceItemParamName'
       value:
-        example: 3025
+        example: "3025"
         type: string
       type:
         $ref: '#/definitions/ServiceItemParamType'

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -16,13 +16,22 @@ info:
 basePath: /support/v1
 schemes:
   - http
+tags:
+  - name: moveTaskOrder
+  - name: paymentRequests
+  - name: mtoServiceItem
+  - name: mtoShipment
+  - name: webhook
 paths:
   '/move-task-orders':
     get:
       summary: listMTOs
-      description: >
-        Gets all move task orders.
-        Provides all move task orders regardless of whether or not they have been made available to prime.
+      description: |
+        ### Functionality
+        This endpoint lists all MoveTaskOrders regardless of whether or not they have been made available to Prime.
+
+        It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
       operationId: listMTOs
       tags:
         - moveTaskOrder
@@ -105,9 +114,12 @@ paths:
     get:
       summary: getMoveTaskOrder
       description: |
-        Gets an individual move task order by ID. <br />
-        <br />
-        This is a support endpoint and will not be available in production.
+        ### Functionality
+        This endpoint gets an individual MoveTaskOrder by ID.
+
+        It will provide nested information about the Customer and any associated MTOShipments, MTOServiceItems and PaymentRequests.
+
+        This is a support endpoint and is not available in production.
       operationId: getMoveTaskOrder
       tags:
         - moveTaskOrder
@@ -179,8 +191,13 @@ paths:
   /move-task-orders/{moveTaskOrderID}/payment-requests:
     get:
       summary: listMTOPaymentRequests
-      description: >
-        Gets all payment requests for a given move task order
+      description: |
+        ### Functionality
+
+        This endpoint lists all PaymentRequests associated with a given MoveTaskOrder.
+
+        This is a support endpoint and is not available in production.
+
       operationId: listMTOPaymentRequests
       tags:
         - paymentRequests
@@ -220,9 +237,10 @@ paths:
       summary: updatePaymentRequestStatus
       description: |
         Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, or PAID.
-        A status of REVIEWED can optionally have a `rejectionReason`. <br />
-        <br />
-        This is a support endpoint and will not be available in production.
+
+        A status of REVIEWED can optionally have a `rejectionReason`.
+
+        This is a support endpoint and is not available in production.
       operationId: updatePaymentRequestStatus
       tags:
         - paymentRequests
@@ -653,7 +671,6 @@ definitions:
         pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         x-nullable: true
       currentAddress:
-        x-nullable: true
         $ref: '#/definitions/Address'
       id:
         type: string
@@ -816,7 +833,6 @@ definitions:
         description: Date that the service member must report to the new DutyStation by.
         type: string
         format: date
-        example: '2020-01-01'
       status:
         $ref: '#/definitions/OrdersStatus'
       uploadedOrders:
@@ -835,7 +851,6 @@ definitions:
         description: The date the orders were issued.
         type: string
         format: date
-        example: '2020-01-01'
       eTag:
         description: |
           Uniquely identifies the state of the MoveOrder object (but not the nested objects)
@@ -875,7 +890,6 @@ definitions:
         description: ID of the MoveOrder object
       moveOrder:
         $ref: '#/definitions/MoveOrder'
-        description: MoveOrder associated with this MoveTaskOrder.
       referenceId:
         example: 1001-3456
         type: string
@@ -937,7 +951,6 @@ definitions:
         readOnly: true
       status:
         $ref: '#/definitions/MoveStatus'
-        description: move status
       locator:
         description: Unique 6-character code the customer can use to refer to their move
         type: string
@@ -948,7 +961,7 @@ definitions:
     type: array
   MoveStatus:
     type: string
-    title: Move status
+    description: Current status of this MoveTaskOrder
     enum:
       - DRAFT
       - SUBMITTED
@@ -1125,16 +1138,12 @@ definitions:
         type: integer
         example: 4500
       pickupAddress:
-        x-nullabe: true
         $ref: '#/definitions/Address'
       destinationAddress:
-        x-nullabe: true
         $ref: '#/definitions/Address'
       secondaryPickupAddress:
-        x-nullabe: true
         $ref: '#/definitions/Address'
       secondaryDeliveryAddress:
-        x-nullabe: true
         $ref: '#/definitions/Address'
       customerRemarks:
         type: string


### PR DESCRIPTION
## Description

Tiny PR. Just cleaning up some issues using a linter for yaml, no effective code changes for these, just comments and yaml.

* According to openApi we should have all tags predeclared at the global level
* Examples for strings should be, well, strings
* There are not supposed to be siblings of the $ref tag according to openapi 
  - In fact after removing them, even those that I assumed would do something, there were no code changes. 
  - The descriptions were not being displayed on redoc either.
* Some of the x-nullable tags were not only $ref siblings but also misspelled.
