### PR TITLE
MB-5483 MB-5543 MB-5544 Update service to check for configuration vars or error

### DIFF
--- a/pkg/services/invoice/syncada_sftp_sender.go
+++ b/pkg/services/invoice/syncada_sftp_sender.go
@@ -32,8 +32,33 @@ func NewSyncadaSFTPSession(port string, userID string, remote string, password s
 }
 
 // InitNewSyncadaSFTPSession initialize a NewSyncadaSFTPSession and return services.SyncadaSFTPSender
-func InitNewSyncadaSFTPSession() services.SyncadaSFTPSender {
-	return NewSyncadaSFTPSession(os.Getenv("SYNCADA_SFTP_PORT"), os.Getenv("SYNCADA_SFTP_USER_ID"), os.Getenv("SYNCADA_SFTP_IP_ADDRESS"), os.Getenv("SYNCADA_SFTP_PASSWORD"), os.Getenv("SYNCADA_SFTP_INBOUND_DIRECTORY"))
+func InitNewSyncadaSFTPSession() (services.SyncadaSFTPSender, error) {
+	port := os.Getenv("SYNCADA_SFTP_PORT")
+	if port == "" {
+		return nil, fmt.Errorf("Invalid credentials sftp missing SYNCADA_SFTP_PORT")
+	}
+
+	userID := os.Getenv("SYNCADA_SFTP_USER_ID")
+	if userID == "" {
+		return nil, fmt.Errorf("Invalid credentials sftp missing SYNCADA_SFTP_USER_ID")
+	}
+
+	ipAddress := os.Getenv("SYNCADA_SFTP_IP_ADDRESS")
+	if ipAddress == "" {
+		return nil, fmt.Errorf("Invalid credentials sftp missing SYNCADA_SFTP_IP_ADDRESS")
+	}
+
+	password := os.Getenv("SYNCADA_SFTP_PASSWORD")
+	if password == "" {
+		return nil, fmt.Errorf("Invalid credentials sftp missing SYNCADA_SFTP_PASSWORD")
+	}
+
+	inboundDir := os.Getenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+	if inboundDir == "" {
+		return nil, fmt.Errorf("Invalid credentials sftp missing SYNCADA_SFTP_INBOUND_DIRECTORY")
+	}
+
+	return NewSyncadaSFTPSession(port, userID, ipAddress, password, inboundDir), nil
 }
 
 // SendToSyncadaViaSFTP copies specified local content to Syncada's SFTP server

--- a/pkg/services/invoice/syncada_sftp_sender_test.go
+++ b/pkg/services/invoice/syncada_sftp_sender_test.go
@@ -1,0 +1,108 @@
+package invoice
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type SyncadaSftpSenderSuite struct {
+	testingsuite.PopTestSuite
+	logger Logger
+}
+
+func TestSyncadaSftpSenderSuite(t *testing.T) {
+
+	ts := &SyncadaSftpSenderSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("syncada_sftp_sender")),
+		logger:       zap.NewNop(), // Use a no-op logger during testing
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}
+
+func (suite *SyncadaSftpSenderSuite) TestSendToSyncadaSftp() {
+	type setupEnvVars func()
+
+	missingCreds := []struct {
+		TestEnvironmentVar string
+		Setup              setupEnvVars
+	}{
+		{
+			TestEnvironmentVar: "SYNCADA_SFTP_PORT",
+			Setup: func() {
+				os.Unsetenv("SYNCADA_SFTP_PORT")
+				os.Unsetenv("SYNCADA_SFTP_USER_ID")
+				os.Unsetenv("SYNCADA_SFTP_IP_ADDRESS")
+				os.Unsetenv("SYNCADA_SFTP_PASSWORD")
+				os.Unsetenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+			},
+		},
+		{
+			TestEnvironmentVar: "SYNCADA_SFTP_USER_ID",
+			Setup: func() {
+				os.Setenv("SYNCADA_SFTP_PORT", "1234")
+				os.Unsetenv("SYNCADA_SFTP_USER_ID")
+				os.Unsetenv("SYNCADA_SFTP_IP_ADDRESS")
+				os.Unsetenv("SYNCADA_SFTP_PASSWORD")
+				os.Unsetenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+			},
+		},
+		{
+			TestEnvironmentVar: "SYNCADA_SFTP_IP_ADDRESS",
+			Setup: func() {
+				os.Setenv("SYNCADA_SFTP_PORT", "1234")
+				os.Setenv("SYNCADA_SFTP_USER_ID", "FAKE_USER_ID")
+				os.Unsetenv("SYNCADA_SFTP_IP_ADDRESS")
+				os.Unsetenv("SYNCADA_SFTP_PASSWORD")
+				os.Unsetenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+			},
+		},
+		{
+			TestEnvironmentVar: "SYNCADA_SFTP_PASSWORD",
+			Setup: func() {
+				os.Setenv("SYNCADA_SFTP_PORT", "1234")
+				os.Setenv("SYNCADA_SFTP_USER_ID", "FAKE_USER_ID")
+				os.Setenv("SYNCADA_SFTP_IP_ADDRESS", "127.0.0.1")
+				os.Unsetenv("SYNCADA_SFTP_PASSWORD")
+				os.Unsetenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+			},
+		},
+		{
+			TestEnvironmentVar: "SYNCADA_SFTP_INBOUND_DIRECTORY",
+			Setup: func() {
+				os.Setenv("SYNCADA_SFTP_PORT", "1234")
+				os.Setenv("SYNCADA_SFTP_USER_ID", "FAKE_USER_ID")
+				os.Setenv("SYNCADA_SFTP_IP_ADDRESS", "127.0.0.1")
+				os.Setenv("SYNCADA_SFTP_PASSWORD", "FAKE PASSWORD")
+				os.Unsetenv("SYNCADA_SFTP_INBOUND_DIRECTORY")
+			},
+		},
+	}
+
+	for _, data := range missingCreds {
+		suite.T().Run(fmt.Sprintf("constructor fails if %s is missing", data.TestEnvironmentVar), func(t *testing.T) {
+			data.Setup()
+			sender, err := InitNewSyncadaSFTPSession()
+			suite.Error(err)
+			suite.Nil(sender)
+			suite.Equal(fmt.Sprintf("Invalid credentials sftp missing %s", data.TestEnvironmentVar), err.Error())
+		})
+	}
+
+	suite.T().Run("constructor doesn't fail if passed in all env", func(t *testing.T) {
+		os.Setenv("SYNCADA_SFTP_PORT", "1234")
+		os.Setenv("SYNCADA_SFTP_USER_ID", "FAKE_USER_ID")
+		os.Setenv("SYNCADA_SFTP_IP_ADDRESS", "127.0.0.1")
+		os.Setenv("SYNCADA_SFTP_PASSWORD", "FAKE PASSWORD")
+		os.Setenv("SYNCADA_SFTP_INBOUND_DIRECTORY", "/Dropoff")
+		sender, err := InitNewSyncadaSFTPSession()
+		suite.NoError(err)
+		suite.NotNil(sender)
+	})
+}

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -243,11 +243,11 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 		return nil, services.NewConflictError(moveTaskOrder.Orders.ServiceMemberID, fmt.Sprintf("ServiceMember on MoveTaskOrder (ID: %s) missing Last Name", moveTaskOrder.ID))
 	}
 	// Verify Rank
