### PR TITLE
Update CAC migration with latest sha

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -565,3 +565,4 @@
 20201007210622_sandy_cac.up.sql
 20201008171129_ryan_cac.up.sql
 20201012143646_add_index_to_gbloc.up.sql
+20201020164146_gidjin_cac.up.sql

--- a/migrations/app/secure/20201020164146_gidjin_cac.up.sql
+++ b/migrations/app/secure/20201020164146_gidjin_cac.up.sql
@@ -1,0 +1,17 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.
+-- SCRUBBED OF Sensitive Data
+-- This migration allows a CAC cert to have read/write access to all orders and the prime API.
+-- The Orders API and the Prime API use client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed which includes CACs.
+-- Using a person's CAC as the certificate is a convenient way to permit a
+-- single trusted individual to interact with the Orders API and the Prime API. Eventually
+-- this CAC certificate should be removed.
+-- Updating sha256 for new cac
+UPDATE client_certs
+SET sha256_digest = '31d9903c22119796ebb7ea04321ae35ebd6265015aae260ff7662e66de0c6e1d',
+	subject = 'CN=gidjin,OU=DoD+OU=PKI+OU=CONTRACTOR,O=U.S. Government,C=US',
+	updated_at = NOW()
+WHERE id = '4fea0eb1-0009-47a8-98f4-0a102ee53a4f';


### PR DESCRIPTION
## Description

I had to do an update on my CAC card to reassociate my teams account, which changed the sha, this migration updates it.

## Setup

Ensure that `migrations/app/secure/20201020164146_gidjin_cac.up.sql` doesn't have the private portion of the migration

Down load the migrations for stg, exp and prd and verify that STG and EXP are good but prd is a stub placeholder
```sh
download-secure-migration 20201020164146_gidjin_cac.up.sql
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [X] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [X] Have been communicated to #g-database
  * [X] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [X] Request review from a member of a different team.