### PR TITLE
Create MakeStubbedUser for faster tests

### DIFF
--- a/pkg/handlers/adminapi/admin_users_test.go
+++ b/pkg/handlers/adminapi/admin_users_test.go
@@ -36,7 +36,7 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 	testdatagen.MakeAdminUser(suite.DB(), assertions)
 	testdatagen.MakeDefaultAdminUser(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/admin_users", nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 
@@ -138,7 +138,7 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 	}
 	testdatagen.MakeAdminUser(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/admin_users/%s", id), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -229,7 +229,7 @@ func (suite *HandlerSuite) TestCreateAdminUserHandler() {
 	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
 
 	req := httptest.NewRequest("POST", "/admin_users", nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := adminuserop.CreateAdminUserParams{
@@ -284,7 +284,7 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 
 	endpoint := fmt.Sprintf("/admin_users/%s", adminUserID)
 	req := httptest.NewRequest("PUT", endpoint, nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := adminuserop.UpdateAdminUserParams{

--- a/pkg/handlers/adminapi/electronic_orders_test.go
+++ b/pkg/handlers/adminapi/electronic_orders_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestGetElectronicOrdersTotalsHandler() {
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/electronic_orders/totals", nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/notifications_test.go
+++ b/pkg/handlers/adminapi/notifications_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestIndexNotificationsHandler() {
 	testdatagen.MakeNotification(suite.DB(), assertions)
 	testdatagen.MakeDefaultNotification(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/notifications", nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -41,7 +41,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 	testdatagen.MakeOfficeUser(suite.DB(), assertions)
 	testdatagen.MakeDefaultOfficeUser(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/office_users", nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 	}
 	testdatagen.MakeOfficeUser(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/office_users/%s", id), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -205,7 +205,7 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
 
 	req := httptest.NewRequest("POST", "/office_users", nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := officeuserop.CreateOfficeUserParams{
@@ -261,7 +261,7 @@ func (suite *HandlerSuite) TestUpdateOfficeUserHandler() {
 
 	endpoint := fmt.Sprintf("/office_users/%s", officeUserID)
 	req := httptest.NewRequest("PUT", endpoint, nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := officeuserop.UpdateOfficeUserParams{

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -29,7 +29,7 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 	}
 	testdatagen.MakeTransportationOffice(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/offices", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/organizations_test.go
+++ b/pkg/handlers/adminapi/organizations_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 	}
 	testdatagen.MakeOrganization(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/organizations", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerSuite) TestIndexTSPPsHandler() {
 	}
 	testdatagen.MakeTSPPerformance(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/transportation_service_provider_performances", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -128,7 +128,7 @@ func (suite *HandlerSuite) TestGetTSPPHandler() {
 	}
 	testdatagen.MakeTSPPerformance(suite.DB(), assertions)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/transportation_service_provider_performances/"+uuidString, nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -68,7 +68,7 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 	uploadInstance := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{UserUpload: uploadUserAssertions})
 	suite.MustSave(&uploadInstance)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/uploads/%s", uploadID.String()), nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -45,7 +45,7 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 	userIDString := user.ID.String()
 	userID := user.ID
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/users/%s", userID), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -141,7 +141,7 @@ func (suite *HandlerSuite) TestRevokeUserSessionHandler() {
 
 	endpoint := fmt.Sprintf("/users/%s", userID)
 	req := httptest.NewRequest("PUT", endpoint, nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	revokeMilSession := true

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -68,7 +68,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 	moveTaskOrder := testdatagen.MakeDefaultMove(suite.DB())
 
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
 
 	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
@@ -142,7 +142,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 	moveTaskOrder := testdatagen.MakeDefaultMove(suite.DB())
 
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -19,7 +19,7 @@ import (
 func (suite *HandlerSuite) TestGetMoveHandler() {
 	move := testdatagen.MakeDefaultMove(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/move/#{move.locator}"), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 	params := moveops.GetMoveParams{

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -21,7 +21,7 @@ import (
 func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 	testMTOAgent := testdatagen.MakeDefaultMTOAgent(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/move-task-orders/%s/mto-agents", testMTOAgent.ID.String()), nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -39,7 +39,7 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{ID: mtoShipmentID},
 	})
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	serviceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
 			ID: serviceItemID, MoveTaskOrderID: mto.ID, ReServiceID: reService.ID, MTOShipmentID: &mtoShipment.ID,
@@ -128,7 +128,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
 		moveTaskOrderID, serviceItemID), nil)
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := mtoserviceitemop.UpdateMTOServiceItemStatusParams{
@@ -254,7 +254,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		mto := testdatagen.MakeDefaultMove(suite.DB())
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
 			moveTaskOrderID, serviceItemID), nil)
@@ -290,7 +290,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		mto := testdatagen.MakeDefaultMove(suite.DB())
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
 			moveTaskOrderID, serviceItemID), nil)
@@ -328,7 +328,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			Move: availableMove,
 		})
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		availableMoveID := availableMove.ID
 		mtoServiceItemID := mtoServiceItem.ID
 

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -41,7 +41,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 	})
 
 	shipments := models.MTOShipments{mtoShipment}
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/move_task_orders/%s/mto_shipments", mto.ID.String()), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
@@ -148,7 +148,7 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		})
 	}
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_shipments/%s", mto.ID.String(), mtoShipment.ID.String()), nil)

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -139,7 +139,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("GET", fmt.Sprintf("/payment_request"), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -197,7 +197,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -232,7 +232,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(availablePaymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", availablePaymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -264,7 +264,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -293,7 +293,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -322,7 +322,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -351,7 +351,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 

--- a/pkg/handlers/ghcapi/payment_service_items_test.go
+++ b/pkg/handlers/ghcapi/payment_service_items_test.go
@@ -24,7 +24,7 @@ import (
 func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 	mto := testdatagen.MakeDefaultMove(suite.DB())
 	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move-task-orders/%s/payment-service-items/%s/status", mto.ID.String(), paymentServiceItem.ID.String()), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
@@ -136,7 +136,7 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		availablePaymentServiceItem := testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
 			Move: availableMTO,
 		})
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move-task-orders/%s/payment-service-items/%s/status", availableMTO.ID.String(), availablePaymentServiceItem.ID.String()), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)

--- a/pkg/handlers/internalapi/access_code_test.go
+++ b/pkg/handlers/internalapi/access_code_test.go
@@ -86,7 +86,7 @@ func (suite *HandlerSuite) TestFetchAccessCodeHandler_FeatureFlagIsOff() {
 
 func (suite *HandlerSuite) TestValidateAccessCodeHandler_Valid() {
 	// create user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := testdatagen.MakeStubbedUser(suite.DB())
 	selectedMoveType := models.SelectedMoveTypePPM
 
 	// creates access code
@@ -125,7 +125,7 @@ func (suite *HandlerSuite) TestValidateAccessCodeHandler_Valid() {
 
 func (suite *HandlerSuite) TestValidateAccessCodeHandler_Invalid() {
 	// create user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := testdatagen.MakeStubbedUser(suite.DB())
 	selectedMoveType := models.SelectedMoveTypeHHG
 	smID, _ := uuid.NewV4()
 

--- a/pkg/handlers/internalapi/addresses_test.go
+++ b/pkg/handlers/internalapi/addresses_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestShowAddressHandler() {
 	}
 	suite.MustSave(&address)
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	fakeUUID, _ := uuid.FromString("not-valid-uuid")
 

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -503,7 +503,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 	})
 
 	shipments := models.MTOShipments{mtoShipment, mtoShipment2}
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/moves/%s/mto_shipments", mto.ID.String()), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -261,7 +261,7 @@ func (suite *HandlerSuite) TestApprovePPMHandlerForbidden() {
 
 func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 	// Given: a set of orders, a move, user and servicemember
-	reimbursement, _ := testdatagen.MakeRequestedReimbursement(suite.DB())
+	reimbursement := testdatagen.MakeDefaultRequestedReimbursement(suite.DB())
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 	// And: the context contains the auth values
@@ -286,7 +286,7 @@ func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 
 func (suite *HandlerSuite) TestApproveReimbursementHandlerForbidden() {
 	// Given: a set of orders, a move, user and servicemember
-	reimbursement, _ := testdatagen.MakeRequestedReimbursement(suite.DB())
+	reimbursement := testdatagen.MakeDefaultRequestedReimbursement(suite.DB())
 	user := testdatagen.MakeDefaultServiceMember(suite.DB())
 
 	// And: the context contains the auth values

--- a/pkg/handlers/internalapi/postal_codes_test.go
+++ b/pkg/handlers/internalapi/postal_codes_test.go
@@ -14,7 +14,7 @@ import (
 
 func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 	// create user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := testdatagen.MakeStubbedUser(suite.DB())
 
 	postalCode := "30813"
 	postalCodeTypeString := "Destination"
@@ -52,7 +52,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 
 func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
 	// create user
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := testdatagen.MakeStubbedUser(suite.DB())
 
 	postalCode := "00000"
 	postalCodeTypeString := "Destination"

--- a/pkg/handlers/internalapi/users_test.go
+++ b/pkg/handlers/internalapi/users_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestUnknownLoggedInUserHandler() {
-	unknownUser := testdatagen.MakeDefaultUser(suite.DB())
+	unknownUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("GET", "/users/logged_in", nil)
 	req = suite.AuthenticateUserRequest(req, unknownUser)

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -265,7 +265,7 @@ func (suite *HandlerSuite) TestListMoveTaskOrdersHandlerReturnsUpdated() {
 func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	mto := testdatagen.MakeDefaultMove(suite.DB())
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	eTag := base64.StdEncoding.EncodeToString([]byte(mto.UpdatedAt.Format(time.RFC3339Nano)))
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -31,7 +31,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 	moveTaskOrderID, _ := uuid.FromString("96e21765-3e29-4acf-89a2-1317a9f7f0da")
 	paymentRequestID, _ := uuid.FromString("70c0c9c1-cf3f-4195-b15c-d185dc5cd0bf")
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	suite.T().Run("successful create payment request", func(t *testing.T) {
 		returnedPaymentRequest := models.PaymentRequest{

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestCreateUploadHandler() {
-	primeUser := testdatagen.MakeDefaultUser(suite.DB())
+	primeUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -55,7 +55,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		})
 	}
 
-	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s", mtoShipment.ID.String()), nil)

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -105,7 +105,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -137,7 +137,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -166,7 +166,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		requestUser := testdatagen.MakeDefaultUser(suite.DB())
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", paymentRequestID), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -177,7 +177,7 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 func (suite *ModelSuite) TestFetchAppUserIdentities() {
 
 	suite.T().Run("default user no profile", func(t *testing.T) {
-		testdatagen.MakeDefaultUser(suite.DB())
+		testdatagen.MakeStubbedUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
 		suite.NoError(err)
 		suite.Empty(identities)

--- a/pkg/notifications/move_approved_test.go
+++ b/pkg/notifications/move_approved_test.go
@@ -12,7 +12,7 @@ import (
 func (suite *NotificationSuite) TestMoveApproved() {
 	ctx := context.Background()
 
-	approver := testdatagen.MakeDefaultUser(suite.DB())
+	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 
 	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
@@ -35,7 +35,7 @@ func (suite *NotificationSuite) TestMoveApproved() {
 }
 
 func (suite *NotificationSuite) TestMoveApprovedHTMLTemplateRender() {
-	approver := testdatagen.MakeDefaultUser(suite.DB())
+	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
 		UserID:          approver.ID,
@@ -82,7 +82,7 @@ func (suite *NotificationSuite) TestMoveApprovedHTMLTemplateRender() {
 
 func (suite *NotificationSuite) TestMoveApprovedTextTemplateRender() {
 
-	approver := testdatagen.MakeDefaultUser(suite.DB())
+	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
 		UserID:          approver.ID,

--- a/pkg/notifications/move_submitted_test.go
+++ b/pkg/notifications/move_submitted_test.go
@@ -31,7 +31,7 @@ func (suite *NotificationSuite) TestMoveSubmitted() {
 }
 
 func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRender() {
-	approver := testdatagen.MakeDefaultUser(suite.DB())
+	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	notification := NewMoveSubmitted(suite.DB(), suite.logger, &auth.Session{
 		UserID:          approver.ID,
@@ -76,7 +76,7 @@ func (suite *NotificationSuite) TestMoveSubmittedHTMLTemplateRender() {
 
 func (suite *NotificationSuite) TestMoveSubmittedTextTemplateRender() {
 
-	approver := testdatagen.MakeDefaultUser(suite.DB())
+	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	notification := NewMoveSubmitted(suite.DB(), suite.logger, &auth.Session{
 		UserID:          approver.ID,

--- a/pkg/testdatagen/make_access_code.go
+++ b/pkg/testdatagen/make_access_code.go
@@ -18,7 +18,7 @@ func MakeAccessCode(db *pop.Connection, assertions Assertions) models.AccessCode
 
 	mergeModels(&accessCode, assertions.AccessCode)
 
-	mustCreate(db, &accessCode)
+	mustCreate(db, &accessCode, assertions.Stub)
 
 	return accessCode
 }

--- a/pkg/testdatagen/make_address.go
+++ b/pkg/testdatagen/make_address.go
@@ -21,7 +21,7 @@ func MakeAddress(db *pop.Connection, assertions Assertions) models.Address {
 
 	mergeModels(&address, assertions.Address)
 
-	mustCreate(db, &address)
+	mustCreate(db, &address, assertions.Stub)
 
 	return address
 }
@@ -40,7 +40,7 @@ func MakeAddress2(db *pop.Connection, assertions Assertions) models.Address {
 
 	mergeModels(&address, assertions.Address)
 
-	mustCreate(db, &address)
+	mustCreate(db, &address, assertions.Stub)
 
 	return address
 }
@@ -59,7 +59,7 @@ func MakeAddress3(db *pop.Connection, assertions Assertions) models.Address {
 
 	mergeModels(&address, assertions.Address)
 
-	mustCreate(db, &address)
+	mustCreate(db, &address, assertions.Stub)
 
 	return address
 }
@@ -78,7 +78,7 @@ func MakeAddress4(db *pop.Connection, assertions Assertions) models.Address {
 
 	mergeModels(&address, assertions.Address)
 
-	mustCreate(db, &address)
+	mustCreate(db, &address, assertions.Stub)
 
 	return address
 }

--- a/pkg/testdatagen/make_admin_user.go
+++ b/pkg/testdatagen/make_admin_user.go
@@ -36,7 +36,7 @@ func MakeAdminUser(db *pop.Connection, assertions Assertions) models.AdminUser {
 
 	mergeModels(&adminUser, assertions.AdminUser)
 
-	mustCreate(db, &adminUser)
+	mustCreate(db, &adminUser, assertions.Stub)
 
 	return adminUser
 }
@@ -59,7 +59,7 @@ func MakeAdminUserWithNoUser(db *pop.Connection, assertions Assertions) models.A
 
 	mergeModels(&adminUser, assertions.AdminUser)
 
-	mustCreate(db, &adminUser)
+	mustCreate(db, &adminUser, assertions.Stub)
 
 	return adminUser
 }

--- a/pkg/testdatagen/make_backup_contact.go
+++ b/pkg/testdatagen/make_backup_contact.go
@@ -26,7 +26,7 @@ func MakeBackupContact(db *pop.Connection, assertions Assertions) models.BackupC
 
 	mergeModels(&backupContact, assertions.BackupContact)
 
-	mustCreate(db, &backupContact)
+	mustCreate(db, &backupContact, assertions.Stub)
 
 	return backupContact
 }

--- a/pkg/testdatagen/make_blackout_date.go
+++ b/pkg/testdatagen/make_blackout_date.go
@@ -47,7 +47,7 @@ func MakeBlackoutDate(db *pop.Connection, assertions Assertions) models.Blackout
 
 	mergeModels(&blackoutDate, assertions.BlackoutDate)
 
-	mustCreate(db, &blackoutDate)
+	mustCreate(db, &blackoutDate, assertions.Stub)
 
 	return blackoutDate
 }

--- a/pkg/testdatagen/make_contractor.go
+++ b/pkg/testdatagen/make_contractor.go
@@ -38,7 +38,7 @@ func MakeContractor(db *pop.Connection, assertions Assertions) models.Contractor
 	// Overwrite values with those from assertions
 	mergeModels(&contractor, assertions.Contractor)
 
-	mustCreate(db, &contractor)
+	mustCreate(db, &contractor, assertions.Stub)
 
 	return contractor
 }

--- a/pkg/testdatagen/make_distance_calculation.go
+++ b/pkg/testdatagen/make_distance_calculation.go
@@ -28,7 +28,7 @@ func MakeDistanceCalculation(db *pop.Connection, assertions Assertions) models.D
 
 	mergeModels(&distanceCalculation, assertions.DistanceCalculation)
 
-	mustCreate(db, &distanceCalculation)
+	mustCreate(db, &distanceCalculation, assertions.Stub)
 
 	return distanceCalculation
 }

--- a/pkg/testdatagen/make_document.go
+++ b/pkg/testdatagen/make_document.go
@@ -22,7 +22,7 @@ func MakeDocument(db *pop.Connection, assertions Assertions) models.Document {
 	// Overwrite values with those from assertions
 	mergeModels(&document, assertions.Document)
 
-	mustCreate(db, &document)
+	mustCreate(db, &document, assertions.Stub)
 
 	return document
 }

--- a/pkg/testdatagen/make_dps_user.go
+++ b/pkg/testdatagen/make_dps_user.go
@@ -20,6 +20,6 @@ func MakeDpsUser(db *pop.Connection, assertions Assertions) models.DpsUser {
 		Active:        true,
 	}
 
-	mustCreate(db, &user)
+	mustCreate(db, &user, assertions.Stub)
 	return user
 }

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -42,7 +42,7 @@ func MakeDutyStation(db *pop.Connection, assertions Assertions) models.DutyStati
 	}
 	mergeModels(&station, assertions.DutyStation)
 
-	mustCreate(db, &station)
+	mustCreate(db, &station, assertions.Stub)
 
 	return station
 }

--- a/pkg/testdatagen/make_electronic_order.go
+++ b/pkg/testdatagen/make_electronic_order.go
@@ -19,7 +19,7 @@ func MakeElectronicOrder(db *pop.Connection, assertions Assertions) models.Elect
 	}
 
 	mergeModels(&order, assertions.ElectronicOrder)
-	mustCreate(db, &order)
+	mustCreate(db, &order, assertions.Stub)
 
 	rev := models.ElectronicOrdersRevision{
 		ElectronicOrderID: order.ID,
@@ -39,7 +39,7 @@ func MakeElectronicOrder(db *pop.Connection, assertions Assertions) models.Elect
 	}
 
 	mergeModels(&rev, assertions.ElectronicOrdersRevision)
-	mustCreate(db, &rev)
+	mustCreate(db, &rev, assertions.Stub)
 
 	return order
 }

--- a/pkg/testdatagen/make_entitlement.go
+++ b/pkg/testdatagen/make_entitlement.go
@@ -29,7 +29,7 @@ func MakeEntitlement(db *pop.Connection, assertions Assertions) models.Entitleme
 	// Overwrite values with those from assertions
 	mergeModels(&entitlement, assertions.Entitlement)
 
-	mustCreate(db, &entitlement)
+	mustCreate(db, &entitlement, assertions.Stub)
 
 	return entitlement
 }

--- a/pkg/testdatagen/make_fuel_eia_diesel_price.go
+++ b/pkg/testdatagen/make_fuel_eia_diesel_price.go
@@ -107,7 +107,7 @@ func MakeFuelEIADieselPrices(db *pop.Connection, assertions Assertions) {
 			nextPubDate = nextPubDate.AddDate(0, 0, 28)
 			nextStartDate = nextEndDate.AddDate(0, 0, 1)
 			nextEndDate = nextStartDate.AddDate(0, 1, -1)
-			mustCreate(db, &fuelPrice)
+			mustCreate(db, &fuelPrice, assertions.Stub)
 
 			recordCount++
 		}
@@ -180,7 +180,7 @@ func MakeFuelEIADieselPriceForDate(db *pop.Connection, shipmentDate time.Time, a
 	// Overwrite values with those from assertions
 	mergeModels(&fuelPrice, assertions.FuelEIADieselPrice)
 
-	mustCreate(db, &fuelPrice)
+	mustCreate(db, &fuelPrice, assertions.Stub)
 
 	return fuelPrice
 }

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -60,7 +60,7 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 	// Overwrite values with those from assertions
 	mergeModels(&move, assertions.Move)
 
-	mustCreate(db, &move)
+	mustCreate(db, &move, assertions.Stub)
 
 	return move
 }
@@ -100,7 +100,7 @@ func MakeMoveWithoutMoveType(db *pop.Connection, assertions Assertions) models.M
 	// Overwrite values with those from assertions
 	mergeModels(&move, assertions.Move)
 
-	mustCreate(db, &move)
+	mustCreate(db, &move, assertions.Stub)
 
 	return move
 }

--- a/pkg/testdatagen/make_move_document.go
+++ b/pkg/testdatagen/make_move_document.go
@@ -51,7 +51,7 @@ func MakeMoveDocument(db *pop.Connection, assertions Assertions) models.MoveDocu
 	// Overwrite values with those from assertions
 	mergeModels(&moveDocument, assertions.MoveDocument)
 
-	mustCreate(db, &moveDocument)
+	mustCreate(db, &moveDocument, assertions.Stub)
 
 	return moveDocument
 }

--- a/pkg/testdatagen/make_moving_expense_document.go
+++ b/pkg/testdatagen/make_moving_expense_document.go
@@ -27,7 +27,7 @@ func MakeMovingExpenseDocument(db *pop.Connection, assertions Assertions) models
 	// Overwrite values with those from assertions
 	mergeModels(&movingExpenseDocument, assertions.MovingExpenseDocument)
 
-	mustCreate(db, &movingExpenseDocument)
+	mustCreate(db, &movingExpenseDocument, assertions.Stub)
 
 	return movingExpenseDocument
 }

--- a/pkg/testdatagen/make_mto_agent.go
+++ b/pkg/testdatagen/make_mto_agent.go
@@ -34,7 +34,7 @@ func MakeMTOAgent(db *pop.Connection, assertions Assertions) models.MTOAgent {
 
 	mergeModels(&MTOAgent, assertions.MTOAgent)
 
-	mustCreate(db, &MTOAgent)
+	mustCreate(db, &MTOAgent, assertions.Stub)
 
 	return MTOAgent
 }

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -49,7 +49,7 @@ func makeServiceItem(db *pop.Connection, assertions Assertions, isBasicServiceIt
 	// Overwrite values with those from assertions
 	mergeModels(&MTOServiceItem, assertions.MTOServiceItem)
 
-	mustCreate(db, &MTOServiceItem)
+	mustCreate(db, &MTOServiceItem, assertions.Stub)
 
 	return MTOServiceItem
 }

--- a/pkg/testdatagen/make_mto_service_item_customer_contact.go
+++ b/pkg/testdatagen/make_mto_service_item_customer_contact.go
@@ -27,7 +27,7 @@ func MakeMTOServiceItemCustomerContact(db *pop.Connection, assertions Assertions
 	// Overwrite values with those from assertions
 	mergeModels(&MTOServiceItemCustomerContact, assertions.MTOServiceItemCustomerContact)
 
-	mustCreate(db, &MTOServiceItemCustomerContact)
+	mustCreate(db, &MTOServiceItemCustomerContact, assertions.Stub)
 
 	return MTOServiceItemCustomerContact
 }

--- a/pkg/testdatagen/make_mto_service_item_dimension.go
+++ b/pkg/testdatagen/make_mto_service_item_dimension.go
@@ -28,7 +28,7 @@ func MakeMTOServiceItemDimension(db *pop.Connection, assertions Assertions) mode
 	// Overwrite values with those from assertions
 	mergeModels(&MTOServiceItemDimension, assertions.MTOServiceItemDimension)
 
-	mustCreate(db, &MTOServiceItemDimension)
+	mustCreate(db, &MTOServiceItemDimension, assertions.Stub)
 
 	return MTOServiceItemDimension
 }

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -90,7 +90,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	// Overwrite values with those from assertions
 	mergeModels(&MTOShipment, assertions.MTOShipment)
 
-	mustCreate(db, &MTOShipment)
+	mustCreate(db, &MTOShipment, assertions.Stub)
 
 	return MTOShipment
 }
@@ -127,7 +127,7 @@ func MakeMTOShipmentMinimal(db *pop.Connection, assertions Assertions) models.MT
 	// Overwrite values with those from assertions
 	mergeModels(&MTOShipment, assertions.MTOShipment)
 
-	mustCreate(db, &MTOShipment)
+	mustCreate(db, &MTOShipment, assertions.Stub)
 
 	return MTOShipment
 }

--- a/pkg/testdatagen/make_notification.go
+++ b/pkg/testdatagen/make_notification.go
@@ -28,7 +28,7 @@ func MakeNotification(db *pop.Connection, assertions Assertions) models.Notifica
 
 	mergeModels(&notification, assertions.Notification)
 
-	mustCreate(db, &notification)
+	mustCreate(db, &notification, assertions.Stub)
 
 	return notification
 }

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -45,9 +45,7 @@ func MakeOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeUser
 
 	mergeModels(&officeUser, assertions.OfficeUser)
 
-	if assertions.Stub != true {
-		mustCreate(db, &officeUser)
-	}
+	mustCreate(db, &officeUser, assertions.Stub)
 
 	return officeUser
 }
@@ -77,7 +75,7 @@ func MakeOfficeUserWithNoUser(db *pop.Connection, assertions Assertions) models.
 
 	mergeModels(&officeUser, assertions.OfficeUser)
 
-	mustCreate(db, &officeUser)
+	mustCreate(db, &officeUser, assertions.Stub)
 
 	return officeUser
 }

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -95,7 +95,7 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	// Overwrite values with those from assertions
 	mergeModels(&order, assertions.Order)
 
-	mustCreate(db, &order)
+	mustCreate(db, &order, assertions.Stub)
 
 	return order
 }

--- a/pkg/testdatagen/make_organization.go
+++ b/pkg/testdatagen/make_organization.go
@@ -27,7 +27,7 @@ func MakeOrganization(db *pop.Connection, assertions Assertions) models.Organiza
 
 	mergeModels(&organization, assertions.Organization)
 
-	mustCreate(db, &organization)
+	mustCreate(db, &organization, assertions.Stub)
 
 	return organization
 }

--- a/pkg/testdatagen/make_payment_request.go
+++ b/pkg/testdatagen/make_payment_request.go
@@ -39,7 +39,7 @@ func MakePaymentRequest(db *pop.Connection, assertions Assertions) models.Paymen
 	// Overwrite values with those from assertions
 	mergeModels(&paymentRequest, assertions.PaymentRequest)
 
-	mustCreate(db, &paymentRequest)
+	mustCreate(db, &paymentRequest, assertions.Stub)
 
 	return paymentRequest
 }

--- a/pkg/testdatagen/make_payment_service_item.go
+++ b/pkg/testdatagen/make_payment_service_item.go
@@ -35,7 +35,7 @@ func MakePaymentServiceItem(db *pop.Connection, assertions Assertions) models.Pa
 	// Overwrite values with those from assertions
 	mergeModels(&paymentServiceItem, assertions.PaymentServiceItem)
 
-	mustCreate(db, &paymentServiceItem)
+	mustCreate(db, &paymentServiceItem, assertions.Stub)
 
 	return paymentServiceItem
 }

--- a/pkg/testdatagen/make_payment_service_item_param.go
+++ b/pkg/testdatagen/make_payment_service_item_param.go
@@ -36,7 +36,7 @@ func MakePaymentServiceItemParam(db *pop.Connection, assertions Assertions) mode
 	// Overwrite values with those from assertions
 	mergeModels(&paymentServiceItemParam, assertions.PaymentServiceItemParam)
 
-	mustCreate(db, &paymentServiceItemParam)
+	mustCreate(db, &paymentServiceItemParam, assertions.Stub)
 
 	return paymentServiceItemParam
 }

--- a/pkg/testdatagen/make_personally_procured_move.go
+++ b/pkg/testdatagen/make_personally_procured_move.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+	//"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -34,7 +35,7 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 	// Overwrite values with those from assertions
 	mergeModels(&ppm, assertions.PersonallyProcuredMove)
 
-	mustCreate(db, &ppm)
+	mustCreate(db, &ppm, assertions.Stub)
 
 	// Add the ppm we just created to the move.ppm array
 	ppm.Move.PersonallyProcuredMoves = append(ppm.Move.PersonallyProcuredMoves, ppm)
@@ -45,7 +46,8 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 // MakeDefaultPPM makes a PPM with default values
 func MakeDefaultPPM(db *pop.Connection) models.PersonallyProcuredMove {
 	advance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
-	mustCreate(db, &advance)
+	mustSave(db, &advance)
+
 	return MakePPM(db, Assertions{
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			Advance:             &advance,

--- a/pkg/testdatagen/make_prime_upload.go
+++ b/pkg/testdatagen/make_prime_upload.go
@@ -62,7 +62,7 @@ func MakePrimeUpload(db *pop.Connection, assertions Assertions) models.PrimeUplo
 
 		mergeModels(primeUpload, assertions.PrimeUpload)
 
-		mustCreate(db, primeUpload)
+		mustCreate(db, primeUpload, assertions.Stub)
 	}
 
 	return *primeUpload

--- a/pkg/testdatagen/make_proof_of_service_doc.go
+++ b/pkg/testdatagen/make_proof_of_service_doc.go
@@ -29,7 +29,7 @@ func MakeProofOfServiceDoc(db *pop.Connection, assertions Assertions) models.Pro
 	// Overwrite values with those from assertions
 	mergeModels(&posDoc, assertions.ProofOfServiceDoc)
 
-	mustCreate(db, &posDoc)
+	mustCreate(db, &posDoc, assertions.Stub)
 
 	return posDoc
 }

--- a/pkg/testdatagen/make_re_contract.go
+++ b/pkg/testdatagen/make_re_contract.go
@@ -16,7 +16,7 @@ func MakeReContract(db *pop.Connection, assertions Assertions) models.ReContract
 	// Overwrite values with those from assertions
 	mergeModels(&reContract, assertions.ReContract)
 
-	mustCreate(db, &reContract)
+	mustCreate(db, &reContract, assertions.Stub)
 
 	return reContract
 }

--- a/pkg/testdatagen/make_re_contract_year.go
+++ b/pkg/testdatagen/make_re_contract_year.go
@@ -28,7 +28,7 @@ func MakeReContractYear(db *pop.Connection, assertions Assertions) models.ReCont
 	// Overwrite values with those from assertions
 	mergeModels(&reContractYear, assertions.ReContractYear)
 
-	mustCreate(db, &reContractYear)
+	mustCreate(db, &reContractYear, assertions.Stub)
 
 	return reContractYear
 }

