### PR TITLE
[MB-4451] Remove cancel buttons from wizardpage and wizard form 

### DIFF
--- a/cypress/integration/mymove/ppmCloseout.js
+++ b/cypress/integration/mymove/ppmCloseout.js
@@ -315,14 +315,6 @@ function serviceMemberCanFinishWeightTicketLater(vehicleType) {
 
   cy.get('button').contains('Finish Later').click();
 
-  cy.get('button').contains('Cancel').click();
-
-  cy.location().should((loc) => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
-  });
-
-  cy.get('button').contains('Finish Later').click();
-
   cy.get('button').contains('OK').click();
 
   cy.location().should((loc) => {

--- a/src/pages/MyMove/Orders.jsx
+++ b/src/pages/MyMove/Orders.jsx
@@ -69,7 +69,6 @@ export class Orders extends Component {
         additionalParams={{ serviceMemberId }}
         className={formName}
         handleSubmit={this.handleSubmit}
-        hideCancelBtn
         initialValues={initialValues}
         pageKey={pageKey}
         pageList={pages}

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -21,5 +21,4 @@ describe('Orders page', () => {
     </MockProviders>,
   );
   expect(wrapper.length).toEqual(1);
-  expect(wrapper.find('[data-testid="wizardCancelButton"]').length).toBe(0);
 });

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -69,7 +69,6 @@ export class UploadOrders extends Component {
         dirty={isDirty}
         error={error}
         handleSubmit={no_op}
-        hideCancelBtn
         pageIsValid={isValid}
         pageKey={pageKey}
         pageList={pages}

--- a/src/pages/MyMove/UploadOrders.test.jsx
+++ b/src/pages/MyMove/UploadOrders.test.jsx
@@ -10,8 +10,8 @@ import thunk from 'redux-thunk';
 import UploadOrders from './UploadOrders';
 
 const defaultProps = {
-  pages: [],
-  pageKey: '',
+  pages: ['1', '2', '3'],
+  pageKey: '2',
   fetchLatestOrders: () => {},
 };
 
@@ -35,8 +35,8 @@ function mountUploadOrders(props = defaultProps) {
 }
 
 describe('UploadOrders component', () => {
-  it('renders component with no cancel button', () => {
+  it('renders component with next button', () => {
     const wrapper = mountUploadOrders();
-    expect(wrapper.find('[data-testid="wizardCancelButton"]').length).toBe(0);
+    expect(wrapper.find('[data-testid="wizardNextButton"]').length).toBe(1);
   });
 });

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -10,7 +10,6 @@ import generatePath from './generatePath';
 import './index.css';
 import { validateRequiredFields } from 'shared/JsonSchemaForm';
 import { reduxForm } from 'redux-form';
-import { mobileSize } from 'shared/constants';
 import scrollToTop from 'shared/scrollToTop';
 
 import { getNextPagePath, getPreviousPagePath, isFirstPage, isLastPage, beforeTransition } from './utils';
@@ -20,14 +19,12 @@ export class WizardFormPage extends Component {
     super(props);
     this.nextPage = this.nextPage.bind(this);
     this.previousPage = this.previousPage.bind(this);
-    this.cancelFlow = this.cancelFlow.bind(this);
     this.beforeTransition = beforeTransition.bind(this);
     this.submit = this.submit.bind(this);
   }
 
   static defaultProps = {
     readyToSubmit: true,
-    hideCancelBtn: false,
   };
 
   componentDidUpdate(prevProps) {
@@ -58,9 +55,6 @@ export class WizardFormPage extends Component {
     push(generatePath(path, combinedParams));
   }
 
-  cancelFlow() {
-    this.props.push(`/`);
-  }
   nextPage() {
     if (this.props.reduxFormSubmit) {
       return this.props.reduxFormSubmit().then(() => this.beforeTransition(getNextPagePath, false));
@@ -84,7 +78,6 @@ export class WizardFormPage extends Component {
   }
 
   render() {
-    const isMobile = this.props.windowWidth < mobileSize;
     // when reduxFormSubmit is supplied it's expected that the form will use redux-form's handlesubmit prop
     // and accompanying submit validation https://redux-form.com/8.2.0/examples/submitvalidation/
     // while forms that provide their own handlesubmit prop are expected to not be using redux-form's submit validation
@@ -99,7 +92,6 @@ export class WizardFormPage extends Component {
       valid,
       dirty,
       readyToSubmit,
-      hideCancelBtn,
     } = this.props;
     const canMoveForward = valid && readyToSubmit;
     const canMoveBackward = (valid || !dirty) && !isFirstPage(pageList, pageKey);
@@ -140,17 +132,7 @@ export class WizardFormPage extends Component {
                 </button>
               )}
             </div>
-            <div className="grid-col-2 margin-top-6 tablet:margin-top-3">
-              {!isMobile && !hideCancelBtn && (
-                <button
-                  className="usa-button usa-button--unstyled padding-left-0"
-                  onClick={this.cancelFlow}
-                  data-testid="wizardCancelButton"
-                >
-                  Cancel
-                </button>
-              )}
-            </div>
+
             {isLastPage(pageList, pageKey) && (
               <button
                 className="usa-button"

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -8,7 +8,6 @@ import { push } from 'connected-react-router';
 import Alert from 'shared/Alert'; // eslint-disable-line
 import generatePath from './generatePath';
 import './index.css';
-import { mobileSize } from 'shared/constants';
 import scrollToTop from 'shared/scrollToTop';
 
 import { getNextPagePath, getPreviousPagePath, isFirstPage, isLastPage, beforeTransition } from './utils';
@@ -18,7 +17,7 @@ export class WizardPage extends Component {
     super(props);
     this.nextPage = this.nextPage.bind(this);
     this.previousPage = this.previousPage.bind(this);
-    this.cancelFlow = this.cancelFlow.bind(this);
+    this.goHome = this.goHome.bind(this);
     this.beforeTransition = beforeTransition.bind(this);
   }
   componentDidUpdate() {
@@ -27,7 +26,7 @@ export class WizardPage extends Component {
   componentDidMount() {
     scrollToTop();
   }
-  cancelFlow() {
+  goHome() {
     this.props.push(`/`);
   }
 
@@ -51,18 +50,7 @@ export class WizardPage extends Component {
   }
 
   render() {
-    const isMobile = this.props.windowWidth < mobileSize;
-    const {
-      handleSubmit,
-      pageKey,
-      pageList,
-      children,
-      error,
-      pageIsValid,
-      dirty,
-      canMoveNext,
-      hideCancelBtn,
-    } = this.props;
+    const { handleSubmit, pageKey, pageList, children, error, pageIsValid, dirty, canMoveNext } = this.props;
     const canMoveForward = pageIsValid && canMoveNext;
     const canMoveBackward = (pageIsValid || !dirty) && !isFirstPage(pageList, pageKey);
     return (
@@ -112,17 +100,6 @@ export class WizardPage extends Component {
                 Complete
               </button>
             )}
-            {!isMobile && !hideCancelBtn && (
-              <button
-                type="button"
-                className="usa-button usa-button--unstyled padding-left-0"
-                onClick={this.cancelFlow}
-                disabled={false}
-                data-testid="wizardCancelButton"
-              >
-                Cancel
-              </button>
-            )}
           </div>
         </div>
       </div>
@@ -148,7 +125,6 @@ WizardPage.defaultProps = {
   pageIsValid: true,
   canMoveNext: true,
   dirty: true,
-  hideCancelBtn: false,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -32,11 +32,9 @@ describe('given a WizardPage', () => {
             );
           });
 
-          it('it renders buttons for cancel and next', () => {
+          it('it renders buttons for next', () => {
             const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
             expect(nextButton.text()).toBe('Next');
-            const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-            expect(cancelButton.text()).toBe('Cancel');
           });
 
           it('does not render a back button', () => {
@@ -61,9 +59,7 @@ describe('given a WizardPage', () => {
             );
           });
 
-          it('it renders buttons for cancel, back, and complete', () => {
-            const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-            expect(cancelButton.text()).toBe('Cancel');
+          it('it renders buttons for back and complete', () => {
             const backButton = wrapper.find('[data-testid="wizardBackButton"]');
             expect(backButton.text()).toBe('Back');
             const completeButton = wrapper.find('[data-testid="wizardCompleteButton"]');
@@ -124,11 +120,9 @@ describe('given a WizardPage', () => {
           expect(childContainer.first().text()).toBe('<Alert />');
         });
 
-        it('it renders button for cancel, back, next', () => {
+        it('it renders button for back, next', () => {
           const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
           expect(nextButton.text()).toBe('Next');
-          const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-          expect(cancelButton.text()).toBe('Cancel');
           const backButton = wrapper.find('[data-testid="wizardBackButton"]');
           expect(backButton.text()).toBe('Back');
         });
@@ -136,11 +130,6 @@ describe('given a WizardPage', () => {
         it('does not render a complete button', () => {
           const completeButton = wrapper.find('[data-testid="wizardCompleteButton"]');
           expect(completeButton.exists()).toBe(false);
-        });
-
-        it('the cancel button is enabled', () => {
-          const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-          expect(cancelButton.prop('disabled')).toBe(false);
         });
 
         it('the back button is enabled', () => {
@@ -182,10 +171,6 @@ describe('given a WizardPage', () => {
           expect(submit.mock.calls.length).toBe(0);
         });
       });
-      it('the cancel button is enabled', () => {
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.prop('disabled')).toBe(false);
-      });
       it('the next button is enabled', () => {
         const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
         expect(nextButton.prop('disabled')).toBeFalsy();
@@ -217,16 +202,9 @@ describe('given a WizardPage', () => {
       it('it starts on the first page', () => {
         expect(wrapper.children().first().text()).toBe('This is page 1');
       });
-      it('it renders button for cancel and next', () => {
+      it('it renders button for next', () => {
         const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
         expect(nextButton.text()).toBe('Next');
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.text()).toBe('Cancel');
-      });
-
-      it('the cancel button is enabled', () => {
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.prop('disabled')).toBe(false);
       });
       it('the next button is enabled', () => {
         const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
@@ -257,11 +235,9 @@ describe('given a WizardPage', () => {
       it('it shows its child', () => {
         expect(wrapper.children().first().text()).toBe('This is page 2');
       });
-      it('it renders button for cancel, back, next', () => {
+      it('it renders button for back, next', () => {
         const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
         expect(nextButton.text()).toBe('Next');
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.text()).toBe('Cancel');
         const backButton = wrapper.find('[data-testid="wizardBackButton"]');
         expect(backButton.text()).toBe('Back');
       });
@@ -279,10 +255,6 @@ describe('given a WizardPage', () => {
           expect(mockPush.mock.calls.length).toBe(1);
           expect(mockPush.mock.calls[0][0]).toBe('1');
         });
-      });
-      it('the cancel button is enabled', () => {
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.prop('disabled')).toBe(false);
       });
       it('the next button is enabled', () => {
         const nextButton = wrapper.find('[data-testid="wizardNextButton"]');
@@ -316,11 +288,9 @@ describe('given a WizardPage', () => {
       it('it shows its child', () => {
         expect(wrapper.children().first().text()).toBe('This is page 3');
       });
-      it('it renders button for cancel, back, and complete', () => {
+      it('it renders button for back and complete', () => {
         const completeButton = wrapper.find('[data-testid="wizardCompleteButton"]');
         expect(completeButton.text()).toBe('Complete');
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.text()).toBe('Cancel');
         const backButton = wrapper.find('[data-testid="wizardBackButton"]');
         expect(backButton.text()).toBe('Back');
       });
@@ -338,10 +308,6 @@ describe('given a WizardPage', () => {
           expect(mockPush.mock.calls.length).toBe(1);
           expect(mockPush.mock.calls[0][0]).toBe('2');
         });
-      });
-      it('the cancel button is enabled', () => {
-        const cancelButton = wrapper.find('[data-testid="wizardCancelButton"]');
-        expect(cancelButton.prop('disabled')).toBe(false);
       });
       it('the Complete button is enabled', () => {
         const completeButton = wrapper.find('[data-testid="wizardCompleteButton"]');


### PR DESCRIPTION
## Description

Removes the cancel button from wizard and all references to it in all tests.

## Reviewer Notes

To design et al: are we 100% sure we don't currently use or rely on the cancel button now that this change will break?

## Setup

Run the app and check that the cancel button is indeed not there, or anywhere.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=MB&modal=detail&selectedIssue=MB-4451&quickFilter=60) for this change

## Screenshots

