### PR TITLE
[MB-5156] Removed L3 from service item sections and put at end of sequence

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -586,11 +586,7 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				LadingLineItemNumber: hierarchicalIDNumber,
 			}
 
-			l3Segment := edisegment.L3{
-				PriceCents: int64(*serviceItem.PriceCents),
-			}
-
-			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment, &l3Segment)
+			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment)
 		// pack and unpack, dom dest and dom origin have weight no distance
 		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
 			models.ReServiceCodeDPK, models.ReServiceCodeDDP:
@@ -614,13 +610,7 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				WeightUnitCode:       "L",
 			}
 
-			l3Segment := edisegment.L3{
-				Weight:          weightFloat,
-				WeightQualifier: "B",
-				PriceCents:      int64(*serviceItem.PriceCents),
-			}
-
-			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment, &l3Segment)
+			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment)
 
 		default:
 			var err error
@@ -645,15 +635,15 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				WeightUnitCode:         "L",
 			}
 
-			l3Segment := edisegment.L3{
-				Weight:          weightFloat,
-				WeightQualifier: "B",
-				PriceCents:      int64(*serviceItem.PriceCents),
-			}
-
-			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment, &l3Segment)
+			segments = append(segments, &hlSegment, &n9Segment, &l5Segment, &l0Segment)
 		}
 	}
+
+	l3Segment := edisegment.L3{
+		PriceCents: 0, // TODO: hard-coded to zero for now
+	}
+
+	segments = append(segments, &l3Segment)
 
 	return segments, nil
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -209,7 +209,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds se end segment", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(66, result.SE.NumberOfIncludedSegments)
+		suite.Equal(58, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -368,7 +368,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.Equal(*paymentRequest.MoveTaskOrder.Orders.TAC, fa2.FinancialInformationCode)
 	})
 
-	var numOfSegments = 5
+	var numOfSegments = 4
 	for idx, paymentServiceItem := range paymentServiceItems {
 		var hierarchicalNumberInt = idx + 1
 		var hierarchicalNumber = strconv.Itoa(hierarchicalNumberInt)
@@ -404,12 +404,6 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				l0 := result.ServiceItems[segmentOffset+3].(*edisegment.L0)
 				suite.Equal(hierarchicalNumberInt, l0.LadingLineItemNumber)
 			})
-
-			suite.T().Run("adds l3 service item segment", func(t *testing.T) {
-				suite.IsType(&edisegment.L3{}, result.ServiceItems[segmentOffset+4])
-				l3 := result.ServiceItems[segmentOffset+4].(*edisegment.L3)
-				suite.Equal(paymentServiceItem.PriceCents.Int64(), l3.PriceCents)
-			})
 		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
 			models.ReServiceCodeDPK, models.ReServiceCodeDDP:
 			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
@@ -428,14 +422,6 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				suite.Equal(float64(4242), l0.Weight)
 				suite.Equal("B", l0.WeightQualifier)
 				suite.Equal("L", l0.WeightUnitCode)
-			})
-
-			suite.T().Run("adds l3 service item segment", func(t *testing.T) {
-				suite.IsType(&edisegment.L3{}, result.ServiceItems[segmentOffset+4])
-				l3 := result.ServiceItems[segmentOffset+4].(*edisegment.L3)
-				suite.Equal(float64(4242), l3.Weight)
-				suite.Equal("B", l3.WeightQualifier)
-				suite.Equal(paymentServiceItem.PriceCents.Int64(), l3.PriceCents)
 			})
 		default:
 			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
@@ -461,16 +447,15 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				suite.Equal("B", l0.WeightQualifier)
 				suite.Equal("L", l0.WeightUnitCode)
 			})
-
-			suite.T().Run("adds l3 service item segment", func(t *testing.T) {
-				suite.IsType(&edisegment.L3{}, result.ServiceItems[segmentOffset+4])
-				l3 := result.ServiceItems[segmentOffset+4].(*edisegment.L3)
-				suite.Equal(float64(4242), l3.Weight)
-				suite.Equal("B", l3.WeightQualifier)
-				suite.Equal(paymentServiceItem.PriceCents.Int64(), l3.PriceCents)
-			})
 		}
 	}
+
+	l3Location := numOfSegments * len(paymentServiceItems)
+	suite.T().Run("adds l3 service item segment", func(t *testing.T) {
+		suite.IsType(&edisegment.L3{}, result.ServiceItems[l3Location])
+		l3 := result.ServiceItems[l3Location].(*edisegment.L3)
+		suite.Equal(int64(0), l3.PriceCents) // TODO: hard-coded to zero for now
+	})
 }
 
 func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {


### PR DESCRIPTION
## Description

This PR modifies the EDI so that the L3 segments are no longer in each service item section.  Instead, a single L3 segment exists at the end of the sequence of service items.

## Reviewer Notes

- Weight is not included since some service items (like MS and CS) are not weight-based.  Is this correct?
- The price has been hard-coded to zero for now per the story.

## Setup

- `make db_dev_e2e_populate`
- `make server_run`

Save payload below into `tmp/local_create_payment_request.json`:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Create the payment request:
```
prime-api-client --insecure create-payment-request --filename tmp/local_create_payment_request.json | jq '.paymentRequestNumber,.id'
```

Using the payment request number output above, generate the EDI:
```
go run ./cmd/generate-payment-request-edi/ --payment-request-number <payment_request_number>
```

Verify that the L3 segment only appears once at the end of all the service items now rather than in each individual service item segment.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5156) for this change