--- a/pkg/testdatagen/make_re_domestic_service_area.go
+++ b/pkg/testdatagen/make_re_domestic_service_area.go
@@ -24,7 +24,7 @@ func MakeReDomesticServiceArea(db *pop.Connection, assertions Assertions) models
 	// Overwrite values with those from assertions
 	mergeModels(&reDomesticServiceArea, assertions.ReDomesticServiceArea)
 
-	mustCreate(db, &reDomesticServiceArea)
+	mustCreate(db, &reDomesticServiceArea, assertions.Stub)
 
 	return reDomesticServiceArea
 }

--- a/pkg/testdatagen/make_re_service.go
+++ b/pkg/testdatagen/make_re_service.go
@@ -19,7 +19,7 @@ func MakeReService(db *pop.Connection, assertions Assertions) models.ReService {
 	// Overwrite values with those from assertions
 	mergeModels(&reService, assertions.ReService)
 
-	mustCreate(db, &reService)
+	mustCreate(db, &reService, assertions.Stub)
 
 	return reService
 }

--- a/pkg/testdatagen/make_re_zip3.go
+++ b/pkg/testdatagen/make_re_zip3.go
@@ -29,7 +29,7 @@ func MakeReZip3(db *pop.Connection, assertions Assertions) models.ReZip3 {
 	// Overwrite values with those from assertions
 	mergeModels(&reZip3, assertions.ReZip3)
 
-	mustCreate(db, &reZip3)
+	mustCreate(db, &reZip3, assertions.Stub)
 
 	return reZip3
 }

