### PR TITLE
[MB-5115] generate-payment-request-edi CLI: Added usage instructions and better error handling

### DIFF
--- a/cmd/generate-payment-request-edi/main.go
+++ b/cmd/generate-payment-request-edi/main.go
@@ -90,10 +90,6 @@ func main() {
 	}
 
 	paymentRequestNumber := v.GetString("payment-request-number")
-	if paymentRequestNumber == "" {
-		fmt.Fprintln(os.Stderr, "ERROR: Must provide payment-request-number")
-		os.Exit(1)
-	}
 
 	var paymentRequest models.PaymentRequest
 	err = dbConnection.Where("payment_request_number = ?", paymentRequestNumber).First(&paymentRequest)


### PR DESCRIPTION
## Description

This PR adds some better usage instructions and error handling for the `generate-payment-request-edi` CLI.

## Setup

- `make db_dev_e2e_populate`
- `make server_run`

Save payload below into `tmp/local_create_payment_request.json`:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Create the payment request:
```
prime-api-client --insecure create-payment-request --filename tmp/local_create_payment_request.json | jq '.paymentRequestNumber,.id'
```

Using the payment request number output above, generate the EDI:
```
go run ./cmd/generate-payment-request-edi/ --payment-request-number <payment_request_number>
```

Also, try to make it fail in these ways:

No parameters -- should give an error and output usage.
```
go run ./cmd/generate-payment-request-edi/
```

Non-existent payment request number -- should give an error.
```
go run ./cmd/generate-payment-request-edi/ --payment-request-number 12345
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5115) for this change
