### PR TITLE
MB-4940 Display move info for all valid move types

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -581,3 +581,4 @@
 20201117203528_fix_orders_status_comment.up.sql
 20201117222119_alter_users_login_gov_uuid_nullable.up.sql
 20201117222339_create_user_records_for_office_and_admin_users_without.up.sql
+20201120174609_add_indexes_for_move_selected_type.up.sql

--- a/migrations/app/schema/20201120174609_add_indexes_for_move_selected_type.up.sql
+++ b/migrations/app/schema/20201120174609_add_indexes_for_move_selected_type.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX on moves (selected_move_type);

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -468,14 +468,9 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 	queueMoveOrders := make(ghcmessages.QueueMoves, len(moves))
 	for i, move := range moves {
 		customer := move.Orders.ServiceMember
-		// Finds the first move that is an HHG and use that locator.  Should we include combo HHG_PPM or others?
-		var hhgMove models.Move
-		if *move.SelectedMoveType == models.SelectedMoveTypeHHG {
-			hhgMove = move
-		}
 
 		var validMTOShipments []models.MTOShipment
-		for _, shipment := range hhgMove.MTOShipments {
+		for _, shipment := range move.MTOShipments {
 			if shipment.Status == models.MTOShipmentStatusSubmitted || shipment.Status == models.MTOShipmentStatusApproved {
 				validMTOShipments = append(validMTOShipments, shipment)
 			}
@@ -488,9 +483,9 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 
 		queueMoveOrders[i] = &ghcmessages.QueueMove{
 			Customer:               Customer(&customer),
-			Status:                 ghcmessages.QueueMoveStatus(hhgMove.Status),
+			Status:                 ghcmessages.QueueMoveStatus(move.Status),
 			ID:                     *handlers.FmtUUID(move.Orders.ID),
-			Locator:                hhgMove.Locator,
+			Locator:                move.Locator,
 			DepartmentIndicator:    ghcmessages.DeptIndicator(deptIndicator),
 			ShipmentsCount:         int64(len(validMTOShipments)),
 			DestinationDutyStation: DutyStation(&move.Orders.NewDutyStation),

--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -70,7 +70,8 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *service
 		InnerJoin("duty_stations as origin_ds", "orders.origin_duty_station_id = origin_ds.id").
 		InnerJoin("transportation_offices as origin_to", "origin_ds.transportation_office_id = origin_to.id").
 		LeftJoin("duty_stations as dest_ds", "dest_ds.id = orders.new_duty_station_id").
-		Where("show = ?", swag.Bool(true))
+		Where("show = ?", swag.Bool(true)).
+		Where("moves.selected_move_type NOT IN (?)", models.SelectedMoveTypePPM, models.SelectedMoveTypeUB, models.SelectedMoveTypePOV)
 
 	for _, option := range options {
 		if option != nil {

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -3,8 +3,6 @@ package moveorder
 import (
 	"testing"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/services"
 
 	"github.com/go-openapi/swag"
@@ -144,35 +142,18 @@ func (suite *MoveOrderServiceSuite) TestListMovesUSMCGBLOC() {
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
 
 	suite.T().Run("returns USMC order for USMC office user", func(t *testing.T) {
-		officeUUID, _ := uuid.NewV4()
 		marines := models.AffiliationMARINES
-		army := models.AffiliationARMY
-
-		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-			TransportationOffice: models.TransportationOffice{
-				Gbloc: "USMC",
-				ID:    officeUUID,
-			},
-			Move: models.Move{
-				Status: models.MoveStatusSUBMITTED,
-			},
+		// It doesn't matter what the Origin GBLOC is for the move. Only the Marines
+		// affiliation matters for office users who are tied to the USMC GBLOC.
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
 			ServiceMember: models.ServiceMember{Affiliation: &marines},
 		})
 
-		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-			Move: models.Move{
-				Status: models.MoveStatusSUBMITTED,
-			},
-			ServiceMember: models.ServiceMember{Affiliation: &army},
-		})
+		// Create move where service member has the default ARMY affiliation
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 
-		officeUserOooRah := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{OfficeUser: models.OfficeUser{TransportationOfficeID: officeUUID}})
+		officeUserOooRah := testdatagen.MakeOfficeUserWithUSMCGBLOC(suite.DB())
+		// Create office user tied to the default LKNQ GBLOC
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 		params := services.ListMoveOrderParams{PerPage: swag.Int64(2), Page: swag.Int64(1)}
@@ -188,7 +169,23 @@ func (suite *MoveOrderServiceSuite) TestListMovesUSMCGBLOC() {
 		suite.FatalNoError(err)
 		suite.Equal(1, len(moves))
 		suite.Equal(models.AffiliationARMY, *moves[0].Orders.ServiceMember.Affiliation)
+	})
+}
 
+func (suite *MoveOrderServiceSuite) TestListMovesMarines() {
+	suite.T().Run("does not return moves where the service member affiliation is Marines for non-USMC office user", func(t *testing.T) {
+		moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
+		marines := models.AffiliationMARINES
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
+			ServiceMember: models.ServiceMember{Affiliation: &marines},
+		})
+		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
+		params := services.ListMoveOrderParams{PerPage: swag.Int64(2), Page: swag.Int64(1)}
+		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
+
+		suite.FatalNoError(err)
+		suite.Equal(0, len(moves))
 	})
 }
 
@@ -235,16 +232,7 @@ func (suite *MoveOrderServiceSuite) TestListMovesWithPagination() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 	for i := 0; i < 2; i++ {
-		expectedMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
-
-		// Only orders with shipments are returned, so we need to add a shipment
-		// to the move we just created
-		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			Move: expectedMove,
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-		})
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 	}
 
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
@@ -259,37 +247,36 @@ func (suite *MoveOrderServiceSuite) TestListMovesWithPagination() {
 
 func (suite *MoveOrderServiceSuite) TestListMovesWithSortOrder() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-	expectedMove1 := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED, Locator: "AA1234"}})