--- a/pkg/testdatagen/make_reimbursement.go
+++ b/pkg/testdatagen/make_reimbursement.go
@@ -6,22 +6,17 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// MakeDraftReimbursement creates a single draft status Reimbursement
-func MakeDraftReimbursement(db *pop.Connection) (models.Reimbursement, error) {
-
-	reimbursement := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
-
-	mustCreate(db, &reimbursement)
-
-	return reimbursement, nil
-}
-
 // MakeRequestedReimbursement creates a single requested status Reimbursement
-func MakeRequestedReimbursement(db *pop.Connection) (models.Reimbursement, error) {
+func MakeRequestedReimbursement(db *pop.Connection, assertions Assertions) models.Reimbursement {
 
 	reimbursement := models.BuildRequestedReimbursement(2000, models.MethodOfReceiptGTCC)
 
-	mustCreate(db, &reimbursement)
+	mustCreate(db, &reimbursement, assertions.Stub)
 
-	return reimbursement, nil
+	return reimbursement
+}
+
+// MakeDefaultRequestedReimbursement makes a user with default values
+func MakeDefaultRequestedReimbursement(db *pop.Connection) models.Reimbursement {
+	return MakeRequestedReimbursement(db, Assertions{})
 }

--- a/pkg/testdatagen/make_service_item_param_key.go
+++ b/pkg/testdatagen/make_service_item_param_key.go
@@ -21,7 +21,7 @@ func MakeServiceItemParamKey(db *pop.Connection, assertions Assertions) models.S
 	// Overwrite values with those from assertions
 	mergeModels(&serviceItemParamKey, assertions.ServiceItemParamKey)
 
-	mustCreate(db, &serviceItemParamKey)
+	mustCreate(db, &serviceItemParamKey, assertions.Stub)
 
 	return serviceItemParamKey
 }

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -64,7 +64,7 @@ func MakeServiceMember(db *pop.Connection, assertions Assertions) models.Service
 	// Overwrite values with those from assertions
 	mergeModels(&serviceMember, assertions.ServiceMember)
 
