### PR TITLE
Attempt to fix Cypress flakes

### DIFF
--- a/cypress/integration/office/txo/tioFlows.js
+++ b/cypress/integration/office/txo/tioFlows.js
@@ -24,6 +24,9 @@ describe('TIO user', () => {
     cy.server();
     cy.route('GET', '/ghc/v1/swagger.yaml').as('getGHCClient');
     cy.route('GET', '/ghc/v1/queues/payment-requests?**').as('getPaymentRequests');
+    cy.route('GET', '/ghc/v1/queues/payment-requests?sort=age&order=desc&page=1&perPage=20').as(
+      'getSortedPaymentRequests',
+    );
     cy.route('GET', '/ghc/v1/payment-requests/**').as('getPaymentRequest');
     cy.route('GET', '/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
     cy.route('GET', '/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
@@ -42,7 +45,7 @@ describe('TIO user', () => {
     const paymentRequestId = 'ea945ab7-099a-4819-82de-6968efe131dc';
 
     // TIO Payment Requests queue
-    cy.wait(['@getGHCClient', '@getPaymentRequests']);
+    cy.wait(['@getGHCClient', '@getPaymentRequests', '@getSortedPaymentRequests']);
     cy.get('[data-uuid="' + paymentRequestId + '"]').click();
 
     // Payment Request detail page

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -10,6 +10,7 @@ describe('TOO user', () => {
     cy.server();
     cy.route('GET', '/ghc/v1/swagger.yaml').as('getGHCClient');
     cy.route('GET', '/ghc/v1/queues/moves?**').as('getMoveOrders');
+    cy.route('GET', '/ghc/v1/queues/moves?page=1&perPage=20&sort=status&order=asc').as('getSortedMoveOrders');
     cy.route('GET', '/ghc/v1/move-orders/**/move-task-orders').as('getMoveTaskOrders');
     cy.route('GET', '/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
     cy.route('GET', '/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
@@ -28,6 +29,7 @@ describe('TOO user', () => {
     const moveLocator = 'TEST12';
 
     // TOO Moves queue
+    cy.wait(['@getSortedMoveOrders']);
     cy.contains(moveLocator).click();
     cy.url().should('include', `/moves/${moveOrderId}/details`);
 
@@ -83,6 +85,7 @@ describe('TOO user', () => {
     const moveLocator = 'TEST12';
 
     // TOO Moves queue
+    cy.wait(['@getSortedMoveOrders']);
     cy.contains(moveLocator).click();
     cy.url().should('include', `/moves/${moveOrderId}/details`);
     cy.get('[data-testid="MoveTaskOrder-Tab"]').click();


### PR DESCRIPTION
For some reason, we are making two requests on the TXO pages: one with 
page, per page, and order, and then a second request with the same 
params, but this time with sort added to the mix.

Because we were using a glob to match all requests to the TXO 
endpoints, calling cy.wait will stop at the first match, and will not 
also wait for the second request. I added a second named route to 
match the second request, and we are now waiting for that one as well.

Examples of recent failed tests:
https://app.circleci.com/pipelines/github/transcom/mymove/23944/workflows/3f4e6f60-9ae3-4bb4-bf00-521ec34183dc/jobs/370649
https://app.circleci.com/pipelines/github/transcom/mymove/23954/workflows/f872e2a7-6a40-466a-9918-d7003174fb0e/jobs/370793

Resources and other potential things we can try if this doesn't work:
https://www.cypress.io/blog/2020/11/17/when-can-the-test-submit-a-form/
https://github.com/cypress-io/cypress/issues/5743#issuecomment-650421731
https://github.com/cypress-io/cypress/issues/7306