+	// Default New Duty Station name is Fort Gordon
+	expectedMove1 := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status:  models.MoveStatusAPPROVED,
+			Locator: "AA1234",
+		},
+	})
 
 	serviceMemberLastName := "Zephyer"
 	affiliation := models.AffiliationNAVY
 	edipi := "9999999999"
-	dutyStationName := "Ze Duty Station"
-
-	// Only moves with shipments are returned, so we need to add a shipment
-	// to the move we just created
-	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: expectedMove1,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
+	newDutyStationName := "Ze Duty Station"
+	newDutyStation2 := testdatagen.MakeDutyStation(suite.DB(), testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			Name: newDutyStationName,
 		},
 	})
 
-	expectedShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
+	expectedMove2 := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
 		Move: models.Move{
-			Status:  models.MoveStatusSUBMITTED,
 			Locator: "TTZ123",
 		},
 		ServiceMember: models.ServiceMember{Affiliation: &affiliation, LastName: &serviceMemberLastName, Edipi: &edipi},
-		DutyStation:   models.DutyStation{Name: dutyStationName},
+		Order: models.Order{
+			NewDutyStation:   newDutyStation2,
+			NewDutyStationID: newDutyStation2.ID,
+		},
 	})
+
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
-
-	expectedMove2 := expectedShipment2.MoveTaskOrder
-
 	// Sort by service member name
 	params := services.ListMoveOrderParams{Sort: swag.String("lastName"), Order: swag.String("asc")}
 	moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
