### PR TITLE
Refactor devseed for easier batch creation

### DIFF
--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -27,8 +27,11 @@ type devSeedScenario NamedScenario
 // DevSeedScenario Is the thing
 var DevSeedScenario = devSeedScenario{"dev_seed"}
 
-// Run does that data load thing
-func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, storer *storage.Filesystem) {
+var estimatedWeight = unit.Pound(1400)
+var actualWeight = unit.Pound(2000)
+var hhgMoveType = models.SelectedMoveTypeHHG
+
+func createPPMOfficeUser(db *pop.Connection) {
 	/*
 	 * Basic user with office access
 	 */
@@ -38,7 +41,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		log.Panic(fmt.Errorf("Failed to find RoleTypePPMOfficeUsers in the DB: %w", err))
 	}
 
-	email := "officeuser1@example.com"
+	email := "ppm_role@office.mil"
 	userID := uuid.Must(uuid.FromString("9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b"))
 	testdatagen.MakeOfficeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -53,35 +56,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			Active: true,
 		},
 	})
+}
 
-	/*
-	 * Service member with no uploaded orders
-	 */
-	email = "needs@orde.rs"
-	uuidStr := "feac0e92-66ec-4cab-ad29-538129bf918e"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("c52a9f13-ccc7-4c1b-b5ef-e1132a4f4db9"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("NEEDS"),
-			LastName:      models.StringPointer("ORDERS"),
-			PersonalEmail: models.StringPointer(email),
-		},
-	})
-
+func createPPMWithAdvance(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * Service member with uploaded orders and a new ppm
 	 */
-	email = "ppm@incomple.te"
-	uuidStr = "e10d5964-c070-49cb-9bd1-eaf9f7348eb6"
+	email := "ppm@incomple.te"
+	uuidStr := "e10d5964-c070-49cb-9bd1-eaf9f7348eb6"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString(uuidStr)),
@@ -113,12 +95,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	})
 	ppm0.Move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &ppm0.Move)
+}
 
+func createPPMWithNoAdvance(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * Service member with uploaded orders, a new ppm and no advance
 	 */
-	email = "ppm@advance.no"
-	uuidStr = "f0ddc118-3f7e-476b-b8be-0f964a5feee2"
+	email := "ppm@advance.no"
+	uuidStr := "f0ddc118-3f7e-476b-b8be-0f964a5feee2"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString(uuidStr)),
@@ -146,152 +130,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	})
 	ppmNoAdvance.Move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &ppmNoAdvance.Move)
+}
 
-	/*
-	 * office user finds the move: office user completes storage panel
-	 */
-	email = "office.user.completes@storage.panel"
-	uuidStr = "ebac4efd-c980-48d6-9cce-99fb34644789"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	ppmStorage := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("76eb1c93-16f7-4c8e-a71c-67d5c9093dd3"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Storage"),
-			LastName:      models.StringPointer("Panel"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("25fb9bf6-2a38-4463-8247-fce2a5571ab7"),
-			Locator: "STORAG",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &nextValidMoveDate,
-		},
-		UserUploader: userUploader,
-	})
-	ppmStorage.Move.Submit(time.Now())
-	ppmStorage.Move.Approve()
-	ppmStorage.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppmStorage.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	ppmStorage.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmStorage.Move)
-
-	/*
-	 * office user finds the move: office user cancels storage panel
-	 */
-	email = "office.user.cancelss@storage.panel"
-	uuidStr = "cbb56f00-97f7-4d20-83cf-25a7b2f150b6"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	ppmNoStorage := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("b9673e29-ac8d-4945-abc2-36f8eafd6fd8"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Storage"),
-			LastName:      models.StringPointer("Panel"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("9d0409b8-3587-4fad-9caf-7fc853e1c001"),
-			Locator: "NOSTRG",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &nextValidMoveDate,
-		},
-		UserUploader: userUploader,
-	})
-	ppmNoStorage.Move.Submit(time.Now())
-	ppmNoStorage.Move.Approve()
-	ppmNoStorage.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppmNoStorage.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	ppmNoStorage.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmNoStorage.Move)
-
-	/*
-	 * A move, that will be canceled by the E2E test
-	 */
-	email = "ppm-to-cancel@example.com"
-	uuidStr = "e10d5964-c070-49cb-9bd1-eaf9f7348eb7"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	ppmToCancel := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("94ced723-fabc-42af-b9ee-87f8986bb5ca"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("Submitted"),
-			Edipi:         models.StringPointer("1234567890"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("0db80bd6-de75-439e-bf89-deaafa1d0dc9"),
-			Locator: "CANCEL",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &nextValidMoveDate,
-		},
-		UserUploader: userUploader,
-	})
-	ppmToCancel.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &ppmToCancel.Move)
-
-	/*
-	 * Service member with a ppm in progress
-	 */
-	email = "ppm.on@progre.ss"
-	uuidStr = "20199d12-5165-4980-9ca7-19b5dc9f1032"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	pastTime := nextValidMoveDateMinusTen
-	ppm1 := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("466c41b9-50bf-462c-b3cd-1ae33a2dad9b"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("In Progress"),
-			Edipi:         models.StringPointer("1617033988"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("c9df71f2-334f-4f0e-b2e7-050ddb22efa1"),
-			Locator: "GBXYUI",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &pastTime,
-		},
-		UserUploader: userUploader,
-	})
-	ppm1.Move.Submit(time.Now())
-	ppm1.Move.Approve()
-	models.SaveMoveDependencies(db, &ppm1.Move)
-
+func createPPMWithPaymentRequest(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * Service member with a ppm move with payment requested
 	 */
-	email = "ppm@paymentrequest.ed"
-	uuidStr = "1842091b-b9a0-4d4a-ba22-1e2f38f26317"
+	email := "ppm@paymentrequest.ed"
+	uuidStr := "1842091b-b9a0-4d4a-ba22-1e2f38f26317"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString(uuidStr)),
@@ -333,152 +179,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	ppm2.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppm2.Move.PersonallyProcuredMoves[0].RequestPayment()
 	models.SaveMoveDependencies(db, &ppm2.Move)
