### PR TITLE
Fix the orders.status comment

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -578,3 +578,4 @@
 20201111015201_add_sit_fields_zip_entry_departure.up.sql
 20201111170419_jacquelinemckinney_cac.up.sql
 20201111232031_remove_ssn.up.sql
+20201117203528_fix_orders_status_comment.up.sql

--- a/migrations/app/schema/20201117203528_fix_orders_status_comment.up.sql
+++ b/migrations/app/schema/20201117203528_fix_orders_status_comment.up.sql
@@ -1,1 +1,1 @@
-COMMENT ON COLUMN orders.status IS 'The status of the orders. Values can be: DRAFT, SUBMITTED, APPROVED, CANCELED';
+COMMENT ON COLUMN orders.status IS 'The status of the orders. Allowed values are DRAFT, SUBMITTED, APPROVED, CANCELED.';

--- a/migrations/app/schema/20201117203528_fix_orders_status_comment.up.sql
+++ b/migrations/app/schema/20201117203528_fix_orders_status_comment.up.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN orders.status IS 'The status of the orders. Values can be: DRAFT, SUBMITTED, APPROVED, CANCELED';


### PR DESCRIPTION
This is a fix to update the `orders.status` comment in the db. 
This comment field slipped by in my [orig pr](https://github.com/transcom/mymove/pull/4703/files#diff-0472a78a3baa4fc9234d564df1b0c382c1b496b9e39f3bf8432504a05c7ad22eR60) and this fixes my mistake.

Originally found by Alexi: https://ustcdp3.slack.com/archives/CTNTFJSBA/p1600141165329600