-	if serviceMember.Rank == nil {
+	if serviceMember.Rank == nil || *serviceMember.Rank == "" {
 		return nil, services.NewConflictError(moveTaskOrder.Orders.ServiceMemberID, fmt.Sprintf("ServiceMember on MoveTaskOrder (ID: %s) missing Rank", moveTaskOrder.ID))
 	}
 	// Verify Affiliation
-	if serviceMember.Affiliation == nil {
+	if serviceMember.Affiliation == nil || *serviceMember.Affiliation == "" {
 		return nil, services.NewConflictError(moveTaskOrder.Orders.ServiceMemberID, fmt.Sprintf("ServiceMember on MoveTaskOrder (ID: %s) missing Affiliation", moveTaskOrder.ID))
 	}
 

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -484,6 +484,24 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				return fmt.Sprintf("id: %s is in a conflicting state ServiceMember on MoveTaskOrder (ID: %s) missing Rank", serviceMemberID, mtoID)
 			},
 		},
+		// ServiceMember with blank Rank
+		{
+			TestDescription: "Given move with service member that has blank Rank, the create should fail",
+			InvalidMove: func() models.Move {
+				mtoInvalid := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+				sm := mtoInvalid.Orders.ServiceMember
+				var blank models.ServiceMemberRank
+				blank = ""
+				sm.Rank = &blank
+				err := suite.DB().Update(&sm)
+				suite.FatalNoError(err)
+				return mtoInvalid
+			},
+			ExpectedError: services.ConflictError{},
+			ExpectedErrorMessage: func(serviceMemberID uuid.UUID, mtoID uuid.UUID) string {
+				return fmt.Sprintf("id: %s is in a conflicting state ServiceMember on MoveTaskOrder (ID: %s) missing Rank", serviceMemberID, mtoID)
+			},
+		},
 		// ServiceMember with no Affiliation
 		{
 			TestDescription: "Given move with service member that has no Affiliation, the create should fail",
@@ -491,6 +509,24 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				mtoInvalid := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 				sm := mtoInvalid.Orders.ServiceMember
 				sm.Affiliation = nil
+				err := suite.DB().Update(&sm)
+				suite.FatalNoError(err)
+				return mtoInvalid
+			},
+			ExpectedError: services.ConflictError{},
+			ExpectedErrorMessage: func(serviceMemberID uuid.UUID, mtoID uuid.UUID) string {
+				return fmt.Sprintf("id: %s is in a conflicting state ServiceMember on MoveTaskOrder (ID: %s) missing Affiliation", serviceMemberID, mtoID)
+			},
+		},
+		// ServiceMember with blank Affiliation
+		{
+			TestDescription: "Given move with service member that has blank Affiliation, the create should fail",
+			InvalidMove: func() models.Move {
+				mtoInvalid := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+				sm := mtoInvalid.Orders.ServiceMember
+				var blank models.ServiceMemberAffiliation
+				blank = ""
+				sm.Affiliation = &blank
 				err := suite.DB().Update(&sm)
 				suite.FatalNoError(err)
 				return mtoInvalid

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -48,7 +48,11 @@ func InitNewPaymentRequestReviewedProcessor(db *pop.Connection, logger Logger, s
 	reviewedPaymentRequestFetcher := NewPaymentRequestReviewedFetcher(db)
 	generator := invoice.NewGHCPaymentRequestInvoiceGenerator(db)
 	var sftpSession services.SyncadaSFTPSender
-	sftpSession = nil
+	sftpSession, err := invoice.InitNewSyncadaSFTPSession()
+	if err != nil {
+		// just log the error, sftpSession is set to nil if there is an error
+		logger.Error(fmt.Errorf("Configuration of SyncadaSFTPSession failed: %w", err).Error())
+	}
 	var gexSender services.GexSender
 	gexSender = nil
 

--- a/pkg/services/payment_request/payment_request_reviewed_processor_test.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor_test.go
@@ -152,7 +152,7 @@ func (suite *PaymentRequestServiceSuite) TestProcessReviewedPaymentRequest() {
 	suite.T().Run("process reviewed payment request successfully (0 Payments to review)", func(t *testing.T) {
 		reviewedPaymentRequestFetcher := NewPaymentRequestReviewedFetcher(suite.DB())
 		generator := invoice.NewGHCPaymentRequestInvoiceGenerator(suite.DB())
-		SFTPSession := invoice.InitNewSyncadaSFTPSession()
+		SFTPSession, _ := invoice.InitNewSyncadaSFTPSession()
 		var gexSender services.GexSender
 		gexSender = nil
 		sendToSyncada := false
@@ -182,7 +182,7 @@ func (suite *PaymentRequestServiceSuite) TestProcessReviewedPaymentRequest() {
 
 		reviewedPaymentRequestFetcher := NewPaymentRequestReviewedFetcher(suite.DB())
 		generator := invoice.NewGHCPaymentRequestInvoiceGenerator(suite.DB())
-		SFTPSession := invoice.InitNewSyncadaSFTPSession()
+		SFTPSession, _ := invoice.InitNewSyncadaSFTPSession()
 		var gexSender services.GexSender
 		gexSender = nil
 		sendToSyncada := false
@@ -205,7 +205,7 @@ func (suite *PaymentRequestServiceSuite) TestProcessReviewedPaymentRequest() {
 		suite.createPaymentRequest(4)
 
 		reviewedPaymentRequestFetcher := NewPaymentRequestReviewedFetcher(suite.DB())
-		SFTPSession := invoice.InitNewSyncadaSFTPSession()
+		SFTPSession, _ := invoice.InitNewSyncadaSFTPSession()
 		var gexSender services.GexSender
 		gexSender = nil
 		sendToSyncada := false
@@ -233,7 +233,7 @@ func (suite *PaymentRequestServiceSuite) TestProcessReviewedPaymentRequest() {
 		suite.createPaymentRequest(4)
 
 		ediGenerator := invoice.NewGHCPaymentRequestInvoiceGenerator(suite.DB())
-		SFTPSession := invoice.InitNewSyncadaSFTPSession()
+		SFTPSession, _ := invoice.InitNewSyncadaSFTPSession()
 		var gexSender services.GexSender
 		gexSender = nil
 		sendToSyncada := false


### PR DESCRIPTION
## Description

As part of MB-5483 we want to ensure that the variables for configuring Syncada SFTP connection are passed in. If they are not present we should gracefully handle that. This PR implements MB-5543 and MB-5544 to check for the presence of the configuration options and return an error if they are missing.

## Reviewer Notes

Not that I can think of

## Setup

```sh
make server_test
make db_dev_e2e_populate
make server_run
make bin/prime-api-client
```

Save this payload
```json
{
  "body": {
    "sendToSyncada": false
  }
}
```

Send above payload
```sh
❯ prime-api-client --insecure support-reviewed-payment-requests --filename tmp/payloads/local_process_payment.json | jq .
[
  {
    "eTag": "MjAyMC0xMS0yMFQxNjo0MTozNC42MzQ5Mzla",
    "id": "cfd110d4-1f62-401c-a92c-39987a0b4228",
    "isFinal": false,
    "moveTaskOrderID": "7cbe57ba-fd3a-45a7-aa9a-1970f1908ae7",
    "paymentRequestNumber": "8777-4251-1",
    "status": "SENT_TO_GEX"
  }
]
```

If you set `sendToSyncada` to true and unset one of the syncada variables like `SYNCADA_SFTP_PASSWORD` before starting the server you should see following error logged in the server log, but still get the above response

```sh
2020-11-20T16:43:35.337Z        ERROR   payment_request/payment_request_reviewed_processor.go:54        Configuration of SyncadaSFTPSession failed: Invalid credentials sftp missing SYNCADA_SFTP_PASSWORD      {"git_branch": "MB-5483_pass_variables_needed_to_connect_to_syncada_via_sftp", "git_commit": "f74b8e5933ff8d6eb49e1e2413cfc640bbd5009d", "milmove_trace_id": "68db60af-de30-4ec8-84bf-2e767b02d3ad"}
github.com/transcom/mymove/pkg/services/payment_request.InitNewPaymentRequestReviewedProcessor
        /Users/john/projects/dod/mymove/pkg/services/payment_request/payment_request_reviewed_processor.go:54
github.com/transcom/mymove/pkg/handlers/supportapi.ProcessReviewedPaymentRequestsHandler.Handle
        /Users/john/projects/dod/mymove/pkg/handlers/supportapi/payment_request.go:260
github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/payment_request.(*ProcessReviewedPaymentRequests).ServeHTTP
        /Users/john/projects/dod/mymove/pkg/gen/supportapi/supportoperations/payment_request/process_reviewed_payment_requests.go:60
github.com/go-openapi/runtime/middleware.NewOperationExecutor.func1
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/go-openapi/runtime@v0.19.23/middleware/operation.go:28
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/go-openapi/runtime/middleware.NewRouter.func1
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/go-openapi/runtime@v0.19.23/middleware/router.go:77
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/go-openapi/runtime/middleware.Redoc.func1
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/go-openapi/runtime@v0.19.23/middleware/redoc.go:72
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/go-openapi/runtime/middleware.Spec.func1
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/go-openapi/runtime@v0.19.23/middleware/spec.go:46
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
goji%2eio.dispatch.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/dispatch.go:17
github.com/felixge/httpsnoop.CaptureMetrics.func1
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:30
github.com/felixge/httpsnoop.CaptureMetricsFn
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:81
github.com/felixge/httpsnoop.CaptureMetrics
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/github.com/felixge/httpsnoop@v1.0.1/capture_metrics.go:29
github.com/transcom/mymove/pkg/middleware.RequestLogger.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/request_logger.go:77
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/middleware.NoCache.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/no_cache.go:13
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/auth/authentication.PrimeAuthorizationMiddleware.func1.1
        /Users/john/projects/dod/mymove/pkg/auth/authentication/auth.go:241
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/auth/authentication.ClientCertMiddleware.func1.1
        /Users/john/projects/dod/mymove/pkg/auth/authentication/client_cert.go:61
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/auth.HostnameDetectorMiddleware.func1.1
        /Users/john/projects/dod/mymove/pkg/auth/hostname_detector.go:21
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
goji%2eio.(*Mux).ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/mux.go:74
goji%2eio.dispatch.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/dispatch.go:17
github.com/transcom/mymove/pkg/middleware.LimitBodySize.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/limit_body_size.go:15
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/middleware.SecurityHeaders.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/security_headers.go:28
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/middleware.Recovery.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/recovery.go:50
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/middleware.ContextLogger.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/context_logger.go:18
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
github.com/transcom/mymove/pkg/middleware.Trace.func1.1
        /Users/john/projects/dod/mymove/pkg/middleware/trace.go:29
net/http.HandlerFunc.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2042
goji%2eio.(*Mux).ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/mux.go:74
goji%2eio.dispatch.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/dispatch.go:17
goji%2eio.(*Mux).ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/packages/pkg/mod/goji.io@v2.0.2+incompatible/mux.go:74
net/http.serverHandler.ServeHTTP
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /Users/john/.asdf/installs/golang/1.15.2/go/src/net/http/server.go:1925
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5483) for this change
* [Jira subtask](https://dp3.atlassian.net/browse/MB-5543) for this change
* [Jira subtask](https://dp3.atlassian.net/browse/MB-5544) for this change