### PR TITLE
Add secure migration for gidjin cac update

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -560,3 +560,4 @@
 20200929210500_remove_rdhariwal_cac.up.sql
 20201001183657_rriser_cac.up.sql
 20201006180000_dspencer_cac.up.sql
+20201006232216_gidjin_cac.up.sql

--- a/migrations/app/secure/20201006232216_gidjin_cac.up.sql
+++ b/migrations/app/secure/20201006232216_gidjin_cac.up.sql
@@ -1,0 +1,14 @@
+
+-- This migration allows a CAC cert to have read/write access to all orders and the prime API.
+-- The Orders API and the Prime API use client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed which includes CACs.
+-- Using a person's CAC as the certificate is a convenient way to permit a
+-- single trusted individual to interact with the Orders API and the Prime API. Eventually
+-- this CAC certificate should be removed.
+-- Updating sha256 for new cac
+-- LOCAL MIGRATION SECURE DATA REMOVED
+UPDATE client_certs
+SET sha256_digest = 'fda2d1f3b265c280e20cea2e693fe86199f7777af802957cb9b1bbe3e6868338',
+	subject = 'CN=gidjin,OU=DoD+OU=PKI+OU=CONTRACTOR,O=U.S. Government,C=US',
+	updated_at = NOW()
+WHERE id = '4fea0eb1-0009-47a8-98f4-0a102ee53a4f';


### PR DESCRIPTION
## Description

I got my updated CAC this PR updates the certs in Staging and Experimental so I can once again access the api in those environments

## Reviewer Notes

I pushed my branch to exp and my cac worked against the prime api.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
download-secure-migration 20201006232216_gidjin_cac.up.sql
// review the migrations
// Clean up migrations
rm -rf tmp/secure_migrations
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [X] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [X] Have been communicated to #g-database
  * [X] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [X] Request review from a member of a different team.