### PR TITLE
[MB-5578] Edit profile expected behavior

### DIFF
--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -100,6 +100,8 @@ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session 
 		"DutyStation.Address",
 		"DutyStation.TransportationOffice",
 		"Orders.NewDutyStation.TransportationOffice",
+		"Orders.Moves",
+		"Orders.UploadedOrders.UserUploads.Upload",
 		"ResidentialAddress").Find(&serviceMember, id)
 	if err != nil {
 		if errors.Cause(err).Error() == RecordNotFoundErrorString {


### PR DESCRIPTION
## Description

Previously, when you Edit Profile and save, it would revert the client to a stale state. Saving Edit Profile now have the expected behavior. `Orders` were being loaded but auxiliary pieces of data, that we need, like `moves` and `uploads` were not. This loads the correct data

## Setup
`make server_run`
`make client_run`
1. Set up a service member
2. Continue through flow and set up entire move
3. Edit Profile
4. Save
Expected behavior: Home page should be in the correct state

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5578) for this change
