### PR TITLE
MB-4943 | fix review page post move submission add a shipment language & logic

### DIFF
--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -182,7 +182,11 @@ export class Summary extends Component {
 
     const showPPMShipmentSummary = !isReviewPage && Object.keys(currentPPM).length && currentPPM.status !== 'DRAFT';
     const showHHGShipmentSummary = isReviewPage && !!mtoShipments.length;
-    const hasPPMorHHG = (isReviewPage && Object.keys(currentPPM).length) || !!mtoShipments.length;
+    const hasPPM = Object.keys(currentPPM).length;
+
+    // customer can add another shipment IFF the move is still draft OR it's not a draft & they don't have a PPM yet
+    // double not is to prevent js from converting false to 0 and displaying said 0 on the page
+    const canAddAnotherShipment = isReviewPage && !!(currentMove.status === MOVE_STATUSES.DRAFT || !hasPPM);
 
     const showMoveSetup = showPPMShipmentSummary || showHHGShipmentSummary;
     const shipmentSelectionPath = `/moves/${currentMove.id}/select-type`;
@@ -237,16 +241,20 @@ export class Summary extends Component {
           {showPPMShipmentSummary && (
             <PPMShipmentSummary ppm={currentPPM} movePath={rootReviewAddressWithMoveId} orders={currentOrders} />
           )}
-          {hasPPMorHHG && (
-            <div className="grid-col-row margin-top-5">
-              <span className="float-right">Optional</span>
-              <h3>Add another shipment</h3>
-              <p>Will you move any belongings to or from another location?</p>
-              <Button className="usa-button--secondary" onClick={() => history.push(shipmentSelectionPath)}>
-                Add another shipment
-              </Button>
-            </div>
-          )}
+          <div className="grid-col-row margin-top-5">
+            <span className="float-right">Optional</span>
+            <h3>Add another shipment</h3>
+            {canAddAnotherShipment ? (
+              <>
+                <p>Do you have more to move, either to or from another location, or by another method?</p>
+                <Button className="usa-button--secondary" onClick={() => history.push(shipmentSelectionPath)}>
+                  Add another shipment
+                </Button>
+              </>
+            ) : (
+              <p>Talk with your movers directly if you want to add or change shipments.</p>
+            )}
+          </div>
           {moveIsApproved && (
             <div className="approved-edit-warning">
               *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
@@ -260,7 +268,7 @@ export class Summary extends Component {
 }
 
 Summary.propTypes = {
-  currentMove: shape({ id: string.isRequired }).isRequired,
+  currentMove: shape({ id: string.isRequired, status: string.isRequired }).isRequired,
   currentOrders: shape({}).isRequired,
   currentPPM: shape({}).isRequired,
   history: shape({ push: func.isRequired }).isRequired,


### PR DESCRIPTION
## Description

This is a small change:
- updating the copy to match the spreadsheet
- fixing the post move submission logic to hide the button if customer already has PPM

## Reviewer Notes

Are those comments too verbose? I added them because reading long nested conditionals can be hard. Sometimes having that same thing spelled out in words helps. Keep it? Toss it? 👍 

## Setup

1. Pull locally and create a move with some shipments but no PPM shipments.
2. Sign and submit the move, verifying that the add a shipment button is visible on the review page both before and after submitting.
3. Add a PPM shipment and return to the review page. Verify that the add a shipment button is gone and the new text displays.

## References

- [Jira story](https://dp3.atlassian.net/browse/MB-4937)
- [Copy spreadsheet](https://docs.google.com/spreadsheets/d/14_qlyhSN6-VjXmBLRtBHj2OUwy76NONOEUbYiRYQ2-w/edit?ts=5ee3fe45#gid=1041135497) (see lines 477-478)

## Screenshots

### Anytime before submitting & after submission if no PPM
<img width="724" alt="Screen Shot 2020-11-30 at 1 36 11 PM" src="https://user-images.githubusercontent.com/10818509/100668649-1e417900-3311-11eb-88fd-2fda5fb75dc0.png">

### After submission if PPM already
<img width="726" alt="Screen Shot 2020-11-30 at 1 36 32 PM" src="https://user-images.githubusercontent.com/10818509/100668651-1eda0f80-3311-11eb-8999-9a557f2fc6d7.png">

