### PR TITLE
Update prime api demo script

### DIFF
--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1441,13 +1441,13 @@ func createHHGMoveWithTaskOrderServices(db *pop.Connection, userUploader *upload
 
 	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:     uuid.FromStringOrNil("eee4b555-2475-4e67-a5b8-102f28d950f8"),
+			ID:     uuid.FromStringOrNil("fd6741a5-a92c-44d5-8303-1d7f5e60afbf"),
 			Status: models.MTOServiceItemStatusApproved,
 		},
 		Move:        mtoWithTaskOrderServices,
 		MTOShipment: mtoShipment4,
 		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("4b85962e-25d3-4485-b43c-2497c4365598"), // DSH
+			ID: uuid.FromStringOrNil("8d600f25-1def-422d-b159-617c7d59156e"), // DLH
 		},
 	})
 
@@ -1465,13 +1465,13 @@ func createHHGMoveWithTaskOrderServices(db *pop.Connection, userUploader *upload
 
 	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:     uuid.FromStringOrNil("fd6741a5-a92c-44d5-8303-1d7f5e60afbf"),
+			ID:     uuid.FromStringOrNil("eee4b555-2475-4e67-a5b8-102f28d950f8"),
 			Status: models.MTOServiceItemStatusApproved,
 		},
 		Move:        mtoWithTaskOrderServices,
 		MTOShipment: mtoShipment5,
 		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("8d600f25-1def-422d-b159-617c7d59156e"), // DLH
+			ID: uuid.FromStringOrNil("4b85962e-25d3-4485-b43c-2497c4365598"), // DSH
 		},
 	})
 

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -103,25 +103,38 @@ echo "eTag: ${shipmentEtag}"
 
 printf "\n==========\n\n"
 
-printf "It's time for the prime to update dates:\n\n"
+printf "It's time for the prime to update dates and destination address:\n\n"
+destDutyZip=$(jq '.moveOrder.destinationDutyStation.address.postalCode' tmp/pad_demo_mto.json | tr -d '"')
+destDutyCity=$(jq '.moveOrder.destinationDutyStation.address.city' tmp/pad_demo_mto.json | tr -d '"')
+destDutyState=$(jq '.moveOrder.destinationDutyStation.address.state' tmp/pad_demo_mto.json | tr -d '"')
 read -p "Provide a scheduled pickup date (yyyy-mm-dd): " -r scheduledPickupDate
 read -p "Provide an actual pickup date (yyyy-mm-dd): " -r actualPickupDate
+echo "Provide the customer's destination address. defaults from new duty station address"
+read -p "  street address: " -r destStreetAddress1
+read -p "  city (default ${destDutyCity}): " -r destCity
+read -p "  state (default ${destDutyState}): " -r destState
+read -p "  zip (default ${destDutyZip}): " -r destZip
 
-echo
-
-cat > tmp/pad_update_dates.json <<- EOM
+cat > tmp/pad_update_mto_shipment.json <<- EOM
 {
   "mtoShipmentID": ${shipmentID},
   "ifMatch": ${shipmentEtag},
   "body": {
     "scheduledPickupDate": "${scheduledPickupDate}",
-    "actualPickupDate": "${actualPickupDate}"
+    "actualPickupDate": "${actualPickupDate}",
+    "destinationAddress": {
+      "streetAddress1": "${destStreetAddress1}",
+      "city": "${destCity:-${destDutyCity}}",
+      "state": "${destState:-${destDutyState}}",
+      "postalCode": "${destZip:-${destDutyZip}}",
+      "country": "US"
+    }
   }
 }
 EOM
 
 printf "We will be sending this payload to milmove:\n\n"
-jq . tmp/pad_update_dates.json
+jq . tmp/pad_update_mto_shipment.json
 
 echo
 
@@ -129,20 +142,20 @@ read -p "Ready to continue? Hit enter..." -n 1 -r
 
 printf "\n==========\n\n"
 
