### PR TITLE
Reduce CHROME_CONCURRENCY since we had timeouts in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -902,7 +902,7 @@ jobs:
           name: make storybook_tests
           command: make storybook_tests
           environment:
-            CHROME_CONCURRENCY: 3
+            CHROME_CONCURRENCY: 2
       - run: make storybook_build
       - persist_to_workspace:
           root: /home/circleci/transcom/mymove/


### PR DESCRIPTION
## Description

Seeing failures in circle CI for loki storybook tests that are inconsistent even across re-runs. This PR reduces the concurrency of loki tests from 3 to 2. It was increased from 1 to 3 when we changed executor size but seems we are now hitting limits again given the number of tests. We will need to consider some longer term solution unless the Happo ADR is accepted and we replace these tests with Happo. 

* https://app.circleci.com/pipelines/github/transcom/mymove/21167/workflows/f14411aa-3de1-4989-8d6b-4cfff8a17281/jobs/327354
* https://app.circleci.com/pipelines/github/transcom/mymove/21167/workflows/cd49ffe2-ba20-4a32-8544-a188635369f5/jobs/327402

## Setup

Master builds are failing but this build is passing

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Slack thread](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1600788427024400) for this change