### PR TITLE
Make Onboarding layout markup consistent

### DIFF
--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { Radio } from '@trussworks/react-uswds';
 import { func, PropTypes } from 'prop-types';
@@ -6,47 +6,40 @@ import { func, PropTypes } from 'prop-types';
 import { setConusStatus, selectedConusStatus } from 'scenes/Moves/ducks';
 import { CONUS_STATUS } from 'shared/constants';
 
-// eslint-disable-next-line react/prefer-stateless-function
-export class ConusOrNot extends Component {
-  render() {
-    const { setLocation, conusStatus } = this.props;
-
-    return (
-      <div className="grid-row">
-        <div className="grid-col">
-          <h1 className="sm-heading">Where are you moving?</h1>
-          <Radio
-            id={CONUS_STATUS.CONUS}
-            label="CONUS"
-            value={CONUS_STATUS.CONUS}
-            name="conusStatus"
-            onChange={(e) => setLocation(e.target.value)}
-            checked={conusStatus === CONUS_STATUS.CONUS}
-          />
-          <span className="usa-hint" id="conusStatus">
-            Starts and ends in the continental US
-          </span>
-          <Radio
-            id={CONUS_STATUS.OCONUS}
-            label="OCONUS"
-            value={CONUS_STATUS.OCONUS}
-            onChange={(e) => setLocation(e.target.value)}
-            name="conusStatus"
-            checked={conusStatus === CONUS_STATUS.OCONUS}
-          />
-          <span className="usa-hint" id="conusStatus">
-            Starts or ends in Alaska, Hawaii, or International locations
-          </span>
-          {conusStatus === CONUS_STATUS.OCONUS && (
-            <div>
-              MilMove does not support OCONUS moves yet. Contact your current transportation office to set up your move.
-            </div>
-          )}
+export const ConusOrNot = ({ setLocation, conusStatus }) => {
+  return (
+    <>
+      <h1>Where are you moving?</h1>
+      <Radio
+        id={CONUS_STATUS.CONUS}
+        label="CONUS"
+        value={CONUS_STATUS.CONUS}
+        name="conusStatus"
+        onChange={(e) => setLocation(e.target.value)}
+        checked={conusStatus === CONUS_STATUS.CONUS}
+      />
+      <span className="usa-hint" id="conusStatus">
+        Starts and ends in the continental US
+      </span>
+      <Radio
+        id={CONUS_STATUS.OCONUS}
+        label="OCONUS"
+        value={CONUS_STATUS.OCONUS}
+        onChange={(e) => setLocation(e.target.value)}
+        name="conusStatus"
+        checked={conusStatus === CONUS_STATUS.OCONUS}
+      />
+      <span className="usa-hint" id="conusStatus">
+        Starts or ends in Alaska, Hawaii, or International locations
+      </span>
+      {conusStatus === CONUS_STATUS.OCONUS && (
+        <div>
+          MilMove does not support OCONUS moves yet. Contact your current transportation office to set up your move.
         </div>
-      </div>
-    );
-  }
-}
+      )}
+    </>
+  );
+};
 
 ConusOrNot.propTypes = {
   setLocation: func.isRequired,

--- a/src/pages/MyMove/MoveLanding.jsx
+++ b/src/pages/MyMove/MoveLanding.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 export const MoveLanding = ({ serviceMember }) => {
   return (
     <div className="usa-grid">
-      <h1 className="sm-heading">Home</h1>
+      <h1>Home</h1>
       <h2>Welcome {get(serviceMember, 'first_name', '')}</h2>
     </div>
   );

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -3,34 +3,30 @@ import React from 'react';
 // eslint-disable-next-line react/prefer-stateless-function
 export const MovingInfo = () => {
   return (
-    <div className="usa-grid">
-      <div className="grid-row">
-        <div className="grid-col">
-          <h1 data-testid="shipmentsHeader" className="sm-heading">
-            Figure out your shipments
-          </h1>
-          <p>Handy tips as you decide how to move</p>
-          <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-            Move in one shipment or more
-          </h2>
-          <p>
-            It’s common to move in a few shipments. Everything can go in one batch, or you can divide your belongings
-            into several shipments.
-          </p>
-          <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-            Keep important things with you
-          </h2>
-          <p>
-            It’s a good idea to move things you’ll need right away and prized possessions yourself. Select a PPM
-            (personally procured move) shipment to do that.
-          </p>
-          <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-            Spread out your pickup dates
-          </h2>
-          <p>It’s easier to coordinate multiple shipments if you don’t schedule all the pickups on the same day.</p>
-        </div>
-      </div>
-    </div>
+    <>
+      <h1 data-testid="shipmentsHeader" className="sm-heading">
+        Figure out your shipments
+      </h1>
+      <p>Handy tips as you decide how to move</p>
+      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
+        Move in one shipment or more
+      </h2>
+      <p>
+        It’s common to move in a few shipments. Everything can go in one batch, or you can divide your belongings into
+        several shipments.
+      </p>
+      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
+        Keep important things with you
+      </h2>
+      <p>
+        It’s a good idea to move things you’ll need right away and prized possessions yourself. Select a PPM (personally
+        procured move) shipment to do that.
+      </p>
+      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
+        Spread out your pickup dates
+      </h2>
+      <p>It’s easier to coordinate multiple shipments if you don’t schedule all the pickups on the same day.</p>
+    </>
   );
 };
 

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -1,30 +1,21 @@
 import React from 'react';
 
-// eslint-disable-next-line react/prefer-stateless-function
 export const MovingInfo = () => {
   return (
     <>
-      <h1 data-testid="shipmentsHeader" className="sm-heading">
-        Figure out your shipments
-      </h1>
+      <h1 data-testid="shipmentsHeader">Figure out your shipments</h1>
       <p>Handy tips as you decide how to move</p>
-      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-        Move in one shipment or more
-      </h2>
+      <h2 data-testid="shipmentsSubHeader">Move in one shipment or more</h2>
       <p>
         It’s common to move in a few shipments. Everything can go in one batch, or you can divide your belongings into
         several shipments.
       </p>
-      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-        Keep important things with you
-      </h2>
+      <h2 data-testid="shipmentsSubHeader">Keep important things with you</h2>
       <p>
         It’s a good idea to move things you’ll need right away and prized possessions yourself. Select a PPM (personally
         procured move) shipment to do that.
       </p>
-      <h2 data-testid="shipmentsSubHeader" className="sm-heading">
-        Spread out your pickup dates
-      </h2>
+      <h2 data-testid="shipmentsSubHeader">Spread out your pickup dates</h2>
       <p>It’s easier to coordinate multiple shipments if you don’t schedule all the pickups on the same day.</p>
     </>
   );

--- a/src/pages/MyMove/Orders.jsx
+++ b/src/pages/MyMove/Orders.jsx
@@ -75,7 +75,7 @@ export class Orders extends Component {
         readyToSubmit={!newDutyStationErrorMsg}
         serverError={error}
       >
-        <h1 className="sm-heading">Tell us about your move orders</h1>
+        <h1>Tell us about your move orders</h1>
         <SwaggerField
           fieldName="orders_type"
           swagger={showAllOrdersTypes ? this.props.schema : modifiedSchemaForOrdersTypesFlag}

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -40,41 +40,35 @@ export class SelectMoveType extends Component {
         handleSubmit={this.handleSubmit}
         push={push}
       >
-        <div className="usa-grid">
-          <div className="grid-row">
-            <div className="grid-col">
-              <h1 className="sm-heading">How do you want to move your belongings?</h1>
-              <Radio
-                id={SHIPMENT_OPTIONS.PPM}
-                label="I’ll move things myself"
-                value={SHIPMENT_OPTIONS.PPM}
-                name="moveType"
-                onChange={(e) => this.setMoveType(e)}
-                checked={moveType === SHIPMENT_OPTIONS.PPM}
-              />
-              <ul>
-                <li>This is a PPM - “personally procured move”</li>
-                <li>You arrange to move some or all of your belongings</li>
-                <li>The government pays you an incentive based on weight</li>
-                <li>DIY or hire your own movers</li>
-              </ul>
-              <Radio
-                id={SHIPMENT_OPTIONS.HHG}
-                label="The government packs for me and moves me"
-                value={SHIPMENT_OPTIONS.HHG}
-                onChange={(e) => this.setMoveType(e)}
-                name="moveType"
-                checked={moveType === SHIPMENT_OPTIONS.HHG}
-              />
-              <ul>
-                <li>This is an HHG shipment — “household goods”</li>
-                <li>The most popular kind of shipment</li>
-                <li>Professional movers take care of the whole shipment</li>
-                <li>They pack and move it for you</li>
-              </ul>
-            </div>
-          </div>
-        </div>
+        <h1 className="sm-heading">How do you want to move your belongings?</h1>
+        <Radio
+          id={SHIPMENT_OPTIONS.PPM}
+          label="I’ll move things myself"
+          value={SHIPMENT_OPTIONS.PPM}
+          name="moveType"
+          onChange={(e) => this.setMoveType(e)}
+          checked={moveType === SHIPMENT_OPTIONS.PPM}
+        />
+        <ul>
+          <li>This is a PPM - “personally procured move”</li>
+          <li>You arrange to move some or all of your belongings</li>
+          <li>The government pays you an incentive based on weight</li>
+          <li>DIY or hire your own movers</li>
+        </ul>
+        <Radio
+          id={SHIPMENT_OPTIONS.HHG}
+          label="The government packs for me and moves me"
+          value={SHIPMENT_OPTIONS.HHG}
+          onChange={(e) => this.setMoveType(e)}
+          name="moveType"
+          checked={moveType === SHIPMENT_OPTIONS.HHG}
+        />
+        <ul>
+          <li>This is an HHG shipment — “household goods”</li>
+          <li>The most popular kind of shipment</li>
+          <li>Professional movers take care of the whole shipment</li>
+          <li>They pack and move it for you</li>
+        </ul>
       </WizardPage>
     );
   }

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -40,7 +40,7 @@ export class SelectMoveType extends Component {
         handleSubmit={this.handleSubmit}
         push={push}
       >
-        <h1 className="sm-heading">How do you want to move your belongings?</h1>
+        <h1>How do you want to move your belongings?</h1>
         <Radio
           id={SHIPMENT_OPTIONS.PPM}
           label="I’ll move things myself"

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -74,7 +74,7 @@ export class UploadOrders extends Component {
         pageList={pages}
       >
         <div>
-          <h1 className="sm-heading">Upload your orders</h1>
+          <h1>Upload your orders</h1>
           <p>In order to schedule your move, we need to have a complete copy of your orders.</p>
           <p>You can upload a PDF, or you can take a picture of each page and upload the images.</p>
           <p>{documentSizeLimitMsg}</p>

--- a/src/scenes/DPSAuthCookie/index.jsx
+++ b/src/scenes/DPSAuthCookie/index.jsx
@@ -42,7 +42,7 @@ export class DPSAuthCookie extends Component {
   render() {
     return (
       <div className="usa-grid">
-        <h1 className="sm-heading">Set DPS Auth Cookie</h1>
+        <h1>Set DPS Auth Cookie</h1>
         <form onSubmit={this.props.handleSubmit(this.sendRequest)}>
           <SwaggerField fieldName="cookie_name" swagger={this.props.schema} />
           <SwaggerField fieldName="dps_redirect_url" swagger={this.props.schema} />

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -278,126 +278,122 @@ export class PpmWeight extends Component {
     const { includesProgear, isProgearMoreThan1000, hasEstimateError } = this.state;
 
     return (
-      <div>
-        <div className="grid-container usa-prose">
-          <WeightWizardForm
-            handleSubmit={this.handleSubmit}
-            pageList={pages}
-            pageKey={pageKey}
-            serverError={error}
-            additionalValues={{
-              hasEstimateInProgress,
-              incentiveEstimateMax,
-            }}
-            readyToSubmit={!hasShortHaulError(rateEngineError)}
-          >
-            <h1 data-testid="weight-page-title">How much do you think you'll move?</h1>
-            <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
-            <div>
-              <RangeSlider
-                id="incentive-estimation-slider"
-                max={this.props.entitlement.weight}
-                step={this.props.entitlement.weight <= 2500 ? 100 : 500}
-                min={0}
-                defaultValue={this.state.pendingPpmWeight}
-                prependTooltipText="about"
-                appendTooltipText="lbs"
-                onChange={this.onWeightSelected}
-              />
-              {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
-            </div>
+      <WeightWizardForm
+        handleSubmit={this.handleSubmit}
+        pageList={pages}
+        pageKey={pageKey}
+        serverError={error}
+        additionalValues={{
+          hasEstimateInProgress,
+          incentiveEstimateMax,
+        }}
+        readyToSubmit={!hasShortHaulError(rateEngineError)}
+      >
+        <h1 data-testid="weight-page-title">How much do you think you'll move?</h1>
+        <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
+        <div>
+          <RangeSlider
+            id="incentive-estimation-slider"
+            max={this.props.entitlement.weight}
+            step={this.props.entitlement.weight <= 2500 ? 100 : 500}
+            min={0}
+            defaultValue={this.state.pendingPpmWeight}
+            prependTooltipText="about"
+            appendTooltipText="lbs"
+            onChange={this.onWeightSelected}
+          />
+          {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
+        </div>
+        <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
+          {this.chooseVehicleIcon(this.state.pendingPpmWeight)}
+          {this.chooseEstimateText(this.state.pendingPpmWeight)}
+          <h4>Your incentive for moving {this.state.pendingPpmWeight} lbs:</h4>
+          <h3 className={styles['incentive-range-text']} data-testid="incentive-range-text">
+            {this.chooseIncentiveRangeText(hasEstimateError)}
+          </h3>
+          <p className="text-gray-50">Final payment will be based on the weight you actually move.</p>
+        </div>
+        <div className="radio-group-wrapper normalize-margins">
+          <h3>Do you also have pro-gear to move?</h3>
+          <RadioButton
+            inputClassName="usa-radio__input inline_radio"
+            labelClassName="usa-radio__label inline_radio"
+            label="Yes"
+            value="Yes"
+            name="includesProgear"
+            checked={includesProgear === 'Yes'}
+            onChange={(event) => this.handleChange(event, 'includesProgear')}
+          />
+
+          <RadioButton
+            inputClassName="usa-radio__input inline_radio"
+            labelClassName="usa-radio__label inline_radio"
+            label="No"
+            value="No"
+            name="includesProgear"
+            checked={includesProgear === 'No'}
+            onChange={(event) => this.handleChange(event, 'includesProgear')}
+          />
+          <RadioButton
+            inputClassName="usa-radio__input inline_radio"
+            labelClassName="usa-radio__label inline_radio"
+            label="Not sure"
+            value="Not Sure"
+            name="includesProgear"
+            checked={includesProgear === 'Not Sure'}
+            onChange={(event) => this.handleChange(event, 'includesProgear')}
+          />
+          <p>
+            Books, papers, and equipment needed for official duties. <a href="#">What counts as pro-gear?</a>{' '}
+          </p>
+        </div>
+        {(includesProgear === 'Yes' || includesProgear === 'Not Sure') && (
+          <>
             <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
-              {this.chooseVehicleIcon(this.state.pendingPpmWeight)}
-              {this.chooseEstimateText(this.state.pendingPpmWeight)}
-              <h4>Your incentive for moving {this.state.pendingPpmWeight} lbs:</h4>
-              <h3 className={styles['incentive-range-text']} data-testid="incentive-range-text">
-                {this.chooseIncentiveRangeText(hasEstimateError)}
-              </h3>
-              <p className="text-gray-50">Final payment will be based on the weight you actually move.</p>
+              You can be paid for moving up to 2,500 lbs of pro-gear, in addition to your weight entitlement of{' '}
+              {formatCentsRange(incentiveEstimateMin, incentiveEstimateMax)}.
             </div>
             <div className="radio-group-wrapper normalize-margins">
-              <h3>Do you also have pro-gear to move?</h3>
+              <h3>Do you think your pro-gear weighs 1000 lbs or more?</h3>
+              <p>You can move up to 2000 lbs of qualified pro-gear, plus 500 pounds for your spouse.</p>
               <RadioButton
                 inputClassName="usa-radio__input inline_radio"
                 labelClassName="usa-radio__label inline_radio"
                 label="Yes"
                 value="Yes"
-                name="includesProgear"
-                checked={includesProgear === 'Yes'}
-                onChange={(event) => this.handleChange(event, 'includesProgear')}
+                name="isProgearMoreThan1000"
+                checked={isProgearMoreThan1000 === 'Yes'}
+                onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
               />
-
               <RadioButton
                 inputClassName="usa-radio__input inline_radio"
                 labelClassName="usa-radio__label inline_radio"
                 label="No"
                 value="No"
-                name="includesProgear"
-                checked={includesProgear === 'No'}
-                onChange={(event) => this.handleChange(event, 'includesProgear')}
+                name="isProgearMoreThan1000"
+                checked={isProgearMoreThan1000 === 'No'}
+                onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
               />
               <RadioButton
                 inputClassName="usa-radio__input inline_radio"
                 labelClassName="usa-radio__label inline_radio"
                 label="Not sure"
                 value="Not Sure"
-                name="includesProgear"
-                checked={includesProgear === 'Not Sure'}
-                onChange={(event) => this.handleChange(event, 'includesProgear')}
+                name="isProgearMoreThan1000"
+                checked={isProgearMoreThan1000 === 'Not Sure'}
+                onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
               />
-              <p>
-                Books, papers, and equipment needed for official duties. <a href="#">What counts as pro-gear?</a>{' '}
-              </p>
             </div>
-            {(includesProgear === 'Yes' || includesProgear === 'Not Sure') && (
-              <>
-                <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
-                  You can be paid for moving up to 2,500 lbs of pro-gear, in addition to your weight entitlement of{' '}
-                  {formatCentsRange(incentiveEstimateMin, incentiveEstimateMax)}.
-                </div>
-                <div className="radio-group-wrapper normalize-margins">
-                  <h3>Do you think your pro-gear weighs 1000 lbs or more?</h3>
-                  <p>You can move up to 2000 lbs of qualified pro-gear, plus 500 pounds for your spouse.</p>
-                  <RadioButton
-                    inputClassName="usa-radio__input inline_radio"
-                    labelClassName="usa-radio__label inline_radio"
-                    label="Yes"
-                    value="Yes"
-                    name="isProgearMoreThan1000"
-                    checked={isProgearMoreThan1000 === 'Yes'}
-                    onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
-                  />
-                  <RadioButton
-                    inputClassName="usa-radio__input inline_radio"
-                    labelClassName="usa-radio__label inline_radio"
-                    label="No"
-                    value="No"
-                    name="isProgearMoreThan1000"
-                    checked={isProgearMoreThan1000 === 'No'}
-                    onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
-                  />
-                  <RadioButton
-                    inputClassName="usa-radio__input inline_radio"
-                    labelClassName="usa-radio__label inline_radio"
-                    label="Not sure"
-                    value="Not Sure"
-                    name="isProgearMoreThan1000"
-                    checked={isProgearMoreThan1000 === 'Not Sure'}
-                    onChange={(event) => this.handleChange(event, 'isProgearMoreThan1000')}
-                  />
-                </div>
-              </>
-            )}
-            {(isProgearMoreThan1000 === 'Yes' || isProgearMoreThan1000 === 'Not Sure') && (
-              <>
-                <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
-                  Pack your pro-gear separately. It might need to be weighed and verified.
-                </div>
-              </>
-            )}
-          </WeightWizardForm>
-        </div>
-      </div>
+          </>
+        )}
+        {(isProgearMoreThan1000 === 'Yes' || isProgearMoreThan1000 === 'Not Sure') && (
+          <>
+            <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
+              Pack your pro-gear separately. It might need to be weighed and verified.
+            </div>
+          </>
+        )}
+      </WeightWizardForm>
     );
   }
 }

--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -37,7 +37,7 @@ let EditBackupContactForm = (props) => {
               Backup Contact
             </h1>
             <hr />
-            <h3 className="sm-heading">Edit Backup Contact:</h3>
+            <h3>Edit Backup Contact:</h3>
             <p>Any person you assign as a backup contact must be 18 years of age or older.</p>
             <SwaggerField fieldName="name" swagger={schema} required />
             <SwaggerField fieldName="email" swagger={schema} required />

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -46,12 +46,12 @@ let EditDateAndLocationForm = (props) => {
       <div className="grid-row">
         <div className="grid-col-12">
           <form onSubmit={handleSubmit}>
-            <h1 className="sm-heading"> Edit PPM Dates & Locations </h1>
+            <h1>Edit PPM Dates & Locations</h1>
             <p>Changes could impact your move, including the estimated PPM incentive.</p>
-            <h3 className="sm-heading-2"> Move Date </h3>
+            <h3>Move Date</h3>
             <SwaggerField fieldName="original_move_date" onChange={getSitEstimate} swagger={schema} required />
             <hr className="spacer" />
-            <h3 className="sm-heading-2">Pickup Location</h3>
+            <h3>Pickup Location</h3>
             <SwaggerField fieldName="pickup_postal_code" onChange={getSitEstimate} swagger={schema} required />
             <SwaggerField fieldName="has_additional_postal_code" swagger={schema} component={YesNoBoolean} />
             {get(props, 'formValues.has_additional_postal_code', false) && (
@@ -61,7 +61,7 @@ let EditDateAndLocationForm = (props) => {
               </Fragment>
             )}
             <hr className="spacer" />
-            <h3 className="sm-heading-2">Destination Location</h3>
+            <h3>Destination Location</h3>
             <p>
               Enter the ZIP for your new home if you know it, or for{' '}
               {currentOrders && currentOrders.new_duty_station.name} if you don't.

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -71,7 +71,7 @@ let EditOrdersForm = (props) => {
               Orders
             </h1>
             <hr />
-            <h3 className="sm-heading">Edit Orders:</h3>
+            <h3>Edit Orders:</h3>
             <SwaggerField
               fieldName="orders_type"
               swagger={showAllOrdersTypes ? schema : modifiedSchemaForOrdersTypesFlag}

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -52,7 +52,7 @@ let EditProfileForm = (props) => {
               Profile
             </h1>
             <hr />
-            <h3 className="sm-heading">Edit Profile:</h3>
+            <h3>Edit Profile:</h3>
             <SwaggerField fieldName="first_name" swagger={schema} required />
             <SwaggerField fieldName="middle_name" swagger={schema} />
             <SwaggerField fieldName="last_name" swagger={schema} required />

--- a/src/scenes/Review/EditWeight.css
+++ b/src/scenes/Review/EditWeight.css
@@ -33,10 +33,9 @@
   display: none;
 }
 
-.edit-weight-container h4.sm-heading {
+.edit-weight-container h4 {
   margin-bottom: 0;
 }
-
 
 .examples-table {
   margin-top: 3rem;

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -103,12 +103,12 @@ let EditWeightForm = (props) => {
               Profile
             </h1>
             <hr />
-            <h3 className="sm-heading">Edit PPM Weight:</h3>
+            <h3>Edit PPM Weight:</h3>
             <p>Changes could impact your move, including the estimated PPM incentive.</p>
             <EntitlementBar entitlement={entitlement} />
             <div className="edit-weight-container">
               <div className="usa-width-one-half">
-                <h4 className="sm-heading">Move estimate</h4>
+                <h4>Move estimate</h4>
                 <div>
                   <SwaggerField
                     className={fullFieldClass}
@@ -161,7 +161,7 @@ let EditWeightForm = (props) => {
               </div>
 
               <div className="usa-width-one-half">
-                <h4 className="sm-heading">Examples</h4>
+                <h4>Examples</h4>
                 <table className="examples-table">
                   <thead>
                     <tr>

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -27,15 +27,11 @@ class Review extends Component {
           hideBackBtn
           showFinishLaterBtn
         >
-          <div className="grid-row">
-            <div className="grid-col-12 edit-title">
-              <h1 data-testid="review-move-header">Review your details</h1>
-              <p>
-                You’re almost done setting up your move. Double-check that your information is accurate, then move on to
-                the final step.
-              </p>
-            </div>
-          </div>
+          <h1 data-testid="review-move-header">Review your details</h1>
+          <p>
+            You’re almost done setting up your move. Double-check that your information is accurate, then move on to the
+            final step.
+          </p>
           <Summary />
         </WizardPage>
       </div>

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -108,22 +108,18 @@ class ContactForm extends Component {
     const fields = schema.properties || {};
 
     return (
-      <div className="grid-row">
-        <div className="grid-col-12">
-          <form>
-            <h1 className="sm-heading">Backup contact</h1>
-            <p>If we can't reach you, who can we contact (such as spouse or parent)?</p>
-            <p>Any person you assign as a backup contact must be 18 years of age or older.</p>
+      <form>
+        <h1 className="sm-heading">Backup contact</h1>
+        <p>If we can't reach you, who can we contact (such as spouse or parent)?</p>
+        <p>Any person you assign as a backup contact must be 18 years of age or older.</p>
 
-            {renderField('name', fields, '')}
-            {renderField('email', fields, '')}
-            {renderField('telephone', fields, '')}
+        {renderField('name', fields, '')}
+        {renderField('email', fields, '')}
+        {renderField('telephone', fields, '')}
 
-            {/* TODO: Uncomment line below after backup contact auth is implemented.  */}
-            {/* <Field name="permission" component={permissionsField} /> */}
-          </form>
-        </div>
-      </div>
+        {/* TODO: Uncomment line below after backup contact auth is implemented.  */}
+        {/* <Field name="permission" component={permissionsField} /> */}
+      </form>
     );
   }
 }

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -109,7 +109,7 @@ class ContactForm extends Component {
 
     return (
       <form>
-        <h1 className="sm-heading">Backup contact</h1>
+        <h1>Backup contact</h1>
         <p>If we can't reach you, who can we contact (such as spouse or parent)?</p>
         <p>Any person you assign as a backup contact must be 18 years of age or older.</p>
 

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -33,15 +33,11 @@ export class BackupMailingAddress extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <div className="grid-row">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Backup mailing address</h1>
-            <p>
-              Where should we send mail if we can’t reach you at your primary address? You might use a parent's or
-              friend’s address, or a post office box.
-            </p>
-          </div>
-        </div>
+        <h1 className="sm-heading">Backup mailing address</h1>
+        <p>
+          Where should we send mail if we can’t reach you at your primary address? You might use a parent's or friend’s
+          address, or a post office box.
+        </p>
         <AddressForm schema={this.props.schema} />
       </BackupMailingWizardForm>
     );

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -33,7 +33,7 @@ export class BackupMailingAddress extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <h1 className="sm-heading">Backup mailing address</h1>
+        <h1>Backup mailing address</h1>
         <p>
           Where should we send mail if we can’t reach you at your primary address? You might use a parent's or friend’s
           address, or a post office box.

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -57,20 +57,16 @@ export class ContactInfo extends Component {
         serverError={error}
         initialValues={initialValues}
       >
-        <div className="grid-row">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Your contact info</h1>
-            <SwaggerField fieldName="telephone" swagger={schema} required />
-            <SwaggerField fieldName="secondary_telephone" swagger={schema} />
-            <SwaggerField fieldName="personal_email" swagger={schema} required />
+        <h1 className="sm-heading">Your contact info</h1>
+        <SwaggerField fieldName="telephone" swagger={schema} required />
+        <SwaggerField fieldName="secondary_telephone" swagger={schema} />
+        <SwaggerField fieldName="personal_email" swagger={schema} required />
 
-            <fieldset className="usa-fieldset" key="contact_preferences">
-              <p htmlFor="contact_preferences">Preferred contact method(s) during your move:</p>
-              <SwaggerField fieldName="phone_is_preferred" swagger={schema} />
-              <SwaggerField fieldName="email_is_preferred" swagger={schema} />
-            </fieldset>
-          </div>
-        </div>
+        <fieldset className="usa-fieldset" key="contact_preferences">
+          <p htmlFor="contact_preferences">Preferred contact method(s) during your move:</p>
+          <SwaggerField fieldName="phone_is_preferred" swagger={schema} />
+          <SwaggerField fieldName="email_is_preferred" swagger={schema} />
+        </fieldset>
       </ContactWizardForm>
     );
   }

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -57,7 +57,7 @@ export class ContactInfo extends Component {
         serverError={error}
         initialValues={initialValues}
       >
-        <h1 className="sm-heading">Your contact info</h1>
+        <h1>Your contact info</h1>
         <SwaggerField fieldName="telephone" swagger={schema} required />
         <SwaggerField fieldName="secondary_telephone" swagger={schema} />
         <SwaggerField fieldName="personal_email" swagger={schema} required />

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -125,7 +125,7 @@ export class DodInfo extends Component {
         initialValues={initialValues}
         ssnOnServer={ssnOnServer}
       >
-        <h1 className="sm-heading">Create your profile</h1>
+        <h1>Create your profile</h1>
         <p>Before we can schedule your move, we need to know a little more about you.</p>
         <SwaggerField fieldName="affiliation" swagger={schema} required />
         <SwaggerField fieldName="edipi" swagger={schema} required />

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -125,21 +125,12 @@ export class DodInfo extends Component {
         initialValues={initialValues}
         ssnOnServer={ssnOnServer}
       >
-        <div className="grid-row">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Create your profile</h1>
-            <p>Before we can schedule your move, we need to know a little more about you.</p>
-            <SwaggerField fieldName="affiliation" swagger={schema} required />
-            <SwaggerField fieldName="edipi" swagger={schema} required />
-            <Field
-              name="social_security_number"
-              component={SSNField}
-              ssnOnServer={ssnOnServer}
-              normalize={normalizeSSN}
-            />
-            <SwaggerField fieldName="rank" swagger={schema} required />
-          </div>
-        </div>
+        <h1 className="sm-heading">Create your profile</h1>
+        <p>Before we can schedule your move, we need to know a little more about you.</p>
+        <SwaggerField fieldName="affiliation" swagger={schema} required />
+        <SwaggerField fieldName="edipi" swagger={schema} required />
+        <Field name="social_security_number" component={SSNField} ssnOnServer={ssnOnServer} normalize={normalizeSSN} />
+        <SwaggerField fieldName="rank" swagger={schema} required />
       </DodWizardForm>
     );
   }

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -74,7 +74,7 @@ export class DutyStation extends Component {
         initialValues={initialValues}
         serverError={error}
       >
-        <h1 className="sm-heading">Current duty station</h1>
+        <h1>Current duty station</h1>
         <Field
           name="current_station"
           title="What is your current duty station?"

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -74,17 +74,13 @@ export class DutyStation extends Component {
         initialValues={initialValues}
         serverError={error}
       >
-        <div className="grid-row">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Current duty station</h1>
-            <Field
-              name="current_station"
-              title="What is your current duty station?"
-              component={DutyStationSearchBox}
-              errorMsg={newDutyStationErrorMsg}
-            />
-          </div>
-        </div>
+        <h1 className="sm-heading">Current duty station</h1>
+        <Field
+          name="current_station"
+          title="What is your current duty station?"
+          component={DutyStationSearchBox}
+          errorMsg={newDutyStationErrorMsg}
+        />
       </DutyStationWizardForm>
     );
   }

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -36,7 +36,7 @@ export class Name extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <h1 className="sm-heading">Name</h1>
+        <h1>Name</h1>
         <SwaggerField fieldName="first_name" swagger={this.props.schema} required />
         <SwaggerField fieldName="middle_name" swagger={this.props.schema} />
         <SwaggerField fieldName="last_name" swagger={this.props.schema} required />

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -36,15 +36,11 @@ export class Name extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <div className="grid-row">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Name</h1>
-            <SwaggerField fieldName="first_name" swagger={this.props.schema} required />
-            <SwaggerField fieldName="middle_name" swagger={this.props.schema} />
-            <SwaggerField fieldName="last_name" swagger={this.props.schema} required />
-            <SwaggerField fieldName="suffix" swagger={this.props.schema} />
-          </div>
-        </div>
+        <h1 className="sm-heading">Name</h1>
+        <SwaggerField fieldName="first_name" swagger={this.props.schema} required />
+        <SwaggerField fieldName="middle_name" swagger={this.props.schema} />
+        <SwaggerField fieldName="last_name" swagger={this.props.schema} required />
+        <SwaggerField fieldName="suffix" swagger={this.props.schema} />
       </NameWizardForm>
     );
   }

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -45,11 +45,7 @@ export class ResidentialAddress extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <div className="grid-row grid-gap">
-          <div className="grid-col-12">
-            <h1 className="sm-heading">Current residence</h1>
-          </div>
-        </div>
+        <h1 className="sm-heading">Current residence</h1>
         <AddressForm schema={this.props.schema} />
       </ResidentalWizardForm>
     );

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -45,7 +45,7 @@ export class ResidentialAddress extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <h1 className="sm-heading">Current residence</h1>
+        <h1>Current residence</h1>
         <AddressForm schema={this.props.schema} />
       </ResidentalWizardForm>
     );

--- a/src/shared/JsonSchemaForm/index.css
+++ b/src/shared/JsonSchemaForm/index.css
@@ -2,14 +2,6 @@ form.default {
   padding: 2rem;
 }
 
-h1.sm-heading {
-  line-height: 1.1;
-}
-
-h2.sm-heading-2 {
-  line-height: 1.1;
-}
-
 .DayPicker {
   border: 0.1rem solid #5b616b;
   font-size: 1.25rem;

--- a/src/shared/JsonSchemaForm/index.jsx
+++ b/src/shared/JsonSchemaForm/index.jsx
@@ -169,7 +169,7 @@ export const JsonSchemaFormBody = (props) => {
 
   return (
     <Fragment>
-      <h1 className="sm-heading">{title}</h1>
+      <h1>{title}</h1>
       {description && <p>{description}</p>}
       {renderSchema(schema, uiSchema)}
       {todos && (

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -107,7 +107,11 @@ export class WizardFormPage extends Component {
             </div>
           </div>
         )}
-        <form className={className}>{children}</form>
+        <div className="grid-row">
+          <div className="grid-col">
+            <form className={className}>{children}</form>
+          </div>
+        </div>
         <div className="grid-row" style={{ marginTop: '0.5rem' }}>
           <div className="grid-col-12 text-right margin-top-6 margin-left-neg-1 tablet:margin-top-3">
             <div className="display-flex">

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -75,7 +75,9 @@ export class WizardPage extends Component {
             </div>
           </div>
         )}
-        {children}
+        <div className="grid-row">
+          <div className="grid-col">{children}</div>
+        </div>
         <div className="grid-row" style={{ marginTop: '2rem' }}>
           {!isFirstPage(pageList, pageKey) && !hideBackBtn && (
             <button


### PR DESCRIPTION
## Description

This PR makes the `WizardPage` and `WizardForm` components responsible for rendering their children in consistent grid container markup, and removes extraneous `div` elements from the onboarding pages.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
