### PR TITLE
PrimeAPI Alphabetically sort the definitions

### DIFF
--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -663,27 +663,6 @@ definitions:
       - title
       - detail
       - instance
-  CreatePaymentRequest:
-    type: object
-    properties:
-      isFinal:
-        default: false
-        type: boolean
-      moveTaskOrderID:
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-        format: uuid
-        type: string
-      serviceItems:
-        type: array
-        minItems: 1
-        items:
-          $ref: '#/definitions/ServiceItem'
-      pointOfContact:
-        type: string
-        description: Email or id of a contact person for this update.
-    required:
-      - moveTaskOrderID
-      - serviceItems
   CreateMTOShipment:
     type: object
     properties:
@@ -720,6 +699,27 @@ definitions:
       - destinationAddress
       - shipmentType
       - requestedPickupDate
+  CreatePaymentRequest:
+    type: object
+    properties:
+      isFinal:
+        default: false
+        type: boolean
+      moveTaskOrderID:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      serviceItems:
+        type: array
+        minItems: 1
+        items:
+          $ref: '#/definitions/ServiceItem'
+      pointOfContact:
+        type: string
+        description: Email or id of a contact person for this update.
+    required:
+      - moveTaskOrderID
+      - serviceItems
   Customer:
     type: object
     properties:
@@ -755,6 +755,18 @@ definitions:
       eTag:
         type: string
         readOnly: true
+  CustomerContactType:
+    description: Describes a customer contact type for a MTOServiceItemDomesticDestSIT.
+    type: string
+    enum:
+      - FIRST
+      - SECOND
+  DimensionType:
+    description: Describes a dimension type for a MTOServiceItemDimension.
+    type: string
+    enum:
+      - ITEM
+      - CRATE
   DutyStation:
     type: object
     properties:
@@ -930,11 +942,6 @@ definitions:
     items:
       $ref: '#/definitions/MoveTaskOrder'
     type: array
-  MTOAgents:
-    items:
-      $ref: '#/definitions/MTOAgent'
-    type: array
-    maxItems: 2
   MTOAgent:
     properties:
       id:
@@ -974,6 +981,226 @@ definitions:
       agentType:
         $ref: '#/definitions/MTOAgentType'
     type: object
