### PR TITLE
[MB-4374] update to change upload filename

### DIFF
--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -74,7 +74,6 @@ func (h CreateUploadHandler) Handle(params paymentrequestop.CreateUploadParams) 
 
 	uploadCreator := paymentrequest.NewPaymentRequestUploadCreator(h.DB(), logger, h.FileStorer())
 	createdUpload, err := uploadCreator.CreateUpload(file.Data, paymentRequestID, contractorID, file.Header.Filename)
-	//createdUpload, err := uploadCreator.CreateUpload(params.File, paymentRequestID, contractorID)
 	if err != nil {
 		logger.Error("primeapi.CreateUploadHandler error", zap.Error(err))
 		switch e := err.(type) {

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -1,6 +1,7 @@
 package primeapi
 
 import (
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 
@@ -65,8 +66,15 @@ func (h CreateUploadHandler) Handle(params paymentrequestop.CreateUploadParams) 
 			"The payment request ID must be a valid UUID.", h.GetTraceID(), nil))
 	}
 
+	file, ok := params.File.(*runtime.File)
+	if !ok {
+		logger.Error("This should always be a runtime.File, something has changed in go-swagger.")
+		return paymentrequestop.NewCreateUploadInternalServerError()
+	}
+
 	uploadCreator := paymentrequest.NewPaymentRequestUploadCreator(h.DB(), logger, h.FileStorer())
