### PR TITLE
[MB-5580] Remove text-indent css prop from queue status multiselect

### DIFF
--- a/src/components/Table/Filters/MultiSelectCheckBoxFilter.module.scss
+++ b/src/components/Table/Filters/MultiSelectCheckBoxFilter.module.scss
@@ -10,7 +10,7 @@
     @include u-font-size('body', 4);
 
     label {
-      @include u-margin-y(.5);
+      @include u-margin-y(0.5);
     }
 
     .MultiSelectCheckBoxFilter__placeholder {
@@ -32,14 +32,14 @@
     .MultiSelectCheckBoxFilter__control--is-focused {
       box-shadow: none;
       border-color: $base-darkest;
-      outline: .25rem solid #2491ff !important;
+      outline: 0.25rem solid #2491ff !important;
       outline-offset: 0;
     }
 
     .MultiSelectCheckBoxFilter__menu {
-      @include u-margin-top(.5);
+      @include u-margin-top(0.5);
       @include u-radius(0);
-      max-width: 183px;
+      //max-width: 183px;
     }
 
     .MultiSelectCheckBoxFilter__value-container {
@@ -53,7 +53,7 @@
     }
 
     .MultiSelectCheckBoxFilter__value-container div span + span:before {
-      content: ", ";
+      content: ', ';
     }
 
     .MultiSelectCheckBoxFilter__indicator-separator {
@@ -71,6 +71,7 @@
         display: flex;
         align-items: center;
         padding-left: 0;
+        text-indent: unset;
       }
 
       .usa-checkbox label:before {
@@ -79,7 +80,8 @@
       }
     }
 
-    .MultiSelectCheckBoxFilter__option:not(:first-child), :global .MultiSelectCheckBoxFilter__option:first-child {
+    .MultiSelectCheckBoxFilter__option:not(:first-child),
+    :global .MultiSelectCheckBoxFilter__option:first-child {
       border-top: 0;
     }
 
@@ -89,8 +91,8 @@
 
     .MultiSelectCheckBoxFilter__indicator svg {
       color: $base-darker;
-      height: .9rem;
-      width: .9rem;
+      height: 0.9rem;
+      width: 0.9rem;
     }
   }
 }

--- a/src/components/Table/Filters/MultiSelectCheckBoxFilter.module.scss
+++ b/src/components/Table/Filters/MultiSelectCheckBoxFilter.module.scss
@@ -39,7 +39,6 @@
     .MultiSelectCheckBoxFilter__menu {
       @include u-margin-top(0.5);
       @include u-radius(0);
-      //max-width: 183px;
     }
 
     .MultiSelectCheckBoxFilter__value-container {


### PR DESCRIPTION
## Description

The multiselect status filter options in the TOO and TIO queues were being obscured by the checkbox input.  I removed the text-indent styling on the checkbox input label which renders the label after the checkbox.

## Reviewer Notes

I tested on Firefox, Chrome, and Safari and it visually looks the same cross browser.

The accessibility needs improved on this element, I couldn't tab down into the options like I would have expected.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

1. Login in as either the TOO or the TIO office user.
2. Click on the status filter select to reveal the menu of options.
3. Check that the label no longer overlaps with the checkbox input.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5580) for this change

## Screenshots

![Screen Recording 2020-11-24 at 10 00 27 AM mov](https://user-images.githubusercontent.com/52669884/100111829-8b01d280-2e3c-11eb-95a5-d10385abb79c.gif)

<img width="619" alt="Screen Shot 2020-11-24 at 10 06 02 AM" src="https://user-images.githubusercontent.com/52669884/100112732-930e4200-2e3d-11eb-91ed-6fd30ea58c93.png">
