### PR TITLE
[MB-3605] Fixes UpdateMTOPostCounselingInfoHandler payload response

### DIFF
--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -116,6 +116,14 @@ func (o *moveTaskOrderUpdater) UpdatePostCounselingInfo(moveTaskOrderID uuid.UUI
 		return nil, services.NewNotFoundError(moveTaskOrderID, "while looking for moveTaskOrder.")
 	}
 
+	err = o.db.Q().Eager(
+		"Orders.NewDutyStation.Address",
+		"Orders.ServiceMember").Find(&moveTaskOrder, moveTaskOrderID)
+
+	if err != nil {
+		return nil, services.NewNotFoundError(moveTaskOrderID, "while looking for moveTaskOrder.")
+	}
+
 	estimatedWeight := unit.Pound(body.PpmEstimatedWeight)
 	moveTaskOrder.PPMType = &body.PpmType
 	moveTaskOrder.PPMEstimatedWeight = &estimatedWeight

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -107,18 +107,12 @@ type UpdateMoveTaskOrderQueryBuilder interface {
 func (o *moveTaskOrderUpdater) UpdatePostCounselingInfo(moveTaskOrderID uuid.UUID, body movetaskorderops.UpdateMTOPostCounselingInformationBody, eTag string) (*models.Move, error) {
 	var moveTaskOrder models.Move
 
-	queryFilters := []services.QueryFilter{
-		query.NewQueryFilter("id", "=", moveTaskOrderID),
-	}
-	err := o.builder.FetchOne(&moveTaskOrder, queryFilters)
-
-	if err != nil {
-		return nil, services.NewNotFoundError(moveTaskOrderID, "while looking for moveTaskOrder.")
-	}
-
-	err = o.db.Q().Eager(
+	err := o.db.Q().Eager(
 		"Orders.NewDutyStation.Address",
-		"Orders.ServiceMember").Find(&moveTaskOrder, moveTaskOrderID)
+		"Orders.ServiceMember",
+		"MTOShipments",
+		"PaymentRequests",
+	).Find(&moveTaskOrder, moveTaskOrderID)
 
 	if err != nil {
 		return nil, services.NewNotFoundError(moveTaskOrderID, "while looking for moveTaskOrder.")

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -100,7 +100,6 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 
 // UpdateMoveTaskOrderQueryBuilder is the query builder for updating MTO
 type UpdateMoveTaskOrderQueryBuilder interface {
-	FetchOne(model interface{}, filters []services.QueryFilter) error
 	UpdateOne(model interface{}, eTag *string) (*validate.Errors, error)
 }
 

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -1,0 +1,60 @@
+package movetaskorder_test
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/transcom/mymove/pkg/etag"
+	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	. "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCounselingInfo() {
+	expectedOrder := testdatagen.MakeDefaultOrder(suite.DB())
+	expectedMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Order: expectedOrder,
+	})
+
+	queryBuilder := query.NewQueryBuilder(suite.DB())
+	mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mtoserviceitem.NewMTOServiceItemCreator(queryBuilder))
+	body := movetaskorderops.UpdateMTOPostCounselingInformationBody{
+		PpmType:            "FULL",
+		PpmEstimatedWeight: 3000,
+		PointOfContact:     "user@prime.com",
+	}
+
+	suite.T().Run("MTO post counseling information is updated succesfully", func(t *testing.T) {
+		eTag := base64.StdEncoding.EncodeToString([]byte(expectedMTO.UpdatedAt.Format(time.RFC3339Nano)))
+
+		actualMTO, err := mtoUpdater.UpdatePostCounselingInfo(expectedMTO.ID, body, eTag)
+
+		suite.NoError(err)
+
+		suite.NotZero(expectedMTO.ID, actualMTO.ID)
+		suite.Equal(expectedMTO.Orders.ID, actualMTO.Orders.ID)
+		suite.NotZero(actualMTO.Orders)
+		suite.NotNil(expectedMTO.ReferenceID)
+		suite.NotNil(expectedMTO.Locator)
+		suite.Nil(expectedMTO.AvailableToPrimeAt)
+		suite.NotEqual(expectedMTO.Status, models.MoveStatusCANCELED)
+
+		suite.NotNil(expectedMTO.Orders.ServiceMember.FirstName)
+		suite.NotNil(expectedMTO.Orders.ServiceMember.LastName)
+		suite.NotNil(expectedMTO.Orders.NewDutyStation.Address.City)
+		suite.NotNil(expectedMTO.Orders.NewDutyStation.Address.State)
+	})
+
+	suite.T().Run("Etag is stale", func(t *testing.T) {
+		eTag := etag.GenerateEtag(time.Now())
+		_, err := mtoUpdater.UpdatePostCounselingInfo(expectedMTO.ID, body, eTag)
+
+		suite.Error(err)
+		suite.IsType(services.PreconditionFailedError{}, err)
+	})
+}


### PR DESCRIPTION
## Description

This PR introduces a fix to ensure that the API response for `UpdateMTOPostCounselingInfoHandler` includes `moveOrder.customer` and `moveOrder.destinationDutyStation`. Prior to this work, there were not values being returned for these attributes. 

## Reviewer Notes

In-line comments

## Setup

```
# Ensure tests are passing successfully
mylaptop ~ %: cd /mymove
mylaptop ~ %: make server_run
mylaptop ~ %: go test ./pkg/handlers/ghcapi --testify.m "TestMoveTaskOrderUpdater_UpdatePostCounselingInfo" -v 

# Ensure payload includes `moveOrder.customer` and `moveOrder.destinationDutyStation`
# Note: Substitute `moveTaskOrderID`and `etag`
curl --location --request PATCH 'https://primelocal:9443/prime/v1/move-task-orders/{moveTaskOrderID}/post-counseling-info' \
--header 'If-Match: {eTag}' \
--header 'Content-Type: application/json' \
--data-raw '{
    "ppmEstimatedWeight": 1500,
    "ppmType": "FULL"
}'
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3605) 

## Screenshots
![Screen Shot 2020-11-11 at 9 18 27 PM](https://user-images.githubusercontent.com/7574207/98887215-924fd600-2463-11eb-82e4-8ac2be551aaf.png)
