### PR TITLE
MB-4141 Return error if missing MTO id

### DIFF
--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -196,7 +196,10 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 
 func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection, paymentRequest *models.PaymentRequest, requestedAt time.Time) (*models.PaymentRequest, error) {
 	// Verify that the MTO ID exists
-	//
+	if paymentRequest.MoveTaskOrderID == uuid.Nil {
+		return nil, services.NewInvalidCreateInputError(nil, "Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create")
+	}
+
 	// Lock on the parent row to keep multiple transactions from getting this count at the same time
 	// for the same move_id.  This should block if another payment request comes in for the
 	// same move_id.  Payment requests for other move_ids should run concurrently.

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -310,6 +310,19 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 		suite.Equal(true, ok)
 	})
 
+	suite.T().Run("Given no move task order id, the create should fail", func(t *testing.T) {
+		invalidPaymentRequest := models.PaymentRequest{
+			MoveTaskOrderID: uuid.Nil,
+			IsFinal:         false,
+		}
+		_, err := creator.CreatePaymentRequest(&invalidPaymentRequest)
+
+		suite.Error(err)
+		_, ok := err.(services.InvalidCreateInputError)
+		suite.Equal(true, ok)
+		suite.Equal("Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create", err.Error())
+	})
+
 	suite.T().Run("Given a non-existent service item id, the create should fail", func(t *testing.T) {
 		badID, _ := uuid.FromString("0aee14dd-b5ea-441a-89ad-db4439fa4ea2")
 		invalidPaymentRequest := models.PaymentRequest{


### PR DESCRIPTION
## Description

The story MB-4141 is about handling various error states for payment request creation. This PR covers MB-5344 when the MTO Id is `uuid.Nil` aka all zeros. If it is this will return a InvalidCreateInputError

## Reviewer Notes

Is `InvalidCreateInputError` appropriate, or would `BadDataError` or `InvalidInputError` be more appropriate here. I'm going with `InvalidCreateInputError` because MTO Id is user input (from the prime) and this is being checked on create.

## Setup

Setup server

```sh
make db_dev_e2e_populate
make server_run
```

Save this json to a payload.json
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "00000000-0000-0000-0000-000000000000",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Try to create a new payment request see the error
```sh
prime-api-client --insecure create-payment-request --filename payload.json | jq
{
  "Payload": {
    "detail": "Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create",
    "instance": "689f5fb5-d73e-4d60-9fd9-6700135e0107",
    "title": "Validation Error",
    "invalidFields": null
  }
}

```

Validate handler returns correct error a `422 Unprocessable Entity`:

```sh
❯ prime-api-client --insecure create-payment-request --filename tmp/payloads/local_create_payment_request.json -v
POST /prime/v1/payment-requests HTTP/1.1
Host: primelocal:9443
User-Agent: Go-http-client/1.1
Content-Length: 332
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip

{"isFinal":false,"moveTaskOrderID":"00000000-0000-0000-0000-000000000000","serviceItems":[{"id":"94bc8b44-fefe-469f-83a0-39b1e31116fb","params":null},{"id":"eee4b555-2475-4e67-a5b8-102f28d950f8","params":null},{"id":"6431e3e2-4ee4-41b5-b226-393f9133eb6c","params":null},{"id":"fd6741a5-a92c-44d5-8303-1d7f5e60afbf","params":null}]}

HTTP/1.1 422 Unprocessable Entity
Content-Length: 192
Cache-Control: no-cache, no-store, must-revalidate
Content-Security-Policy: frame-ancestors 'none'
Content-Type: application/json
Date: Tue, 10 Nov 2020 17:05:50 GMT
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Frame-Options: deny
X-Xss-Protection: 1; mode=block

{"detail":"Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create","instance":"646c5b61-5db4-4c53-8e30-da5c3858e1ea","title":"Validation Error","invalidFields":null}

{"Payload":{"detail":"Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create","instance":"646c5b61-5db4-4c53-8e30-da5c3858e1ea","title":"Validation Error","detail":"Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create","instance":"646c5b61-5db4-4c53-8e30-da5c3858e1ea","invalidFields":null,"title":"Validation Error","invalidFields":null}}% 
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4141) for this change
* [Jira subtask](https://dp3.atlassian.net/browse/MB-5344) for this change