### PR TITLE
MB-5592 | remediate & annotate g402 tls minversion linter findings

### DIFF
--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -120,11 +120,7 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 		logger.Fatal("Error in getting tls certs", zap.Error(err))
 	}
 
-	tlsConfig := &tls.Config{
-		Certificates: certificates,
-		RootCAs:      rootCAs,
-		MinVersion:   tls.VersionTLS12,
-	}
+	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	filename := foramtFilename("filename")
 	urlWithFilename := fmt.Sprintf("%s&fname=%s", v.GetString("gex-url"), filename)

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -120,8 +120,11 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 		logger.Fatal("Error in getting tls certs", zap.Error(err))
 	}
 
-	// #nosec G402 TODO needs review
-	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs}
+	tlsConfig := &tls.Config{
+		Certificates: certificates,
+		RootCAs:      rootCAs,
+		MinVersion:   tls.VersionTLS12,
+	}
 
 	filename := foramtFilename("filename")
 	urlWithFilename := fmt.Sprintf("%s&fname=%s", v.GetString("gex-url"), filename)

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -584,8 +584,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	logger.Debug("Trusted Certificate Authorities", zap.Any("subjects", rootCAs.Subjects()))
 
 	// Set the GexSender() and GexSender fields
-	// #nosec G402 TODO needs review
-	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs}
+	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 	var gexRequester services.GexSender
 	gexURL := v.GetString(cli.GEXURLFlag)
 	if len(gexURL) == 0 {
@@ -596,8 +595,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		gexRequester = invoice.NewGexSenderHTTP(
 			server.URL,
 			false,
-			// #nosec G402 TODO needs review
-			&tls.Config{},
+			&tls.Config{MinVersion: tls.VersionTLS12},
 			"",
 			"",
 		)

--- a/cmd/send-to-gex/main.go
+++ b/cmd/send-to-gex/main.go
@@ -120,8 +120,7 @@ func main() {
 		log.Fatal("Error in getting tls certs", err)
 	}
 
-	// #nosec G402 TODO needs review
-	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs}
+	tlsConfig := &tls.Config{Certificates: certificates, RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	logger.Println("Sending to GEX ...")
 	resp, err := invoice.NewGexSenderHTTP(

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -126,10 +126,10 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 
 	//RA Summary: gosec - G402 - TLS MinVersion too low
 	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
-	//RA: However, this by design. The purpose of the tls-checker is to attempt to deploy the app with some
-	//RA: known bad versions of TLS -- including 1.0 and 1.1. Relevant PR in which tls-checker was added:
+	//RA: However, this is by design. The purpose of the tls-checker is to attempt to deploy the app with
+	//RA: some known bad versions of TLS including 1.0 and 1.1. Relevant PR in which tls-checker was added:
 	//RA: - https://github.com/transcom/mymove/pull/3340
-	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, **Mitigated**, Need Developer Fix, False Positive, Bad Practice}
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:
@@ -166,10 +166,10 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 
 	//RA Summary: gosec - G402 - TLS MinVersion too low
 	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
-	//RA: However, this by design. The purpose of the tls-checker is to attempt to deploy the app with some
-	//RA: known bad versions of TLS -- including 1.0 and 1.1. Relevant PR in which tls-checker was added:
+	//RA: However, this is by design. The purpose of the tls-checker is to attempt to deploy the app with
+	//RA: some known bad versions of TLS including 1.0 and 1.1. Relevant PR in which tls-checker was added:
 	//RA: - https://github.com/transcom/mymove/pull/3340
-	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, **Mitigated**, Need Developer Fix, False Positive, Bad Practice}
+	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity:

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -130,9 +130,8 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 	//RA: The subroutine is executed by the MilMove pipeline, post-deployment.  It is not included in the production system.
 	//RA: Related pull request... https://github.com/transcom/mymove/pull/3340
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Validator Status: Mitigated
+	//RA Modified Severity: N/A
 	// #nosec G402
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{keyPair},
@@ -170,9 +169,8 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 	//RA: This subroutine is executed by the MilMove pipeline, post-deployment.  It is not included in the production system.
 	//RA: Related pull request... https://github.com/transcom/mymove/pull/3340
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Validator Status: Mitigated
+	//RA Modified Severity: N/A
 	// #nosec G402
 	tlsConfig := &tls.Config{
 		MinVersion: tlsVersion,

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -124,8 +124,16 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 		return nil, err
 	}
 
