### PR TITLE
MB-4409 donald update cac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1355,7 +1355,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4409-donald-update-cac
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1369,7 +1369,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4409-donald-update-cac
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1377,7 +1377,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4409-donald-update-cac
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1385,7 +1385,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4409-donald-update-cac
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1432,49 +1432,49 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - push_app_exp:
           requires:
             - build_app
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1488,28 +1488,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4409-donald-update-cac
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1355,7 +1355,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4409-donald-update-cac
 
       - integration_tests_mtls:
           requires:
@@ -1369,7 +1369,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4409-donald-update-cac
 
       - client_test:
           requires:
@@ -1377,7 +1377,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4409-donald-update-cac
 
       - server_test:
           requires:
@@ -1385,7 +1385,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4409-donald-update-cac
 
       - build_app:
           requires:
@@ -1432,49 +1432,49 @@ workflows:
             - push_migrations_legacy
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - push_app_exp:
           requires:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_exp_migrations:
           requires:
@@ -1488,28 +1488,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4409-donald-update-cac
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -554,3 +554,4 @@
 20200910033042_add-move-submitted-at.up.sql
 20200911161101_add_fake_contractors_prod.up.sql
 20200914173006_hide_move_on_prod_gov_cloud.up.sql
+20200923204433_donald_cac.up.sql

--- a/migrations/app/secure/20200923204433_donald_cac.up.sql
+++ b/migrations/app/secure/20200923204433_donald_cac.up.sql
@@ -1,0 +1,11 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.
+
+-- Updating sha256 for new cac
+UPDATE client_certs
+    SET sha256_digest = 'fb364ff8130fd7c456a0c53809b78f80844cd75682253c9e53be7bcd7b5faaa9',
+        subject = 'CN=donaldthai,OU=DoD+OU=PKI+OU=CONTRACTOR,O=U.S. Government,C=US',
+        updated_at = NOW()
+    WHERE id = 'de7605ec-2edd-4252-b176-27f0d3fe4b6f';


### PR DESCRIPTION
## Description

New CAC obtained. PR will update the `sha256_digest` and `subject` column values for cac access with new card.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make run_prod_migrations
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4409) for this change
* [this article](https://github.com/transcom/mymove/wiki/use-mtls-with-cac) explains more about the approach used.