### PR TITLE
[MB-5354][MB-5536] Fix bug in fetch-mto-updates causing identical destination addresses

### DIFF
--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -53,8 +53,8 @@ func MoveTaskOrders(moveTaskOrders *models.Moves) []*primemessages.MoveTaskOrder
 	payload := make(primemessages.MoveTaskOrders, len(*moveTaskOrders))
 
 	for i, m := range *moveTaskOrders {
-		// #nosec G601 TODO needs review
-		payload[i] = MoveTaskOrder(&m)
+		copyOfM := m // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload[i] = MoveTaskOrder(&copyOfM)
 	}
 	return payload
 }
@@ -215,8 +215,8 @@ func MTOAgents(mtoAgents *models.MTOAgents) *primemessages.MTOAgents {
 	agents := make(primemessages.MTOAgents, len(*mtoAgents))
 
 	for i, m := range *mtoAgents {
-		// #nosec G601 TODO needs review
-		agents[i] = MTOAgent(&m)
+		copyOfM := m // Make copy to avoid implicit memory aliasing of items from a range statement.
+		agents[i] = MTOAgent(&copyOfM)
 	}
 
 	return &agents
@@ -250,8 +250,8 @@ func PaymentRequests(paymentRequests *models.PaymentRequests) *primemessages.Pay
 	payload := make(primemessages.PaymentRequests, len(*paymentRequests))
 
 	for i, p := range *paymentRequests {
-		// #nosec G601 TODO needs review
-		payload[i] = PaymentRequest(&p)
+		copyOfP := p // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload[i] = PaymentRequest(&copyOfP)
 	}
 	return &payload
 }
@@ -291,8 +291,8 @@ func PaymentServiceItems(paymentServiceItems *models.PaymentServiceItems) *prime
 	payload := make(primemessages.PaymentServiceItems, len(*paymentServiceItems))
 
 	for i, p := range *paymentServiceItems {
-		// #nosec G601 TODO needs review
-		payload[i] = PaymentServiceItem(&p)
+		copyOfP := p // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload[i] = PaymentServiceItem(&copyOfP)
 	}
 	return &payload
 }
@@ -323,8 +323,8 @@ func PaymentServiceItemParams(paymentServiceItemParams *models.PaymentServiceIte
 	payload := make(primemessages.PaymentServiceItemParams, len(*paymentServiceItemParams))
 
 	for i, p := range *paymentServiceItemParams {
-		// #nosec G601 TODO needs review
-		payload[i] = PaymentServiceItemParam(&p)
+		copyOfP := p // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload[i] = PaymentServiceItemParam(&copyOfP)
 	}
 	return &payload
 }
@@ -393,8 +393,8 @@ func MTOShipments(mtoShipments *models.MTOShipments) *primemessages.MTOShipments
 	payload := make(primemessages.MTOShipments, len(*mtoShipments))
 
 	for i, m := range *mtoShipments {
-		// #nosec G601 TODO needs review
-		payload[i] = MTOShipment(&m)
+		copyOfM := m // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload[i] = MTOShipment(&copyOfM)
 	}
 	return &payload
 }
@@ -475,8 +475,8 @@ func MTOServiceItems(mtoServiceItems *models.MTOServiceItems) *[]primemessages.M
 	var payload []primemessages.MTOServiceItem
 
 	for _, p := range *mtoServiceItems {
-		// #nosec G601 TODO needs review
-		payload = append(payload, MTOServiceItem(&p))
+		copyOfP := p // Make copy to avoid implicit memory aliasing of items from a range statement.
+		payload = append(payload, MTOServiceItem(&copyOfP))
 	}
 	return &payload
 }

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -2214,4 +2214,39 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		Move:          move8,
 		PrimeUploader: primeUploader,
 	}, 35)
+
+	// Make an available to prime move with a unique address.
+	address := testdatagen.MakeAddress(db, testdatagen.Assertions{
+		Address: models.Address{
+			StreetAddress1: "2 Second St",
+			StreetAddress2: swag.String("Apt 2"),
+			StreetAddress3: swag.String("Suite B"),
+			City:           "Columbia",
+			State:          "SC",
+			PostalCode:     "29212",
+			Country:        swag.String("US"),
+		},
+	})
+
+	newDutyStation := testdatagen.MakeDutyStation(db, testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			AddressID: address.ID,
+			Address:   address,
+		},
+	})
+
+	moveOrder := testdatagen.MakeOrder(db, testdatagen.Assertions{
+		Order: models.Order{
+			NewDutyStationID: newDutyStation.ID,
+			NewDutyStation:   newDutyStation,
+		},
+	})
+
+	testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			AvailableToPrimeAt: swag.Time(time.Now()),
+			Status:             models.MoveStatusAPPROVED,
+		},
+		Order: moveOrder,
+	})
 }

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -2244,6 +2244,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
+			ID:                 uuid.FromStringOrNil("ecbc2e6a-1b45-403b-9bd4-ea315d4d3d93"),
 			AvailableToPrimeAt: swag.Time(time.Now()),
 			Status:             models.MoveStatusAPPROVED,
 		},

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1617,6 +1617,43 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 	)
 }
 
