### PR TITLE
Fix TOO/TIO display errors for NTSR shipments

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -242,7 +242,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 		ETag:                     etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 
-	if mtoShipment.RequestedPickupDate != nil {
+	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {
 		payload.RequestedPickupDate = *handlers.FmtDatePtr(mtoShipment.RequestedPickupDate)
 	}
 

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -39,7 +39,7 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
           </div>
           <div className={styles.row}>
             <dt>Current address</dt>
-            <dd>{formatAddress(displayInfo.currentAddress)}</dd>
+            <dd>{displayInfo.currentAddress && formatAddress(displayInfo.currentAddress)}</dd>
           </div>
           <div className={styles.row}>
             <dt className={styles.label}>Destination address</dt>


### PR DESCRIPTION
## Description

The TOO/TIO screen to view the details of an order/move was failing when a move with an NTSR shipment was submitted. To fix this, we had to patch a nil dereference error when converting the `mtoShipment.RequestedPickupDate` field into the format needed in the response. 

We also had to fix a small display error in the `ShipmentDisplay` component that was trying to format the non-existent pickup address. Now this page will display nothing for the Current Address for NTSR shipments. 

## Setup

To check this fix, you'll need to run your server and your client:

```sh
make server_run
make client_run
```

Next, either create a new move with an NTSR shipment by going through the customer interface or find an existing move with an NTSR shipment and navigate to this page in the office interface: `http://officelocal:3000/moves/<orderID>/details` as TOO or TIO user. You should be able to see the NTSR shipment with a blank Current Address.

## Screenshots

![Screen Shot 2020-10-30 at 1 52 38 PM](https://user-images.githubusercontent.com/62574202/97746670-bea94100-1ab8-11eb-9418-5c4f06cba328.png)