+}
 
-	/*
-	 * Service member with a ppm move that has requested payment
-	 */
-	email = "ppmpayment@request.ed"
-	uuidStr = "beccca28-6e15-40cc-8692-261cae0d4b14"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	// Date picked essentially at random, but needs to be within TestYear
-	originalMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
-	actualMoveDate := time.Date(testdatagen.TestYear, time.November, 11, 10, 0, 0, 0, time.UTC)
-	moveTypeDetail := internalmessages.OrdersTypeDetailPCSTDY
-	ppm3 := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("3c24bab5-fd13-4057-a321-befb97d90c43"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("Payment Requested"),
-			Edipi:         models.StringPointer("7617033988"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		// These values should be populated for an approved move
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("12345"),
-			OrdersTypeDetail:    &moveTypeDetail,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("d6b8980d-6f88-41be-9ae2-1abcbd2574bc"),
-			Locator: "PAYMNT",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &originalMoveDate,
-			ActualMoveDate:   &actualMoveDate,
-		},
-		UserUploader: userUploader,
-	})
-	docAssertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
-			MoveID:                   ppm3.Move.ID,
-			Move:                     ppm3.Move,
-			PersonallyProcuredMoveID: &ppm3.ID,
-			Status:                   "AWAITING_REVIEW",
-			MoveDocumentType:         "WEIGHT_TICKET",
-		},
-		Document: models.Document{
-			ID:              uuid.FromStringOrNil("c26421b0-e4c3-446b-88f3-493bb25c1756"),
-			ServiceMemberID: ppm3.Move.Orders.ServiceMember.ID,
-			ServiceMember:   ppm3.Move.Orders.ServiceMember,
-		},
-	}
-	testdatagen.MakeMoveDocument(db, docAssertions)
-	ppm3.Move.Submit(time.Now())
-	ppm3.Move.Approve()
-	// This is the same PPM model as ppm3, but this is the one that will be saved by SaveMoveDependencies
-	ppm3.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppm3.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	ppm3.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppm3.Move)
-
-	/*
-	 * Service member with a ppm move that has requested payment
-	 */
-
-	email = "ppm.excludecalculations.expenses"
-	uuidStr = "4f092d53-9005-4371-814d-0c88e970d2f7"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	// Date picked essentialy at random, but needs to be within TestYear
-	originalMoveDate = time.Date(testdatagen.TestYear, time.December, 10, 23, 0, 0, 0, time.UTC)
-	actualMoveDate = time.Date(testdatagen.TestYear, time.December, 11, 10, 0, 0, 0, time.UTC)
-	moveTypeDetail = internalmessages.OrdersTypeDetailPCSTDY
-	assertions := testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("350f0450-1cb8-4aa8-8a85-2d0f45899447"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("Payment Requested"),
-			Edipi:         models.StringPointer("5427033988"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		// These values should be populated for an approved move
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("12345"),
-			OrdersTypeDetail:    &moveTypeDetail,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("687e3ee4-62ff-44b3-a5cb-73338c9fdf95"),
-			Locator: "PMTRVW",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			ID:               uuid.FromStringOrNil("38c4fc15-062f-4325-bceb-13ea167001da"),
-			OriginalMoveDate: &originalMoveDate,
-			ActualMoveDate:   &actualMoveDate,
-		},
-		UserUploader: userUploader,
-	}
-	ppmExcludedCalculations := testdatagen.MakePPM(db, assertions)
-
-	ppmExcludedCalculations.Move.Submit(time.Now())
-	ppmExcludedCalculations.Move.Approve()
-	// This is the same PPM model as ppm3, but this is the one that will be saved by SaveMoveDependencies
-	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmExcludedCalculations.Move)
-
-	testdatagen.MakeMoveDocument(db, testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
-			MoveID:                   ppmExcludedCalculations.Move.ID,
-			Move:                     ppmExcludedCalculations.Move,
-			MoveDocumentType:         models.MoveDocumentTypeEXPENSE,
-			Status:                   models.MoveDocumentStatusAWAITINGREVIEW,
-			PersonallyProcuredMoveID: &assertions.PersonallyProcuredMove.ID,
-			Title:                    "Expense Document",
-			ID:                       uuid.FromStringOrNil("02021626-20ee-4c65-9194-87e6455f385e"),
-		},
-	})
-
-	testdatagen.MakeMovingExpenseDocument(db, testdatagen.Assertions{
-		MovingExpenseDocument: models.MovingExpenseDocument{
-			MoveDocumentID:       uuid.FromStringOrNil("02021626-20ee-4c65-9194-87e6455f385e"),
-			MovingExpenseType:    models.MovingExpenseTypeCONTRACTEDEXPENSE,
-			PaymentMethod:        "GTCC",
-			RequestedAmountCents: unit.Cents(10000),
-		},
-	})
-
+func createCanceledPPM(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * A PPM move that has been canceled.
 	 */
-	email = "ppm-canceled@example.com"
-	uuidStr = "20102768-4d45-449c-a585-81bc386204b1"
+	email := "ppm-canceled@example.com"
+	uuidStr := "20102768-4d45-449c-a585-81bc386204b1"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString(uuidStr)),
@@ -508,46 +216,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	models.SaveMoveDependencies(db, &ppmCanceled.Move)
 	ppmCanceled.Move.Cancel("reasons")
 	models.SaveMoveDependencies(db, &ppmCanceled.Move)
+}
 
