### PR TITLE
Update script to check for latest aws-vault

### DIFF
--- a/scripts/check-aws-vault-version
+++ b/scripts/check-aws-vault-version
@@ -5,9 +5,11 @@ set -eu -o pipefail
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-VERSION="v5.4"
+VERSION="v6.2"
 
-VAULT_VERSION=$(type -p aws-vault && aws-vault --version)
+# first part gets path of aws-vault
+# second part gets version, which is returned on stderr thus rerouted to stdout
+VAULT_VERSION="$(type -p aws-vault) $(aws-vault --version 2>&1)"
 
 # Knocks off everything after the last decimal
 SHORT_VERSION=${VAULT_VERSION%.*}


### PR DESCRIPTION
## Description

This PR updates the `check-aws-vault-version` script to account for the fact that brew installs version `6.2` now and that `aws-vault --version` outputs the version to `stderr`. 

## Reviewer Notes

If you still have `aws-vault 5.4.2` you can still test this script as it will tell you it is out of date.

## Setup

```sh
scripts/check-aws-vault-version
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.

## References

* [this slack thread](https://trussworks.slack.com/archives/CLNC1MUBS/p1603228898225900) explains more about the approach used.