### PR TITLE
Use yarn frozen lockfile feature and avoid caching node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,26 +502,15 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Install YARN dependencies
-          # setting network concurrency to 1 because using the default failed with errors trying to extract package tar files saying they were corrupt.
-          # this was workaround that seemed to fix the issue See for details https://github.com/yarnpkg/yarn/issues/7212
-          # This is caused by a timing issue when using react-uswds branch. It can be removed once we switch to a released version
-          command: yarn install --network-concurrency 1
+          command: yarn install --frozen-lockfile
       - run: scripts/check-generated-code yarn.lock
       # `v3-cache-yarn-v3-{{ checksum "yarn.lock" }}` is used to cache yarn sources
       - save_cache:
           key: v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v3
-      # `v3-mymove-node-modules-{{ checksum "yarn.lock" }}` is used to cache installed node modules
-      - save_cache:
-          key: v3-mymove-node-modules-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/transcom/mymove/node_modules
       - announce_failure
 
   pre_deps_cypress:
@@ -531,23 +520,14 @@ jobs:
       - restore_cache:
           keys:
             - v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v1-cache-cypress-node-modules-{{ checksum "cypress/yarn.lock" }}
       - run:
           name: Install YARN dependencies
-          # setting network concurrency to 1 to follow the others; this is pretty standard for cloud yarning. see note in pre_deps_yarn for more detail.
-          command: yarn install --network-concurrency 1
+          command: yarn install --frozen-lockfile
       # `v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}` is used to cache yarn sources
       - save_cache:
           key: v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}
           paths:
             - ~/.cache/cypress/yarn/v1
-      # `v1-cache-cypress-node-modules-{{ checksum "cypress/yarn.lock" }}` is used to cache installed node modules
-      - save_cache:
-          key: v1-cache-cypress-node-modules-{{ checksum "cypress/yarn.lock" }}
-          paths:
-            - ~/.cache/cypress/node_modules/v1
       - announce_failure
 
   # `check_generated_code` is used to ensure generated code doesn't change
@@ -607,9 +587,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -743,13 +720,7 @@ jobs:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
             - v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v1-cache-cypress-node-modules-{{ checksum "cypress/yarn.lock" }}
       - attach_workspace:
           at: /home/circleci/transcom/mymove/bin
       - run:
@@ -794,9 +765,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: /home/circleci/transcom/mymove/bin
       - run: rm -f pkg/assets/assets.go && make pkg/assets/assets.go
@@ -880,9 +848,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run: make bin/rds-ca-2019-root.pem
       - run: make bin/rds-ca-us-gov-west-1-2017-root.pem
       - run: make client_build
@@ -958,9 +923,6 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v3-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Output processes and resource usage every 5 seconds while job is running
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1297,7 +1297,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: gdjn_yarn_frozen_lockfile
 
       - integration_tests_mtls:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: gdjn_yarn_frozen_lockfile
 
       - client_test:
           requires:
@@ -1319,7 +1319,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: gdjn_yarn_frozen_lockfile
 
       - server_test:
           requires:
@@ -1327,7 +1327,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: gdjn_yarn_frozen_lockfile
 
       - build_app:
           requires:
@@ -1367,21 +1367,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - deploy_exp_migrations:
           requires:
@@ -1395,28 +1395,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gdjn_yarn_frozen_lockfile
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1297,7 +1297,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: gdjn_yarn_frozen_lockfile
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: gdjn_yarn_frozen_lockfile
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1319,7 +1319,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: gdjn_yarn_frozen_lockfile
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1327,7 +1327,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: gdjn_yarn_frozen_lockfile
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1367,21 +1367,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1395,28 +1395,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: gdjn_yarn_frozen_lockfile
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,6 +774,9 @@ jobs:
       - run: make server_generate
       - run: rm -f bin/generate-test-data && make bin/generate-test-data
       - run: rm -f bin/prime-api-client && make bin/prime-api-client
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile
       - e2e_tests_mtls
       - store_test_results:
           path: cypress/results
@@ -810,9 +813,9 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile
       - run: make client_test_coverage
       - announce_failure
 
@@ -853,6 +856,9 @@ jobs:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
       - run: make bin/rds-ca-2019-root.pem
       - run: make bin/rds-ca-us-gov-west-1-2017-root.pem
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile
       - run: make client_build
       - run: make server_build
       - build_image:
@@ -935,6 +941,9 @@ jobs:
               echo "======"
             done
           background: true
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile
       - run:
           name: Happo tests
           command: yarn happo-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ jobs:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
       - run:
-          name: Install YARN dependencies
+          name: Install Frozen YARN dependencies
           command: yarn install --frozen-lockfile
       - run: scripts/check-generated-code yarn.lock
       # `v3-cache-yarn-v3-{{ checksum "yarn.lock" }}` is used to cache yarn sources
@@ -521,7 +521,7 @@ jobs:
           keys:
             - v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}
       - run:
-          name: Install YARN dependencies
+          name: Install Frozen YARN dependencies
           command: yarn install --frozen-lockfile
       # `v1-cache-cypress-yarn-{{ checksum "cypress/yarn.lock" }}` is used to cache yarn sources
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,6 +600,9 @@ jobs:
             done
           background: true
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
+      - run:
+          name: Install Frozen YARN dependencies
+          command: yarn install --frozen-lockfile
       # this is so we can avoid go mod downloading and resulting in an error on a false positive
       - run: scripts/pre-commit-go-mod || exit 0
       - run:


### PR DESCRIPTION
## Description

The best practice recommendation for consistent builds when using `yarn` for managing dependencies is to use the `--frozen-lockfile` flag and rely on `yarn` to use its cache. Currently our build caches `node_modules` and the yarn cache which duplicates data caching. To speed up our builds and reduce the number of things we are caching this PR updates the jobs to use `--frozen-lockfile` and not cache `node_modules`.

This PR also removes the network concurrency flag as we now have releases of `react-uswds` so downloads can happen concurrently again.

## Reviewer Notes

Is this worth applying?

## Setup

Check out the builds

## Code Review Verification Steps

* [X] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [X] Request review from a member of a different team.

## References

* [Slack Thread](https://trussworks.slack.com/archives/C2360K10T/p1605563953084300) for this change
* [this article](https://github.com/actions/cache/issues/67) explains more about the approach used.
* [this stack overflow](https://stackoverflow.com/questions/58482655/what-is-the-closest-to-npm-ci-in-yarn/64783982#64783982) explains more about the approach used.
* [yarn frozen lockfile docs](https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile) explains more about the approach used.