### PR TITLE
Remove md-toc because it's not used

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "lodash-webpack-plugin": "^0.11.5",
     "markdown-spellcheck": "^1.3.1",
     "markdown-toc": "^1.2.0",
-    "md-toc": "^1.0.0",
     "mime-types": "^2.1.27",
     "mockdate": "^3.0.2",
     "prettier": "=2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12316,11 +12316,6 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
   integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
-md-toc@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/md-toc/-/md-toc-1.0.0.tgz#28a535960518f3f3e9135f9713dd0a697245742d"
-  integrity sha1-KKU1lgUY8/PpE1+XE90KaXJFdC0=
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
## Description

In a previous PR, we added both `markdown-toc` and `md-toc` to our package.json in order to fix a Circle CI issue that was blocking all builds. We added both dependencies because that's what worked for the Infra team, who ran into the same issue. Now that we're unblocked, we can remove `md-toc` because it doesn't look like we're using it.
