### PR TITLE
[MB-4959] Write the SendToSyncada function

### DIFF
--- a/cmd/send-to-syncada-via-sftp/main.go
+++ b/cmd/send-to-syncada-via-sftp/main.go
@@ -2,20 +2,17 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/pkg/sftp"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging"
+	"github.com/transcom/mymove/pkg/services/invoice"
 )
 
 // Call this from command line with go run ./cmd/send-to-syncada-via-sftp/ --local-file-path <localFilePath> --destination-file-name <destinationFileName>
@@ -81,57 +78,12 @@ func main() {
 		logger.Fatal("invalid configuration", zap.Error(err))
 	}
 
-	userID := v.GetString(cli.SyncadaSFTPUserIDFlag)
-	password := v.GetString(cli.SyncadaSFTPPsswrdFlag)
-	remote := v.GetString(cli.SyncadaSFTPIPAddressFlag)
-	port := v.GetString(cli.SyncadaSFTPPortFlag)
-	syncadaInboundDirectory := v.GetString(cli.SyncadaSFTPInboundDirectoryFlag)
+	syncadaSFTPSession := invoice.NewSyncadaSFTPSession(v.GetString(cli.SyncadaSFTPPortFlag), v.GetString(cli.SyncadaSFTPUserIDFlag), v.GetString(cli.SyncadaSFTPIPAddressFlag), v.GetString(cli.SyncadaSFTPPsswrdFlag), v.GetString(cli.SyncadaSFTPInboundDirectoryFlag))
 
