### PR TITLE
Add SIT fields to MTOServiceItem model

### DIFF
--- a/pkg/models/mto_service_items.go
+++ b/pkg/models/mto_service_items.go
@@ -34,6 +34,9 @@ type MTOServiceItem struct {
 	RejectionReason  *string                        `db:"rejection_reason"`
 	Status           MTOServiceItemStatus           `db:"status"`
 	PickupPostalCode *string                        `db:"pickup_postal_code"`
+	SITPostalCode    *string                        `db:"sit_postal_code"`
+	SITEntryDate     *time.Time                     `db:"sit_entry_date"`
+	SITDepartureDate *time.Time                     `db:"sit_departure_date"`
 	Description      *string                        `db:"description"`
 	Dimensions       MTOServiceItemDimensions       `has_many:"mto_service_item_dimensions" fk_id:"mto_service_item_id"`
 	CustomerContacts MTOServiceItemCustomerContacts `has_many:"mto_service_item_customer_contacts" fk_id:"mto_service_item_id"`


### PR DESCRIPTION
## Description

This PR adds the new SIT fields that we added to the `mto_service_items` table last sprint to the `MTOServiceItem` model.

## Setup

You can run server tests to check that everything is still functional as expected. 
