### PR TITLE
MB-5223 no_MtoID_no_error

### DIFF
--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -369,3 +369,40 @@ func (suite *EventServiceSuite) TestMoveOrderEventTrigger() {
 		suite.Equal(move.Orders.OriginDutyStation.ID.String(), moveOrderPayload.OriginDutyStation.ID.String())
 	})
 }
+
+func (suite *EventServiceSuite) TestNotificationEventHandler() {
+	order := testdatagen.MakeDefaultOrder(suite.DB())
+	dummyRequest := http.Request{
+		URL: &url.URL{
+			Path: "",
+		},
+	}
+	logger, _ := zap.NewDevelopment()
+	handler := handlers.NewHandlerContext(suite.DB(), logger)
+	traceID, _ := uuid.NewV4()
+	handler.SetTraceID(traceID)
+
+	// Test a nil MTO ID is present and no notification stored
+	suite.T().Run("No move and notification stored", func(t *testing.T) {
+		count, _ := suite.DB().Count(&models.WebhookNotification{})
+		event := Event{
+			EventKey:        MoveOrderUpdateEventKey,
+			MtoID:           uuid.Nil,
+			UpdatedObjectID: order.ID,
+			Request:         &dummyRequest,
+			EndpointKey:     InternalUpdateOrdersEndpointKey,
+			HandlerContext:  handler,
+			DBConnection:    suite.DB(),
+		}
+		_, err := TriggerEvent(event)
+		suite.NoError(err)
+
+		afterCount, _ := suite.DB().Count(&models.WebhookNotification{})
+		suite.Equal(count, afterCount)
+
+		// No notificationn adn nil error returned
+		_, err = suite.getNotification(order.ID, traceID)
+		suite.Error(err)
+		suite.Equal("sql: no rows in result set", err.Error())
+	})
+}

--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -400,7 +400,7 @@ func (suite *EventServiceSuite) TestNotificationEventHandler() {
 		afterCount, _ := suite.DB().Count(&models.WebhookNotification{})
 		suite.Equal(count, afterCount)
 
-		// No notificationn adn nil error returned
+		// No notification stored and nil error returned
 		_, err = suite.getNotification(order.ID, traceID)
 		suite.Error(err)
 		suite.Equal("sql: no rows in result set", err.Error())

--- a/pkg/services/event/notification.go
+++ b/pkg/services/event/notification.go
@@ -215,6 +215,12 @@ func objectEventHandler(event *Event, modelBeingUpdated interface{}) (bool, erro
 		return false, nil
 	}
 
+	// CHECK IF MOVE ID IS NIL
+	// If moveID (mto ID) is nil, then return false, nil
+	if event.MtoID == uuid.Nil {
+		return false, nil
+	}
+
 	// CHECK FOR AVAILABILITY TO PRIME
 	// Continue only if MTO is available to Prime
 	if isAvailableToPrime, err := checkAvailabilityToPrime(event); !isAvailableToPrime {
@@ -254,6 +260,28 @@ func objectEventHandler(event *Event, modelBeingUpdated interface{}) (bool, erro
 	return true, nil
 }
 
+// func ordersEventHandler(event *Event, modelBeingUpdated interface{}) (bool, error) {
+// 	// CHECK SOURCE
+// 	// Continue only if source of event is not Prime
+// 	if isSourcePrime(event) {
+// 		return false, nil
+// 	}
+
+// 	// CHECK IF MOVE ID IS NIL
+// 	// If moveID (mto ID) is nil, then return false, nil
+// 	if event.MtoID == uuid.Nil {
+// 		return false, nil
+// 	}
+
+// 	// CHECK FOR AVAILABILITY TO PRIME
+// 	// Continue only if MTO is available to Prime
+// 	if isAvailableToPrime, _ := checkAvailabilityToPrime(event); !isAvailableToPrime {
+// 		return false, nil
+// 	}
+
+// 	return true, nil
+// }
+
 // NotificationEventHandler receives notifications from the events package
 // For alerting ALL errors should be logged here.
 func NotificationEventHandler(event *Event) error {
@@ -266,6 +294,7 @@ func NotificationEventHandler(event *Event) error {
 	}
 
 	// Call the default handler
+	// if the event is Orders.Update then call ordersEventHandler
 	stored, err := objectEventHandler(event, modelBeingUpdated)
 
 	// Log what happened.

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -201,5 +201,3 @@ func (suite *EventServiceSuite) TestAssembleMoveOrderPayload() {
 		}
 	})
 }
-
-// Check Success that if thre is an MTO, a notification is STORED, but if there isn't no error is returned.

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -201,3 +201,5 @@ func (suite *EventServiceSuite) TestAssembleMoveOrderPayload() {
 		}
 	})
 }
+
+// Check Success that if thre is an MTO, a notification is STORED, but if there isn't no error is returned.


### PR DESCRIPTION
## Description

When a move has not been created for an order, and that order is updated, it is possible for a nil uuid to be stored in place of the MtoID. No notification will be sent to the prime and no error will be returned for that nil MtoID

## Reviewer Notes

Please check my tests are testing what is expected.

## Setup

To run the tests in event_test.go:
Happy path test: `go test ./pkg/services/event --testify.m TestMoveOrderEventTrigger -v`
Unhappy path to test when there is a nil MtoID`go test ./pkg/services/event --testify.m TestNotificationEventHandler -v`

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5223) for this change