-	// TODO: annotate
-	// #nosec G402 TODO needs review
+	//RA Summary: gosec - G402 - TLS MinVersion too low
+	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
+	//RA: However, this by design. The purpose of the tls-checker is to attempt to deploy the app with some
+	//RA: known bad versions of TLS -- including 1.0 and 1.1. Relevant PR in which tls-checker was added:
+	//RA: - https://github.com/transcom/mymove/pull/3340
+	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, **Mitigated**, Need Developer Fix, False Positive, Bad Practice}
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+	// #nosec G402
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{keyPair},
 		MinVersion:   tlsVersion,
@@ -156,8 +164,16 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 		}
 	}
 
-	// Supported TLS versions
-	// #nosec G402 TODO needs review
+	//RA Summary: gosec - G402 - TLS MinVersion too low
+	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
+	//RA: However, this by design. The purpose of the tls-checker is to attempt to deploy the app with some
+	//RA: known bad versions of TLS -- including 1.0 and 1.1. Relevant PR in which tls-checker was added:
+	//RA: - https://github.com/transcom/mymove/pull/3340
+	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, **Mitigated**, Need Developer Fix, False Positive, Bad Practice}
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+	// #nosec G402
 	tlsConfig := &tls.Config{
 		MinVersion: tlsVersion,
 		MaxVersion: tlsVersion,

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -124,6 +124,7 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 		return nil, err
 	}
 
+	// TODO: annotate
 	// #nosec G402 TODO needs review
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{keyPair},

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -126,9 +126,9 @@ func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, tlsVersion 
 
 	//RA Summary: gosec - G402 - TLS MinVersion too low
 	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
-	//RA: However, this is by design. The purpose of the tls-checker is to attempt to deploy the app with
-	//RA: some known bad versions of TLS including 1.0 and 1.1. Relevant PR in which tls-checker was added:
-	//RA: - https://github.com/transcom/mymove/pull/3340
+	//RA: The code is part of a subroutine that checks that MilMove public endpoints use TLS v1.2 or higher.
+	//RA: The subroutine is executed by the MilMove pipeline, post-deployment.  It is not included in the production system.
+	//RA: Related pull request... https://github.com/transcom/mymove/pull/3340
 	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org
@@ -166,9 +166,9 @@ func createHTTPClient(v *viper.Viper, logger *zap.Logger, tlsVersion uint16) (*h
 
 	//RA Summary: gosec - G402 - TLS MinVersion too low
 	//RA: The linter flagged this line of code, because we are passing in a tlsVersion which could be bad.
-	//RA: However, this is by design. The purpose of the tls-checker is to attempt to deploy the app with
-	//RA: some known bad versions of TLS including 1.0 and 1.1. Relevant PR in which tls-checker was added:
-	//RA: - https://github.com/transcom/mymove/pull/3340
+	//RA: The code is part of a subroutine that checks that MilMove public endpoints use TLS v1.2 or higher.
+	//RA: This subroutine is executed by the MilMove pipeline, post-deployment.  It is not included in the production system.
+	//RA: Related pull request... https://github.com/transcom/mymove/pull/3340
 	//RA Developer Status: Mitigated
 	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
 	//RA Validator: jneuner@mitre.org

--- a/pkg/iws/rbs_person_lookup.go
+++ b/pkg/iws/rbs_person_lookup.go
@@ -118,10 +118,10 @@ func NewRBSPersonLookup(host string, dodCACertPackage string, certString string,
 	}
 
 	// Setup HTTPS client
-	// #nosec G402 TODO needs review
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
 	}
 	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}


### PR DESCRIPTION
## Description

There are 7 total G402 TLS minversion linter findings.
- 5 are remediated in this PR by adding a minversion to the tls.Config object
- 2 are annotated in this PR, because we are actually using them to intentionally pass bad TLS versions in order to validate that we __cannot__ deploy with TLS 1.0 or 1.1.

## Reviewer Notes

This does not cover the other 4 G402's which are throwing a different warning related to insecure TLS verification. Those remaining instances will be covered in a separate PR / [jira sub-task](https://dp3.atlassian.net/browse/MB-5593).

@shimonacarvalho && @monfresh --- added you to sanity check the min version changes won't break anything.

## References

- [Jira task](https://dp3.atlassian.net/browse/MB-5592) for this change
- [ChrisG's PR to add tls-checker](https://github.com/transcom/mymove/pull/3340) (referred to in annotations)