-	config := &ssh.ClientConfig{
-		User: userID,
-		Auth: []ssh.AuthMethod{
-			ssh.Password(password),
-		},
-		/* #nosec */
-		// The hostKey was removed because authentication is performed using a user ID and password
-		// If hostKey configuration is needed, please see PR #5039: https://github.com/transcom/mymove/pull/5039
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		// HostKeyCallback: ssh.FixedHostKey(hostKey),
-	}
-
-	// connect
-	connection, err := ssh.Dial("tcp", remote+":"+port, config)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer connection.Close()
-
-	// create new SFTP client
-	client, err := sftp.NewClient(connection)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Close()
-
-	// open local file
-	localFile, err := os.Open(filepath.Clean(v.GetString("local-file-path")))
+	transferConfirmation, err := syncadaSFTPSession.SendToSyncada(v.GetString("local-file-path"), v.GetString("destination-file-name"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// create destination file
-	destinationFileName := v.GetString(("destination-file-name"))
-	destinationFilePath := fmt.Sprintf("/%s/%s/%s", userID, syncadaInboundDirectory, destinationFileName)
-	destinationFile, err := client.Create(destinationFilePath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer destinationFile.Close()
-
-	// copy source file to destination file
-	bytes, err := io.Copy(destinationFile, localFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("%d bytes copied\n", bytes)
+	fmt.Printf("%v", transferConfirmation)
 }

--- a/pkg/services/invoice/syncada_sender_sftp.go
+++ b/pkg/services/invoice/syncada_sender_sftp.go
@@ -1,0 +1,82 @@
+package invoice
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// SyncadaSenderSFTPSession contains information to create a new Syncada SFTP session
+type SyncadaSenderSFTPSession struct {
+	port                     string
+	userID                   string
+	remote                   string
+	password                 string
+	destinationFileDirectory string
+}
+
+// NewSyncadaSFTPSession creates a new SyncadaSFTPSession service object
+func NewSyncadaSFTPSession(port string, userID string, remote string, password string, destinationFileDirectory string) SyncadaSenderSFTPSession {
+	return SyncadaSenderSFTPSession{
+		port,
+		userID,
+		remote,
+		password,
+		destinationFileDirectory,
+	}
+}
+
+// SendToSyncada converts a speicified file to a string and copies it to Syncada's SFTP server
+func (s *SyncadaSenderSFTPSession) SendToSyncada(localFilePath string, destinationFileName string) (resp string, err error) {
+	config := &ssh.ClientConfig{
+		User: s.userID,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(s.password),
+		},
+		/* #nosec */
+		// The hostKey was removed because authentication is performed using a user ID and password
+		// If hostKey configuration is needed, please see PR #5039: https://github.com/transcom/mymove/pull/5039
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		// HostKeyCallback: ssh.FixedHostKey(hostKey),
+	}
+
+	// connect
+	connection, err := ssh.Dial("tcp", s.remote+":"+s.port, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer connection.Close()
+
+	// create new SFTP client
+	client, err := sftp.NewClient(connection)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// open local file
+	localFile, err := os.Open(filepath.Clean(localFilePath))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create destination file
+	destinationFilePath := fmt.Sprintf("/%s/%s/%s", s.userID, s.destinationFileDirectory, destinationFileName)
+	destinationFile, err := client.Create(destinationFilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer destinationFile.Close()
+
+	// copy source file to destination file
+	bytes, err := io.Copy(destinationFile, localFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf("%d bytes copied\n", bytes), err
+}


### PR DESCRIPTION
## Description

This PR transition the logic in the `send-to-syncada-via-sftp` CLI utilityto a service: `pkg/services/invoice/syncada_sender_sftp.go`.

## Setup

1. Reset your dev database: `make db_dev_e2e_populate`
2. Build both CLI utilities: `make bin/generate-payment-request-edi && make bin/send-to-syncada-via-sftp`
3. Run your server locally: `make server_run`
4. Create a new JSON file into which you can put your payload: `touch new_payment_request.json`
5. Paste the following payload into your newly created JSON file:
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```
6. Use the Prime API Client to create the payment request and return the payment request number:
```shell
prime-api-client --insecure create-payment-request --filename  new_payment_request.json| jq '.paymentRequestNumber'
```
7. Use the `generate-payment-request-edi` CLI utility to generate the EDI858 and send the output to a text file. Remember to pass the payment request number obtained above:
```shell
bin/generate-payment-request-edi --payment-request-number [pass payment request number] > sample_edi.txt
```
8. Open the newly created `sample_edi.txt` and ensure the contents look similar to the EDI858 below:
```txt
logger:  &{0xc000c601e0 true  0xc000c43040 true 1 0}
ISA*00*0084182369*00*_   _*ZZ*GOVDPIBS*12*8004171844*20201014*1943*U*00401*100001272*0*T*|
GS*SI*MYMOVE*8004171844*20201014*1943*100001251*X*004010
ST*858*0001
BX*00*J*PP*7111-9295*TRUS**4
N9*CN*7111-9295-1**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*10*20201014*0*
G62*76*20201013*0*
G62*86*20200316*0*
N1*ST**10*CNNQ
N3*Fort Gordon*
N4*Augusta*GA*30813*United States**
N1*SF*Xm7G3reuV8*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*US**
FA1*DF
FA2*TA*F8E1
HL*1**|
N9*PO*4f9aef1b-62a9-44c5-9379-1976501a0daf**
L5*1*DLH*TBD*D**
L0*1*373.000*DM*1349.000*B******L
L3*1349.000*B*1221717
SE*24*0001
GE*1*100001251
IEA*1*100001272
```
9. Use the `send-to-syncada-via-sftp` CLI utility to send the EDI858 to US Bank. Remember to pass the path of the text file where the EDI858 generated above is stored (in this case you would pass `sample_edi.txt`) and the name you'd like the file to have on the Syncada server:
```shell
bin/send-to-syncada-via-sftp --local-file-path [pass file path] --destination-file-name sample_edi.txt
```
10. You should see a message like the following in the command line:
```shell
logger:  &{0xc0003a1f20 true  0xc000349de0 true 1 0}
2020-10-16T16:53:39.964Z        DEBUG   send-to-syncada-via-sftp/main.go:25     checking config
708 bytes copied
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4959) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
