### PR TITLE
fix nts-r logic hole

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -123,8 +123,8 @@ func (f mtoShipmentCreator) CreateMTOShipment(shipment *models.MTOShipment, serv
 				return fmt.Errorf("failed to create pickup address %#v %e", verrs, err)
 			}
 			shipment.PickupAddressID = &shipment.PickupAddress.ID
-		} else if shipment.ShipmentType == models.MTOShipmentTypeHHG {
-			return services.NewInvalidInputError(uuid.Nil, nil, nil, "PickupAddress is required to create an HHG type MTO shipment")
+		} else if shipment.ShipmentType != models.MTOShipmentTypeHHGOutOfNTSDom {
+			return services.NewInvalidInputError(uuid.Nil, nil, nil, "PickupAddress is required to create an HHG or NTS type MTO shipment")
 		}
 
 		if shipment.DestinationAddress != nil {
@@ -136,8 +136,8 @@ func (f mtoShipmentCreator) CreateMTOShipment(shipment *models.MTOShipment, serv
 		}
 
 		// check that required items to create shipment are present
-		if shipment.RequestedPickupDate == nil {
-			return services.NewInvalidInputError(uuid.Nil, nil, nil, "RequestedPickupDate is required to create MTO shipment")
+		if shipment.RequestedPickupDate == nil && shipment.ShipmentType != models.MTOShipmentTypeHHGOutOfNTSDom {
+			return services.NewInvalidInputError(uuid.Nil, nil, nil, "RequestedPickupDate is required to create an HHG or NTS type MTO shipment")
 		}
 
 		//assign status to shipment draft by default


### PR DESCRIPTION
## Description

Fix NTS-R logic hole by only throwing an error if requested pickup date is nil on non NTS-R type shipments.

## Reviewer Notes

@NamibiaLT -- lmk if you want me to branch off your branch to add another test case for this NTS-R type edge case. since we weren't checking the zero value before, I think this error check wasn't causing any problems--- but once your change merges this will become an issue for the customer side of creating NTS-R shipments.