### PR TITLE
MB-5581 Exclude hidden moves from TXO queues

### DIFF
--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -68,6 +68,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *service
 		InnerJoin("mto_shipments", "moves.id = mto_shipments.move_id").
 		InnerJoin("duty_stations", "orders.origin_duty_station_id = duty_stations.id").
 		InnerJoin("transportation_offices", "duty_stations.transportation_office_id = transportation_offices.id").
+		Where("show = ?", swag.Bool(true)).
 		Order("status desc")
 
 	for _, option := range options {
@@ -89,7 +90,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *service
 		params.Page = swag.Int64(0)
 	}
 	if params.PerPage == nil {
-		params.Page = swag.Int64(0)
+		params.PerPage = swag.Int64(0)
 	}
 
 	err = query.GroupBy("moves.id").Paginate(int(*params.Page), int(*params.PerPage)).All(&moves)

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -45,6 +45,7 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestList(officeUserID uuid.UU
 		InnerJoin("service_members", "orders.service_member_id = service_members.id").
 		InnerJoin("duty_stations", "duty_stations.id = orders.origin_duty_station_id").
 		InnerJoin("transportation_offices", "transportation_offices.id = duty_stations.transportation_office_id").
+		Where("moves.show = ?", swag.Bool(true)).
 		Order("status asc")
 
 	branchQuery := branchFilter(params.Branch)

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -24,14 +24,19 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestList() {
 			Gbloc: "ABCD",
 		},
 	})
-	testdatagen.MakeDefaultPaymentRequest(suite.DB())
+	// Hidden move should not be returned
+	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Show: swag.Bool(false),
+		},
+	})
 
-	suite.T().Run("Returns payment requests matching office user GBLOC", func(t *testing.T) {
+	suite.T().Run("Only returns visible (where Move.Show is not false) payment requests matching office user GBLOC", func(t *testing.T) {
 		expectedPaymentRequests, _, err := paymentRequestListFetcher.FetchPaymentRequestList(officeUser.ID,
 			&services.FetchPaymentRequestListParams{Page: swag.Int64(1), PerPage: swag.Int64(2)})
 
 		suite.NoError(err)
-		suite.Equal(2, len(*expectedPaymentRequests))
+		suite.Equal(1, len(*expectedPaymentRequests))
 	})
 
 	suite.T().Run("Returns payment request matching an arbitrary filter", func(t *testing.T) {

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -123,6 +123,53 @@ func MakeDefaultMove(db *pop.Connection) models.Move {
 	return MakeMove(db, Assertions{})
 }
 
+// MakeHHGMoveWithShipment makes an HHG Move with one submitted shipment
+func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+	hhgMoveType := models.SelectedMoveTypeHHG
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			SelectedMoveType: &hhgMoveType,
+			Status:           models.MoveStatusSUBMITTED,
+		},
+		ServiceMember:        assertions.ServiceMember,
+		TransportationOffice: assertions.TransportationOffice,
+		Stub:                 assertions.Stub,
+	})
+
+	MakeMTOShipment(db, Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Stub: assertions.Stub,
+	})
+
+	return move
+}
+
+// MakeHiddenHHGMoveWithShipment makes an HHG Move with show = false
+func MakeHiddenHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
+	hhgMoveType := models.SelectedMoveTypeHHG
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			SelectedMoveType: &hhgMoveType,
+			Status:           models.MoveStatusSUBMITTED,
+			Show:             swag.Bool(false),
+		},
+		Stub: assertions.Stub,
+	})
+
+	MakeMTOShipment(db, Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Stub: assertions.Stub,
+	})
+
+	return move
+}
+
 func setShow(assertionShow *bool) *bool {
 	show := swag.Bool(true)
 	if assertionShow != nil {


### PR DESCRIPTION
## Description

In the admin interface, we have the ability to set a Move's `Show`
field to `false`, which should exclude it from showing up in any TXO
queue. This PR ensures we only return visible moves and payment
requests.

## Reviewer Notes

1. Sign in locally as a TIO
2. Make a note of the Move Code for one of the listed payment requests
3. Using a DB GUI like TablePlus, or `psql`, or your preferred method, find that move, and update its `Show` field to false
4. Verify that the move disappears from both the TIO and TXO queues

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5581) for this change
