### PR TITLE
MB-5467 Validates and created standalone DOASIT Service Item

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -105,7 +105,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 
 	if serviceItem.ReService.Code == models.ReServiceCodeDOASIT {
 		// DOASIT must be associated with shipment that has DOFSIT
-		serviceItem, err = o.validateDOASITServiceItem(serviceItem, models.ReServiceCodeDOASIT)
+		serviceItem, err = o.validateDOASITServiceItem(serviceItem, models.ReServiceCodeDOFSIT)
 
 		if err != nil {
 			return nil, nil, err
@@ -225,20 +225,14 @@ func (o *mtoServiceItemCreator) validateDOASITServiceItem(serviceItem *models.MT
 	var mtoServiceItem models.MTOServiceItem
 	var mtoShipmentID uuid.UUID
 	var validReService models.ReService
-	var parentReServiceCode models.ReServiceCode
 
 	mtoShipmentID = *serviceItem.MTOShipmentID
 
-	// #TODO: Add in scenario for DDASIT/DDDSIT in future ticket MB-5547
-	if reServiceCode == models.ReServiceCodeDOASIT {
-		parentReServiceCode = models.ReServiceCodeDOFSIT
-	}
-
 	queryFilter := []services.QueryFilter{
-		query.NewQueryFilter("code", "=", parentReServiceCode),
+		query.NewQueryFilter("code", "=", reServiceCode),
 	}
 
-	// Fetch the ID for the ReService, so we can check the shipment for its existence
+	// Fetch the ID for the ReServiceCode passed in, so we can check the shipment for its existence
 	err := o.builder.FetchOne(&validReService, queryFilter)
 
 	if err != nil {

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -105,7 +105,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 
 	if serviceItem.ReService.Code == models.ReServiceCodeDOASIT {
 		// DOASIT must be associated with shipment that has DOFSIT
-		serviceItem, err = o.validateDOASITServiceItem(serviceItem, models.ReServiceCodeDOFSIT)
+		serviceItem, err = o.validateSITStandaloneServiceItem(serviceItem, models.ReServiceCodeDOFSIT)
 
 		if err != nil {
 			return nil, nil, err
@@ -221,7 +221,7 @@ func validateTimeMilitaryField(timeMilitary string) error {
 	return nil
 }
 
-func (o *mtoServiceItemCreator) validateDOASITServiceItem(serviceItem *models.MTOServiceItem, reServiceCode models.ReServiceCode) (*models.MTOServiceItem, error) {
+func (o *mtoServiceItemCreator) validateSITStandaloneServiceItem(serviceItem *models.MTOServiceItem, reServiceCode models.ReServiceCode) (*models.MTOServiceItem, error) {
 	var mtoServiceItem models.MTOServiceItem
 	var mtoShipmentID uuid.UUID
 	var validReService models.ReService

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -39,7 +39,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	}
 	// check if Move exists
 	err = o.builder.FetchOne(&move, queryFilters)
-
 	if err != nil {
 
 		return nil, nil, services.NewNotFoundError(moveID, "in Moves")
@@ -52,7 +51,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		query.NewQueryFilter("code", "=", reServiceCode),
 	}
 	err = o.builder.FetchOne(&reService, queryFilters)
-
 	if err != nil {
 		return nil, nil, services.NewNotFoundError(uuid.Nil, fmt.Sprintf("for service item with code: %s", reServiceCode))
 	}
@@ -90,7 +88,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		query.NewQueryFilter("id", "=", mtoShipmentID),
 		query.NewQueryFilter("move_id", "=", moveID),
 	}
-
 	err = o.builder.FetchOne(&mtoShipment, queryFilters)
 	if err != nil {
 		return nil, nil, services.NewNotFoundError(mtoShipmentID,

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -52,7 +52,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 			dimension,
 		},
 	}
-
 	// Happy path: If the service item is created successfully it should be returned
 	suite.T().Run("success", func(t *testing.T) {
 		fakeCreateOne := func(model interface{}) (*validate.Errors, error) {
@@ -373,4 +372,123 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 			suite.NoError(err)
 		})
 	})
+}
+
+func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
+	// Set up data to use for all Origin SIT Service Item tests
+	moveTaskOrder := testdatagen.MakeAvailableMove(suite.DB())
+	moveTaskOrder.Status = models.MoveStatusAPPROVED
+	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+		Move: moveTaskOrder,
+	})
+
+	reServiceDOASIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOASIT,
+		},
+	})
+
+	reServiceDOFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOFSIT,
+		},
+	})
+
+	serviceItemDOASIT := models.MTOServiceItem{
+		MoveTaskOrder:   moveTaskOrder,
+		MoveTaskOrderID: moveTaskOrder.ID,
+		MTOShipment:     mtoShipment,
+		MTOShipmentID:   &mtoShipment.ID,
+		ReService:       reServiceDOASIT,
+	}
+
+	sitEntryDate := time.Date(2020, time.October, 24, 0, 0, 0, 0, time.UTC)
+	sitPostalCode := "99999"
+	reason := "lorem ipsum"
+
+	suite.T().Run("Create DOFSIT service item", func(t *testing.T) {
+		serviceItemDOFSIT := models.MTOServiceItem{
+			MoveTaskOrder:   moveTaskOrder,
+			MoveTaskOrderID: moveTaskOrder.ID,
+			MTOShipment:     mtoShipment,
+			MTOShipmentID:   &mtoShipment.ID,
+			ReService:       reServiceDOFSIT,
+			SITEntryDate:    &sitEntryDate,
+			SITPostalCode:   &sitPostalCode,
+			Reason:          &reason,
+		}
+		builder := query.NewQueryBuilder(suite.DB())
+		creator := NewMTOServiceItemCreator(builder)
+
+		createdServiceItems, _, err := creator.CreateMTOServiceItem(&serviceItemDOFSIT)
+
+		suite.NotNil(createdServiceItems)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("Create DOASIT item for shipment with DOFSIT", func(t *testing.T) {
+		builder := query.NewQueryBuilder(suite.DB())
+		creator := NewMTOServiceItemCreator(builder)
+
+		createdServiceItems, _, err := creator.CreateMTOServiceItem(&serviceItemDOASIT)
+
+		createdDOASITItem := (*createdServiceItems)[0]
+		originalDate, _ := sitEntryDate.MarshalText()
+		returnedDate, _ := createdDOASITItem.SITEntryDate.MarshalText()
+
+		// Item is created successfully
+		suite.NotNil(createdServiceItems)
+		suite.NoError(err)
+		// Item contains fields copied over from DOFSIT parent
+		suite.EqualValues(originalDate, returnedDate)
+		suite.EqualValues(*createdDOASITItem.Reason, reason)
+		suite.EqualValues(*createdDOASITItem.SITPostalCode, sitPostalCode)
+	})
+
+	suite.T().Run("Do not create DOASIT if there is no DOFSIT on shipment", func(t *testing.T) {
+		mtoShipmentNoServiceItems := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrder,
+		})
+
+		serviceItemDOASIT := models.MTOServiceItem{
+			MoveTaskOrder:   moveTaskOrder,
+			MoveTaskOrderID: moveTaskOrder.ID,
+			MTOShipment:     mtoShipmentNoServiceItems,
+			MTOShipmentID:   &mtoShipmentNoServiceItems.ID,
+			ReService:       reServiceDOASIT,
+		}
+
+		builder := query.NewQueryBuilder(suite.DB())
+		creator := NewMTOServiceItemCreator(builder)
+
+		createdServiceItems, _, err := creator.CreateMTOServiceItem(&serviceItemDOASIT)
+
+		suite.Nil(createdServiceItems)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, err)
+	})
+
+	suite.T().Run("Do not create DOASIT if the DOFSIT ReService Code is bad", func(t *testing.T) {
+		badReService := models.ReService{
+			Code: "bad code",
+		}
+
+		serviceItemDOASIT := models.MTOServiceItem{
+			MoveTaskOrder:   moveTaskOrder,
+			MoveTaskOrderID: moveTaskOrder.ID,
+			MTOShipment:     mtoShipment,
+			MTOShipmentID:   &mtoShipment.ID,
+			ReService:       badReService,
+		}
+
+		builder := query.NewQueryBuilder(suite.DB())
+		creator := NewMTOServiceItemCreator(builder)
+
+		createdServiceItems, _, err := creator.CreateMTOServiceItem(&serviceItemDOASIT)
+
+		suite.Nil(createdServiceItems)
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, err)
+	})
+
 }


### PR DESCRIPTION
## Description

Adds functionality to `mto_service_item_creator` service object to create standalone DOASIT service item if a DOFSIT service item exists on the same shipment.

The following fields should be copied from the related DOFSIT to the new DOASIT:
* reason
* sit_postal_code
* sit_entry_date 


## Setup

To run new tests:

```sh
make db_test_e2e_populate
go test ./pkg/services/mto_service_item --testify.m "TestCreateOriginSITServiceItem" -v
```


## Code Review Verification Steps


* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5467) for this change
