### PR TITLE
MB-4876 Round age field to ceiling on TIO queue

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3046,7 +3046,7 @@ func init() {
         "age": {
           "description": "Days since the payment request has been requested.  Decimal representation will allow more accurate sorting.",
           "type": "number",
-          "format": "float"
+          "format": "integer"
         },
         "customer": {
           "$ref": "#/definitions/Customer"
@@ -6859,7 +6859,7 @@ func init() {
         "age": {
           "description": "Days since the payment request has been requested.  Decimal representation will allow more accurate sorting.",
           "type": "number",
-          "format": "float"
+          "format": "integer"
         },
         "customer": {
           "$ref": "#/definitions/Customer"

--- a/pkg/gen/ghcmessages/queue_payment_request.go
+++ b/pkg/gen/ghcmessages/queue_payment_request.go
@@ -18,7 +18,7 @@ import (
 type QueuePaymentRequest struct {
 
 	// Days since the payment request has been requested.  Decimal representation will allow more accurate sorting.
-	Age float32 `json:"age,omitempty"`
+	Age int64 `json:"age,omitempty"`
 
 	// customer
 	Customer *Customer `json:"customer,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1,6 +1,7 @@
 package payloads
 
 import (
+	"math"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -537,7 +538,7 @@ func QueuePaymentRequests(paymentRequests *models.PaymentRequests) *ghcmessages.
 			MoveID:      *handlers.FmtUUID(moveTaskOrder.ID),
 			Customer:    Customer(&orders.ServiceMember),
 			Status:      ghcmessages.PaymentRequestStatus(paymentRequest.Status),
-			Age:         float32(time.Since(paymentRequest.CreatedAt).Hours() / 24.0),
+			Age:         int64(math.Ceil(time.Since(paymentRequest.CreatedAt).Hours() / 24.0)),
 			SubmittedAt: *handlers.FmtDateTime(paymentRequest.CreatedAt), // RequestedAt does not seem to be populated
 			Locator:     moveTaskOrder.Locator,
 			OriginGBLOC: ghcmessages.GBLOC(orders.OriginDutyStation.TransportationOffice.Gbloc),

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -2,7 +2,6 @@ package ghcapi
 
 import (
 	"errors"
-	"math"
 	"net/http/httptest"
 	"time"
 
@@ -354,7 +353,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 	suite.Equal(actualPaymentRequest.Status.String(), string(paymentRequest.Status))
 
 	createdAt := actualPaymentRequest.CreatedAt
-	age := int64(math.Ceil(time.Since(createdAt).Hours() / 24.0))
+	age := int64(2)
 
 	suite.Equal(age, paymentRequest.Age)
 	suite.Equal(createdAt.Format("2006-01-02T15:04:05.000Z07:00"), paymentRequest.SubmittedAt.String()) // swagger formats to milliseconds

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -2,7 +2,7 @@ package ghcapi
 
 import (
 	"errors"
-	"fmt"
+	"math"
 	"net/http/httptest"
 	"time"
 
@@ -354,9 +354,9 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 	suite.Equal(actualPaymentRequest.Status.String(), string(paymentRequest.Status))
 
 	createdAt := actualPaymentRequest.CreatedAt
-	age := time.Since(createdAt).Hours() / 24.0
+	age := int64(math.Ceil(time.Since(createdAt).Hours() / 24.0))
 
-	suite.Equal(fmt.Sprintf("%.2f", age), fmt.Sprintf("%.2f", paymentRequest.Age))
+	suite.Equal(age, paymentRequest.Age)
 	suite.Equal(createdAt.Format("2006-01-02T15:04:05.000Z07:00"), paymentRequest.SubmittedAt.String()) // swagger formats to milliseconds
 	suite.Equal(hhgMove.Locator, paymentRequest.Locator)
 

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -329,7 +329,7 @@ export const formatAgeToDays = (age) => {
   if (age < 1) {
     return 'Less than 1 day';
   }
-  if (age > 1 && age < 2) {
+  if (age >= 1 && age < 2) {
     return '1 day';
   }
   return `${Math.floor(age)} days`;

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2445,7 +2445,7 @@ definitions:
         $ref: '#/definitions/PaymentRequestStatus'
       age:
         type: number
-        format: float
+        format: integer
         description: Days since the payment request has been requested.  Decimal representation will allow more accurate sorting.
       submittedAt:
         type: string


### PR DESCRIPTION
## Description

Changes the rounding on the payment queues handler so that it uses math.ceil to round up.



## Setup

```sh
make db_dev_e2e_populate
```
Should see days count in the age column at `/invoicing/queues/`

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4876) for this change

