### PR TITLE
[MB-5577] Edit shipment cancel button bug

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentFormFields.jsx
@@ -259,6 +259,7 @@ const MtoShipmentFormFields = ({
               editMode
               onNextClick={() => submitHandler(values)}
               onBackClick={history.goBack}
+              onCancelClick={history.goBack}
             />
           </div>
         )}


### PR DESCRIPTION
## Description

User can click on cancel button and go back to the previous page

## Reviewer Notes
- there were already tests for this, was just missing a prop

## Setup
`make server_run`
`make client_run`
```
1. create profile
2. upload orders
3. add a shipment
4. click on Edit button for shipment from the Review screen
5. click on the Cancel button from the /edit-shipment page
Expected Result: Cancel button should take you back to the review page
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5577) for this change
