### PR TITLE
[MB-4323] Home state 4

### DIFF
--- a/src/components/Customer/Home/Step/Step.stories.jsx
+++ b/src/components/Customer/Home/Step/Step.stories.jsx
@@ -110,10 +110,11 @@ export const ConfirmMove = () => (
     <Step
       complete={boolean('Complete', false)}
       completedHeaderText={text('Complete Header Text', 'Shipments')}
-      headerText={text('Header Text', 'Confirm and move request')}
+      headerText={text('Header Text', 'Review your request')}
       step={text('Step', '4')}
       actionBtnLabel="Review and submit"
-      actionBtnDisabled
+      secondaryBtn
+      secondaryBtnStyle={{ boxShadow: 'inset 0 0 0 2px #0050d8' }}
     >
       <p>
         {

--- a/src/components/Customer/Home/Step/Step.stories.jsx
+++ b/src/components/Customer/Home/Step/Step.stories.jsx
@@ -109,12 +109,10 @@ export const ConfirmMove = () => (
     <h3>Confirm move</h3>
     <Step
       complete={boolean('Complete', false)}
-      completedHeaderText={text('Complete Header Text', 'Shipments')}
-      headerText={text('Header Text', 'Review your request')}
+      completedHeaderText={text('Complete Header Text', 'Move request confirmed')}
+      headerText={text('Header Text', 'Confirm move request')}
       step={text('Step', '4')}
       actionBtnLabel="Review and submit"
-      secondaryBtn
-      secondaryBtnStyle={{ boxShadow: 'inset 0 0 0 2px #0050d8' }}
     >
       <p>
         {
@@ -122,6 +120,23 @@ export const ConfirmMove = () => (
           'Review your move details and sign the legal paperwork, then send the info on to your move counselor')
         }
       </p>
+    </Step>
+  </div>
+);
+
+export const MoveSubmitted = () => (
+  <div className="grid-container">
+    <h3>Move submitted</h3>
+    <Step
+      complete={boolean('Complete', true)}
+      completedHeaderText={text('Complete Header Text', 'Move request confirmed')}
+      headerText={text('Header Text', 'Review your request')}
+      step={text('Step', '4')}
+      actionBtnLabel="Review your request"
+      secondaryBtn
+      secondaryBtnStyle={{ boxShadow: 'inset 0 0 0 2px #0050d8' }}
+    >
+      <p>{(text('Description'), 'Move submitted 03 Nov 2020')}</p>
     </Step>
   </div>
 );

--- a/src/components/Customer/Home/Step/index.jsx
+++ b/src/components/Customer/Home/Step/index.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { bool, node, string, oneOfType, number, func } from 'prop-types';
+import { bool, node, string, oneOfType, number, func, shape } from 'prop-types';
 import classnames from 'classnames';
 import { Button } from '@trussworks/react-uswds';
 
@@ -29,6 +29,7 @@ const Step = ({
   onEditBtnClick,
   secondaryBtn,
   secondaryBtnClassName,
+  secondaryBtnStyle,
   step,
 }) => {
   const showThoughNotFunctional = false; // remove when all Edit buttons work
@@ -61,6 +62,7 @@ const Step = ({
           onClick={onActionBtnClick}
           type="button"
           secondary={secondaryBtn}
+          style={secondaryBtnStyle}
         >
           {actionBtnLabel}
         </Button>
@@ -84,6 +86,7 @@ Step.propTypes = {
   onEditBtnClick: func,
   secondaryBtn: bool,
   secondaryBtnClassName: string,
+  secondaryBtnStyle: shape({}),
   step: oneOfType([string, number]).isRequired,
 };
 
@@ -101,6 +104,7 @@ Step.defaultProps = {
   onEditBtnClick: () => {},
   secondaryBtn: false,
   secondaryBtnClassName: '',
+  secondaryBtnStyle: {},
 };
 
 export default Step;

--- a/src/components/Customer/Home/Step/index.jsx
+++ b/src/components/Customer/Home/Step/index.jsx
@@ -28,12 +28,17 @@ const Step = ({
   onActionBtnClick,
   onEditBtnClick,
   secondaryBtn,
+  secondaryBtnClassName,
   step,
 }) => {
   const showThoughNotFunctional = false; // remove when all Edit buttons work
-  const actionBtnClassName = classnames(styles['action-btn'], {
-    [styles['action-button--secondary']]: secondaryBtn,
-  });
+  const actionBtnClassName = classnames(
+    styles['action-btn'],
+    {
+      [styles['action-button--secondary']]: secondaryBtn,
+    },
+    secondaryBtnClassName,
+  );
 
   return (
     <div data-testid={`stepContainer${step}`} className={`${styles['step-container']} ${containerClassName}`}>
@@ -78,6 +83,7 @@ Step.propTypes = {
   onActionBtnClick: func,
   onEditBtnClick: func,
   secondaryBtn: bool,
+  secondaryBtnClassName: string,
   step: oneOfType([string, number]).isRequired,
 };
 
@@ -94,6 +100,7 @@ Step.defaultProps = {
   onActionBtnClick: () => {},
   onEditBtnClick: () => {},
   secondaryBtn: false,
+  secondaryBtnClassName: '',
 };
 
 export default Step;

--- a/src/components/Customer/Review/ShipmentCard/HHGShipmentCard/index.jsx
+++ b/src/components/Customer/Review/ShipmentCard/HHGShipmentCard/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, shape, number, func } from 'prop-types';
+import { string, shape, number, func, bool } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
 import { AddressShape } from '../../../../../types/address';
@@ -24,6 +24,7 @@ const HHGShipmentCard = ({
   shipmentId,
   shipmentNumber,
   shipmentType,
+  showEditBtn,
 }) => {
   const editPath = `/moves/${moveId}/mto-shipments/${shipmentId}/edit-shipment?shipmentNumber=${shipmentNumber}`;
   return (
@@ -36,14 +37,16 @@ const HHGShipmentCard = ({
             </h3>
             <p>#{shipmentId.substring(0, 8).toUpperCase()}</p>
           </div>
-          <Button
-            className={styles.editBtn}
-            data-testid="edit-shipment-btn"
-            onClick={() => onEditClick(editPath)}
-            unstyled
-          >
-            Edit
-          </Button>
+          {showEditBtn && (
+            <Button
+              className={styles.editBtn}
+              data-testid="edit-shipment-btn"
+              onClick={() => onEditClick(editPath)}
+              unstyled
+            >
+              Edit
+            </Button>
+          )}
         </div>
         <dl className={styles.shipmentCardSubsection}>
           <PickupDisplay
@@ -78,6 +81,7 @@ HHGShipmentCard.propTypes = {
   shipmentNumber: number.isRequired,
   shipmentType: string.isRequired,
   shipmentId: string.isRequired,
+  showEditBtn: bool.isRequired,
   requestedPickupDate: string.isRequired,
   pickupLocation: AddressShape.isRequired,
   destinationLocation: AddressShape,

--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -150,6 +150,7 @@ export class Summary extends Component {
           shipmentId={shipment.id}
           shipmentNumber={hhgShipmentNumber}
           shipmentType={shipment.shipmentType}
+          showEditBtn={showEditBtn}
         />
       );
     });

--- a/src/pages/MyMove/Home/Home.module.scss
+++ b/src/pages/MyMove/Home/Home.module.scss
@@ -7,6 +7,10 @@
   max-width: 64rem;
   padding-left: 1.25rem;
   padding-right: 1.25rem;
+
+  .secondaryBtn {
+    box-shadow: inset 0 0 0 2px $primary;
+  }
 }
 
 .customer-header {

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -359,6 +359,7 @@ class Home extends Component {
                       headerText="Confirm move request"
                       onActionBtnClick={() => this.handleNewPathClick(confirmationPath)}
                       secondaryBtn={this.hasSubmittedMove}
+                      secondaryBtnClassName={styles.secondaryBtn}
                       step="4"
                     >
                       {this.hasSubmittedMove ? (

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -40,10 +40,19 @@ import {
 } from 'shared/Data/users';
 import { formatCustomerDate } from 'utils/formatters';
 
-const Description = ({ children }) => <p className={styles.description}>{children}</p>;
+const Description = ({ children, dataTestId }) => (
+  <p className={styles.description} data-testid={dataTestId}>
+    {children}
+  </p>
+);
 
 Description.propTypes = {
+  dataTestId: string,
   children: node.isRequired,
+};
+
+Description.defaultProps = {
+  dataTestId: '',
 };
 
 class Home extends Component {
@@ -349,11 +358,13 @@ class Home extends Component {
                       containerClassName="margin-bottom-8"
                       headerText="Confirm move request"
                       onActionBtnClick={() => this.handleNewPathClick(confirmationPath)}
-                      secondaryBtn={move.submitted_at}
+                      secondaryBtn={this.hasSubmittedMove}
                       step="4"
                     >
                       {this.hasSubmittedMove ? (
-                        <Description>Move submitted {formatCustomerDate(move.submitted_at)}.</Description>
+                        <Description dataTestId="move-submitted-description">
+                          Move submitted {formatCustomerDate(move.submitted_at)}.
+                        </Description>
                       ) : (
                         <Description>
                           Review your move details and sign the legal paperwork, then send the info on to your move

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -38,6 +38,7 @@ import {
   selectGetCurrentUserIsLoading,
   selectGetCurrentUserIsSuccess,
 } from 'shared/Data/users';
+import { formatCustomerDate } from 'utils/formatters';
 
 const Description = ({ children }) => <p className={styles.description}>{children}</p>;
 
@@ -340,18 +341,19 @@ class Home extends Component {
                       )}
                     </Step>
                     <Step
-                      complete={this.hasSubmittedMove}
                       actionBtnDisabled={!this.hasAnyShipments}
-                      actionBtnLabel={!this.hasSubmittedMove ? 'Review and submit' : ''}
                       actionBtnId="review-and-submit-btn"
+                      actionBtnLabel={!this.hasSubmittedMove ? 'Review and submit' : 'Review your request'}
+                      complete={this.hasSubmittedMove}
+                      completedHeaderText="Move request confirmed"
                       containerClassName="margin-bottom-8"
                       headerText="Confirm move request"
-                      completedHeaderText="Move request confirmed"
                       onActionBtnClick={() => this.handleNewPathClick(confirmationPath)}
+                      secondaryBtn={move.submitted_at}
                       step="4"
                     >
                       {this.hasSubmittedMove ? (
-                        <Description>Move submitted.</Description>
+                        <Description>Move submitted {formatCustomerDate(move.submitted_at)}.</Description>
                       ) : (
                         <Description>
                           Review your move details and sign the legal paperwork, then send the info on to your move

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 import Home from '.';
 
 import { store } from 'shared/store';
+import { formatCustomerDate } from 'utils/formatters';
 
 const defaultProps = {
   serviceMember: {
@@ -148,12 +149,26 @@ describe('Home component', () => {
     });
 
     describe('for HHG/PPM combo moves', () => {
+      const submittedAt = new Date();
+
       const wrapper = mountHome({
         orders: { id: 'testOrder123', new_duty_station: { name: 'Test Duty Station' } },
         uploadedOrderDocuments: [{ filename: 'testOrder1.pdf' }],
         mtoShipments: [{ id: 'test123', shipmentType: 'HHG' }],
-        move: { status: 'SUBMITTED' },
+        move: { status: 'SUBMITTED', submitted_at: submittedAt },
         currentPpm: { id: 'mockPpm' },
+      });
+
+      it('renders submitted date at step 4', () => {
+        expect(wrapper.find('[data-testid="move-submitted-description"]').text()).toBe(
+          `Move submitted ${formatCustomerDate(submittedAt)}.`,
+        );
+      });
+
+      it('renders secondary button when step 4 is completed', () => {
+        expect(wrapper.find('[data-testid="review-and-submit-btn"]').at(1).hasClass('usa-button--secondary')).toBe(
+          true,
+        );
       });
 
       it('renders the SubmittedMove helper', () => {


### PR DESCRIPTION
## Description

As a SM, I would like to be able to see the date I submitted my move and be able to review my move details. Also, should hide the edit button on the hhg shipment card on submitted moves 

## Setup
`make server_run`
`make client_run`
1. Setup a move and submit it
Expected results: On the homepage on step 4, it should have the date when you submitted the move
You should also have a review your request secondary button

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4323) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/98288682-108c1400-1f5c-11eb-8585-b31b89ccf8bb.png)