@@ -314,7 +301,7 @@ func (suite *MoveOrderServiceSuite) TestListMovesWithSortOrder() {
 	suite.Equal(expectedMove1.Locator, moves[0].Locator)
 	suite.Equal(expectedMove2.Locator, moves[1].Locator)
 
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("moveID"), Order: swag.String("desc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("moveID"), Order: swag.String("desc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
@@ -322,14 +309,14 @@ func (suite *MoveOrderServiceSuite) TestListMovesWithSortOrder() {
 	suite.Equal(expectedMove1.Locator, moves[1].Locator)
 
 	// sort by move statuses
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("status"), Order: swag.String("asc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("status"), Order: swag.String("asc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
 	suite.Equal(expectedMove1.Status, moves[0].Status)
 	suite.Equal(expectedMove2.Status, moves[1].Status)
 
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("status"), Order: swag.String("desc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("status"), Order: swag.String("desc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
@@ -337,29 +324,29 @@ func (suite *MoveOrderServiceSuite) TestListMovesWithSortOrder() {
 	suite.Equal(expectedMove1.Status, moves[1].Status)
 
 	// Sort by service member affiliations
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("branch"), Order: swag.String("asc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("branch"), Order: swag.String("asc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
 	suite.Equal(*expectedMove1.Orders.ServiceMember.Affiliation, *moves[0].Orders.ServiceMember.Affiliation)
 	suite.Equal(*expectedMove2.Orders.ServiceMember.Affiliation, *moves[1].Orders.ServiceMember.Affiliation)
 
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("branch"), Order: swag.String("desc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("branch"), Order: swag.String("desc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
 	suite.Equal(*expectedMove2.Orders.ServiceMember.Affiliation, *moves[0].Orders.ServiceMember.Affiliation)
 	suite.Equal(*expectedMove1.Orders.ServiceMember.Affiliation, *moves[1].Orders.ServiceMember.Affiliation)
 
-	// Sort by  destination duty station
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("destinationDutyStation"), Order: swag.String("asc")}
+	// Sort by destination duty station
+	params = services.ListMoveOrderParams{Sort: swag.String("destinationDutyStation"), Order: swag.String("asc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))
 	suite.Equal(expectedMove1.Orders.NewDutyStation.Name, moves[0].Orders.NewDutyStation.Name)
 	suite.Equal(expectedMove2.Orders.NewDutyStation.Name, moves[1].Orders.NewDutyStation.Name)
 
-	params = services.ListMoveOrderParams{Page: swag.Int64(1), PerPage: swag.Int64(2), Sort: swag.String("destinationDutyStation"), Order: swag.String("desc")}
+	params = services.ListMoveOrderParams{Sort: swag.String("destinationDutyStation"), Order: swag.String("desc")}
 	moves, _, err = moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 	suite.NoError(err)
 	suite.Equal(2, len(moves))

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -123,17 +123,15 @@ func MakeDefaultMove(db *pop.Connection) models.Move {
 	return MakeMove(db, Assertions{})
 }
 
-// MakeHHGMoveWithShipment makes an HHG Move with one submitted shipment
-func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+// MakeHiddenHHGMoveWithShipment makes an HHG Move with show = false
+func MakeHiddenHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
 	hhgMoveType := models.SelectedMoveTypeHHG
 	move := MakeMove(db, Assertions{
 		Move: models.Move{
 			SelectedMoveType: &hhgMoveType,
 			Status:           models.MoveStatusSUBMITTED,
+			Show:             swag.Bool(false),
 		},
-		ServiceMember:        assertions.ServiceMember,
-		TransportationOffice: assertions.TransportationOffice,
-		Stub:                 assertions.Stub,
 	})
 
 	MakeMTOShipment(db, Assertions{
@@ -147,14 +145,43 @@ func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.M
 	return move
 }
 
-// MakeHiddenHHGMoveWithShipment makes an HHG Move with show = false
-func MakeHiddenHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+// MakeHHGMoveWithShipment makes an HHG Move with one submitted shipment
+func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
 	hhgMoveType := models.SelectedMoveTypeHHG
 	move := MakeMove(db, Assertions{
 		Move: models.Move{
 			SelectedMoveType: &hhgMoveType,
 			Status:           models.MoveStatusSUBMITTED,
-			Show:             swag.Bool(false),
+		},
+		ServiceMember:        assertions.ServiceMember,
+		TransportationOffice: assertions.TransportationOffice,
+		Order:                assertions.Order,
+		Stub:                 assertions.Stub,
+	})
+
+	mergeModels(&move, assertions.Move)
+	if !assertions.Stub {
+		mustSave(db, &move)
+	}
+
+	MakeMTOShipment(db, Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Stub: assertions.Stub,
+	})
+
+	return move
+}
+
+// MakeHHGPPMMoveWithShipment makes an HHG_PPM Move with one submitted shipment
+func MakeHHGPPMMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+	hhgPPMMoveType := models.SelectedMoveTypeHHGPPM
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			SelectedMoveType: &hhgPPMMoveType,
+			Status:           models.MoveStatusSUBMITTED,
 		},
 		Stub: assertions.Stub,
 	})
@@ -163,6 +190,54 @@ func MakeHiddenHHGMoveWithShipment(db *pop.Connection, assertions Assertions) mo
 		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Stub: assertions.Stub,
+	})
+
+	return move
+}
+
+// MakeNTSMoveWithShipment makes an NTS Move with one submitted shipment
+func MakeNTSMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+	ntsMoveType := models.SelectedMoveTypeNTS
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			SelectedMoveType: &ntsMoveType,
+			Status:           models.MoveStatusSUBMITTED,
+		},
+		ServiceMember: assertions.ServiceMember,
+		Stub:          assertions.Stub,
+	})
+
+	MakeMTOShipment(db, Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType: models.MTOShipmentTypeHHGIntoNTSDom,
+			Status:       models.MTOShipmentStatusSubmitted,
+		},
+		Stub: assertions.Stub,
+	})
+
+	return move
+}
+
+// MakeNTSRMoveWithShipment makes an NTSR Move with one submitted shipment
+func MakeNTSRMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+	ntsrMoveType := models.SelectedMoveTypeNTSR
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			SelectedMoveType: &ntsrMoveType,
+			Status:           models.MoveStatusSUBMITTED,
+		},
+		ServiceMember: assertions.ServiceMember,
+		Stub:          assertions.Stub,
+	})
+
+	MakeMTOShipment(db, Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType: models.MTOShipmentTypeHHGOutOfNTSDom,
+			Status:       models.MTOShipmentStatusSubmitted,
 		},
 		Stub: assertions.Stub,
 	})

