### PR TITLE
Create adminUser without a User

### DIFF
--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -867,7 +867,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminNotFound() {
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserAdminLogsIn() {
 	// user is in admin_users but has not logged into the app before
-	adminUser := testdatagen.MakeAdminUser(suite.DB(), testdatagen.Assertions{
+	adminUser := testdatagen.MakeAdminUserWithNoUser(suite.DB(), testdatagen.Assertions{
 		AdminUser: models.AdminUser{
 			Active: true,
 		},


### PR DESCRIPTION
## Description

Fixes intermittently failing server test: `TestAuthorizeUnknownUserAdminLogsIn`.

## Reviewer Notes

It turned out that the issue was that we were creating 2 Users, one in `MakeAdminUser` and one in `authorizeUnknownUser`.  Therefore, `GetUserEmail` was fetching two records and using the first one which did not have the session on it, so the session was ''.

## Setup

To replicate locally, run `go test -count=10 ./pkg/auth/authentication --testify.m "TestAuthorizeUnknownUserAdminLogsIn"`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4580) for this change