-	/*
-	 * Service member with orders and a move
-	 */
-	email = "profile@comple.te"
-	uuidStr = "13f3949d-0d53-4be4-b1b1-ae4314793f34"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("0a1e72b0-1b9f-442b-a6d3-7b7cfa6bbb95"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Profile"),
-			LastName:      models.StringPointer("Complete"),
-			Edipi:         models.StringPointer("8893308161"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Order: models.Order{
-			HasDependents:    true,
-			SpouseHasProGear: true,
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("173da49c-fcec-4d01-a622-3651e81c654e"),
-			Locator: "BLABLA",
-			Status:  models.MoveStatusSUBMITTED,
-		},
-		UserUploader: userUploader,
-	})
-
+func createServiceMemberWithOrdersButNoMoveType(db *pop.Connection) {
 	/*
 	 * A service member with orders and a move, but no move type selected
 	 */
-	email = "sm_no_move_type@example.com"
-	uuidStr = "9ceb8321-6a82-4f6d-8bb3-a1d85922a202"
+	email := "sm_no_move_type@example.com"
+	uuidStr := "9ceb8321-6a82-4f6d-8bb3-a1d85922a202"
 
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -571,12 +247,39 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			Locator: "ZPGVED",
 		},
 	})
+}
 
+func createServiceMemberWithNoUploadedOrders(db *pop.Connection) {
+	/*
+	 * Service member with no uploaded orders
+	 */
+	email := "needs@orde.rs"
+	uuidStr := "feac0e92-66ec-4cab-ad29-538129bf918e"
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovEmail: email,
+			Active:        true,
+		},
+	})
+
+	testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("c52a9f13-ccc7-4c1b-b5ef-e1132a4f4db9"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("NEEDS"),
+			LastName:      models.StringPointer("ORDERS"),
+			PersonalEmail: models.StringPointer(email),
+		},
+	})
+}
+
+func createMoveWithPPMAndHHG(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * A service member with orders and a submitted move with a ppm and hhg
 	 */
-	email = "combo@ppm.hhg"
-	uuidStr = "6016e423-f8d5-44ca-98a8-af03c8445c94"
+	email := "combo@ppm.hhg"
+	uuidStr := "6016e423-f8d5-44ca-98a8-af03c8445c94"
 
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -598,7 +301,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 	// currently don't have "combo move" selection option, so testing ppm office when type is HHG
-	selectedMoveType := models.SelectedMoveTypeHHG
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Order: models.Order{
 			ServiceMemberID: uuid.FromStringOrNil(smIDCombo),
@@ -607,7 +309,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("7024c8c5-52ca-4639-bf69-dd8238308c98"),
 			Locator:          "COMBOS",
-			SelectedMoveType: &selectedMoveType,
+			SelectedMoveType: &hhgMoveType,
 		},
 	})
 
@@ -664,12 +366,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	move.PersonallyProcuredMoves = models.PersonallyProcuredMoves{ppm}
 	move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &move)
+}
 
+func createUnsubmittedHHGMove(db *pop.Connection) {
 	/*
 	 * A service member with an hhg only, unsubmitted move
 	 */
-	email = "hhg@only.unsubmitted"
-	uuidStr = "f08146cf-4d6b-43d5-9ca5-c8d239d37b3e"
+	email := "hhg@only.unsubmitted"
+	uuidStr := "f08146cf-4d6b-43d5-9ca5-c8d239d37b3e"
 
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -691,8 +395,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 
-	selectedMoveType = models.SelectedMoveTypeHHG
-	move = testdatagen.MakeMove(db, testdatagen.Assertions{
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Order: models.Order{
 			ServiceMemberID: uuid.FromStringOrNil(smWithHHGID),
 			ServiceMember:   smWithHHG,
@@ -700,12 +403,12 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("3a8c9f4f-7344-4f18-9ab5-0de3ef57b901"),
 			Locator:          "ONEHHG",
-			SelectedMoveType: &selectedMoveType,
+			SelectedMoveType: &hhgMoveType,
 		},
 	})
 
-	estimatedHHGWeight = unit.Pound(1400)
-	actualHHGWeight = unit.Pound(2000)
+	estimatedHHGWeight := unit.Pound(1400)
+	actualHHGWeight := unit.Pound(2000)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
 			ID:                   uuid.FromStringOrNil("b67157bd-d2eb-47e2-94b6-3bc90f6fb8fe"),
@@ -718,12 +421,14 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			MoveTaskOrderID:      move.ID,
 		},
 	})
+}
 
+func createUnsubmittedMoveWithNTSAndNTSR(db *pop.Connection) {
 	/*
 	 * A service member with an NTS, NTS-R shipment, & unsubmitted move
 	 */
-	email = "nts@ntsr.unsubmitted"
-	uuidStr = "583cfbe1-cb34-4381-9e1f-54f68200da1b"
+	email := "nts@ntsr.unsubmitted"
+	uuidStr := "583cfbe1-cb34-4381-9e1f-54f68200da1b"
 
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -745,8 +450,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 
-	selectedMoveType = models.SelectedMoveTypeNTS
-	move = testdatagen.MakeMove(db, testdatagen.Assertions{
+	selectedMoveType := models.SelectedMoveTypeNTS
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Order: models.Order{
 			ServiceMemberID: uuid.FromStringOrNil(smWithNTSID),
 			ServiceMember:   smWithNTS,
@@ -802,61 +507,17 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			MTOAgentType:  models.MTOAgentReceiving,
 		},
 	})
+}
 