+  MTOAgents:
+    items:
+      $ref: '#/definitions/MTOAgent'
+    type: array
+    maxItems: 2
+  MTOAgentType:
+    type: string
+    title: MTO Agent Type
+    example: RELEASING_AGENT
+    enum:
+      - RELEASING_AGENT
+      - RECEIVING_AGENT
+  MTOServiceItem:
+    description: MTOServiceItem describes a base type of a service item. Polymorphic type. Both Move Task Orders and MTO Shipments will have MTO Service Items.
+    type: object
+    discriminator: modelType
+    properties:
+      id:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      moveTaskOrderID:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      mtoShipmentID:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      reServiceName:
+        type: string
+        readOnly: true
+      status:
+        $ref: '#/definitions/MTOServiceItemStatus'
+      rejectionReason:
+        example: item was too heavy
+        type: string
+        x-nullable: true
+        readOnly: true
+      modelType: # Base type and sub-types of MTOServiceItem
+        $ref: '#/definitions/MTOServiceItemModelType'
+      eTag:
+        type: string
+        readOnly: true
+    required:
+      - modelType
+      - moveTaskOrderID
+  MTOServiceItemBasic:
+    description: Describes a basic service item subtype of a MTOServiceItem.
+    allOf:
+      - $ref: '#/definitions/MTOServiceItem'
+      - type: object
+        properties:
+          reServiceCode:
+            $ref: '#/definitions/ReServiceCode'
+        required:
+          - reServiceCode
+
+  MTOServiceItemDDFSIT:
+    description: Describes a domestic destination 1st day SIT service item subtype of a MTOServiceItem.
+    allOf:
+      - $ref: '#/definitions/MTOServiceItem'
+      - type: object
+        properties:
+          reServiceCode:
+            type: string
+            description: Service code allowed for this model type.
+            enum:
+              - DDFSIT # Domestic Destination First Day SIT
+          type:
+            $ref: '#/definitions/CustomerContactType'
+          timeMilitary1:
+            type: string
+            example: 1400Z
+            description: Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
+            pattern: '\d{4}Z'
+          firstAvailableDeliveryDate1:
+            format: date
+            type: string
+            description: First available date that Prime can deliver SIT service item.
+          timeMilitary2:
+            type: string
+            example: 1400Z
+            description: Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
+            pattern: '\d{4}Z'
+          firstAvailableDeliveryDate2:
+            format: date
+            type: string
+            description: Second available date that Prime can deliver SIT service item.
+        required:
+          - reServiceCode
+          - timeMilitary1
+          - firstAvailableDeliveryDate1
+          - timeMilitary2
+          - firstAvailableDeliveryDate2
+  MTOServiceItemDimension:
+    description: Describes a dimension object for the MTOServiceItem.
+    type: object
+    properties:
+      id:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      type:
+        $ref: '#/definitions/DimensionType'
+      length:
+        description: Length in thousandth inches. 1000 thou = 1 inch.
+        example: 1000
+        type: integer
+        format: int32
+      width:
+        description: Width in thousandth inches. 1000 thou = 1 inch.
+        example: 1000
+        type: integer
+        format: int32
+      height:
+        description: Height in thousandth inches. 1000 thou = 1 inch.
+        example: 1000
+        type: integer
+        format: int32
+    required:
+      - length
+      - width
+      - height
+  MTOServiceItemDOFSIT:
+    description: Describes a domestic origin 1st day SIT service item subtype of a MTOServiceItem.
+    allOf:
+      - $ref: '#/definitions/MTOServiceItem'
+      - type: object
+        properties:
+          reServiceCode:
+            type: string
+            description: Service code allowed for this model type.
+            enum:
+              - DOFSIT # Domestic Origin First Day SIT
+          reason:
+            type: string
+            example: Storage items need to be picked up
+            description: Explanation of why Prime is picking up SIT item.
+          pickupPostalCode:
+            type: string
+            format: zip
+            example: "90210"
+            pattern: '^(\d{5}([\-]\d{4})?)$'
+        required:
+          - reServiceCode
+          - reason
+          - pickupPostalCode
+  MTOServiceItemDomesticCrating:
+    description: Describes a domestic crating/uncrating service item subtype of a MTOServiceItem.
+    allOf:
+      - $ref: '#/definitions/MTOServiceItem'
+      - type: object
+        properties:
+          reServiceCode:
+            type: string
+            description: Service codes allowed for this model type.
+            enum:
+              - DCRT # Domestic Crating
+              - DCRTSA # Domestic Crating - Standalone
+              - DUCRT # Domestic Uncrating
+          item:
+            $ref: '#/definitions/MTOServiceItemDimension'
+          crate:
+            $ref: '#/definitions/MTOServiceItemDimension'
+          description:
+            type: string
+            example: Decorated horse head to be crated.
+        required:
+          - reServiceCode
+          - item
+          - crate
+          - description
+  MTOServiceItemModelType:
+    description: >
+      Describes all model sub-types for a MTOServiceItem model.
+      Prime can only request the following service codes for which they will use the corresponding modelType
+        * DOFSIT - MTOServiceItemDOFSIT
+        * DDFSIT - MTOServiceItemDDFSIT
+        * DOSHUT, DDSHUT - MTOServiceItemShuttle
+        * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+    type: string
+    enum:
+      - MTOServiceItemBasic
+      - MTOServiceItemDOFSIT
+      - MTOServiceItemDDFSIT
+      - MTOServiceItemShuttle
+      - MTOServiceItemDomesticCrating
+  MTOServiceItemShuttle:
+    description: Describes a shuttle service item.
+    allOf:
+      - $ref: '#/definitions/MTOServiceItem'
+      - type: object
+        properties:
+          reServiceCode:
+            type: string
+            description: Service codes allowed for this model type.
+            enum:
+              - DOSHUT # Domestic Origin Shuttle Service
+              - DDSHUT # Domestic Destination Shuttle Service
+          reason:
+            type: string
+            example: Storage items need to be picked up.
+            description: Explanation of why a shuttle service is required.
+          description:
+            type: string
+            example: Things to be moved to the place by shuttle.
+            description: Further details about the shuttle service.
+        required:
+          - reason
+          - reServiceCode
+          - description
+  MTOServiceItemStatus:
+    description: Describes all statuses for a MTOServiceItem.
+    type: string
+    readOnly: true
+    enum:
+      - SUBMITTED
+      - APPROVED
+      - REJECTED
   MTOShipment:
     properties:
       moveTaskOrderID:
