### PR TITLE
MB-4384 Display empty string for 0 SIT allowance

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -2071,6 +2071,7 @@ func init() {
         },
         "storageInTransit": {
           "type": "integer",
+          "x-nullable": true,
           "example": 90
         },
         "totalDependents": {
@@ -5713,6 +5714,7 @@ func init() {
         },
         "storageInTransit": {
           "type": "integer",
+          "x-nullable": true,
           "example": 90
         },
         "totalDependents": {

--- a/pkg/gen/ghcmessages/entitlements.go
+++ b/pkg/gen/ghcmessages/entitlements.go
@@ -43,7 +43,7 @@ type Entitlements struct {
 	ProGearWeightSpouse int64 `json:"proGearWeightSpouse,omitempty"`
 
 	// storage in transit
-	StorageInTransit int64 `json:"storageInTransit,omitempty"`
+	StorageInTransit *int64 `json:"storageInTransit,omitempty"`
 
 	// total dependents
 	TotalDependents int64 `json:"totalDependents,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -154,7 +154,7 @@ func Entitlement(entitlement *models.Entitlement) *ghcmessages.Entitlements {
 		PrivatelyOwnedVehicle: entitlement.PrivatelyOwnedVehicle,
 		ProGearWeight:         proGearWeight,
 		ProGearWeightSpouse:   proGearWeightSpouse,
-		StorageInTransit:      sit,
+		StorageInTransit:      &sit,
 		TotalDependents:       totalDependents,
 		TotalWeight:           totalWeight,
 		ETag:                  etag.GenerateEtag(entitlement.UpdatedAt),

--- a/src/components/Office/AllowancesTable.jsx
+++ b/src/components/Office/AllowancesTable.jsx
@@ -68,7 +68,7 @@ const AllowancesTable = ({ info }) => {
             <th scope="row" className="text-bold">
               Storage in transit
             </th>
-            <td data-testid="storageInTransit">{`${info.storageInTransit} days`}</td>
+            <td data-testid="storageInTransit">{info.storageInTransit ? `${info.storageInTransit} days` : ''}</td>
           </tr>
           <tr>
             <th scope="row" className="text-bold">

--- a/src/components/Office/AllowancesTable.test.jsx
+++ b/src/components/Office/AllowancesTable.test.jsx
@@ -26,3 +26,11 @@ describe('Allowances Table', () => {
     expect(wrapper.find({ 'data-testid': 'dependents' }).text()).toMatch('Authorized');
   });
 });
+
+describe('Allowances Table when SIT is 0', () => {
+  it('displays an empty string for the SIT allowance', () => {
+    info.storageInTransit = 0;
+    const wrapper = shallow(<AllowancesTable info={info} />);
+    expect(wrapper.find({ 'data-testid': 'storageInTransit' }).text()).toEqual('');
+  });
+});

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1419,6 +1419,7 @@ definitions:
       storageInTransit:
         example: 90
         type: integer
+        x-nullable: true
       totalWeight:
         example: 500
         type: integer


### PR DESCRIPTION
## Description

By default, a service member's SIT (storage in transit) allowance is
90 days. However, the `StorageInTransit` field does not have a default
value in the DB, and we are not explicitly setting it to 90 days
when the customer creates their move. This was causing the frontend
to display `undefined days` as the SIT Allowance in the Move Details
page in the TOO interface. This is because the `StorageInTransit`
field was not being returned at all as part of the payload when it is
zero. Note that there is a separate JIRA story to set the default
SIT allowance.

In this PR, we are fixing the frontend so that it displays an empty
string if SIT is zero. To do that, we set the `x-nullable` attribute
for `storageInTransit` to `true`, which allows the frontend to check
if it is zero or non-zero. If it is zero, we display an empty string.

If it's ever possible for the SIT allowance to only be one day, we
might consider using some kind of pluralization helper so that it
would display the singular `day` as opposed to the hardcoded plural
`days` that we have now.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4384) for this change

## Screenshots

Before:

<img width="985" alt="Screen Shot 2020-09-23 at 10 05 35 AM" src="https://user-images.githubusercontent.com/811150/94327201-55915380-ff77-11ea-95f5-932002d274b3.png">


After:

<img width="996" alt="Screen Shot 2020-09-25 at 9 37 05 PM" src="https://user-images.githubusercontent.com/811150/94327180-4ca08200-ff77-11ea-959a-265c0beb6373.png">
