### PR TITLE
MB-5113 Fix null value problem in TOO office app for NTSr shipments (address field)

### DIFF
--- a/src/components/Office/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview.jsx
@@ -88,7 +88,7 @@ const ShipmentApprovalPreview = ({
                             <th className="text-bold" scope="row">
                               Current Address
                             </th>
-                            <td>{formatAddress(shipment.pickupAddress)}</td>
+                            <td>{shipment.pickupAddress && formatAddress(shipment.pickupAddress)}</td>
                           </tr>
                           <tr>
                             <th className="text-bold" scope="row">


### PR DESCRIPTION
## Description

Adds a truthy check into the shipment approval modal on the TOO app so that we don't pass a null value into the address formatter.


## Setup

After loading up data with the command below and starting the backend and frontend services up you will want to choose the item in the queue with a name that mentions NTS and NTSr. Clicking on that one should let you try to approve an NTSr shipment, which should now succeed.

```sh
make db_dev_e2e_populate
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5113) for this change