@@ -1081,239 +1308,6 @@ definitions:
       HHG: HHG
       INTERNATIONAL_HHG: International HHG
       INTERNATIONAL_UB: International UB
-  DimensionType:
-    description: Describes a dimension type for a MTOServiceItemDimension.
-    type: string
-    enum:
-      - ITEM
-      - CRATE
-  CustomerContactType:
-    description: Describes a customer contact type for a MTOServiceItemDomesticDestSIT.
-    type: string
-    enum:
-      - FIRST
-      - SECOND
-  MTOServiceItemDimension:
-    description: Describes a dimension object for the MTOServiceItem.
-    type: object
-    properties:
-      id:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
-      type:
-        $ref: '#/definitions/DimensionType'
-      length:
-        description: Length in thousandth inches. 1000 thou = 1 inch.
-        example: 1000
-        type: integer
-        format: int32
-      width:
-        description: Width in thousandth inches. 1000 thou = 1 inch.
-        example: 1000
-        type: integer
-        format: int32
-      height:
-        description: Height in thousandth inches. 1000 thou = 1 inch.
-        example: 1000
-        type: integer
-        format: int32
-    required:
-      - length
-      - width
-      - height
-  MTOServiceItemStatus:
-    description: Describes all statuses for a MTOServiceItem.
-    type: string
-    readOnly: true
-    enum:
-      - SUBMITTED
-      - APPROVED
-      - REJECTED
-  MTOServiceItemModelType:
-    description: >
-      Describes all model sub-types for a MTOServiceItem model.
-      Prime can only request the following service codes for which they will use the corresponding modelType
-        * DOFSIT - MTOServiceItemDOFSIT
-        * DDFSIT - MTOServiceItemDDFSIT
-        * DOSHUT, DDSHUT - MTOServiceItemShuttle
-        * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
-    type: string
-    enum:
-      - MTOServiceItemBasic
-      - MTOServiceItemDOFSIT
-      - MTOServiceItemDDFSIT
-      - MTOServiceItemShuttle
-      - MTOServiceItemDomesticCrating
-  MTOAgentType:
-    type: string
-    title: MTO Agent Type
-    example: RELEASING_AGENT
-    enum:
-      - RELEASING_AGENT
-      - RECEIVING_AGENT
-  MTOServiceItem:
-    description: MTOServiceItem describes a base type of a service item. Polymorphic type. Both Move Task Orders and MTO Shipments will have MTO Service Items.
-    type: object
-    discriminator: modelType
-    properties:
-      id:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
-      moveTaskOrderID:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
-      mtoShipmentID:
-        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-        format: uuid
-        type: string
-      reServiceName:
-        type: string
-        readOnly: true
-      status:
-        $ref: '#/definitions/MTOServiceItemStatus'
-      rejectionReason:
-        example: item was too heavy
-        type: string
-        x-nullable: true
-        readOnly: true
-      modelType: # Base type and sub-types of MTOServiceItem
-        $ref: '#/definitions/MTOServiceItemModelType'
-      eTag:
-        type: string
-        readOnly: true
-    required:
-      - modelType
-      - moveTaskOrderID
-  MTOServiceItemBasic:
-    description: Describes a basic service item subtype of a MTOServiceItem.
-    allOf:
-      - $ref: '#/definitions/MTOServiceItem'
-      - type: object
-        properties:
-          reServiceCode:
-            $ref: '#/definitions/ReServiceCode'
-        required:
-          - reServiceCode
-  MTOServiceItemDOFSIT:
-    description: Describes a domestic origin 1st day SIT service item subtype of a MTOServiceItem.
-    allOf:
-      - $ref: '#/definitions/MTOServiceItem'
-      - type: object
-        properties:
-          reServiceCode:
-            type: string
-            description: Service code allowed for this model type.
-            enum:
-              - DOFSIT # Domestic Origin First Day SIT
-          reason:
-            type: string
-            example: Storage items need to be picked up
-            description: Explanation of why Prime is picking up SIT item.
-          pickupPostalCode:
-            type: string
-            format: zip
-            example: "90210"
-            pattern: '^(\d{5}([\-]\d{4})?)$'
-        required:
-          - reServiceCode
-          - reason
-          - pickupPostalCode
-  MTOServiceItemDDFSIT:
-    description: Describes a domestic destination 1st day SIT service item subtype of a MTOServiceItem.
-    allOf:
-      - $ref: '#/definitions/MTOServiceItem'
-      - type: object
-        properties:
-          reServiceCode:
-            type: string
-            description: Service code allowed for this model type.
-            enum:
-              - DDFSIT # Domestic Destination First Day SIT
-          type:
-            $ref: '#/definitions/CustomerContactType'
-          timeMilitary1:
-            type: string
-            example: 1400Z
-            description: Time of delivery corresponding to `firstAvailableDeliveryDate1`, in military format.
-            pattern: '\d{4}Z'
-          firstAvailableDeliveryDate1:
-            format: date
-            type: string
-            description: First available date that Prime can deliver SIT service item.
-          timeMilitary2:
-            type: string
-            example: 1400Z
-            description: Time of delivery corresponding to `firstAvailableDeliveryDate2`, in military format.
-            pattern: '\d{4}Z'
-          firstAvailableDeliveryDate2:
-            format: date
-            type: string
-            description: Second available date that Prime can deliver SIT service item.
-        required:
-          - reServiceCode
-          - timeMilitary1
-          - firstAvailableDeliveryDate1
-          - timeMilitary2
-          - firstAvailableDeliveryDate2
-  MTOServiceItemShuttle:
-    description: Describes a shuttle service item.
-    allOf:
-      - $ref: '#/definitions/MTOServiceItem'
-      - type: object
-        properties:
-          reServiceCode:
-            type: string
-            description: Service codes allowed for this model type.
-            enum:
-              - DOSHUT # Domestic Origin Shuttle Service
-              - DDSHUT # Domestic Destination Shuttle Service
-          reason:
-            type: string
-            example: Storage items need to be picked up.
-            description: Explanation of why a shuttle service is required.
-          description:
-            type: string
-            example: Things to be moved to the place by shuttle.
-            description: Further details about the shuttle service.
-        required:
-          - reason
-          - reServiceCode
-          - description
-  MTOServiceItemDomesticCrating:
-    description: Describes a domestic crating/uncrating service item subtype of a MTOServiceItem.
-    allOf:
-      - $ref: '#/definitions/MTOServiceItem'
-      - type: object
-        properties:
-          reServiceCode:
-            type: string
-            description: Service codes allowed for this model type.
-            enum:
-              - DCRT # Domestic Crating
-              - DCRTSA # Domestic Crating - Standalone
-              - DUCRT # Domestic Uncrating
-          item:
-            $ref: '#/definitions/MTOServiceItemDimension'
-          crate:
-            $ref: '#/definitions/MTOServiceItemDimension'
-          description:
-            type: string
-            example: Decorated horse head to be crated.
-        required:
-          - reServiceCode
-          - item
-          - crate
-          - description
-  ProofOfServiceDocs:
-    properties:
-      uploads:
-        items:
-          $ref: '#/definitions/Upload'
-        type: array
-    type: object
   PaymentRequest:
     properties:
       id:
