### PR TITLE
[MB-4442] Add Ability to Generate EDI for DPK, DUPK, DOP and DDP Service Items

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -414,14 +414,23 @@ func (g ghcPaymentRequestInvoiceGenerator) fetchPaymentServiceItemParam(serviceI
 	return paymentServiceItemParam, nil
 }
 
-func (g ghcPaymentRequestInvoiceGenerator) getPaymentParamsForDefaultServiceItems(serviceItem models.PaymentServiceItem) (float64, float64, error) {
-	// TODO: update to have a case statement as different service items may or may not have weight
-	// and the distance key can differ (zip3 v zip5, and distances for SIT)
+func (g ghcPaymentRequestInvoiceGenerator) getWeightParams(serviceItem models.PaymentServiceItem) (float64, error) {
 	weight, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNameWeightBilledActual)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 	weightFloat, err := strconv.ParseFloat(weight.Value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Could not parse weight for PaymentServiceItem %s: %w", serviceItem.ID, err)
+	}
+
+	return weightFloat, nil
+}
+
+func (g ghcPaymentRequestInvoiceGenerator) getWeightAndDistanceParams(serviceItem models.PaymentServiceItem) (float64, float64, error) {
+	// TODO: update to have a case statement as different service items may or may not have weight
+	// and the distance key can differ (zip3 v zip5, and distances for SIT)
+	weightFloat, err := g.getWeightParams(serviceItem)
 	if err != nil {
 		return 0, 0, fmt.Errorf("Could not parse weight for PaymentServiceItem %s: %w", serviceItem.ID, err)
 	}
@@ -481,10 +490,40 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 			}
 
 			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment, &l3Segment)
+		// pack and unpack, dom dest and dom origin have weight no distance
+		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
+			models.ReServiceCodeDPK, models.ReServiceCodeDDP:
+			var err error
+			weightFloat, err = g.getWeightParams(serviceItem)
+			if err != nil {
+				return segments, fmt.Errorf("Could not parse weight or distance for PaymentServiceItem %w", err)
+			}
+
+			l5Segment := edisegment.L5{
+				LadingLineItemNumber:   hierarchicalIDNumber,
+				LadingDescription:      string(serviceCode),
+				CommodityCode:          "TBD",
+				CommodityCodeQualifier: "D",
+			}
+
+			l0Segment := edisegment.L0{
+				LadingLineItemNumber: hierarchicalIDNumber,
+				Weight:               weightFloat,
+				WeightQualifier:      "B",
+				WeightUnitCode:       "L",
+			}
+
+			l3Segment := edisegment.L3{
+				Weight:          weightFloat,
+				WeightQualifier: "B",
+				PriceCents:      int64(*serviceItem.PriceCents),
+			}
+
+			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment, &l3Segment)
 
 		default:
 			var err error
-			weightFloat, distanceFloat, err = g.getPaymentParamsForDefaultServiceItems(serviceItem)
+			weightFloat, distanceFloat, err = g.getWeightAndDistanceParams(serviceItem)
 			if err != nil {
 				return segments, fmt.Errorf("Could not parse weight or distance for PaymentServiceItem %w", err)
 			}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -115,8 +115,32 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		paymentRequest,
 		basicPaymentServiceItemParams,
 	)
+	dop := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+		suite.DB(),
+		models.ReServiceCodeDOP,
+		paymentRequest,
+		basicPaymentServiceItemParams,
+	)
+	ddp := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+		suite.DB(),
+		models.ReServiceCodeDDP,
+		paymentRequest,
+		basicPaymentServiceItemParams,
+	)
+	dpk := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+		suite.DB(),
+		models.ReServiceCodeDPK,
+		paymentRequest,
+		basicPaymentServiceItemParams,
+	)
+	dupk := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+		suite.DB(),
+		models.ReServiceCodeDUPK,
+		paymentRequest,
+		basicPaymentServiceItemParams,
+	)
 
-	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh)
+	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk)
 
 	serviceMember := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -169,7 +193,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds se end segment", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(42, result.SE.NumberOfIncludedSegments)
+		suite.Equal(62, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -329,6 +353,33 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				l3 := result.ServiceItems[segmentOffset+4].(*edisegment.L3)
 				suite.Equal(paymentServiceItem.PriceCents.Int64(), l3.PriceCents)
 			})
