### PR TITLE
MB-5238: Pushing build failures to #prac-engineering vs. #on-call

### DIFF
--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -6,7 +6,7 @@ NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 pretext="CircleCI $CIRCLE_BRANCH branch failure!"
 title="CircleCI build #$CIRCLE_BUILD_NUM failed on job $CIRCLE_JOB"
-message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
+message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME information."
 
 #####
 ## Announce in Slack channel
@@ -20,7 +20,7 @@ fi
 slack_payload=$(
 cat <<EOM
 {
-    "channel": "#on-call",
+    "channel": "#prac-engineering",
     "attachments": [
         {
             "fallback": "$message $CIRCLE_BUILD_URL",

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -6,7 +6,7 @@ NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 pretext="CircleCI $CIRCLE_BRANCH branch failure!"
 title="CircleCI build #$CIRCLE_BUILD_NUM failed on job $CIRCLE_JOB"
-message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME information."
+message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
 
 #####
 ## Announce in Slack channel


### PR DESCRIPTION
## Description

A minor revision to change the CI Build failure notifications to #prac-engineering vs. #on-call. Once this is merged, I will update the slack URL in the circleci project config. 

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5238) for this change

