### PR TITLE
MB-5359 Create DOASIT and DOPSIT when creating DOFSIT service item

### DIFF
--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http/httptest"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
@@ -21,8 +23,6 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/mocks"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/models"
 
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
@@ -37,10 +37,9 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 	})
-	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+	testdatagen.MakeDOFSITReService(suite.DB(), testdatagen.Assertions{
 		ReService: models.ReService{
-			ID:   uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"),
-			Code: "DOFSIT",
+			ID: uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"),
 		},
 	})
 	builder := query.NewQueryBuilder(suite.DB())

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -110,13 +110,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		}
 	}
 
-	if serviceItem.ReService.Code == models.ReServiceCodeDOPSIT {
-		verrs = validate.NewErrors()
-		verrs.Add("reServiceCode", fmt.Sprintf("%s cannot be created", serviceItem.ReService.Code))
-		return nil, nil, services.NewInvalidInputError(serviceItem.ID, nil, verrs,
-			fmt.Sprintf("A service item with reServiceCode %s cannot be manually created.", serviceItem.ReService.Code))
-	}
-
 	for index := range serviceItem.CustomerContacts {
 		createCustContacts := &serviceItem.CustomerContacts[index]
 		err = validateTimeMilitaryField(createCustContacts.TimeMilitary)
@@ -125,7 +118,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		}
 	}
 
-	if serviceItem.ReService.Code == models.ReServiceCodeDDDSIT {
+	if serviceItem.ReService.Code == models.ReServiceCodeDDDSIT || serviceItem.ReService.Code == models.ReServiceCodeDOPSIT {
 		verrs = validate.NewErrors()
 		verrs.Add("reServiceCode", fmt.Sprintf("%s cannot be created", serviceItem.ReService.Code))
 		return nil, nil, services.NewInvalidInputError(serviceItem.ID, nil, verrs,

--- a/pkg/testdatagen/make_re_service.go
+++ b/pkg/testdatagen/make_re_service.go
@@ -74,3 +74,32 @@ func MakeDDFSITReService(db *pop.Connection) models.ReService {
 
 	return reService
 }
+
+// MakeDOFSITReService creates the three origin SIT service codes: DOFSIT, DOPSIT, DOASIT. Returns DOFSIT only.
+func MakeDOFSITReService(db *pop.Connection, assertions Assertions) models.ReService {
+	assertionsDOFSIT := Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOFSIT,
+		},
+	}
+	// Any assertions passed in should be applied to the DOFSIT only
+	mergeModels(&assertionsDOFSIT, assertions)
+
+	reService := MakeReService(db, assertionsDOFSIT)
+
+	assertionsDOASIT := Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOASIT,
+		},
+	}
+	MakeReService(db, assertionsDOASIT)
+
+	assertionsDOPSIT := Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOPSIT,
+		},
+	}
+	MakeReService(db, assertionsDOPSIT)
+
+	return reService
+}


### PR DESCRIPTION
## Description

When the Prime created a DOFSIT Service Item, a DOASIT and DOPSIT service item should also be created. This PR adds the necessary validation to the CreateMTOServiceItem service object, and adds test coverage.

## Setup

The server tests have been updated to add test cases for this functionality.
`go test ./pkg/services/mto_service_item --testify.m "TestCreateOriginSITServiceItem" -v`

You can also create a DOFSIT Service Item using Postman.
* You must first make the associated move APPROVED in the db.
* The DOASIT and DOPSIT will be returned with the json, but some fields may be null (addressed in future stories).

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5259) for this change
