### PR TITLE
Update editor config with insert_final_newline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
+insert_final_newline = true
 tab_width = 2
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
**Why**: It's a common practice to have an empty line at the end of
each file. However, not everyone has that feature turned on in their
editor. I noticed that running `pre-commit` on all files found a bunch
of files with a missing final newline. By adding this property to
our `.editorconfig`, we ensure that this gets applied automatically
for everyone.

