### PR TITLE
MB-5807: add tests to webhook-client in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,13 +759,47 @@ jobs:
 
   # `webhook_client_test` runs the webhook client Go tests
   webhook_client_test:
-    executor: mymove_large
+    executor: mymove_and_postgres_large
     steps:
       - checkout
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
-      - run: make webhook_client_test
+      - run: make db_test_reset
+      - run:
+          command: make db_test_migrate
+          environment:
+            APPLICATION: app
+            DB_HOST: localhost
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            DB_PASSWORD: mysecretpassword
+            DB_PORT: 5432
+            DB_PORT_TEST: 5432
+            DB_USER: postgres
+            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/app/migrations_manifest.txt'
+            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
+      - run:
+          command: make db_e2e_up
+          environment:
+            APPLICATION: app
+            DB_HOST: localhost
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            DB_PASSWORD: mysecretpassword
+            DB_PORT: 5432
+            DB_PORT_TEST: 5432
+            DB_USER: postgres
+      - run:
+          command: make webhook_client_test_standalone
+          environment:
+            DB_HOST: localhost
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            DB_PASSWORD: mysecretpassword
+            DB_PORT: 5432
+            DB_PORT_TEST: 5432
+            DB_USER: postgres
       - announce_failure
 
   # `build_tools` builds the mymove-specific CLI tools in `mymove/cmd`
@@ -1304,7 +1338,7 @@ workflows:
 
       - webhook_client_test:
           requires:
-            - pre_deps_golang
+            - build_tools
 
       - build_app:
           requires:
@@ -1341,7 +1375,6 @@ workflows:
       - build_webhook_client:
           requires:
             - anti_virus
-            - pre_deps_golang
             - webhook_client_test
 
       - push_app_exp:

--- a/Makefile
+++ b/Makefile
@@ -894,8 +894,11 @@ webhook_client_docker:
 	docker build -f Dockerfile.webhook_client_local -t $(WEBHOOK_CLIENT_DOCKER_CONTAINER):latest .
 
 .PHONY: webhook_client_test
-webhook_client_test:
-	echo "This is a placeholder for webhook-client tests"
+webhook_client_test: db_test_e2e_populate webhook_client_test_standalone
+
+.PHONY: webhook_client_test
+webhook_client_test_standalone:
+	go test -v -count 1 -short ./cmd/webhook-client/webhook
 
 #
 # ----- END WEBHOOK CLIENT TARGETS -----


### PR DESCRIPTION
## Description

Add tests to the webhook-client pipeline in CircleCI. These are the same tests used by team ROCI when developing locally. Now they can run in CircleCI.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make webhook_client_test
make webhook_client_test_standalone
```

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5807) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/118205/101968654-1321ff00-3bd5-11eb-8382-6b19828a7e98.png)