### PR TITLE
MB-4489 Show ZIP code if shipment address missing

### DIFF
--- a/src/components/Office/ShipmentContainer.stories.jsx
+++ b/src/components/Office/ShipmentContainer.stories.jsx
@@ -25,7 +25,12 @@ export const HHG = () => (
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationAddress: text('ShipmentInfo.destinationAddress', 'Tacoma, WA 98421'),
+        destinationAddress: object('MTOShipment.destinationAddress', {
+          street_address_1: '123 Any Street',
+          city: 'Tacoma',
+          state: 'WA',
+          postal_code: '98421',
+        }),
         scheduledPickupDate: text('ShipmentInfo.destinationPostalCode', '27 Mar 2020'),
       }}
     />
@@ -40,7 +45,12 @@ export const MTOAccessorial = () => (
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationAddress: text('ShipmentInfo.destinationCity', 'Tacoma, WA 98421'),
+        destinationAddress: object('MTOShipment.destinationAddress', {
+          street_address_1: '123 Any Street',
+          city: 'Tacoma',
+          state: 'WA',
+          postal_code: '98421',
+        }),
         scheduledPickupDate: text('ShipmentInfo.destinationPostalCode', '27 Mar 2020'),
       }}
     />

--- a/src/components/Office/ShipmentContainer.stories.jsx
+++ b/src/components/Office/ShipmentContainer.stories.jsx
@@ -25,9 +25,7 @@ export const HHG = () => (
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationCity: text('ShipmentInfo.destinationCity', 'Tacoma'),
-        destinationState: text('ShipmentInfo.destinationState', 'WA'),
-        destinationPostalCode: text('ShipmentInfo.destinationPostalCode', '98421'),
+        destinationAddress: text('ShipmentInfo.destinationAddress', 'Tacoma, WA 98421'),
         scheduledPickupDate: text('ShipmentInfo.destinationPostalCode', '27 Mar 2020'),
       }}
     />
@@ -42,9 +40,7 @@ export const MTOAccessorial = () => (
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationCity: text('ShipmentInfo.destinationCity', 'Tacoma'),
-        destinationState: text('ShipmentInfo.destinationState', 'WA'),
-        destinationPostalCode: text('ShipmentInfo.destinationPostalCode', '98421'),
+        destinationAddress: text('ShipmentInfo.destinationCity', 'Tacoma, WA 98421'),
         scheduledPickupDate: text('ShipmentInfo.destinationPostalCode', '27 Mar 2020'),
       }}
     />

--- a/src/components/Office/ShipmentHeading.jsx
+++ b/src/components/Office/ShipmentHeading.jsx
@@ -2,16 +2,26 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import { AddressShape } from '../../types/address';
+
 import styles from './shipmentHeading.module.scss';
