### PR TITLE
[MB-4529] MyMove API data load

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,5 +2,6 @@
   "compilerOptions": {
     "baseUrl": "./src/",
     "jsx": "react"
-  }
+  },
+  "exclude": ["node_modules", "build", "storybook-static"]
 }

--- a/src/pages/MyMove/HHGShipmentSetup.jsx
+++ b/src/pages/MyMove/HHGShipmentSetup.jsx
@@ -4,17 +4,15 @@ import { arrayOf, string, shape, bool, func } from 'prop-types';
 
 import EditShipment from '../../components/Customer/EditShipment';
 
-import {
-  loadMTOShipments as loadMTOShipmentsAction,
-  selectMTOShipmentForMTO,
-} from 'shared/Entities/modules/mtoShipments';
+import { selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
+import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import HHGDetailsForm from 'components/Customer/HHGDetailsForm';
 import '../../ghc_index.scss';
 
 class HHGShipmentSetup extends Component {
   componentDidMount() {
-    const { match, loadMTOShipments } = this.props;
-    loadMTOShipments(match.params.moveId);
+    const { fetchCustomerData } = this.props;
+    fetchCustomerData();
   }
 
   render() {
@@ -46,7 +44,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = {
-  loadMTOShipments: loadMTOShipmentsAction,
+  fetchCustomerData: fetchCustomerDataAction,
 };
 
 HHGShipmentSetup.propTypes = {
@@ -64,7 +62,7 @@ HHGShipmentSetup.propTypes = {
     goBack: func.isRequired,
     push: func.isRequired,
   }).isRequired,
-  loadMTOShipments: func.isRequired,
+  fetchCustomerData: func.isRequired,
   mtoShipment: shape({
     agents: arrayOf(
       shape({

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import React, { Component } from 'react';
-import { func, arrayOf, bool, shape, string, node, oneOfType } from 'prop-types';
+import { arrayOf, bool, shape, string, node, oneOfType } from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { get, isEmpty } from 'lodash';
@@ -24,19 +24,11 @@ import Step from 'components/Customer/Home/Step';
 import DocsUploaded from 'components/Customer/Home/DocsUploaded';
 import ShipmentList from 'components/Customer/Home/ShipmentList';
 import Contact from 'components/Customer/Home/Contact';
-import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
-import {
-  createServiceMember as createServiceMemberAction,
-  isProfileComplete as isProfileCompleteCheck,
-} from 'scenes/ServiceMembers/ducks';
+import { isProfileComplete as isProfileCompleteCheck } from 'scenes/ServiceMembers/ducks';
 import { selectServiceMemberFromLoggedInUser } from 'shared/Entities/modules/serviceMembers';
 import { selectUploadedOrders, selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
 import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
-import {
-  selectMTOShipmentsByMoveId,
-  loadMTOShipments as loadMTOShipmentsAction,
-  selectMTOShipmentForMTO,
-} from 'shared/Entities/modules/mtoShipments';
+import { selectMTOShipmentsByMoveId, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import {
@@ -53,35 +45,10 @@ Description.propTypes = {
 };
 
 class Home extends Component {
-  componentDidMount() {
-    const { showLoggedInUser, move, loadMTOShipments } = this.props;
-    showLoggedInUser();
-    if (move.id) {
-      loadMTOShipments(move.id);
-    }
-  }
-
   componentDidUpdate(prevProps) {
-    const {
-      showLoggedInUser,
-      serviceMember,
-      createdServiceMemberIsLoading,
-      createdServiceMemberError,
-      loggedInUserSuccess,
-      createServiceMember,
-      isProfileComplete,
-      move,
-      loadMTOShipments,
-    } = this.props;
+    const { serviceMember, loggedInUserSuccess, isProfileComplete } = this.props;
     if (!prevProps.loggedInUserSuccess && loggedInUserSuccess) {
-      if (!createdServiceMemberIsLoading && isEmpty(serviceMember) && !createdServiceMemberError) {
-        // Once the logged in user loads, if the service member doesn't
-        // exist we need to dispatch creating one, once.
-        createServiceMember({}).then(() => {
-          // re-fetch user data to populate serviceMember
-          showLoggedInUser();
-        });
-      } else if (!isEmpty(serviceMember) && !isProfileComplete) {
+      if (!isEmpty(serviceMember) && !isProfileComplete) {
         // If the service member exists, but is not complete, redirect to next incomplete page.
         this.resumeMove();
       }
@@ -94,10 +61,6 @@ class Home extends Component {
     if (!isEmpty(prevProps.serviceMember) && prevProps.serviceMember !== serviceMember && !isProfileComplete) {
       // if service member existed but was updated, redirect to next incomplete page.
       this.resumeMove();
-    }
-
-    if (prevProps.move && prevProps.move.id !== move.id) {
-      loadMTOShipments(move.id);
     }
   }
 
@@ -403,8 +366,6 @@ Home.propTypes = {
     first_name: string,
     last_name: string,
   }).isRequired,
-  showLoggedInUser: func.isRequired,
-  loadMTOShipments: func.isRequired,
   mtoShipments: arrayOf(
     shape({
       id: string,
@@ -427,11 +388,9 @@ Home.propTypes = {
   loggedInUserSuccess: bool.isRequired,
   loggedInUserError: bool.isRequired,
   isProfileComplete: bool.isRequired,
-  createdServiceMemberIsLoading: bool,
   createdServiceMemberError: string,
   moveSubmitSuccess: bool.isRequired,
   location: shape({}).isRequired,
-  createServiceMember: func.isRequired,
   selectedMoveType: string,
   lastMoveIsCanceled: bool,
   backupContacts: arrayOf(oneOfType([string, shape({})])),
@@ -445,7 +404,6 @@ Home.propTypes = {
 };
 
 Home.defaultProps = {
-  createdServiceMemberIsLoading: false,
   createdServiceMemberError: '',
   selectedMoveType: '',
   lastMoveIsCanceled: false,
@@ -469,8 +427,6 @@ const mapStateToProps = (state) => {
     loggedInUserIsLoading: selectGetCurrentUserIsLoading(state),
     loggedInUserSuccess: selectGetCurrentUserIsSuccess(state),
     loggedInUserError: selectGetCurrentUserIsError(state),
-    createdServiceMemberIsLoading: state.serviceMember.isLoading,
-    createdServiceMemberSuccess: state.serviceMember.hasSubmitSuccess,
     createdServiceMemberError: state.serviceMember.error,
     isProfileComplete: isProfileCompleteCheck(state),
     moveSubmitSuccess: state.signedCertification.moveSubmitSuccess,
@@ -493,10 +449,4 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...ownProps,
 });
 
-const mapDispatchToProps = {
-  showLoggedInUser: showLoggedInUserAction,
-  loadMTOShipments: loadMTOShipmentsAction,
-  createServiceMember: createServiceMemberAction,
-};
-
-export default withContext(connect(mapStateToProps, mapDispatchToProps, mergeProps)(Home));
+export default withContext(connect(mapStateToProps, mergeProps)(Home));

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,7 +1,12 @@
 import { all } from 'redux-saga/effects';
 
 import watchFetchUser from './auth';
+import { watchInitializeOnboarding } from './onboarding';
 
 export default function* rootSaga() {
   yield all([watchFetchUser()]);
+}
+
+export function* rootCustomerSaga() {
+  yield all([watchFetchUser(), watchInitializeOnboarding()]);
 }

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -1,0 +1,32 @@
+import { takeLatest, put, call } from 'redux-saga/effects';
+
+import { INIT_ONBOARDING, initOnboardingFailed, initOnboardingComplete } from 'store/onboarding/actions';
+import { getLoggedInUser, getMTOShipmentsForMove } from 'services/internalApi';
+import { addEntities } from 'shared/Entities/actions';
+
+export function* initializeOnboarding() {
+  try {
+    // First load the user & store in entities
+    const user = yield call(getLoggedInUser);
+    yield put(addEntities(user));
+
+    // TODO - create service member if doesn't exist
+
+    // Load MTO shipments if there is a move
+    const { moves } = user;
+    if (moves && Object.keys(moves).length > 0) {
+      const [moveId] = Object.keys(moves);
+      // User has a move, load MTO shipments & store in entities
+      const mtoShipments = yield call(getMTOShipmentsForMove, moveId);
+      yield put(addEntities(mtoShipments));
+    }
+
+    yield put(initOnboardingComplete());
+  } catch (error) {
+    yield put(initOnboardingFailed(error));
+  }
+}
+
+export function* watchInitializeOnboarding() {
+  yield takeLatest(INIT_ONBOARDING, initializeOnboarding);
+}

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -6,14 +6,20 @@ import {
   initOnboardingFailed,
   initOnboardingComplete,
 } from 'store/onboarding/actions';
-import { getLoggedInUser, getMTOShipmentsForMove } from 'services/internalApi';
+import {
+  getLoggedInUser,
+  getMTOShipmentsForMove,
+  createServiceMember as createServiceMemberApi,
+} from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
+import { CREATE_SERVICE_MEMBER } from 'scenes/ServiceMembers/ducks';
 
 export function* fetchCustomerData() {
   // First load the user & store in entities
   const user = yield call(getLoggedInUser);
   yield put(addEntities(user));
 
+  // TODO - fork/spawn additional API calls
   // Load MTO shipments if there is a move
   const { moves } = user;
   if (moves && Object.keys(moves).length > 0) {
@@ -22,16 +28,31 @@ export function* fetchCustomerData() {
     const mtoShipments = yield call(getMTOShipmentsForMove, moveId);
     yield put(addEntities(mtoShipments));
   }
+
+  return user;
 }
 
 export function* watchFetchCustomerData() {
   yield takeLatest(FETCH_CUSTOMER_DATA, fetchCustomerData);
 }
 
+export function* createServiceMember() {
+  try {
+    yield put({ type: CREATE_SERVICE_MEMBER.start });
+    const serviceMember = yield call(createServiceMemberApi);
+    yield put({ type: CREATE_SERVICE_MEMBER.success, payload: serviceMember });
+    yield call(fetchCustomerData);
+  } catch (e) {
+    yield put({ type: CREATE_SERVICE_MEMBER.failure, error: e });
+  }
+}
+
 export function* initializeOnboarding() {
   try {
-    yield call(fetchCustomerData);
-    // TODO - create service member if doesn't exist
+    const user = yield call(fetchCustomerData);
+    if (!user.serviceMembers) {
+      yield call(createServiceMember);
+    }
     yield put(initOnboardingComplete());
     yield call(watchFetchCustomerData);
   } catch (error) {

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -4,23 +4,25 @@ import { INIT_ONBOARDING, initOnboardingFailed, initOnboardingComplete } from 's
 import { getLoggedInUser, getMTOShipmentsForMove } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
+export function* fetchCustomerData() {
+  // First load the user & store in entities
+  const user = yield call(getLoggedInUser);
+  yield put(addEntities(user));
+
+  // Load MTO shipments if there is a move
+  const { moves } = user;
+  if (moves && Object.keys(moves).length > 0) {
+    const [moveId] = Object.keys(moves);
+    // User has a move, load MTO shipments & store in entities
+    const mtoShipments = yield call(getMTOShipmentsForMove, moveId);
+    yield put(addEntities(mtoShipments));
+  }
+}
+
 export function* initializeOnboarding() {
   try {
-    // First load the user & store in entities
-    const user = yield call(getLoggedInUser);
-    yield put(addEntities(user));
-
+    yield call(fetchCustomerData);
     // TODO - create service member if doesn't exist
-
-    // Load MTO shipments if there is a move
-    const { moves } = user;
-    if (moves && Object.keys(moves).length > 0) {
-      const [moveId] = Object.keys(moves);
-      // User has a move, load MTO shipments & store in entities
-      const mtoShipments = yield call(getMTOShipmentsForMove, moveId);
-      yield put(addEntities(mtoShipments));
-    }
-
     yield put(initOnboardingComplete());
   } catch (error) {
     yield put(initOnboardingFailed(error));

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -1,6 +1,11 @@
 import { takeLatest, put, call } from 'redux-saga/effects';
 
-import { INIT_ONBOARDING, initOnboardingFailed, initOnboardingComplete } from 'store/onboarding/actions';
+import {
+  INIT_ONBOARDING,
+  FETCH_CUSTOMER_DATA,
+  initOnboardingFailed,
+  initOnboardingComplete,
+} from 'store/onboarding/actions';
 import { getLoggedInUser, getMTOShipmentsForMove } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -19,11 +24,16 @@ export function* fetchCustomerData() {
   }
 }
 
+export function* watchFetchCustomerData() {
+  yield takeLatest(FETCH_CUSTOMER_DATA, fetchCustomerData);
+}
+
 export function* initializeOnboarding() {
   try {
     yield call(fetchCustomerData);
     // TODO - create service member if doesn't exist
     yield put(initOnboardingComplete());
+    yield call(watchFetchCustomerData);
   } catch (error) {
     yield put(initOnboardingFailed(error));
   }

--- a/src/sagas/onboarding.test.js
+++ b/src/sagas/onboarding.test.js
@@ -1,8 +1,18 @@
 import { takeLatest, put, call } from 'redux-saga/effects';
 
-import { watchInitializeOnboarding, fetchCustomerData, initializeOnboarding } from './onboarding';
+import {
+  watchInitializeOnboarding,
+  watchFetchCustomerData,
+  fetchCustomerData,
+  initializeOnboarding,
+} from './onboarding';
 
-import { INIT_ONBOARDING, initOnboardingFailed, initOnboardingComplete } from 'store/onboarding/actions';
+import {
+  INIT_ONBOARDING,
+  FETCH_CUSTOMER_DATA,
+  initOnboardingFailed,
+  initOnboardingComplete,
+} from 'store/onboarding/actions';
 import { getLoggedInUser, getMTOShipmentsForMove } from 'services/internalApi';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -15,6 +25,14 @@ describe('watchInitializeOnboarding', () => {
 
   it('is done', () => {
     expect(generator.next().done).toEqual(true);
+  });
+});
+
+describe('watchFetchCustomerData', () => {
+  const generator = watchFetchCustomerData();
+
+  it('takes a FETCH_CUSTOMER_DATA action and calls fetchCustomerData', () => {
+    expect(generator.next().value).toEqual(takeLatest(FETCH_CUSTOMER_DATA, fetchCustomerData));
   });
 });
 
@@ -118,6 +136,10 @@ describe('initializeOnboarding', () => {
 
     it('puts action initOnboardingComplete', () => {
       expect(generator.next().value).toEqual(put(initOnboardingComplete()));
+    });
+
+    it('starts the watchFetchCustomerData saga', () => {
+      expect(generator.next().value).toEqual(call(watchFetchCustomerData));
     });
 
     it('is done', () => {

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -53,15 +53,17 @@ import HHGShipmentSetup from 'pages/MyMove/HHGShipmentSetup';
 import Home from '../../pages/MyMove/Home';
 
 import { loadUser as loadUserAction } from 'store/auth/actions';
+import { initOnboarding as initOnboardingAction } from 'store/onboarding/actions';
 
 export class AppWrapper extends Component {
   state = { hasError: false };
 
   componentDidMount() {
-    const { loadUser, loadInternalSchema } = this.props;
+    const { loadUser, loadInternalSchema, initOnboarding } = this.props;
 
     loadInternalSchema();
     loadUser();
+    initOnboarding();
   }
 
   componentDidCatch(error, info) {
@@ -173,6 +175,7 @@ export class AppWrapper extends Component {
 AppWrapper.propTypes = {
   loadInternalSchema: PropTypes.func,
   loadUser: PropTypes.func,
+  initOnboarding: PropTypes.func,
   conusStatus: PropTypes.string.isRequired,
   context: PropTypes.shape({
     flags: PropTypes.shape({
@@ -185,6 +188,7 @@ AppWrapper.propTypes = {
 AppWrapper.defaultProps = {
   loadInternalSchema: no_op,
   loadUser: no_op,
+  initOnboarding: no_op,
   conusStatus: CONUS_STATUS.CONUS,
   context: {
     flags: {
@@ -215,6 +219,7 @@ const mapDispatchToProps = (dispatch) =>
       push,
       loadInternalSchema,
       loadUser: loadUserAction,
+      initOnboarding: initOnboardingAction,
     },
     dispatch,
   );

--- a/src/scenes/ServiceMembers/ducks.js
+++ b/src/scenes/ServiceMembers/ducks.js
@@ -121,7 +121,7 @@ export function serviceMemberReducer(state = initialState, action) {
   switch (action.type) {
     case GET_LOGGED_IN_USER.success:
       return Object.assign({}, state, {
-        currentServiceMember: reshape(action.payload.service_member),
+        currentServiceMember: reshape(action.payload.service_member) || state.currentServiceMember,
         currentBackupContacts: get(action, 'payload.service_member.backup_contacts', []),
         hasLoadError: false,
         hasLoadSuccess: true,

--- a/src/scenes/ServiceMembers/ducks.test.js
+++ b/src/scenes/ServiceMembers/ducks.test.js
@@ -68,11 +68,28 @@ describe('Service Member Reducer', () => {
         hasLoadSuccess: true,
       });
     });
+
     it('should handle emptyPayload', () => {
       //todo: should this do anything with back up contacts (once the handler returns them properly)
       const newState = serviceMemberReducer({}, emptyPayload);
       expect(newState).toEqual({
-        currentServiceMember: null,
+        currentServiceMember: undefined,
+        currentBackupContacts: [],
+        hasLoadError: false,
+        hasLoadSuccess: true,
+      });
+    });
+
+    it('SUCCESS with empty payload does not overwrite existing currentServiceMember', () => {
+      const existingServiceMember = {
+        id: 'test123',
+        first_name: 'Existing',
+        last_name: 'Old name',
+        someOtherAttribute: 'still exists',
+      };
+      const newState = serviceMemberReducer({ currentServiceMember: existingServiceMember }, emptyPayload);
+      expect(newState).toEqual({
+        currentServiceMember: existingServiceMember,
         currentBackupContacts: [],
         hasLoadError: false,
         hasLoadSuccess: true,

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -1,21 +1,6 @@
 import Swagger from 'swagger-client';
-import * as Cookies from 'js-cookie';
 
-import { makeSwaggerRequest } from './swaggerRequest';
-
-// setting up the same config from Swagger/api.js
-const requestInterceptor = (req) => {
-  if (!req.loadSpec) {
-    const token = Cookies.get('masked_gorilla_csrf');
-    if (token) {
-      req.headers['X-CSRF-Token'] = token;
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn('Unable to retrieve CSRF Token from cookie');
-    }
-  }
-  return req;
-};
+import { makeSwaggerRequest, requestInterceptor } from './swaggerRequest';
 
 let ghcClient = null;
 

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -32,3 +32,12 @@ export async function getMTOShipmentsForMove(moveTaskOrderID, normalize = true) 
     { normalize, label: 'mtoShipment.listMTOShipments', schemaKey: 'mtoShipments' },
   );
 }
+
+/** BELOW API CALLS ARE STILL USING DUCKS, NOT NORMALIZED BY DEFAULT */
+export async function createServiceMember(serviceMember = {}) {
+  return makeInternalRequest(
+    'service_members.createServiceMember',
+    { createServiceMemberPayload: serviceMember },
+    { normalize: false },
+  );
+}

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -1,0 +1,34 @@
+import Swagger from 'swagger-client';
+
+import { makeSwaggerRequest, requestInterceptor } from './swaggerRequest';
+
+let internalClient = null;
+
+// setting up the same config from Swagger/api.js
+export async function getInternalClient() {
+  if (!internalClient) {
+    internalClient = await Swagger({
+      url: '/internal/swagger.yaml',
+      requestInterceptor,
+    });
+  }
+
+  return internalClient;
+}
+
+export async function makeInternalRequest(operationPath, params = {}, options = {}) {
+  const client = await getInternalClient();
+  return makeSwaggerRequest(client, operationPath, params, options);
+}
+
+export async function getLoggedInUser(normalize = true) {
+  return makeInternalRequest('users.showLoggedInUser', {}, { normalize });
+}
+
+export async function getMTOShipmentsForMove(moveTaskOrderID, normalize = true) {
+  return makeInternalRequest(
+    'mtoShipment.listMTOShipments',
+    { moveTaskOrderID },
+    { normalize, label: 'mtoShipment.listMTOShipments', schemaKey: 'mtoShipments' },
+  );
+}

--- a/src/services/swaggerRequest.js
+++ b/src/services/swaggerRequest.js
@@ -1,8 +1,23 @@
 /* eslint-disable import/prefer-default-export */
 import { get } from 'lodash';
 import { normalize } from 'normalizr';
+import * as Cookies from 'js-cookie';
 
 import * as schema from 'shared/Entities/schema';
+
+// setting up the same config from Swagger/api.js
+export const requestInterceptor = (req) => {
+  if (!req.loadSpec) {
+    const token = Cookies.get('masked_gorilla_csrf');
+    if (token) {
+      req.headers['X-CSRF-Token'] = token;
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to retrieve CSRF Token from cookie');
+    }
+  }
+  return req;
+};
 
 /**
  * This is a new Swagger request function that does not rely on Redux
@@ -50,7 +65,17 @@ function successfulReturnType(routeDefinition, status) {
   return toCamelCase(schemaKey);
 }
 
-export async function makeSwaggerRequest(client, operationPath, params = {}, options = {}) {
+export function normalizeResponse(data, schemaKey) {
+  const responseSchema = schema[`${schemaKey}`];
+
+  if (!responseSchema) {
+    throw new Error(`Could not find a schema for ${schemaKey}`);
+  }
+
+  return normalize(data, responseSchema).entities;
+}
+
+export async function makeSwaggerRequest(client, operationPath, params = {}, options = {}, normalizeData = true) {
   const operation = get(client, `apis.${operationPath}`);
   if (!operation) {
     throw new Error(`Operation '${operationPath}' does not exist!`);
@@ -68,31 +93,33 @@ export async function makeSwaggerRequest(client, operationPath, params = {}, opt
 
   return request
     .then((response) => {
-      const routeDefinition = findMatchingRoute(client.spec.paths, operationPath);
-      if (!routeDefinition) {
-        throw new Error(`Could not find routeDefinition for ${operationPath}`);
+      // Normalize the data (defaults to true)
+      if (normalizeData) {
+        /* TODO - deprecrate the below & require an explicit schemaKey parameter */
+        const routeDefinition = findMatchingRoute(client.spec.paths, operationPath);
+        if (!routeDefinition) {
+          throw new Error(`Could not find routeDefinition for ${operationPath}`);
+        }
+
+        let schemaKey = options.schemaKey || successfulReturnType(routeDefinition, response.status);
+        if (!schemaKey) {
+          throw new Error(`Could not find schemaKey for ${operationPath} status ${response.status}`);
+        }
+
+        if (schemaKey.indexOf('Payload') !== -1) {
+          const newSchemaKey = schemaKey.replace('Payload', '');
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Using 'Payload' as a response type prefix is deprecated. Please rename ${schemaKey} to ${newSchemaKey}`,
+          );
+          schemaKey = newSchemaKey;
+        }
+
+        return normalizeResponse(response.body, schemaKey);
       }
 
-      let schemaKey = options.schemaKey || successfulReturnType(routeDefinition, response.status);
-      if (!schemaKey) {
-        throw new Error(`Could not find schemaKey for ${operationPath} status ${response.status}`);
-      }
-
-      if (schemaKey.indexOf('Payload') !== -1) {
-        const newSchemaKey = schemaKey.replace('Payload', '');
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Using 'Payload' as a response type prefix is deprecated. Please rename ${schemaKey} to ${newSchemaKey}`,
-        );
-        schemaKey = newSchemaKey;
-      }
-
-      const payloadSchema = schema[`${schemaKey}`];
-      if (!payloadSchema) {
-        throw new Error(`Could not find a schema for ${schemaKey}`);
-      }
-
-      return normalize(response.body, payloadSchema).entities;
+      // Otherwise, return raw response body
+      return response.body;
     })
     .catch((response) => {
       // eslint-disable-next-line no-console

--- a/src/services/swaggerRequest.js
+++ b/src/services/swaggerRequest.js
@@ -75,7 +75,7 @@ export function normalizeResponse(data, schemaKey) {
   return normalize(data, responseSchema).entities;
 }
 
-export async function makeSwaggerRequest(client, operationPath, params = {}, options = {}, normalizeData = true) {
+export async function makeSwaggerRequest(client, operationPath, params = {}, options = { normalize: true }) {
   const operation = get(client, `apis.${operationPath}`);
   if (!operation) {
     throw new Error(`Operation '${operationPath}' does not exist!`);
@@ -93,6 +93,7 @@ export async function makeSwaggerRequest(client, operationPath, params = {}, opt
 
   return request
     .then((response) => {
+      const normalizeData = options.normalize !== undefined ? options.normalize : true;
       // Normalize the data (defaults to true)
       if (normalizeData) {
         /* TODO - deprecrate the below & require an explicit schemaKey parameter */

--- a/src/services/swaggerRequest.test.js
+++ b/src/services/swaggerRequest.test.js
@@ -149,8 +149,7 @@ describe('makeSwaggerRequest', () => {
       mockClient,
       'shipments.getShipment',
       { shipmentID: 'abcd-1234' },
-      {},
-      false,
+      { normalize: false },
     );
 
     expect(request).toEqual(mockResponse.body);

--- a/src/services/swaggerRequest.test.js
+++ b/src/services/swaggerRequest.test.js
@@ -1,4 +1,4 @@
-import { makeSwaggerRequest } from './swaggerRequest';
+import { makeSwaggerRequest, normalizeResponse } from './swaggerRequest';
 
 function mockGetClient(operationMock) {
   return Promise.resolve({
@@ -46,6 +46,26 @@ function mockGetClient(operationMock) {
     },
   });
 }
+
+describe('normalizeResponse', () => {
+  it('normalizes data with a valid schemaKey', () => {
+    const rawData = {
+      id: 'abcd-1234',
+      type: 'test shipment',
+    };
+
+    const expectedData = {
+      shipments: {
+        'abcd-1234': {
+          id: 'abcd-1234',
+          type: 'test shipment',
+        },
+      },
+    };
+
+    expect(normalizeResponse(rawData, 'shipment')).toEqual(expectedData);
+  });
+});
 
 describe('makeSwaggerRequest', () => {
   it('makes a successful request', async () => {
@@ -111,5 +131,28 @@ describe('makeSwaggerRequest', () => {
     await makeSwaggerRequest(mockClient, 'unknown', { shipmentID: 'abcd-1234' }).catch((error) => {
       expect(error).toEqual(new Error(`Operation 'unknown' does not exist!`));
     });
+  });
+
+  it('returns the raw response body if normalize is false', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      body: {
+        id: 'abcd-1234',
+        type: 'test shipment',
+      },
+    };
+
+    const opMock = jest.fn(() => Promise.resolve(mockResponse));
+    const mockClient = await mockGetClient(opMock);
+    const request = await makeSwaggerRequest(
+      mockClient,
+      'shipments.getShipment',
+      { shipmentID: 'abcd-1234' },
+      {},
+      false,
+    );
+
+    expect(request).toEqual(mockResponse.body);
   });
 });

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -9,11 +9,11 @@ import createSagaMiddleware from 'redux-saga';
 
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 
-import { isDevelopment, isAdminSite } from 'shared/constants';
+import { isDevelopment, isAdminSite, isMilmoveSite } from 'shared/constants';
 import logger from './reduxLogger';
 import * as schema from 'shared/Entities/schema';
 
-import rootSaga from 'sagas/index';
+import rootSaga, { rootCustomerSaga } from 'sagas/index';
 
 export const history = createBrowserHistory();
 
@@ -47,7 +47,11 @@ export const configureStore = (history, initialState = {}) => {
   const store = createStore(persistedReducer, initialState, composeEnhancers(applyMiddleware(...middlewares)));
   const persistor = persistStore(store);
 
-  sagaMiddleware.run(rootSaga);
+  if (isMilmoveSite) {
+    sagaMiddleware.run(rootCustomerSaga);
+  } else {
+    sagaMiddleware.run(rootSaga);
+  }
 
   return { store, persistor };
 };

--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -1,0 +1,16 @@
+export const INIT_ONBOARDING = 'INIT_ONBOARDING';
+export const INIT_ONBOARDING_FAILED = 'INIT_ONBOARDING_FAILED';
+export const INIT_ONBOARDING_COMPLETE = 'INIT_ONBOARDING_COMPLETE';
+
+export const initOnboarding = () => ({
+  type: INIT_ONBOARDING,
+});
+
+export const initOnboardingFailed = (error) => ({
+  type: INIT_ONBOARDING_FAILED,
+  error,
+});
+
+export const initOnboardingComplete = () => ({
+  type: INIT_ONBOARDING_COMPLETE,
+});

--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -2,6 +2,8 @@ export const INIT_ONBOARDING = 'INIT_ONBOARDING';
 export const INIT_ONBOARDING_FAILED = 'INIT_ONBOARDING_FAILED';
 export const INIT_ONBOARDING_COMPLETE = 'INIT_ONBOARDING_COMPLETE';
 
+export const FETCH_CUSTOMER_DATA = 'FETCH_CUSTOMER_DATA';
+
 export const initOnboarding = () => ({
   type: INIT_ONBOARDING,
 });
@@ -13,4 +15,8 @@ export const initOnboardingFailed = (error) => ({
 
 export const initOnboardingComplete = () => ({
   type: INIT_ONBOARDING_COMPLETE,
+});
+
+export const fetchCustomerData = () => ({
+  type: FETCH_CUSTOMER_DATA,
 });


### PR DESCRIPTION
## Description

The goal of this PR is to establish a new pattern for loading API data into the Customer app that is de-coupled from rendering UI, and can be called easily as needed throughout the flow, using Redux actions.

### New pattern is:
- Created [`rootCustomerSaga` for bootstrapping sagas that should only happen in the customer app](https://github.com/transcom/mymove/pull/4946/files#diff-c5bb6481b319d418e4307f67a9b1e8ecR10)
- Wrote [`initializeOnboarding` saga to handle hydrating onboarding user data when a customer logs in](https://github.com/transcom/mymove/pull/4946/files#diff-d41bccd15113a160657933168162f6c9R50). This should only happen once-per-page load, so [it is triggered at the highest level of the customer app (`MyMove/index componentDidMount`)](https://github.com/transcom/mymove/pull/4946/files#diff-6eb50225743dcbdf87fad2a63022f3a4R66), and it handles the following:
  - Get logged in user
  - If user doesn't have a service member, create one
  - If user has moves, load MTO shipments also
  - Populate user data & MTO shipments into Entities
- All API calls should be defined in `src/services` and use the [new `makeSwaggerRequest` function](https://github.com/transcom/mymove/pull/4946/files#diff-eadb579699721add54d5fa7d9853ef3cR78)
  - Existing API calls should be relocated from entities files as needed
  - `makeSwaggerRequest` accepts a `normalize` option (defaults to true) so that API calls can be used to populate both entities _and_ ducks state for backwards compatibility, and to safely proceed with Redux refactor work.

### Proof-of-concepts:
- Replaced `loadMTOShipments` in `HHGShipmentSetup componentDidMount` with new `fetchCustomerData` action, to demonstrate how to refresh _all_ customer data into entities
- Added `initializeOnboarding` action to `MyMove/index componentDidMount` to kick off new onboarding API flow 
- Removed `showLoggedInUser` and `loadMTOShipments` in `MyMove/Home/index componentDidMount, componentDidUpdate` since those calls will happen as part of `initializeOnboarding`
- Removed `createServiceMember` in `MyMove/Home/index componentDidUpdate` since that will happen as part of `initializeOnboarding`
- Added `updateServiceMember` saga to populate service member entities throughout onboarding steps in order to pass tests (this will get cleaned up when service member ducks are refactored)

### Next steps:
- The customer app is calling `getLoggedInUser` twice (once in `initializeOnboarding` and once in `loadUser`) -- clean this up so only one call is made, in a way that is compatible with the office app.
- Identify any other API calls that should be triggered when a customer user logs in (in addition to MTO shipments)
- Identify other places where re-fetch API calls may not be needed anymore and can be deleted, or replaced with `fetchCustomerData` (or something smaller)
- **Continue to replace API calls with sagas so they can update data in ducks & entities simultaneously for backwards compatibility**
  - Once this is completed, we can continue to remove ducks code with more reliability 🎉 

## Reviewer Notes

Test cases:
- Log in as existing MilMove customer & verify your data loads and you are directed to the right place
- Log in as new MilMove customer & verify your service member is created and you are directed to the right place

## Setup

```
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4529) for this change

## Screenshots

Here is a fun diagram I made that illustrates the saga flows: 
![image](https://user-images.githubusercontent.com/2723066/95790638-647d4300-0ca5-11eb-81cf-17b2fb774821.png)
