### PR TITLE
Use pre-commit-golang to run golangci-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,10 @@ repos:
       - id: trailing-whitespace
         exclude: public/swagger-ui/*
 
-  - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.6
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: master
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run -v ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.22.0

--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -61,6 +61,7 @@ has psql "brew install postgresql"
 has nodenv "brew install nodenv"
 has_path ".nodenv/shims" "nodenv init"
 has node "nodenv local 12.16.3"
+has golangci-lint "brew install golangci/tap/golangci-lint"
 
 # not on CircleCI
 if [[ -z ${CIRCLECI-} ]]; then


### PR DESCRIPTION
When the Go version is managed by `asdf`, the golanci-lint pre-commit
hook fails to find it. I believe the issue is how we're calling it
in the `entry` section. I found a repo that compiles a bunch of Golang
hooks for use with pre-commit, and the way they configure it works
with `asdf`.

Note that this requires that everyone install golangci-lint with
Homebrew, which is why I added it to `scripts/prereqs`.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
