### PR TITLE
Test no calls to function with AssertNumberOfCalls

### DIFF
--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -83,7 +83,7 @@ func (suite *HandlerSuite) TestListMoveOrdersHandler() {
 		officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 			Stub: true,
 		})
-		moveOrderFetcher.On("ListMoveOrders", officeUser.ID).Return(moveOrders, nil).Once()
+		moveOrderFetcher.AssertNumberOfCalls(t, "ListMoveOrders", 0)
 
 		req := httptest.NewRequest("GET", fmt.Sprintf("/move_orders"), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -80,7 +80,7 @@ func (suite *HandlerSuite) TestListPaymentRequestsHandler() {
 		officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 			Stub: true,
 		})
-		paymentRequestListFetcher.On("FetchPaymentRequestList", officeUser.ID).Return(&paymentRequests, nil).Once()
+		paymentRequestListFetcher.AssertNumberOfCalls(t, "FetchPaymentRequestList", 0)
 
 		req := httptest.NewRequest("GET", fmt.Sprintf("/payment_requests"), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)


### PR DESCRIPTION
This is follow-up cleanup work based on comments on earlier PRs.
In both of these cases, we want to test that the authorization happens
first in the handler, before calling the service object functions.

