### PR TITLE
[MB-3946] Notification handler for MoveTaskOrder

### DIFF
--- a/pkg/services/event/event.go
+++ b/pkg/services/event/event.go
@@ -39,11 +39,11 @@ type Event struct {
 	logger          handlers.Logger         // The logger
 }
 
-// PaymentRequestCreateEventKey is a key containing PaymentRequest.Create
-const PaymentRequestCreateEventKey KeyType = "PaymentRequest.Create"
+// MoveTaskOrderCreateEventKey is a key containing MoveTaskOrder.Create
+const MoveTaskOrderCreateEventKey KeyType = "MoveTaskOrder.Create"
 
-// PaymentRequestUpdateEventKey is a key containing PaymentRequest.Update
-const PaymentRequestUpdateEventKey KeyType = "PaymentRequest.Update"
+// MoveTaskOrderUpdateEventKey is a key containing MoveTaskOrder.Update
+const MoveTaskOrderUpdateEventKey KeyType = "MoveTaskOrder.Update"
 
 // MTOShipmentCreateEventKey is a key containing MTOShipment.Create
 const MTOShipmentCreateEventKey KeyType = "MTOShipment.Create"
@@ -57,13 +57,21 @@ const MTOServiceItemCreateEventKey KeyType = "MTOServiceItem.Create"
 // MTOServiceItemUpdateEventKey is a key containing MTOServiceItem.Update
 const MTOServiceItemUpdateEventKey KeyType = "MTOServiceItem.Update"
 
+// PaymentRequestCreateEventKey is a key containing PaymentRequest.Create
+const PaymentRequestCreateEventKey KeyType = "PaymentRequest.Create"
+
+// PaymentRequestUpdateEventKey is a key containing PaymentRequest.Update
+const PaymentRequestUpdateEventKey KeyType = "PaymentRequest.Update"
+
 var eventModels map[KeyType]eventModel = map[KeyType]eventModel{
-	PaymentRequestCreateEventKey: {PaymentRequestCreateEventKey, models.PaymentRequest{}},
-	PaymentRequestUpdateEventKey: {PaymentRequestUpdateEventKey, models.PaymentRequest{}},
+	MoveTaskOrderCreateEventKey:  {MoveTaskOrderCreateEventKey, models.Move{}},
+	MoveTaskOrderUpdateEventKey:  {MoveTaskOrderUpdateEventKey, models.Move{}},
 	MTOShipmentCreateEventKey:    {MTOShipmentCreateEventKey, models.MTOShipment{}},
 	MTOShipmentUpdateEventKey:    {MTOShipmentUpdateEventKey, models.MTOShipment{}},
 	MTOServiceItemCreateEventKey: {MTOServiceItemCreateEventKey, models.MTOServiceItem{}},
 	MTOServiceItemUpdateEventKey: {MTOServiceItemUpdateEventKey, models.MTOServiceItem{}},
+	PaymentRequestCreateEventKey: {PaymentRequestCreateEventKey, models.PaymentRequest{}},
+	PaymentRequestUpdateEventKey: {PaymentRequestUpdateEventKey, models.PaymentRequest{}},
 }
 
 // IsCreateEvent returns true if this event is a create event

