### PR TITLE
Add annotation for all instances of G101

### DIFF
--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -41,9 +41,9 @@ func (e *errInvalidHostname) Error() string {
 //RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
 //RA: This variable does not store an application token.
 //RA Developer Status: Mitigated
-//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Validator Status: Mitigated
 //RA Validator: jneuner@mitre.org
-//RA Modified Severity:
+//RA Modified Severity: CAT III
 
 // GorillaCSRFToken is the name of the base CSRF token
 const GorillaCSRFToken = "_gorilla_csrf" // #nosec G101

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -39,8 +39,8 @@ func (e *errInvalidHostname) Error() string {
 //RA Summary: gosec - G101 - Password Management: Hardcoded Password
 //RA: This line was flagged because it detected use of the word "token"
 //RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
-//RA: This variable does not identify the actual token, just the name, so is not a risk.
-//RA Developer Status: False Positive
+//RA: This variable does not store an application token.
+//RA Developer Status: Mitigated
 //RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 //RA Validator: jneuner@mitre.org
 //RA Modified Severity:

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -36,6 +36,15 @@ func (e *errInvalidHostname) Error() string {
 	return fmt.Sprintf("invalid hostname %s, must be one of %s, %s, or %s", e.Hostname, e.MilApp, e.OfficeApp, e.AdminApp)
 }
 
+//RA Summary: gosec - G101 - Password Management: Hardcoded Password
+//RA: This line was flagged because it detected use of the word "token"
+//RA: This line is used to identify the name of the token.
+//RA: This variable does not identify the actual token, just the name, so is not a risk.
+//RA Developer Status: False Positive
+//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Validator: jneuner@mitre.org
+//RA Modified Severity:
+
 // GorillaCSRFToken is the name of the base CSRF token
 const GorillaCSRFToken = "_gorilla_csrf" // #nosec G101
 

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -38,7 +38,7 @@ func (e *errInvalidHostname) Error() string {
 
 //RA Summary: gosec - G101 - Password Management: Hardcoded Password
 //RA: This line was flagged because it detected use of the word "token"
-//RA: This line is used to identify the name of the token.
+//RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
 //RA: This variable does not identify the actual token, just the name, so is not a risk.
 //RA Developer Status: False Positive
 //RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -16,9 +16,9 @@ const (
 	//RA: This line is used to identify the name of the flag. ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag.
 	//RA: This value of this variable does not store an application secret.
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Modified Severity: CAT III
 
 	// ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag // #nosec G101
 	ClientAuthSecretKeyFlag string = "client-auth-secret-key"

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -13,7 +13,7 @@ import (
 const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
-	//RA: This line is used to identify the name of the flag.
+	//RA: This line is used to identify the name of the flag. ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag.
 	//RA: This value of this variable does not identify the actual secret, so is not a risk.
 	//RA Developer Status: False Positive
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -14,8 +14,8 @@ const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
 	//RA: This line is used to identify the name of the flag. ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag.
-	//RA: This value of this variable does not identify the actual secret, so is not a risk.
-	//RA Developer Status: False Positive
+	//RA: This value of this variable does not store an application secret.
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -11,9 +11,17 @@ import (
 )
 
 const (
-	// ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag #nosec G101
-	ClientAuthSecretKeyFlag string = "client-auth-secret-key"
+	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	//RA: This line was flagged because of use of the word "secret"
+	//RA: This line is used to identify the name of the flag.
+	//RA: This value of this variable does not identify the actual secret, so is not a risk.
+	//RA Developer Status: False Positive
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
 
+	// ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag // #nosec G101
+	ClientAuthSecretKeyFlag string = "client-auth-secret-key"
 	// LoginGovCallbackProtocolFlag is the Login.gov Callback Protocol Flag
 	LoginGovCallbackProtocolFlag string = "login-gov-callback-protocol"
 	// LoginGovCallbackPortFlag is the Login.gov Callback Port Flag

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -19,7 +19,7 @@ const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
 	//RA: This line is used to identify the name of the flag. DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag.
-	//RA: The value of this variable does not identify the actual secret, so is not a risk.
+	//RA: This variable does not store an application secret.
 	//RA Developer Status: False Positive
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -20,7 +20,7 @@ const (
 	//RA: This line was flagged because of use of the word "secret"
 	//RA: This line is used to identify the name of the flag. DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag.
 	//RA: This variable does not store an application secret.
-	//RA Developer Status: False Positive
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:
@@ -37,8 +37,8 @@ const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
 	//RA: This line is used to identify the name of the flag. DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag
-	//RA: The value of this variable does not identify the actual secret, so is not a risk.
-	//RA Developer Status: False Positive
+	//RA: The value of this variable does not store an application secret.
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -15,7 +15,17 @@ const (
 	HTTPSDDCPortFlag string = "http-sddc-port"
 	// HTTPDPSServerNameFlag is the HTTP DPS Server Name Flag
 	HTTPDPSServerNameFlag string = "http-dps-server-name"
-	// DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag #nosec G101
+
+	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	//RA: This line was flagged because of use of the word "secret"
+	//RA: This line is used to identify the name of the flag.
+	//RA: The value of this variable does not identify the actual secret, so is not a risk.
+	//RA Developer Status: False Positive
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+
+	// DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag // #nosec G101
 	DPSAuthSecretKeyFlag string = "dps-auth-secret-key"
 	// DPSRedirectURLFlag is the DPS Redirect URL Flag
 	DPSRedirectURLFlag string = "dps-redirect-url"
@@ -23,7 +33,17 @@ const (
 	DPSCookieNameFlag string = "dps-cookie-name"
 	// DPSCookieDomainFlag is the DPS Cookie Domain Flag Flag
 	DPSCookieDomainFlag string = "dps-cookie-domain"
-	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Scret Key Flag #nosec G101
+
+	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	//RA: This line was flagged because of use of the word "secret"
+	//RA: This line is used to identify the name of the flag.
+	//RA: The value of this variable does not identify the actual secret, so is not a risk.
+	//RA Developer Status: False Positive
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+
+	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Scret Key Flag // #nosec G101
 	DPSAuthCookieSecretKeyFlag string = "dps-auth-cookie-secret-key"
 	// DPSCookieExpiresInMinutesFlag is the DPS Cookie Expires In Minutes Flag
 	DPSCookieExpiresInMinutesFlag string = "dps-cookie-expires-in-minutes"

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -18,7 +18,7 @@ const (
 
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
-	//RA: This line is used to identify the name of the flag.
+	//RA: This line is used to identify the name of the flag. DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag.
 	//RA: The value of this variable does not identify the actual secret, so is not a risk.
 	//RA Developer Status: False Positive
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
@@ -36,14 +36,14 @@ const (
 
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
-	//RA: This line is used to identify the name of the flag.
+	//RA: This line is used to identify the name of the flag. DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag
 	//RA: The value of this variable does not identify the actual secret, so is not a risk.
 	//RA Developer Status: False Positive
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:
 
-	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Scret Key Flag // #nosec G101
+	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag // #nosec G101
 	DPSAuthCookieSecretKeyFlag string = "dps-auth-cookie-secret-key"
 	// DPSCookieExpiresInMinutesFlag is the DPS Cookie Expires In Minutes Flag
 	DPSCookieExpiresInMinutesFlag string = "dps-cookie-expires-in-minutes"

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -21,9 +21,9 @@ const (
 	//RA: This line is used to identify the name of the flag. DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag.
 	//RA: This variable does not store an application secret.
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Modified Severity: CAT III
 
 	// DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag // #nosec G101
 	DPSAuthSecretKeyFlag string = "dps-auth-secret-key"
@@ -39,9 +39,9 @@ const (
 	//RA: This line is used to identify the name of the flag. DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag
 	//RA: The value of this variable does not store an application secret.
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Modified Severity: CAT III
 
 	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag // #nosec G101
 	DPSAuthCookieSecretKeyFlag string = "dps-auth-cookie-secret-key"

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -11,6 +11,15 @@ import (
 const (
 	// GEXBasicAuthUsernameFlag is the GEX Basic Auth Username Flag
 	GEXBasicAuthUsernameFlag string = "gex-basic-auth-username"
+	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
+	//RA: This line was flagged because of use of the word "password"
+	//RA: This line is used to identify the name of the flag. GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag.
+	//RA: This value of this variable does not identify the actual password, so is not a risk.
+	//RA Developer Status: False Positive
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+
 	// GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag #nosec G101
 	GEXBasicAuthPasswordFlag string = "gex-basic-auth-password"
 	// GEXSendProdInvoiceFlag is the GEX Send Prod Invoice Flag

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -14,8 +14,8 @@ const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "password"
 	//RA: This line is used to identify the name of the flag. GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag.
-	//RA: This value of this variable does not identify the actual password, so is not a risk.
-	//RA Developer Status: False Positive
+	//RA: This value of this variable does not store an application password.
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -16,9 +16,9 @@ const (
 	//RA: This line is used to identify the name of the flag. GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag.
 	//RA: This value of this variable does not store an application password.
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Modified Severity: CAT III
 
 	// GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag #nosec G101
 	GEXBasicAuthPasswordFlag string = "gex-basic-auth-password"


### PR DESCRIPTION
## Description

All occurrences of G101: Password Management: Hardcoded Password I categorized as false positives, as the linter was flagging the use of the words "token" and "secret", and they were all references to names rather than the keys/secrets themselves.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

`pre-commit run -v --all-files golangci-lint | grep G101` and you will still see 5 occurrences.  However, all have annotation.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4970) for this change
