### PR TITLE
Getting yarn.lock back in sync

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,34 +2767,6 @@
     react-textarea-autosize "^8.1.1"
     ts-dedent "^1.1.1"
 
-"@storybook/components@6.0.28":
-  version "6.0.28"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.0.28.tgz#aca24419a3941e0f5a20dd349f2b13614542b3da"
-  integrity sha512-rp18w+xC5/ATQThnUR6Rv2cg/DAokbV88uZLPCGHX8HsPY2jFPLyCsWnNiIHBF/SfUCjIlljChlX3bzGk+SQUA==
-  dependencies:
-    "@storybook/client-logger" "6.0.28"
-    "@storybook/csf" "0.0.1"
-    "@storybook/theming" "6.0.28"
-    "@types/overlayscrollbars" "^1.9.0"
-    "@types/react-color" "^3.0.1"
-    "@types/react-syntax-highlighter" "11.0.4"
-    core-js "^3.0.1"
-    fast-deep-equal "^3.1.1"
-    global "^4.3.2"
-    lodash "^4.17.15"
-    markdown-to-jsx "^6.11.4"
-    memoizerific "^1.11.3"
-    overlayscrollbars "^1.10.2"
-    polished "^3.4.4"
-    popper.js "^1.14.7"
-    react "^16.8.3"
-    react-color "^2.17.0"
-    react-dom "^16.8.3"
-    react-popper-tooltip "^2.11.0"
-    react-syntax-highlighter "^12.2.1"
-    react-textarea-autosize "^8.1.1"
-    ts-dedent "^1.1.1"
-
 "@storybook/components@6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.0.tgz#fd5038e8f64b733fb45ac333bb378dde527320c3"


### PR DESCRIPTION
## Description

This PR regenerates the `yarn.lock` file that seems to have gotten out of sync after a dependabot merge in #5278.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
