### PR TITLE
Add FA1 and FA2 segments to edi headers

### DIFF
--- a/pkg/edi/segment/fa1.go
+++ b/pkg/edi/segment/fa1.go
@@ -2,21 +2,11 @@ package edisegment
 
 import (
 	"fmt"
-
-	"github.com/transcom/mymove/pkg/models"
 )
-
-// AffiliationToAgency is a map from our affiliation to the FA1 segment's AgencyQualifierCode field
-var AffiliationToAgency = map[models.ServiceMemberAffiliation]string{
-	models.AffiliationARMY:     "DZ",
-	models.AffiliationNAVY:     "DN",
-	models.AffiliationMARINES:  "DX",
-	models.AffiliationAIRFORCE: "DY",
-}
 
 // FA1 represents the FA1 EDI segment
 type FA1 struct {
-	AgencyQualifierCode string `validate:"oneof=DN DX DY DZ"`
+	AgencyQualifierCode string `validate:"eq=DF"`
 }
 
 // StringArray converts FA1 to an array of strings

--- a/pkg/edi/segment/fa1_test.go
+++ b/pkg/edi/segment/fa1_test.go
@@ -6,7 +6,7 @@ import (
 
 func (suite *SegmentSuite) TestValidateFA1() {
 	validFA1 := FA1{
-		AgencyQualifierCode: "DZ",
+		AgencyQualifierCode: "DF",
 	}
 
 	suite.T().Run("validate success", func(t *testing.T) {
@@ -20,7 +20,7 @@ func (suite *SegmentSuite) TestValidateFA1() {
 		}
 
 		err := suite.validator.Struct(fa1)
-		suite.ValidateError(err, "AgencyQualifierCode", "oneof")
+		suite.ValidateError(err, "AgencyQualifierCode", "eq")
 		suite.ValidateErrorLen(err, 1)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds new segments to the EDI headers: FA1 and FA2.

## Reviewer Notes

For now, we're not including the LOA segments for each service item because it could cause unnecessary repetition. @gidjin is [going to check](https://dp3.atlassian.net/browse/MB-4338?focusedCommentId=13202) whether or not this is okay with US Bank.

## Setup

1. `make server_run`
2. Create a payment request. Create a file called `create_payment_request.json` in the project root and paste in the JSON payload provided below:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "722a6f4e-b438-4655-88c7-51609056550d"
      },
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

This payload includes DLH, MS, CS, and FSC service items .

2. Use the Prime API Client to create the payment request and return the payment request number by running the command below:

```sh
prime-api-client --insecure create-payment-request --filename  create_payment_request.json | jq '.paymentRequestNumber'
```
3. Use the CLI utility to generate the EDI858 and view it in your terminal. Remember to pass the payment request number of the payment request you just created.

```sh
go run ./cmd/generate-payment-request-edi/ --payment-request-number [$paymentRequestNumber]
```

You should see output that includes the FA1 and FA2 segments in the header:
```sh
ISA*00*0084182369*00*_   _*ZZ*GOVDPIBS*12*8004171844*20200923*1918*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*20200923*1918*100001251*X*004010
ST*858*0001
BX*00*J*PP*1561-7342*TRUS**4
N9*CN*1561-7342-2**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*86*2020-09-18*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
N1*SF*32j0Hza8kA*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
FA1*DF
FA2*TA*F8E1
HL*1**|
N9*PO*1e153f79-42b8-4f79-9fce-f743b7bc124c**
L5*1*DLH - Domestic Line Haul*TBD*D**
L0*1*373.000*DM*1349.000*B******L
L3*1349.000*B*1296181
HL*2**|
N9*PO*d2e3cd0e-6f97-459e-9c8b-92ee787db7ae**
L0*2**********
L3***45423
HL*3**|
N9*PO*02447340-ac2b-4813-8233-48796ab3d69c**
L0*3**********
L3***22353
HL*4**|
N9*PO*24c2833f-b041-42ca-9985-1246a3dc33e3**
L0*4*373.000*DM*1349.000*B******L
L3*1349.000*B*362
SE*34*0001
GE*1*100001251
IEA*1*100001272
```
## References

- [JIRA Story](https://dp3.atlassian.net/browse/MB-4338) for this PR
