### PR TITLE
MB-4385 Allow MTO tab to render all the time

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "resolutions": {
     "bl": "^4.0.3",
     "kind-of": "^6.0.2",
+    "node-forge": "^0.10.0",
     "selfsigned": "^1.10.8",
     "serialize-javascript": "^3.1.0"
   },

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -102,7 +102,7 @@ export const MoveTaskOrder = ({ match }) => {
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
-  const serviceItems = mtoServiceItemsArr.map((item) => {
+  const serviceItems = mtoServiceItemsArr?.map((item) => {
     const newItem = { ...item };
     newItem.code = item.reServiceCode;
     newItem.serviceItem = item.reServiceName;
@@ -125,6 +125,17 @@ export const MoveTaskOrder = ({ match }) => {
     setIsModalVisible(true);
   };
 
+  const approved = (shipment) => shipment.status === 'APPROVED';
+  const mtoShipmentsArr = Object.values(mtoShipments);
+
+  if (!mtoShipmentsArr.some(approved)) {
+    return (
+      <div>
+        <p>This Move does not have any approved shipments yet.</p>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.tabContent}>
       <GridContainer className={styles.gridContainer} data-testid="too-shipment-container">
@@ -143,7 +154,10 @@ export const MoveTaskOrder = ({ match }) => {
           </div>
         </div>
 
-        {Object.values(mtoShipments).map((mtoShipment) => {
+        {mtoShipmentsArr.map((mtoShipment) => {
+          if (mtoShipment.status !== 'APPROVED') {
+            return false;
+          }
           const serviceItemsForShipment = serviceItems.filter((item) => item.mtoShipmentID === mtoShipment.id);
           const requestedServiceItems = serviceItemsForShipment.filter(
             (item) => item.status === SERVICE_ITEM_STATUS.SUBMITTED,

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -50,6 +50,7 @@ jest.mock('hooks/queries', () => ({
             state: 'NJ',
             postal_code: '08401',
           },
+          status: 'APPROVED',
         },
       },
       mtoServiceItems: {


### PR DESCRIPTION
**Description**
Previously, if you clicked on the Move task order tab when looking
at a Move as a TOO, and when no shipments had been approved yet,
it would throw an exception. This was because the code was assuming
there would always be service items present.

To fix this, we can use the Null Propagation operator so that if
something is null, it doesn't throw an `undefined` exception. In
addition, we added a conditional around the ShipmentContainer so that
only approved shipments appear.

## Reviewer Notes

### Scenario where no approved shipments exist
1. Run the setup commands in the section below
2. Visit http://officelocal:3000/devlocal-auth/login
3. Click the `Login` button next to `too_role@office.mil (PPM office)`
4. Click on a move that doesn't have any approved shipments yet
5. Click on the Move task order tab

Expected Result: You don't see an exception. Instead, the MTO tab renders, but with nothing displayed.

### Scenario where at least one approved shipment exists
1. Run the setup commands in the section below
2. Visit http://officelocal:3000/devlocal-auth/login
3. Click the `Login` button next to `too_role@office.mil (PPM office)`
4. Click on, or create a move that has 2 shipments: one that is approved, and one that is not approved.
5. Click on the Move task order tab

Expected Result: Only the approved shipment, along with its service items, appears in the MTO tab.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run (in a separate terminal tab)
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4385) for this change

## Screenshots

<img width="1423" alt="Screen Shot 2020-09-30 at 3 17 08 PM" src="https://user-images.githubusercontent.com/811150/94729701-0dd04a80-0330-11eb-9fb6-59a8433113b4.png">