-	createdUpload, err := uploadCreator.CreateUpload(params.File, paymentRequestID, contractorID)
+	createdUpload, err := uploadCreator.CreateUpload(file.Data, paymentRequestID, contractorID, file.Header.Filename)
+	//createdUpload, err := uploadCreator.CreateUpload(params.File, paymentRequestID, contractorID)
 	if err != nil {
 		logger.Error("primeapi.CreateUploadHandler error", zap.Error(err))
 		switch e := err.(type) {

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -3,7 +3,6 @@ package primeapi
 import (
 	"fmt"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -36,9 +35,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 			context,
 		}
 
-		file, err := os.Open("../../testdatagen/testdata/test.pdf")
-		defer file.Close()
-		suite.NoError(err)
+		file := suite.Fixture("test.pdf")
 
 		params := uploadop.CreateUploadParams{
 			HTTPRequest:      req,
@@ -56,9 +53,8 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 		handler := CreateUploadHandler{
 			context,
 		}
-		file, err := os.Open("../../testdatagen/testdata/test.pdf")
-		defer file.Close()
-		suite.NoError(err)
+
+		file := suite.Fixture("test.pdf")
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/payment_requests/%s/uploads", paymentRequest.ID), nil)
 		req = suite.AuthenticateUserRequest(req, primeUser)
@@ -78,9 +74,8 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 		handler := CreateUploadHandler{
 			context,
 		}
-		file, err := os.Open("../../testdatagen/testdata/test.pdf")
-		defer file.Close()
-		suite.NoError(err)
+
+		file := suite.Fixture("test.pdf")
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/payment_requests/%s/uploads", paymentRequest.ID), nil)
 		req = suite.AuthenticateUserRequest(req, primeUser)

--- a/pkg/services/mocks/PaymentRequestUploadCreator.go
+++ b/pkg/services/mocks/PaymentRequestUploadCreator.go
@@ -16,13 +16,13 @@ type PaymentRequestUploadCreator struct {
 	mock.Mock
 }
 
-// CreateUpload provides a mock function with given fields: file, paymentRequestID, userID
-func (_m *PaymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, userID uuid.UUID) (*models.Upload, error) {
-	ret := _m.Called(file, paymentRequestID, userID)
+// CreateUpload provides a mock function with given fields: file, paymentRequestID, userID, filename
+func (_m *PaymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, userID uuid.UUID, filename string) (*models.Upload, error) {
+	ret := _m.Called(file, paymentRequestID, userID, filename)
 
 	var r0 *models.Upload
-	if rf, ok := ret.Get(0).(func(io.ReadCloser, uuid.UUID, uuid.UUID) *models.Upload); ok {
-		r0 = rf(file, paymentRequestID, userID)
+	if rf, ok := ret.Get(0).(func(io.ReadCloser, uuid.UUID, uuid.UUID, string) *models.Upload); ok {
+		r0 = rf(file, paymentRequestID, userID, filename)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Upload)
@@ -30,8 +30,8 @@ func (_m *PaymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentR
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(io.ReadCloser, uuid.UUID, uuid.UUID) error); ok {
-		r1 = rf(file, paymentRequestID, userID)
+	if rf, ok := ret.Get(1).(func(io.ReadCloser, uuid.UUID, uuid.UUID, string) error); ok {
+		r1 = rf(file, paymentRequestID, userID, filename)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -35,5 +35,5 @@ type PaymentRequestStatusUpdater interface {
 // PaymentRequestUploadCreator is the exported interface for creating a payment request upload
 //go:generate mockery -name PaymentRequestUploadCreator
 type PaymentRequestUploadCreator interface {
-	CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, userID uuid.UUID) (*models.Upload, error)
+	CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, userID uuid.UUID, filename string) (*models.Upload, error)
 }

--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -33,21 +33,21 @@ func NewPaymentRequestUploadCreator(db *pop.Connection, logger Logger, fileStore
 	return &paymentRequestUploadCreator{db, logger, fileStorer, uploader.MaxFileSizeLimit}
 }
 
-func (p *paymentRequestUploadCreator) assembleUploadFilePathName(paymentRequestID uuid.UUID) (string, error) {
+func (p *paymentRequestUploadCreator) assembleUploadFilePathName(paymentRequestID uuid.UUID, filename string) (string, error) {
 	var paymentRequest models.PaymentRequest
 	err := p.db.Where("id=$1", paymentRequestID).First(&paymentRequest)
 	if err != nil {
 		return "", services.NewNotFoundError(paymentRequestID, "")
 	}
 
-	filename := "timestamp-" + time.Now().Format(VersionTimeFormat)
+	newfilename := time.Now().Format(VersionTimeFormat) + "-" + filename
 	uploadFilePath := fmt.Sprintf("/app/payment-request-uploads/mto-%s/payment-request-%s", paymentRequest.MoveTaskOrderID, paymentRequest.ID)
-	uploadFileName := path.Join(uploadFilePath, filename)
+	uploadFileName := path.Join(uploadFilePath, newfilename)
 
 	return uploadFileName, err
 }
 
-func (p *paymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, contractorID uuid.UUID) (*models.Upload, error) {
+func (p *paymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRequestID uuid.UUID, contractorID uuid.UUID, uploadFilename string) (*models.Upload, error) {
 	var upload *models.Upload
 	transactionError := p.db.Transaction(func(tx *pop.Connection) error {
 		newUploader, err := uploader.NewPrimeUploader(tx, p.logger, p.fileStorer, p.fileSizeLimit)
@@ -58,7 +58,7 @@ func (p *paymentRequestUploadCreator) CreateUpload(file io.ReadCloser, paymentRe
 			return err
 		}
 
-		fileName, err := p.assembleUploadFilePathName(paymentRequestID)
+		fileName, err := p.assembleUploadFilePathName(paymentRequestID, uploadFilename)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -16,6 +16,11 @@ import (
 	"github.com/transcom/mymove/pkg/uploader"
 )
 
+const (
+	// VersionTimeFormat is the Go time format for creating a version number.
+	VersionTimeFormat string = "20060102150405"
+)
+
 type paymentRequestUploadCreator struct {
 	db            *pop.Connection
 	logger        Logger
@@ -35,7 +40,7 @@ func (p *paymentRequestUploadCreator) assembleUploadFilePathName(paymentRequestI
 		return "", services.NewNotFoundError(paymentRequestID, "")
 	}
 
-	filename := "timestamp-" + time.Now().String()
+	filename := "timestamp-" + time.Now().Format(VersionTimeFormat)
 	uploadFilePath := fmt.Sprintf("/app/payment-request-uploads/mto-%s/payment-request-%s", paymentRequest.MoveTaskOrderID, paymentRequest.ID)
 	uploadFileName := path.Join(uploadFilePath, filename)
 

--- a/pkg/services/payment_request/upload_creator_test.go
+++ b/pkg/services/payment_request/upload_creator_test.go
@@ -39,7 +39,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadSuccess() {
 
 	suite.T().Run("PrimeUpload is created successfully", func(t *testing.T) {
 		uploadCreator := NewPaymentRequestUploadCreator(suite.DB(), suite.logger, fakeS3)
-		upload, err := uploadCreator.CreateUpload(testFile, paymentRequest.ID, contractor.ID)
+		upload, err := uploadCreator.CreateUpload(testFile, paymentRequest.ID, contractor.ID, "unit-test-file.pdf")
 
 		expectedFilename := fmt.Sprintf("/app/payment-request-uploads/mto-%s/payment-request-%s", moveTaskOrderID, paymentRequest.ID)
 		suite.NoError(err)
@@ -72,7 +72,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 		suite.NoError(err)
 		defer testFile.Close()
 		uploadCreator := NewPaymentRequestUploadCreator(suite.DB(), suite.logger, fakeS3)
-		_, err = uploadCreator.CreateUpload(testFile, uuid.FromStringOrNil("96b77644-4028-48c2-9ab8-754f33309db9"), contractor.ID)
+		_, err = uploadCreator.CreateUpload(testFile, uuid.FromStringOrNil("96b77644-4028-48c2-9ab8-754f33309db9"), contractor.ID, "unit-test-file.pdf")
 		suite.Error(err)
 	})
 
@@ -83,7 +83,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 
 		paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 		uploadCreator := NewPaymentRequestUploadCreator(suite.DB(), suite.logger, fakeS3)
-		_, err = uploadCreator.CreateUpload(testFile, paymentRequest.ID, uuid.FromStringOrNil("806e2f96-f9f9-4cbb-9a3d-d2f488539a1f"))
+		_, err = uploadCreator.CreateUpload(testFile, paymentRequest.ID, uuid.FromStringOrNil("806e2f96-f9f9-4cbb-9a3d-d2f488539a1f"), "unit-test-file.pdf")
 		suite.Error(err)
 	})
 
@@ -94,7 +94,7 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 		suite.NoError(err)
 		defer wrongTypeFile.Close()
 
-		_, err = uploadCreator.CreateUpload(wrongTypeFile, paymentRequest.ID, contractor.ID)
+		_, err = uploadCreator.CreateUpload(wrongTypeFile, paymentRequest.ID, contractor.ID, "unit-test-file.pdf")
 		suite.Error(err)
 	})
 


### PR DESCRIPTION
## Description

Cleaner name for file upload created for payment request 

## Reviewer Notes

n/a

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
└─ $ ▶ go run ./cmd/prime-api-client --insecure create-upload  --paymentRequestID "ea945ab7-099a-4819-82de-6968efe131dc" --filename "/Users/jm/Documents/mymove/pcs orders/dd1614_pcs.pdf" | jq

{
  "bytes": 187095,
  "contentType": "application/pdf",
  "createdAt": "2020-09-25T16:30:01.800Z",
  "filename": "/app/payment-request-uploads/mto-99783f4d-ee83-4fc9-8e0c-d32496bef32b/payment-request-ea945ab7-099a-4819-82de-6968efe131dc/20200925163001-<orginal_filename.pdf>",
  "updatedAt": "2020-09-25T16:30:01.800Z"
}
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4374) for this change


## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
