### PR TITLE
[MB-4224] Added additional G62 segments for scheduled/actual dates

### DIFF
--- a/pkg/edi/segment/g62.go
+++ b/pkg/edi/segment/g62.go
@@ -9,7 +9,7 @@ import (
 // Requested Pickup Date 68, Requested Pickup Time 5
 // Actual Pickup Date 86, Actual Pickup Time 8
 type G62 struct {
-	DateQualifier int    `validate:"oneof=68 86"`
+	DateQualifier int    `validate:"oneof=10 76 86"`
 	Date          string `validate:"timeformat=20060102"`
 	TimeQualifier int    `validate:"oneof=5 8"`
 	Time          string `validate:"timeformat=1504"`

--- a/pkg/edi/segment/g62_test.go
+++ b/pkg/edi/segment/g62_test.go
@@ -12,7 +12,7 @@ func (suite *SegmentSuite) TestValidateG62() {
 		Time:          "1617",
 	}
 	validG62RequestedPickupDateTime := G62{
-		DateQualifier: 68,
+		DateQualifier: 10,
 		Date:          "20200909",
 		TimeQualifier: 5,
 		Time:          "1617",

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -259,7 +259,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 			Value:   "2424",
 		},
 	}
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDLH,
 		basicPaymentServiceItemParams,

--- a/pkg/services/ghcrateengine/counseling_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/counseling_services_pricer_test.go
@@ -44,7 +44,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceCounselingServices() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupCounselingServicesItem() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeCS,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -18,7 +18,7 @@ const (
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestinationWithServiceItemParamsBadData() {
 	suite.setUpDomesticDestinationData()
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDDP,
 		[]testdatagen.CreatePaymentServiceItemParams{
@@ -185,7 +185,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticDestinationServiceItems() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDDP,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
@@ -122,7 +122,7 @@ func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulData() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulServiceItem() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDLH,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -18,7 +18,7 @@ const (
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemParamsBadData() {
 	suite.setUpDomesticOriginData()
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDOP,
 		[]testdatagen.CreatePaymentServiceItemParams{
@@ -185,7 +185,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticOriginServiceItems() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDOP,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
@@ -18,7 +18,7 @@ const (
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPackWithServiceItemParamsBadData() {
 	suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDPK)
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDPK,
 		[]testdatagen.CreatePaymentServiceItemParams{
@@ -185,7 +185,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticPackServiceItems() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDPK,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
@@ -19,7 +19,7 @@ const (
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticShorthaulWithServiceItemParamsBadData() {
 	suite.setUpDomesticShorthaulData()
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDSH,
 		[]testdatagen.CreatePaymentServiceItemParams{
@@ -207,7 +207,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticShorthaul() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticShorthaulServiceItems() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDSH,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/domestic_unpack_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_unpack_pricer_test.go
@@ -18,7 +18,7 @@ const (
 
 func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpackWithServiceItemParamsBadData() {
 	suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDUPK)
-	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDUPK,
 		[]testdatagen.CreatePaymentServiceItemParams{
@@ -185,7 +185,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupDomesticUnpackServiceItems() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDUPK,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
+++ b/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
@@ -61,7 +61,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupFuelSurchargeServiceItem() models.PaymentServiceItem {
-	model := testdatagen.MakePaymentServiceItemWithParams(
+	model := testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeFSC,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/management_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/management_services_pricer_test.go
@@ -44,7 +44,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceManagementServices() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupManagementServicesItem() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeMS,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/ghcrateengine/service_item_pricer_test.go
+++ b/pkg/services/ghcrateengine/service_item_pricer_test.go
@@ -103,7 +103,7 @@ func (suite *GHCRateEngineServiceSuite) setupPriceServiceItemData() {
 }
 
 func (suite *GHCRateEngineServiceSuite) setupPriceServiceItem() models.PaymentServiceItem {
-	return testdatagen.MakePaymentServiceItemWithParams(
+	return testdatagen.MakeDefaultPaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeMS,
 		[]testdatagen.CreatePaymentServiceItemParams{

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -170,7 +170,7 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 
 	if !msOrCsOnly(paymentServiceItems) {
 		var g62Segments []edisegment.Segment
-		g62Segments, err = g.createG62Segments(paymentRequest.ID, moveTaskOrder.Orders)
+		g62Segments, err = g.createG62Segments(paymentRequest.ID)
 		if err != nil {
 			return ediinvoice.Invoice858C{}, err
 		}
@@ -252,29 +252,55 @@ func (g ghcPaymentRequestInvoiceGenerator) createServiceMemberDetailSegments(pay
 	return serviceMemberDetails, nil
 }
 
-func (g ghcPaymentRequestInvoiceGenerator) createG62Segments(paymentRequestID uuid.UUID, orders models.Order) ([]edisegment.Segment, error) {
-	g62Segments := []edisegment.Segment{}
+func (g ghcPaymentRequestInvoiceGenerator) createG62Segments(paymentRequestID uuid.UUID) ([]edisegment.Segment, error) {
+	var g62Segments []edisegment.Segment
 
-	// Add requested pickup date
-	var requestedPickupDateParam models.PaymentServiceItemParam
+	// Get all the shipments associated with this payment request's service items, ordered by shipment creation date.
+	var shipments models.MTOShipments
 	err := g.db.Q().
-		Join("service_item_param_keys sipk", "payment_service_item_params.service_item_param_key_id = sipk.id").
-		Join("payment_service_items psi", "payment_service_item_params.payment_service_item_id = psi.id").
-		Join("payment_requests pr", "psi.payment_request_id = pr.id").
-		Where("pr.id = ?", paymentRequestID).
-		Where("sipk.key = ?", models.ServiceItemParamNameRequestedPickupDate).
-		First(&requestedPickupDateParam)
-
+		Join("mto_service_items msi", "mto_shipments.id = msi.mto_shipment_id").
+		Join("payment_service_items psi", "msi.id = psi.mto_service_item_id").
+		Where("psi.payment_request_id = ?", paymentRequestID).
+		Order("msi.created_at").
+		All(&shipments)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't find requested pickup date: %s", err)
+		return nil, fmt.Errorf("error querying for shipments to use in G62 segments in PaymentRequest %s: %w", paymentRequestID, err)
 	}
 
-	requestedPickupDateSegment := edisegment.G62{
-		DateQualifier: 86,
-		Date:          requestedPickupDateParam.Value,
+	// If no shipments, then just return because we will not have access to the dates.
+	if len(shipments) == 0 {
+		return g62Segments, nil
 	}
 
-	g62Segments = append(g62Segments, &requestedPickupDateSegment)
+	// Use the first (earliest) shipment.
+	shipment := shipments[0]
+
+	// Insert request pickup date, if available.
+	if shipment.RequestedPickupDate != nil {
+		requestedPickupDateSegment := edisegment.G62{
+			DateQualifier: 10,
+			Date:          shipment.RequestedPickupDate.Format(dateFormat),
+		}
+		g62Segments = append(g62Segments, &requestedPickupDateSegment)
+	}
+
+	// Insert expected pickup date, if available.
+	if shipment.ScheduledPickupDate != nil {
+		scheduledPickupDateSegment := edisegment.G62{
+			DateQualifier: 76,
+			Date:          shipment.ScheduledPickupDate.Format(dateFormat),
+		}
+		g62Segments = append(g62Segments, &scheduledPickupDateSegment)
+	}
+
+	// Insert expected pickup date, if available.
+	if shipment.ActualPickupDate != nil {
+		actualPickupDateSegment := edisegment.G62{
+			DateQualifier: 86,
+			Date:          shipment.ActualPickupDate.Format(dateFormat),
+		}
+		g62Segments = append(g62Segments, &actualPickupDateSegment)
+	}
 
 	return g62Segments, nil
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -75,69 +75,87 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		Move: mto,
 		PaymentRequest: models.PaymentRequest{
-			ID:              uuid.FromStringOrNil("d66d9f35-218c-8b85-b9d1-631449b9d984"),
-			MoveTaskOrder:   mto,
 			IsFinal:         false,
 			Status:          models.PaymentRequestStatusPending,
 			RejectionReason: nil,
 		},
 	})
 
+	requestedPickupDate := time.Date(testdatagen.GHCTestYear, time.September, 15, 0, 0, 0, 0, time.UTC)
+	scheduledPickupDate := time.Date(testdatagen.GHCTestYear, time.September, 20, 0, 0, 0, 0, time.UTC)
+	actualPickupDate := time.Date(testdatagen.GHCTestYear, time.September, 22, 0, 0, 0, 0, time.UTC)
+
+	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+		Move: mto,
+		MTOShipment: models.MTOShipment{
+			RequestedPickupDate: &requestedPickupDate,
+			ScheduledPickupDate: &scheduledPickupDate,
+			ActualPickupDate:    &actualPickupDate,
+		},
+	})
+
+	assertions := testdatagen.Assertions{
+		Move:           mto,
+		MTOShipment:    mtoShipment,
+		PaymentRequest: paymentRequest,
+	}
+
 	var paymentServiceItems models.PaymentServiceItems
-	dlh := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	dlh := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDLH,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	fsc := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	fsc := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeFSC,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	ms := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	ms := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeMS,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	cs := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	cs := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeCS,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	dsh := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	dsh := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDSH,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	dop := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	dop := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDOP,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	ddp := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	ddp := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDDP,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	dpk := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	dpk := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDPK,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	dupk := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	dupk := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDUPK,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
 
 	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk)
@@ -191,7 +209,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds se end segment", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(62, result.SE.NumberOfIncludedSegments)
+		suite.Equal(64, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -245,9 +263,19 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds actual pickup date to header", func(t *testing.T) {
 		suite.IsType(&edisegment.G62{}, result.Header[6])
-		g62 := result.Header[6].(*edisegment.G62)
-		suite.Equal(86, g62.DateQualifier)
-		suite.Equal(currentTime.Format(testDateFormat), g62.Date)
+		g62Requested := result.Header[6].(*edisegment.G62)
+		suite.Equal(10, g62Requested.DateQualifier)
+		suite.Equal(requestedPickupDate.Format(testDateFormat), g62Requested.Date)
+
+		suite.IsType(&edisegment.G62{}, result.Header[7])
+		g62Scheduled := result.Header[7].(*edisegment.G62)
+		suite.Equal(76, g62Scheduled.DateQualifier)
+		suite.Equal(scheduledPickupDate.Format(testDateFormat), g62Scheduled.Date)
+
+		suite.IsType(&edisegment.G62{}, result.Header[8])
+		g62Actual := result.Header[8].(*edisegment.G62)
+		suite.Equal(86, g62Actual.DateQualifier)
+		suite.Equal(actualPickupDate.Format(testDateFormat), g62Actual.Date)
 	})
 
 	suite.T().Run("adds orders destination address", func(t *testing.T) {
@@ -255,21 +283,21 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		expectedDutyStation := paymentRequest.MoveTaskOrder.Orders.NewDutyStation
 		transportationOffice, err := models.FetchDutyStationTransportationOffice(suite.DB(), expectedDutyStation.ID)
 		suite.FatalNoError(err)
-		suite.IsType(&edisegment.N1{}, result.Header[7])
-		n1 := result.Header[7].(*edisegment.N1)
+		suite.IsType(&edisegment.N1{}, result.Header[9])
+		n1 := result.Header[9].(*edisegment.N1)
 		suite.Equal("ST", n1.EntityIdentifierCode)
 		suite.Equal(expectedDutyStation.Name, n1.Name)
 		suite.Equal("10", n1.IdentificationCodeQualifier)
 		suite.Equal(transportationOffice.Gbloc, n1.IdentificationCode)
 		// street address
 		address := expectedDutyStation.Address
-		suite.IsType(&edisegment.N3{}, result.Header[8])
-		n3 := result.Header[8].(*edisegment.N3)
+		suite.IsType(&edisegment.N3{}, result.Header[10])
+		n3 := result.Header[10].(*edisegment.N3)
 		suite.Equal(address.StreetAddress1, n3.AddressInformation1)
 		suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
 		// city state info
-		suite.IsType(&edisegment.N4{}, result.Header[9])
-		n4 := result.Header[9].(*edisegment.N4)
+		suite.IsType(&edisegment.N4{}, result.Header[11])
+		n4 := result.Header[11].(*edisegment.N4)
 		suite.Equal(address.City, n4.CityName)
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
@@ -279,21 +307,21 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	suite.T().Run("adds orders origin address", func(t *testing.T) {
 		// name
 		expectedDutyStation := paymentRequest.MoveTaskOrder.Orders.OriginDutyStation
-		suite.IsType(&edisegment.N1{}, result.Header[10])
-		n1 := result.Header[10].(*edisegment.N1)
+		suite.IsType(&edisegment.N1{}, result.Header[12])
+		n1 := result.Header[12].(*edisegment.N1)
 		suite.Equal("SF", n1.EntityIdentifierCode)
 		suite.Equal(expectedDutyStation.Name, n1.Name)
 		suite.Equal("10", n1.IdentificationCodeQualifier)
 		suite.Equal(expectedDutyStation.TransportationOffice.Gbloc, n1.IdentificationCode)
 		// street address
 		address := expectedDutyStation.Address
-		suite.IsType(&edisegment.N3{}, result.Header[11])
-		n3 := result.Header[11].(*edisegment.N3)
+		suite.IsType(&edisegment.N3{}, result.Header[13])
+		n3 := result.Header[13].(*edisegment.N3)
 		suite.Equal(address.StreetAddress1, n3.AddressInformation1)
 		suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
 		// city state info
-		suite.IsType(&edisegment.N4{}, result.Header[12])
-		n4 := result.Header[12].(*edisegment.N4)
+		suite.IsType(&edisegment.N4{}, result.Header[14])
+		n4 := result.Header[14].(*edisegment.N4)
 		suite.Equal(address.City, n4.CityName)
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
@@ -301,10 +329,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	})
 
 	suite.T().Run("adds lines of accounting to header", func(t *testing.T) {
-		suite.IsType(&edisegment.FA1{}, result.Header[13])
-		fa1 := result.Header[13].(*edisegment.FA1)
+		suite.IsType(&edisegment.FA1{}, result.Header[15])
+		fa1 := result.Header[15].(*edisegment.FA1)
 		suite.Equal("DF", fa1.AgencyQualifierCode)
-		fa2 := result.Header[14].(*edisegment.FA2)
+		suite.IsType(&edisegment.FA2{}, result.Header[16])
+		fa2 := result.Header[16].(*edisegment.FA2)
 		suite.Equal("TA", fa2.BreakdownStructureDetailCode)
 		suite.Equal(*paymentRequest.MoveTaskOrder.Orders.TAC, fa2.FinancialInformationCode)
 	})
@@ -425,26 +454,30 @@ func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {
 	}
 	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		Move: mto,
 		PaymentRequest: models.PaymentRequest{
-			ID:              uuid.FromStringOrNil("d66d9f35-218c-8b85-b9d1-631449b9d984"),
-			MoveTaskOrder:   mto,
 			IsFinal:         false,
 			Status:          models.PaymentRequestStatusPending,
 			RejectionReason: nil,
 		},
 	})
 
-	testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	assertions := testdatagen.Assertions{
+		Move:           mto,
+		PaymentRequest: paymentRequest,
+	}
+
+	testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeMS,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+	testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeCS,
-		paymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
 
 	_, err := generator.Generate(paymentRequest, false)
@@ -478,30 +511,68 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 
 	generator := NewGHCPaymentRequestInvoiceGenerator(suite.DB())
 	nilMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
-	nilMove.Orders.TAC = nil
-	nilMove.Orders.NewDutyStation.Address.Country = nil
-	nilMove.Orders.OriginDutyStation.Address.Country = nil
-	nilMove.ReferenceID = nil
 
 	nilPaymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		Move: nilMove,
 		PaymentRequest: models.PaymentRequest{
-			ID:              uuid.FromStringOrNil("d66d9f35-819e-8b85-b9d1-631449b9d984"),
-			MoveTaskOrder:   nilMove,
 			IsFinal:         false,
 			Status:          models.PaymentRequestStatusPending,
 			RejectionReason: nil,
 		},
 	})
-	nilPriceDLH := testdatagen.MakePaymentServiceItemWithParamsAndPaymentRequest(
+
+	assertions := testdatagen.Assertions{
+		Move:           nilMove,
+		PaymentRequest: nilPaymentRequest,
+	}
+
+	testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDLH,
-		nilPaymentRequest,
 		basicPaymentServiceItemParams,
+		assertions,
 	)
-	nilPriceDLH.PriceCents = nil
-	suite.T().Run("nil pointers do not cause panic", func(t *testing.T) {
-		// Nil country in Destination Duty Station Address
-		_, err := generator.Generate(nilPaymentRequest, false)
-		suite.NoError(err)
+
+	// This won't work because we don't have PaymentServiceItems on the PaymentRequest right now.
+	// nilPaymentRequest.PaymentServiceItems[0].PriceCents = nil
+
+	panicFunc := func() {
+		generator.Generate(nilPaymentRequest, false)
+	}
+
+	suite.T().Run("nil TAC does not cause panic", func(t *testing.T) {
+		oldTAC := nilPaymentRequest.MoveTaskOrder.Orders.TAC
+		nilPaymentRequest.MoveTaskOrder.Orders.TAC = nil
+		suite.NotPanics(panicFunc)
+		nilPaymentRequest.MoveTaskOrder.Orders.TAC = oldTAC
 	})
+
+	suite.T().Run("nil country for NewDutyStation does not cause panic", func(t *testing.T) {
+		oldCountry := nilPaymentRequest.MoveTaskOrder.Orders.NewDutyStation.Address.Country
+		nilPaymentRequest.MoveTaskOrder.Orders.NewDutyStation.Address.Country = nil
+		suite.NotPanics(panicFunc)
+		nilPaymentRequest.MoveTaskOrder.Orders.NewDutyStation.Address.Country = oldCountry
+	})
+
+	suite.T().Run("nil country for OriginDutyStation does not cause panic", func(t *testing.T) {
+		oldCountry := nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyStation.Address.Country
+		nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyStation.Address.Country = nil
+		suite.NotPanics(panicFunc)
+		nilPaymentRequest.MoveTaskOrder.Orders.OriginDutyStation.Address.Country = oldCountry
+	})
+
+	suite.T().Run("nil reference ID does not cause panic", func(t *testing.T) {
+		oldReferenceID := nilPaymentRequest.MoveTaskOrder.ReferenceID
+		nilPaymentRequest.MoveTaskOrder.ReferenceID = nil
+		suite.NotPanics(panicFunc)
+		nilPaymentRequest.MoveTaskOrder.ReferenceID = oldReferenceID
+	})
+
+	// TODO: Needs some additional thought since PaymentServiceItems is loaded from the DB in Generate.
+	//suite.T().Run("nil PriceCents does not cause panic", func(t *testing.T) {
+	//	oldPriceCents := nilPaymentRequest.PaymentServiceItems[0].PriceCents
+	//	nilPaymentRequest.PaymentServiceItems[0].PriceCents = nil
+	//	suite.NotPanics(panicFunc)
+	//	nilPaymentRequest.PaymentServiceItems[0].PriceCents = oldPriceCents
+	//})
 }

--- a/pkg/testdatagen/make_payment_service_item_param.go
+++ b/pkg/testdatagen/make_payment_service_item_param.go
@@ -41,78 +41,42 @@ func MakePaymentServiceItemParam(db *pop.Connection, assertions Assertions) mode
 	return paymentServiceItemParam
 }
 
-// MakePaymentServiceItemWithParams creates more than one payment service item param at a time
-func MakePaymentServiceItemWithParams(db *pop.Connection, serviceCode models.ReServiceCode, paramsToCreate []CreatePaymentServiceItemParams) models.PaymentServiceItem {
-	var params models.PaymentServiceItemParams
-
-	paymentServiceItem := MakePaymentServiceItem(db, Assertions{
-		ReService: models.ReService{
-			Code: serviceCode,
-		},
-	})
-
-	for _, param := range paramsToCreate {
-		serviceItemParamKey := FetchOrMakeServiceItemParamKey(db,
-			Assertions{
-				ServiceItemParamKey: models.ServiceItemParamKey{
-					Key:  param.Key,
-					Type: param.KeyType,
-				},
-			})
-
-		serviceItemParam := MakePaymentServiceItemParam(db,
-			Assertions{
-				PaymentServiceItem:  paymentServiceItem,
-				ServiceItemParamKey: serviceItemParamKey,
-				PaymentServiceItemParam: models.PaymentServiceItemParam{
-					Value: param.Value,
-				},
-			})
-		params = append(params, serviceItemParam)
-	}
-
-	paymentServiceItem.PaymentServiceItemParams = params
-
-	return paymentServiceItem
-}
-
-// MakePaymentServiceItemWithParamsAndPaymentRequest creates more than one payment service item param at a time
-func MakePaymentServiceItemWithParamsAndPaymentRequest(db *pop.Connection, serviceCode models.ReServiceCode, paymentRequest models.PaymentRequest, paramsToCreate []CreatePaymentServiceItemParams) models.PaymentServiceItem {
-	var params models.PaymentServiceItemParams
-
-	paymentServiceItem := MakePaymentServiceItem(db, Assertions{
-		ReService: models.ReService{
-			Code: serviceCode,
-		},
-		PaymentRequest: paymentRequest,
-	})
-
-	for _, param := range paramsToCreate {
-		serviceItemParamKey := FetchOrMakeServiceItemParamKey(db,
-			Assertions{
-				ServiceItemParamKey: models.ServiceItemParamKey{
-					Key:  param.Key,
-					Type: param.KeyType,
-				},
-			})
-
-		serviceItemParam := MakePaymentServiceItemParam(db,
-			Assertions{
-				PaymentServiceItem:  paymentServiceItem,
-				ServiceItemParamKey: serviceItemParamKey,
-				PaymentServiceItemParam: models.PaymentServiceItemParam{
-					Value: param.Value,
-				},
-			})
-		params = append(params, serviceItemParam)
-	}
-
-	paymentServiceItem.PaymentServiceItemParams = params
-
-	return paymentServiceItem
-}
-
 // MakeDefaultPaymentServiceItemParam makes a PaymentServiceItemParam with default values
 func MakeDefaultPaymentServiceItemParam(db *pop.Connection) models.PaymentServiceItemParam {
 	return MakePaymentServiceItemParam(db, Assertions{})
+}
+
+// MakePaymentServiceItemWithParams creates more than one payment service item param at a time
+func MakePaymentServiceItemWithParams(db *pop.Connection, serviceCode models.ReServiceCode, paramsToCreate []CreatePaymentServiceItemParams, assertions Assertions) models.PaymentServiceItem {
+	var params models.PaymentServiceItemParams
+
+	assertions.ReService = models.ReService{
+		Code: serviceCode,
+	}
+	paymentServiceItem := MakePaymentServiceItem(db, assertions)
+
+	for _, param := range paramsToCreate {
+		assertions.ServiceItemParamKey = models.ServiceItemParamKey{
+			Key:  param.Key,
+			Type: param.KeyType,
+		}
+		serviceItemParamKey := FetchOrMakeServiceItemParamKey(db, assertions)
+
+		assertions.PaymentServiceItem = paymentServiceItem
+		assertions.ServiceItemParamKey = serviceItemParamKey
+		assertions.PaymentServiceItemParam = models.PaymentServiceItemParam{
+			Value: param.Value,
+		}
+		serviceItemParam := MakePaymentServiceItemParam(db, assertions)
+		params = append(params, serviceItemParam)
+	}
+
+	paymentServiceItem.PaymentServiceItemParams = params
+
+	return paymentServiceItem
+}
+
+// MakeDefaultPaymentServiceItemWithParams creates more than one payment service item param at a time with default values
+func MakeDefaultPaymentServiceItemWithParams(db *pop.Connection, serviceCode models.ReServiceCode, paramsToCreate []CreatePaymentServiceItemParams) models.PaymentServiceItem {
+	return MakePaymentServiceItemWithParams(db, serviceCode, paramsToCreate, Assertions{})
 }


### PR DESCRIPTION
## Description

This PR adds scheduled and actual dates (if they exist) as additional G62 segments.

## Reviewer Notes

- Note that we now attempt to get the dates from the first created shipment associated with any payment service items.  If there are no shipments (like with MS/CS), or if a date is not available on a shipment, we do not include the segment.
- I reworked some of the test data setup and testdatagen functions used in the EDI generator tests so that we could pass assertions through.  This allowed me to set up dates on a shipment.  We were also generating more test moves than we probably thought, so I reworked the code to consolidate those as well.
- After the test data setup refactor, I noticed that the `TestNilValues` test did not appear to be testing what we were claiming it was testing, so I adjusted it.  There was one subtest that I commented out for now that would need further exploration (but it wasn't really working before either).

## Setup

1. `make db_dev_e2e_populate`
1. `make server_run`
1. Save the following payload in `create_payment_request.json`:
    ```
    {
      "body": {
        "isFinal": false,
        "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
        "serviceItems": [
          {
            "id": "722a6f4e-b438-4655-88c7-51609056550d"
          },
          {
            "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
          },
          {
            "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
          },
          {
            "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
          }
        ]
      }
    }
    ```
1. Create the payment request using the file above:
    ```
    go run ./cmd/prime-api-client --insecure create-payment-request --filename create_payment_request.json | jq '.id,.paymentRequestNumber'
    ```
    This will show two lines -- the first has the payment request ID and the second has the payment request number.
1. Save the following payload to `get_payment_request_edi.json`, replacing `<paymentRequestID>` with the ID that was output from the previous step:
    ```
    {
      "paymentRequestID": "<paymentRequestID>"
    }
    ```
1. Get the EDI for that payment request:
    ```
    go run ./cmd/prime-api-client --insecure support-get-payment-request-edi --filename get_payment_request_edi.json | jq
    ```
    Given that JSON can't contain embedded newlines, we can use `jq` to help us show it in its raw form:
    ```
    go run ./cmd/prime-api-client --insecure support-get-payment-request-edi --filename get_payment_request_edi.json | jq -r '.edi'
    ```
    You can use this same `prime-api-client` (with appropriate flags) to view the EDI in our deployed environments.
1. Verify that you see three G62 segments with the appropriate dates in the returned EDI.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4224) for this change