-bin/prime-api-client "${primeapiopts[@]}" update-mto-shipment --filename ./tmp/pad_update_dates.json > tmp/pad_update_response_dates.json
+bin/prime-api-client "${primeapiopts[@]}" update-mto-shipment --filename ./tmp/pad_update_mto_shipment.json > tmp/pad_update_response_mto_shipment.json
 
-jq . tmp/pad_update_response_dates.json
+jq . tmp/pad_update_response_mto_shipment.json
 
 printf "\n-----\n\n"
 
-shipmentEtag=$(jq '.eTag' tmp/pad_update_response_dates.json)
+shipmentEtag=$(jq '.eTag' tmp/pad_update_response_mto_shipment.json)
 echo "Updated Shipment eTag: ${shipmentEtag}"
 
 printf "\n==========\n\n"
 
 printf "The prime will also update weights:\n\n"
 
-if jq -e '.primeEstimatedWeight' tmp/pad_update_response_dates.json > tmp/pad_estimated_weight; then
+if jq -e '.primeEstimatedWeight' tmp/pad_update_response_mto_shipment.json > tmp/pad_estimated_weight; then
   # estimated weight is set already
   echo "Prime Estimated Weight Set Already: $(cat tmp/pad_estimated_weight)"
   read -p "Provide the actual weight: " -r actualWeight

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -294,3 +294,22 @@ printf "\n-----\n\n"
 bin/prime-api-client "${primeapiopts[@]}" support-get-payment-request-edi --filename ./tmp/pad_get_payment_request_edi.json > tmp/pad_edi_response.json
 
 jq -r .edi tmp/pad_edi_response.json
+
+echo
+
+echo "Payment request status updated for payment request number: ${prNumber}:"
+
+printf "\n-----\n\n"
+
+cat > ./tmp/pad_update_payment_request_status.json <<-EOM
+{
+  "body": {
+    "paymentRequestID": "${prID}",
+    "sendToSyncada": false
+  }
+}
+EOM
+
+bin/prime-api-client "${primeapiopts[@]}" support-reviewed-payment-requests --filename ./tmp/pad_update_payment_request_status.json > tmp/pad_pr_update_response.json
+
+jq . tmp/pad_pr_update_response.json

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -7,7 +7,7 @@
 set -eu -o pipefail
 
 function usage() {
-  echo "Usage: $0 <moveTaskOrderID> [[hostname] path/to/proof.pdf]"
+  echo "Usage: $0 <moveTaskOrderID|moveOrderID> [[hostname] path/to/proof.pdf]"
   echo
   echo "If omitted, the optional parameters are set as follows:"
   echo "  hostname = local"
@@ -31,7 +31,7 @@ elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
 fi
 
 primeapiopts=(--insecure)
-readonly mtoid=$1
+mtoid=$1
 readonly environment=${2:-local}
 
 # check to see if proofs are passed in
@@ -72,7 +72,20 @@ read -p "Ready to continue? Hit enter..." -n 1 -r
 
 printf "\n==========\n\n"
 
-jq 'map(select(.id == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json
+if jq -e 'map(select(.id == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
+  # MTO found
+  echo "Found by Move Task Order ID"
+else
+  # maybe we have a moveOrderID
+  if jq -e 'map(select(.moveOrderID == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
+    # great
+    mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
+    echo "Found by Move Order ID. Actual MTO ID is ${mtoid}"
+  else
+    echo "ID not found"
+    exit 1
+  fi
+fi
 
 jq . tmp/pad_demo_mto.json
 


### PR DESCRIPTION
## Description

To better support the new flow this PR updates the `prime-api-demo` script. It adds support to set the destination address, it supports mtoID or moveOrderID as the latter is easier to retrieve during the TOO stage, and finally it also triggers the Payment Request's status to go from `Reviewed` to `Sent_to_Gex` after the edi is generated

## Reviewer Notes

I also added to https://github.com/transcom/mymove/wiki/Manually-run-Prime-API-for-Slice-demo

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
prime-api-demo 9c7b255c-2981-4bf8-839f-61c7458e2b4d
```

Feel free to start the client and go through creating a new move and using that move with the demo script.

## Code Review Verification Steps

* [X] Request review from a member of a different team.