### PR TITLE
[MB-4751] fix g62 validation

### DIFF
--- a/pkg/edi/segment/g62.go
+++ b/pkg/edi/segment/g62.go
@@ -12,7 +12,7 @@ type G62 struct {
 	DateQualifier int    `validate:"oneof=10 76 86"`
 	Date          string `validate:"timeformat=20060102"`
 	TimeQualifier int    `validate:"oneof=5 8"`
-	Time          string `validate:"timeformat=1504"`
+	Time          string `validate:"required_with=TimeQualifier,timeformat=1504"`
 }
 
 // StringArray converts G62 to an array of strings


### PR DESCRIPTION
## Description

This PR changes the validation for the G62 segment so that the Time field is required whenever the TimeQualifier field is used.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4751) for this change