-	/*
-	* Creates two valid, unclaimed access codes
-	 */
-	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
-		AccessCode: models.AccessCode{
-			Code:     "X3FQJK",
-			MoveType: models.SelectedMoveTypeHHG,
-		},
-	})
-	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
-		AccessCode: models.AccessCode{
-			Code:     "ABC123",
-			MoveType: models.SelectedMoveTypePPM,
-		},
-	})
-	email = "accesscode@mail.com"
-	uuidStr = "1dc93d47-0f3e-4686-9dcf-5d940d0d3ed9"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	sm := models.ServiceMember{
-		ID:            uuid.FromStringOrNil("09229b74-6da8-47d0-86b7-7c91e991b970"),
-		UserID:        uuid.FromStringOrNil(uuidStr),
-		FirstName:     models.StringPointer("Claimed"),
-		LastName:      models.StringPointer("Access Code"),
-		Edipi:         models.StringPointer("163105198"),
-		PersonalEmail: models.StringPointer(email),
-	}
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: sm,
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("7201788b-92f4-430b-8541-6430b2cc7f3e"),
-			Locator: "CLAIMD",
-		},
-		UserUploader: userUploader,
-	})
-	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
-		AccessCode: models.AccessCode{
-			Code:            "ZYX321",
-			MoveType:        models.SelectedMoveTypePPM,
-			ServiceMember:   sm,
-			ServiceMemberID: &sm.ID,
-		},
-	})
-
+func createPPMReadyToRequestPayment(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * Service member with a ppm ready to request payment
 	 */
-	email = "ppm@requestingpayment.newflow"
-	uuidStr = "745e0eba-4028-4c78-a262-818b00802748"
+	email := "ppm@requestingpayment.newflow"
+	uuidStr := "745e0eba-4028-4c78-a262-818b00802748"
+	typeDetail := internalmessages.OrdersTypeDetailPCSTDY
+	pastTime := nextValidMoveDateMinusTen
+
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString(uuidStr)),
@@ -894,347 +555,28 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	ppm6.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm6.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	models.SaveMoveDependencies(db, &ppm6.Move)
+}
 
-	/*
-	 * Service member with a ppm ready to request payment
-	 */
-	email = "ppm@continue.requestingpayment"
-	uuidStr = "4ebc03b7-c801-4c0d-806c-a95aed242102"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	ppm7 := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("0cfb9fc6-82dd-404b-aa39-4deb6dba6c66"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("ContinueRequesting"),
-			Edipi:         models.StringPointer("6737033007"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		// These values should be populated for an approved move
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("62149"),
-			OrdersTypeDetail:    &typeDetail,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("0581253d-0539-4a93-b1b6-ea4ad384f0c5"),
-			Locator: "RQPAY3",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &pastTime,
-		},
-		UserUploader: userUploader,
-	})
-	ppm7.Move.Submit(time.Now())
-	ppm7.Move.Approve()
-	ppm7.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppm7.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppm7.Move)
-
-	/*
-	 * Service member with a ppm ready to request payment
-	 */
-	email = "ppm@requestingpay.ment"
-	uuidStr = "8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	ppm5 := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("ff1f56c0-544e-4109-8168-f91ebcbbb878"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("RequestingPay"),
-			Edipi:         models.StringPointer("6737033988"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		// These values should be populated for an approved move
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("62341"),
-			OrdersTypeDetail:    &typeDetail,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("946a5d40-0636-418f-b457-474915fb0149"),
-			Locator: "REQPAY",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &pastTime,
-		},
-		UserUploader: userUploader,
-	})
-	ppm5.Move.Submit(time.Now())
-	ppm5.Move.Approve()
-	// This is the same PPM model as ppm5, but this is the one that will be saved by SaveMoveDependencies
-	ppm5.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppm5.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppm5.Move)
-
-	/*
-	 * Service member with a ppm move approved, but not in progress
-	 */
-	email = "ppm@approv.ed"
-	uuidStr = "70665111-7bbb-4876-a53d-18bb125c943e"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-	inProgressDate := nextValidMoveDatePlusTen
-	typeDetails := internalmessages.OrdersTypeDetailPCSTDY
-	ppmApproved := testdatagen.MakePPM(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("acfed739-9e7a-4d95-9a56-698ef0392500"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("PPM"),
-			LastName:      models.StringPointer("Approved"),
-			Edipi:         models.StringPointer("7617044099"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		// These values should be populated for an approved move
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("12345"),
-			OrdersTypeDetail:    &typeDetails,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("bd3d46b3-cb76-40d5-a622-6ada239e5504"),
-			Locator: "APPROV",
-		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate: &inProgressDate,
-		},
-		UserUploader: userUploader,
-	})
-	ppmApproved.Move.Submit(time.Now())
-	ppmApproved.Move.Approve()
-	// This is the same PPM model as ppm2, but this is the one that will be saved by SaveMoveDependencies
-	ppmApproved.Move.PersonallyProcuredMoves[0].Submit(time.Now())
-	ppmApproved.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppmApproved.Move)
-
-	/*
-	 * Another service member with orders and a move
-	 */
-	email = "profile@co.mple.te"
-	uuidStr = "99360a51-8cfa-4e25-ae57-24e66077305f"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("2672baac-53a1-4767-b4a3-976e53cc224e"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Another Profile"),
-			LastName:      models.StringPointer("Complete"),
-			Edipi:         models.StringPointer("8893105161"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Order: models.Order{
-			HasDependents:    true,
-			SpouseHasProGear: true,
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("6f6ac599-e23f-43af-9b83-5d75a78e933f"),
-			Locator: "COMPLE",
-		},
-		UserUploader: userUploader,
-	})
-
-	email = "profile@complete.draft"
-	uuidStr = "3b9360a3-3304-4c60-90f4-83d687884070"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("0ec71d80-ac21-45a7-88ed-2ae8de3961fd"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Move"),
-			LastName:      models.StringPointer("Draft"),
-			Edipi:         models.StringPointer("8893308161"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Order: models.Order{
-			HasDependents:    true,
-			SpouseHasProGear: true,
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("a5d9c7b2-0fe8-4b80-b7c5-3323a066e98c"),
-			Locator: "DFTMVE",
-		},
-		UserUploader: userUploader,
-	})
-
-	email = "profile2@complete.draft"
-	uuidStr = "3b9360a3-3304-4c60-90f4-83d687884077"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("0ec71d80-ac21-45a7-88ed-2ae8de3961ff"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Move"),
-			LastName:      models.StringPointer("Draft"),
-			Edipi:         models.StringPointer("8893308163"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Order: models.Order{
-			HasDependents:    true,
-			SpouseHasProGear: true,
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("a5d9c7b2-0fe8-4b80-b7c5-3323a066e98a"),
-			Locator: "TEST13",
-		},
-		UserUploader: userUploader,
-	})
-
-	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b63"),
-		},
-	})
+func createHHGMoveWithPaymentRequest(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger) {
+	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{})
 	orders := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
