### PR TITLE
Resolves static analysis #402- TLS InsecureSkipVerify set true

### DIFF
--- a/cmd/health-checker/main.go
+++ b/cmd/health-checker/main.go
@@ -173,10 +173,9 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte) (*tls.Confi
 	}
 
 	tlsConfig := &tls.Config{
-		Certificates:       []tls.Certificate{keyPair},
-		InsecureSkipVerify: false,
-		MinVersion:         tls.VersionTLS12,
-		MaxVersion:         tls.VersionTLS13,
+		Certificates: []tls.Certificate{keyPair},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS13,
 	}
 
 	if len(ca) > 0 {

--- a/cmd/health-checker/main.go
+++ b/cmd/health-checker/main.go
@@ -165,17 +165,16 @@ func checkConfig(v *viper.Viper) error {
 	return nil
 }
 
-func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, insecureSkipVerify bool) (*tls.Config, error) {
+func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte) (*tls.Config, error) {
 
 	keyPair, err := tls.X509KeyPair(clientCert, clientKey)
 	if err != nil {
 		return nil, err
 	}
 
-	// #nosec b/c gosec triggers on InsecureSkipVerify
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{keyPair},
-		InsecureSkipVerify: insecureSkipVerify,
+		InsecureSkipVerify: false,
 		MinVersion:         tls.VersionTLS12,
 		MaxVersion:         tls.VersionTLS13,
 	}
@@ -232,7 +231,7 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger) (*http.Client, error) 
 		}
 
 		var tlsConfigErr error
-		tlsConfig, tlsConfigErr = createTLSConfig([]byte(clientKey), []byte(clientCert), caBytes, false)
+		tlsConfig, tlsConfigErr = createTLSConfig([]byte(clientKey), []byte(clientCert), caBytes)
 		if tlsConfigErr != nil {
 			return nil, errors.Wrap(tlsConfigErr, "error creating TLS config")
 		}
@@ -263,7 +262,7 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger) (*http.Client, error) 
 				caBytes = content
 			}
 			var tlsConfigErr error
-			tlsConfig, tlsConfigErr = createTLSConfig(clientKey, clientCert, caBytes, false)
+			tlsConfig, tlsConfigErr = createTLSConfig(clientKey, clientCert, caBytes)
 			if tlsConfigErr != nil {
 				return nil, errors.Wrap(tlsConfigErr, "error creating TLS config")
 			}

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -116,17 +116,16 @@ func checkConfig(v *viper.Viper) error {
 	return nil
 }
 
-func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, insecureSkipVerify bool, tlsVersion uint16) (*tls.Config, error) {
+func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion uint16) (*tls.Config, error) {
 
 	keyPair, err := tls.X509KeyPair(clientCert, clientKey)
 	if err != nil {
 		return nil, err
 	}
 
-	// #nosec b/c gosec triggers on InsecureSkipVerify
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{keyPair},
-		InsecureSkipVerify: insecureSkipVerify,
+		InsecureSkipVerify: false,
 		MinVersion:         tlsVersion,
 		MaxVersion:         tlsVersion,
 	}
@@ -183,7 +182,7 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 		}
 
 		var tlsConfigErr error
-		tlsConfig, tlsConfigErr = createTLSConfig([]byte(clientKey), []byte(clientCert), caBytes, false, tlsVersion)
+		tlsConfig, tlsConfigErr = createTLSConfig([]byte(clientKey), []byte(clientCert), caBytes, tlsVersion)
 		if tlsConfigErr != nil {
 			return nil, errors.Wrap(tlsConfigErr, "error creating TLS config")
 		}
@@ -214,7 +213,7 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 				caBytes = content
 			}
 			var tlsConfigErr error
-			tlsConfig, tlsConfigErr = createTLSConfig(clientKey, clientCert, caBytes, false, tlsVersion)
+			tlsConfig, tlsConfigErr = createTLSConfig(clientKey, clientCert, caBytes, tlsVersion)
 			if tlsConfigErr != nil {
 				return nil, errors.Wrap(tlsConfigErr, "error creating TLS config")
 			}

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -124,10 +124,9 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 	}
 
 	tlsConfig := &tls.Config{
-		Certificates:       []tls.Certificate{keyPair},
-		InsecureSkipVerify: false,
-		MinVersion:         tlsVersion,
-		MaxVersion:         tlsVersion,
+		Certificates: []tls.Certificate{keyPair},
+		MinVersion:   tlsVersion,
+		MaxVersion:   tlsVersion,
 	}
 
 	if len(ca) > 0 {


### PR DESCRIPTION
## Description

Resolves static analysis issue for [gosec #402](https://github.com/securego/gosec#available-rules) - TLS InsecureSkipVerify set true.

## Reviewer Notes

In-line comments 

## Setup

```
pre-commit run -v --all-files golangci-lint
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4968) 
* [Static Code Analysis Report](https://docs.google.com/spreadsheets/d/1eH5ZYkKv7_c-p_D_y5G5ULdWgI_Zrwg_xL4WbLNZoqw/edit#gid=1701318393)