### PR TITLE
MB-3823 Fix error messaging when attempting to update estimated weight without scheduled pickup date

### DIFF
--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -279,12 +279,14 @@ func (h UpdateMTOShipmentHandler) checkPrimeValidationsOnModel(mtoShipment *mode
 			scheduledPickupDate = mtoShipment.ScheduledPickupDate
 		}
 		now := time.Now()
-		if dbShipment.ApprovedDate != nil {
+		if dbShipment.ApprovedDate != nil && scheduledPickupDate != nil {
 			err := validatePrimeEstimatedWeightRecordedDate(now, *scheduledPickupDate, *dbShipment.ApprovedDate)
 			if err != nil {
 				verrs.Add("primeEstimatedWeight", "the time period for updating the estimated weight for a shipment has expired, please contact the TOO directly to request updates to this shipment’s estimated weight")
 				verrs.Add("primeEstimatedWeight", err.Error())
 			}
+		} else if scheduledPickupDate == nil {
+			verrs.Add("primeEstimatedWeight", "the scheduled pickup date must be set before estimating the weight")
 		}
 		mtoShipment.PrimeEstimatedWeightRecordedDate = &now
 	}


### PR DESCRIPTION
## Description

This PR catches the case when a user tries to update the `primeEstimatedWeight` for a shipment before a `scheduledPickupDate` has been set and returns a message that properly explains the error. It also adds a test to check this behavior.

NOTE: The Acceptance Criteria for this ticket originally stipulated that this error should be a `ConflictError` instead of an `InvalidInputError`. However, because of the way the Prime handler structures its validation, this would require a sizable refactor to accomplish. There is also an effort to refactor the `UpdateMTOShipment` validations in general, and that would be a better opportunity to update this error. Therefore, I put this work in a new ticket: [MB-5276](https://dp3.atlassian.net/browse/MB-5276)

## Setup

Please test the `updateMTOShipment` endpoint in the Prime API using the method of your choice ([Postman](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman) or [Prime API Client](https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client)) and verify that trying to update a shipment's weight before the `scheduledPickupDate` has been set returns a useful error. Verify that after setting the `scheduledPickupDate`, then the `primeEstimatedWeight` can be updated.

Tips:
* You may need to create a new shipment that doesn't have a `scheduledPickupDate` first (or manually change a preexisting one using a database viewer).
* If it says that you've missed your chance to update the `primeEstimatedWeight`, try updating the `scheduledPickupDate` to be further in the future.

## Code Review Verification Steps

* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3823) for this change.