-			ID:              uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4988"),
 			ServiceMemberID: customer.ID,
 			ServiceMember:   customer,
 		},
 		UserUploader: userUploader,
 	})
-	mtoSelectedMoveType := models.SelectedMoveTypeHHG
 	mto := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
-			Locator:          "TEST12",
-			ID:               uuid.FromStringOrNil("5d4b25bb-eb04-4c03-9a81-ee0398cb779e"),
 			Status:           models.MoveStatusSUBMITTED,
 			OrdersID:         orders.ID,
 			Orders:           orders,
-			SelectedMoveType: &mtoSelectedMoveType,
+			SelectedMoveType: &hhgMoveType,
 		},
 	})
 
-	customer2 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("a5cc1277-37dd-4588-a982-df3c9fa7fc20"),
-		},
-	})
-	orders2 := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ID:              uuid.FromStringOrNil("42f9cd3b-d630-4762-9762-542e9a3a67e4"),
-			ServiceMemberID: customer2.ID,
-			ServiceMember:   customer2,
-		},
-		UserUploader: userUploader,
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			ID:       uuid.FromStringOrNil("302f3509-562c-4f5c-81c5-b770f4af30e8"),
-			OrdersID: orders2.ID,
-		},
-	})
-
-	customer3 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("08606458-cee9-4529-a2e6-9121e67dac72"),
-		},
-	})
-	orders3 := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ID:              uuid.FromStringOrNil("eb6b0c75-3972-4a09-a453-3a7b257aa7f7"),
-			ServiceMemberID: customer3.ID,
-			ServiceMember:   customer3,
-		},
-		UserUploader: userUploader,
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			ID:       uuid.FromStringOrNil("a97557cd-ec31-4f00-beed-01ac6e4c0976"),
-			OrdersID: orders3.ID,
-		},
-	})
-
-	customer4 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("1a13ee6b-3e21-4170-83bc-0d41f60edb99"),
-		},
-	})
-	orders4 := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ID:              uuid.FromStringOrNil("8779beda-f69a-43bf-8606-ebd22973d474"),
-			ServiceMemberID: customer4.ID,
-			ServiceMember:   customer4,
-		},
-		UserUploader: userUploader,
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			ID:       uuid.FromStringOrNil("c251267f-dbe1-42b9-8239-4f628fa7279f"),
-			OrdersID: orders4.ID,
-		},
-	})
-
-	customer5 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("25a90fef-301e-4682-9758-60f0c76ea8b4"),
-		},
-	})
-	orders5 := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ID:              uuid.FromStringOrNil("f2473488-2504-4872-a6b6-dd385dad4bf9"),
-			ServiceMemberID: customer5.ID,
-			ServiceMember:   customer5,
-		},
-		UserUploader: userUploader,
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			ID:       uuid.FromStringOrNil("2b485ded-a395-4dbb-9aa7-3f902dd4ccea"),
-			OrdersID: orders5.ID,
-		},
-	})
-
-	estimatedWeight := unit.Pound(1400)
-	actualWeight := unit.Pound(2000)
 	MTOShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		MTOShipment: models.MTOShipment{
-			ID:                   uuid.FromStringOrNil("475579d5-aaa4-4755-8c43-c510381ff9b5"),
 			PrimeEstimatedWeight: &estimatedWeight,
 			PrimeActualWeight:    &actualWeight,
 			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
@@ -1246,7 +588,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
 		MTOAgent: models.MTOAgent{
-			ID:            uuid.FromStringOrNil("d73cc488-d5a1-4c9c-bea3-8b02d9bd0dea"),
 			MTOShipment:   MTOShipment,
 			MTOShipmentID: MTOShipment.ID,
 			FirstName:     swag.String("Test"),
@@ -1258,7 +599,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	paymentRequest := testdatagen.MakePaymentRequest(db, testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
-			ID:            uuid.FromStringOrNil("a2c34dba-015f-4f96-a38b-0c0b9272e208"),
 			MoveTaskOrder: mto,
 			IsFinal:       false,
 			Status:        models.PaymentRequestStatusPending,
@@ -1268,9 +608,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	dcrtCost := unit.Cents(99999)
 	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			ID: uuid.FromStringOrNil("998caacf-ab9e-496e-8cf2-360723eb3e2d"),
-		},
 		Move:        mto,
 		MTOShipment: MTOShipment,
 		ReService: models.ReService{
@@ -1288,9 +625,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	ducrtCost := unit.Cents(99999)
 	mtoServiceItemDUCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			ID: uuid.FromStringOrNil("eeb82080-0a83-46b8-938c-63c7b73a7e45"),
-		},
 		Move:        mto,
 		MTOShipment: MTOShipment,
 		ReService: models.ReService{
@@ -1313,7 +647,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	primeContractor := uuid.FromStringOrNil("5db13bb4-6d29-4bdb-bc81-262f4513ecf6")
 	testdatagen.MakePrimeUpload(db, testdatagen.Assertions{
 		PrimeUpload: models.PrimeUpload{
-			ID:                  uuid.FromStringOrNil("18413213-0aaf-4eb1-8d7f-1b557a4e425b"),
 			ProofOfServiceDoc:   proofOfService,
 			ProofOfServiceDocID: proofOfService.ID,
 			Contractor: models.Contractor{
@@ -1342,7 +675,11 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		logger.Error("errors encountered saving test.png prime upload", zap.Error(err))
 	}
 
+}
+
+func createHHGMoveWith10ServiceItems(db *pop.Connection, userUploader *uploader.UserUploader) {
 	msCost := unit.Cents(10000)
+
 	customer8 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID: uuid.FromStringOrNil("9e8da3c7-ffe5-4f7f-b45a-8f01ccc56591"),
@@ -1359,8 +696,10 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	move8 := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
-			ID:       uuid.FromStringOrNil("d4d95b22-2d9d-428b-9a11-284455aa87ba"),
-			OrdersID: orders8.ID,
+			ID:               uuid.FromStringOrNil("d4d95b22-2d9d-428b-9a11-284455aa87ba"),
+			OrdersID:         orders8.ID,
+			Status:           models.MoveStatusSUBMITTED,
+			SelectedMoveType: &hhgMoveType,
 		},
 	})
 
@@ -1638,7 +977,9 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			Width:  2500,
 		},
 	})
