### PR TITLE
MB-4842 Allow filtering by branch

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1630,27 +1630,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "name": "filter",
-            "in": "query"
-          },
-          {
-            "type": "integer",
-            "name": "page",
-            "in": "query"
-          },
-          {
-            "type": "integer",
-            "name": "perPage",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "name": "sort",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "name": "order",
+            "name": "branch",
             "in": "query"
           }
         ],
@@ -5458,27 +5438,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "name": "filter",
-            "in": "query"
-          },
-          {
-            "type": "integer",
-            "name": "page",
-            "in": "query"
-          },
-          {
-            "type": "integer",
-            "name": "perPage",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "name": "sort",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "name": "order",
+            "name": "branch",
             "in": "query"
           }
         ],

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1627,6 +1627,33 @@ func init() {
         ],
         "summary": "Gets queued list of all customer moves by GBLOC origin",
         "operationId": "getMovesQueue",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "name": "perPage",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "order",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successfully returned all moves matching the criteria",
@@ -5428,6 +5455,33 @@ func init() {
         ],
         "summary": "Gets queued list of all customer moves by GBLOC origin",
         "operationId": "getMovesQueue",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "name": "perPage",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "order",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successfully returned all moves matching the criteria",

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_parameters.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -35,23 +34,7 @@ type GetMovesQueueParams struct {
 	/*
 	  In: query
 	*/
-	Filter *string
-	/*
-	  In: query
-	*/
-	Order *bool
-	/*
-	  In: query
-	*/
-	Page *int64
-	/*
-	  In: query
-	*/
-	PerPage *int64
-	/*
-	  In: query
-	*/
-	Sort *string
+	Branch *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -65,28 +48,8 @@ func (o *GetMovesQueueParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	qs := runtime.Values(r.URL.Query())
 
-	qFilter, qhkFilter, _ := qs.GetOK("filter")
-	if err := o.bindFilter(qFilter, qhkFilter, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
-	qOrder, qhkOrder, _ := qs.GetOK("order")
-	if err := o.bindOrder(qOrder, qhkOrder, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
-	qPage, qhkPage, _ := qs.GetOK("page")
-	if err := o.bindPage(qPage, qhkPage, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
-	qPerPage, qhkPerPage, _ := qs.GetOK("perPage")
-	if err := o.bindPerPage(qPerPage, qhkPerPage, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
-	qSort, qhkSort, _ := qs.GetOK("sort")
-	if err := o.bindSort(qSort, qhkSort, route.Formats); err != nil {
+	qBranch, qhkBranch, _ := qs.GetOK("branch")
+	if err := o.bindBranch(qBranch, qhkBranch, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -96,8 +59,8 @@ func (o *GetMovesQueueParams) BindRequest(r *http.Request, route *middleware.Mat
 	return nil
 }
 
-// bindFilter binds and validates parameter Filter from query.
-func (o *GetMovesQueueParams) bindFilter(rawData []string, hasKey bool, formats strfmt.Registry) error {
+// bindBranch binds and validates parameter Branch from query.
+func (o *GetMovesQueueParams) bindBranch(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	var raw string
 	if len(rawData) > 0 {
 		raw = rawData[len(rawData)-1]
@@ -109,91 +72,7 @@ func (o *GetMovesQueueParams) bindFilter(rawData []string, hasKey bool, formats 
 		return nil
 	}
 
-	o.Filter = &raw
-
-	return nil
-}
-
-// bindOrder binds and validates parameter Order from query.
-func (o *GetMovesQueueParams) bindOrder(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	var raw string
-	if len(rawData) > 0 {
-		raw = rawData[len(rawData)-1]
-	}
-
-	// Required: false
-	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
-	}
-
-	value, err := swag.ConvertBool(raw)
-	if err != nil {
-		return errors.InvalidType("order", "query", "bool", raw)
-	}
-	o.Order = &value
-
-	return nil
-}
-
-// bindPage binds and validates parameter Page from query.
-func (o *GetMovesQueueParams) bindPage(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	var raw string
-	if len(rawData) > 0 {
-		raw = rawData[len(rawData)-1]
-	}
-
-	// Required: false
-	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
-	}
-
-	value, err := swag.ConvertInt64(raw)
-	if err != nil {
-		return errors.InvalidType("page", "query", "int64", raw)
-	}
-	o.Page = &value
-
-	return nil
-}
-
-// bindPerPage binds and validates parameter PerPage from query.
-func (o *GetMovesQueueParams) bindPerPage(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	var raw string
-	if len(rawData) > 0 {
-		raw = rawData[len(rawData)-1]
-	}
-
-	// Required: false
-	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
-	}
-
-	value, err := swag.ConvertInt64(raw)
-	if err != nil {
-		return errors.InvalidType("perPage", "query", "int64", raw)
-	}
-	o.PerPage = &value
-
-	return nil
-}
-
-// bindSort binds and validates parameter Sort from query.
-func (o *GetMovesQueueParams) bindSort(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	var raw string
-	if len(rawData) > 0 {
-		raw = rawData[len(rawData)-1]
-	}
-
-	// Required: false
-	// AllowEmptyValue: false
-	if raw == "" { // empty values pass all other validations
-		return nil
-	}
-
-	o.Sort = &raw
+	o.Branch = &raw
 
 	return nil
 }

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_parameters.go
@@ -9,7 +9,11 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
+
+	strfmt "github.com/go-openapi/strfmt"
 )
 
 // NewGetMovesQueueParams creates a new GetMovesQueueParams object
@@ -27,6 +31,27 @@ type GetMovesQueueParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*
+	  In: query
+	*/
+	Filter *string
+	/*
+	  In: query
+	*/
+	Order *bool
+	/*
+	  In: query
+	*/
+	Page *int64
+	/*
+	  In: query
+	*/
+	PerPage *int64
+	/*
+	  In: query
+	*/
+	Sort *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -38,8 +63,137 @@ func (o *GetMovesQueueParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qFilter, qhkFilter, _ := qs.GetOK("filter")
+	if err := o.bindFilter(qFilter, qhkFilter, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOrder, qhkOrder, _ := qs.GetOK("order")
+	if err := o.bindOrder(qOrder, qhkOrder, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPage, qhkPage, _ := qs.GetOK("page")
+	if err := o.bindPage(qPage, qhkPage, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPerPage, qhkPerPage, _ := qs.GetOK("perPage")
+	if err := o.bindPerPage(qPerPage, qhkPerPage, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qSort, qhkSort, _ := qs.GetOK("sort")
+	if err := o.bindSort(qSort, qhkSort, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindFilter binds and validates parameter Filter from query.
+func (o *GetMovesQueueParams) bindFilter(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.Filter = &raw
+
+	return nil
+}
+
+// bindOrder binds and validates parameter Order from query.
+func (o *GetMovesQueueParams) bindOrder(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("order", "query", "bool", raw)
+	}
+	o.Order = &value
+
+	return nil
+}
+
+// bindPage binds and validates parameter Page from query.
+func (o *GetMovesQueueParams) bindPage(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("page", "query", "int64", raw)
+	}
+	o.Page = &value
+
+	return nil
+}
+
+// bindPerPage binds and validates parameter PerPage from query.
+func (o *GetMovesQueueParams) bindPerPage(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("perPage", "query", "int64", raw)
+	}
+	o.PerPage = &value
+
+	return nil
+}
+
+// bindSort binds and validates parameter Sort from query.
+func (o *GetMovesQueueParams) bindSort(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	o.Sort = &raw
+
 	return nil
 }

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_urlbuilder.go
@@ -9,11 +9,21 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/swag"
 )
 
 // GetMovesQueueURL generates an URL for the get moves queue operation
 type GetMovesQueueURL struct {
+	Filter  *string
+	Order   *bool
+	Page    *int64
+	PerPage *int64
+	Sort    *string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -42,6 +52,50 @@ func (o *GetMovesQueueURL) Build() (*url.URL, error) {
 		_basePath = "/ghc/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var filterQ string
+	if o.Filter != nil {
+		filterQ = *o.Filter
+	}
+	if filterQ != "" {
+		qs.Set("filter", filterQ)
+	}
+
+	var orderQ string
+	if o.Order != nil {
+		orderQ = swag.FormatBool(*o.Order)
+	}
+	if orderQ != "" {
+		qs.Set("order", orderQ)
+	}
+
+	var pageQ string
+	if o.Page != nil {
+		pageQ = swag.FormatInt64(*o.Page)
+	}
+	if pageQ != "" {
+		qs.Set("page", pageQ)
+	}
+
+	var perPageQ string
+	if o.PerPage != nil {
+		perPageQ = swag.FormatInt64(*o.PerPage)
+	}
+	if perPageQ != "" {
+		qs.Set("perPage", perPageQ)
+	}
+
+	var sortQ string
+	if o.Sort != nil {
+		sortQ = *o.Sort
+	}
+	if sortQ != "" {
+		qs.Set("sort", sortQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_moves_queue_urlbuilder.go
@@ -9,17 +9,11 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
-
-	"github.com/go-openapi/swag"
 )
 
 // GetMovesQueueURL generates an URL for the get moves queue operation
 type GetMovesQueueURL struct {
-	Filter  *string
-	Order   *bool
-	Page    *int64
-	PerPage *int64
-	Sort    *string
+	Branch *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -55,44 +49,12 @@ func (o *GetMovesQueueURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
-	var filterQ string
-	if o.Filter != nil {
-		filterQ = *o.Filter
+	var branchQ string
+	if o.Branch != nil {
+		branchQ = *o.Branch
 	}
-	if filterQ != "" {
-		qs.Set("filter", filterQ)
-	}
-
-	var orderQ string
-	if o.Order != nil {
-		orderQ = swag.FormatBool(*o.Order)
-	}
-	if orderQ != "" {
-		qs.Set("order", orderQ)
-	}
-
-	var pageQ string
-	if o.Page != nil {
-		pageQ = swag.FormatInt64(*o.Page)
-	}
-	if pageQ != "" {
-		qs.Set("page", pageQ)
-	}
-
-	var perPageQ string
-	if o.PerPage != nil {
-		perPageQ = swag.FormatInt64(*o.PerPage)
-	}
-	if perPageQ != "" {
-		qs.Set("perPage", perPageQ)
-	}
-
-	var sortQ string
-	if o.Sort != nil {
-		sortQ = *o.Sort
-	}
-	if sortQ != "" {
-		qs.Set("sort", sortQ)
+	if branchQ != "" {
+		qs.Set("branch", branchQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -86,7 +86,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(params queues.GetPaymentRequestsQ
 func branchFilter(params queues.GetMovesQueueParams) FilterOption {
 	return func(query *pop.Query) {
 		if params.Branch != nil {
-			query = query.Where("orders.department_indicator = ?", *params.Branch)
+			query = query.InnerJoin("service_members", "service_members.id = orders.service_member_id").Where("service_members.affiliation = ?", *params.Branch)
 		}
 	}
 }

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -139,8 +139,10 @@ func (suite *HandlerSuite) TestGetMoveQueuesBranchFilter() {
 
 	suite.Assertions.IsType(&queues.GetMovesQueueOK{}, response)
 	payload := response.(*queues.GetMovesQueueOK).Payload
+	result := payload.QueueMoves[0]
 
 	suite.Equal(1, len(payload.QueueMoves))
+	suite.Equal("AIR_FORCE", result.Customer.Agency)
 }
 
 func (suite *HandlerSuite) TestGetMoveQueuesHandlerStatuses() {

--- a/pkg/services/mocks/MoveOrderFetcher.go
+++ b/pkg/services/mocks/MoveOrderFetcher.go
@@ -6,6 +6,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	models "github.com/transcom/mymove/pkg/models"
 
+	pop "github.com/gobuffalo/pop"
+
 	uuid "github.com/gofrs/uuid"
 )
 
@@ -37,13 +39,20 @@ func (_m *MoveOrderFetcher) FetchMoveOrder(moveTaskOrderID uuid.UUID) (*models.O
 	return r0, r1
 }
 
-// ListMoveOrders provides a mock function with given fields: officeUserID
-func (_m *MoveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID) ([]models.Order, error) {
-	ret := _m.Called(officeUserID)
+// ListMoveOrders provides a mock function with given fields: officeUserID, options
+func (_m *MoveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, options ...func(*pop.Query)) ([]models.Order, error) {
+	_va := make([]interface{}, len(options))
+	for _i := range options {
+		_va[_i] = options[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, officeUserID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []models.Order
-	if rf, ok := ret.Get(0).(func(uuid.UUID) []models.Order); ok {
-		r0 = rf(officeUserID)
+	if rf, ok := ret.Get(0).(func(uuid.UUID, ...func(*pop.Query)) []models.Order); ok {
+		r0 = rf(officeUserID, options...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.Order)
@@ -51,8 +60,8 @@ func (_m *MoveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID) ([]models.Ord
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(uuid.UUID) error); ok {
-		r1 = rf(officeUserID)
+	if rf, ok := ret.Get(1).(func(uuid.UUID, ...func(*pop.Query)) error); ok {
+		r1 = rf(officeUserID, options...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/move_order.go
+++ b/pkg/services/move_order.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +11,7 @@ import (
 //go:generate mockery -name MoveOrderFetcher
 type MoveOrderFetcher interface {
 	FetchMoveOrder(moveTaskOrderID uuid.UUID) (*models.Order, error)
-	ListMoveOrders(officeUserID uuid.UUID) ([]models.Order, error)
+	ListMoveOrders(officeUserID uuid.UUID, options ...func(query *pop.Query)) ([]models.Order, error)
 }
 
 //MoveOrderUpdater is the service object interface for updating fields of a MoveOrder

--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -43,8 +43,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, options ...func
 		InnerJoin("transportation_offices", "duty_stations.transportation_office_id = transportation_offices.id").
 		Where("transportation_offices.gbloc = ?", gbloc).
 		// TODO: Let's include the status in filters that are passed into this service once we build that feature for the TXO queue (instead of it being hardcoded like it is below right now).
-		Where("moves.status NOT IN ('DRAFT', 'CANCELLED')").
-		GroupBy("orders.id")
+		Where("moves.status NOT IN ('DRAFT', 'CANCELLED')")
 
 	for _, option := range options {
 		if option != nil {
@@ -52,7 +51,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, options ...func
 		}
 	}
 
-	err = query.All(&moveOrders)
+	err = query.GroupBy("orders.id").All(&moveOrders)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -14,7 +14,7 @@ type moveOrderFetcher struct {
 	db *pop.Connection
 }
 
-func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID) ([]models.Order, error) {
+func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, options ...func(query *pop.Query)) ([]models.Order, error) {
 	// Now that we've joined orders and move_orders, we only want to return orders that
 	// have an associated move.
 	var moveOrders []models.Order
@@ -30,7 +30,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID) ([]models.Order
 
 	gbloc := transportationOffice.Gbloc
 
-	err = f.db.Q().Eager(
+	query := f.db.Q().Eager(
 		"ServiceMember",
 		"NewDutyStation.Address",
 		"OriginDutyStation",
@@ -44,9 +44,15 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID) ([]models.Order
 		Where("transportation_offices.gbloc = ?", gbloc).
 		// TODO: Let's include the status in filters that are passed into this service once we build that feature for the TXO queue (instead of it being hardcoded like it is below right now).
 		Where("moves.status NOT IN ('DRAFT', 'CANCELLED')").
-		GroupBy("orders.id").
-		All(&moveOrders)
+		GroupBy("orders.id")
 
+	for _, option := range options {
+		if option != nil {
+			option(query)
+		}
+	}
+
+	err = query.All(&moveOrders)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -9,17 +9,11 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-type Filter struct {
-	Branch string
-}
-
 type FilterOption func(*pop.Query)
 
-func branchFilter(filter Filter) FilterOption {
+func armyBranchFilter() FilterOption {
 	return func(query *pop.Query) {
-		if filter.Branch != "" {
-			query = query.Where("orders.department_indicator = ?", filter.Branch)
-		}
+		query = query.Where("orders.department_indicator = 'ARMY'")
 	}
 }
 
@@ -127,6 +121,9 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
 			TransportationOffice: models.TransportationOffice{
 				Gbloc: "AGFM",
 			},
+			Move: models.Move{
+				Status: models.MoveStatusSUBMITTED,
+			},
 		})
 
 		moveOrders, err := moveOrderFetcher.ListMoveOrders(officeUser.ID)
@@ -144,14 +141,12 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
 			Order: models.Order{
 				DepartmentIndicator: &army,
 			},
+			Move: models.Move{
+				Status: models.MoveStatusSUBMITTED,
+			},
 		})
 
-		filter := Filter{
-			Branch: "ARMY",
-		}
-		branchQuery := branchFilter(filter)
-
-		moveOrders, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, branchQuery)
+		moveOrders, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, armyBranchFilter())
 
 		suite.FatalNoError(err)
 		suite.Equal(1, len(moveOrders))

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -48,7 +48,7 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	TAC := "F8E1"
 	defaultDepartmentIndicator := "AIR_FORCE"
 	departmentIndicator := assertions.Order.DepartmentIndicator
-	if departmentIndicator == nil || *departmentIndicator == "" {
+	if departmentIndicator == nil {
 		departmentIndicator = &defaultDepartmentIndicator
 	}
 	hasDependents := assertions.Order.HasDependents || false

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -46,7 +46,11 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 
 	ordersNumber := "ORDER3"
 	TAC := "F8E1"
-	departmentIndicator := "AIR_FORCE"
+	defaultDepartmentIndicator := "AIR_FORCE"
+	departmentIndicator := assertions.Order.DepartmentIndicator
+	if departmentIndicator == nil || *departmentIndicator == "" {
+		departmentIndicator = &defaultDepartmentIndicator
+	}
 	hasDependents := assertions.Order.HasDependents || false
 	spouseHasProGear := assertions.Order.SpouseHasProGear || false
 	grade := "E_1"
@@ -83,7 +87,7 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 		SpouseHasProGear:    spouseHasProGear,
 		Status:              models.OrderStatusDRAFT,
 		TAC:                 &TAC,
-		DepartmentIndicator: &departmentIndicator,
+		DepartmentIndicator: departmentIndicator,
 		Grade:               &grade,
 		Entitlement:         &entitlement,
 		EntitlementID:       &entitlement.ID,

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -77,9 +77,13 @@ func MakeDefaultServiceMember(db *pop.Connection) models.ServiceMember {
 // MakeExtendedServiceMember creates a single ServiceMember and associated User, Addresses,
 // and Backup Contact.
 func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models.ServiceMember {
+	affiliation := assertions.ServiceMember.Affiliation
+	if affiliation == nil {
+		army := models.AffiliationARMY
+		affiliation = &army
+	}
 	residentialAddress := MakeDefaultAddress(db)
 	backupMailingAddress := MakeDefaultAddress(db)
-	army := models.AffiliationARMY
 	e1 := models.ServiceMemberRankE1
 	station := FetchOrMakeDefaultCurrentDutyStation(db)
 
@@ -87,7 +91,7 @@ func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models
 	smDefaults := models.ServiceMember{
 		Edipi:                  swag.String(randomEdipi()),
 		Rank:                   &e1,
-		Affiliation:            &army,
+		Affiliation:            affiliation,
 		ResidentialAddressID:   &residentialAddress.ID,
 		BackupMailingAddressID: &backupMailingAddress.ID,
 		DutyStationID:          &station.ID,

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1100,6 +1100,22 @@ paths:
       operationId: getMovesQueue
       tags:
         - queues
+      parameters:
+        - in: query
+          name: filter
+          type: string
+        - in: query
+          name: page
+          type: integer
+        - in: query
+          name: perPage
+          type: integer
+        - in: query
+          name: sort
+          type: string
+        - in: query
+          name: order
+          type: boolean
       responses:
         '200':
           description: Successfully returned all moves matching the criteria

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1102,20 +1102,8 @@ paths:
         - queues
       parameters:
         - in: query
-          name: filter
+          name: branch
           type: string
-        - in: query
-          name: page
-          type: integer
-        - in: query
-          name: perPage
-          type: integer
-        - in: query
-          name: sort
-          type: string
-        - in: query
-          name: order
-          type: boolean
       responses:
         '200':
           description: Successfully returned all moves matching the criteria


### PR DESCRIPTION
## Description

As part of the new TOO queue page, we are adding the ability to filter by various parameters. This PR only adds the backend functionality to support these queries. Adding the actual dropdowns and text fields to the queues page will be performed separately.

## Reviewer Notes

To test:

1. Run the setup steps below if you haven't already seeded your local DB
2. Go to http://officelocal:3000/devlocal-auth/login
3. Click on the Login button next to `too_role@office.mil (PPM office)`
4. Visit `http://officelocal:3000/ghc/v1/queues/moves` in Firefox or with a browser extension that makes it easier to read JSON data
5. Note the amount of results you get. With our current setup, this should be 2.
6. Append `?branch=ARMY` to the URL

Expected: No results appear.

7.  Append `?branch=AIR_FORCE` to the URL

Expected: only results where the `departmentIndicator` is "AIR_FORCE" should appear

**Important Note**
Based on the current moves queue displaying the "Branch" value from the order's department indicator, that is how I implemented the filtered query. It has since come to my attention that we most likely implemented this column incorrectly. The Branch is supposed to represent the service member's `Affiliation`. This will require front end changes, which we will most likely do in a separate PR.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make office_client (in a separate terminal tab)
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4842)
