### PR TITLE
[MB-3092] UpdateMTOPostCounselingInformation - Ensures MTO is available to Prime

### DIFF
--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -72,6 +72,7 @@ func NewPrimeAPIHandler(context handlers.HandlerContext) http.Handler {
 		context,
 		fetch.NewFetcher(queryBuilder),
 		movetaskorder.NewMoveTaskOrderUpdater(context.DB(), queryBuilder, mtoserviceitem.NewMTOServiceItemCreator(queryBuilder)),
+		movetaskorder.NewMoveTaskOrderChecker(context.DB()),
 	}
 
 	primeAPI.MtoShipmentCreateMTOShipmentHandler = CreateMTOShipmentHandler{


### PR DESCRIPTION
## Description

This PR introduces a fix that ensures that when the `updateMTOPostCounselingInformationHandler` is requested, it first checks to ensure that the `MTO`, or `move_task_order`, it references has been made available to the prime. All endpoints in the Prime API should require that the MTO must already be available to the prime before updating it. 

The Jira ticket also requests that the `updateMTOPostCounselingInformationHandler` successfully updates `ppmType` and `estimatedWeight`. Upon doing more discovery, it seems like this was already happening so no new additions needed to account for this. 

## Reviewer Notes

In-line comments.

## Setup

```sh
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
mylaptop ~ %: go test ./pkg/handlers/primeapi --testify.m "TestUpdateMTOPostCounselingInfo" -v 
```

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3092) 
