### PR TITLE
[MB-4225] capture per segment

### DIFF
--- a/pkg/edi/segment/per.go
+++ b/pkg/edi/segment/per.go
@@ -6,10 +6,10 @@ import (
 
 // PER represents the PER EDI segment
 type PER struct {
-	ContactFunctionCode          string `validate:"required"`
-	Name                         string `validate:"min=0,max=20,omitempty"`
+	ContactFunctionCode          string `validate:"required,oneof=CN,IC,EM"`
+	Name                         string `validate:"min=1,max=60,omitempty"`
 	CommunicationNumberQualifier string `validate:"omitempty,eq=TE"`
-	CommunicationNumber          string `validate:"omitempty,min=0,max=20"`
+	CommunicationNumber          string `validate:"omitempty,min=1,max=80"`
 }
 
 // StringArray converts PER to an array of strings

--- a/pkg/edi/segment/per.go
+++ b/pkg/edi/segment/per.go
@@ -6,8 +6,8 @@ import (
 
 // PER represents the PER EDI segment
 type PER struct {
-	ContactFunctionCode          string `validate:"required,oneof=CN,IC,EM"`
-	Name                         string `validate:"min=1,max=60,omitempty"`
+	ContactFunctionCode          string `validate:"required,oneof=CN IC EM"`
+	Name                         string `validate:"omitempty,min=1,max=60"`
 	CommunicationNumberQualifier string `validate:"omitempty,eq=TE"`
 	CommunicationNumber          string `validate:"omitempty,min=1,max=80"`
 }

--- a/pkg/edi/segment/per.go
+++ b/pkg/edi/segment/per.go
@@ -1,0 +1,39 @@
+package edisegment
+
+import (
+	"fmt"
+)
+
+// PER represents the PER EDI segment
+type PER struct {
+	ContactFunctionCode          string `validate:"required"`
+	Name                         string `validate:"min=0,max=20,omitempty"`
+	CommunicationNumberQualifier string `validate:"omitempty,eq=TE"`
+	CommunicationNumber          string `validate:"omitempty,min=0,max=20"`
+}
+
+// StringArray converts PER to an array of strings
+func (s *PER) StringArray() []string {
+
+	return []string{
+		"PER",
+		s.ContactFunctionCode,
+		s.Name,
+		s.CommunicationNumberQualifier,
+		s.CommunicationNumber,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the PER struct
+func (s *PER) Parse(parts []string) error {
+	numElements := len(parts)
+	if numElements < 1 || numElements > 4 {
+		return fmt.Errorf("PER: Wrong number of elements, expected between 1 and 4, got %d", numElements)
+	}
+
+	s.ContactFunctionCode = parts[0]
+	s.Name = parts[1]
+	s.CommunicationNumberQualifier = parts[2]
+	s.CommunicationNumber = parts[3]
+	return nil
+}

--- a/pkg/edi/segment/per_test.go
+++ b/pkg/edi/segment/per_test.go
@@ -28,9 +28,9 @@ func (suite *SegmentSuite) TestValidatePER() {
 
 	suite.T().Run("validate failure 1", func(t *testing.T) {
 		per := PER{
-			Name:                         "Cross Dock Testing With Too Long a Name",
+			Name:                         "Cross Dock Testing With Too Long a Name Cross Dock Testing With Too Long a Name",
 			CommunicationNumberQualifier: "BX",
-			CommunicationNumber:          "111111111111111111111111111111111111111115551234567",
+			CommunicationNumber:          "111111111111111111111111111111111111111115551234567111111111111111111111111111111111111111115551234567",
 		}
 
 		err := suite.validator.Struct(per)

--- a/pkg/edi/segment/per_test.go
+++ b/pkg/edi/segment/per_test.go
@@ -40,4 +40,16 @@ func (suite *SegmentSuite) TestValidatePER() {
 		suite.ValidateError(err, "CommunicationNumber", "max")
 		suite.ValidateErrorLen(err, 4)
 	})
+
+	suite.T().Run("validate segment is parsed correctly", func(t *testing.T) {
+		values := []string{"IC", "Cross Dock", "TE", "5551234567"}
+		per := PER{
+			ContactFunctionCode:          "IC",
+			Name:                         "Cross Dock",
+			CommunicationNumberQualifier: "TE",
+			CommunicationNumber:          "5551234567",
+		}
+		err := (*PER).Parse(&per, values)
+		suite.NoError(err)
+	})
 }

--- a/pkg/edi/segment/per_test.go
+++ b/pkg/edi/segment/per_test.go
@@ -1,0 +1,43 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidatePER() {
+	validPERDefault := PER{
+		ContactFunctionCode: "IC",
+	}
+
+	validPERAll := PER{
+		ContactFunctionCode:          "IC",
+		Name:                         "Cross Dock",
+		CommunicationNumberQualifier: "TE",
+		CommunicationNumber:          "5551234567",
+	}
+
+	suite.T().Run("validate success default", func(t *testing.T) {
+		err := suite.validator.Struct(validPERDefault)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success all", func(t *testing.T) {
+		err := suite.validator.Struct(validPERAll)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		per := PER{
+			Name:                         "Cross Dock Testing With Too Long a Name",
+			CommunicationNumberQualifier: "BX",
+			CommunicationNumber:          "111111111111111111111111111111111111111115551234567",
+		}
+
+		err := suite.validator.Struct(per)
+		suite.ValidateError(err, "ContactFunctionCode", "required")
+		suite.ValidateError(err, "Name", "max")
+		suite.ValidateError(err, "CommunicationNumberQualifier", "eq")
+		suite.ValidateError(err, "CommunicationNumber", "max")
+		suite.ValidateErrorLen(err, 4)
+	})
+}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -373,7 +373,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 	originAndDestinationSegments = append(originAndDestinationSegments, &destinationPostalDetails)
 
 	// Destination PER
-	destinationStationPhoneLines := destinationDutyStation.TransportationOffice.PhoneLines
+	destinationStationPhoneLines := destTransportationOffice.PhoneLines
 	var destPhoneLines []string
 	for _, phoneLine := range destinationStationPhoneLines {
 		if phoneLine.Type == "voice" {
@@ -441,7 +441,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 	originAndDestinationSegments = append(originAndDestinationSegments, &originPostalDetails)
 
 	// Origin Station Phone
-	originStationPhoneLines := originDutyStation.TransportationOffice.PhoneLines
+	originStationPhoneLines := originTransportationOffice.PhoneLines
 	var originPhoneLines []string
 	for _, phoneLine := range originStationPhoneLines {
 		if phoneLine.Type == "voice" {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -370,10 +370,25 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 	if destinationDutyStation.Address.Country != nil {
 		destinationPostalDetails.CountryCode = string(*destinationDutyStation.Address.Country)
 	}
-
 	originAndDestinationSegments = append(originAndDestinationSegments, &destinationPostalDetails)
 
-	// TODO: Create PER segment and implement Destination POC Phone
+	// Destination PER
+	destinationStationPhoneLines := destinationDutyStation.TransportationOffice.PhoneLines
+	var destPhoneLines []string
+	for _, phoneLine := range destinationStationPhoneLines {
+		if phoneLine.Type == "voice" {
+			destPhoneLines = append(destPhoneLines, phoneLine.Number)
+		}
+	}
+
+	if len(destPhoneLines) > 0 {
+		destinationPhone := edisegment.PER{
+			ContactFunctionCode:          "CN",
+			CommunicationNumberQualifier: "TE",
+			CommunicationNumber:          destPhoneLines[0],
+		}
+		originAndDestinationSegments = append(originAndDestinationSegments, &destinationPhone)
+	}
 
 	// ========  ORIGIN ========= //
 	// origin station name
@@ -425,7 +440,23 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 
 	originAndDestinationSegments = append(originAndDestinationSegments, &originPostalDetails)
 
-	// TODO: Create PER segment and implement Origin POC Phone
+	// Origin Station Phone
+	originStationPhoneLines := originDutyStation.TransportationOffice.PhoneLines
+	var originPhoneLines []string
+	for _, phoneLine := range originStationPhoneLines {
+		if phoneLine.Type == "voice" {
+			originPhoneLines = append(originPhoneLines, phoneLine.Number)
+		}
+	}
+
+	if len(originPhoneLines) > 0 {
+		originPhone := edisegment.PER{
+			ContactFunctionCode:          "CN",
+			CommunicationNumberQualifier: "TE",
+			CommunicationNumber:          originPhoneLines[0],
+		}
+		originAndDestinationSegments = append(originAndDestinationSegments, &originPhone)
+	}
 
 	return originAndDestinationSegments, nil
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -209,7 +209,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds se end segment", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(64, result.SE.NumberOfIncludedSegments)
+		suite.Equal(65, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -302,26 +302,39 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
 		suite.Equal(*address.Country, n4.CountryCode)
+		// Office Phone
+		destinationStationPhoneLines := expectedDutyStation.TransportationOffice.PhoneLines
+		var destPhoneLines []string
+		for _, phoneLine := range destinationStationPhoneLines {
+			if phoneLine.Type == "voice" {
+				destPhoneLines = append(destPhoneLines, phoneLine.Number)
+			}
+		}
+		suite.IsType(&edisegment.PER{}, result.Header[12])
+		per := result.Header[12].(*edisegment.PER)
+		suite.Equal("CN", per.ContactFunctionCode)
+		suite.Equal("TE", per.CommunicationNumberQualifier)
+		suite.Equal(destPhoneLines[0], per.CommunicationNumber)
 	})
 
 	suite.T().Run("adds orders origin address", func(t *testing.T) {
 		// name
 		expectedDutyStation := paymentRequest.MoveTaskOrder.Orders.OriginDutyStation
-		suite.IsType(&edisegment.N1{}, result.Header[12])
-		n1 := result.Header[12].(*edisegment.N1)
+		suite.IsType(&edisegment.N1{}, result.Header[13])
+		n1 := result.Header[13].(*edisegment.N1)
 		suite.Equal("SF", n1.EntityIdentifierCode)
 		suite.Equal(expectedDutyStation.Name, n1.Name)
 		suite.Equal("10", n1.IdentificationCodeQualifier)
 		suite.Equal(expectedDutyStation.TransportationOffice.Gbloc, n1.IdentificationCode)
 		// street address
 		address := expectedDutyStation.Address
-		suite.IsType(&edisegment.N3{}, result.Header[13])
-		n3 := result.Header[13].(*edisegment.N3)
+		suite.IsType(&edisegment.N3{}, result.Header[14])
+		n3 := result.Header[14].(*edisegment.N3)
 		suite.Equal(address.StreetAddress1, n3.AddressInformation1)
 		suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
 		// city state info
-		suite.IsType(&edisegment.N4{}, result.Header[14])
-		n4 := result.Header[14].(*edisegment.N4)
+		suite.IsType(&edisegment.N4{}, result.Header[15])
+		n4 := result.Header[15].(*edisegment.N4)
 		suite.Equal(address.City, n4.CityName)
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
@@ -329,11 +342,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	})
 
 	suite.T().Run("adds lines of accounting to header", func(t *testing.T) {
-		suite.IsType(&edisegment.FA1{}, result.Header[15])
-		fa1 := result.Header[15].(*edisegment.FA1)
+		suite.IsType(&edisegment.FA1{}, result.Header[16])
+		fa1 := result.Header[16].(*edisegment.FA1)
 		suite.Equal("DY", fa1.AgencyQualifierCode) // Default Order from testdatagen is AIR_FORCE
-		suite.IsType(&edisegment.FA2{}, result.Header[16])
-		fa2 := result.Header[16].(*edisegment.FA2)
+		suite.IsType(&edisegment.FA2{}, result.Header[17])
+		fa2 := result.Header[17].(*edisegment.FA2)
 		suite.Equal("TA", fa2.BreakdownStructureDetailCode)
 		suite.Equal(*paymentRequest.MoveTaskOrder.Orders.TAC, fa2.FinancialInformationCode)
 	})

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -209,7 +209,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds se end segment", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(65, result.SE.NumberOfIncludedSegments)
+		suite.Equal(66, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -339,14 +339,27 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
 		suite.Equal(*address.Country, n4.CountryCode)
+		// Office Phone
+		originStationPhoneLines := expectedDutyStation.TransportationOffice.PhoneLines
+		var originPhoneLines []string
+		for _, phoneLine := range originStationPhoneLines {
+			if phoneLine.Type == "voice" {
+				originPhoneLines = append(originPhoneLines, phoneLine.Number)
+			}
+		}
+		per := result.Header[16].(*edisegment.PER)
+		suite.IsType(&edisegment.PER{}, result.Header[16])
+		suite.Equal("CN", per.ContactFunctionCode)
+		suite.Equal("TE", per.CommunicationNumberQualifier)
+		suite.Equal(originPhoneLines[0], per.CommunicationNumber)
 	})
 
 	suite.T().Run("adds lines of accounting to header", func(t *testing.T) {
-		suite.IsType(&edisegment.FA1{}, result.Header[16])
-		fa1 := result.Header[16].(*edisegment.FA1)
+		suite.IsType(&edisegment.FA1{}, result.Header[17])
+		fa1 := result.Header[17].(*edisegment.FA1)
 		suite.Equal("DY", fa1.AgencyQualifierCode) // Default Order from testdatagen is AIR_FORCE
-		suite.IsType(&edisegment.FA2{}, result.Header[17])
-		fa2 := result.Header[17].(*edisegment.FA2)
+		suite.IsType(&edisegment.FA2{}, result.Header[18])
+		fa2 := result.Header[18].(*edisegment.FA2)
 		suite.Equal("TA", fa2.BreakdownStructureDetailCode)
 		suite.Equal(*paymentRequest.MoveTaskOrder.Orders.TAC, fa2.FinancialInformationCode)
 	})


### PR DESCRIPTION
## Description

This PR adds segments to the EDI to capture the phone number of the transportation office 

## Reviewer Notes

1. There are 2 types of phone number that a transportation office can have: fax or voice. This code pulls out the first voice number found. Should it instead choose a different number? I looked in the front-end and saw that the first number was being selected there as well.

2. Are the validations and default values for the PER segment as expected? I pulled from https://docs.google.com/document/d/1t4nokaYMoaQ2uBzhmxy--S3HlTTju4QhZTPIjc-Qcgs/edit

## Setup

1. Run your server `make server_run`.
2. Create a payment request with a Domestic Linehaul service item. Create a file called `create_payment_request.json` in the project root and paste in the JSON payload provided below:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

2. Use the Prime API Client to create the payment request and return the payment request number by running the command below:

```sh
prime-api-client --insecure create-payment-request --filename  create_payment_request.json| jq '.paymentRequestNumber'
```
3. Use the CLI utility to generate the EDI858 and view it in your terminal. Remember to pass the payment request number of the payment request you just created.

```sh
go run ./cmd/generate-payment-request-edi/ --payment-request-number [$paymentRequestNumber]
```
### Expected Output
```txt
ISA*00*0084182369*00*_   _*ZZ*GOVDPIBS*12*8004171844*20201014*1803*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*20201014*1803*100001251*X*004010
ST*858*0001
BX*00*J*PP*2103-4844*TRUS**4
N9*CN*2103-4844-4**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*10*20201014*0*
G62*76*20201013*0*
G62*86*20200316*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
PER*CN**TE*706-791-4184  <--- NEW LINE
N1*SF*4lNPgn8mpO*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
PER*CN**TE*(510) 555-5555 <--- NEW LINE
FA1*DY
FA2*TA*F8E1
HL*1**|
N9*PO*2103-4844-9bbf7ddd**
L5*1*DDP*TBD*D**
L0*1***1349.000*B******L
L3*1349.000*B*10835
HL*2**|
N9*PO*2103-4844-d5d26b84**
L5*2*DSH*TBD*D**
L0*2*373.000*DM*1349.000*B******L
L3*1349.000*B*457053
HL*3**|
N9*PO*2103-4844-97fc8e42**
L5*3*DLH*TBD*D**
L0*3*373.000*DM*1349.000*B******L
L3*1349.000*B*1221717
HL*4**|
N9*PO*2103-4844-c96bdb89**
L5*4*FSC*TBD*D**
L0*4*373.000*DM*1349.000*B******L
L3*1349.000*B*362
SE*41*0001
GE*1*100001251
IEA*1*100001272
```
## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4225) for this change