--- a/pkg/testdatagen/make_move_document.go
+++ b/pkg/testdatagen/make_move_document.go
@@ -81,7 +81,9 @@ func MakeMoveDocumentWeightTicketSet(db *pop.Connection, assertions Assertions) 
 	weightTicketSetDocument := MakeWeightTicketSetDocument(db, weightTicketSetAssertions)
 	moveDocument.WeightTicketSetDocument = &weightTicketSetDocument
 
-	mustSave(db, &moveDocument)
+	if !assertions.Stub {
+		mustSave(db, &moveDocument)
+	}
 
 	return moveDocument
 }

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -121,10 +121,28 @@ func MakeTOOOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeU
 
 	officeUser := MakeOfficeUser(db, Assertions{
 		OfficeUser: models.OfficeUser{
+			ID:   uuid.Must(uuid.NewV4()),
 			User: tooUser,
 		},
 		Stub: assertions.Stub,
 	})
 
 	return officeUser
+}
+
+// MakeOfficeUserWithUSMCGBLOC makes an OfficeUser tied to the USMC GBLOC
+func MakeOfficeUserWithUSMCGBLOC(db *pop.Connection) models.OfficeUser {
+	officeUUID, _ := uuid.NewV4()
+	transportationOffice := MakeTransportationOffice(db, Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "USMC",
+			ID:    officeUUID,
+		},
+	})
+
+	return MakeOfficeUser(db, Assertions{
+		OfficeUser: models.OfficeUser{
+			TransportationOffice: transportationOffice,
+		},
+	})
 }

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -122,7 +122,9 @@ func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models
 	}
 	backupContact := MakeBackupContact(db, contactAssertions)
 	serviceMember.BackupContacts = append(serviceMember.BackupContacts, backupContact)
-	mustSave(db, &serviceMember)
+	if !assertions.Stub {
+		mustSave(db, &serviceMember)
+	}
 
 	return serviceMember
 }

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -529,6 +529,24 @@ func createUnsubmittedMoveWithNTSAndNTSR(db *pop.Connection) {
 	})
 }
 
