### PR TITLE
[MB-4601] Initial TIO payment request queue component with routing

### DIFF
--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { GridContainer } from '@trussworks/react-uswds';
+
+import styles from './PaymentRequestQueue.module.scss';
+
+import Table from 'components/Table/Table';
+import { createHeader } from 'components/Table/utils';
+
+const columns = [
+  createHeader('Customer name', ''),
+  createHeader('DoD ID', 'customer.dodID'),
+  createHeader('Status', 'status'),
+  createHeader('Age', 'age'),
+  createHeader('Submitted At', 'submittedAt'),
+  createHeader('Move ID', 'locator'),
+  createHeader('Branch', 'departmentIndicator'),
+  createHeader('Destination duty station', 'destinationDutyStation.name'),
+  createHeader('Origin GBLOC', 'originGBLOC'),
+];
+
+const PaymentRequestQueue = () => {
+  return (
+    <GridContainer containerSize="widescreen" className={styles.PaymentRequestQueue}>
+      <h1>Payment Requests (0)</h1>
+      <div className={styles.tableContainer}>
+        <Table columns={columns} />
+      </div>
+    </GridContainer>
+  );
+};
+
+export default PaymentRequestQueue;

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -10,7 +10,8 @@ const columns = [
   createHeader('Customer name', ''),
   createHeader('DoD ID', 'customer.dodID'),
   createHeader('Status', 'status'),
-  createHeader('Age', 'age'), // Submitted At doesn't have a header but comes after the age column
+  createHeader('Age', 'age'),
+  createHeader('Submitted', 'submittedAt'),
   createHeader('Move ID', 'locator'),
   createHeader('Branch', 'departmentIndicator'),
   createHeader('Destination duty station', 'destinationDutyStation.name'),

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -20,7 +20,7 @@ const columns = [
 const PaymentRequestQueue = () => {
   return (
     <GridContainer containerSize="widescreen" className={styles.PaymentRequestQueue}>
-      <h1>Payment Requests (0)</h1>
+      <h1>Payment requests (0)</h1>
       <div className={styles.tableContainer}>
         <Table columns={columns} />
       </div>

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -10,8 +10,7 @@ const columns = [
   createHeader('Customer name', ''),
   createHeader('DoD ID', 'customer.dodID'),
   createHeader('Status', 'status'),
-  createHeader('Age', 'age'),
-  createHeader('Submitted At', 'submittedAt'),
+  createHeader('Age', 'age'), // Submitted At doesn't have a header but comes after the age column
   createHeader('Move ID', 'locator'),
   createHeader('Branch', 'departmentIndicator'),
   createHeader('Destination duty station', 'destinationDutyStation.name'),

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.module.scss
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.module.scss
@@ -1,0 +1,19 @@
+@import '../../../shared/styles/basics';
+@import '../../../shared/styles/mixins';
+@import '../../../shared/styles/colors';
+
+.PaymentRequestQueue {
+  .tableContainer {
+    @include u-margin-top(1);
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+
+    tr {
+      cursor: pointer;
+    }
+  }
+}

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
@@ -13,7 +13,7 @@ describe('PaymentRequestQueue', () => {
   );
 
   it('should render the h1', () => {
-    expect(wrapper.find('h1').text()).toBe('Payment Requests (0)');
+    expect(wrapper.find('h1').text()).toBe('Payment requests (0)');
   });
 
   it('should render the table', () => {

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import PaymentRequestQueue from './PaymentRequestQueue';
+
+import { MockProviders } from 'testUtils';
+
+describe('PaymentRequestQueue', () => {
+  const wrapper = mount(
+    <MockProviders initialEntries={['invoicing/queue']}>
+      <PaymentRequestQueue />
+    </MockProviders>,
+  );
+
+  it('should render the h1', () => {
+    expect(wrapper.find('h1').text()).toBe('Payment Requests (0)');
+  });
+
+  it('should render the table', () => {
+    expect(wrapper.find('Table').exists()).toBe(true);
+  });
+});

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -44,6 +44,7 @@ const MoveQueue = lazy(() => import('pages/Office/MoveQueue/MoveQueue'));
 const CustomerDetails = lazy(() => import('scenes/Office/TOO/customerDetails'));
 // TIO pages
 const PaymentRequestIndex = lazy(() => import('pages/Office/PaymentRequestIndex/PaymentRequestIndex'));
+const PaymentRequestQueue = lazy(() => import('pages/Office/PaymentRequestQueue/PaymentRequestQueue'));
 
 export class OfficeApp extends Component {
   constructor(props) {
@@ -166,7 +167,7 @@ export class OfficeApp extends Component {
 
                 {/* TXO */}
                 <PrivateRoute path="/moves/queue" exact component={MoveQueue} requiredRoles={[roleTypes.TOO]} />
-                <PrivateRoute path="/invoicing/queue" component={PaymentRequestIndex} requiredRoles={[roleTypes.TIO]} />
+                <PrivateRoute path="/invoicing/queue" component={PaymentRequestQueue} requiredRoles={[roleTypes.TIO]} />
 
                 {/* PPM & TXO conflicting routes - select based on user role */}
                 {selectedRole === roleTypes.PPM ? ppmRoutes : txoRoutes}


### PR DESCRIPTION
## Description

This adds the Queue table component with column headers but does not yet integrate with the payment requests api endpoint.

## Reviewer Notes

There will need to be a column without a header added for the creation/submitted date range after age but I left it out here.

## Setup

```
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Log in as the TIO office user
2. Navigate to the [http://officelocal:3000/invoicing/queue](http://officelocal:3000/invoicing/queue)
3. Check that the empty queue component renders with the right column headers matching the [mock](https://share.goabstract.com/3cff868b-be81-401c-82fc-3634b1e26b52?collectionLayerId=976ace69-682e-4a11-bb4e-ed5ce27572f8&mode=design).

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4601) for this change

## Screenshots

![Screen Shot 2020-10-15 at 15 24 58](https://user-images.githubusercontent.com/52669884/96176670-a81cba80-0efa-11eb-8dfe-53887296e371.png)