-	mustCreate(db, &serviceMember)
+	mustCreate(db, &serviceMember, assertions.Stub)
 
 	return serviceMember
 }

--- a/pkg/testdatagen/make_service_param.go
+++ b/pkg/testdatagen/make_service_param.go
@@ -39,7 +39,7 @@ func MakeServiceParam(db *pop.Connection, assertions Assertions) models.ServiceP
 	// Overwrite values with those from assertions
 	mergeModels(&serviceParam, assertions.ServiceParam)
 
-	mustCreate(db, &serviceParam)
+	mustCreate(db, &serviceParam, assertions.Stub)
 
 	return serviceParam
 }

--- a/pkg/testdatagen/make_signed_certification.go
+++ b/pkg/testdatagen/make_signed_certification.go
@@ -33,7 +33,7 @@ func MakeSignedCertification(db *pop.Connection, assertions Assertions) models.S
 	// Overwrite values with those from assertions
 	mergeModels(&signedCertification, assertions.SignedCertification)
 
-	mustCreate(db, &signedCertification)
+	mustCreate(db, &signedCertification, assertions.Stub)
 
 	return signedCertification
 }

--- a/pkg/testdatagen/make_tariff400ng_item.go
+++ b/pkg/testdatagen/make_tariff400ng_item.go
@@ -22,7 +22,7 @@ func MakeTariff400ngItem(db *pop.Connection, assertions Assertions) models.Tarif
 	// Overwrite values with those from assertions
 	mergeModels(&item, assertions.Tariff400ngItem)
 
