### PR TITLE
MB-4626 don't prefill move type and disable next btn if unselected

### DIFF
--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { string, bool, func, arrayOf, shape } from 'prop-types';
-import { get } from 'lodash';
 
 import styles from './SelectMoveType.module.scss';
 
@@ -24,7 +23,6 @@ export class SelectMoveType extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      moveType: props.selectedMoveType,
       showStorageInfoModal: false,
     };
   }
@@ -64,6 +62,7 @@ export class SelectMoveType extends Component {
     const ppmCount = hasPpm ? 1 : 0;
     const mtosCount = mtoShipments?.length || 0;
     const shipmentNumber = 1 + ppmCount + mtosCount;
+    const canMoveNext = moveType ? moveType !== '' : false;
     const ppmCardText =
       'You pack and move your things, or make other arrangements, The government pays you for the weight you move.  This is a a Personally Procured Move (PPM), sometimes called a DITY.';
     const hhgCardText =
@@ -146,6 +145,7 @@ export class SelectMoveType extends Component {
               handleSubmit={this.handleSubmit}
               push={push}
               footerText={footerText}
+              canMoveNext={canMoveNext}
             >
               <h6 data-testid="number-eyebrow" className="sm-heading">
                 Shipment {shipmentNumber}
@@ -212,7 +212,6 @@ SelectMoveType.propTypes = {
   push: func.isRequired,
   updateMove: func.isRequired,
   loadMTOShipments: func.isRequired,
-  selectedMoveType: string.isRequired,
   move: MoveTaskOrderShape.isRequired,
   mtoShipments: arrayOf(MTOShipmentShape).isRequired,
 };
@@ -223,7 +222,6 @@ function mapStateToProps(state) {
 
   const props = {
     move,
-    selectedMoveType: get(move, 'selected_move_type'),
     mtoShipments,
   };
   return props;

--- a/src/pages/MyMove/SelectMoveType.test.jsx
+++ b/src/pages/MyMove/SelectMoveType.test.jsx
@@ -15,7 +15,6 @@ describe('SelectMoveType', () => {
     push: jest.fn(),
     loadMTOShipments: jest.fn(),
     move: { id: 'mockId', status: MOVE_STATUSES.DRAFT },
-    selectedMoveType: SHIPMENT_OPTIONS.PPM,
     mtoShipments: [],
   };
 
@@ -23,23 +22,18 @@ describe('SelectMoveType', () => {
     return mount(<SelectMoveType {...defaultProps} {...props} />);
   };
 
-  it('should render radio buttons with PPM selected', () => {
+  it('should render radio buttons with no option selected', () => {
     const wrapper = getWrapper();
     expect(wrapper.find(Radio).length).toBe(4);
 
-    // PPM button should be checked on page load
+    // Ppm and HHG text renders
     expect(wrapper.find(Radio).at(0).text()).toContain('Do it yourself');
-    expect(wrapper.find(Radio).at(0).find('.usa-radio__input').html()).toContain('checked');
-  });
-
-  it('should render radio buttons with HHG selected', () => {
-    const props = { selectedMoveType: SHIPMENT_OPTIONS.HHG };
-    const wrapper = getWrapper(props);
-    expect(wrapper.find(Radio).length).toBe(4);
-
     expect(wrapper.find(Radio).at(1).text()).toContain('Professional movers');
-    // HHG button should be checked on page load
-    expect(wrapper.find(Radio).at(1).find('.usa-radio__input').html()).toContain('checked');
+    // No buttons should not be checked on page load
+    expect(wrapper.find(Radio).at(0).find('.usa-radio__input').prop('checked')).toBe(false);
+    expect(wrapper.find(Radio).at(1).find('.usa-radio__input').prop('checked')).toBe(false);
+    expect(wrapper.find(Radio).at(2).find('.usa-radio__input').prop('checked')).toBe(false);
+    expect(wrapper.find(Radio).at(3).find('.usa-radio__input').prop('checked')).toBe(false);
   });
 
   describe('modals', () => {


### PR DESCRIPTION
## Description

On the Select Move type page, no option should be selected when the page loads. Currently, if a shipment has been created, the type of move will be pre-selected when the user goes to the select page. The user should also not be able to select "next" if no type has been selected.  

Acceptance criteria:

GIVEN I am a SM with a at least one shipment already on my move

WHEN I am on the Shipment Selection screen

THEN I should not see any of the shipment types pre-selected

AND THEN I should not be able to click on the NEXT button until I have selected a shipment type

NEXT button will remain grayed out until a shipment type has been selected

No radio is selected upon arrival on the page


## Setup

Run the app and log in as either hhg unsubmitted or nts user type in local sign in. You can also create a move with any shipment option manually.

On the review page, select "add another shipment". Verify that no move type is pre-selected when you are routed to the select move type page, and the next button is disabled. Select a shipment - verify that the next button is enabled and you are able to go through and add another shipment. Test with multiple/different shipment types.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4626) for this change

## Screenshots
<img width="615" alt="Screen Shot 2020-10-26 at 3 15 26 PM" src="https://user-images.githubusercontent.com/8170735/97234494-22bcc400-179e-11eb-844e-ab2d950bbc3a.png">

