### PR TITLE
MMDM-1742 Add migration to remove Lee's CAC access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1323,7 +1323,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1337,7 +1337,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1345,7 +1345,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1353,7 +1353,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: am-remove-lee-cac-access
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1393,21 +1393,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1421,28 +1421,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: am-remove-lee-cac-access
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1323,7 +1323,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - integration_tests_mtls:
           requires:
@@ -1337,7 +1337,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - client_test:
           requires:
@@ -1345,7 +1345,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - server_test:
           requires:
@@ -1353,7 +1353,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: am-remove-lee-cac-access
 
       - build_app:
           requires:
@@ -1393,21 +1393,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - deploy_exp_migrations:
           requires:
@@ -1421,28 +1421,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: am-remove-lee-cac-access
 
       - push_app_stg:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -568,3 +568,4 @@
 20201020164146_gidjin_cac.up.sql
 20201023202845_update_selectedMoveType_NTS.up.sql
 20201027143150_moncef_cac.up.sql
+20201103225532_remove_mr337_cac.up.sql

--- a/migrations/app/schema/20201103225532_remove_mr337_cac.up.sql
+++ b/migrations/app/schema/20201103225532_remove_mr337_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove mr337 CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='6f684e8ed9f697a5b6099f31f5346042db6339ecd8029000df8924369defb069';


### PR DESCRIPTION
## Description

Removes CAC access. This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes

NOTE: This needs to be deployed manually to experimental to apply in that environment.

## Setup

```make db_dev_run db_dev_migrate```