### PR TITLE
[MB-5716] Resolve approve MTO Shipment promises inside approve MTO callback

### DIFF
--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -45,10 +45,6 @@ const RequestedShipments = ({
       shipments: [],
     },
     onSubmit: (values, { setSubmitting }) => {
-      const shipmentRequests = filteredShipments.map((shipment) =>
-        approveMTOShipment(moveTaskOrder.id, shipment.id, 'APPROVED', shipment.eTag),
-      );
-
       const mtoApprovalServiceItemCodes = {
         serviceCodeMS: values.shipmentManagementFee,
         serviceCodeCS: values.counselingFee,
@@ -59,7 +55,11 @@ const RequestedShipments = ({
         approveMTO(moveTaskOrder.id, moveTaskOrder.eTag, mtoApprovalServiceItemCodes)
           .then((result) => {
             if (result?.response?.status === 200) {
-              Promise.all(shipmentRequests)
+              Promise.all(
+                filteredShipments.map((shipment) =>
+                  approveMTOShipment(moveTaskOrder.id, shipment.id, 'APPROVED', shipment.eTag),
+                ),
+              )
                 .then((results) => {
                   if (results.every((shipmentResult) => shipmentResult.response.status === 200)) {
                     // TODO: We will need to change this so that it goes to the MoveTaskOrder view when we're implementing the success UI element in a later story.
@@ -78,7 +78,11 @@ const RequestedShipments = ({
           });
       } else {
         // The MTO was previously approved along with at least one shipment, only update the new shipment statuses
-        Promise.all(shipmentRequests)
+        Promise.all(
+          filteredShipments.map((shipment) =>
+            approveMTOShipment(moveTaskOrder.id, shipment.id, 'APPROVED', shipment.eTag),
+          ),
+        )
           .then((results) => {
             if (results.every((shipmentResult) => shipmentResult.response.status === 200)) {
               // TODO: We will need to change this so that it goes to the MoveTaskOrder view when we're implementing the success UI element in a later story.


### PR DESCRIPTION
## Description

The approveMTOShipment requests were still being executed prior to the approveMTO request when making an MTO available to the prime in the TOO Move Details page.

There is some async/Promise behavior that is still a little confusing as to why they were called out of order causing an invalid transition error of the move status.  I've moved the map call to only happen after the move status gets updated, maybe the swagger request promise was being executed not just populated in the array.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TOO user
2. Find a move in the queue in the New move status
3. Approve at least one shipment with a basic service item
4. Navigate back to the queue and the move should have the status Approvals requested 

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5716) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
