### PR TITLE
MB-5457 Fix sort order of moves in TOO queue

### DIFF
--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -56,7 +56,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 		listMoveOrderParams.PerPage = swag.Int64(20)
 	}
 
-	orders, count, err := h.MoveOrderFetcher.ListMoveOrders(
+	moves, count, err := h.MoveOrderFetcher.ListMoveOrders(
 		session.OfficeUserID,
 		&listMoveOrderParams,
 	)
@@ -66,7 +66,7 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 		return queues.NewGetMovesQueueInternalServerError()
 	}
 
-	queueMoves := payloads.QueueMoves(orders)
+	queueMoves := payloads.QueueMoves(moves)
 
 	result := &ghcmessages.QueueMovesResult{
 		Page:       *listMoveOrderParams.Page,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -332,6 +332,8 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerFilters() {
 		payload := response.(*queues.GetMovesQueueOK).Payload
 		suite.EqualValues(3, payload.TotalCount)
 		suite.Len(payload.QueueMoves, 3)
+		// test that the moves are sorted by status descending
+		suite.Equal(ghcmessages.QueueMoveStatus("SUBMITTED"), payload.QueueMoves[0].Status)
 	})
 
 	suite.Run("loads results with all STATUSes and 1 page selected", func() {

--- a/pkg/services/mocks/MoveOrderFetcher.go
+++ b/pkg/services/mocks/MoveOrderFetcher.go
@@ -40,15 +40,15 @@ func (_m *MoveOrderFetcher) FetchMoveOrder(moveTaskOrderID uuid.UUID) (*models.O
 }
 
 // ListMoveOrders provides a mock function with given fields: officeUserID, params
-func (_m *MoveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *services.ListMoveOrderParams) ([]models.Order, int, error) {
+func (_m *MoveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *services.ListMoveOrderParams) ([]models.Move, int, error) {
 	ret := _m.Called(officeUserID, params)
 
-	var r0 []models.Order
-	if rf, ok := ret.Get(0).(func(uuid.UUID, *services.ListMoveOrderParams) []models.Order); ok {
+	var r0 []models.Move
+	if rf, ok := ret.Get(0).(func(uuid.UUID, *services.ListMoveOrderParams) []models.Move); ok {
 		r0 = rf(officeUserID, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.Order)
+			r0 = ret.Get(0).([]models.Move)
 		}
 	}
 

--- a/pkg/services/move_order.go
+++ b/pkg/services/move_order.go
@@ -10,7 +10,7 @@ import (
 //go:generate mockery -name MoveOrderFetcher
 type MoveOrderFetcher interface {
 	FetchMoveOrder(moveTaskOrderID uuid.UUID) (*models.Order, error)
-	ListMoveOrders(officeUserID uuid.UUID, params *ListMoveOrderParams) ([]models.Order, int, error)
+	ListMoveOrders(officeUserID uuid.UUID, params *ListMoveOrderParams) ([]models.Move, int, error)
 }
 
 //MoveOrderUpdater is the service object interface for updating fields of a MoveOrder

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -65,17 +65,17 @@ func (suite *MoveOrderServiceSuite) TestMoveOrderFetcherWithEmptyFields() {
 	suite.Nil(moveOrder.Grade)
 }
 
-func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
+func (suite *MoveOrderServiceSuite) TestListMoves() {
 	// Create a Move without a shipment to test that only Orders with shipments
 	// are displayed to the TOO
 	testdatagen.MakeDefaultMove(suite.DB())
 
-	expectedMoveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
+	expectedMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
 
 	// Only orders with shipments are returned, so we need to add a shipment
 	// to the move we just created
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: expectedMoveTaskOrder,
+		Move: expectedMove,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},
@@ -83,33 +83,32 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
 
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
-	expectedMoveOrder := expectedMoveTaskOrder.Orders
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
 
-	suite.T().Run("returns move orders", func(t *testing.T) {
-		moveOrders, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
+	suite.T().Run("returns moves", func(t *testing.T) {
+		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
 
 		suite.FatalNoError(err)
-		suite.Len(moveOrders, 1)
+		suite.Len(moves, 1)
 
-		moveOrder := moveOrders[0]
+		move := moves[0]
 
-		suite.NotNil(moveOrder.ServiceMember)
-		suite.Equal(expectedMoveOrder.ServiceMember.FirstName, moveOrder.ServiceMember.FirstName)
-		suite.Equal(expectedMoveOrder.ServiceMember.LastName, moveOrder.ServiceMember.LastName)
-		suite.Equal(expectedMoveOrder.ID, moveOrder.ID)
-		suite.Equal(expectedMoveOrder.ServiceMemberID, moveOrder.ServiceMemberID)
-		suite.NotNil(moveOrder.NewDutyStation)
-		suite.Equal(expectedMoveOrder.NewDutyStationID, moveOrder.NewDutyStation.ID)
-		suite.NotNil(moveOrder.Entitlement)
-		suite.Equal(*expectedMoveOrder.EntitlementID, moveOrder.Entitlement.ID)
-		suite.Equal(expectedMoveOrder.OriginDutyStation.ID, moveOrder.OriginDutyStation.ID)
-		suite.NotNil(moveOrder.OriginDutyStation)
-		suite.Equal(expectedMoveOrder.OriginDutyStation.AddressID, moveOrder.OriginDutyStation.AddressID)
-		suite.Equal(expectedMoveOrder.OriginDutyStation.Address.StreetAddress1, moveOrder.OriginDutyStation.Address.StreetAddress1)
+		suite.NotNil(move.Orders.ServiceMember)
+		suite.Equal(expectedMove.Orders.ServiceMember.FirstName, move.Orders.ServiceMember.FirstName)
+		suite.Equal(expectedMove.Orders.ServiceMember.LastName, move.Orders.ServiceMember.LastName)
+		suite.Equal(expectedMove.Orders.ID, move.Orders.ID)
+		suite.Equal(expectedMove.Orders.ServiceMemberID, move.Orders.ServiceMemberID)
+		suite.NotNil(move.Orders.NewDutyStation)
+		suite.Equal(expectedMove.Orders.NewDutyStationID, move.Orders.NewDutyStation.ID)
+		suite.NotNil(move.Orders.Entitlement)
+		suite.Equal(*expectedMove.Orders.EntitlementID, move.Orders.Entitlement.ID)
+		suite.Equal(expectedMove.Orders.OriginDutyStation.ID, move.Orders.OriginDutyStation.ID)
+		suite.NotNil(move.Orders.OriginDutyStation)
+		suite.Equal(expectedMove.Orders.OriginDutyStation.AddressID, move.Orders.OriginDutyStation.AddressID)
+		suite.Equal(expectedMove.Orders.OriginDutyStation.Address.StreetAddress1, move.Orders.OriginDutyStation.Address.StreetAddress1)
 	})
 
-	suite.T().Run("returns move orders filtered by GBLOC", func(t *testing.T) {
+	suite.T().Run("returns moves filtered by GBLOC", func(t *testing.T) {
 		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
 				Status: models.MTOShipmentStatusSubmitted,
@@ -122,13 +121,13 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
 			},
 		})
 
-		moveOrders, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
+		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moveOrders))
+		suite.Equal(1, len(moves))
 	})
 
-	suite.T().Run("returns orders filtered by an arbitrary query", func(t *testing.T) {
+	suite.T().Run("returns moves filtered by an arbitrary query", func(t *testing.T) {
 		army := "ARMY"
 		params := services.ListMoveOrderParams{Branch: &army, PerPage: swag.Int64(1), Page: swag.Int64(1)}
 		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
@@ -143,14 +142,14 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrders() {
 			},
 		})
 
-		moveOrders, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
+		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moveOrders))
+		suite.Equal(1, len(moves))
 	})
 }
 
-func (suite *MoveOrderServiceSuite) TestListMoveOrdersUSMCGBLOC() {
+func (suite *MoveOrderServiceSuite) TestListMovesUSMCGBLOC() {
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
 
 	suite.T().Run("returns USMC order for USMC office user", func(t *testing.T) {
@@ -202,7 +201,7 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrdersUSMCGBLOC() {
 	})
 }
 
-func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithEmptyFields() {
+func (suite *MoveOrderServiceSuite) TestListMovesWithEmptyFields() {
 	expectedOrder := testdatagen.MakeDefaultOrder(suite.DB())
 
 	expectedOrder.Entitlement = nil
@@ -212,13 +211,13 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithEmptyFields() {
 	expectedOrder.OriginDutyStationID = nil
 	suite.MustSave(&expectedOrder)
 
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: expectedOrder,
 	})
 	// Only orders with shipments are returned, so we need to add a shipment
 	// to the move we just created
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrder,
+		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},
@@ -226,7 +225,7 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithEmptyFields() {
 	// Add a second shipment to make sure we only return 1 order even if its
 	// move has more than one shipment
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrder,
+		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},
@@ -234,23 +233,23 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithEmptyFields() {
 
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
-	moveOrders, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
+	moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
 
 	suite.FatalNoError(err)
-	suite.Nil(moveOrders)
+	suite.Nil(moves)
 
 }
 
-func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithPagination() {
+func (suite *MoveOrderServiceSuite) TestListMovesWithPagination() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 	for i := 0; i < 2; i++ {
-		expectedMoveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
+		expectedMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
 
 		// Only orders with shipments are returned, so we need to add a shipment
 		// to the move we just created
 		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			Move: expectedMoveTaskOrder,
+			Move: expectedMove,
 			MTOShipment: models.MTOShipment{
 				Status: models.MTOShipmentStatusSubmitted,
 			},
@@ -259,10 +258,10 @@ func (suite *MoveOrderServiceSuite) TestListMoveOrdersWithPagination() {
 
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
 	params := services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(1)}
-	moveOrders, count, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
+	moves, count, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 
 	suite.NoError(err)
-	suite.Equal(1, len(moveOrders))
+	suite.Equal(1, len(moves))
 	suite.Equal(2, count)
 
 }

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -185,18 +185,18 @@ func (suite *MoveOrderServiceSuite) TestListMovesUSMCGBLOC() {
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 		params := services.ListMoveOrderParams{PerPage: swag.Int64(2), Page: swag.Int64(1)}
-		moveOrders, _, err := moveOrderFetcher.ListMoveOrders(officeUserOooRah.ID, &params)
+		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUserOooRah.ID, &params)
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moveOrders))
-		suite.Equal(models.AffiliationMARINES, *moveOrders[0].ServiceMember.Affiliation)
+		suite.Equal(1, len(moves))
+		suite.Equal(models.AffiliationMARINES, *moves[0].Orders.ServiceMember.Affiliation)
 
 		params = services.ListMoveOrderParams{PerPage: swag.Int64(2), Page: swag.Int64(1)}
-		moveOrders, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
+		moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moveOrders))
-		suite.Equal(models.AffiliationARMY, *moveOrders[0].ServiceMember.Affiliation)
+		suite.Equal(1, len(moves))
+		suite.Equal(models.AffiliationARMY, *moves[0].Orders.ServiceMember.Affiliation)
 
 	})
 }


### PR DESCRIPTION
## Description

We want to sort by the move status, but we were sorting by the order
status. The easiest way to fix this is to have the query return moves
instead of orders.

The payload is returning a list of moves, and the UI also refers to
the list as a collection of moves. To avoid confusion, the DB query
should return moves as well.

## Reviewer Notes

1. Run `make db_dev_e2e_populate`
2. Sign in as a TOO
3. You should see 2 Submitted moves
4. Approve the shipments for one of them

Expected: You should see the Submitted move at the top

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5457) for this change

## Screenshots