+}
 
+func createHHGMoveWith2PaymentRequests(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/* Customer with two payment requests */
 	customer7 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -1660,6 +1001,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			ID:                 uuid.FromStringOrNil("99783f4d-ee83-4fc9-8e0c-d32496bef32b"),
 			OrdersID:           orders7.ID,
 			AvailableToPrimeAt: swag.Time(time.Now()),
+			Status:             models.MoveStatusSUBMITTED,
+			SelectedMoveType:   &hhgMoveType,
 		},
 	})
 
@@ -1698,7 +1041,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	})
 
 	// for soft deleted proof of service docs
-	proofOfService = testdatagen.MakeProofOfServiceDoc(db, testdatagen.Assertions{
+	proofOfService := testdatagen.MakeProofOfServiceDoc(db, testdatagen.Assertions{
 		PaymentRequest: paymentRequest7,
 	})
 
@@ -1727,6 +1070,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 
+	msCost := unit.Cents(10000)
+
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
 			PriceCents: &msCost,
@@ -1744,6 +1089,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			ID: uuid.FromStringOrNil("8d600f25-1def-422d-b159-617c7d59156e"), // DLH - Domestic Linehaul
 		},
 	})
+
+	dlhCost := unit.Cents(99999)
 
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
@@ -1776,12 +1123,26 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 
+	csCost := unit.Cents(25000)
+
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
 			PriceCents: &csCost,
 		},
 		PaymentRequest: additionalPaymentRequest7,
 		MTOServiceItem: serviceItemCS7,
+	})
+
+	MTOShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			ID:                   uuid.FromStringOrNil("475579d5-aaa4-4755-8c43-c510381ff9b5"),
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
+			ApprovedDate:         swag.Time(time.Now()),
+			Status:               models.MTOShipmentStatusSubmitted,
+		},
+		Move: mto7,
 	})
 
 	serviceItemFSC7 := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
@@ -1795,6 +1156,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		},
 	})
 
+	fscCost := unit.Cents(55555)
+
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
 			PriceCents: &fscCost,
@@ -1802,32 +1165,17 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		PaymentRequest: additionalPaymentRequest7,
 		MTOServiceItem: serviceItemFSC7,
 	})
+}
 
-	/* A user with Roles */
-	smRole := roles.Role{}
-	err = db.Where("role_type = $1", roles.RoleTypeCustomer).First(&smRole)
-	if err != nil {
-		log.Panic(fmt.Errorf("Failed to find RoleTypeCustomer in the DB: %w", err))
-	}
-	email = "role_tester@service.mil"
-	uuidStr = "3b9360a3-3304-4c60-90f4-83d687884079"
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-			Active:        true,
-			Roles:         []roles.Role{smRole},
-		},
-	})
-
+func createTOO(db *pop.Connection) {
 	/* A user with too role */
 	tooRole := roles.Role{}
-	err = db.Where("role_type = $1", roles.RoleTypeTOO).First(&tooRole)
+	err := db.Where("role_type = $1", roles.RoleTypeTOO).First(&tooRole)
 	if err != nil {
 		log.Panic(fmt.Errorf("Failed to find RoleTypeTOO in the DB: %w", err))
 	}
 
-	email = "too_role@office.mil"
+	email := "too_role@office.mil"
 	tooUUID := uuid.Must(uuid.FromString("dcf86235-53d3-43dd-8ee8-54212ae3078f"))
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -1845,15 +1193,17 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			UserID: &tooUUID,
 		},
 	})
+}
 
+func createTIO(db *pop.Connection) {
 	/* A user with tio role */
 	tioRole := roles.Role{}
-	err = db.Where("role_type = $1", roles.RoleTypeTIO).First(&tioRole)
+	err := db.Where("role_type = $1", roles.RoleTypeTIO).First(&tioRole)
 	if err != nil {
 		log.Panic(fmt.Errorf("Failed to find RoleTypeTIO in the DB: %w", err))
 	}
 
-	email = "tio_role@office.mil"
+	email := "tio_role@office.mil"
 	tioUUID := uuid.Must(uuid.FromString("3b2cc1b0-31a2-4d1b-874f-0591f9127374"))
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -1871,9 +1221,23 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			UserID: &tioUUID,
 		},
 	})
+}
 
+func createTXO(db *pop.Connection) {
 	/* A user with both too and tio roles */
-	email = "too_tio_role@office.mil"
+	email := "too_tio_role@office.mil"
+	tooRole := roles.Role{}
+	err := db.Where("role_type = $1", roles.RoleTypeTOO).First(&tooRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("Failed to find RoleTypeTOO in the DB: %w", err))
+	}
+
+	tioRole := roles.Role{}
+	err = db.Where("role_type = $1", roles.RoleTypeTIO).First(&tioRole)
+	if err != nil {
+		log.Panic(fmt.Errorf("Failed to find RoleTypeTIO in the DB: %w", err))
+	}
+
 	tooTioUUID := uuid.Must(uuid.FromString("9bda91d2-7a0c-4de1-ae02-b8cf8b4b858b"))
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -1891,111 +1255,119 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			UserID: &tooTioUUID,
 		},
 	})
