### PR TITLE
[MB-5797] Add migration to create zip3_distances table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -582,3 +582,4 @@
 20201117222119_alter_users_login_gov_uuid_nullable.up.sql
 20201117222339_create_user_records_for_office_and_admin_users_without.up.sql
 20201120174609_add_indexes_for_move_selected_type.up.sql
+20201207223002_create_zip3_distances.up.sql

--- a/migrations/app/schema/20201207223002_create_zip3_distances.up.sql
+++ b/migrations/app/schema/20201207223002_create_zip3_distances.up.sql
@@ -15,9 +15,9 @@ CREATE UNIQUE INDEX zip3_distances_unique_zip3s ON zip3_distances (from_zip3, to
 
 COMMENT ON TABLE zip3_distances IS 'Stores the distances between zip3 pairs; there should only be one record for any zip3 pair, with from_zip3 always alphabetically before to_zip3.';
 COMMENT ON COLUMN zip3_distances.id IS 'UUID that uniquely identifies the record.';
-COMMENT ON COLUMN zip3_distances.from_zip3 IS 'The starting zip3; this should always be alphabetically before from_zip3.';
-COMMENT ON COLUMN zip3_distances.to_zip3 IS 'The ending zip3; this should always be alphabetically after to_zip3.';
-COMMENT ON COLUMN zip3_distances.distance_miles IS 'The distance in miles between the from_zip3 and to_zip3.';
+COMMENT ON COLUMN zip3_distances.from_zip3 IS 'The starting zip3; this should always be alphabetically before to_zip3.';
+COMMENT ON COLUMN zip3_distances.to_zip3 IS 'The ending zip3; this should always be alphabetically after from_zip3.';
+COMMENT ON COLUMN zip3_distances.distance_miles IS 'The distance in miles between from_zip3 and to_zip3.';
 COMMENT ON COLUMN zip3_distances.created_at IS 'Timestamp when the record was first created.';
 COMMENT ON COLUMN zip3_distances.updated_at IS 'Timestamp when the record was first updated.';
 COMMENT ON CONSTRAINT zip3_distances_ordering ON zip3_distances IS 'Ensures that from_zip3 is always alphabetically before to_zip3.';

--- a/migrations/app/schema/20201207223002_create_zip3_distances.up.sql
+++ b/migrations/app/schema/20201207223002_create_zip3_distances.up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE zip3_distances
+(
+    id UUID NOT NULL
+        CONSTRAINT zip3_distances_pkey PRIMARY KEY,
+    from_zip3 CHAR(3) NOT NULL,
+    to_zip3 CHAR(3) NOT NULL,
+    distance_miles INTEGER NOT NULL,
+    -- Defaulting these to NOW() to reduce size of input file since there are so many rows.
+    created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
+    CONSTRAINT zip3_distances_ordering CHECK (from_zip3 < to_zip3)
+);
+
+CREATE UNIQUE INDEX zip3_distances_unique_zip3s ON zip3_distances (from_zip3, to_zip3);
+
+COMMENT ON TABLE zip3_distances IS 'Stores the distances between zip3 pairs; there should only be one record for any zip3 pair, with from_zip3 always alphabetically before to_zip3.';
+COMMENT ON COLUMN zip3_distances.id IS 'UUID that uniquely identifies the record.';
+COMMENT ON COLUMN zip3_distances.from_zip3 IS 'The starting zip3; this should always be alphabetically before from_zip3.';
+COMMENT ON COLUMN zip3_distances.to_zip3 IS 'The ending zip3; this should always be alphabetically after to_zip3.';
+COMMENT ON COLUMN zip3_distances.distance_miles IS 'The distance in miles between the from_zip3 and to_zip3.';
+COMMENT ON COLUMN zip3_distances.created_at IS 'Timestamp when the record was first created.';
+COMMENT ON COLUMN zip3_distances.updated_at IS 'Timestamp when the record was first updated.';
+COMMENT ON CONSTRAINT zip3_distances_ordering ON zip3_distances IS 'Ensures that from_zip3 is always alphabetically before to_zip3.';
+COMMENT ON INDEX zip3_distances_unique_zip3s IS 'Ensures that we have only one entry for a from/to zip3 pair.';


### PR DESCRIPTION
## Description

This PR adds a migration to create a `zip3_distances` table that will be storing zip3-to-zip3 distances (data coming in a subsequent subtask/migration).  This data will eventually be used for pricing moves.

See the [design doc](https://docs.google.com/document/d/1RWh1hGYZltWKYpiejauoBambRL_REcZJVfBnLN3P0_M/edit#) for this work.

## Reviewer Notes

- We only store unique zip3-to-zip3 pairs in one direction (since presumably the opposite direction should have the same distance and our input file only gives us one direction).  The `zip3_distances_ordering` constraint and `zip3_distances_unique_zip3s` unique index enforce that.
- I put a default of `NOW()` on the created/updated timestamps.  We don't do that on many other tables since Pop sends it anyway, but Pop isn't involved in the data load.  Since the data load will be a large file, using the defaults helps to reduce the file size.
- We haven't historically documented constraints/indexes, but these two seemed like good candidates to have further explanation.

## Setup

- `make db_dev_reset db_dev_migrate` to make sure the migration runs without errors and you see the schema changed appropriately.
- `make schemaspy`, then open the `index.html` file in the generated web site (link at end of `make` output).  You should see the comments appear for that table.  Alternatively, use GoLand or some other database tool that shows Postgres comments.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5797) for this change
* [Design Doc](https://docs.google.com/document/d/1RWh1hGYZltWKYpiejauoBambRL_REcZJVfBnLN3P0_M/edit#)
