### PR TITLE
[MB-3920] Trigger event updateMTOServiceItemStatus Handler

### DIFF
--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/transcom/mymove/pkg/services/event"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
@@ -162,6 +164,21 @@ func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemop.Update
 			logger.Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", mtoServiceItemID, err))
 			return mtoserviceitemop.NewUpdateMTOServiceItemStatusInternalServerError()
 		}
+	}
+
+	// trigger webhook event for Prime
+	_, err = event.TriggerEvent(event.Event{
+		EventKey:        event.MTOServiceItemUpdateEventKey,
+		MtoID:           existingMTOServiceItem.MoveTaskOrder.ID,
+		UpdatedObjectID: existingMTOServiceItem.ID,
+		Request:         params.HTTPRequest,
+		EndpointKey:     event.GhcUpdateMTOServiceItemStatusEndpointKey,
+		DBConnection:    h.DB(),
+		HandlerContext:  h,
+	})
+
+	if err != nil {
+		logger.Error("ghcapi.UpdateMTOServiceItemStatusHandler could not generate the event")
 	}
 
 	payload := payloads.MTOServiceItemModel(updatedMTOServiceItem)


### PR DESCRIPTION
## Description

This PR introduces the an event trigger when the MTO service item status is updated. When the API endpoint is hit and the status has been updated, an event is triggered to notify the Prime partner that this update has happened. Along with the new functionality, this PR also adds a test to ensure that the event trigger has been successfully triggered. 

## Reviewer Notes

In-line comments. 

## Setup

```
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
mylaptop ~ %: go test ./pkg/handlers/ghcapi --testify.m "TestUpdateMTOServiceItemStatusHandler" -v 
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3920)