### PR TITLE
[MB-3940] Event trigger patchMTOShipmentStatus

### DIFF
--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -68,6 +68,14 @@ func (suite *BaseHandlerTestSuite) HasWebhookNotification(objectID uuid.UUID, tr
 	suite.NoError(err)
 }
 
+// HasNoWebhookNotification checks that there's no record on the WebhookNotifications table for the object and trace IDs
+func (suite *BaseHandlerTestSuite) HasNoWebhookNotification(objectID uuid.UUID, traceID uuid.UUID) {
+	notification := &models.WebhookNotification{}
+	numRows, err := suite.DB().Where("object_id = $1 AND trace_id = $2", objectID.String(), traceID.String()).Count(notification)
+	suite.NoError(err)
+	suite.Equal(numRows, 0)
+}
+
 // IsNotErrResponse enforces handler does not return an error response
 func (suite *BaseHandlerTestSuite) IsNotErrResponse(response middleware.Responder) {
 	r, ok := response.(*ErrResponse)

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -15,6 +15,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/event"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/services/query"
 )
@@ -103,6 +104,21 @@ func (h PatchShipmentHandler) Handle(params mtoshipmentops.PatchMTOShipmentStatu
 		default:
 			return mtoshipmentops.NewPatchMTOShipmentStatusInternalServerError()
 		}
+	}
+
+	_, err = event.TriggerEvent(event.Event{
+		EndpointKey: event.GhcPatchMTOShipmentStatusEndpointKey,
+		// Endpoint that is being handled
+		EventKey:        event.MTOShipmentUpdateEventKey, // Event that you want to trigger
+		UpdatedObjectID: shipment.ID,                     // ID of the updated logical object
+		MtoID:           shipment.MoveTaskOrderID,        // ID of the associated Move
+		Request:         params.HTTPRequest,              // Pass on the http.Request
+		DBConnection:    h.DB(),                          // Pass on the pop.Connection
+		HandlerContext:  h,                               // Pass on the handlerContext
+	})
+	// If the event trigger fails, just log the error.
+	if err != nil {
+		logger.Error("ghcapi.PatchShipmentHandler could not generate the event")
 	}
 
 	payload := payloads.MTOShipment(shipment)

--- a/pkg/services/event/notification.go
+++ b/pkg/services/event/notification.go
@@ -275,7 +275,8 @@ func NotificationEventHandler(event *Event) error {
 	} else if !stored {
 		event.logger.Info("event.NotificationEventHandler: No notification needed to be created.")
 	} else {
-		event.logger.Info("event.NotificationEventHandler: Notification created and stored.")
+		msg := fmt.Sprintf("event.NotificationEventHandler: Notification stored for %s event triggered by %s endpoint.", event.EventKey, event.EndpointKey)
+		event.logger.Info(msg)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Added the trigger for patchMTOShipment Status, and added tests. 

## Setup

You can test in the UI! 

1. Login as a TOO in the office app, locally
2. After login, click on any moves marked as unsubmitted 
3. Select a shipment and a service item on the move details page
4. Click on Approve selected shipments
5. Click on Approve and send button

## References

* [ [MB-3940] Push Enable: Prime can receive MTO shipment status change notification - Jira](https://dp3.atlassian.net/browse/MB-3940) for this change
* [How to Add an Event Trigger · transcom/mymove Wiki](https://github.com/transcom/mymove/wiki/How-to-Add-an-Event-Trigger)


[MB-3940]: https://dp3.atlassian.net/browse/MB-3940