### PR TITLE
MB-4236 Add code for UpdateMTOAgentHandler

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -490,9 +490,6 @@ func init() {
           "404": {
             "$ref": "#/responses/NotFound"
           },
-          "409": {
-            "$ref": "#/responses/Conflict"
-          },
           "412": {
             "$ref": "#/responses/PreconditionFailed"
           },
@@ -501,9 +498,6 @@ func init() {
           },
           "500": {
             "$ref": "#/responses/ServerError"
-          },
-          "501": {
-            "$ref": "#/responses/NotImplemented"
           }
         }
       }
@@ -2733,12 +2727,6 @@ func init() {
               "$ref": "#/definitions/ClientError"
             }
           },
-          "409": {
-            "description": "The request could not be processed because of conflict in the current state of the resource.",
-            "schema": {
-              "$ref": "#/definitions/ClientError"
-            }
-          },
           "412": {
             "description": "Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.",
             "schema": {
@@ -2753,12 +2741,6 @@ func init() {
           },
           "500": {
             "description": "A server error occurred.",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "501": {
-            "description": "The requested feature is still in development.",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1060,6 +1060,10 @@ func init() {
           "format": "date-time",
           "readOnly": true
         },
+        "eTag": {
+          "type": "string",
+          "readOnly": true
+        },
         "email": {
           "type": "string",
           "format": "x-email",
@@ -3334,6 +3338,10 @@ func init() {
         "createdAt": {
           "type": "string",
           "format": "date-time",
+          "readOnly": true
+        },
+        "eTag": {
+          "type": "string",
           "readOnly": true
         },
         "email": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1067,7 +1067,7 @@ func init() {
         "email": {
           "type": "string",
           "format": "x-email",
-          "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+          "pattern": "^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})?$",
           "x-nullable": true
         },
         "firstName": {
@@ -1093,7 +1093,7 @@ func init() {
         "phone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true
         },
         "updatedAt": {
@@ -3347,7 +3347,7 @@ func init() {
         "email": {
           "type": "string",
           "format": "x-email",
-          "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+          "pattern": "^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})?$",
           "x-nullable": true
         },
         "firstName": {
@@ -3373,7 +3373,7 @@ func init() {
         "phone": {
           "type": "string",
           "format": "telephone",
-          "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$",
+          "pattern": "^([2-9]\\d{2}-\\d{3}-\\d{4})?$",
           "x-nullable": true
         },
         "updatedAt": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -426,7 +426,7 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}/agents/{agentID}": {
       "put": {
-        "description": "### Functionality\nThis endpoint is used to **update** the agents for an MTO Shipment.\n\n### Errors:\nThe agent must be associated with the MTO shipment passed in the url.\n\nThe shipment should be associated with an MTO that is available to the Prime.\nIf the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.\n",
+        "description": "### Functionality\nThis endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.\n\n### Errors:\nThe agent must always have a name and at least one method of contact (either ` + "`" + `email` + "`" + ` or ` + "`" + `phone` + "`" + `).\n\nThe agent must be associated with the MTO shipment passed in the url.\n\nThe shipment should be associated with an MTO that is available to the Prime.\nIf the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.\n",
         "consumes": [
           "application/json"
         ],
@@ -2651,7 +2651,7 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}/agents/{agentID}": {
       "put": {
-        "description": "### Functionality\nThis endpoint is used to **update** the agents for an MTO Shipment.\n\n### Errors:\nThe agent must be associated with the MTO shipment passed in the url.\n\nThe shipment should be associated with an MTO that is available to the Prime.\nIf the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.\n",
+        "description": "### Functionality\nThis endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.\n\n### Errors:\nThe agent must always have a name and at least one method of contact (either ` + "`" + `email` + "`" + ` or ` + "`" + `phone` + "`" + `).\n\nThe agent must be associated with the MTO shipment passed in the url.\n\nThe shipment should be associated with an MTO that is available to the Prime.\nIf the caller requests an update to an agent, and the shipment is not on an available MTO, the caller will receive a **NotFound** response.\n",
         "consumes": [
           "application/json"
         ],

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent.go
@@ -34,9 +34,11 @@ func NewUpdateMTOAgent(ctx *middleware.Context, handler UpdateMTOAgentHandler) *
 updateMTOAgent
 
 ### Functionality
-This endpoint is used to **update** the agents for an MTO Shipment.
+This endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.
 
 ### Errors:
+The agent must always have a name and at least one method of contact (either `email` or `phone`).
+
 The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Prime.

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_agent_responses.go
@@ -233,50 +233,6 @@ func (o *UpdateMTOAgentNotFound) WriteResponse(rw http.ResponseWriter, producer 
 	}
 }
 
-// UpdateMTOAgentConflictCode is the HTTP code returned for type UpdateMTOAgentConflict
-const UpdateMTOAgentConflictCode int = 409
-
-/*UpdateMTOAgentConflict The request could not be processed because of conflict in the current state of the resource.
-
-swagger:response updateMTOAgentConflict
-*/
-type UpdateMTOAgentConflict struct {
-
-	/*
-	  In: Body
-	*/
-	Payload *primemessages.ClientError `json:"body,omitempty"`
-}
-
-// NewUpdateMTOAgentConflict creates UpdateMTOAgentConflict with default headers values
-func NewUpdateMTOAgentConflict() *UpdateMTOAgentConflict {
-
-	return &UpdateMTOAgentConflict{}
-}
-
-// WithPayload adds the payload to the update m t o agent conflict response
-func (o *UpdateMTOAgentConflict) WithPayload(payload *primemessages.ClientError) *UpdateMTOAgentConflict {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the update m t o agent conflict response
-func (o *UpdateMTOAgentConflict) SetPayload(payload *primemessages.ClientError) {
-	o.Payload = payload
-}
-
-// WriteResponse to the client
-func (o *UpdateMTOAgentConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.WriteHeader(409)
-	if o.Payload != nil {
-		payload := o.Payload
-		if err := producer.Produce(rw, payload); err != nil {
-			panic(err) // let the recovery middleware deal with this
-		}
-	}
-}
-
 // UpdateMTOAgentPreconditionFailedCode is the HTTP code returned for type UpdateMTOAgentPreconditionFailed
 const UpdateMTOAgentPreconditionFailedCode int = 412
 
@@ -401,50 +357,6 @@ func (o *UpdateMTOAgentInternalServerError) SetPayload(payload *primemessages.Er
 func (o *UpdateMTOAgentInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	if o.Payload != nil {
-		payload := o.Payload
-		if err := producer.Produce(rw, payload); err != nil {
-			panic(err) // let the recovery middleware deal with this
-		}
-	}
-}
-
-// UpdateMTOAgentNotImplementedCode is the HTTP code returned for type UpdateMTOAgentNotImplemented
-const UpdateMTOAgentNotImplementedCode int = 501
-
-/*UpdateMTOAgentNotImplemented The requested feature is still in development.
-
-swagger:response updateMTOAgentNotImplemented
-*/
-type UpdateMTOAgentNotImplemented struct {
-
-	/*
-	  In: Body
-	*/
-	Payload *primemessages.Error `json:"body,omitempty"`
-}
-
-// NewUpdateMTOAgentNotImplemented creates UpdateMTOAgentNotImplemented with default headers values
-func NewUpdateMTOAgentNotImplemented() *UpdateMTOAgentNotImplemented {
-
-	return &UpdateMTOAgentNotImplemented{}
-}
-
-// WithPayload adds the payload to the update m t o agent not implemented response
-func (o *UpdateMTOAgentNotImplemented) WithPayload(payload *primemessages.Error) *UpdateMTOAgentNotImplemented {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the update m t o agent not implemented response
-func (o *UpdateMTOAgentNotImplemented) SetPayload(payload *primemessages.Error) {
-	o.Payload = payload
-}
-
-// WriteResponse to the client
-func (o *UpdateMTOAgentNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.WriteHeader(501)
 	if o.Payload != nil {
 		payload := o.Payload
 		if err := producer.Produce(rw, payload); err != nil {

--- a/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
@@ -78,9 +78,11 @@ func (a *Client) CreateMTOShipment(params *CreateMTOShipmentParams) (*CreateMTOS
 UpdateMTOAgent updates m t o agent
 
 ### Functionality
-This endpoint is used to **update** the agents for an MTO Shipment.
+This endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.
 
 ### Errors:
+The agent must always have a name and at least one method of contact (either `email` or `phone`).
+
 The agent must be associated with the MTO shipment passed in the url.
 
 The shipment should be associated with an MTO that is available to the Prime.

--- a/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/update_m_t_o_agent_responses.go
@@ -54,12 +54,6 @@ func (o *UpdateMTOAgentReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
-	case 409:
-		result := NewUpdateMTOAgentConflict()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
 	case 412:
 		result := NewUpdateMTOAgentPreconditionFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -74,12 +68,6 @@ func (o *UpdateMTOAgentReader) ReadResponse(response runtime.ClientResponse, con
 		return nil, result
 	case 500:
 		result := NewUpdateMTOAgentInternalServerError()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-	case 501:
-		result := NewUpdateMTOAgentNotImplemented()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -255,39 +243,6 @@ func (o *UpdateMTOAgentNotFound) readResponse(response runtime.ClientResponse, c
 	return nil
 }
 
-// NewUpdateMTOAgentConflict creates a UpdateMTOAgentConflict with default headers values
-func NewUpdateMTOAgentConflict() *UpdateMTOAgentConflict {
-	return &UpdateMTOAgentConflict{}
-}
-
-/*UpdateMTOAgentConflict handles this case with default header values.
-
-The request could not be processed because of conflict in the current state of the resource.
-*/
-type UpdateMTOAgentConflict struct {
-	Payload *primemessages.ClientError
-}
-
-func (o *UpdateMTOAgentConflict) Error() string {
-	return fmt.Sprintf("[PUT /mto-shipments/{mtoShipmentID}/agents/{agentID}][%d] updateMTOAgentConflict  %+v", 409, o.Payload)
-}
-
-func (o *UpdateMTOAgentConflict) GetPayload() *primemessages.ClientError {
-	return o.Payload
-}
-
-func (o *UpdateMTOAgentConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	o.Payload = new(primemessages.ClientError)
-
-	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
-		return err
-	}
-
-	return nil
-}
-
 // NewUpdateMTOAgentPreconditionFailed creates a UpdateMTOAgentPreconditionFailed with default headers values
 func NewUpdateMTOAgentPreconditionFailed() *UpdateMTOAgentPreconditionFailed {
 	return &UpdateMTOAgentPreconditionFailed{}
@@ -376,39 +331,6 @@ func (o *UpdateMTOAgentInternalServerError) GetPayload() *primemessages.Error {
 }
 
 func (o *UpdateMTOAgentInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	o.Payload = new(primemessages.Error)
-
-	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
-		return err
-	}
-
-	return nil
-}
-
-// NewUpdateMTOAgentNotImplemented creates a UpdateMTOAgentNotImplemented with default headers values
-func NewUpdateMTOAgentNotImplemented() *UpdateMTOAgentNotImplemented {
-	return &UpdateMTOAgentNotImplemented{}
-}
-
-/*UpdateMTOAgentNotImplemented handles this case with default header values.
-
-The requested feature is still in development.
-*/
-type UpdateMTOAgentNotImplemented struct {
-	Payload *primemessages.Error
-}
-
-func (o *UpdateMTOAgentNotImplemented) Error() string {
-	return fmt.Sprintf("[PUT /mto-shipments/{mtoShipmentID}/agents/{agentID}][%d] updateMTOAgentNotImplemented  %+v", 501, o.Payload)
-}
-
-func (o *UpdateMTOAgentNotImplemented) GetPayload() *primemessages.Error {
-	return o.Payload
-}
-
-func (o *UpdateMTOAgentNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(primemessages.Error)
 

--- a/pkg/gen/primemessages/m_t_o_agent.go
+++ b/pkg/gen/primemessages/m_t_o_agent.go
@@ -30,7 +30,7 @@ type MTOAgent struct {
 	ETag string `json:"eTag,omitempty"`
 
 	// email
-	// Pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
+	// Pattern: ^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})?$
 	Email *string `json:"email,omitempty"`
 
 	// first name
@@ -50,7 +50,7 @@ type MTOAgent struct {
 	MtoShipmentID strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 	// phone
-	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+	// Pattern: ^([2-9]\d{2}-\d{3}-\d{4})?$
 	Phone *string `json:"phone,omitempty"`
 
 	// updated at
@@ -132,7 +132,7 @@ func (m *MTOAgent) validateEmail(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("email", "body", string(*m.Email), `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`); err != nil {
+	if err := validate.Pattern("email", "body", string(*m.Email), `^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})?$`); err != nil {
 		return err
 	}
 
@@ -171,7 +171,7 @@ func (m *MTOAgent) validatePhone(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("phone", "body", string(*m.Phone), `^[2-9]\d{2}-\d{3}-\d{4}$`); err != nil {
+	if err := validate.Pattern("phone", "body", string(*m.Phone), `^([2-9]\d{2}-\d{3}-\d{4})?$`); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_agent.go
+++ b/pkg/gen/primemessages/m_t_o_agent.go
@@ -25,6 +25,10 @@ type MTOAgent struct {
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
+	// e tag
+	// Read Only: true
+	ETag string `json:"eTag,omitempty"`
+
 	// email
 	// Pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
 	Email *string `json:"email,omitempty"`

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 
+	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
+
 	"github.com/go-openapi/loads"
 
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -85,7 +87,7 @@ func NewPrimeAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	primeAPI.MtoShipmentUpdateMTOAgentHandler = UpdateMTOAgentHandler{
 		context,
-		// TODO add updater
+		mtoagent.NewMTOAgentUpdater(context.DB()),
 	}
 
 	return primeAPI.Serve(nil)

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -3,6 +3,8 @@ package primeapi
 import (
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/transcom/mymove/pkg/services"
+
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
@@ -11,7 +13,7 @@ import (
 // UpdateMTOAgentHandler is the handler to update an address
 type UpdateMTOAgentHandler struct {
 	handlers.HandlerContext
-	//MTOAgentUpdater services.MTOAgentUpdater TODO
+	MTOAgentUpdater services.MTOAgentUpdater
 }
 
 // Handle updates an address on a shipment

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -61,10 +61,6 @@ func (h UpdateMTOAgentHandler) Handle(params mtoshipmentops.UpdateMTOAgentParams
 		case services.InvalidInputError:
 			return mtoshipmentops.NewUpdateMTOAgentUnprocessableEntity().WithPayload(
 				payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceID(), e.ValidationErrors))
-		// ConflictError -> Conflict Error Response
-		case services.ConflictError:
-			return mtoshipmentops.NewUpdateMTOAgentConflict().WithPayload(
-				payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceID()))
 		// QueryError -> Internal Server Error
 		case services.QueryError:
 			if e.Unwrap() != nil {

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -2,6 +2,10 @@ package primeapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
+	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
 
 	"github.com/transcom/mymove/pkg/services"
 
@@ -10,14 +14,67 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 )
 
-// UpdateMTOAgentHandler is the handler to update an address
+// UpdateMTOAgentHandler is the handler to update an agent
 type UpdateMTOAgentHandler struct {
 	handlers.HandlerContext
 	MTOAgentUpdater services.MTOAgentUpdater
 }
 
-// Handle updates an address on a shipment
+// Handle updates an MTO Agent for a shipment
 func (h UpdateMTOAgentHandler) Handle(params mtoshipmentops.UpdateMTOAgentParams) middleware.Responder {
-	return mtoshipmentops.NewUpdateMTOAgentNotImplemented().WithPayload(
-		payloads.NotImplementedError(nil, h.GetTraceID()))
+	logger := h.LoggerFromRequest(params.HTTPRequest)
+
+	// Get the params and payload
+	payload := params.Body
+	eTag := params.IfMatch
+	mtoShipmentID := uuid.FromStringOrNil(params.MtoShipmentID.String())
+	agentID := uuid.FromStringOrNil(params.AgentID.String())
+
+	// Get the new agent model
+	mtoAgent := payloads.MTOAgentModel(payload)
+	mtoAgent.ID = agentID // TODO set IDs method w/ error
+	mtoAgent.MTOShipmentID = mtoShipmentID
+
+	// Call the service object
+	updatedAgent, err := h.MTOAgentUpdater.UpdateMTOAgent(mtoAgent, eTag, mtoagent.UpdateMTOAgentPrimeValidator)
+
+	// Convert the errors into error responses to return to caller
+	if err != nil {
+		logger.Error("primeapi.UpdateMTOAgentHandler", zap.Error(err))
+
+		switch e := err.(type) {
+		// PreconditionFailedError -> Precondition Failed Response
+		case services.PreconditionFailedError:
+			return mtoshipmentops.NewUpdateMTOAgentPreconditionFailed().WithPayload(
+				payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
+		// NotFoundError -> Not Found Response
+		case services.NotFoundError:
+			return mtoshipmentops.NewUpdateMTOAgentNotFound().WithPayload(
+				payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
+		// InvalidInputError -> Unprocessable Entity Response
+		case services.InvalidInputError:
+			return mtoshipmentops.NewUpdateMTOAgentUnprocessableEntity().WithPayload(
+				payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceID(), e.ValidationErrors))
+		// ConflictError -> Conflict Error Response
+		case services.ConflictError:
+			return mtoshipmentops.NewUpdateMTOAgentConflict().WithPayload(
+				payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceID()))
+		// QueryError -> Internal Server Error
+		case services.QueryError:
+			if e.Unwrap() != nil {
+				logger.Error("primeapi.UpdateMTOAgentHandler error", zap.Error(e.Unwrap()))
+			}
+			return mtoshipmentops.NewUpdateMTOAgentInternalServerError().WithPayload(
+				payloads.InternalServerError(nil, h.GetTraceID()))
+		// Unknown -> Internal Server Error
+		default:
+			return mtoshipmentops.NewUpdateMTOAgentInternalServerError().
+				WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+		}
+
+	}
+
+	// If no error, create a successful payload to return
+	mtoAgentPayload := payloads.MTOAgent(updatedAgent)
+	return mtoshipmentops.NewUpdateMTOAgentOK().WithPayload(mtoAgentPayload)
 }

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -129,7 +129,33 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 
 	// Test invalid input
 	suite.T().Run("422 - Unprocessable response for invalid input", func(t *testing.T) {
+		empty := ""
 
+		payload := payloads.MTOAgent(&newAgent)
+		payload.FirstName = &empty
+		payload.Email = &empty
+		payload.Phone = &empty
+
+		params := mtoshipmentops.UpdateMTOAgentParams{
+			HTTPRequest:   req,
+			AgentID:       *handlers.FmtUUID(agent.ID),
+			MtoShipmentID: *handlers.FmtUUID(agent.MTOShipmentID),
+			Body:          payload,
+			IfMatch:       updatedETag,
+		}
+		// Run swagger validations
+		suite.NoError(params.Body.Validate(strfmt.Default))
+
+		// Run handler and check response
+		response := handler.Handle(params)
+		suite.IsType(&mtoshipmentops.UpdateMTOAgentUnprocessableEntity{}, response)
+
+		// Check error message for the invalid fields
+		agentUnprocessable := response.(*mtoshipmentops.UpdateMTOAgentUnprocessableEntity)
+		_, okFirstName := agentUnprocessable.Payload.InvalidFields["firstName"]
+		//_, okContactInfo := agentUnprocessable.Payload.InvalidFields["contactInfo"]
+		suite.True(okFirstName)
+		//suite.True(okContactInfo)
 	})
 
 	// Test not found response

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
+
 	"github.com/go-openapi/strfmt"
 
 	"github.com/transcom/mymove/pkg/etag"
@@ -22,7 +24,7 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 	// Create handler
 	handler := UpdateMTOAgentHandler{
 		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-		//mtoshipment.NewMTOAgentUpdater(suite.DB()), TODO
+		mtoagent.NewMTOAgentUpdater(suite.DB()),
 	}
 
 	suite.T().Run("NotImplemented response", func(t *testing.T) {

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -26,9 +26,9 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 		Move: testdatagen.MakeAvailableMove(suite.DB()),
 	})
 
-	firstName := "Test"
-	lastName := "Testerson"
-	email := "test.testerson@example.com"
+	firstName := "Carol"
+	lastName := "Romilly"
+	email := "carol.romilly@example.com"
 	phone := "456-555-7890"
 
 	newAgent := models.MTOAgent{

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -30,12 +30,10 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 	phone := "555-456-7890"
 
 	newAgent := models.MTOAgent{
-		ID:            agent.ID,
-		MTOShipmentID: agent.MTOShipmentID,
-		FirstName:     &firstName,
-		LastName:      &lastName,
-		Email:         &email,
-		Phone:         &phone,
+		FirstName: &firstName,
+		LastName:  &lastName,
+		Email:     &email,
+		Phone:     &phone,
 	}
 
 	// Create handler and request
@@ -46,7 +44,7 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 	req := httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s/agents/%s", agent.MTOShipmentID.String(), agent.ID.String()), nil)
 
 	eTag := etag.GenerateEtag(agent.UpdatedAt)
-	//var updatedETag string
+	var updatedETag string
 
 	// Test a successful request + update
 	suite.T().Run("200 - OK response", func(t *testing.T) {
@@ -67,18 +65,33 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 
 		// Check values
 		agentOK := response.(*mtoshipmentops.UpdateMTOAgentOK)
-		suite.Equal(agentOK.Payload.ID, agent.ID)
-		suite.Equal(agentOK.Payload.MtoShipmentID, agent.MTOShipmentID)
+		suite.Equal(agentOK.Payload.ID.String(), agent.ID.String())
+		suite.Equal(agentOK.Payload.MtoShipmentID.String(), agent.MTOShipmentID.String())
+		suite.Equal(string(agentOK.Payload.AgentType), string(agent.MTOAgentType)) // wasn't updated, should be original value
 		suite.Equal(agentOK.Payload.FirstName, newAgent.FirstName)
 		suite.Equal(agentOK.Payload.LastName, newAgent.LastName)
 		suite.Equal(agentOK.Payload.Email, newAgent.Email)
 		suite.Equal(agentOK.Payload.Phone, newAgent.Phone)
-		//updatedETag = agentOK.Payload.ETag
+		updatedETag = agentOK.Payload.ETag
 	})
 
 	// Test stale eTag
 	suite.T().Run("412 - Precondition failed response", func(t *testing.T) {
+		// Let's test with the same valid values, but the original, expired eTag:
+		payload := payloads.MTOAgent(&newAgent)
+		params := mtoshipmentops.UpdateMTOAgentParams{
+			HTTPRequest:   req,
+			AgentID:       *handlers.FmtUUID(agent.ID),
+			MtoShipmentID: *handlers.FmtUUID(agent.MTOShipmentID),
+			Body:          payload,
+			IfMatch:       eTag, // stale
+		}
+		// Run swagger validations
+		suite.NoError(params.Body.Validate(strfmt.Default))
 
+		// Run handler and check response
+		response := handler.Handle(params)
+		suite.IsType(&mtoshipmentops.UpdateMTOAgentPreconditionFailed{}, response)
 	})
 
 	// Test invalid IDs in the body vs. path values
@@ -93,7 +106,24 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 
 	// Test not found response
 	suite.T().Run("404 - Not found response", func(t *testing.T) {
+		payload := payloads.MTOAgent(&newAgent)
+		params := mtoshipmentops.UpdateMTOAgentParams{
+			HTTPRequest:   req,
+			AgentID:       *handlers.FmtUUID(agent.MTOShipmentID), // instead of agent.ID
+			MtoShipmentID: *handlers.FmtUUID(agent.MTOShipmentID),
+			Body:          payload,
+			IfMatch:       updatedETag,
+		}
+		// Run swagger validations
+		suite.NoError(params.Body.Validate(strfmt.Default))
 
+		// Run handler and check response
+		response := handler.Handle(params)
+		suite.IsType(&mtoshipmentops.UpdateMTOAgentNotFound{}, response)
+
+		// Check error message for the incorrect ID
+		agentNotFound := response.(*mtoshipmentops.UpdateMTOAgentNotFound)
+		suite.Contains(*agentNotFound.Payload.Detail, agent.MTOShipmentID.String())
 	})
 
 	// Test not Prime-available (not found response)

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -153,9 +153,9 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 		// Check error message for the invalid fields
 		agentUnprocessable := response.(*mtoshipmentops.UpdateMTOAgentUnprocessableEntity)
 		_, okFirstName := agentUnprocessable.Payload.InvalidFields["firstName"]
-		//_, okContactInfo := agentUnprocessable.Payload.InvalidFields["contactInfo"]
+		_, okContactInfo := agentUnprocessable.Payload.InvalidFields["contactInfo"]
 		suite.True(okFirstName)
-		//suite.True(okContactInfo)
+		suite.True(okContactInfo)
 	})
 
 	// Test not found response

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -5,14 +5,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
-
 	"github.com/go-openapi/strfmt"
 
 	"github.com/transcom/mymove/pkg/etag"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
-	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
+
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -26,6 +26,18 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 		mtoagent.NewMTOAgentUpdater(suite.DB()),
 	}
+
+	// Test a successful request + update
+
+	// Test invalid IDs in the body vs. path values
+
+	// Test stale eTag
+
+	// Test not found response
+
+	// Test not Prime-available (not found response)
+
+	// Test invalid input
 
 	suite.T().Run("NotImplemented response", func(t *testing.T) {
 		payload := payloads.MTOAgent(&agent)
@@ -42,6 +54,6 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 
 		// Run handler and check response
 		response := handler.Handle(params)
-		suite.IsType(&mtoshipmentops.UpdateMTOAgentNotImplemented{}, response)
+		suite.NotNil(response)
 	})
 }

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -27,7 +27,7 @@ func (suite *HandlerSuite) TestUpdateMTOAgentHandler() {
 	firstName := "Test"
 	lastName := "Testerson"
 	email := "test.testerson@example.com"
-	phone := "555-456-7890"
+	phone := "456-555-7890"
 
 	newAgent := models.MTOAgent{
 		FirstName: &firstName,

--- a/pkg/handlers/primeapi/mto_shipment_address.go
+++ b/pkg/handlers/primeapi/mto_shipment_address.go
@@ -48,7 +48,7 @@ func (h UpdateMTOShipmentAddressHandler) Handle(params mtoshipmentops.UpdateMTOS
 			return mtoshipmentops.NewUpdateMTOShipmentAddressNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
 		// InvalidInputError -> Unprocessable Entity Response
 		case services.InvalidInputError:
-			return mtoshipmentops.NewCreateMTOShipmentUnprocessableEntity().WithPayload(
+			return mtoshipmentops.NewUpdateMTOShipmentAddressUnprocessableEntity().WithPayload(
 				payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceID(), e.ValidationErrors))
 		// ConflictError -> ConflictError Response
 		case services.ConflictError:

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -201,6 +201,7 @@ func MTOAgent(mtoAgent *models.MTOAgent) *primemessages.MTOAgent {
 		MtoShipmentID: strfmt.UUID(mtoAgent.MTOShipmentID.String()),
 		CreatedAt:     strfmt.DateTime(mtoAgent.CreatedAt),
 		UpdatedAt:     strfmt.DateTime(mtoAgent.UpdatedAt),
+		ETag:          etag.GenerateEtag(mtoAgent.UpdatedAt),
 	}
 }
 

--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -35,8 +35,8 @@ func (suite *ModelSuite) Test_MTOAgentTestdataGen() {
 	MTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{})
 	suite.Equal(MTOAgent.FirstName, swag.String("Jason"))
 	suite.Equal(MTOAgent.LastName, swag.String("Ash"))
-	suite.Equal(MTOAgent.Email, swag.String("jason.ash@gmail.com"))
-	suite.Equal(MTOAgent.Phone, swag.String("2025559301"))
+	suite.Equal(MTOAgent.Email, swag.String("jason.ash@example.com"))
+	suite.Equal(MTOAgent.Phone, swag.String("202-555-9301"))
 	suite.Equal(MTOAgent.MTOAgentType, models.MTOAgentReleasing)
 	// test with assertions
 	someFirstName := "Some other agent name"

--- a/pkg/services/mto_agent/mto_agent_updater_test.go
+++ b/pkg/services/mto_agent/mto_agent_updater_test.go
@@ -66,9 +66,9 @@ func (suite *MTOAgentServiceSuite) TestMTOAgentUpdater() {
 
 	// Test successful update
 	suite.T().Run("Success", func(t *testing.T) {
-		firstName := "Test"
-		lastName := "Tester"
-		email := "special.test@example.com"
+		firstName := "Carol"
+		lastName := "Romilly"
+		email := "carol.romilly@example.com"
 
 		newAgent.FirstName = &firstName
 		newAgent.LastName = &lastName
@@ -150,7 +150,7 @@ func (suite *MTOAgentServiceSuite) TestValidateUpdateMTOAgent() {
 		suite.FatalNoError(err, "error while copying Prime-available agent models")
 
 		// Ensure we have the minimum required contact info
-		firstName := "Test"
+		firstName := "Carol"
 		email := "test@example.com"
 		newAgentPrime.FirstName = &firstName
 		newAgentPrime.Email = &email

--- a/pkg/services/mto_agent/mto_agent_validators.go
+++ b/pkg/services/mto_agent/mto_agent_validators.go
@@ -107,7 +107,7 @@ func (v *updateMTOAgentData) checkContactInfo() error {
 	}
 
 	// Check that we have something in the FirstName field:
-	if *firstName == "" || firstName == nil {
+	if firstName == nil || *firstName == "" {
 		v.verrs.Add("firstName", "cannot be blank")
 	}
 
@@ -122,7 +122,7 @@ func (v *updateMTOAgentData) checkContactInfo() error {
 	}
 
 	// Check that we have one method of contacting the agent:
-	if (*email == "" || email == nil) && (*phone == "" || phone == nil) {
+	if (email == nil || *email == "") && (phone == nil || *phone == "") {
 		v.verrs.Add("contactInfo", "agent must have at least one contact method provided")
 	}
 
@@ -152,15 +152,31 @@ func (v *updateMTOAgentData) setNewMTOAgent(newAgent *models.MTOAgent) error {
 	}
 	if v.updatedAgent.FirstName != nil {
 		newAgent.FirstName = v.updatedAgent.FirstName
+
+		if *v.updatedAgent.FirstName == "" {
+			newAgent.FirstName = nil
+		}
 	}
 	if v.updatedAgent.LastName != nil {
 		newAgent.LastName = v.updatedAgent.LastName
+
+		if *v.updatedAgent.LastName == "" {
+			newAgent.LastName = nil
+		}
 	}
 	if v.updatedAgent.Email != nil {
 		newAgent.Email = v.updatedAgent.Email
+
+		if *v.updatedAgent.Email == "" {
+			newAgent.Email = nil
+		}
 	}
 	if v.updatedAgent.Phone != nil {
 		newAgent.Phone = v.updatedAgent.Phone
+
+		if *v.updatedAgent.Phone == "" {
+			newAgent.Phone = nil
+		}
 	}
 
 	return nil

--- a/pkg/services/mto_agent/mto_agent_validators_test.go
+++ b/pkg/services/mto_agent/mto_agent_validators_test.go
@@ -98,7 +98,7 @@ func (suite *MTOAgentServiceSuite) TestUpdateMTOAgentData() {
 		firstName := "Test"
 		lastName := ""
 		email := ""
-		phone := "555-123-4567"
+		phone := "234-555-4567"
 
 		successAgent.FirstName = &firstName
 		successAgent.LastName = &lastName

--- a/pkg/services/mto_agent/mto_agent_validators_test.go
+++ b/pkg/services/mto_agent/mto_agent_validators_test.go
@@ -95,7 +95,7 @@ func (suite *MTOAgentServiceSuite) TestUpdateMTOAgentData() {
 
 	// Test successful check for contact info
 	suite.T().Run("checkContactInfo - success", func(t *testing.T) {
-		firstName := "Test"
+		firstName := "Carol"
 		lastName := ""
 		email := ""
 		phone := "234-555-4567"

--- a/pkg/testdatagen/make_mto_agent.go
+++ b/pkg/testdatagen/make_mto_agent.go
@@ -19,8 +19,8 @@ func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 
 	firstName := "Jason"
 	lastName := "Ash"
-	email := "jason.ash@gmail.com"
-	phone := "2025559301"
+	email := "jason.ash@example.com"
+	phone := "202-555-9301"
 
 	MTOAgent := models.MTOAgent{
 		MTOShipment:   mtoShipment,

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -303,9 +303,11 @@ paths:
       summary: updateMTOAgent
       description: |
         ### Functionality
-        This endpoint is used to **update** the agents for an MTO Shipment.
+        This endpoint is used to **update** the agents for an MTO Shipment. Only the fields being modified need to be sent in the request body.
 
         ### Errors:
+        The agent must always have a name and at least one method of contact (either `email` or `phone`).
+
         The agent must be associated with the MTO shipment passed in the url.
 
         The shipment should be associated with an MTO that is available to the Prime.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -356,16 +356,12 @@ paths:
           $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
-        '409':
-          $ref: '#/responses/Conflict'
         '412':
           $ref: '#/responses/PreconditionFailed'
         '422':
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
-        '501':
-          $ref: '#/responses/NotImplemented'
   '/mto-service-items':
     post:
       summary: createMTOServiceItem

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -968,12 +968,12 @@ definitions:
       email:
         type: string
         format: x-email
-        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        pattern: '^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})?$'
         x-nullable: true
       phone:
         type: string
         format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        pattern: '^([2-9]\d{2}-\d{3}-\d{4})?$'
         x-nullable: true
       agentType:
         $ref: '#/definitions/MTOAgentType'

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -977,6 +977,9 @@ definitions:
         x-nullable: true
       agentType:
         $ref: '#/definitions/MTOAgentType'
+      eTag:
+        type: string
+        readOnly: true
     type: object
   MTOAgents:
     items:


### PR DESCRIPTION
## Description

This PR fleshes out `UpdateMTOAgentHandler` with a call to the new service object and adds tests for the handler. It also updates the `updateMTOAgent` endpoint description in the `prime.yaml` and fixes a couple of small bugs (a copy pasta bug in `UpdateMTOShipmentAddressHandler` and some bad fake phone number values).

## Setup

Set up your dev environment for testing:

```sh
make db_dev_e2e_populate && make server_run
```

Use the instructions [here](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman) to set up Postman (or a comparable REST API client) for testing the Prime API.

Once Postman is set up, call the `fetchMTOUpdates` endpoint (`/move-task-orders`) to get a list of all Prime-available moves and their related info. Find any MTO shipment that has at least one MTO agent connected to it. Grab the ID of the MTO agent, the ID of the MTO shipment, and the eTag of the agent. 

_Example output:_
```json
[
    {
        "availableToPrimeAt": "2020-09-17T16:46:45.848Z",
        "createdAt": "2020-09-17T16:46:45.928Z",
        "eTag": "MjAyMC0wOS0xN1QxNjo0Njo0NS45MjgyMVo=",
        "id": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
        "isCanceled": false,
        "moveOrder": { ... },
        "moveOrderID": "6fca843a-a87e-4752-b454-0fac67aa4988",
        "mtoShipments": [
            {
                "actualPickupDate": "2020-03-16",
                "agents": [
                    {
                        "agentType": "RELEASING_AGENT",
                        "createdAt": "2020-09-17T16:46:46.576Z",
                        "eTag": "MjAyMC0wOS0xN1QxNjo0Njo0Ni41NzY3MjNa", *
                        "email": "test@test.email.com",
                        "firstName": "Test",
                        "id": "d73cc488-d5a1-4c9c-bea3-8b02d9bd0dea", *
                        "lastName": "Agent",
                        "mtoShipmentID": "475579d5-aaa4-4755-8c43-c510381ff9b5", *
                        "updatedAt": "2020-09-17T16:46:46.576Z"
                    }
                ],
               ...
            }
        ],
        "paymentRequests": [ ... ],
        ...
    },
    ...
]
```

Pull up the `updateMTOAgent` endpoint and enter the two IDs as the `mtoShipmentID` and `agentID` url parameters. Enter the `eTag` value as the `If-Match` header value. For the body, fill in any fields you'd like to try updating. 

_Example body (all other fields should be unchanged):_
```json
{
  "firstName": "Testly",
  "phone": "245-555-0091"
}
```

Keep testing until you're satisfied! Some scenarios to try:

* Try to clear out fields, for example: `"firstName": ""`
* Try to mess with the ID values (both `agentID` and `mtoShipmentID`)
* Try to pass in extra fields or fields that shouldn't be updated
* Try to save incorrectly formatted phone numbers or email addresses
* Try to update a non Prime-available MTO Agent
  * This will be tricky unless you have the GHC API set up for testing (hard) or have the database set up with a viewer that makes it easy to access/update (not so bad)
  * If you have a DB viewer, you can use `fetchMTOUpdates` to grab the `eTag` for an agent, and then go into the database and change the `availableToPrimeAt` value for that move to `null`

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4236) for this change.
* [Prime API Documentation](https://github.com/transcom/prime_api_deliverable/wiki)
