### PR TITLE
[MB-5594] Add Updatemtoserviceitem handler 

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -287,14 +287,14 @@ func init() {
           "409": {
             "$ref": "#/responses/Conflict"
           },
+          "412": {
+            "$ref": "#/responses/PreconditionFailed"
+          },
           "422": {
             "$ref": "#/responses/UnprocessableEntity"
           },
           "500": {
             "$ref": "#/responses/ServerError"
-          },
-          "501": {
-            "$ref": "#/responses/NotImplemented"
           }
         }
       }
@@ -2632,6 +2632,12 @@ func init() {
               "$ref": "#/definitions/ClientError"
             }
           },
+          "412": {
+            "description": "Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.",
+            "schema": {
+              "$ref": "#/definitions/ClientError"
+            }
+          },
           "422": {
             "description": "The payload was unprocessable.",
             "schema": {
@@ -2640,12 +2646,6 @@ func init() {
           },
           "500": {
             "description": "A server error occurred.",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          },
-          "501": {
-            "description": "The requested feature is still in development.",
             "schema": {
               "$ref": "#/definitions/Error"
             }

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -229,7 +229,7 @@ func init() {
       }
     },
     "/mto-service-items/{mtoServiceItemID}": {
-      "post": {
+      "patch": {
         "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n\n### Errors\n\nCurrently this is not implemented and will generated the NotImplemented error.\n",
         "consumes": [
           "application/json"
@@ -269,10 +269,7 @@ func init() {
           "200": {
             "description": "Successfully updated the MTO service item.",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MTOServiceItem"
-              }
+              "$ref": "#/definitions/MTOServiceItem"
             }
           },
           "400": {
@@ -2562,7 +2559,7 @@ func init() {
       }
     },
     "/mto-service-items/{mtoServiceItemID}": {
-      "post": {
+      "patch": {
         "description": "Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.\n\nThis endpoint supports different body definitions. In the modelType field below, select the modelType corresponding\n to the service item you wish to update and the documentation will update with the new definition.\n\nTo create a service item, please use [createMTOServiceItem](#operation/createMTOServiceItem)) endpoint.\n\n### Errors\n\nCurrently this is not implemented and will generated the NotImplemented error.\n",
         "consumes": [
           "application/json"
@@ -2602,10 +2599,7 @@ func init() {
           "200": {
             "description": "Successfully updated the MTO service item.",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/MTOServiceItem"
-              }
+              "$ref": "#/definitions/MTOServiceItem"
             }
           },
           "400": {

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item.go
@@ -29,7 +29,7 @@ func NewUpdateMTOServiceItem(ctx *middleware.Context, handler UpdateMTOServiceIt
 	return &UpdateMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*UpdateMTOServiceItem swagger:route POST /mto-service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
+/*UpdateMTOServiceItem swagger:route PATCH /mto-service-items/{mtoServiceItemID} mtoServiceItem updateMTOServiceItem
 
 updateMTOServiceItem
 

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
@@ -277,6 +277,50 @@ func (o *UpdateMTOServiceItemConflict) WriteResponse(rw http.ResponseWriter, pro
 	}
 }
 
+// UpdateMTOServiceItemPreconditionFailedCode is the HTTP code returned for type UpdateMTOServiceItemPreconditionFailed
+const UpdateMTOServiceItemPreconditionFailedCode int = 412
+
+/*UpdateMTOServiceItemPreconditionFailed Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+
+swagger:response updateMTOServiceItemPreconditionFailed
+*/
+type UpdateMTOServiceItemPreconditionFailed struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *primemessages.ClientError `json:"body,omitempty"`
+}
+
+// NewUpdateMTOServiceItemPreconditionFailed creates UpdateMTOServiceItemPreconditionFailed with default headers values
+func NewUpdateMTOServiceItemPreconditionFailed() *UpdateMTOServiceItemPreconditionFailed {
+
+	return &UpdateMTOServiceItemPreconditionFailed{}
+}
+
+// WithPayload adds the payload to the update m t o service item precondition failed response
+func (o *UpdateMTOServiceItemPreconditionFailed) WithPayload(payload *primemessages.ClientError) *UpdateMTOServiceItemPreconditionFailed {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update m t o service item precondition failed response
+func (o *UpdateMTOServiceItemPreconditionFailed) SetPayload(payload *primemessages.ClientError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateMTOServiceItemPreconditionFailed) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(412)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // UpdateMTOServiceItemUnprocessableEntityCode is the HTTP code returned for type UpdateMTOServiceItemUnprocessableEntity
 const UpdateMTOServiceItemUnprocessableEntityCode int = 422
 
@@ -357,50 +401,6 @@ func (o *UpdateMTOServiceItemInternalServerError) SetPayload(payload *primemessa
 func (o *UpdateMTOServiceItemInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	if o.Payload != nil {
-		payload := o.Payload
-		if err := producer.Produce(rw, payload); err != nil {
-			panic(err) // let the recovery middleware deal with this
-		}
-	}
-}
-
-// UpdateMTOServiceItemNotImplementedCode is the HTTP code returned for type UpdateMTOServiceItemNotImplemented
-const UpdateMTOServiceItemNotImplementedCode int = 501
-
-/*UpdateMTOServiceItemNotImplemented The requested feature is still in development.
-
-swagger:response updateMTOServiceItemNotImplemented
-*/
-type UpdateMTOServiceItemNotImplemented struct {
-
-	/*
-	  In: Body
-	*/
-	Payload *primemessages.Error `json:"body,omitempty"`
-}
-
-// NewUpdateMTOServiceItemNotImplemented creates UpdateMTOServiceItemNotImplemented with default headers values
-func NewUpdateMTOServiceItemNotImplemented() *UpdateMTOServiceItemNotImplemented {
-
-	return &UpdateMTOServiceItemNotImplemented{}
-}
-
-// WithPayload adds the payload to the update m t o service item not implemented response
-func (o *UpdateMTOServiceItemNotImplemented) WithPayload(payload *primemessages.Error) *UpdateMTOServiceItemNotImplemented {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the update m t o service item not implemented response
-func (o *UpdateMTOServiceItemNotImplemented) SetPayload(payload *primemessages.Error) {
-	o.Payload = payload
-}
-
-// WriteResponse to the client
-func (o *UpdateMTOServiceItemNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.WriteHeader(501)
 	if o.Payload != nil {
 		payload := o.Payload
 		if err := producer.Produce(rw, payload); err != nil {

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/update_m_t_o_service_item_responses.go
@@ -25,7 +25,7 @@ type UpdateMTOServiceItemOK struct {
 	/*
 	  In: Body
 	*/
-	Payload []primemessages.MTOServiceItem `json:"body,omitempty"`
+	Payload primemessages.MTOServiceItem `json:"body,omitempty"`
 }
 
 // NewUpdateMTOServiceItemOK creates UpdateMTOServiceItemOK with default headers values
@@ -35,13 +35,13 @@ func NewUpdateMTOServiceItemOK() *UpdateMTOServiceItemOK {
 }
 
 // WithPayload adds the payload to the update m t o service item o k response
-func (o *UpdateMTOServiceItemOK) WithPayload(payload []primemessages.MTOServiceItem) *UpdateMTOServiceItemOK {
+func (o *UpdateMTOServiceItemOK) WithPayload(payload primemessages.MTOServiceItem) *UpdateMTOServiceItemOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update m t o service item o k response
-func (o *UpdateMTOServiceItemOK) SetPayload(payload []primemessages.MTOServiceItem) {
+func (o *UpdateMTOServiceItemOK) SetPayload(payload primemessages.MTOServiceItem) {
 	o.Payload = payload
 }
 
@@ -49,14 +49,11 @@ func (o *UpdateMTOServiceItemOK) SetPayload(payload []primemessages.MTOServiceIt
 func (o *UpdateMTOServiceItemOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(200)
-	payload := o.Payload
-	if payload == nil {
-		// return empty array
-		payload = make([]primemessages.MTOServiceItem, 0, 50)
-	}
-
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 

--- a/pkg/gen/primeapi/primeoperations/mymove_api.go
+++ b/pkg/gen/primeapi/primeoperations/mymove_api.go
@@ -353,10 +353,10 @@ func (o *MymoveAPI) initHandlerCache() {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
 	o.handlers["PATCH"]["/move-task-orders/{moveTaskOrderID}/post-counseling-info"] = move_task_order.NewUpdateMTOPostCounselingInformation(o.context, o.MoveTaskOrderUpdateMTOPostCounselingInformationHandler)
-	if o.handlers["POST"] == nil {
-		o.handlers["POST"] = make(map[string]http.Handler)
+	if o.handlers["PATCH"] == nil {
+		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/mto-service-items/{mtoServiceItemID}"] = mto_service_item.NewUpdateMTOServiceItem(o.context, o.MtoServiceItemUpdateMTOServiceItemHandler)
+	o.handlers["PATCH"]["/mto-service-items/{mtoServiceItemID}"] = mto_service_item.NewUpdateMTOServiceItem(o.context, o.MtoServiceItemUpdateMTOServiceItemHandler)
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}

--- a/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
+++ b/pkg/gen/primeclient/mto_service_item/mto_service_item_client.go
@@ -104,7 +104,7 @@ func (a *Client) UpdateMTOServiceItem(params *UpdateMTOServiceItemParams) (*Upda
 
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "updateMTOServiceItem",
-		Method:             "POST",
+		Method:             "PATCH",
 		PathPattern:        "/mto-service-items/{mtoServiceItemID}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},

--- a/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
@@ -93,21 +93,21 @@ func NewUpdateMTOServiceItemOK() *UpdateMTOServiceItemOK {
 Successfully updated the MTO service item.
 */
 type UpdateMTOServiceItemOK struct {
-	Payload []primemessages.MTOServiceItem
+	Payload primemessages.MTOServiceItem
 }
 
 func (o *UpdateMTOServiceItemOK) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemOK  %+v", 200, o.Payload)
 }
 
-func (o *UpdateMTOServiceItemOK) GetPayload() []primemessages.MTOServiceItem {
+func (o *UpdateMTOServiceItemOK) GetPayload() primemessages.MTOServiceItem {
 	return o.Payload
 }
 
 func (o *UpdateMTOServiceItemOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload as interface type
-	payload, err := primemessages.UnmarshalMTOServiceItemSlice(response.Body(), consumer)
+	payload, err := primemessages.UnmarshalMTOServiceItem(response.Body(), consumer)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ type UpdateMTOServiceItemBadRequest struct {
 }
 
 func (o *UpdateMTOServiceItemBadRequest) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemBadRequest) GetPayload() *primemessages.ClientError {
@@ -163,7 +163,7 @@ type UpdateMTOServiceItemUnauthorized struct {
 }
 
 func (o *UpdateMTOServiceItemUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemUnauthorized) GetPayload() *primemessages.ClientError {
@@ -196,7 +196,7 @@ type UpdateMTOServiceItemForbidden struct {
 }
 
 func (o *UpdateMTOServiceItemForbidden) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemForbidden) GetPayload() *primemessages.ClientError {
@@ -229,7 +229,7 @@ type UpdateMTOServiceItemNotFound struct {
 }
 
 func (o *UpdateMTOServiceItemNotFound) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemNotFound) GetPayload() *primemessages.ClientError {
@@ -262,7 +262,7 @@ type UpdateMTOServiceItemConflict struct {
 }
 
 func (o *UpdateMTOServiceItemConflict) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemConflict  %+v", 409, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemConflict) GetPayload() *primemessages.ClientError {
@@ -295,7 +295,7 @@ type UpdateMTOServiceItemUnprocessableEntity struct {
 }
 
 func (o *UpdateMTOServiceItemUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemUnprocessableEntity  %+v", 422, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemUnprocessableEntity  %+v", 422, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemUnprocessableEntity) GetPayload() *primemessages.ValidationError {
@@ -328,7 +328,7 @@ type UpdateMTOServiceItemInternalServerError struct {
 }
 
 func (o *UpdateMTOServiceItemInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemInternalServerError) GetPayload() *primemessages.Error {
@@ -361,7 +361,7 @@ type UpdateMTOServiceItemNotImplemented struct {
 }
 
 func (o *UpdateMTOServiceItemNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemNotImplemented  %+v", 501, o.Payload)
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemNotImplemented  %+v", 501, o.Payload)
 }
 
 func (o *UpdateMTOServiceItemNotImplemented) GetPayload() *primemessages.Error {

--- a/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
+++ b/pkg/gen/primeclient/mto_service_item/update_m_t_o_service_item_responses.go
@@ -59,6 +59,12 @@ func (o *UpdateMTOServiceItemReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return nil, result
+	case 412:
+		result := NewUpdateMTOServiceItemPreconditionFailed()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewUpdateMTOServiceItemUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -67,12 +73,6 @@ func (o *UpdateMTOServiceItemReader) ReadResponse(response runtime.ClientRespons
 		return nil, result
 	case 500:
 		result := NewUpdateMTOServiceItemInternalServerError()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
-	case 501:
-		result := NewUpdateMTOServiceItemNotImplemented()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -281,6 +281,39 @@ func (o *UpdateMTOServiceItemConflict) readResponse(response runtime.ClientRespo
 	return nil
 }
 
+// NewUpdateMTOServiceItemPreconditionFailed creates a UpdateMTOServiceItemPreconditionFailed with default headers values
+func NewUpdateMTOServiceItemPreconditionFailed() *UpdateMTOServiceItemPreconditionFailed {
+	return &UpdateMTOServiceItemPreconditionFailed{}
+}
+
+/*UpdateMTOServiceItemPreconditionFailed handles this case with default header values.
+
+Precondition failed, likely due to a stale eTag (If-Match). Fetch the request again to get the updated eTag value.
+*/
+type UpdateMTOServiceItemPreconditionFailed struct {
+	Payload *primemessages.ClientError
+}
+
+func (o *UpdateMTOServiceItemPreconditionFailed) Error() string {
+	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemPreconditionFailed  %+v", 412, o.Payload)
+}
+
+func (o *UpdateMTOServiceItemPreconditionFailed) GetPayload() *primemessages.ClientError {
+	return o.Payload
+}
+
+func (o *UpdateMTOServiceItemPreconditionFailed) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(primemessages.ClientError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
 // NewUpdateMTOServiceItemUnprocessableEntity creates a UpdateMTOServiceItemUnprocessableEntity with default headers values
 func NewUpdateMTOServiceItemUnprocessableEntity() *UpdateMTOServiceItemUnprocessableEntity {
 	return &UpdateMTOServiceItemUnprocessableEntity{}
@@ -336,39 +369,6 @@ func (o *UpdateMTOServiceItemInternalServerError) GetPayload() *primemessages.Er
 }
 
 func (o *UpdateMTOServiceItemInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	o.Payload = new(primemessages.Error)
-
-	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
-		return err
-	}
-
-	return nil
-}
-
-// NewUpdateMTOServiceItemNotImplemented creates a UpdateMTOServiceItemNotImplemented with default headers values
-func NewUpdateMTOServiceItemNotImplemented() *UpdateMTOServiceItemNotImplemented {
-	return &UpdateMTOServiceItemNotImplemented{}
-}
-
-/*UpdateMTOServiceItemNotImplemented handles this case with default header values.
-
-The requested feature is still in development.
-*/
-type UpdateMTOServiceItemNotImplemented struct {
-	Payload *primemessages.Error
-}
-
-func (o *UpdateMTOServiceItemNotImplemented) Error() string {
-	return fmt.Sprintf("[PATCH /mto-service-items/{mtoServiceItemID}][%d] updateMTOServiceItemNotImplemented  %+v", 501, o.Payload)
-}
-
-func (o *UpdateMTOServiceItemNotImplemented) GetPayload() *primemessages.Error {
-	return o.Payload
-}
-
-func (o *UpdateMTOServiceItemNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(primemessages.Error)
 

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -46,6 +46,11 @@ func NewPrimeAPIHandler(context handlers.HandlerContext) http.Handler {
 		movetaskorder.NewMoveTaskOrderChecker(context.DB()),
 	}
 
+	primeAPI.MtoServiceItemUpdateMTOServiceItemHandler = UpdateMTOServiceItemHandler{
+		context,
+		mtoserviceitem.NewMTOServiceItemUpdater(builder),
+	}
+
 	primeAPI.MtoShipmentUpdateMTOShipmentHandler = UpdateMTOShipmentHandler{
 		context,
 		mtoshipment.NewMTOShipmentUpdater(context.DB(), builder, fetcher, context.Planner()),

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -113,7 +113,7 @@ type UpdateMTOServiceItemHandler struct {
 	services.MTOServiceItemUpdater
 }
 
-// Handle handler that updates a mto shipment
+// Handle handler that updates an MTOServiceItem. Only a limited number of service items and fields may be updated.
 func (h UpdateMTOServiceItemHandler) Handle(params mtoserviceitemops.UpdateMTOServiceItemParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
@@ -135,6 +135,8 @@ func (h UpdateMTOServiceItemHandler) Handle(params mtoserviceitemops.UpdateMTOSe
 			return mtoserviceitemops.NewUpdateMTOServiceItemUnprocessableEntity().WithPayload(payloads.ValidationError(e.Error(), h.GetTraceID(), e.ValidationErrors))
 		case services.ConflictError:
 			return mtoserviceitemops.NewUpdateMTOServiceItemConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceID()))
+		case services.PreconditionFailedError:
+			return mtoserviceitemops.NewUpdateMTOServiceItemPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
 		case services.QueryError:
 			if e.Unwrap() != nil {
 				// If you can unwrap, log the internal error (usually a pq error) for better debugging

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
 	"go.uber.org/zap"
 
@@ -124,7 +123,8 @@ func (h UpdateMTOServiceItemHandler) Handle(params mtoserviceitemops.UpdateMTOSe
 			verrs.Error(), h.GetTraceID(), verrs))
 	}
 
-	updatedMTOServiceItem, err := h.MTOServiceItemUpdater.UpdateMTOServiceItemStatus(mtoServiceItem.ID, models.MTOServiceItemStatusApproved, swag.String("something"), params.IfMatch)
+	eTag := params.IfMatch
+	updatedMTOServiceItem, err := h.MTOServiceItemUpdater.UpdateMTOServiceItemPrime(h.DB(), mtoServiceItem, eTag)
 
 	if err != nil {
 		logger.Error("primeapi.UpdateMTOServiceItemHandler error", zap.Error(err))

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/unit"
 
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 
@@ -440,14 +441,14 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDDFSITHandler() {
 	})
 }
 
-func (suite *HandlerSuite) TestUpdateMTOServiceItemHandler() {
+func (suite *HandlerSuite) TestUpdateMTOServiceItemDDDSIT() {
 
 	// Under test: updateMTOServiceItemHandler.Handle function
 	//             MTOServiceItemUpdater.Update service object function
 	// SETUP
-	// Create the service item in the db
+	// Create the service item in the db for dofsit and dddsit
 	timeNow := time.Now()
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+	dddsit := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 		Move: models.Move{
 			AvailableToPrimeAt: &timeNow,
 		},
@@ -455,36 +456,36 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemHandler() {
 			SITEntryDate: swag.Time(time.Now()),
 		},
 		ReService: models.ReService{
-			Code: "DOFSIT",
+			Code: "DDDSIT",
 		},
 	})
-	mockUpdater := mocks.MTOServiceItemUpdater{}
 
 	// Create the payload with the desired update
-	id := uuid.Must(uuid.NewV4())
-	payload := &primemessages.UpdateMTOServiceItemSIT{
-		ReServiceCode:    "DOPSIT",
-		SitDepartureDate: *handlers.FmtDate(time.Now()),
+	reqPayload := &primemessages.UpdateMTOServiceItemSIT{
+		ReServiceCode:    "DDDSIT",
+		SitDepartureDate: *handlers.FmtDate(time.Now().AddDate(0, 0, 5)),
 	}
-	payload.SetID(strfmt.UUID(id.String()))
+	reqPayload.SetID(strfmt.UUID(dddsit.ID.String()))
 
 	// Create the handler
+	queryBuilder := query.NewQueryBuilder(suite.DB())
 	handler := UpdateMTOServiceItemHandler{
 		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-		&mockUpdater,
+		mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder),
 	}
-	mockUpdater.On("UpdateMTOServiceItemStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mtoServiceItem, nil)
 
 	// create the params struct
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-service_items/%s", payload.ID()), nil)
-	eTag := etag.GenerateEtag(time.Now())
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-service_items/%s", dddsit.ID), nil)
+	eTag := etag.GenerateEtag(dddsit.UpdatedAt)
 	params := mtoserviceitemops.UpdateMTOServiceItemParams{
 		HTTPRequest: req,
-		Body:        payload,
+		Body:        reqPayload,
 		IfMatch:     eTag,
 	}
 
 	suite.T().Run("Successful PATCH - Updated SITDepartureDate on DOPSIT", func(t *testing.T) {
+		// Under test: updateMTOServiceItemHandler.Handle function
+		//             MTOServiceItemUpdater.Update service object function
 		// Set up:     We create an mto service item using DOFSIT (which was created above)
 		//             And send an update to the sit entry date
 		// Expected outcome:
@@ -496,46 +497,71 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemHandler() {
 
 		// CHECK RESULTS
 		suite.IsType(&mtoserviceitemops.UpdateMTOServiceItemOK{}, response)
+		r := response.(*mtoserviceitemops.UpdateMTOServiceItemOK)
+		resp1 := r.Payload
+
+		respPayload := resp1.(*primemessages.MTOServiceItemDDFSIT)
+		suite.Equal(reqPayload.ID(), respPayload.ID())
+		suite.Equal(reqPayload.SitDepartureDate.String(), respPayload.SitDepartureDate.String())
+
+		// Return to good state for next test
+		params.IfMatch = respPayload.ETag()
+
 	})
 
-	suite.T().Run("Failed PATCH - No DOFSIT found", func(t *testing.T) {
-		// Set up:     We use a move with no DOFSIT (which means we can't updated DOPSIT)
+	suite.T().Run("Failed PATCH - No DDDSIT found", func(t *testing.T) {
+		// Under test: updateMTOServiceItemHandler.Handle function
+		//             MTOServiceItemUpdater.Update service object function
+		// Set up:     We use a non existent DDDSIT item
 		//             And send an update to DOPSIT to the SitDepartureDate
 		// Expected outcome:
-		//             Receive a fail response
+		//             Receive a NotFound error response
 
 		// SETUP
-		// MYTODO: Create a move with no DOFSIT service item
+		// Replace the request path with a bad id that won't be found
+		badUUID := uuid.Must(uuid.NewV4())
+		badReq := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-service_items/%s", badUUID), nil)
+		params.HTTPRequest = badReq
+		reqPayload.SetID(strfmt.UUID(badUUID.String()))
 
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
 		response := handler.Handle(params)
 
 		// CHECK RESULTS
-		suite.IsType(&mtoserviceitemops.UpdateMTOServiceItemOK{}, response)
+		suite.IsType(&mtoserviceitemops.UpdateMTOServiceItemNotFound{}, response)
+
+		// return to good state for next test
+		params.HTTPRequest = req
+		reqPayload.SetID(strfmt.UUID(dddsit.ID.String()))
 	})
 
-	suite.T().Run("Failed PATCH - Attempted to update DDDSIT", func(t *testing.T) {
-		// Set up:     We use a move with a DOFSIT (which means we can updated DOPSIT)
-		//             But send an update to DDDSIT instead to the SitDepartureDate
+	suite.T().Run("Failed PATCH - Payment request created", func(t *testing.T) {
+		// Under test: updateMTOServiceItemHandler.Handle function
+		//             MTOServiceItemUpdater.Update service object function
+		// Set up:     We use a DDDSIT that already has a payment request associated
+		//             Then try to update the SitDepartureDate on that
 		// Expected outcome:
-		//             Receive a fail response
+		//             Receive a ConflictError response
 
 		// SETUP
-		// Create the payload with the desired update
-		id := uuid.Must(uuid.NewV4())
-		payload := &primemessages.UpdateMTOServiceItemSIT{
-			ReServiceCode:    "DDDSIT",
-			SitDepartureDate: *handlers.FmtDate(time.Now()),
-		}
-		payload.SetID(strfmt.UUID(id.String()))
+		// Make a payment request and link to the dddsit service item
+		paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
+		cost := unit.Cents(20000)
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+			},
+			PaymentRequest: paymentRequest,
+			MTOServiceItem: dddsit,
+		})
 
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
 		response := handler.Handle(params)
 
 		// CHECK RESULTS
-		suite.IsType(&mtoserviceitemops.UpdateMTOServiceItemOK{}, response)
+		suite.IsType(&mtoserviceitemops.UpdateMTOServiceItemConflict{}, response)
 	})
 
 }

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -407,6 +407,8 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	// here we determine which payload model to use based on the re service code
 	switch mtoServiceItem.ReService.Code {
 	case models.ReServiceCodeDOFSIT:
+	case models.ReServiceCodeDOASIT:
+	case models.ReServiceCodeDOPSIT:
 		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
 		if mtoServiceItem.SITDepartureDate != nil {
 			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
@@ -416,8 +418,11 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			PickupPostalCode: mtoServiceItem.PickupPostalCode,
 			Reason:           mtoServiceItem.Reason,
 			SitDepartureDate: sitDepartureDate,
+			SitEntryDate:     handlers.FmtDatePtr(mtoServiceItem.SITEntryDate),
 		}
 	case models.ReServiceCodeDDFSIT:
+	case models.ReServiceCodeDDASIT:
+	case models.ReServiceCodeDDDSIT:
 		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
 		if mtoServiceItem.SITDepartureDate != nil {
 			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
@@ -431,6 +436,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			TimeMilitary2:               handlers.FmtString(secondContact.TimeMilitary),
 			FirstAvailableDeliveryDate2: handlers.FmtDate(secondContact.FirstAvailableDeliveryDate),
 			SitDepartureDate:            sitDepartureDate,
+			SitEntryDate:                handlers.FmtDatePtr(mtoServiceItem.SITEntryDate),
 		}
 	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
 		item := getDimension(mtoServiceItem.Dimensions, models.DimensionTypeItem)

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -1,6 +1,8 @@
 package payloads
 
 import (
+	"time"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
@@ -405,13 +407,21 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	// here we determine which payload model to use based on the re service code
 	switch mtoServiceItem.ReService.Code {
 	case models.ReServiceCodeDOFSIT:
+		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
+		if mtoServiceItem.SITDepartureDate != nil {
+			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
+		}
 		payload = &primemessages.MTOServiceItemDOFSIT{
 			ReServiceCode:    handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			PickupPostalCode: mtoServiceItem.PickupPostalCode,
 			Reason:           mtoServiceItem.Reason,
+			SitDepartureDate: sitDepartureDate,
 		}
-		payload.SetID(strfmt.UUID(mtoServiceItem.ID.String()))
 	case models.ReServiceCodeDDFSIT:
+		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
+		if mtoServiceItem.SITDepartureDate != nil {
+			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
+		}
 		firstContact := getCustomerContact(mtoServiceItem.CustomerContacts, models.CustomerContactTypeFirst)
 		secondContact := getCustomerContact(mtoServiceItem.CustomerContacts, models.CustomerContactTypeSecond)
 		payload = &primemessages.MTOServiceItemDDFSIT{
@@ -420,6 +430,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			FirstAvailableDeliveryDate1: handlers.FmtDate(firstContact.FirstAvailableDeliveryDate),
 			TimeMilitary2:               handlers.FmtString(secondContact.TimeMilitary),
 			FirstAvailableDeliveryDate2: handlers.FmtDate(secondContact.FirstAvailableDeliveryDate),
+			SitDepartureDate:            sitDepartureDate,
 		}
 	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
 		item := getDimension(mtoServiceItem.Dimensions, models.DimensionTypeItem)

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -406,9 +406,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	var payload primemessages.MTOServiceItem
 	// here we determine which payload model to use based on the re service code
 	switch mtoServiceItem.ReService.Code {
-	case models.ReServiceCodeDOFSIT:
-	case models.ReServiceCodeDOASIT:
-	case models.ReServiceCodeDOPSIT:
+	case models.ReServiceCodeDOFSIT, models.ReServiceCodeDOASIT, models.ReServiceCodeDOPSIT:
 		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
 		if mtoServiceItem.SITDepartureDate != nil {
 			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
@@ -420,9 +418,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			SitDepartureDate: sitDepartureDate,
 			SitEntryDate:     handlers.FmtDatePtr(mtoServiceItem.SITEntryDate),
 		}
-	case models.ReServiceCodeDDFSIT:
-	case models.ReServiceCodeDDASIT:
-	case models.ReServiceCodeDDDSIT:
+	case models.ReServiceCodeDDFSIT, models.ReServiceCodeDDASIT, models.ReServiceCodeDDDSIT:
 		sitDepartureDate := strfmt.Date(time.Time{}) // Set to empty/zero time
 		if mtoServiceItem.SITDepartureDate != nil {
 			sitDepartureDate = strfmt.Date(*mtoServiceItem.SITDepartureDate)
@@ -478,7 +474,9 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 		shipmentIDStr = mtoServiceItem.MTOShipmentID.String()
 	}
 
-	payload.SetID(strfmt.UUID(mtoServiceItem.ID.String()))
+	one := mtoServiceItem.ID.String()
+	two := strfmt.UUID(one)
+	payload.SetID(two)
 	payload.SetMoveTaskOrderID(handlers.FmtUUID(mtoServiceItem.MoveTaskOrderID))
 	payload.SetMtoShipmentID(strfmt.UUID(shipmentIDStr))
 	payload.SetReServiceName(mtoServiceItem.ReService.Name)

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/primemessages"
-	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -214,8 +213,6 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		model.ReService.Code = models.ReServiceCodeDOFSIT
 		model.Reason = dofsit.Reason
 		model.PickupPostalCode = dofsit.PickupPostalCode
-		model.SITDepartureDate = swag.Time(time.Time(dofsit.SitDepartureDate))
-		model.SITEntryDate = handlers.FmtDatePtrToPopPtr(dofsit.SitEntryDate)
 
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDDFSIT:
 		ddfsit := mtoServiceItem.(*primemessages.MTOServiceItemDDFSIT)
@@ -232,8 +229,6 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 				FirstAvailableDeliveryDate: time.Time(*ddfsit.FirstAvailableDeliveryDate2),
 			},
 		}
-		model.SITDepartureDate = swag.Time(time.Time(ddfsit.SitDepartureDate))
-		model.SITEntryDate = handlers.FmtDatePtrToPopPtr(ddfsit.SitEntryDate)
 
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle:
 		shuttleService := mtoServiceItem.(*primemessages.MTOServiceItemShuttle)

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/primemessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -213,6 +214,9 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		model.ReService.Code = models.ReServiceCodeDOFSIT
 		model.Reason = dofsit.Reason
 		model.PickupPostalCode = dofsit.PickupPostalCode
+		model.SITDepartureDate = swag.Time(time.Time(dofsit.SitDepartureDate))
+		model.SITEntryDate = handlers.FmtDatePtrToPopPtr(dofsit.SitEntryDate)
+
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDDFSIT:
 		ddfsit := mtoServiceItem.(*primemessages.MTOServiceItemDDFSIT)
 		model.ReService.Code = models.ReServiceCodeDDFSIT
@@ -228,6 +232,9 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 				FirstAvailableDeliveryDate: time.Time(*ddfsit.FirstAvailableDeliveryDate2),
 			},
 		}
+		model.SITDepartureDate = swag.Time(time.Time(ddfsit.SitDepartureDate))
+		model.SITEntryDate = handlers.FmtDatePtrToPopPtr(ddfsit.SitEntryDate)
+
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle:
 		shuttleService := mtoServiceItem.(*primemessages.MTOServiceItemShuttle)
 		// values to get from payload

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -269,6 +269,35 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 	return model, nil
 }
 
+// MTOServiceItemModelFromUpdate converts the payload from UpdateMTOServiceItem to a normal MTOServiceItem model.
+// The payload for this is different than the one for create.
+func MTOServiceItemModelFromUpdate(mtoServiceItem primemessages.UpdateMTOServiceItem) (*models.MTOServiceItem, *validate.Errors) {
+	verrs := validate.NewErrors()
+	if mtoServiceItem == nil {
+		verrs.Add("mtoServiceItem", "was nil")
+		return nil, verrs
+	}
+
+	// Create the service item model
+	model := &models.MTOServiceItem{
+		ID: uuid.FromStringOrNil(mtoServiceItem.ID().String()),
+	}
+
+	// Here we initialize more fields below for the specific model types.
+	// Currently only UpdateMTOServiceItemSIT is supported, more to be expected
+	modelType := mtoServiceItem.ModelType()
+	if modelType == primemessages.UpdateMTOServiceItemModelTypeUpdateMTOServiceItemSIT {
+		sit := mtoServiceItem.(*primemessages.UpdateMTOServiceItemSIT)
+		model.SITDepartureDate = swag.Time(time.Time(sit.SitDepartureDate))
+		model.ReService.Code = models.ReServiceCode(sit.ReServiceCode)
+		return model, nil
+	}
+
+	verrs.Add("mtoServiceItem", "The model type of the service item is not allowed")
+	return nil, verrs
+
+}
+
 // validateDomesticCrating validates this mto service item domestic crating
 func validateDomesticCrating(m primemessages.MTOServiceItemDomesticCrating) *validate.Errors {
 	return validate.Validate(

--- a/pkg/services/errors.go
+++ b/pkg/services/errors.go
@@ -23,7 +23,7 @@ func NewPreconditionFailedError(id uuid.UUID, err error) PreconditionFailedError
 
 // Error is the string representation of the precondition failed error
 func (e PreconditionFailedError) Error() string {
-	return fmt.Sprintf("id: '%s' could not be updated due to the record being stale", e.id.String())
+	return fmt.Sprintf("Precondition failed on update to object with id: '%s'. The If-Match header value did not match the eTag for this record.", e.id.String())
 }
 
 //NotFoundError is returned when a given struct is not found

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -466,12 +466,12 @@ paths:
           $ref: '#/responses/NotFound'
         '409':
           $ref: '#/responses/Conflict'
+        '412':
+          $ref: '#/responses/PreconditionFailed'
         '422':
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
-        '501':
-          $ref: '#/responses/NotImplemented'
   /payment-requests:
     post:
       summary: createPaymentRequest

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -414,7 +414,7 @@ paths:
         '500':
           $ref: '#/responses/ServerError'
   '/mto-service-items/{mtoServiceItemID}':
-    post:
+    patch:
       summary: updateMTOServiceItem
       description: |
         Updates MTOServiceItems after creation. Not all service items or fields may be updated, please see details below.
@@ -455,9 +455,7 @@ paths:
         '200':
           description: Successfully updated the MTO service item.
           schema:
-            type: array
-            items: # we return the same definition as the create function for the response
-              $ref: '#/definitions/MTOServiceItem'
+            $ref: '#/definitions/MTOServiceItem'
         '400':
           $ref: '#/responses/InvalidRequest'
         '401':


### PR DESCRIPTION
## Description

We now have a live endpoint for updating MTOServiceItems, it connects to the updateMTOServiceItem service object. 
You can use this to update a DDDSIT or DOPSIT departure date. 

## Setup

### Unit test version
Two tests were added
`go test ./pkg/handlers/primeapi/ --testify.m TestCreateMTOServiceItemDDFSITHandler -v`
`go test ./pkg/handlers/primeapi/ --testify.m TestUpdateMTOServiceItemDOPSIT -v`

### Real world version
Use postman or prime-api-client. Pick a move and shipment to which you will add the SIT. 
You will need to ensure that the move you selected has status set to APPROVED.

Hit the createMTOServiceItem endpoint with a DOFSIT, this should create all three items, DOFSIT, DOASIT and DOPSIT. However the response is not perfect yet as this is being worked on in another ticket. 

Once you have a DOPSIT in your DB, hit the updateMTOServiceItem end point using the ID of the DOPSIT item. 
Send a "sitDepartureDate" value and you should see it updated in the response. 

## Reference
* [MB-5594 - SIT Service Items: updateMTOServiceItem endpoint - Add Prime API handler function](https://dp3.atlassian.net/browse/MB-5594)