+}
 
-	// A more recent MTO for demonstrating the since parameter
-	customer6 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
-		},
-	})
-	orders6 := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ID:              uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4981"),
-			ServiceMemberID: customer6.ID,
-			ServiceMember:   customer6,
-		},
-		UserUploader: userUploader,
-	})
-	mto2 := testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move: models.Move{
-			ID:                 uuid.FromStringOrNil("da3f34cc-fb94-4e0b-1c90-ba3333cb7791"),
-			OrdersID:           orders6.ID,
-			UpdatedAt:          time.Unix(1576779681256, 0),
-			AvailableToPrimeAt: swag.Time(time.Now()),
-		},
-	})
+// func createRecentlyUpdatedHHGMove(db *pop.Connection, userUploader *uploader.UserUploader) {
+// 	// A more recent MTO for demonstrating the since parameter
+// 	customer6 := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
+// 		ServiceMember: models.ServiceMember{
+// 			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
+// 		},
+// 	})
+// 	orders6 := testdatagen.MakeOrder(db, testdatagen.Assertions{
+// 		Order: models.Order{
+// 			ID:              uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4981"),
+// 			ServiceMemberID: customer6.ID,
+// 			ServiceMember:   customer6,
+// 		},
+// 		UserUploader: userUploader,
+// 	})
+// 	mto2 := testdatagen.MakeMove(db, testdatagen.Assertions{
+// 		Move: models.Move{
+// 			ID:                 uuid.FromStringOrNil("da3f34cc-fb94-4e0b-1c90-ba3333cb7791"),
+// 			OrdersID:           orders6.ID,
+// 			UpdatedAt:          time.Unix(1576779681256, 0),
+// 			AvailableToPrimeAt: swag.Time(time.Now()),
+// 			Status:             models.MoveStatusSUBMITTED,
+// 			SelectedMoveType:   &hhgMoveType,
+// 		},
+// 	})
 
-	mtoShipment2 := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		Move: mto2,
-	})
+// 	mtoShipment2 := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+// 		Move: mto2,
+// 	})
 
-	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		Move: mto2,
-	})
+// 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+// 		Move: mto2,
+// 	})
 
-	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
-		MTOAgent: models.MTOAgent{
-			MTOShipment:   mtoShipment2,
-			MTOShipmentID: mtoShipment2.ID,
-			FirstName:     swag.String("Test"),
-			LastName:      swag.String("Agent"),
-			Email:         swag.String("test@test.email.com"),
-			MTOAgentType:  models.MTOAgentReleasing,
-		},
-	})
+// 	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
+// 		MTOAgent: models.MTOAgent{
+// 			MTOShipment:   mtoShipment2,
+// 			MTOShipmentID: mtoShipment2.ID,
+// 			FirstName:     swag.String("Test"),
+// 			LastName:      swag.String("Agent"),
+// 			Email:         swag.String("test@test.email.com"),
+// 			MTOAgentType:  models.MTOAgentReleasing,
+// 		},
+// 	})
 
-	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
-		MTOAgent: models.MTOAgent{
-			MTOShipment:   mtoShipment2,
-			MTOShipmentID: mtoShipment2.ID,
-			FirstName:     swag.String("Test"),
-			LastName:      swag.String("Agent"),
-			Email:         swag.String("test@test.email.com"),
-			MTOAgentType:  models.MTOAgentReceiving,
-		},
-	})
+// 	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
+// 		MTOAgent: models.MTOAgent{
+// 			MTOShipment:   mtoShipment2,
+// 			MTOShipmentID: mtoShipment2.ID,
+// 			FirstName:     swag.String("Test"),
+// 			LastName:      swag.String("Agent"),
+// 			Email:         swag.String("test@test.email.com"),
+// 			MTOAgentType:  models.MTOAgentReceiving,
+// 		},
+// 	})
 
-	mtoShipment3 := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		MTOShipment: models.MTOShipment{
-			ShipmentType: models.MTOShipmentTypeHHGIntoNTSDom,
-		},
-		Move: mto2,
-	})
+// 	mtoShipment3 := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+// 		MTOShipment: models.MTOShipment{
+// 			ShipmentType: models.MTOShipmentTypeHHGIntoNTSDom,
+// 		},
+// 		Move: mto2,
+// 	})
 
-	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
-		MTOAgent: models.MTOAgent{
-			MTOShipment:   mtoShipment3,
-			MTOShipmentID: mtoShipment3.ID,
-			FirstName:     swag.String("Test"),
-			LastName:      swag.String("Agent"),
-			Email:         swag.String("test@test.email.com"),
-			MTOAgentType:  models.MTOAgentReleasing,
-		},
-	})
+// 	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
+// 		MTOAgent: models.MTOAgent{
+// 			MTOShipment:   mtoShipment3,
+// 			MTOShipmentID: mtoShipment3.ID,
+// 			FirstName:     swag.String("Test"),
+// 			LastName:      swag.String("Agent"),
+// 			Email:         swag.String("test@test.email.com"),
+// 			MTOAgentType:  models.MTOAgentReleasing,
+// 		},
+// 	})
 
-	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
-		MTOAgent: models.MTOAgent{
-			MTOShipment:   mtoShipment3,
-			MTOShipmentID: mtoShipment3.ID,
-			FirstName:     swag.String("Test"),
-			LastName:      swag.String("Agent"),
-			Email:         swag.String("test@test.email.com"),
-			MTOAgentType:  models.MTOAgentReceiving,
-		},
-	})
+// 	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
+// 		MTOAgent: models.MTOAgent{
+// 			MTOShipment:   mtoShipment3,
+// 			MTOShipmentID: mtoShipment3.ID,
+// 			FirstName:     swag.String("Test"),
+// 			LastName:      swag.String("Agent"),
+// 			Email:         swag.String("test@test.email.com"),
+// 			MTOAgentType:  models.MTOAgentReceiving,
+// 		},
+// 	})
 
