### PR TITLE
minor tweak: don't send delivery address in API call when customer clears their delivery address info.

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -12,7 +12,7 @@ import { HhgShipmentShape, MatchShape, HistoryShape, PageKeyShape, PageListShape
 import { formatMtoShipmentForAPI, formatMtoShipmentForDisplay } from 'utils/formatMtoShipment';
 
 class MtoShipmentForm extends Component {
-  submitMTOShipment = ({ shipmentType, pickup, delivery, customerRemarks }) => {
+  submitMTOShipment = ({ shipmentType, pickup, hasDeliveryAddress, delivery, customerRemarks }) => {
     const {
       createMTOShipment,
       updateMTOShipment,
@@ -24,12 +24,17 @@ class MtoShipmentForm extends Component {
     } = this.props;
     const { moveId } = match.params;
 
+    const deliveryDetails = delivery;
+    if (hasDeliveryAddress === 'no') {
+      delete deliveryDetails.address;
+    }
+
     const pendingMtoShipment = formatMtoShipmentForAPI({
       shipmentType: shipmentType || selectedMoveType,
       moveId,
       customerRemarks,
       pickup,
-      delivery,
+      delivery: deliveryDetails,
     });
 
     if (isCreatePage) {


### PR DESCRIPTION
## Description

this doesn't fix the underlying bugs (DB values are not updated when customer attempts to clear delivery address or releasing/receiving agent details), but it does at least ensure we're not sending delivery details in the API call when the customer selects has no delivery address.

## Reviewer Notes

there is a larger discussion about the right way to handle the BE side of these bugs in #prac-engineering and in #prac-infrasec. it's largely about the complexities of deleting associated records. in the morning, I'll write up a summary and attach it to the relevant bugs.

## Setup

1. login to an account which has unsubmitted move with an HHG or NTS-R shipment. if the shipment doesn't already have a delivery address, you'll need to edit (& save) it to have one.
2. open the network tab so you can spy on your API calls.
3. in the edit shipment page, toggle has no delivery address and attempt to save again.
4. delight in the PATCH `internal/mto-shipments/<guid>` request which no longer includes the old `destinationAddress`.
~~5. anguish in the same PATCH's response, which still includes the old address.~~

## References

- jira story: [edit shipment's delivery address weirdness](https://dp3.atlassian.net/browse/MB-4942)

## Screenshots of Firefox network tab

this does not make any visible UI changes.

### behavior on staging: destinationAddress included in API request even when hasDeliveryAddress==='no'

<img width="413" alt="Screen Shot 2020-10-28 at 1 22 29 AM" src="https://user-images.githubusercontent.com/10818509/97411938-20518b80-18be-11eb-8e25-63dfd137c111.png">

### behavior on this branch: no destinationAddress included in API request when hasDeliveryAddress==='no'

<img width="519" alt="Screen Shot 2020-10-28 at 1 20 41 AM" src="https://user-images.githubusercontent.com/10818509/97411932-1e87c800-18be-11eb-8a2d-63200711b155.png">