-	mustCreate(db, &item)
+	mustCreate(db, &item, assertions.Stub)
 
 	return item
 }

--- a/pkg/testdatagen/make_tariff400ng_item_rate.go
+++ b/pkg/testdatagen/make_tariff400ng_item_rate.go
@@ -22,7 +22,7 @@ func MakeTariff400ngItemRate(db *pop.Connection, assertions Assertions) models.T
 	// Overwrite values with those from assertions
 	mergeModels(&rate, assertions.Tariff400ngItemRate)
 
-	mustCreate(db, &rate)
+	mustCreate(db, &rate, assertions.Stub)
 
 	return rate
 }

--- a/pkg/testdatagen/make_tariff400ng_service_area.go
+++ b/pkg/testdatagen/make_tariff400ng_service_area.go
@@ -24,7 +24,7 @@ func MakeTariff400ngServiceArea(db *pop.Connection, assertions Assertions) model
 
 	mergeModels(&serviceArea, assertions.Tariff400ngServiceArea)
 
-	mustCreate(db, &serviceArea)
+	mustCreate(db, &serviceArea, assertions.Stub)
 
 	return serviceArea
 }

--- a/pkg/testdatagen/make_tariff400ng_zip3.go
+++ b/pkg/testdatagen/make_tariff400ng_zip3.go
@@ -22,7 +22,7 @@ func MakeTariff400ngZip3(db *pop.Connection, assertions Assertions) models.Tarif
 
 	mergeModels(&zip3, assertions.Tariff400ngZip3)
 
