### PR TITLE
MB 4545 my.move.mil Landing page Spacing

### DIFF
--- a/src/scenes/PpmLanding/StatusTimeline.scss
+++ b/src/scenes/PpmLanding/StatusTimeline.scss
@@ -112,7 +112,7 @@
   left: 1rem;
 }
 
-a.usa-button {
+.st-wrapper a.usa-button {
   margin-left: 16px;
   max-width: 90%;
 }
@@ -121,7 +121,7 @@ a.usa-button {
   .shipment_box_contents .status_timeline {
     @include u-font-size('body', '2xs');
   }
-  a.usa-button {
+  .st-wrapper a.usa-button {
     max-width: 100%;
   }
 }

--- a/src/scenes/SystemAdmin/shared/SignIn.jsx
+++ b/src/scenes/SystemAdmin/shared/SignIn.jsx
@@ -22,7 +22,6 @@ const SignIn = ({ context, location }) => {
           </div>
         )}
         <h1 className="align-center">Welcome to {context.siteName}!</h1>
-        <br />
         <p className="align-center">
           This is a new system from USTRANSCOM to support the relocation of families during PCS.
         </p>

--- a/src/shared/User/SignIn.jsx
+++ b/src/shared/User/SignIn.jsx
@@ -21,7 +21,6 @@ const SignIn = ({ context, location }) => {
             </div>
           )}
           <h1 className="align-center">Welcome to {context.siteName}!</h1>
-          <br />
           <p>This is a new system from USTRANSCOM to support the relocation of families during PCS.</p>
           {context.showLoginWarning && (
             <div>


### PR DESCRIPTION
## Description
Follow up branch to [MB-4436 Header Size Standardization](https://dp3.atlassian.net/browse/MB-4436). Adjusts some weird spacing on the landing page that removes a `<br>` that is no longer needed and re-targets css that was betting loaded in from the `StatusTimeline` component that was not specific enough, so it does not add an unnecessary margin to the button on this page.

## Reviewer Notes

This is pretty minimal, but I decided to do it right away because this is quite possibly the most viewed page of the app!

## Setup

```sh
make server_run
make client_run
```
visible at the first page you see at [milmovelocal:3000](milmovelocal:3000)

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4545?atlOrigin=eyJpIjoiNTA5MDgzZDU5NmE0NGMwZGE0NGFkMWI4MjkzODM3MTIiLCJwIjoiaiJ9) for this change

## Screenshots

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/59394696/95133920-06de7900-0730-11eb-8551-7f47e0f370c2.png">

