### PR TITLE
[MB-5251][MB-5572] Origin Contact Info on home screen

### DIFF
--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -99,6 +99,7 @@ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session 
 		"BackupContacts",
 		"DutyStation.Address",
 		"DutyStation.TransportationOffice",
+		"DutyStation.TransportationOffice.PhoneLines",
 		"Orders.NewDutyStation.TransportationOffice",
 		"Orders.Moves",
 		"Orders.UploadedOrders.UserUploads.Upload",

--- a/src/components/Customer/Home/Contact/Contact.module.scss
+++ b/src/components/Customer/Home/Contact/Contact.module.scss
@@ -1,7 +1,7 @@
 @import 'shared/styles/colors';
 @import 'shared/styles/_basics';
 
-.contact-container {
+.contactContainer {
   border-radius: 5px;
   border: 1px solid $base-lighter;
   @include u-padding-top(2);
@@ -21,12 +21,12 @@
     margin: 0px;
   }
 
-  p:nth-child(3) {
+  p + p {
     margin-top: 12px;
   }
 }
 
-.contact-header {
+.contactHeader {
   @include u-margin-bottom(1);
   text-transform: uppercase;
 }

--- a/src/components/Customer/Home/Contact/Contact.module.scss
+++ b/src/components/Customer/Home/Contact/Contact.module.scss
@@ -20,6 +20,10 @@
     line-height: 18px;
     margin: 0px;
   }
+
+  p:nth-child(3) {
+    margin-top: 12px;
+  }
 }
 
 .contact-header {

--- a/src/components/Customer/Home/Contact/Contact.stories.jsx
+++ b/src/components/Customer/Home/Contact/Contact.stories.jsx
@@ -7,9 +7,9 @@ import Contact from '.';
 export const Basic = () => (
   <div className="grid-container">
     <Contact
-      dutyStationName={text('Duty Station Name', 'Some duty station')}
-      header={text('Header', 'This is the header')}
-      officeType={text('Office type', 'Some office type')}
+      dutyStationName={text('Duty Station Name', 'Fort Knox')}
+      header={text('Header', 'Contacts')}
+      officeType={text('Office type', 'Origin Transportation Office')}
       telephone={text('Telephone', '(777) 777-7777')}
     />
   </div>
@@ -18,10 +18,10 @@ export const Basic = () => (
 export const MoveSubmitted = () => (
   <div className="grid-container">
     <Contact
-      dutyStationName={text('Duty Station Name', 'Some duty station')}
-      header={text('Header', 'This is the header')}
+      dutyStationName={text('Duty Station Name', 'Fort Knox')}
+      header={text('Header', 'Contacts')}
       moveSubmitted
-      officeType={text('Office type', 'Some office type')}
+      officeType={text('Office type', 'Origin Transportation Office')}
       telephone={text('Telephone', '(777) 777-7777')}
     />
   </div>

--- a/src/components/Customer/Home/Contact/Contact.stories.jsx
+++ b/src/components/Customer/Home/Contact/Contact.stories.jsx
@@ -7,8 +7,20 @@ import Contact from '.';
 export const Basic = () => (
   <div className="grid-container">
     <Contact
-      header={text('Header', 'This is the header')}
       dutyStationName={text('Duty Station Name', 'Some duty station')}
+      header={text('Header', 'This is the header')}
+      officeType={text('Office type', 'Some office type')}
+      telephone={text('Telephone', '(777) 777-7777')}
+    />
+  </div>
+);
+
+export const MoveSubmitted = () => (
+  <div className="grid-container">
+    <Contact
+      dutyStationName={text('Duty Station Name', 'Some duty station')}
+      header={text('Header', 'This is the header')}
+      moveSubmitted
       officeType={text('Office type', 'Some office type')}
       telephone={text('Telephone', '(777) 777-7777')}
     />

--- a/src/components/Customer/Home/Contact/Contact.stories.jsx
+++ b/src/components/Customer/Home/Contact/Contact.stories.jsx
@@ -2,32 +2,43 @@
 import React from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
-import Contact from '.';
+import Contact from './index';
 
 export const Basic = () => (
-  <div className="grid-container">
-    <Contact
-      dutyStationName={text('Duty Station Name', 'Fort Knox')}
-      header={text('Header', 'Contacts')}
-      officeType={text('Office type', 'Origin Transportation Office')}
-      telephone={text('Telephone', '(777) 777-7777')}
-    />
-  </div>
+  <Contact
+    dutyStationName={text('Duty Station Name', 'Fort Knox')}
+    header={text('Header', 'Contacts')}
+    officeType={text('Office type', 'Origin Transportation Office')}
+    telephone={text('Telephone', '(777) 777-7777')}
+  />
 );
 
 export const MoveSubmitted = () => (
-  <div className="grid-container">
-    <Contact
-      dutyStationName={text('Duty Station Name', 'Fort Knox')}
-      header={text('Header', 'Contacts')}
-      moveSubmitted
-      officeType={text('Office type', 'Origin Transportation Office')}
-      telephone={text('Telephone', '(777) 777-7777')}
-    />
-  </div>
+  <Contact
+    dutyStationName={text('Duty Station Name', 'Fort Knox')}
+    header={text('Header', 'Contacts')}
+    moveSubmitted
+    officeType={text('Office type', 'Origin Transportation Office')}
+    telephone={text('Telephone', '(777) 777-7777')}
+  />
+);
+
+export const missingPhone = () => (
+  <Contact
+    dutyStationName={text('Duty Station Name', 'Fort Knox')}
+    header={text('Header', 'Contacts')}
+    officeType={text('Office type', 'Origin Transportation Office')}
+  />
 );
 
 export default {
   title: 'Customer Components | Contact',
-  decorators: [withKnobs],
+  decorators: [
+    withKnobs,
+    (Story) => (
+      <div className="grid-container">
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/components/Customer/Home/Contact/Contact.test.jsx
+++ b/src/components/Customer/Home/Contact/Contact.test.jsx
@@ -49,7 +49,7 @@ describe('Contact component', () => {
     };
     const wrapper = mountFooter(props);
     expect(wrapper.find('[data-testid="move-submitted-instructions"]').text()).toBe(
-      'After you hear from your move counselor, they should be your first resource for questions.',
+      'Talk to your move counselor or directly with your movers if you have questions during your move.',
     );
   });
 });

--- a/src/components/Customer/Home/Contact/Contact.test.jsx
+++ b/src/components/Customer/Home/Contact/Contact.test.jsx
@@ -24,6 +24,7 @@ describe('Contact component', () => {
       dutyStationName,
       officeType,
       telephone,
+      moveSubmitted: false,
     };
     const wrapper = mountFooter(props);
     expect(wrapper.find('h6').text()).toBe(header);
@@ -31,5 +32,24 @@ describe('Contact component', () => {
     expect(wrapper.find('span').length).toBe(2);
     expect(wrapper.find('span').at(0).text()).toBe(officeType);
     expect(wrapper.find('span').at(1).text()).toBe(telephone);
+    expect(wrapper.find('[data-testid="move-submitted-instructions"]').exists()).toBe(false);
+  });
+
+  it('renders additional copy if the move is submitted', () => {
+    const header = 'Contact Info';
+    const dutyStationName = 'Headquarters';
+    const officeType = 'Homebase';
+    const telephone = '(777) 777-7777';
+    const props = {
+      header,
+      dutyStationName,
+      officeType,
+      telephone,
+      moveSubmitted: true,
+    };
+    const wrapper = mountFooter(props);
+    expect(wrapper.find('[data-testid="move-submitted-instructions"]').text()).toBe(
+      'After you hear from your move counselor, they should be your first resource for questions.',
+    );
   });
 });

--- a/src/components/Customer/Home/Contact/index.jsx
+++ b/src/components/Customer/Home/Contact/index.jsx
@@ -4,8 +4,8 @@ import { string, bool } from 'prop-types';
 import styles from './Contact.module.scss';
 
 const Contact = ({ header, dutyStationName, moveSubmitted, officeType, telephone }) => (
-  <div className={styles['contact-container']}>
-    <h6 className={styles['contact-header']}>{header}</h6>
+  <div className={styles.contactContainer}>
+    <h6 className={styles.contactHeader}>{header}</h6>
     <p>
       <strong>{dutyStationName}</strong>
       <br />
@@ -15,7 +15,7 @@ const Contact = ({ header, dutyStationName, moveSubmitted, officeType, telephone
     </p>
     {moveSubmitted && (
       <p data-testid="move-submitted-instructions">
-        After you hear from your move counselor, they should be your first resource for questions.
+        Talk to your move counselor or directly with your movers if you have questions during your move.
       </p>
     )}
   </div>

--- a/src/components/Customer/Home/Contact/index.jsx
+++ b/src/components/Customer/Home/Contact/index.jsx
@@ -13,16 +13,7 @@ const Contact = ({ header, dutyStationName, moveSubmitted, officeType, telephone
       <br />
       <span>{telephone}</span>
     </p>
-    <p>
-      {moveSubmitted && (
-        <>
-          You&apos;ll hear from a move counselor and the movers themselves within the next few days.
-          <br />
-          <br />
-          Talk to either of them with questions about your move.
-        </>
-      )}
-    </p>
+    {moveSubmitted && <p>After you hear from your move counselor, they should be your first resource for questions.</p>}
   </div>
 );
 

--- a/src/components/Customer/Home/Contact/index.jsx
+++ b/src/components/Customer/Home/Contact/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { string } from 'prop-types';
+import { string, bool } from 'prop-types';
 
 import styles from './Contact.module.scss';
 
-const Contact = ({ header, dutyStationName, officeType, telephone }) => (
+const Contact = ({ header, dutyStationName, moveSubmitted, officeType, telephone }) => (
   <div className={styles['contact-container']}>
     <h6 className={styles['contact-header']}>{header}</h6>
     <p>
@@ -13,12 +13,23 @@ const Contact = ({ header, dutyStationName, officeType, telephone }) => (
       <br />
       <span>{telephone}</span>
     </p>
+    <p>
+      {moveSubmitted && (
+        <>
+          You&apos;ll hear from a move counselor and the movers themselves within the next few days.
+          <br />
+          <br />
+          Talk to either of them with questions about your move.
+        </>
+      )}
+    </p>
   </div>
 );
 
 Contact.propTypes = {
-  header: string.isRequired,
   dutyStationName: string.isRequired,
+  header: string.isRequired,
+  moveSubmitted: bool.isRequired,
   officeType: string.isRequired,
   telephone: string.isRequired,
 };

--- a/src/components/Customer/Home/Contact/index.jsx
+++ b/src/components/Customer/Home/Contact/index.jsx
@@ -13,7 +13,11 @@ const Contact = ({ header, dutyStationName, moveSubmitted, officeType, telephone
       <br />
       <span>{telephone}</span>
     </p>
-    {moveSubmitted && <p>After you hear from your move counselor, they should be your first resource for questions.</p>}
+    {moveSubmitted && (
+      <p data-testid="move-submitted-instructions">
+        After you hear from your move counselor, they should be your first resource for questions.
+      </p>
+    )}
   </div>
 );
 

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -197,7 +197,7 @@ class Home extends Component {
     return (
       <p>
         You&apos;re moving to <strong>{orders.new_duty_station.name}</strong> from{' '}
-        <strong>{serviceMember.current_station.name}.</strong> Report by{' '}
+        <strong>{serviceMember?.current_station?.name}.</strong> Report by{' '}
         <strong>{moment(orders.report_by_date).format('DD MMM YYYY')}.</strong>
         <br />
         Weight allowance: <strong>{serviceMember.weight_allotment.total_weight_self} lbs</strong>
@@ -416,9 +416,9 @@ class Home extends Component {
                     </SectionWrapper>
                     <Contact
                       header="Contacts"
-                      dutyStationName={current_station?.transportation_office.name}
+                      dutyStationName={current_station?.transportation_office?.name}
                       officeType="Origin Transportation Office"
-                      telephone={current_station?.transportation_office.phone_lines[0]}
+                      telephone={current_station?.transportation_office?.phone_lines[0]}
                       moveSubmitted={move.status === MOVE_STATUSES.SUBMITTED}
                     />
                   </>

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -300,6 +300,7 @@ class Home extends Component {
     const profileEditPath = '/moves/review/edit-profile';
     const ordersEditPath = `/moves/${move.id}/review/edit-orders`;
     const allSortedShipments = this.sortAllShipments(mtoShipments, currentPpm);
+
     return (
       <>
         <div className={styles.homeContainer}>

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -291,6 +291,7 @@ class Home extends Component {
       signedCertification,
       uploadedOrderDocuments,
     } = this.props;
+    const { current_station } = serviceMember;
     const ordersPath = this.hasOrdersNoUpload ? '/orders/upload' : '/orders';
     const shipmentSelectionPath = this.hasAnyShipments
       ? `/moves/${move.id}/select-type`
@@ -415,9 +416,10 @@ class Home extends Component {
                     </SectionWrapper>
                     <Contact
                       header="Contacts"
-                      dutyStationName="Seymour Johnson AFB"
+                      dutyStationName={current_station.transportation_office.name}
                       officeType="Origin Transportation Office"
-                      telephone="(919) 722-5458"
+                      telephone={current_station.transportation_office.phone_lines[0]}
+                      moveSubmitted={move.status === MOVE_STATUSES.SUBMITTED}
                     />
                   </>
                 )}

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -190,14 +190,14 @@ class Home extends Component {
     if (!this.hasOrders) {
       return (
         <p>
-          You&apos;re leaving <strong>{serviceMember?.current_station?.name}</strong>
+          You&apos;re leaving <strong>{serviceMember.current_station?.name}</strong>
         </p>
       );
     }
     return (
       <p>
         You&apos;re moving to <strong>{orders.new_duty_station.name}</strong> from{' '}
-        <strong>{serviceMember?.current_station?.name}.</strong> Report by{' '}
+        <strong>{serviceMember.current_station?.name}.</strong> Report by{' '}
         <strong>{moment(orders.report_by_date).format('DD MMM YYYY')}.</strong>
         <br />
         Weight allowance: <strong>{serviceMember.weight_allotment.total_weight_self} lbs</strong>
@@ -307,7 +307,7 @@ class Home extends Component {
             <header data-testid="customer-header" className={styles['customer-header']}>
               <div className={`usa-prose grid-container ${styles['grid-container']}`}>
                 <h2>
-                  {serviceMember?.first_name} {serviceMember?.last_name}
+                  {serviceMember.first_name} {serviceMember.last_name}
                 </h2>
                 {this.renderCustomerHeader()}
               </div>

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -416,9 +416,9 @@ class Home extends Component {
                     </SectionWrapper>
                     <Contact
                       header="Contacts"
-                      dutyStationName={current_station.transportation_office.name}
+                      dutyStationName={current_station?.transportation_office.name}
                       officeType="Origin Transportation Office"
-                      telephone={current_station.transportation_office.phone_lines[0]}
+                      telephone={current_station?.transportation_office.phone_lines[0]}
                       moveSubmitted={move.status === MOVE_STATUSES.SUBMITTED}
                     />
                   </>

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -9,6 +9,7 @@ import Home from '.';
 import { MockProviders } from 'testUtils';
 import { store } from 'shared/store';
 import { formatCustomerDate } from 'utils/formatters';
+import { MOVE_STATUSES } from 'shared/constants';
 
 const defaultProps = {
   serviceMember: {
@@ -71,6 +72,29 @@ describe('Home component', () => {
       expect(wrapper.find('ShipmentListItem').at(0).text()).toContain('HHG 1');
       expect(wrapper.find('ShipmentListItem').at(1).text()).toContain('PPM');
       expect(wrapper.find('ShipmentListItem').at(2).text()).toContain('HHG 2');
+    });
+  });
+
+  describe('contents of Step 4 (user has submitted move)', () => {
+    it('contains contacts box with additional information', () => {
+      const props = {
+        serviceMember: {
+          current_station: {
+            transportation_office: {
+              name: 'Fort Knox',
+              phone_lines: ['(777) 777-7777'],
+            },
+          },
+        },
+        move: {
+          status: MOVE_STATUSES.SUBMITTED,
+        },
+      };
+
+      const wrapper = mountHome(props);
+      expect(wrapper.find('[data-testid="move-submitted-instructions"]').text()).toBe(
+        'After you hear from your move counselor, they should be your first resource for questions.',
+      );
     });
   });
 

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -92,9 +92,7 @@ describe('Home component', () => {
       };
 
       const wrapper = mountHome(props);
-      expect(wrapper.find('[data-testid="move-submitted-instructions"]').text()).toBe(
-        'After you hear from your move counselor, they should be your first resource for questions.',
-      );
+      expect(wrapper.find('Contact').prop('moveSubmitted')).toEqual(true);
     });
   });
 


### PR DESCRIPTION
## Description

Originally, there was static data for the contact info on the home screen. This adds dynamic contact info and additional copy for when the move is submitted

## Setup
`make server_run`
`make client_run`
1. Log in
2. Set up a move and submit it
3. Scroll to bottom of home screen
Expected result: Contact component should have correct origin duty station and additional text

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5251) for this change
* Also handles [this Jira story](https://dp3.atlassian.net/browse/MB-5572)

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/100276759-e7392500-2f16-11eb-8461-fae473daba0c.png)