@@ -1346,6 +1340,10 @@ definitions:
         type: string
         readOnly: true
     type: object
+  PaymentRequests:
+    type: array
+    items:
+      $ref: '#/definitions/PaymentRequest'
   PaymentRequestStatus:
     enum:
       - PENDING
@@ -1355,10 +1353,6 @@ definitions:
       - PAID
     title: Payment Request Status
     type: string
-  PaymentRequests:
-    type: array
-    items:
-      $ref: '#/definitions/PaymentRequest'
   PaymentServiceItem:
     properties:
       id:
@@ -1391,19 +1385,6 @@ definitions:
         type: string
         readOnly: true
     type: object
-  PaymentServiceItemStatus:
-    enum:
-      - REQUESTED
-      - APPROVED
-      - DENIED
-      - SENT_TO_GEX
-      - PAID
-    title: Payment Service Item Status
-    type: string
-  PaymentServiceItems:
-    type: array
-    items:
-      $ref: '#/definitions/PaymentServiceItem'
   PaymentServiceItemParam:
     properties:
       id:
@@ -1432,27 +1413,25 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/PaymentServiceItemParam'
-  ServiceItem:
+  PaymentServiceItems:
+    type: array
+    items:
+      $ref: '#/definitions/PaymentServiceItem'
+  PaymentServiceItemStatus:
+    enum:
+      - REQUESTED
+      - APPROVED
+      - DENIED
+      - SENT_TO_GEX
+      - PAID
+    title: Payment Service Item Status
+    type: string
+  ProofOfServiceDocs:
     properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      params:
