### PR TITLE
[MB-4931] on Select move type page, conditionally show footer text only when SM does not already have a move

### DIFF
--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -131,7 +131,7 @@ export class SelectMoveType extends Component {
     const footerText = (
       <div>
         {!hasMove && (
-          <div className={`${styles.footer} grid-col-12`}>
+          <div data-testid="helper-footer" className={`${styles.footer} grid-col-12`}>
             It’s OK if you’re not sure about your choices. Your move counselor will go over all your options and can
             help make changes if necessary.
           </div>

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -64,6 +64,7 @@ export class SelectMoveType extends Component {
     const ppmCount = hasPpm ? 1 : 0;
     const mtosCount = mtoShipments?.length || 0;
     const shipmentNumber = 1 + ppmCount + mtosCount;
+    const hasMove = shipmentNumber > 1;
     const ppmCardText =
       'You pack and move your things, or make other arrangements, The government pays you for the weight you move.  This is a a Personally Procured Move (PPM), sometimes called a DITY.';
     const hhgCardText =
@@ -128,9 +129,13 @@ export class SelectMoveType extends Component {
       />
     );
     const footerText = (
-      <div className={`${styles.footer} grid-col-12`}>
-        It’s OK if you’re not sure about your choices. Your move counselor will go over all your options and can help
-        make changes if necessary.
+      <div>
+        {!hasMove && (
+          <div className={`${styles.footer} grid-col-12`}>
+            It’s OK if you’re not sure about your choices. Your move counselor will go over all your options and can
+            help make changes if necessary.
+          </div>
+        )}
       </div>
     );
     return (

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -62,7 +62,7 @@ export class SelectMoveType extends Component {
     const ppmCount = hasPpm ? 1 : 0;
     const mtosCount = mtoShipments?.length || 0;
     const shipmentNumber = 1 + ppmCount + mtosCount;
-    const hasMove = shipmentNumber > 1;
+    const hasShipment = ppmCount + mtosCount > 0;
     const canMoveNext = moveType ? moveType !== '' : false;
     const ppmCardText =
       'You pack and move your things, or make other arrangements, The government pays you for the weight you move.  This is a a Personally Procured Move (PPM), sometimes called a DITY.';
@@ -129,7 +129,7 @@ export class SelectMoveType extends Component {
     );
     const footerText = (
       <div>
-        {!hasMove && (
+        {!hasShipment && (
           <div data-testid="helper-footer" className={`${styles.footer} grid-col-12`}>
             It’s OK if you’re not sure about your choices. Your move counselor will go over all your options and can
             help make changes if necessary.

--- a/src/pages/MyMove/SelectMoveType.test.jsx
+++ b/src/pages/MyMove/SelectMoveType.test.jsx
@@ -78,6 +78,7 @@ describe('SelectMoveType', () => {
         'You pack and move your things, or make other arrangements, The government pays you for the weight you move.  This is a a Personally Procured Move (PPM), sometimes called a DITY.',
       );
       expect(wrapper.find('[data-testid="number-eyebrow"]').text()).toContain('Shipment 1');
+      expect(wrapper.find('[data-testid="helper-footer"]').text()).toContain('Your move counselor will go');
     });
   });
 
@@ -96,6 +97,7 @@ describe('SelectMoveType', () => {
         'You arrange to move some or all of your belongings',
       );
       expect(wrapper.find('[data-testid="number-eyebrow"]').text()).toContain('Shipment 2');
+      expect(wrapper.find('[data-testid="helper-footer"]').length).toBe(0);
     });
     it('should disable PPM form option if PPM is already submitted', () => {
       const wrapper = getWrapper(props);


### PR DESCRIPTION
## Description

Currently the Select move type page shows helper text regarding the move counselor regardless of whether or not the service member already has a move. This PR makes that helper text conditionally show only when the service member does not already have a move or storage request.

(I also confirmed that the helper text no longer shows regardless if a new SM profile selects any of the move/storage options and then clicks through to add another shipment.)

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
Local login (I used needs@orde.rs) and follow through adding orders until you progress to the select move type page. See that the helper text is displayed regarding move choices and questions for move counselors. Progress through, adding a move or a storage request, then click to add another shipment. On the select move type page, see that the service member is no longer shown the helper text.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4931) for this change

## Screenshots

**Helper text showing for a brand new service member profile without any shipments:**
![Screen Shot 2020-10-26 at 5 12 38 PM](https://user-images.githubusercontent.com/16230705/97241532-aaaaca00-17ae-11eb-8972-f499b4372f3c.png)


**Helper text no longer showing on the same profile once a move has been added:** 
![Screen Shot 2020-10-26 at 5 14 58 PM](https://user-images.githubusercontent.com/16230705/97241655-fd848180-17ae-11eb-9f74-5d18a8aebad9.png)

