### PR TITLE
Remediate all instances of gosec G304

### DIFF
--- a/cmd/health-checker/main.go
+++ b/cmd/health-checker/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -242,19 +243,19 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger) (*http.Client, error) 
 
 		if len(clientKeyFile) > 0 && len(clientCertFile) > 0 {
 
-			clientKey, clientKeyErr := ioutil.ReadFile(clientKeyFile) // #nosec b/c we need to read a file from a user-defined path
+			clientKey, clientKeyErr := ioutil.ReadFile(filepath.Clean(clientKeyFile))
 			if clientKeyErr != nil {
 				return nil, errors.Wrap(clientKeyErr, "error reading client key file at "+clientKeyFile)
 			}
 
-			clientCert, clientCertErr := ioutil.ReadFile(clientCertFile) // #nosec b/c we need to read a file from a user-defined path
+			clientCert, clientCertErr := ioutil.ReadFile(filepath.Clean(clientCertFile))
 			if clientCertErr != nil {
 				return nil, errors.Wrap(clientCertErr, "error reading client cert file at "+clientKeyFile)
 			}
 
 			caBytes := make([]byte, 0)
 			if caFile := v.GetString("ca-file"); len(caFile) > 0 {
-				content, err := ioutil.ReadFile(caFile) // #nosec b/c we need to read a file from a user-defined path
+				content, err := ioutil.ReadFile(filepath.Clean(caFile))
 				if err != nil {
 					return nil, errors.Wrap(err, "error reading ca file at "+caFile)
 				}

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -300,7 +301,7 @@ func indexHandler(buildDir string, logger logger) http.HandlerFunc {
 
 	indexPath := path.Join(buildDir, "index.html")
 	// #nosec - indexPath does not come from user input
-	indexHTML, err := ioutil.ReadFile(indexPath)
+	indexHTML, err := ioutil.ReadFile(filepath.Clean(indexPath))
 	if err != nil {
 		logger.Fatal("could not read index.html template: run make client_build", zap.Error(err))
 	}
@@ -963,7 +964,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		if stringSliceContains([]string{cli.EnvironmentTest, cli.EnvironmentDevelopment}, v.GetString(cli.EnvironmentFlag)) {
 			logger.Info("Adding devlocal CA to root CAs")
 			devlocalCAPath := v.GetString(cli.DevlocalCAFlag)
-			devlocalCa, readFileErr := ioutil.ReadFile(devlocalCAPath) // #nosec
+			devlocalCa, readFileErr := ioutil.ReadFile(filepath.Clean(devlocalCAPath))
 			if readFileErr != nil {
 				logger.Error(fmt.Sprintf("Unable to read devlocal CA from path %s", devlocalCAPath), zap.Error(readFileErr))
 			} else {

--- a/cmd/send-to-gex/main.go
+++ b/cmd/send-to-gex/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -92,7 +93,7 @@ func main() {
 
 	ediFile := v.GetString("edi")
 
-	file, err := os.Open(ediFile) // #nosec
+	file, err := os.Open(filepath.Clean(ediFile))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -195,19 +196,19 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 
 		if len(clientKeyFile) > 0 && len(clientCertFile) > 0 {
 
-			clientKey, clientKeyErr := ioutil.ReadFile(clientKeyFile) // #nosec b/c we need to read a file from a user-defined path
+			clientKey, clientKeyErr := ioutil.ReadFile(filepath.Clean(clientKeyFile))
 			if clientKeyErr != nil {
 				return nil, errors.Wrap(clientKeyErr, "error reading client key file at "+clientKeyFile)
 			}
 
-			clientCert, clientCertErr := ioutil.ReadFile(clientCertFile) // #nosec b/c we need to read a file from a user-defined path
+			clientCert, clientCertErr := ioutil.ReadFile(filepath.Clean(clientCertFile))
 			if clientCertErr != nil {
 				return nil, errors.Wrap(clientCertErr, "error reading client cert file at "+clientKeyFile)
 			}
 
 			caBytes := make([]byte, 0)
 			if caFile := v.GetString("ca-file"); len(caFile) > 0 {
-				content, err := ioutil.ReadFile(caFile) // #nosec b/c we need to read a file from a user-defined path
+				content, err := ioutil.ReadFile(filepath.Clean(caFile))
 				if err != nil {
 					return nil, errors.Wrap(err, "error reading ca file at "+caFile)
 				}

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -49,7 +50,7 @@ func InitDoDCertificates(v *viper.Viper, logger Logger) ([]tls.Certificate, *x50
 	logger.Info("DOD keypair", zap.Any("certificates", len(keyPair.Certificate)))
 
 	pathToPackage := v.GetString(cli.DoDCAPackageFlag)
-	pkcs7Package, err := ioutil.ReadFile(pathToPackage) // #nosec
+	pkcs7Package, err := ioutil.ReadFile(filepath.Clean(pathToPackage))
 	if err != nil {
 		return make([]tls.Certificate, 0), nil, errors.Wrap(err, fmt.Sprintf("%s is invalid", cli.DoDCAPackageFlag))
 	}

--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -195,7 +196,7 @@ func CheckDatabase(v *viper.Viper, logger Logger) error {
 	}
 
 	if filename := v.GetString(DbSSLRootCertFlag); len(filename) > 0 {
-		b, err := ioutil.ReadFile(filename) // #nosec
+		b, err := ioutil.ReadFile(filepath.Clean(filename))
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading %s at %q", DbSSLRootCertFlag, filename))
 		}

--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime/debug"
 
 	"github.com/gofrs/uuid"
@@ -209,8 +210,7 @@ func (suite *BaseHandlerTestSuite) Fixture(name string) *runtime.File {
 
 	fixturePath := path.Join(cwd, "..", "..", fixtureDir, name)
 
-	// #nosec never comes from user input
-	file, err := os.Open(fixturePath)
+	file, err := os.Open(filepath.Clean(fixturePath))
 	if err != nil {
 		suite.logger.Fatal("Error opening fixture file", zap.Error(err))
 	}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -170,7 +171,7 @@ func Fixture(name string) afero.File {
 
 	fixturePath := path.Join(cwd, "pkg/testdatagen", fixtureDir, name)
 	// #nosec This will only be using test data
-	file, err := os.Open(fixturePath)
+	file, err := os.Open(filepath.Clean(fixturePath))
 	if err != nil {
 		log.Panic(fmt.Errorf("Error opening local file: %v", err))
 	}


### PR DESCRIPTION
## Description

This remediates all occurrences of gosec G304: Potential file inclusion via variable.  Although some of the instances could be justified because either they did not include user input or were only for tests, I went ahead and used the fix using `filepath.Clean()` suggested in the [securego.io documentation](https://securego.io/docs/rules/g304.html).

## Reviewer Notes

Is it extraneous to use filepath.Clean where it's not necessary?  Or ok to just use it for consistency and it doesn't hurt?
Although Discovery subtast suggested using annotation for ones that were acceptable and remediation for others, I chose to just do remediation for all.

[filepath.Clean() documentation](https://golang.org/pkg/path/filepath/#Clean)

This touches the serve.go- any reason to test in experimental first?

## Setup

`pre-commit run -v --all-files golangci-lint | grep G304`

There should be no occurrences found of G304.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4961) for this change
