### PR TITLE
MB-4750 Correct validation errors in ISA segment of EDI

### DIFF
--- a/pkg/edi/segment/isa_test.go
+++ b/pkg/edi/segment/isa_test.go
@@ -1,6 +1,7 @@
 package edisegment
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -11,9 +12,9 @@ func (suite *SegmentSuite) TestValidateISA() {
 		SecurityInformationQualifier:      "00",
 		SecurityInformation:               "0000000000",
 		InterchangeSenderIDQualifier:      "ZZ",
-		InterchangeSenderID:               "MYMOVE         ",
+		InterchangeSenderID:               fmt.Sprintf("%-15s", "MYMOVE"),
 		InterchangeReceiverIDQualifier:    "12",
-		InterchangeReceiverID:             "8004171844     ",
+		InterchangeReceiverID:             fmt.Sprintf("%-15s", "8004171844"),
 		InterchangeDate:                   "190903",
 		InterchangeTime:                   "1644",
 		InterchangeControlStandards:       "U",
@@ -31,22 +32,22 @@ func (suite *SegmentSuite) TestValidateISA() {
 
 	suite.T().Run("validate failure 1", func(t *testing.T) {
 		isa := ISA{
-			AuthorizationInformationQualifier: "11",              // eq
-			AuthorizationInformation:          "1111111111",      // eq
-			SecurityInformationQualifier:      "11",              // eq
-			SecurityInformation:               "1111111111",      // eq
-			InterchangeSenderIDQualifier:      "QQ",              // eq
-			InterchangeSenderID:               "ABCDEF         ", // eq
-			InterchangeReceiverIDQualifier:    "15",              // eq
-			InterchangeReceiverID:             "1234566133     ", // eq
-			InterchangeDate:                   "190933",          // timeformat
-			InterchangeTime:                   "344",             // timeformat
-			InterchangeControlStandards:       "Q",               // eq
-			InterchangeControlVersionNumber:   "00403",           // eq
-			InterchangeControlNumber:          0,                 // min
-			AcknowledgementRequested:          5,                 // eq
-			UsageIndicator:                    "Q",               // oneof
-			ComponentElementSeparator:         ",",               // eq
+			AuthorizationInformationQualifier: "11",                               // eq
+			AuthorizationInformation:          "1111111111",                       // eq
+			SecurityInformationQualifier:      "11",                               // eq
+			SecurityInformation:               "1111111111",                       // eq
+			InterchangeSenderIDQualifier:      "QQ",                               // eq
+			InterchangeSenderID:               fmt.Sprintf("%-15s", "ABCDEF"),     // eq
+			InterchangeReceiverIDQualifier:    "15",                               // eq
+			InterchangeReceiverID:             fmt.Sprintf("%-15s", "1234566133"), // eq
+			InterchangeDate:                   "190933",                           // timeformat
+			InterchangeTime:                   "344",                              // timeformat
+			InterchangeControlStandards:       "Q",                                // eq
+			InterchangeControlVersionNumber:   "00403",                            // eq
+			InterchangeControlNumber:          0,                                  // min
+			AcknowledgementRequested:          5,                                  // eq
+			UsageIndicator:                    "Q",                                // oneof
+			ComponentElementSeparator:         ",",                                // eq
 		}
 
 		err := suite.validator.Struct(isa)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -96,9 +96,9 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		SecurityInformationQualifier:      "00", // No security information
 		SecurityInformation:               "0000000000",
 		InterchangeSenderIDQualifier:      "ZZ",
-		InterchangeSenderID:               "MYMOVE         ",
+		InterchangeSenderID:               fmt.Sprintf("%-15s", "MYMOVE"),
 		InterchangeReceiverIDQualifier:    "12",
-		InterchangeReceiverID:             "8004171844     ",
+		InterchangeReceiverID:             fmt.Sprintf("%-15s", "8004171844"),
 		InterchangeDate:                   currentTime.Format(dateFormat),
 		InterchangeTime:                   currentTime.Format(timeFormat),
 		InterchangeControlStandards:       "U",

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -26,7 +26,7 @@ func NewGHCPaymentRequestInvoiceGenerator(db *pop.Connection) services.GHCPaymen
 	}
 }
 
-const dateFormat = "20060102"
+const dateFormat = "060102"
 const timeFormat = "1504"
 
 // Generate method takes a payment request and returns an Invoice858C
@@ -94,11 +94,11 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		AuthorizationInformationQualifier: "00", // No authorization information
 		AuthorizationInformation:          "0084182369",
 		SecurityInformationQualifier:      "00", // No security information
-		SecurityInformation:               "_   _",
+		SecurityInformation:               "0000000000",
 		InterchangeSenderIDQualifier:      "ZZ",
-		InterchangeSenderID:               "GOVDPIBS",
+		InterchangeSenderID:               "MYMOVE         ",
 		InterchangeReceiverIDQualifier:    "12",
-		InterchangeReceiverID:             "8004171844",
+		InterchangeReceiverID:             "8004171844     ",
 		InterchangeDate:                   currentTime.Format(dateFormat),
 		InterchangeTime:                   currentTime.Format(timeFormat),
 		InterchangeControlStandards:       "U",

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -39,7 +39,7 @@ func TestGHCInvoiceSuite(t *testing.T) {
 	ts.PopTestSuite.TearDown()
 }
 
-const testDateFormat = "20060102"
+const testDateFormat = "060102"
 const testTimeFormat = "1504"
 
 func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
@@ -176,11 +176,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.Equal("00", result.ISA.AuthorizationInformationQualifier)
 		suite.Equal("0084182369", result.ISA.AuthorizationInformation)
 		suite.Equal("00", result.ISA.SecurityInformationQualifier)
-		suite.Equal("_   _", result.ISA.SecurityInformation)
+		suite.Equal("0000000000", result.ISA.SecurityInformation)
 		suite.Equal("ZZ", result.ISA.InterchangeSenderIDQualifier)
-		suite.Equal("GOVDPIBS", result.ISA.InterchangeSenderID)
+		suite.Equal("MYMOVE         ", result.ISA.InterchangeSenderID)
 		suite.Equal("12", result.ISA.InterchangeReceiverIDQualifier)
-		suite.Equal("8004171844", result.ISA.InterchangeReceiverID)
+		suite.Equal("8004171844     ", result.ISA.InterchangeReceiverID)
 		suite.Equal(currentTime.Format(testDateFormat), result.ISA.InterchangeDate)
 		suite.Equal(currentTime.Format(testTimeFormat), result.ISA.InterchangeTime)
 		suite.Equal("U", result.ISA.InterchangeControlStandards)


### PR DESCRIPTION
## Description

There were errors reported by Syncada in our EDI file. This PR fixes the ISA segment errors

ISA 04 - must have 10 spaces
ISA 06 - must have 15 spaces
ISA 08 - must have 15 spaces
ISA 90 - Invalid date (format should be YYMMDD not YYYYMMDD)

## Reviewer Notes

Note this PR does not trigger the validation code, that is coming in a later story.

## Setup

Start the server with e2e basic data

```sh
make db_dev_e2e_populate
make server_run
```

Save following payload to a file

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Create a payment request:

```sh
❯ go run ./cmd/prime-api-client --insecure create-payment-request --filename filename_from_above.json | jq '.paymentRequestNumber,.id'
"0286-2181-1"
"26f7b874-0995-4f30-8215-00f901bd09f2"
```

Then generate the EDI file

```sh
❯ go run ./cmd/generate-payment-request-edi/ --payment-request-number 0286-2181-1
logger:  &{0xc0009c2780 true  0xc000534a20 true 1 0}
2020-10-20T22:43:48.447Z        DEBUG   generate-payment-request-edi/main.go:24 checking config
2020-10-20T22:43:48.447Z        INFO    cli/dbconn.go:257       Connecting to the database      {"url": "postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable", "db-ssl-root-cert": ""}
2020-10-20T22:43:48.447Z        INFO    cli/dbconn.go:362       Starting database ping....
2020-10-20T22:43:48.459Z        INFO    cli/dbconn.go:369       ...DB ping successful!
```

Expected EDI is below, this PR deals only with the `ISA` segment
```
ISA*00*0084182369*00*0000000000*ZZ*MYMOVE         *12*8004171844     *201020*2243*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*201020*2243*100001251*X*004010
ST*858*0001
BX*00*J*PP*0286-2181*TRUS**4
N9*CN*0286-2181-1**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*10*201020*0*
G62*76*201019*0*
G62*86*200316*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
PER*CN**TE*706-791-4184
N1*SF*VoWuXvJN7G*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
PER*CN**TE*(510) 555-5555
FA1*DY
FA2*TA*F8E1
HL*1**|
N9*PO*0286-2181-dd91f767**
L5*1*DDP*TBD*D**
L0*1***1349.000*B******L
L3*1349.000*B*10835
HL*2**|
N9*PO*0286-2181-aa0bacaf**
L5*2*DSH*TBD*D**
L0*2*413.000*DM*1349.000*B******L
L3*1349.000*B*506066
HL*3**|
N9*PO*0286-2181-e46e3edb**
L5*3*DLH*TBD*D**
L0*3*373.000*DM*1349.000*B******L
L3*1349.000*B*1221717
HL*4**|
N9*PO*0286-2181-2fad5ba0**
L5*4*FSC*TBD*D**
L0*4*373.000*DM*1349.000*B******L
L3*1349.000*B*362
SE*41*0001
GE*1*100001251
IEA*1*100001272
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [MB-4750](https://dp3.atlassian.net/browse/MB-4750) for this change