-	mustCreate(db, &zip3)
+	mustCreate(db, &zip3, assertions.Stub)
 
 	return zip3
 }

--- a/pkg/testdatagen/make_transportation_office.go
+++ b/pkg/testdatagen/make_transportation_office.go
@@ -29,9 +29,7 @@ func MakeTransportationOffice(db *pop.Connection, assertions Assertions) models.
 
 	mergeModels(&office, assertions.TransportationOffice)
 
-	if assertions.Stub != true {
-		mustCreate(db, &office)
-	}
+	mustCreate(db, &office, assertions.Stub)
 
 	var phoneLines []models.OfficePhoneLine
 	phoneLine := models.OfficePhoneLine{
@@ -42,9 +40,7 @@ func MakeTransportationOffice(db *pop.Connection, assertions Assertions) models.
 		Type:                   "voice",
 	}
 	phoneLines = append(phoneLines, phoneLine)
-	if assertions.Stub != true {
-		mustCreate(db, &phoneLine)
-	}
+	mustCreate(db, &phoneLine, assertions.Stub)
 
 	office.PhoneLines = phoneLines
 

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -63,7 +63,7 @@ func MakeUpload(db *pop.Connection, assertions Assertions) models.Upload {
 
 		mergeModels(upload, assertions.Upload)
 
-		mustCreate(db, upload)
+		mustCreate(db, upload, assertions.Stub)
 	}
 
 	return *upload

