### PR TITLE
[MB-5716] Approve MTO prior to MTO Shipment status update and service item creation

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1051,6 +1051,12 @@ func init() {
               "$ref": "#/responses/NotFound"
             }
           },
+          "409": {
+            "description": "Conflict error",
+            "schema": {
+              "$ref": "#/responses/Conflict"
+            }
+          },
           "412": {
             "description": "Precondition Failed",
             "schema": {
@@ -4813,6 +4819,15 @@ func init() {
             "description": "The requested resource wasn't found",
             "schema": {
               "description": "The requested resource wasn't found",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict error",
+            "schema": {
+              "description": "Conflict error",
               "schema": {
                 "$ref": "#/definitions/Error"
               }

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
@@ -225,6 +225,48 @@ func (o *UpdateMoveTaskOrderStatusNotFound) WriteResponse(rw http.ResponseWriter
 	}
 }
 
+// UpdateMoveTaskOrderStatusConflictCode is the HTTP code returned for type UpdateMoveTaskOrderStatusConflict
+const UpdateMoveTaskOrderStatusConflictCode int = 409
+
+/*UpdateMoveTaskOrderStatusConflict Conflict error
+
+swagger:response updateMoveTaskOrderStatusConflict
+*/
+type UpdateMoveTaskOrderStatusConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload interface{} `json:"body,omitempty"`
+}
+
+// NewUpdateMoveTaskOrderStatusConflict creates UpdateMoveTaskOrderStatusConflict with default headers values
+func NewUpdateMoveTaskOrderStatusConflict() *UpdateMoveTaskOrderStatusConflict {
+
+	return &UpdateMoveTaskOrderStatusConflict{}
+}
+
+// WithPayload adds the payload to the update move task order status conflict response
+func (o *UpdateMoveTaskOrderStatusConflict) WithPayload(payload interface{}) *UpdateMoveTaskOrderStatusConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update move task order status conflict response
+func (o *UpdateMoveTaskOrderStatusConflict) SetPayload(payload interface{}) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateMoveTaskOrderStatusConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+}
+
 // UpdateMoveTaskOrderStatusPreconditionFailedCode is the HTTP code returned for type UpdateMoveTaskOrderStatusPreconditionFailed
 const UpdateMoveTaskOrderStatusPreconditionFailedCode int = 412
 

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -17,7 +17,7 @@ import (
 	"github.com/transcom/mymove/pkg/services/audit"
 )
 
-// GetMoveTaskOrderHandler fetches a of a Move Task Order
+// GetMoveTaskOrderHandler fetches a Move Task Order
 type GetMoveTaskOrderHandler struct {
 	handlers.HandlerContext
 	moveTaskOrderFetcher services.MoveTaskOrderFetcher

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -17,13 +17,13 @@ import (
 	"github.com/transcom/mymove/pkg/services/audit"
 )
 
-// GetMoveTaskOrderHandler updates the status of a Move Task Order
+// GetMoveTaskOrderHandler fetches a of a Move Task Order
 type GetMoveTaskOrderHandler struct {
 	handlers.HandlerContext
 	moveTaskOrderFetcher services.MoveTaskOrderFetcher
 }
 
-// Handle updates the status of a MoveTaskOrder
+// Handle fetches a single MoveTaskOrder
 func (h GetMoveTaskOrderHandler) Handle(params movetaskorderops.GetMoveTaskOrderParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
@@ -76,6 +76,8 @@ func (h UpdateMoveTaskOrderStatusHandlerFunc) Handle(params movetaskorderops.Upd
 			return movetaskorderops.NewUpdateMoveTaskOrderStatusBadRequest()
 		case services.PreconditionFailedError:
 			return movetaskorderops.NewUpdateMoveTaskOrderStatusPreconditionFailed().WithPayload(&ghcmessages.Error{Message: handlers.FmtString(err.Error())})
+		case services.ConflictError:
+			return movetaskorderops.NewUpdateMoveTaskOrderStatusConflict().WithPayload(&ghcmessages.Error{Message: handlers.FmtString(err.Error())})
 		default:
 			return movetaskorderops.NewUpdateMoveTaskOrderStatusInternalServerError()
 		}

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -53,7 +53,7 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 
 		verrs, err = o.builder.UpdateOne(mto, &eTag)
 		if verrs != nil && verrs.HasAny() {
-			return &models.Move{}, services.InvalidInputError{}
+			return &models.Move{}, services.NewInvalidInputError(mto.ID, nil, verrs, "")
 		}
 		if err != nil {
 			switch err.(type) {

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -1,6 +1,7 @@
 package movetaskorder
 
 import (
+	"errors"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
@@ -46,6 +47,19 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 		if mto.Status == models.MoveStatusSUBMITTED {
 			err = mto.Approve()
 			if err != nil {
+				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+			}
+		}
+
+		verrs, err = o.builder.UpdateOne(mto, &eTag)
+		if verrs != nil && verrs.HasAny() {
+			return &models.Move{}, services.InvalidInputError{}
+		}
+		if err != nil {
+			switch err.(type) {
+			case query.StaleIdentifierError:
+				return nil, services.NewPreconditionFailedError(mto.ID, err)
+			default:
 				return &models.Move{}, err
 			}
 		}
@@ -63,6 +77,17 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 				ApprovedAt:      &now,
 			})
 		}
+
+		if err != nil {
+			if errors.Is(err, models.ErrInvalidTransition) {
+				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+			}
+			return &models.Move{}, err
+		}
+		if verrs != nil {
+			return &models.Move{}, verrs
+		}
+
 		if includeServiceCodeCS {
 			// create if doesn't exist
 			_, verrs, err = o.serviceItemCreator.CreateMTOServiceItem(&models.MTOServiceItem{
@@ -75,22 +100,19 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 		}
 
 		if err != nil {
+			if errors.Is(err, models.ErrInvalidTransition) {
+				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+			}
 			return &models.Move{}, err
 		}
 		if verrs != nil {
 			return &models.Move{}, verrs
 		}
-	}
 
-	verrs, err = o.builder.UpdateOne(mto, &eTag)
-	if verrs != nil && verrs.HasAny() {
-		return &models.Move{}, services.InvalidInputError{}
-	}
-	if err != nil {
-		switch err.(type) {
-		case query.StaleIdentifierError:
-			return nil, services.NewPreconditionFailedError(mto.ID, err)
-		default:
+		// CreateMTOServiceItem may have updated the mto status so refetch as to not return incorrect status
+		// TODO: Modify CreateMTOServiceItem to return the updated move or refactor to operate on the passed in reference
+		mto, err = o.FetchMoveTaskOrder(moveTaskOrderID)
+		if err != nil {
 			return &models.Move{}, err
 		}
 	}

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -189,12 +189,11 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		return nil, verrs, services.NewQueryError("unknown", err, "")
 	}
 
-	// TODO: Fix error message to be conflict error instead of server error so user knows the Move status is wrong
 	// TODO: Determine if this should be in the same transaction as the service items (they get created even if this fails)
 	if move.Status != models.MoveStatusAPPROVALSREQUESTED {
 		err := move.SetApprovalsRequested()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, services.NewConflictError(move.ID, err.Error())
 		}
 		verrs, err := o.builder.UpdateOne(&move, nil)
 		if verrs != nil || err != nil {

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -567,16 +567,11 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 	})
 
 	suite.T().Run("When move status is not already approved", func(t *testing.T) {
-		submittedMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
-		shipment7 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			Move: submittedMTO,
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-		})
-		eTag = etag.GenerateEtag(shipment7.UpdatedAt)
+		submittedMTO := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+		mtoShipment := submittedMTO.MTOShipments[0]
+		eTag = etag.GenerateEtag(mtoShipment.UpdatedAt)
 
-		updatedShipment, err := updater.UpdateMTOShipmentStatus(shipment7.ID, models.MTOShipmentStatusApproved, nil, eTag)
+		updatedShipment, err := updater.UpdateMTOShipmentStatus(mtoShipment.ID, models.MTOShipmentStatusApproved, nil, eTag)
 		suite.Nil(updatedShipment)
 		suite.Error(err)
 		suite.IsType(services.ConflictError{}, err)

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -164,13 +164,15 @@ func MakeHHGMoveWithShipment(db *pop.Connection, assertions Assertions) models.M
 		mustSave(db, &move)
 	}
 
-	MakeMTOShipment(db, Assertions{
+	shipment := MakeMTOShipment(db, Assertions{
 		Move: move,
 		MTOShipment: models.MTOShipment{
 			Status: models.MTOShipmentStatusSubmitted,
 		},
 		Stub: assertions.Stub,
 	})
+
+	move.MTOShipments = models.MTOShipments{shipment}
 
 	return move
 }

--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -54,7 +54,7 @@ const RequestedShipments = ({
         serviceCodeCS: values.counselingFee,
       };
 
-      // if mto is not yet approved, add request to approve it
+      // The MTO has not yet been approved so resolve before updating the shipment statuses and creating accessorial service items
       if (!moveTaskOrder.availableToPrimeAt) {
         approveMTO(moveTaskOrder.id, moveTaskOrder.eTag, mtoApprovalServiceItemCodes)
           .then((result) => {
@@ -70,6 +70,19 @@ const RequestedShipments = ({
                   // TODO: Decide if we want to display an error notice, log error event, or retry
                   setSubmitting(false);
                 });
+            }
+          })
+          .catch(() => {
+            // TODO: Decide if we want to display an error notice, log error event, or retry
+            setSubmitting(false);
+          });
+      } else {
+        // The MTO was previously approved along with at least one shipment, only update the new shipment statuses
+        Promise.all(shipmentRequests)
+          .then((results) => {
+            if (results.every((shipmentResult) => shipmentResult.response.status === 200)) {
+              // TODO: We will need to change this so that it goes to the MoveTaskOrder view when we're implementing the success UI element in a later story.
+              window.location.reload();
             }
           })
           .catch(() => {

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -755,6 +755,10 @@ paths:
           description: The requested resource wasn't found
           schema:
             $ref: '#/responses/NotFound'
+        '409':
+          description: Conflict error
+          schema:
+            $ref: '#/responses/Conflict'
         '412':
           description: Precondition Failed
           schema:
@@ -1050,7 +1054,7 @@ paths:
         - in: query
           name: order
           type: string
-          enum: [ asc, desc ]
+          enum: [asc, desc]
           description: direction of sort order if applied
         - in: query
           name: branch
@@ -1105,12 +1109,12 @@ paths:
         - in: query
           name: sort
           type: string
-          enum: [ lastName, locator, submittedAt, branch, status, dodID, age]
+          enum: [lastName, locator, submittedAt, branch, status, dodID, age]
           description: field that results should be sorted by
         - in: query
           name: order
           type: string
-          enum: [ asc, desc ]
+          enum: [asc, desc]
           description: direction of sort order if applied
         - in: query
           name: page


### PR DESCRIPTION
## Description

After the introduction of an additional move status `APPROVALS_REQUESTED`, related to the TOO moves queue work, we began getting 500 errors when approving the MTO (making it available to the prime) with shipments and service items.  Instead of the approve modal dismissing it would stay open until you refreshed the page because of a non 200 success response.

We were making the MTO approval status update and the mto shipment status update requests in parallel using promises in our form submit handler.  Meanwhile the create mto service item service required that the MTO be in approved status to transition to the `APPROVALS_REQUESTED` status.  Because these calls could resolve in a non-deterministic order there would often be an error returned.

The interim solution is to make the mto shipment status updates wait until the initial approval of the mto has completed successfully.  Also in the event that we do hit these errors again, they should now return more gracefully as conflict errors instead of internal server errors.

Due to the closeness of the demo and amount of work being done in this part of the codebase I restrained myself from refactoring further.  Others have pointed out these multiple calls should likely be captured in a transaction.  I would also point out that the flows for basic service item creation and shipment accessorial service items seem different enough to split out their logic.  We're also continually requerying for the MTO object which we already have and are doing redundant work there. 

## Reviewer Notes

I tried mocking out the approveMTOShipment function in the jest component test but it wasn't detecting it getting called for some reason.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TOO user in the office app
2. Find a move in the queue that is in the 'New Move' status, ideally one with 2 shipments
3. Select at least one of the shipments and a service item for approval
4. Click the Approve and send button on the confirmation modal
(Optional) 4b. Select the other shipment for approval given the MTO status is already available to the prime
5. The multiple network requests to update the mto and shipment status should no longer return error rsponses
6. The modal should close and the page should refresh on success.
7. Navigate back to the queue and the move should now have the status 'Approvals requested'

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5716) for this change

## Screenshots
