### PR TITLE
MB-4829 Include dependents in weight allowance

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -134,7 +134,11 @@ func Entitlement(entitlement *models.Entitlement) *ghcmessages.Entitlements {
 	if entitlement.WeightAllotment() != nil {
 		proGearWeight = int64(entitlement.WeightAllotment().ProGearWeight)
 		proGearWeightSpouse = int64(entitlement.WeightAllotment().ProGearWeightSpouse)
-		totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
+		if *entitlement.DependentsAuthorized {
+			totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelfPlusDependents)
+		} else {
+			totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
+		}
 	}
 	var authorizedWeight *int64
 	if entitlement.AuthorizedWeight() != nil {

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -131,13 +131,13 @@ func Entitlement(entitlement *models.Entitlement) *ghcmessages.Entitlements {
 		return nil
 	}
 	var proGearWeight, proGearWeightSpouse, totalWeight int64
-	if entitlement.WeightAllotment() != nil {
-		proGearWeight = int64(entitlement.WeightAllotment().ProGearWeight)
-		proGearWeightSpouse = int64(entitlement.WeightAllotment().ProGearWeightSpouse)
+	if weightAllotment := entitlement.WeightAllotment(); weightAllotment != nil {
+		proGearWeight = int64(weightAllotment.ProGearWeight)
+		proGearWeightSpouse = int64(weightAllotment.ProGearWeightSpouse)
 		if *entitlement.DependentsAuthorized {
-			totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelfPlusDependents)
+			totalWeight = int64(weightAllotment.TotalWeightSelfPlusDependents)
 		} else {
-			totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
+			totalWeight = int64(weightAllotment.TotalWeightSelf)
 		}
 	}
 	var authorizedWeight *int64

--- a/pkg/testdatagen/make_entitlement.go
+++ b/pkg/testdatagen/make_entitlement.go
@@ -1,6 +1,7 @@
 package testdatagen
 
 import (
+	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -18,7 +19,7 @@ func MakeEntitlement(db *pop.Connection, assertions Assertions) models.Entitleme
 	}
 
 	entitlement := models.Entitlement{
-		DependentsAuthorized:  &truePtr,
+		DependentsAuthorized:  setDependentsAuthorized(assertions.Entitlement.DependentsAuthorized),
 		TotalDependents:       &dependents,
 		NonTemporaryStorage:   &truePtr,
 		PrivatelyOwnedVehicle: &truePtr,
@@ -32,4 +33,12 @@ func MakeEntitlement(db *pop.Connection, assertions Assertions) models.Entitleme
 	mustCreate(db, &entitlement, assertions.Stub)
 
 	return entitlement
+}
+
+func setDependentsAuthorized(assertionDependentsAuthorized *bool) *bool {
+	dependentsAuthorized := swag.Bool(true)
+	if assertionDependentsAuthorized != nil {
+		dependentsAuthorized = assertionDependentsAuthorized
+	}
+	return dependentsAuthorized
 }


### PR DESCRIPTION
## Description

Previously, the GHC API payload, when returning an order, was setting
the `totalWeight` key to the weight allowance based only on the
service member's rank, regardless of whether or not they have
dependents.

This PR fixes the bug in the simplest way as a first pass, by adding
a conditional to check if the entitlement includes dependents, and if
so, it uses the `TotalWeightSelfPlusDependents` key in the lookup
table in `entitlements.go`. Otherwise, it uses `TotalWeightSelfPlus`
as before.

I added 2 handler tests for both scenarios.

## Reviewer Notes

1. Log in as a TOO locally
2. Click on the first move.
3. Assuming it shows the service member rank as E-1, the weight allowance should show 8000 lbs.

Note that the authorized weight is still wrong. It should also be 8000 lbs (they should both the same initially). That bug is being fixed in a [separate JIRA story](https://dp3.atlassian.net/browse/MB-4830).

## Setup

```sh
make db_dev_e2e_populate
make office_client_run (in a separate tab)
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4829)

## Screenshots

**Before:**
<img width="493" alt="Screen Shot 2020-11-23 at 3 09 25 PM" src="https://user-images.githubusercontent.com/811150/100148017-28273000-2e6a-11eb-9871-23dbc49bd4e7.png">

**After:**
<img width="987" alt="Screen Shot 2020-11-24 at 3 09 29 PM" src="https://user-images.githubusercontent.com/811150/100148043-337a5b80-2e6a-11eb-9e14-01d08372b975.png">