### PR TITLE
MB-4927 Fix for makeAvailableToPrime process

### DIFF
--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -65,7 +65,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 }
 
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
-	moveTaskOrder := testdatagen.MakeDefaultMove(suite.DB())
+	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
 
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
@@ -113,6 +113,10 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 	suite.IsNotErrResponse(response)
 	moveTaskOrdersResponse := response.(*movetaskorderops.UpdateMoveTaskOrderStatusOK)
 	moveTaskOrdersPayload := moveTaskOrdersResponse.Payload
+
+	updatedMove := models.Move{}
+	suite.DB().Find(&updatedMove, moveTaskOrdersPayload.ID)
+	suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 
 	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
 	suite.Equal(moveTaskOrdersPayload.ID, strfmt.UUID(moveTaskOrder.ID.String()))

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -43,6 +43,13 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 		now := time.Now()
 		mto.AvailableToPrimeAt = &now
 
+		if mto.Status == models.MoveStatusSUBMITTED {
+			err = mto.Approve()
+			if err != nil {
+				return &models.Move{}, err
+			}
+		}
+
 		// When provided, this will auto create and approve MTO level service items. This is going to typically happen
 		// from the ghc api via the office app. The handler in question is this one: UpdateMoveTaskOrderStatusHandlerFunc
 		// in ghcapi/move_task_order.go

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -524,16 +524,6 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 	}
 
 	if shipment.Status == models.MTOShipmentStatusApproved {
-		// If we're approving a shipment, we also need the move the shipment is in to change statuses
-		moveToUpdate := shipment.MoveTaskOrder
-		if moveToUpdate.Status == models.MoveStatusSUBMITTED {
-			err = moveToUpdate.Approve()
-			if err != nil {
-				return &models.MTOShipment{}, err
-			}
-		}
-
-		verrs, err := o.builder.UpdateOne(&moveToUpdate, nil)
 
 		if verrs != nil && verrs.HasAny() {
 			invalidInputError := services.NewInvalidInputError(shipment.ID, nil, verrs, "There was an issue with validating the updates")


### PR DESCRIPTION
## Description

Fixes bug that was preventing moves from being made available to the prime.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Use the command below to populate data into your local environment. From there go through the shipment approval flow as a TOO on the office app. Once you hit approve you should be able to see the madeAvailableToPrimeAt date as populated in what comes back from the GHC API.

```sh
make db_dev_e2e_populate
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4927) for this change


