### PR TITLE
[MB-5214] TIO payment request paid status filter 500 error

### DIFF
--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -92,7 +92,6 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestList(officeUserID uuid.UU
 	}
 
 	err := query.GroupBy("payment_requests.id, service_members.id, moves.id").Paginate(int(*params.Page), int(*params.PerPage)).All(&paymentRequests)
-
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -208,12 +207,13 @@ func paymentRequestsStatusFilter(statuses []string) QueryOption {
 				if strings.EqualFold(status, "Payment requested") {
 					translatedStatuses = append(translatedStatuses, models.PaymentRequestStatusPending.String())
 
-				}
-				if strings.EqualFold(status, "reviewed") {
+				} else if strings.EqualFold(status, "Reviewed") {
 					translatedStatuses = append(translatedStatuses,
 						models.PaymentRequestStatusReviewed.String(),
 						models.PaymentRequestStatusSentToGex.String(),
 						models.PaymentRequestStatusReceivedByGex.String())
+				} else if strings.EqualFold(status, "Paid") {
+					translatedStatuses = append(translatedStatuses, models.PaymentRequestStatusPaid.String())
 				}
 			}
 			query = query.Where("payment_requests.status in (?)", translatedStatuses)


### PR DESCRIPTION
## Description

When filtering by status in the TIO queue of payment requests, selecting the paid status returned a 500 error. We weren't mapping the Paid api param in the option filter and we ended with an empty array in the where clause in the query.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TIO user.
2. Select "Paid" from the status dropdown
3. Even if there are no paid payment requests in the database there should be no more error and the queue should be empty.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5214) for this change

## Screenshots

![Screen Shot 2020-11-24 at 13 12 40](https://user-images.githubusercontent.com/52669884/100134813-ca3d1d00-2e56-11eb-92b2-ce0993388b5a.png)

