### PR TITLE
MB-4836 Exclude canceled and draft moves

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1,7 +1,6 @@
 package payloads
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -520,10 +519,8 @@ func queueMoveStatus(move models.Move) string {
 	// approvals requested status when the move is in an APPROVED status and there are mtoServiceItems in
 	// a submitted status. This is all detailed in: https://dp3.atlassian.net/browse/MB-4158
 	if move.Status == models.MoveStatusAPPROVED {
-		fmt.Println("move status is approved")
 		// Let's check to see if there are any MTOServiceItems for this move that need review (SUBMITTED status)
 		for _, mtoSI := range move.MTOServiceItems {
-			fmt.Println("move has service items")
 			// If we find one, we'll immediately return this status as there's no need to continue iterating through.
 			if mtoSI.Status == "SUBMITTED" {
 				return QueueMoveStatusAPPROVALSREQUESTED

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -1,6 +1,7 @@
 package payloads
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -519,8 +520,10 @@ func queueMoveStatus(move models.Move) string {
 	// approvals requested status when the move is in an APPROVED status and there are mtoServiceItems in
 	// a submitted status. This is all detailed in: https://dp3.atlassian.net/browse/MB-4158
 	if move.Status == models.MoveStatusAPPROVED {
+		fmt.Println("move status is approved")
 		// Let's check to see if there are any MTOServiceItems for this move that need review (SUBMITTED status)
 		for _, mtoSI := range move.MTOServiceItems {
+			fmt.Println("move has service items")
 			// If we find one, we'll immediately return this status as there's no need to continue iterating through.
 			if mtoSI.Status == "SUBMITTED" {
 				return QueueMoveStatusAPPROVALSREQUESTED

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -172,8 +172,7 @@ func submittedAtFilter(submittedAt *string) FilterOption {
 func moveStatusFilter(statuses []string) FilterOption {
 	return func(query *pop.Query) {
 		if len(statuses) <= 0 {
-			queryString := fmt.Sprintf("moves.status NOT IN ('%s', '%s')", models.MoveStatusDRAFT, models.MoveStatusCANCELED)
-			query = query.Where(queryString)
+			query = query.Where("moves.status NOT IN (?)", models.MoveStatusDRAFT, models.MoveStatusCANCELED)
 		}
 	}
 }

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -40,6 +40,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 	dodIDQuery := dodIDFilter(params.DodID)
 	lastNameQuery := lastNameFilter(params.LastName)
 	dutyStationQuery := destinationDutyStationFilter(params.DestinationDutyStation)
+	moveStatusQuery := moveStatusFilter(params.Status)
 
 	orders, err := h.MoveOrderFetcher.ListMoveOrders(
 		session.OfficeUserID,
@@ -48,6 +49,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 		lastNameQuery,
 		dutyStationQuery,
 		dodIDQuery,
+		moveStatusQuery,
 	)
 
 	if err != nil {
@@ -58,7 +60,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 	queueMoves := payloads.QueueMoves(orders)
 	// ToDo - May want to move this logic into the pop query later.
 	// filter queueMoves by status
-	queueMoves = moveStatusFilter(params.Status, queueMoves)
+	queueMoves = movesFilteredByStatus(params.Status, queueMoves)
 
 	result := &ghcmessages.QueueMovesResult{
 		Page:       0,
@@ -167,8 +169,17 @@ func submittedAtFilter(submittedAt *string) FilterOption {
 	}
 }
 
-// statusFilter filters the status after the pop query call.
-func moveStatusFilter(statuses []string, moves *ghcmessages.QueueMoves) *ghcmessages.QueueMoves {
+func moveStatusFilter(statuses []string) FilterOption {
+	return func(query *pop.Query) {
+		if len(statuses) <= 0 {
+			queryString := fmt.Sprintf("moves.status NOT IN ('%s', '%s')", models.MoveStatusDRAFT, models.MoveStatusCANCELED)
+			query = query.Where(queryString)
+		}
+	}
+}
+
+// movesFilteredByStatus filters the status after the pop query call.
+func movesFilteredByStatus(statuses []string, moves *ghcmessages.QueueMoves) *ghcmessages.QueueMoves {
 	if len(statuses) <= 0 || moves == nil {
 		return moves
 	}


### PR DESCRIPTION
## Description

When the `status` filter is not present, we only want to return moves
that are neither canceled nor in draft status. This fixes a bug where
we were including canceled and draft moves.

## Reviewer Notes

1. Using an app like TablePlus, or psql, modify the status of some local HHG moves to DRAFT or CANCELED.
2. Sign in as a TOO using the master branch. Verify that you see moves with either DRAFT or CANCELED status.
3. Switch to this branch and sign in again with the same TOO

Expected Result: no moves in DRAFT or CANCELED status appear.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_test_e2e_populate
make office_client_run
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4836) for this change