+		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
+			models.ReServiceCodeDPK, models.ReServiceCodeDDP:
+			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
+				suite.IsType(&edisegment.L5{}, result.ServiceItems[segmentOffset+2])
+				l5 := result.ServiceItems[segmentOffset+2].(*edisegment.L5)
+				suite.Equal(hierarchicalNumberInt, l5.LadingLineItemNumber)
+				suite.Equal(string(serviceCode), l5.LadingDescription)
+				suite.Equal("TBD", l5.CommodityCode)
+				suite.Equal("D", l5.CommodityCodeQualifier)
+			})
+
+			suite.T().Run("adds l0 service item segment", func(t *testing.T) {
+				suite.IsType(&edisegment.L0{}, result.ServiceItems[segmentOffset+3])
+				l0 := result.ServiceItems[segmentOffset+3].(*edisegment.L0)
+				suite.Equal(hierarchicalNumberInt, l0.LadingLineItemNumber)
+				suite.Equal(float64(4242), l0.Weight)
+				suite.Equal("B", l0.WeightQualifier)
+				suite.Equal("L", l0.WeightUnitCode)
+			})
+
+			suite.T().Run("adds l3 service item segment", func(t *testing.T) {
+				suite.IsType(&edisegment.L3{}, result.ServiceItems[segmentOffset+4])
+				l3 := result.ServiceItems[segmentOffset+4].(*edisegment.L3)
+				suite.Equal(float64(4242), l3.Weight)
+				suite.Equal("B", l3.WeightQualifier)
+				suite.Equal(paymentServiceItem.PriceCents.Int64(), l3.PriceCents)
+			})
 		default:
 			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
 				suite.IsType(&edisegment.L5{}, result.ServiceItems[segmentOffset+2])
@@ -402,10 +453,3 @@ func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {
 	_, err := generator.Generate(paymentRequest, false)
 	suite.NoError(err)
 }
-
-// func helperLoadExpectedEDI(suite *GHCInvoiceSuite, name string) string {
-// 	path := filepath.Join("testdata", name) // relative path
-// 	bytes, err := ioutil.ReadFile(path)
-// 	suite.NoError(err, "error loading expected EDI fixture")
-// 	return string(bytes)
-// }


### PR DESCRIPTION
## Description

This PR adds ability for the EDI to generate the following payment service items: 
- Dom Origin Price
- Dom Destination Price
- Dom Unpack
- Dom Pack

## Reviewer Notes

These 4 service items do not rely on distance. So the L0 segment omits the 2 distance related fields

## Setup

1. `make server_run`
2. Create a payment request. Create a file called `create_payment_request.json` in the project root and paste in the JSON payload provided below:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "722a6f4e-b438-4655-88c7-51609056550d"
      },
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      },
      {
        "id": "999504a9-45b0-477f-a00b-3ede8ffde379"
      },
      {
        "id": "a6e5debc-9e73-421b-8f68-92936ce34737"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "d886431c-c357-46b7-a084-a0c85dd496d3"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

This payload includes DLH, MS, CS, DSH, DOP, DDP, DPK, DUPK and FSC service items .

2. Use the Prime API Client to create the payment request and return the payment request number by running the command below:

```sh
prime-api-client --insecure create-payment-request --filename  create_payment_request.json | jq '.paymentRequestNumber'
```
3. Use the CLI utility to generate the EDI858 and view it in your terminal. Remember to pass the payment request number of the payment request you just created.

```sh
go run ./cmd/generate-payment-request-edi/ --payment-request-number [$paymentRequestNumber]
```

## Expected Output 

```sh
ISA*00*0084182369*00*_   _*ZZ*GOVDPIBS*12*8004171844*20201001*0013*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*20201001*0013*100001251*X*004010
ST*858*0001
BX*00*J*PP*7244-5957*TRUS**4
N9*CN*7244-5957-1**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*86*2020-10-01*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
N1*SF*30SizCDyEv*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
FA1*DF
FA2*TA*F8E1
HL*1**|
N9*PO*f9249128-e2c0-4a51-99b5-e19c352cf3c0**
L5*1*DPK*TBD*D**
L0*1***1349.000*B******L
L3*1349.000*B*101814
HL*2**|
N9*PO*baf2fc2f-0c21-44dc-a0d9-44070320c9c5**
L5*2*DSH*TBD*D**
L0*2*409.000*DM*1349.000*B******L
L3*1349.000*B*501165
HL*3**|
N9*PO*555a605b-d2a2-49b8-ad18-01cc447a18fa**
L5*3*DDP*TBD*D**
L0*3***1349.000*B******L
L3*1349.000*B*10835
HL*4**|
N9*PO*7e34e5d8-f5ab-4dd2-9baa-5078713238c0**
L5*4*DOP*TBD*D**
L0*4***1540.000*B******L
L3*1540.000*B*6222
HL*5**|
N9*PO*b0682481-0d96-47d3-8983-191ae1e9f5cf**
L5*5*DLH*TBD*D**
L0*5*373.000*DM*1349.000*B******L
L3*1349.000*B*1221717
HL*6**|
N9*PO*c80dc4a0-29ae-4fe7-9247-4e54b447de99**
L5*6*MS*TBD*D**
L0*6**********
L3***45423
HL*7**|
N9*PO*27cc2a34-f01f-455a-9f8d-cb94d1fa1db7**
L5*7*CS*TBD*D**
L0*7**********
L3***22353
HL*8**|
N9*PO*2e0f73c5-7eab-4f87-911a-1378a002299b**
L5*8*DUPK*TBD*D**
L0*8***1349.000*B******L
L3*1349.000*B*8219
HL*9**|
N9*PO*2fb5bdb5-170b-49ed-ba6d-f9abbf76ccd6**
L5*9*FSC*TBD*D**
L0*9*373.000*DM*1349.000*B******L
L3*1349.000*B*362
SE*62*0001
GE*1*100001251
IEA*1*100001272
```
## References

- [JIRA Story](https://dp3.atlassian.net/browse/MB-4442) for this PR
