### PR TITLE
Specify node version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_language_version:
+  # this should match the version in .node-version at the root of this project
+  node: 12.16.3
+
 repos:
   - repo: local
     hooks:
@@ -39,7 +43,6 @@ repos:
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md
-        language_version: 12.16.3
 
   - repo: git://github.com/detailyang/pre-commit-shell
     rev: 1.0.5
@@ -52,7 +55,6 @@ repos:
         name: prettier
         entry: node_modules/.bin/prettier --write
         language: node
-        language_version: 12.16.3
         files: \.(js|jsx)$
 
   - repo: local
@@ -61,7 +63,6 @@ repos:
         name: eslint
         entry: node_modules/.bin/eslint --ext .js,.jsx --max-warnings=0
         language: node
-        language_version: 12.16.3
         files: \.(js|jsx)$
         exclude: >
           (?x)^(
@@ -95,12 +96,9 @@ repos:
     hooks:
       - id: gen-docs
         args: ['docs/adr']
-        language_version: 12.16.3
       - id: circleci-validate
       - id: markdown-toc
-        language_version: 12.16.3
       - id: mdspell
-        language_version: 12.16.3
         exclude: >
           (?x)^(
             node_modules/|
@@ -112,7 +110,6 @@ repos:
     rev: v0.1.0
     hooks:
       - id: dockerfilelint
-        language_version: 12.16.3
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,12 @@ repos:
       - id: golangci-lint
         entry: bash -c 'exec golangci-lint run -v ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.24.0
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md
+        language_version: 12.16.3
 
   - repo: git://github.com/detailyang/pre-commit-shell
     rev: 1.0.5
@@ -51,6 +52,7 @@ repos:
         name: prettier
         entry: node_modules/.bin/prettier --write
         language: node
+        language_version: 12.16.3
         files: \.(js|jsx)$
 
   - repo: local
@@ -59,6 +61,7 @@ repos:
         name: eslint
         entry: node_modules/.bin/eslint --ext .js,.jsx --max-warnings=0
         language: node
+        language_version: 12.16.3
         files: \.(js|jsx)$
         exclude: >
           (?x)^(
@@ -92,9 +95,12 @@ repos:
     hooks:
       - id: gen-docs
         args: ['docs/adr']
+        language_version: 12.16.3
       - id: circleci-validate
       - id: markdown-toc
+        language_version: 12.16.3
       - id: mdspell
+        language_version: 12.16.3
         exclude: >
           (?x)^(
             node_modules/|
@@ -106,6 +112,7 @@ repos:
     rev: v0.1.0
     hooks:
       - id: dockerfilelint
+        language_version: 12.16.3
 
   - repo: local
     hooks:

--- a/docs/adr/0013-rest-api-updates.md
+++ b/docs/adr/0013-rest-api-updates.md
@@ -95,7 +95,7 @@ In particular, we want to consider a couple of use cases, viz:
 
 ## Decision Outcome
 
-### Chosen Alternative: *Use `PATCH` with partial JSON objects (falling back to `POST`) to allow updates and `action` URLS for more complex operations *
+### Chosen Alternative: *Use `PATCH` with partial JSON objects (falling back to `POST`) to allow updates and `action` URLS for more complex operations*
 
 * Justification: While using `PATCH` with partial objects (application/json) is frowned upon by some
  [commentators](http://williamdurand.fr/2014/02/14/please-do-not-patch-like-an-idiot/), it is common practice,


### PR DESCRIPTION
**Why**: By default, pre-commit expects a language to be available
globally. We use nodenv to manage node versions, and we shouldn't
expect folks to set their global version to always match the one we
use on the project.

To tell pre-commit to use a specific version of a language, you can
use the `language_version` key. This works for `node`, but not for
`golang` unfortunately. When I tried it, I got this message:

```
An unexpected error has occurred: AssertionError: For now, pre-commit
requires system-installed golang
```

I verified that when I didn't have `node` installed globally, the
`pre-commit install-hooks` command hung when trying to install the
node-based hooks. After I added the `language_version`, everything
installed as expected without hanging.