--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -19,7 +19,7 @@ func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 	// Overwrite values with those from assertions
 	mergeModels(&user, assertions.User)
 
-	if assertions.Stub != true {
+	if !assertions.Stub {
 		mustCreate(db, &user)
 	}
 	return user
@@ -28,4 +28,9 @@ func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 // MakeDefaultUser makes a user with default values
 func MakeDefaultUser(db *pop.Connection) models.User {
 	return MakeUser(db, Assertions{})
+}
+
+// MakeStubbedUser returns a user without hitting the DB
+func MakeStubbedUser(db *pop.Connection) models.User {
+	return MakeUser(db, Assertions{Stub: true})
 }

--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -19,9 +19,8 @@ func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 	// Overwrite values with those from assertions
 	mergeModels(&user, assertions.User)
 
-	if !assertions.Stub {
-		mustCreate(db, &user)
-	}
+	mustCreate(db, &user, assertions.Stub)
+
 	return user
 }
 

--- a/pkg/testdatagen/make_user_upload.go
+++ b/pkg/testdatagen/make_user_upload.go
@@ -54,7 +54,7 @@ func MakeUserUpload(db *pop.Connection, assertions Assertions) models.UserUpload
 
 		mergeModels(userUpload, assertions.UserUpload)
 
-		mustCreate(db, userUpload)
+		mustCreate(db, userUpload, assertions.Stub)
 	}
 
 	return *userUpload

