### PR TITLE
[MB-3439] Added handler for MTOShipment Payload

### DIFF
--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -30,6 +32,12 @@ func TestEventServiceSuite(t *testing.T) {
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()
+}
+
+func (suite *EventServiceSuite) getNotification(mtoID uuid.UUID, traceID uuid.UUID) (*models.WebhookNotification, error) {
+	var notification = new(models.WebhookNotification)
+	err := suite.DB().Where("object_id = $1 AND trace_id = $2", mtoID.String(), traceID.String()).First(notification)
+	return notification, err
 }
 
 func (suite *EventServiceSuite) Test_EventTrigger() {
@@ -193,6 +201,8 @@ func (suite *EventServiceSuite) Test_MTOShipmentEventTrigger() {
 	}
 	logger, _ := zap.NewDevelopment()
 	handler := handlers.NewHandlerContext(suite.DB(), logger)
+	traceID, _ := uuid.NewV4()
+	handler.SetTraceID(traceID)
 
 	// Test successful event passing with Support API
 	suite.T().Run("Success with GHC MTOShipment endpoint", func(t *testing.T) {
@@ -206,9 +216,21 @@ func (suite *EventServiceSuite) Test_MTOShipmentEventTrigger() {
 			HandlerContext:  handler,
 			DBConnection:    suite.DB(),
 		})
-		// TODO: Once proper payload is generated this should not return error
-		suite.Error(err)
-		// TODO: Add sandy's webhook notification check
+		suite.Nil(err)
+
+		// Get the notification
+		notification, err := suite.getNotification(mtoShipmentID, traceID)
+		suite.NoError(err)
+		suite.Equal(&mtoShipmentID, notification.ObjectID)
+
+		// Reinflate the json from the notification payload
+		suite.NotEmpty(notification.Payload)
+		var mtoShipmentInPayload primemessages.MTOShipment
+		json.Unmarshal([]byte(*notification.Payload), &mtoShipmentInPayload)
+
+		// Check some params
+		suite.EqualValues(mtoShipment.ShipmentType, mtoShipmentInPayload.ShipmentType)
+		suite.EqualValues(handlers.FmtDatePtr(mtoShipment.RequestedPickupDate).String(), mtoShipmentInPayload.RequestedPickupDate.String())
 
 	})
 }

--- a/pkg/services/event/notification.go
+++ b/pkg/services/event/notification.go
@@ -93,8 +93,13 @@ func assembleMTOShipmentPayload(db *pop.Connection, updatedObjectID uuid.UUID) (
 		return nil, notFoundError
 	}
 
-	// TODO: This should convert the model to payload and then return the bytes
-	return model.ID.Bytes(), nil
+	payload := payloads.MTOShipment(&model)
+	payloadArray, err := json.Marshal(payload)
+	if err != nil {
+		unknownErr := services.NewEventError("Unknown error creating MTOShipment payload.", err)
+		return nil, unknownErr
+	}
+	return payloadArray, nil
 
 }
 


### PR DESCRIPTION
## Description

Completed the `assembleMTOShipmentPayload` function and test. The function creates the payload to be sent in the notification.

## Setup

Check that the unit test works
`TestEventServiceSuite/Test_MTOShipmentEventTrigger/Success_with_GHC_MTOShipment_endpoint`

## References

* [ [MB-3439] Push Enable: Add notification Handler for MTOShipment - Jira](https://dp3.atlassian.net/browse/MB-3439) for this change


[MB-3439]: https://dp3.atlassian.net/browse/MB-3439