--- a/pkg/services/event/notification_payloads.go
+++ b/pkg/services/event/notification_payloads.go
@@ -6,8 +6,82 @@ import (
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 )
+
+// MoveTaskOrder has a custom payload definition, because it differs from the one in primeapi
+type MoveTaskOrder struct {
+
+	// available to prime at
+	// Read Only: true
+	// Format: date-time
+	AvailableToPrimeAt *strfmt.DateTime `json:"availableToPrimeAt,omitempty"`
+
+	// created at
+	// Read Only: true
+	// Format: date-time
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
+
+	// e tag
+	// Read Only: true
+	ETag string `json:"eTag,omitempty"`
+
+	// id
+	// Format: uuid
+	ID strfmt.UUID `json:"id,omitempty"`
+
+	// is canceled
+	IsCanceled *bool `json:"isCanceled,omitempty"`
+
+	// move order ID
+	// Format: uuid
+	MoveOrderID strfmt.UUID `json:"moveOrderID,omitempty"`
+
+	// ppm estimated weight
+	PpmEstimatedWeight int64 `json:"ppmEstimatedWeight,omitempty"`
+
+	// ppm type
+	// Enum: [FULL PARTIAL]
+	PpmType string `json:"ppmType,omitempty"`
+
+	// reference Id
+	ReferenceID string `json:"referenceId,omitempty"`
+
+	// updated at
+	// Read Only: true
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
+}
+
+// MoveTaskOrderModelToPayload converts the Move model into a MoveTaskOrder payload
+// Ideally it would be great to have this definition in the yaml - OpenAPI 3.0 should have
+// ability to put callback payloads in the yaml
+func MoveTaskOrderModelToPayload(moveTaskOrder *models.Move) *MoveTaskOrder {
+	if moveTaskOrder == nil {
+		return nil
+	}
+	payload := &MoveTaskOrder{
+		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
+		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
+		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
+		IsCanceled:         moveTaskOrder.IsCanceled(),
+		MoveOrderID:        strfmt.UUID(moveTaskOrder.OrdersID.String()),
+		ReferenceID:        *moveTaskOrder.ReferenceID,
+		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
+		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+	}
+
+	if moveTaskOrder.PPMEstimatedWeight != nil {
+		payload.PpmEstimatedWeight = int64(*moveTaskOrder.PPMEstimatedWeight)
+	}
+
+	if moveTaskOrder.PPMType != nil {
+		payload.PpmType = *moveTaskOrder.PPMType
+	}
+
+	return payload
+}
 
 // PaymentRequestModelToPayload creates a model we can use to populate the payload column
 // Currently we are using the primemessages struct as the payload.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1028,7 +1028,7 @@ definitions:
     required:
       - modelType
       - moveTaskOrderID
-  MTOServiceItemBasic:
+  MTOServiceItemBasic: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a basic service item subtype of a MTOServiceItem.
     allOf:
       - $ref: '#/definitions/MTOServiceItem'
@@ -1038,7 +1038,7 @@ definitions:
             $ref: '#/definitions/ReServiceCode'
         required:
           - reServiceCode
-  MTOServiceItemDDFSIT:
+  MTOServiceItemDDFSIT: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic destination 1st day SIT service item subtype of a MTOServiceItem.
     allOf:
       - $ref: '#/definitions/MTOServiceItem'
@@ -1104,7 +1104,7 @@ definitions:
       - length
       - width
       - height
-  MTOServiceItemDOFSIT:
+  MTOServiceItemDOFSIT: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic origin 1st day SIT service item subtype of a MTOServiceItem.
     allOf:
       - $ref: '#/definitions/MTOServiceItem'
@@ -1128,7 +1128,7 @@ definitions:
           - reServiceCode
           - reason
           - pickupPostalCode
-  MTOServiceItemDomesticCrating:
+  MTOServiceItemDomesticCrating: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic crating/uncrating service item subtype of a MTOServiceItem.
     allOf:
       - $ref: '#/definitions/MTOServiceItem'
@@ -1168,7 +1168,7 @@ definitions:
       - MTOServiceItemDDFSIT
       - MTOServiceItemShuttle
       - MTOServiceItemDomesticCrating
-  MTOServiceItemShuttle:
+  MTOServiceItemShuttle: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a shuttle service item.
     allOf:
       - $ref: '#/definitions/MTOServiceItem'


### PR DESCRIPTION
## Description

Added the `assembleMTOPayload` function. Also had to add a payload definition and a custom model_to_payload because the MoveTaskOrder payload in primeapi contains unnecessary items, like MoveOrders, MTOShipments, PaymentRequests. 

Some of them, like MTOShipments and PaymentRequests, if unpopulated, just show up as empty arrays which would be sort of ok. But MoveOrders shows up as an object with empty fields and that looks broken.

I tried a few things to avoid having to define a new payload but none were successful 
- I looked for a way to tell the json unmarshall to ignore the MoveOrders object but couldn't find anything that wouldn't require retooling the MoveTaskOrder object. But it's gen'ed by swagger so we can't control it that much.
- I tried splitting the MoveTaskOrder yaml definition into a minimal and extended version and recombine them using `allof` . That failed, it actually generated pkg/gen code that was uncompile-able. I think the polymorphism of MTOServiceItems does not play well with the allOf functionality.
- Would be interested to hear other ideas.

## Setup

Run the unit test added. 
## References

* [ [MB-3946] Push Enable: Add notification handler for MoveTaskOrder - Jira](https://dp3.atlassian.net/browse/MB-3946) for this change


[MB-3946]: https://dp3.atlassian.net/browse/MB-3946