+
+function formatDestinationAddress(address) {
+  if (address.city) {
+    // eslint-disable-next-line camelcase
+    return `${address.city}, ${address.state} ${address.postal_code}`;
+  }
+  // eslint-disable-next-line camelcase
+  return `${address.postal_code}`;
+}
 
 function ShipmentHeading({ shipmentInfo }) {
   return (
     <div className={classNames(styles.shipmentHeading, 'shipment-heading')}>
       <h3 data-testid="office-shipment-heading-h3">{shipmentInfo.shipmentType}</h3>
       <small>
-        {`${shipmentInfo.originCity} ${shipmentInfo.originState} ${shipmentInfo.originPostalCode} to
-    ${shipmentInfo.destinationCity} ${shipmentInfo.destinationState} ${shipmentInfo.destinationPostalCode}
-    on ${shipmentInfo.scheduledPickupDate}`}
+        {`${shipmentInfo.originCity}, ${shipmentInfo.originState} ${shipmentInfo.originPostalCode} to
+        ${formatDestinationAddress(shipmentInfo.destinationAddress)} on ${shipmentInfo.scheduledPickupDate}`}
       </small>
     </div>
   );
@@ -23,9 +33,7 @@ ShipmentHeading.propTypes = {
     originCity: PropTypes.string.isRequired,
     originState: PropTypes.string.isRequired,
     originPostalCode: PropTypes.string.isRequired,
-    destinationCity: PropTypes.string.isRequired,
-    destinationState: PropTypes.string.isRequired,
-    destinationPostalCode: PropTypes.string.isRequired,
+    destinationAddress: AddressShape,
     scheduledPickupDate: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/components/Office/ShipmentHeading.test.jsx
+++ b/src/components/Office/ShipmentHeading.test.jsx
@@ -3,23 +3,43 @@ import { shallow } from 'enzyme';
 
 import ShipmentHeading from './ShipmentHeading';
 
+const shipmentDestinationAddressWithPostalOnly = {
+  postal_code: '98421',
+};
+
+const shipmentDestinationAddress = {
+  street_1: '123 Main St',
+  city: 'Tacoma',
+  state: 'WA',
+  postal_code: '98421',
+};
+
 const headingInfo = {
   shipmentType: 'Household Goods',
   originCity: 'San Antonio',
   originState: 'TX',
   originPostalCode: '98421',
-  destinationCity: 'Tacoma',
-  destinationState: 'WA',
-  destinationPostalCode: '98421',
+  destinationAddress: shipmentDestinationAddress,
   scheduledPickupDate: '27 Mar 2020',
 };
 
-describe('Shipment Heading', () => {
+describe('Shipment Heading with full destination address', () => {
   it('should render the data passed to it within the heading', () => {
     const wrapper = shallow(<ShipmentHeading shipmentInfo={headingInfo} />);
     expect(wrapper.find('h3').text()).toEqual('Household Goods');
-    expect(wrapper.find('small').text()).toContain('San Antonio TX 98421');
-    expect(wrapper.find('small').text()).toContain('Tacoma WA 98421');
+    expect(wrapper.find('small').text()).toContain('San Antonio, TX 98421');
+    expect(wrapper.find('small').text()).toContain('Tacoma, WA 98421');
+    expect(wrapper.find('small').text()).toContain('27 Mar 2020');
+  });
+});
+
+describe('Shipment Heading with missing destination address', () => {
+  it("only renders the postal_code of the order's new duty station", () => {
+    headingInfo.destinationAddress = shipmentDestinationAddressWithPostalOnly;
+    const wrapper = shallow(<ShipmentHeading shipmentInfo={headingInfo} />);
+    expect(wrapper.find('h3').text()).toEqual('Household Goods');
+    expect(wrapper.find('small').text()).toContain('San Antonio, TX 98421');
+    expect(wrapper.find('small').text()).toContain('98421');
     expect(wrapper.find('small').text()).toContain('27 Mar 2020');
   });
 });

--- a/src/components/Office/shipmentheading.stories.jsx
+++ b/src/components/Office/shipmentheading.stories.jsx
@@ -13,9 +13,7 @@ storiesOf('TOO/TIO Components|ShipmentHeading', module)
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationCity: text('ShipmentInfo.destinationCity', 'Tacoma'),
-        destinationState: text('ShipmentInfo.destinationState', 'WA'),
-        destinationPostalCode: text('ShipmentInfo.destinationPostalCode', '98421'),
+        destinationAddress: text('ShipmentInfo.destinationAddress', 'Tacoma, WA 98421'),
         scheduledPickupDate: text('ShipmentInfo.scheduledPickupDate', '27 Mar 2020'),
       }}
     />

--- a/src/components/Office/shipmentheading.stories.jsx
+++ b/src/components/Office/shipmentheading.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, object, text } from '@storybook/addon-knobs';
 
 import ShipmentHeading from './ShipmentHeading';
 
@@ -13,7 +13,12 @@ storiesOf('TOO/TIO Components|ShipmentHeading', module)
         originCity: text('ShipmentInfo.originCity', 'San Antonio'),
         originState: text('ShipmentInfo.originState', 'TX'),
         originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
-        destinationAddress: text('ShipmentInfo.destinationAddress', 'Tacoma, WA 98421'),
+        destinationAddress: object('MTOShipment.destinationAddress', {
+          street_address_1: '123 Any Street',
+          city: 'Tacoma',
+          state: 'WA',
+          postal_code: '98421',
+        }),
         scheduledPickupDate: text('ShipmentInfo.scheduledPickupDate', '27 Mar 2020'),
       }}
     />

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -154,6 +154,9 @@ export const MoveTaskOrder = ({ match }) => {
           const rejectedServiceItems = serviceItemsForShipment.filter(
             (item) => item.status === SERVICE_ITEM_STATUS.REJECTED,
           );
+          // eslint-disable-next-line camelcase
+          const dutyStationPostal = { postal_code: moveOrder.destinationDutyStation.address.postal_code };
+
           return (
             <ShipmentContainer
               key={mtoShipment.id}
@@ -167,9 +170,7 @@ export const MoveTaskOrder = ({ match }) => {
                   originCity: get(mtoShipment.pickupAddress, 'city'),
                   originState: get(mtoShipment.pickupAddress, 'state'),
                   originPostalCode: get(mtoShipment.pickupAddress, 'postal_code'),
-                  destinationCity: get(mtoShipment.destinationAddress, 'city'),
-                  destinationState: get(mtoShipment.destinationAddress, 'state'),
-                  destinationPostalCode: get(mtoShipment.destinationAddress, 'postal_code'),
+                  destinationAddress: mtoShipment.destinationAddress || dutyStationPostal,
                   scheduledPickupDate: formatShipmentDate(mtoShipment.scheduledPickupDate),
                 }}
               />
@@ -179,7 +180,7 @@ export const MoveTaskOrder = ({ match }) => {
               />
               <ShipmentAddresses
                 pickupAddress={mtoShipment?.pickupAddress}
-                destinationAddress={mtoShipment?.destinationAddress}
+                destinationAddress={mtoShipment?.destinationAddress || dutyStationPostal}
                 originDutyStation={moveOrder?.originDutyStation?.address}
                 destinationDutyStation={moveOrder?.destinationDutyStation?.address}
               />


### PR DESCRIPTION
**Description**
If the service member doesn't know their full destination address for
the shipment, the form defaults to their new duty station ZIP code.
On the Move task order tab in the Office app, we were wrongly assuming
every shipment would have a destination address, resulting in the
string `undefined` for the city, state, and ZIP.

To fix this, we check to see if a destination address exists, and if
not, we fall back to the postal code of the order's new duty station.

I also fixed a formatting issue where a comma was missing between the
city and state of the pickup address.

## Reviewer Notes

1. Sign in as a service member and submit a move with an HHG shipment that doesn't have a full destination address.
2. Sign in as a TOO and view the move you created in step 1.
3. Approve the shipment
4. Click on the Move task order tab

Expected Result: Under the "Household Goods" heading, verify that the you see the postal code of the destination, and not 3 `undefined` strings. See the screenshots below for reference.

## Setup

```
make db_dev_e2e_populate
make server_run
make office_client_run (in a separate terminal tab)
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4489) for this change

## Screenshots

Before:

<img width="1116" alt="Screen Shot 2020-10-01 at 5 21 50 PM" src="https://user-images.githubusercontent.com/811150/94866876-21ea7980-040e-11eb-910b-817e7c8e95d8.png">

After:

<img width="1126" alt="Screen Shot 2020-10-01 at 5 47 52 PM" src="https://user-images.githubusercontent.com/811150/94866948-40e90b80-040e-11eb-89b4-e063e0d2e7e6.png">
