### PR TITLE
[MB-4429] Set FA1 Segment to service-specific code

### DIFF
--- a/pkg/edi/segment/fa1.go
+++ b/pkg/edi/segment/fa1.go
@@ -17,7 +17,7 @@ var AffiliationToAgency = map[models.ServiceMemberAffiliation]string{
 
 // FA1 represents the FA1 EDI segment
 type FA1 struct {
-	AgencyQualifierCode string `validate:"oneof=DN DX DY DZ DF"`
+	AgencyQualifierCode string `validate:"oneof=DN DX DY DZ DF HS"`
 }
 
 // StringArray converts FA1 to an array of strings

--- a/pkg/edi/segment/fa1.go
+++ b/pkg/edi/segment/fa1.go
@@ -2,11 +2,21 @@ package edisegment
 
 import (
 	"fmt"
+
+	"github.com/transcom/mymove/pkg/models"
 )
+
+// AffiliationToAgency is a map from our affiliation to the FA1 segment's AgencyQualifierCode field
+var AffiliationToAgency = map[models.ServiceMemberAffiliation]string{
+	models.AffiliationARMY:     "DZ",
+	models.AffiliationNAVY:     "DN",
+	models.AffiliationMARINES:  "DX",
+	models.AffiliationAIRFORCE: "DY",
+}
 
 // FA1 represents the FA1 EDI segment
 type FA1 struct {
-	AgencyQualifierCode string `validate:"eq=DF"`
+	AgencyQualifierCode string `validate:"oneof=DN DX DY DZ DF"`
 }
 
 // StringArray converts FA1 to an array of strings

--- a/pkg/edi/segment/fa1.go
+++ b/pkg/edi/segment/fa1.go
@@ -8,10 +8,11 @@ import (
 
 // AffiliationToAgency is a map from our affiliation to the FA1 segment's AgencyQualifierCode field
 var AffiliationToAgency = map[models.ServiceMemberAffiliation]string{
-	models.AffiliationARMY:     "DZ",
-	models.AffiliationNAVY:     "DN",
-	models.AffiliationMARINES:  "DX",
-	models.AffiliationAIRFORCE: "DY",
+	models.AffiliationARMY:       "DZ",
+	models.AffiliationNAVY:       "DN",
+	models.AffiliationMARINES:    "DX",
+	models.AffiliationAIRFORCE:   "DY",
+	models.AffiliationCOASTGUARD: "HS",
 }
 
 // FA1 represents the FA1 EDI segment

--- a/pkg/edi/segment/fa1_test.go
+++ b/pkg/edi/segment/fa1_test.go
@@ -20,7 +20,7 @@ func (suite *SegmentSuite) TestValidateFA1() {
 		}
 
 		err := suite.validator.Struct(fa1)
-		suite.ValidateError(err, "AgencyQualifierCode", "eq")
+		suite.ValidateError(err, "AgencyQualifierCode", "oneof")
 		suite.ValidateErrorLen(err, 1)
 	})
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -417,8 +417,15 @@ func (g ghcPaymentRequestInvoiceGenerator) createLoaSegments(orders models.Order
 	if orders.TAC == nil {
 		return segments, fmt.Errorf("Invalid order. Must have a TAC value")
 	}
+	affiliation := models.ServiceMemberAffiliation(*orders.DepartmentIndicator)
+	agencyQualifierCode, found := edisegment.AffiliationToAgency[affiliation]
+
+	if !found {
+		agencyQualifierCode = "DF"
+	}
+
 	fa1 := edisegment.FA1{
-		AgencyQualifierCode: "DF",
+		AgencyQualifierCode: agencyQualifierCode,
 	}
 
 	segments = append(segments, &fa1)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -331,7 +331,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	suite.T().Run("adds lines of accounting to header", func(t *testing.T) {
 		suite.IsType(&edisegment.FA1{}, result.Header[15])
 		fa1 := result.Header[15].(*edisegment.FA1)
-		suite.Equal("DF", fa1.AgencyQualifierCode)
+		suite.Equal("DY", fa1.AgencyQualifierCode) // Default Order from testdatagen is AIR_FORCE
 		suite.IsType(&edisegment.FA2{}, result.Header[16])
 		fa2 := result.Header[16].(*edisegment.FA2)
 		suite.Equal("TA", fa2.BreakdownStructureDetailCode)


### PR DESCRIPTION
## Description

This PR reverses a [previous PR](https://github.com/transcom/mymove/pull/4853/files#)'s removal of service-specific FA1 agency codes, handles setting a coast guard code, and updates the invoice generator. 

## Reviewer Notes

There's an [outstanding question](https://ustcdp3.slack.com/archives/CP6F568DC/p1602001743184400) about how we handle the Navy/Marines case, so we're still waiting on product for that. For now, we'll set the agency qualifier code to `DF` by default.

## Setup

The setup should be exactly the same as in [this PR](https://github.com/transcom/mymove/pull/4853), but you should now see service-specific agency qualifier codes. For example, if the orders for your move are from the Army, you'll see `DZ` in the FA1 segment.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4429) for this change
