### PR TITLE
MB-4625 Fix 500 error TOO queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1290,7 +1290,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4625-500-error-too-queue
 
       - integration_tests_mtls:
           requires:
@@ -1304,7 +1304,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4625-500-error-too-queue
 
       - client_test:
           requires:
@@ -1312,7 +1312,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4625-500-error-too-queue
 
       - server_test:
           requires:
@@ -1320,7 +1320,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-mb-4625-500-error-too-queue
 
       - build_app:
           requires:
@@ -1360,21 +1360,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - deploy_exp_migrations:
           requires:
@@ -1388,28 +1388,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-mb-4625-500-error-too-queue
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1290,7 +1290,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4625-500-error-too-queue
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1304,7 +1304,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4625-500-error-too-queue
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1312,7 +1312,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4625-500-error-too-queue
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1320,7 +1320,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-mb-4625-500-error-too-queue
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1360,21 +1360,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1388,28 +1388,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-mb-4625-500-error-too-queue
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -468,13 +468,17 @@ func QueueMoves(moveOrders []models.Order) *ghcmessages.QueueMoves {
 			}
 		}
 
+		deptIndicator := ""
+		if order.DepartmentIndicator != nil {
+			deptIndicator = *order.DepartmentIndicator
+		}
 		queueMoveOrders[i] = &ghcmessages.QueueMove{
 			ID:       *handlers.FmtUUID(order.ID),
 			Customer: Customer(&customer),
 			// TODO Add status calculation logic here or at service/query level
 			Status:                 ghcmessages.QueueMoveStatus("NEW"),
 			Locator:                hhgMove.Locator,
-			DepartmentIndicator:    ghcmessages.DeptIndicator(*order.DepartmentIndicator),
+			DepartmentIndicator:    ghcmessages.DeptIndicator(deptIndicator),
 			ShipmentsCount:         int64(len(hhgMove.MTOShipments)),
 			DestinationDutyStation: DutyStation(&order.NewDutyStation),
 			OriginGBLOC:            ghcmessages.GBLOC(order.OriginDutyStation.TransportationOffice.Gbloc),


### PR DESCRIPTION
## Description

This PR fixes a bug that crashes the TOO queue (`/moves/queue`) in the office app. Initializes the department indicator to empty string if the value is NULL from the database.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

**To reproduce e2e locally, check out master branch:**
Local - Service member app
1. Log in as a new service member on `milmovelocal:3000`
2. Go through all steps in the flow and submit/sign move

Local - Office app
1. Log in as a TOO role on `officelocal:3000`
2. Navigate to `officelocal:3000/moves/queue`

Expected: TOO queue shows up.
Actual: TOO queue crashes.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4625) for this change