+func createMoveWithUniqueDestinationAddress(db *pop.Connection) {
+	address := testdatagen.MakeAddress(db, testdatagen.Assertions{
+		Address: models.Address{
+			StreetAddress1: "2 Second St",
+			StreetAddress2: swag.String("Apt 2"),
+			StreetAddress3: swag.String("Suite B"),
+			City:           "Columbia",
+			State:          "SC",
+			PostalCode:     "29212",
+			Country:        swag.String("US"),
+		},
+	})
+
+	newDutyStation := testdatagen.MakeDutyStation(db, testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			AddressID: address.ID,
+			Address:   address,
+		},
+	})
+
+	moveOrder := testdatagen.MakeOrder(db, testdatagen.Assertions{
+		Order: models.Order{
+			NewDutyStationID: newDutyStation.ID,
+			NewDutyStation:   newDutyStation,
+		},
+	})
+
+	testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			ID:                 uuid.FromStringOrNil("ecbc2e6a-1b45-403b-9bd4-ea315d4d3d93"),
+			AvailableToPrimeAt: swag.Time(time.Now()),
+			Status:             models.MoveStatusAPPROVED,
+		},
+		Order: moveOrder,
+	})
+}
+
 // Run does that data load thing
 func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, storer *storage.Filesystem) {
 	// PPM Office Queue
@@ -1655,4 +1692,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	// This move below is a PPM move in DRAFT status. It should probably
 	// be changed to an HHG move in SUBMITTED status to reflect reality.
 	createMoveWithBasicServiceItems(db, userUploader)
+	// Sets up a move with a non-default destination duty station address
+	// (to more easily spot issues with addresses being overwritten).
+	createMoveWithUniqueDestinationAddress(db)
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the prime API's `fetch-mto-updates` (and potentially other code that uses the Prime API's model-to-payload converter).  In particular, every destination duty station address returned by `fetch-mto-updates` was being set to the same street/city/state/zip regardless of what address was actually stored in the database (essentially, the last one through the loop "won" as all the addresses were pointing to the same chunk of memory).  I also found that it affected the `isFinal` field of a payment request if more than one payment request was attached to a given move.

The root cause was that we were taking the address of a loop variable set via a range, but not appreciating that Go instantiates the loop variable once and then just copies each item to the same loop variable each iteration.  Taking the address of that loop variable results in the same pointer every iteration which can lead to some hard-to-detect issues.

I have also added [documentation](https://github.com/transcom/mymove/wiki/Using-loop-iterator-variables-in-go) about this to our Wiki.

Some general references about the issue:
- https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
- https://stackoverflow.com/questions/48826460/using-pointers-in-a-for-loop

## Reviewer Notes

- Note that this issue is flagged by the new version of the gosec linter as `G601`, so that should help identify these scenarios.
- Make sure the fix (and the comment next to it) seem clear enough for others that run into this code.
- We may not have ever noticed this with our dev seed data because all of our available-to-prime moves were using the same address.  I added another move with a unique address in our dev seed data to make the issue more obvious.

## Setup

- `make server_build db_dev_e2e_populate`
- I made a test case that demonstrates the issue.  If you roll back the changes to `model_to_payload.go`, you can see the test fail and demonstrate the problem.  Reapply the changes and all tests should pass.
- This problem was hidden in our dev seed data because the three available to prime moves there all were set up with the same address.  I added another one with a unique address in this PR.  If you roll back the changes to `model_to_payload.go` again, then run a `prime-api-client --insecure fetch-mto-updates`, you should see the identical address problem.  Reapply and the issue should go away.  Comparing the two resulting JSON responses should make that clear.
- Until this is merged, you can also see the issue running `fetch-mto-updates` against staging.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Parent story](https://dp3.atlassian.net/browse/MB-5343) for this change
* [Subtask story](https://dp3.atlassian.net/browse/MB-5354) for the unit test
* [Subtask story](https://dp3.atlassian.net/browse/MB-5536) for the fix
* [Wiki documentation](https://github.com/transcom/mymove/wiki/Using-loop-iterator-variables-in-go)
