### PR TITLE
[MB-5712] Dont exclude potential hhg ppm combo move in the move order fetcher

### DIFF
--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -71,7 +71,7 @@ func (f moveOrderFetcher) ListMoveOrders(officeUserID uuid.UUID, params *service
 		InnerJoin("transportation_offices as origin_to", "origin_ds.transportation_office_id = origin_to.id").
 		LeftJoin("duty_stations as dest_ds", "dest_ds.id = orders.new_duty_station_id").
 		Where("show = ?", swag.Bool(true)).
-		Where("moves.selected_move_type NOT IN (?)", models.SelectedMoveTypePPM, models.SelectedMoveTypeUB, models.SelectedMoveTypePOV)
+		Where("moves.selected_move_type NOT IN (?)", models.SelectedMoveTypeUB, models.SelectedMoveTypePOV)
 
 	for _, option := range options {
 		if option != nil {

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -68,33 +68,40 @@ func (suite *MoveOrderServiceSuite) TestListMoves() {
 	// are displayed to the TOO
 	testdatagen.MakeDefaultMove(suite.DB())
 
+	// Create a combination HHG and PPM move and make sure it's included
+	expectedComboMove := testdatagen.MakeHHGPPMMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+
 	expectedMove := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+
+	expectedMoves := []models.Move{expectedComboMove, expectedMove}
 
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 	moveOrderFetcher := NewMoveOrderFetcher(suite.DB())
 
 	suite.T().Run("returns moves", func(t *testing.T) {
-		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
+		moves, moveCount, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{PerPage: swag.Int64(1), Page: swag.Int64(1)})
 
 		suite.FatalNoError(err)
-		suite.Len(moves, 1)
+		suite.Equal(2, moveCount)
 
-		move := moves[0]
+		for i, move := range moves {
+			expectedMove := expectedMoves[i]
 
-		suite.NotNil(move.Orders.ServiceMember)
-		suite.Equal(expectedMove.Orders.ServiceMember.FirstName, move.Orders.ServiceMember.FirstName)
-		suite.Equal(expectedMove.Orders.ServiceMember.LastName, move.Orders.ServiceMember.LastName)
-		suite.Equal(expectedMove.Orders.ID, move.Orders.ID)
-		suite.Equal(expectedMove.Orders.ServiceMemberID, move.Orders.ServiceMemberID)
-		suite.NotNil(move.Orders.NewDutyStation)
-		suite.Equal(expectedMove.Orders.NewDutyStationID, move.Orders.NewDutyStation.ID)
-		suite.NotNil(move.Orders.Entitlement)
-		suite.Equal(*expectedMove.Orders.EntitlementID, move.Orders.Entitlement.ID)
-		suite.Equal(expectedMove.Orders.OriginDutyStation.ID, move.Orders.OriginDutyStation.ID)
-		suite.NotNil(move.Orders.OriginDutyStation)
-		suite.Equal(expectedMove.Orders.OriginDutyStation.AddressID, move.Orders.OriginDutyStation.AddressID)
-		suite.Equal(expectedMove.Orders.OriginDutyStation.Address.StreetAddress1, move.Orders.OriginDutyStation.Address.StreetAddress1)
+			suite.NotNil(move.Orders.ServiceMember)
+			suite.Equal(expectedMove.Orders.ServiceMember.FirstName, move.Orders.ServiceMember.FirstName)
+			suite.Equal(expectedMove.Orders.ServiceMember.LastName, move.Orders.ServiceMember.LastName)
+			suite.Equal(expectedMove.Orders.ID, move.Orders.ID)
+			suite.Equal(expectedMove.Orders.ServiceMemberID, move.Orders.ServiceMemberID)
+			suite.NotNil(move.Orders.NewDutyStation)
+			suite.Equal(expectedMove.Orders.NewDutyStationID, move.Orders.NewDutyStation.ID)
+			suite.NotNil(move.Orders.Entitlement)
+			suite.Equal(*expectedMove.Orders.EntitlementID, move.Orders.Entitlement.ID)
+			suite.Equal(expectedMove.Orders.OriginDutyStation.ID, move.Orders.OriginDutyStation.ID)
+			suite.NotNil(move.Orders.OriginDutyStation)
+			suite.Equal(expectedMove.Orders.OriginDutyStation.AddressID, move.Orders.OriginDutyStation.AddressID)
+			suite.Equal(expectedMove.Orders.OriginDutyStation.Address.StreetAddress1, move.Orders.OriginDutyStation.Address.StreetAddress1)
+		}
 	})
 
 	suite.T().Run("returns moves filtered by GBLOC", func(t *testing.T) {
@@ -108,7 +115,7 @@ func (suite *MoveOrderServiceSuite) TestListMoves() {
 		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &services.ListMoveOrderParams{Page: swag.Int64(1)})
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moves))
+		suite.Equal(2, len(moves))
 	})
 
 	suite.T().Run("only returns visible moves (where show = True)", func(t *testing.T) {
@@ -118,7 +125,7 @@ func (suite *MoveOrderServiceSuite) TestListMoves() {
 		moves, _, err := moveOrderFetcher.ListMoveOrders(officeUser.ID, &params)
 
 		suite.FatalNoError(err)
-		suite.Equal(1, len(moves))
+		suite.Equal(2, len(moves))
 	})
 
 	suite.T().Run("returns moves filtered by service member affiliation", func(t *testing.T) {

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -186,10 +186,6 @@ func MakeHHGPPMMoveWithShipment(db *pop.Connection, assertions Assertions) model
 		Stub: assertions.Stub,
 	})
 
-	if !assertions.Stub {
-		mustSave(db, &move)
-	}
-
 	MakeMTOShipment(db, Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -177,7 +177,7 @@ func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.M
 
 // MakeHHGPPMMoveWithShipment makes an HHG_PPM Move with one submitted shipment
 func MakeHHGPPMMoveWithShipment(db *pop.Connection, assertions Assertions) models.Move {
-	hhgPPMMoveType := models.SelectedMoveTypeHHGPPM
+	hhgPPMMoveType := models.SelectedMoveTypePPM
 	move := MakeMove(db, Assertions{
 		Move: models.Move{
 			SelectedMoveType: &hhgPPMMoveType,
@@ -185,6 +185,10 @@ func MakeHHGPPMMoveWithShipment(db *pop.Connection, assertions Assertions) model
 		},
 		Stub: assertions.Stub,
 	})
+
+	if !assertions.Stub {
+		mustSave(db, &move)
+	}
 
 	MakeMTOShipment(db, Assertions{
 		Move: move,

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -30,6 +30,7 @@ var DevSeedScenario = devSeedScenario{"dev_seed"}
 var estimatedWeight = unit.Pound(1400)
 var actualWeight = unit.Pound(2000)
 var hhgMoveType = models.SelectedMoveTypeHHG
+var ppmMoveType = models.SelectedMoveTypePPM
 
 func createPPMOfficeUser(db *pop.Connection) {
 	/*
@@ -316,7 +317,7 @@ func createMoveWithPPMAndHHG(db *pop.Connection, userUploader *uploader.UserUplo
 			PersonalEmail: models.StringPointer(email),
 		},
 	})
-	// currently don't have "combo move" selection option, so testing ppm office when type is HHG
+	// SelectedMoveType could be either HHG or PPM depending on creation order of combo
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Order: models.Order{
 			ServiceMemberID: uuid.FromStringOrNil(smIDCombo),
@@ -325,7 +326,7 @@ func createMoveWithPPMAndHHG(db *pop.Connection, userUploader *uploader.UserUplo
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("7024c8c5-52ca-4639-bf69-dd8238308c98"),
 			Locator:          "COMBOS",
-			SelectedMoveType: &hhgMoveType,
+			SelectedMoveType: &ppmMoveType,
 		},
 	})
 


### PR DESCRIPTION
## Description

The TOO moves queue is supposed to exclude PPM moves but the change we made also excluded a combo HHG and PPM move when you create the PPM last in the customer flow.

We were relying on the value of the `selected_move_type` in the moves table to indicate when a move was an HHG or a PPM but this was inaccurate because it could end up with the value of PPM on a combo move.

We are already joining to the mto_shipments table, which should exclude moves that are only PPM but we have to remove the PPM selected_move_type from the exclusion list because it could be a combo move with an HHG. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

1. Create a new service member at milmovelocal:3000
2. Complete the user profile with an origin duty station in the 'LKNQ' GBLOC such as Yuma AFB
2. Next create an HHG shipment
3. Add another shipment of type PPM
4. Sign and submit your move
5. Login as the TOO user and the move should now appear in the queue

I've also changed the combo HHG+PPM move in the devseed test data to use the PPM SelectedMoveType so you can verify it appears in the TOO queue still.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5712) for this change

## Screenshots

<img width="1526" alt="Screen Shot 2020-11-25 at 10 24 02 AM" src="https://user-images.githubusercontent.com/52669884/100247792-b81bb700-2f08-11eb-85e0-ad28114825c6.png">