-	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			ID: uuid.FromStringOrNil("8a625314-1922-4987-93c5-a62c0d13f053"),
-		},
-		Move: mto2,
-	})
+// 	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+// 		MTOServiceItem: models.MTOServiceItem{
+// 			ID: uuid.FromStringOrNil("8a625314-1922-4987-93c5-a62c0d13f053"),
+// 		},
+// 		Move: mto2,
+// 	})
 
-	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			ID: uuid.FromStringOrNil("3624d82f-fa87-47f5-a09a-2d5639e45c02"),
-		},
-		Move:        mto2,
-		MTOShipment: mtoShipment3,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("4b85962e-25d3-4485-b43c-2497c4365598"), // DSH
-		},
-	})
+// 	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+// 		MTOServiceItem: models.MTOServiceItem{
+// 			ID: uuid.FromStringOrNil("3624d82f-fa87-47f5-a09a-2d5639e45c02"),
+// 		},
+// 		Move:        mto2,
+// 		MTOShipment: mtoShipment3,
+// 		ReService: models.ReService{
+// 			ID: uuid.FromStringOrNil("4b85962e-25d3-4485-b43c-2497c4365598"), // DSH
+// 		},
+// 	})
+// }
 
+func createHHGMoveWithTaskOrderServices(db *pop.Connection, userUploader *uploader.UserUploader) {
 	mtoWithTaskOrderServices := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
 			ID:                 uuid.FromStringOrNil("9c7b255c-2981-4bf8-839f-61c7458e2b4d"),
 			AvailableToPrimeAt: swag.Time(time.Now()),
+			Status:             models.MoveStatusSUBMITTED,
+			SelectedMoveType:   &hhgMoveType,
 		},
 		UserUploader: userUploader,
 	})
@@ -2120,6 +1492,19 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			ID: uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"), // MS - Move Management
 		},
 	})
+}
+
+func createWebhookSubscriptionForPaymentRequestUpdate(db *pop.Connection) {
+	// Create one webhook subscription for PaymentRequestUpdate
+	testdatagen.MakeWebhookSubscription(db, testdatagen.Assertions{
+		WebhookSubscription: models.WebhookSubscription{
+			CallbackURL: "https://primelocal:9443/support/v1/webhook-notify",
+		},
+	})
+}
+
+func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.UserUploader) {
+	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{})
 
 	orders9 := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
@@ -2202,16 +1587,44 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		basicPaymentServiceItemParams,
 		assertions9,
 	)
+}
 
-	// Create one webhook subscription for PaymentRequestUpdate
-	testdatagen.MakeWebhookSubscription(db, testdatagen.Assertions{
-		WebhookSubscription: models.WebhookSubscription{
-			CallbackURL: "https://primelocal:9443/support/v1/webhook-notify",
-		},
-	})
-	// Create multiple payment requests to fill queue
-	testdatagen.MakeMultiPaymentRequestWithItems(db, testdatagen.Assertions{
-		Move:          move8,
-		PrimeUploader: primeUploader,
-	}, 35)
+// Run does that data load thing
+func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, storer *storage.Filesystem) {
+	// PPM Office Queue
+	createPPMOfficeUser(db)
+	createPPMWithAdvance(db, userUploader)
+	createPPMWithNoAdvance(db, userUploader)
+	createPPMWithPaymentRequest(db, userUploader)
+	createCanceledPPM(db, userUploader)
+	createPPMReadyToRequestPayment(db, userUploader)
+
+	// Onboarding
+	createUnsubmittedHHGMove(db)
+	createUnsubmittedMoveWithNTSAndNTSR(db)
+	createServiceMemberWithOrdersButNoMoveType(db)
+	createServiceMemberWithNoUploadedOrders(db)
+
+	// TXO Queues
+	createTOO(db)
+	createTIO(db)
+	createTXO(db)
+
+	// This allows testing the pagination feature in the TXO queues.
+	// Feel free to comment out the loop if you don't need this many moves.
+	for i := 1; i < 12; i++ {
+		createHHGMoveWithPaymentRequest(db, userUploader, primeUploader, logger)
+	}
+	createMoveWithPPMAndHHG(db, userUploader)
+	createHHGMoveWith10ServiceItems(db, userUploader)
+	createHHGMoveWith2PaymentRequests(db, userUploader)
+	createHHGMoveWithTaskOrderServices(db, userUploader)
+	// This one doesn't have submitted shipments. Can we get rid of it?
+	// createRecentlyUpdatedHHGMove(db, userUploader)
+
+	// Prime API
+	createWebhookSubscriptionForPaymentRequestUpdate(db)
+	// This move below is a PPM move in DRAFT status. It should probably
+	// be changed to an HHG move in SUBMITTED status to reflect reality.
+	createMoveWithBasicServiceItems(db, userUploader)
 }


### PR DESCRIPTION
## Description

By creating functions for each type of entry, it makes the file more
readable, and makes it a lot easier to create many instances of a
particular entry. For example, to test pagination in the TXO queues,
you can now easily loop over one of the functions.

I removed some entries that didn't seem to be used for local testing.

I also noticed that in some cases, we are using the same email for a
bunch of users, which doesn't reflect reality. Similarly, we are using
the default ARMY affiliation for all service members. Ideally, we would 
make email unique and choose a random affiliation, which will make it
easier to test sorting and filtering in the TXO queues. I will do that 
in a separate PR.

## Reviewer Notes

Run `make db_dev_e2e_populate`. It should succeed without failures.
Sign in as a TOO. You should see 15 moves.
Verify that the data you expect to see locally is there.
If there are entries we no longer need for local testing, please flag them.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