+func createNTSMove(db *pop.Connection) {
+	testdatagen.MakeNTSMoveWithShipment(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			FirstName: models.StringPointer("Spaceman"),
+			LastName:  models.StringPointer("NTS"),
+		},
+	})
+}
+
+func createNTSRMove(db *pop.Connection) {
+	testdatagen.MakeNTSRMoveWithShipment(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			FirstName: models.StringPointer("Spaceman"),
+			LastName:  models.StringPointer("NTS-R"),
+		},
+	})
+}
+
 func createPPMReadyToRequestPayment(db *pop.Connection, userUploader *uploader.UserUploader) {
 	/*
 	 * Service member with a ppm ready to request payment
@@ -1702,6 +1720,8 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	createTOO(db)
 	createTIO(db)
 	createTXO(db)
+	createNTSMove(db)
+	createNTSRMove(db)
 
 	// This allows testing the pagination feature in the TXO queues.
 	// Feel free to comment out the loop if you don't need this many moves.

--- a/src/pages/Office/MoveQueue/MoveQueue.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { HistoryShape } from 'types/router';
 import { createHeader } from 'components/Table/utils';
 import { useMovesQueueQueries, useUserQueries } from 'hooks/queries';
-import { serviceMemberAgencyLabel } from 'shared/formatters';
+import { serviceMemberAgencyLabel, moveStatusLabel } from 'shared/formatters';
 import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
 import SelectFilter from 'components/Table/Filters/SelectFilter';
 import { BRANCH_OPTIONS, MOVE_STATUS_OPTIONS, GBLOC } from 'constants/queues';
@@ -28,11 +28,18 @@ const columns = (showBranchFilter = true) => [
     id: 'dodID',
     isFilterable: true,
   }),
-  createHeader('Status', 'status', {
-    isFilterable: true,
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    Filter: (props) => <MultiSelectCheckBoxFilter options={MOVE_STATUS_OPTIONS} {...props} />,
-  }),
+  createHeader(
+    'Status',
+    (row) => {
+      return moveStatusLabel(row.status);
+    },
+    {
+      id: 'status',
+      isFilterable: true,
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      Filter: (props) => <MultiSelectCheckBoxFilter options={MOVE_STATUS_OPTIONS} {...props} />,
+    },
+  ),
   createHeader('Move Code', 'locator', {
     id: 'moveID',
     isFilterable: true,

--- a/src/pages/Office/MoveQueue/MoveQueue.test.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.test.jsx
@@ -33,7 +33,7 @@ jest.mock('hooks/queries', () => ({
             locator: 'AB5P',
             departmentIndicator: 'ARMY',
             shipmentsCount: 2,
-            status: 'NEW',
+            status: 'SUBMITTED',
             destinationDutyStation: {
               name: 'Area 51',
             },
@@ -83,7 +83,7 @@ describe('MoveQueue', () => {
     const firstMove = moves.at(0);
     expect(firstMove.find({ 'data-testid': 'lastName-0' }).text()).toBe('test last, test first');
     expect(firstMove.find({ 'data-testid': 'dodID-0' }).text()).toBe('555555555');
-    expect(firstMove.find({ 'data-testid': 'status-0' }).text()).toBe('NEW');
+    expect(firstMove.find({ 'data-testid': 'status-0' }).text()).toBe('New move');
     expect(firstMove.find({ 'data-testid': 'moveID-0' }).text()).toBe('AB5P');
     expect(firstMove.find({ 'data-testid': 'branch-0' }).text()).toBe('Air Force');
     expect(firstMove.find({ 'data-testid': 'shipmentsCount-0' }).text()).toBe('2');
@@ -93,7 +93,7 @@ describe('MoveQueue', () => {
     const secondMove = moves.at(1);
     expect(secondMove.find({ 'data-testid': 'lastName-1' }).text()).toBe('test another last, test another first');
     expect(secondMove.find({ 'data-testid': 'dodID-1' }).text()).toBe('4444444444');
-    expect(secondMove.find({ 'data-testid': 'status-1' }).text()).toBe('APPROVED');
+    expect(secondMove.find({ 'data-testid': 'status-1' }).text()).toBe('Move approved');
     expect(secondMove.find({ 'data-testid': 'moveID-1' }).text()).toBe('T12A');
     expect(secondMove.find({ 'data-testid': 'branch-1' }).text()).toBe('Marine Corps');
     expect(secondMove.find({ 'data-testid': 'shipmentsCount-1' }).text()).toBe('1');

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -8,6 +8,7 @@ import { DEPARTMENT_INDICATOR_OPTIONS, DEPARTMENT_INDICATOR_LABELS } from 'const
 import { ORDERS_TYPE_OPTIONS, ORDERS_TYPE_DETAILS_OPTIONS } from 'constants/orders';
 import { PAYMENT_REQUEST_STATUS_LABELS } from 'constants/paymentRequestStatus';
 import { SERVICE_MEMBER_AGENCY_LABELS } from 'content/serviceMemberAgencies';
+import { MOVE_STATUS_OPTIONS } from 'constants/queues';
 
 /**
  * Formats number into a dollar string. Eg. $1,234.12
@@ -307,6 +308,10 @@ export const departmentIndicatorLabel = (departmentIndicator) => {
 
 export const serviceMemberAgencyLabel = (agency) => {
   return SERVICE_MEMBER_AGENCY_LABELS[`${agency}`] || agency;
+};
+
+export const moveStatusLabel = (status) => {
+  return MOVE_STATUS_OPTIONS.find((option) => option.value === `${status}`)?.label || status;
 };
 
 export const ordersTypeReadable = (ordersType) => {


### PR DESCRIPTION
## Description

Before, we were only displaying the Move status, locator and number of
shipments for moves of `SelectedMoveType` `HHG`. For now, we also want
to support HHG_PPM, NTS, and NTSR, but not PPM, UB, and POV.

## Reviewer Notes

Run `make db_dev_e2e_populate`
Log in as a TOO
Verify that you see the NTS and NTSR moves and that they show the move locator, status, and number of shipments.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4940) for this change

## Screenshots
<img width="1392" alt="Screen Shot 2020-11-18 at 3 44 54 PM" src="https://user-images.githubusercontent.com/811150/99585949-071b9680-29b5-11eb-8ab3-11a0726784aa.png">