--- a/pkg/testdatagen/make_webhook_notification.go
+++ b/pkg/testdatagen/make_webhook_notification.go
@@ -28,7 +28,7 @@ func MakeWebhookNotification(db *pop.Connection, assertions Assertions) models.W
 	// Overwrite the defaults with values provided
 	mergeModels(&notification, assertions.WebhookNotification)
 
-	mustCreate(db, &notification)
+	mustCreate(db, &notification, assertions.Stub)
 
 	return notification
 }

--- a/pkg/testdatagen/make_webhook_subscription.go
+++ b/pkg/testdatagen/make_webhook_subscription.go
@@ -23,7 +23,7 @@ func MakeWebhookSubscription(db *pop.Connection, assertions Assertions) models.W
 
 	mergeModels(&webhookSubscription, assertions.WebhookSubscription)
 
-	mustCreate(db, &webhookSubscription)
+	mustCreate(db, &webhookSubscription, assertions.Stub)
 
 	return webhookSubscription
 }

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -32,7 +32,7 @@ func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) mode
 	// Overwrite values with those from assertions
 	mergeModels(&weightTicketSetDocument, assertions.WeightTicketSetDocument)
 
-	mustCreate(db, &weightTicketSetDocument)
+	mustCreate(db, &weightTicketSetDocument, assertions.Stub)
 
 	return weightTicketSetDocument
 }

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -99,7 +99,11 @@ func poundPointer(p unit.Pound) *unit.Pound {
 	return &p
 }
 
-func mustCreate(db *pop.Connection, model interface{}) {
+func mustCreate(db *pop.Connection, model interface{}, stub bool) {
+	if stub {
+		return
+	}
+
 	verrs, err := db.ValidateAndCreate(model)
 	if err != nil {
 		log.Panic(fmt.Errorf("Errors encountered saving %#v: %v", model, err))

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -28,11 +28,14 @@ fi
 
 verbose_flag=""
 parallel=8
+failfast_flag="-failfast"
 if [ -n "${CIRCLECI+x}" ]; then
 	# Limit the maximum number of tests to run in parallel for CircleCI due to memory constraints.
   parallel=4
 	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
   verbose_flag="-v"
+  # Don't fail fast in Circle CI so we can see all the tests that failed
+  failfast_flag=""
 fi
 
 # Try to compile tests, but don't run them.
@@ -83,4 +86,4 @@ if [[ "${JUNIT:-}" == "1" ]]; then
 fi
 
 # shellcheck disable=SC2086
-DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
+DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test ${failfast_flag} -vet=off -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"


### PR DESCRIPTION
This PR includes a couple of ways to speed up our tests. I tried to
break them down into small chunks in seperate commits to make it
easier to review.

The first change was to create a `MakeStubbedUser` function in
testdatagen that uses the new `Stub` assertion (which was added in
a previous PR) so that it doesn't touch the database. I then replaced
all instances of `MakeDefaultUser` with `MakeStubbedUser` where we
don't actually need a user in the DB.

The second change was to add the `-failfast` and `-vet=off` flags to
our `go test` command so that we don't have to wait for the entire
test suite to finish just to tell us that a test failed. Note that the
failfast flag is only enabled locally. In Circle CI, we want to know
about all test failures at once.

The third commit was to expand the ability to stub models to all the
ones in testdatagen that call `mustCreate`.

From my unscientific benchmarks, the time savings aren't yet significant,
but every little bit helps. If we get in the habit of using stubbed models
when we don't need the DB, it will prevent our tests from slowing down
unnecessarily.