### PR TITLE
MB-5593 | gosec G402: annotate all remaining g402s

### DIFF
--- a/cmd/prime-api-client/utils/connection.go
+++ b/cmd/prime-api-client/utils/connection.go
@@ -44,7 +44,17 @@ func CreatePrimeClientWithCACStoreParam(v *viper.Viper, store *pksigner.Store) (
 		// must explicitly state what signature algorithms we allow as of Go 1.14 to disable RSA-PSS signatures
 		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
 
-		// #nosec b/c gosec triggers on InsecureSkipVerify
+		//RA Summary: gosec - G402 - Look for bad TLS connection settings
+		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
+		//RA: In production, the value of this flag is always false. We are, however, using
+		//RA: this flag during local development to test the Prime API as further specified in the following docs:
+		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+		//RA Validator: jneuner@mitre.org
+		//RA Modified Severity:
+		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},
 			InsecureSkipVerify: insecure,
@@ -109,7 +119,17 @@ func CreatePrimeClient(v *viper.Viper) (*primeClient.Mymove, *pksigner.Store, er
 		// must explicitly state what signature algorithms we allow as of Go 1.14 to disable RSA-PSS signatures
 		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
 
-		// #nosec b/c gosec triggers on InsecureSkipVerify
+		//RA Summary: gosec - G402 - Look for bad TLS connection settings
+		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
+		//RA: In production, the value of this flag is always false. We are, however, using
+		//RA: this flag during local development to test the Prime API as further specified in the following docs:
+		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+		//RA Validator: jneuner@mitre.org
+		//RA Modified Severity:
+		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},
 			InsecureSkipVerify: insecure,
@@ -174,7 +194,17 @@ func CreateSupportClient(v *viper.Viper) (*supportClient.Mymove, *pksigner.Store
 		// must explicitly state what signature algorithms we allow as of Go 1.14 to disable RSA-PSS signatures
 		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
 
-		// #nosec b/c gosec triggers on InsecureSkipVerify
+		//RA Summary: gosec - G402 - Look for bad TLS connection settings
+		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
+		//RA: In production, the value of this flag is always false. We are, however, using
+		//RA: this flag during local development to test the Prime API as further specified in the following docs:
+		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+		//RA Validator: jneuner@mitre.org
+		//RA Modified Severity:
+		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},
 			InsecureSkipVerify: insecure,

--- a/cmd/prime-api-client/utils/connection.go
+++ b/cmd/prime-api-client/utils/connection.go
@@ -50,7 +50,7 @@ func CreatePrimeClientWithCACStoreParam(v *viper.Viper, store *pksigner.Store) (
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
 		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
 		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
-		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: CAT III
 		// #nosec G402
@@ -124,7 +124,7 @@ func CreatePrimeClient(v *viper.Viper) (*primeClient.Mymove, *pksigner.Store, er
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
 		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
 		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
-		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: CAT III
 		// #nosec G402
@@ -198,7 +198,7 @@ func CreateSupportClient(v *viper.Viper) (*supportClient.Mymove, *pksigner.Store
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
 		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
 		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
-		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: CAT III
 		// #nosec G402

--- a/cmd/prime-api-client/utils/connection.go
+++ b/cmd/prime-api-client/utils/connection.go
@@ -48,12 +48,11 @@ func CreatePrimeClientWithCACStoreParam(v *viper.Viper, store *pksigner.Store) (
 		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
 		//RA: In production, the value of this flag is always false. We are, however, using
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
-		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
-		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
 		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
-		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-		//RA Validator: jneuner@mitre.org
-		//RA Modified Severity:
+		//RA Validator Status: Mitigated
+		//RA Modified Severity: CAT III
 		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},
@@ -123,12 +122,11 @@ func CreatePrimeClient(v *viper.Viper) (*primeClient.Mymove, *pksigner.Store, er
 		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
 		//RA: In production, the value of this flag is always false. We are, however, using
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
-		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
-		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
 		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
-		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-		//RA Validator: jneuner@mitre.org
-		//RA Modified Severity:
+		//RA Validator Status: Mitigated
+		//RA Modified Severity: CAT III
 		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},
@@ -198,12 +196,11 @@ func CreateSupportClient(v *viper.Viper) (*supportClient.Mymove, *pksigner.Store
 		//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
 		//RA: In production, the value of this flag is always false. We are, however, using
 		//RA: this flag during local development to test the Prime API as further specified in the following docs:
-		// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
-		// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+		//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+		//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
 		//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
-		//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-		//RA Validator: jneuner@mitre.org
-		//RA Modified Severity:
+		//RA Validator Status: Mitigated
+		//RA Modified Severity: CAT III
 		// #nosec G402
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},

--- a/cmd/webhook-client/utils/connection.go
+++ b/cmd/webhook-client/utils/connection.go
@@ -50,12 +50,11 @@ func (wr *WebhookRuntime) SetupClient(cert *tls.Certificate) (*WebhookRuntime, e
 	//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
 	//RA: In production, the value of this flag is always false. We are, however, using
 	//RA: this flag during local development to test the Prime API as further specified in the following docs:
-	// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
-	// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+	//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+	//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
 	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-	//RA Validator: jneuner@mitre.org
-	//RA Modified Severity:
+	//RA Validator Status: Mitigated
+	//RA Modified Severity: CAT III
 	// #nosec G402
 	tlsConfig := tls.Config{
 		Certificates:       []tls.Certificate{*cert},

--- a/cmd/webhook-client/utils/connection.go
+++ b/cmd/webhook-client/utils/connection.go
@@ -52,7 +52,7 @@ func (wr *WebhookRuntime) SetupClient(cert *tls.Certificate) (*WebhookRuntime, e
 	//RA: this flag during local development to test the Prime API as further specified in the following docs:
 	//RA: * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
 	//RA: * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
-	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: CAT III
 	// #nosec G402

--- a/cmd/webhook-client/utils/connection.go
+++ b/cmd/webhook-client/utils/connection.go
@@ -46,7 +46,17 @@ func (wr *WebhookRuntime) SetupClient(cert *tls.Certificate) (*WebhookRuntime, e
 
 	// Set up the httpClient with tls certificate
 
-	// #nosec b/c gosec triggers on InsecureSkipVerify
+	//RA Summary: gosec - G402 - Look for bad TLS connection settings
+	//RA: The linter is flagging this line of code because we are passing in a boolean value which can set InsecureSkipVerify to true.
+	//RA: In production, the value of this flag is always false. We are, however, using
+	//RA: this flag during local development to test the Prime API as further specified in the following docs:
+	// * https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client
+	// * https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally
+	//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator: jneuner@mitre.org
+	//RA Modified Severity:
+	// #nosec G402
 	tlsConfig := tls.Config{
 		Certificates:       []tls.Certificate{*cert},
 		InsecureSkipVerify: wr.Insecure,


### PR DESCRIPTION
## Description

Add annotations for all remaining G402s. The reason we want to keep all these remaining insecure verify bools is we are only setting them to true during local development / for local testing.

### Useful historical references

- [PR in which the prime API side was added](https://github.com/transcom/mymove/pull/3395)
- [PR in which the webhook client was added](https://github.com/transcom/mymove/pull/4531)
- [Doc link 1 from annotations (official prime API docs)](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client)
- [Doc link 2 from annotations (transcom/mymove wiki)](https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)#testing-locally)

## Reviewer Notes

How is the phrasing? Should we include those doc refs or refs to the above PRs in the annotation?

## Other references

- [Jira story](https://dp3.atlassian.net/browse/MB-5593)