-        type: array
-        readOnly: true
+      uploads:
         items:
-          properties:
-            key:
-              type: string
-              example: Service Item Parameter Name
-            value:
-              type: string
-              example: Service Item Parameter Value
-          type: object
-      eTag:
-        type: string
-        readOnly: true
+          $ref: '#/definitions/Upload'
+        type: array
     type: object
   ReServiceCode:
     type: string
@@ -1512,6 +1491,28 @@ definitions:
       - MS
       - NSTH
       - NSTUB
+  ServiceItem:
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      params:
+        type: array
+        readOnly: true
+        items:
+          properties:
+            key:
+              type: string
+              example: Service Item Parameter Name
+            value:
+              type: string
+              example: Service Item Parameter Value
+          type: object
+      eTag:
+        type: string
+        readOnly: true
+    type: object
   ServiceItemParamName:
     type: string
     enum:
@@ -1581,6 +1582,18 @@ definitions:
       - DECIMAL
       - TIMESTAMP
       - PaymentServiceItemUUID
+  UpdatePaymentRequestStatus:
+    properties:
+      rejectionReason:
+        example: documentation was incomplete
+        type: string
+        x-nullable: true
+      status:
+        $ref: '#/definitions/PaymentRequestStatus'
+      eTag:
+        type: string
+        readOnly: true
+    type: object
   Upload:
     type: object
     properties:
@@ -1605,18 +1618,6 @@ definitions:
       - bytes
       - createdAt
       - updatedAt
-  UpdatePaymentRequestStatus:
-    properties:
-      rejectionReason:
-        example: documentation was incomplete
-        type: string
-        x-nullable: true
-      status:
-        $ref: '#/definitions/PaymentRequestStatus'
-      eTag:
-        type: string
-        readOnly: true
-    type: object
   ValidationError:
     allOf:
       - $ref: '#/definitions/ClientError'


### PR DESCRIPTION
## Description

We had started with sorted alphabetical definitions and then slowly devolved into unsorted. 
This gets us back to sorted. 
Note this is only the `definitions` in the yaml. Not everything.
I attempted to make ZERO changes in any definitions during this sort but if you have a tool that can check that, would appreciate it.


