### PR TITLE
Edit Shipment F/E work

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -15,29 +15,12 @@ import {
 } from 'shared/Entities/modules/mtoShipments';
 import { selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
 import { selectServiceMemberFromLoggedInUser } from 'shared/Entities/modules/serviceMembers';
-import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
 import { WizardPage } from 'shared/WizardPage';
 import { AddressShape, SimpleAddressShape } from 'types/address';
 import { HhgShipmentShape, MatchShape, HistoryShape, PageKeyShape, PageListShape } from 'types/customerShapes';
 import { formatMtoShipmentForAPI, formatMtoShipmentForDisplay } from 'utils/formatMtoShipment';
 
 class MtoShipmentForm extends Component {
-  componentDidMount() {
-    const { showLoggedInUser } = this.props;
-    showLoggedInUser();
-    // TODO - move this to the parent component instead
-
-    // TODO: confirm this block should exist
-    // If refreshing edit page, need to handle mtoShipment populating from a promise
-    /*
-    if (!isCreatePage && mtoShipment.id) {
-      this.setState({
-        initialValues,
-        hasDeliveryAddress: initialValues.hasDeliveryAddress,
-      });
-    } */
-  }
-
   submitMTOShipment = ({ shipmentType, pickup, delivery, customerRemarks }) => {
     const {
       createMTOShipment,
@@ -199,7 +182,6 @@ MtoShipmentForm.propTypes = {
   pageKey: PageKeyShape,
   createMTOShipment: func.isRequired,
   updateMTOShipment: func.isRequired,
-  showLoggedInUser: func.isRequired,
   isCreatePage: bool,
   currentResidence: AddressShape.isRequired,
   newDutyStationAddress: SimpleAddressShape,
@@ -253,7 +235,6 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = {
   createMTOShipment: createMTOShipmentAction,
   updateMTOShipment: updateMTOShipmentAction,
-  showLoggedInUser: showLoggedInUserAction,
 };
 
 export { MtoShipmentForm as MtoShipmentFormComponent };

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -1,12 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { Component } from 'react';
-<<<<<<< HEAD
 import { bool, string, func, shape } from 'prop-types';
-import { get } from 'lodash';
-import { connect } from 'react-redux';
-=======
-import { bool, string, func } from 'prop-types';
->>>>>>> Remove Redux from MTOShipmentForm
 import { Formik } from 'formik';
 
 import { getShipmentOptions } from './getShipmentOptions';

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -1,20 +1,17 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { Component } from 'react';
+<<<<<<< HEAD
 import { bool, string, func, shape } from 'prop-types';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
+=======
+import { bool, string, func } from 'prop-types';
+>>>>>>> Remove Redux from MTOShipmentForm
 import { Formik } from 'formik';
 
 import { getShipmentOptions } from './getShipmentOptions';
 import MtoShipmentFormFields from './MtoShipmentFormFields';
 
-import {
-  selectMTOShipmentById,
-  createMTOShipment as createMTOShipmentAction,
-  updateMTOShipment as updateMTOShipmentAction,
-} from 'shared/Entities/modules/mtoShipments';
-import { selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
-import { selectServiceMemberFromLoggedInUser } from 'shared/Entities/modules/serviceMembers';
 import { WizardPage } from 'shared/WizardPage';
 import { AddressShape, SimpleAddressShape } from 'types/address';
 import { HhgShipmentShape, MatchShape, HistoryShape, PageKeyShape, PageListShape } from 'types/customerShapes';
@@ -220,23 +217,4 @@ MtoShipmentForm.defaultProps = {
   },
 };
 
-const mapStateToProps = (state, ownProps) => {
-  const orders = selectActiveOrLatestOrdersFromEntities(state);
-  const serviceMember = selectServiceMemberFromLoggedInUser(state);
-
-  const props = {
-    serviceMember,
-    mtoShipment: selectMTOShipmentById(state, ownProps.match.params.mtoShipmentId),
-    currentResidence: get(selectServiceMemberFromLoggedInUser(state), 'residential_address', {}),
-    newDutyStationAddress: get(orders, 'new_duty_station.address', {}),
-  };
-  return props;
-};
-
-const mapDispatchToProps = {
-  createMTOShipment: createMTOShipmentAction,
-  updateMTOShipment: updateMTOShipmentAction,
-};
-
-export { MtoShipmentForm as MtoShipmentFormComponent };
-export default connect(mapStateToProps, mapDispatchToProps)(MtoShipmentForm);
+export default MtoShipmentForm;

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -51,7 +51,7 @@ class MtoShipmentForm extends Component {
   };
 
   getShipmentNumber = () => {
-    // TODO - fix
+    // TODO - this is not supported by IE11, shipment number should be calculable from Redux anyways
     const { search } = window.location;
     const params = new URLSearchParams(search);
     const shipmentNumber = params.get('shipmentNumber');
@@ -85,6 +85,7 @@ class MtoShipmentForm extends Component {
       newDutyStationAddress,
       displayOptions,
       serviceMember,
+      shipmentNumber: displayOptions.displayName === 'HHG' ? this.getShipmentNumber() : null,
     };
 
     return (

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.stories.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 
-import { MtoShipmentFormComponent as MtoShipmentForm } from './MtoShipmentForm';
+import MtoShipmentForm from './MtoShipmentForm';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { history, store } from 'shared/store';

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 
-import MtoShipmentForm, { MtoShipmentFormComponent } from './MtoShipmentForm';
+import MtoShipmentForm from './MtoShipmentForm';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { history, store } from 'shared/store';
@@ -75,7 +75,7 @@ describe('MtoShipmentForm component', () => {
     });
 
     it('renders second address field when has delivery address', () => {
-      const wrapper = mount(<MtoShipmentFormComponent {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
+      const wrapper = mount(<MtoShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
       wrapper.setState({ hasDeliveryAddress: true });
       expect(wrapper.find('AddressFields').length).toBe(2);
     });
@@ -116,7 +116,7 @@ describe('MtoShipmentForm component', () => {
     });
 
     it('renders an address field when has delivery address', () => {
-      const wrapper = mount(<MtoShipmentFormComponent {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.NTSR} />);
+      const wrapper = mount(<MtoShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.NTSR} />);
       wrapper.setState({ hasDeliveryAddress: true });
       expect(wrapper.find('AddressFields').length).toBe(1);
     });

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
@@ -43,7 +43,9 @@ const MtoShipmentFormFields = ({
 
   return (
     <>
-      <div className={`margin-top-2 ${styles['hhg-label']}`}>{`${displayOptions.displayName} ${shipmentNumber}`}</div>
+      {shipmentNumber && (
+        <div className={`margin-top-2 ${styles['hhg-label']}`}>{`${displayOptions.displayName} ${shipmentNumber}`}</div>
+      )}
       <h1 className="margin-top-1">
         {isHHG && hhgFormHeader}
         {isNTS && ntsFormHeader}

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { bool, shape, string, func } from 'prop-types';
 import { Field } from 'formik';
-import { Button, /* Fieldset, */ Label, Radio } from '@trussworks/react-uswds';
+import { Button, /* Fieldset, */ Label, Radio, Checkbox } from '@trussworks/react-uswds';
 
 import styles from './MtoShipmentForm.module.scss';
 
@@ -9,7 +9,6 @@ import { DatePickerInput, TextInput } from 'components/form/fields';
 import { ContactInfoFields } from 'components/form/ContactInfoFields/ContactInfoFields';
 import { AddressFields } from 'components/form/AddressFields/AddressFields';
 import { Form } from 'components/form/Form';
-import Checkbox from 'shared/Checkbox';
 import Divider from 'shared/Divider';
 import Fieldset from 'shared/Fieldset';
 import Hint from 'shared/Hint';
@@ -44,7 +43,6 @@ const MtoShipmentFormFields = ({
 
   return (
     <>
-      <p>{JSON.stringify(values)}</p>
       <div className={`margin-top-2 ${styles['hhg-label']}`}>{`${displayOptions.displayName} ${shipmentNumber}`}</div>
       <h1 className="margin-top-1">
         {isHHG && hhgFormHeader}
@@ -84,6 +82,7 @@ const MtoShipmentFormFields = ({
                     label="Use my current residence address"
                     name="useCurrentResidence"
                     onChange={onUseCurrentResidenceChange}
+                    id="useCurrentResidenceCheckbox"
                   />
                 </div>
               )}

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
@@ -31,9 +31,6 @@ const MtoShipmentFormFields = ({
   // shipment-related data
   displayOptions,
   shipmentNumber,
-  hasDeliveryAddress,
-  onHasDeliveryAddressChange,
-  useCurrentResidence,
   onUseCurrentResidenceChange,
   submitHandler,
   newDutyStationAddress,
@@ -43,9 +40,11 @@ const MtoShipmentFormFields = ({
   const isHHG = displayOptions.displayName === 'HHG';
   const isNTS = displayOptions.displayName === 'NTS';
   const isNTSR = displayOptions.displayName === 'NTS-R';
+  const { hasDeliveryAddress } = values;
 
   return (
     <>
+      <p>{JSON.stringify(values)}</p>
       <div className={`margin-top-2 ${styles['hhg-label']}`}>{`${displayOptions.displayName} ${shipmentNumber}`}</div>
       <h1 className="margin-top-1">
         {isHHG && hhgFormHeader}
@@ -66,7 +65,6 @@ const MtoShipmentFormFields = ({
                 label="Requested pickup date"
                 labelClassName={`margin-top-2 ${styles['small-bold']}`}
                 id="requestedPickupDate"
-                value={values.pickup.requestedDate}
                 validate={validateDate}
               />
             </Fieldset>
@@ -85,8 +83,7 @@ const MtoShipmentFormFields = ({
                     data-testid="useCurrentResidence"
                     label="Use my current residence address"
                     name="useCurrentResidence"
-                    checked={useCurrentResidence}
-                    onChange={() => onUseCurrentResidenceChange(values)}
+                    onChange={onUseCurrentResidenceChange}
                   />
                 </div>
               )}
@@ -109,12 +106,12 @@ const MtoShipmentFormFields = ({
           <>
             <Divider className="margin-bottom-6" />
             <Fieldset legend="Delivery date">
-              <DatePickerInput
+              <Field
+                as={DatePickerInput}
                 name="delivery.requestedDate"
                 label="Requested delivery date"
                 labelClassName={`${styles['small-bold']}`}
                 id="requestedDeliveryDate"
-                value={values.delivery.requestedDate}
                 validate={validateDate}
               />
               <Hint className="margin-top-1">
@@ -126,23 +123,25 @@ const MtoShipmentFormFields = ({
             <Fieldset legend="Delivery location">
               <Label className="margin-top-3 margin-bottom-1">Do you know your delivery address?</Label>
               <div className="display-flex margin-top-1">
-                <Radio
+                <Field
+                  as={Radio}
                   className="margin-right-3"
                   id="has-delivery-address"
                   label="Yes"
                   name="hasDeliveryAddress"
-                  onChange={onHasDeliveryAddressChange}
-                  checked={hasDeliveryAddress}
+                  value="yes"
+                  checked={hasDeliveryAddress === 'yes'}
                 />
-                <Radio
+                <Field
+                  as={Radio}
                   id="no-delivery-address"
                   label="No"
                   name="hasDeliveryAddress"
-                  checked={!hasDeliveryAddress}
-                  onChange={onHasDeliveryAddressChange}
+                  value="no"
+                  checked={hasDeliveryAddress === 'no'}
                 />
               </div>
-              {hasDeliveryAddress ? (
+              {hasDeliveryAddress === 'yes' ? (
                 <AddressFields name="delivery.address" values={values.delivery.address} />
               ) : (
                 <>
@@ -246,7 +245,6 @@ MtoShipmentFormFields.propTypes = {
   // customer data for pre-fill (& submit)
   isCreatePage: bool,
   newDutyStationAddress: SimpleAddressShape.isRequired,
-  onHasDeliveryAddressChange: func.isRequired,
   onUseCurrentResidenceChange: func.isRequired,
   submitHandler: func.isRequired,
   serviceMember: shape({
@@ -257,8 +255,6 @@ MtoShipmentFormFields.propTypes = {
 
   // shipment-related data
   displayOptions: MtoDisplayOptionsShape.isRequired,
-  hasDeliveryAddress: bool.isRequired,
-  useCurrentResidence: bool.isRequired,
   shipmentNumber: string,
 };
 

--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -1,15 +1,20 @@
 import React, { Component } from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { string, func } from 'prop-types';
-
-import '../../ghc_index.scss';
+import { string, func, shape } from 'prop-types';
+import { get } from 'lodash';
 
 import MtoShipmentForm from 'components/Customer/MtoShipmentForm/MtoShipmentForm';
-import { selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
+import {
+  selectMTOShipmentById,
+  createMTOShipment as createMTOShipmentAction,
+  updateMTOShipment as updateMTOShipmentAction,
+} from 'shared/Entities/modules/mtoShipments';
 import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import { HhgShipmentShape, HistoryShape, MatchShape, PageKeyShape, PageListShape } from 'types/customerShapes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
+import { selectServiceMemberFromLoggedInUser } from 'shared/Entities/modules/serviceMembers';
+import { AddressShape, SimpleAddressShape } from 'types/address';
 
 class CreateOrEditMtoShipment extends Component {
   componentDidMount() {
@@ -19,7 +24,19 @@ class CreateOrEditMtoShipment extends Component {
 
   // TODO: (in trailing PR) refactor edit component out of existence :)
   render() {
-    const { match, history, pageList, pageKey, mtoShipment, selectedMoveType } = this.props;
+    const {
+      match,
+      history,
+      pageList,
+      pageKey,
+      mtoShipment,
+      selectedMoveType,
+      currentResidence,
+      newDutyStationAddress,
+      createMTOShipment,
+      updateMTOShipment,
+      serviceMember,
+    } = this.props;
     const isCreatePage = match && match.path ? match.path.includes('start') : false;
 
     // wait until MTO shipment has loaded to render form
@@ -33,23 +50,17 @@ class CreateOrEditMtoShipment extends Component {
           mtoShipment={mtoShipment}
           selectedMoveType={selectedMoveType}
           isCreatePage={isCreatePage}
+          currentResidence={currentResidence}
+          newDutyStationAddress={newDutyStationAddress}
+          createMTOShipment={createMTOShipment}
+          updateMTOShipment={updateMTOShipment}
+          serviceMember={serviceMember}
         />
       );
     }
 
     return <LoadingPlaceholder />;
   }
-}
-
-function mapStateToProps(state, ownProps) {
-  const props = {
-    mtoShipment: selectMTOShipmentForMTO(state, ownProps.match?.params.moveId),
-  };
-  return props;
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchCustomerData: fetchCustomerDataAction }, dispatch);
 }
 
 CreateOrEditMtoShipment.propTypes = {
@@ -62,6 +73,15 @@ CreateOrEditMtoShipment.propTypes = {
   // technically this should be a [Generic]MtoShipmentShape
   // using hhg because it has all the props
   mtoShipment: HhgShipmentShape,
+  currentResidence: AddressShape.isRequired,
+  newDutyStationAddress: SimpleAddressShape,
+  createMTOShipment: func.isRequired,
+  updateMTOShipment: func.isRequired,
+  serviceMember: shape({
+    weight_allotment: shape({
+      total_weight_self: string,
+    }),
+  }).isRequired,
 };
 
 CreateOrEditMtoShipment.defaultProps = {
@@ -80,6 +100,31 @@ CreateOrEditMtoShipment.defaultProps = {
       street_address_1: '',
     },
   },
+  newDutyStationAddress: {
+    city: '',
+    state: '',
+    postal_code: '',
+  },
+};
+
+function mapStateToProps(state, ownProps) {
+  const orders = selectActiveOrLatestOrdersFromEntities(state);
+  const serviceMember = selectServiceMemberFromLoggedInUser(state);
+
+  const props = {
+    serviceMember,
+    mtoShipment: selectMTOShipmentById(state, ownProps.match.params.mtoShipmentId),
+    currentResidence: get(selectServiceMemberFromLoggedInUser(state), 'residential_address', {}),
+    newDutyStationAddress: get(orders, 'new_duty_station.address', {}),
+  };
+
+  return props;
+}
+
+const mapDispatchToProps = {
+  fetchCustomerData: fetchCustomerDataAction,
+  createMTOShipment: createMTOShipmentAction,
+  updateMTOShipment: updateMTOShipmentAction,
 };
 
 export { CreateOrEditMtoShipment as CreateOrEditMtoShipmentComponent };

--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -9,6 +9,7 @@ import MtoShipmentForm from 'components/Customer/MtoShipmentForm/MtoShipmentForm
 import { selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
 import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import { HhgShipmentShape, HistoryShape, MatchShape, PageKeyShape, PageListShape } from 'types/customerShapes';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 class CreateOrEditMtoShipment extends Component {
   componentDidMount() {
@@ -21,17 +22,22 @@ class CreateOrEditMtoShipment extends Component {
     const { match, history, pageList, pageKey, mtoShipment, selectedMoveType } = this.props;
     const isCreatePage = match && match.path ? match.path.includes('start') : false;
 
-    return (
-      <MtoShipmentForm
-        match={match}
-        history={history}
-        pageList={pageList}
-        pageKey={pageKey}
-        mtoShipment={mtoShipment}
-        selectedMoveType={selectedMoveType}
-        isCreatePage={isCreatePage}
-      />
-    );
+    // wait until MTO shipment has loaded to render form
+    if (isCreatePage || mtoShipment?.id) {
+      return (
+        <MtoShipmentForm
+          match={match}
+          history={history}
+          pageList={pageList}
+          pageKey={pageKey}
+          mtoShipment={mtoShipment}
+          selectedMoveType={selectedMoveType}
+          isCreatePage={isCreatePage}
+        />
+      );
+    }
+
+    return <LoadingPlaceholder />;
   }
 }
 

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -41,11 +41,13 @@ function formatAddressForAPI(address) {
 
   if (formattedAddress.state) {
     formattedAddress.state = formattedAddress.state?.toUpperCase();
+    delete formattedAddress.id;
     return formattedAddress;
   }
 
   return undefined;
 }
+
 const emptyAgentShape = {
   firstName: '',
   lastName: '',

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -89,8 +89,7 @@ export function formatMtoShipmentForDisplay({
       address: { ...emptyAddressShape },
       agent: { ...emptyAgentShape },
     },
-    hasDeliveryAddress: false,
-    useCurrentResidence: false,
+    hasDeliveryAddress: 'no',
   };
 
   if (agents) {
@@ -121,7 +120,7 @@ export function formatMtoShipmentForDisplay({
 
   if (destinationAddress) {
     displayValues.delivery.address = { ...emptyAddressShape, ...destinationAddress };
-    displayValues.hasDeliveryAddress = true;
+    displayValues.hasDeliveryAddress = 'yes';
   }
 
   if (requestedDeliveryDate) {


### PR DESCRIPTION
## Description

F/E cleanup around Edit Shipment form:
- hoisted API calls & Redux connect up to the `CreateOrEditShipment` page
-  used Formik props (`values, setValues`) to handle form input logic around the delivery address inputs & current residence
- pass `shipmentNumber` into `MtoShipmentFormFields`
- don't store `initialValues` in state
