### PR TITLE
[MB-3226] Redux Refactor: Moves & MTOShipments (write)

### DIFF
--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -3,11 +3,8 @@ import { connect } from 'react-redux';
 import { bool, string, func, shape, number } from 'prop-types';
 
 import MtoShipmentForm from 'components/Customer/MtoShipmentForm/MtoShipmentForm';
-import {
-  selectMTOShipmentById,
-  createMTOShipment as createMTOShipmentAction,
-  updateMTOShipment as updateMTOShipmentAction,
-} from 'shared/Entities/modules/mtoShipments';
+import { selectMTOShipmentById } from 'shared/Entities/modules/mtoShipments';
+import { updateMTOShipment as updateMTOShipmentAction } from 'store/entities/actions';
 import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import { HhgShipmentShape, HistoryShape, MatchShape, PageKeyShape, PageListShape } from 'types/customerShapes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -31,7 +28,6 @@ export class CreateOrEditMtoShipment extends Component {
       selectedMoveType,
       currentResidence,
       newDutyStationAddress,
-      createMTOShipment,
       updateMTOShipment,
       serviceMember,
       isCreate,
@@ -50,7 +46,6 @@ export class CreateOrEditMtoShipment extends Component {
           isCreatePage={isCreate}
           currentResidence={currentResidence}
           newDutyStationAddress={newDutyStationAddress}
-          createMTOShipment={createMTOShipment}
           updateMTOShipment={updateMTOShipment}
           serviceMember={serviceMember}
         />
@@ -73,7 +68,6 @@ CreateOrEditMtoShipment.propTypes = {
   mtoShipment: HhgShipmentShape,
   currentResidence: AddressShape.isRequired,
   newDutyStationAddress: SimpleAddressShape,
-  createMTOShipment: func.isRequired,
   updateMTOShipment: func.isRequired,
   serviceMember: shape({
     weight_allotment: shape({
@@ -122,7 +116,6 @@ function mapStateToProps(state, ownProps) {
 
 const mapDispatchToProps = {
   fetchCustomerData: fetchCustomerDataAction,
-  createMTOShipment: createMTOShipmentAction,
   updateMTOShipment: updateMTOShipmentAction,
 };
 

--- a/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
@@ -29,7 +29,6 @@ const defaultProps = {
     push: jest.fn(),
   },
   fetchCustomerData: jest.fn(),
-  createMTOShipment: jest.fn(),
   updateMTOShipment: jest.fn(),
   selectedMoveType: '',
   mtoShipment: {},

--- a/src/sagas/entities.js
+++ b/src/sagas/entities.js
@@ -1,6 +1,6 @@
 import { all, takeLatest, put, call } from 'redux-saga/effects';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT } from 'store/entities/actions';
+import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE } from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -26,9 +26,21 @@ export function* updateBackupContact(action) {
   });
 }
 
+export function* updateMove(action) {
+  const { payload } = action;
+
+  const normalizedData = yield call(normalizeResponse, payload, 'move');
+  yield put(addEntities(normalizedData));
+  yield put({
+    type: 'CREATE_OR_UPDATE_MOVE_SUCCESS',
+    payload,
+  });
+}
+
 export function* watchUpdateEntities() {
   yield all([
     takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
     takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
+    takeLatest(UPDATE_MOVE, updateMove),
   ]);
 }

--- a/src/sagas/entities.js
+++ b/src/sagas/entities.js
@@ -1,6 +1,6 @@
 import { all, takeLatest, put, call } from 'redux-saga/effects';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE } from 'store/entities/actions';
+import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE, UPDATE_MTO_SHIPMENT } from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -37,10 +37,17 @@ export function* updateMove(action) {
   });
 }
 
+export function* updateMTOShipment(action) {
+  const { payload } = action;
+  const normalizedData = yield call(normalizeResponse, payload, 'mtoShipment');
+  yield put(addEntities(normalizedData));
+}
+
 export function* watchUpdateEntities() {
   yield all([
     takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
     takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
     takeLatest(UPDATE_MOVE, updateMove),
+    takeLatest(UPDATE_MTO_SHIPMENT, updateMTOShipment),
   ]);
 }

--- a/src/sagas/entities.test.js
+++ b/src/sagas/entities.test.js
@@ -1,8 +1,8 @@
 import { all, takeLatest, put, call } from 'redux-saga/effects';
 
-import { watchUpdateEntities, updateServiceMember, updateBackupContact } from './entities';
+import { watchUpdateEntities, updateServiceMember, updateBackupContact, updateMove } from './entities';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT } from 'store/entities/actions';
+import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE } from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -14,6 +14,7 @@ describe('watchUpdateEntities', () => {
       all([
         takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
         takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
+        takeLatest(UPDATE_MOVE, updateMove),
       ]),
     );
   });
@@ -89,6 +90,46 @@ describe('updateBackupContact', () => {
     expect(generator.next().value).toEqual(
       put({
         type: 'UPDATE_BACKUP_CONTACT_SUCCESS',
+        payload: testAction.payload,
+      }),
+    );
+  });
+
+  it('is done', () => {
+    expect(generator.next().done).toEqual(true);
+  });
+});
+
+describe('updateMove', () => {
+  const testAction = {
+    payload: {
+      created_at: '2020-12-07T17:03:58.767Z',
+      id: '3a8c9f4f-7344-4f18-9ab5-0de3ef57b901',
+      locator: 'ONEHHG',
+      orders_id: 'a413144b-137f-4400-85c2-a99c437ef85e',
+      selected_move_type: 'HHG',
+      service_member_id: '1d06ab96-cb72-4013-b159-321d6d29c6eb',
+      status: 'DRAFT',
+      updated_at: '2020-12-07T22:41:08.999Z',
+    },
+  };
+
+  const normalizedMove = normalizeResponse(testAction.payload, 'move');
+
+  const generator = updateMove(testAction);
+
+  it('normalizes the payload', () => {
+    expect(generator.next().value).toEqual(call(normalizeResponse, testAction.payload, 'move'));
+  });
+
+  it('stores the normalized data in entities', () => {
+    expect(generator.next(normalizedMove).value).toEqual(put(addEntities(normalizedMove)));
+  });
+
+  it('calls the legacy CREATE_OR_UPDATE_MOVE_SUCCESS action with the raw payload', () => {
+    expect(generator.next().value).toEqual(
+      put({
+        type: 'CREATE_OR_UPDATE_MOVE_SUCCESS',
         payload: testAction.payload,
       }),
     );

--- a/src/sagas/entities.test.js
+++ b/src/sagas/entities.test.js
@@ -1,8 +1,14 @@
 import { all, takeLatest, put, call } from 'redux-saga/effects';
 
-import { watchUpdateEntities, updateServiceMember, updateBackupContact, updateMove } from './entities';
+import {
+  watchUpdateEntities,
+  updateServiceMember,
+  updateBackupContact,
+  updateMove,
+  updateMTOShipment,
+} from './entities';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE } from 'store/entities/actions';
+import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE, UPDATE_MTO_SHIPMENT } from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -15,6 +21,7 @@ describe('watchUpdateEntities', () => {
         takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
         takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
         takeLatest(UPDATE_MOVE, updateMove),
+        takeLatest(UPDATE_MTO_SHIPMENT, updateMTOShipment),
       ]),
     );
   });
@@ -133,6 +140,46 @@ describe('updateMove', () => {
         payload: testAction.payload,
       }),
     );
+  });
+
+  it('is done', () => {
+    expect(generator.next().done).toEqual(true);
+  });
+});
+
+describe('updateMTOShipment', () => {
+  const testAction = {
+    payload: {
+      createdAt: '2020-12-08T17:39:05.051Z',
+      customerRemarks: '',
+      eTag: 'MjAyMC0xMi0wOFQxNzozOTowNS4wNTE0Mzha',
+      id: 'dfb950b2-075f-4595-b3cd-a56bb7293ca1',
+      moveTaskOrderID: 'c7621194-ed1e-4ead-9033-761715f179f3',
+      pickupAddress: {
+        city: 'New York',
+        id: '3eedb9b9-fbbb-47c0-93c7-50daaae84cb4',
+        postal_code: '10002',
+        state: 'NY',
+        street_address_1: '415 Grand St, #E306, #E306',
+        street_address_2: '#E306',
+      },
+      requestedPickupDate: '2020-12-22',
+      shipmentType: 'HHG_INTO_NTS_DOMESTIC',
+      status: 'SUBMITTED',
+      updatedAt: '2020-12-08T17:39:05.051Z',
+    },
+  };
+
+  const normalizedMove = normalizeResponse(testAction.payload, 'mtoShipment');
+
+  const generator = updateMTOShipment(testAction);
+
+  it('normalizes the payload', () => {
+    expect(generator.next().value).toEqual(call(normalizeResponse, testAction.payload, 'mtoShipment'));
+  });
+
+  it('stores the normalized data in entities', () => {
+    expect(generator.next(normalizedMove).value).toEqual(put(addEntities(normalizedMove)));
   });
 
   it('is done', () => {

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import PropTypes from 'prop-types';
 import { getFormValues } from 'redux-form';
+
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { selectGetCurrentUserIsSuccess } from 'shared/Data/users';
 import CertificationText from './CertificationText';
@@ -15,7 +16,8 @@ import './index.scss';
 import { createSignedCertification } from 'shared/Entities/modules/signed_certifications';
 import { SIGNED_CERT_OPTIONS } from 'shared/constants';
 import { selectActivePPMForMove, loadPPMs } from 'shared/Entities/modules/ppms';
-import { submitMoveForApproval } from 'shared/Entities/modules/moves';
+import { submitMoveForApproval } from 'services/internalApi';
+import { updateMove as updateMoveAction } from 'store/entities/actions';
 import { completeCertificationText } from './legaleseText';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { setFlashMessage as setFlashMessageAction } from 'store/flash/actions';
@@ -45,9 +47,10 @@ export class SignedCertification extends Component {
     };
 
     if (values) {
-      this.props
-        .submitMoveForApproval(moveId, certificate)
-        .then(() => {
+      submitMoveForApproval(moveId, certificate)
+        .then((response) => {
+          // Update Redux with new data
+          this.props.updateMove(response);
           this.props.setFlashMessage('MOVE_SUBMIT_SUCCESS', 'success', 'You’ve submitted your move request.');
           this.props.push(landingPath);
         })
@@ -91,7 +94,7 @@ export class SignedCertification extends Component {
               <div className="usa-width-one-whole">
                 <div>
                   <h1>Now for the official part...</h1>
-                  <p className="instructions">{instructionsText}</p>
+                  <div className="instructions">{instructionsText}</div>
                   <SectionWrapper>
                     <span className="box_top">
                       <a className="usa-link pdf" onClick={this.print}>
@@ -167,9 +170,9 @@ function mapStateToProps(state, ownProps) {
 const mapDispatchToProps = {
   createSignedCertification,
   loadPPMs,
-  submitMoveForApproval,
   push,
   setFlashMessage: setFlashMessageAction,
+  updateMove: updateMoveAction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(SignedCertification);

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -1,5 +1,5 @@
 import { get, head, pick } from 'lodash';
-import { GetMove, SubmitMoveForApproval } from './api.js';
+import { GetMove } from './api.js';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
 import { fetchActive } from 'shared/utils';
 
@@ -14,9 +14,6 @@ export const GET_MOVE = ReduxHelpers.generateAsyncActionTypes(getMoveType);
 
 export const createOrUpdateMoveType = 'CREATE_OR_UPDATE_MOVE';
 export const CREATE_OR_UPDATE_MOVE = ReduxHelpers.generateAsyncActionTypes(createOrUpdateMoveType);
-
-export const submitForApprovalType = 'SUBMIT_FOR_APPROVAL';
-export const SUBMIT_FOR_APPROVAL = ReduxHelpers.generateAsyncActionTypes(submitForApprovalType);
 
 // Action creation
 export function setConusStatus(moveType) {
@@ -42,7 +39,6 @@ export function loadMove(moveId) {
   };
 }
 
-export const SubmitForApproval = ReduxHelpers.generateAsyncActionCreator(submitForApprovalType, SubmitMoveForApproval);
 //selector
 export const moveIsApproved = (state) => get(state, 'moves.currentMove.status') === 'APPROVED';
 
@@ -116,20 +112,6 @@ export function moveReducer(state = initialState, action) {
         latestMove: null,
         hasLoadSuccess: false,
         hasLoadError: true,
-        error: action.error,
-      });
-    case SUBMIT_FOR_APPROVAL.start:
-      return Object.assign({}, state, {
-        submittedForApproval: false,
-      });
-    case SUBMIT_FOR_APPROVAL.success:
-      return Object.assign({}, state, {
-        currentMove: reshapeMove(action.payload),
-        submittedForApproval: true,
-      });
-    case SUBMIT_FOR_APPROVAL.failure:
-      return Object.assign({}, state, {
-        submittedForApproval: false,
         error: action.error,
       });
     case SET_CONUS_STATUS:

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -1,5 +1,5 @@
 import { get, head, pick } from 'lodash';
-import { UpdateMove, GetMove, SubmitMoveForApproval } from './api.js';
+import { GetMove, SubmitMoveForApproval } from './api.js';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
 import { fetchActive } from 'shared/utils';
 
@@ -30,15 +30,6 @@ export function setPendingMoveType(value) {
 
 export function setSelectedMoveType(moveType) {
   return { type: SET_SELECTED_MOVE_TYPE, moveType };
-}
-export function updateMove(moveId, moveType) {
-  return function (dispatch) {
-    const action = ReduxHelpers.generateAsyncActions(createOrUpdateMoveType);
-    dispatch(action.start());
-    return UpdateMove(moveId, { selected_move_type: moveType })
-      .then((item) => dispatch(action.success(item)))
-      .catch((error) => dispatch(action.error(error)));
-  };
 }
 
 export function loadMove(moveId) {

--- a/src/scenes/Moves/ducks.test.js
+++ b/src/scenes/Moves/ducks.test.js
@@ -1,4 +1,4 @@
-import { CREATE_OR_UPDATE_MOVE, GET_MOVE, SUBMIT_FOR_APPROVAL, moveReducer, setConusStatus } from './ducks';
+import { CREATE_OR_UPDATE_MOVE, GET_MOVE, moveReducer, setConusStatus } from './ducks';
 import loggedInUserPayload, { emptyPayload } from 'shared/User/sampleLoggedInUserPayload';
 import { SHIPMENT_OPTIONS, CONUS_STATUS } from 'shared/constants';
 
@@ -134,35 +134,6 @@ describe('move Reducer', () => {
         latestMove: null,
         hasLoadError: true,
         hasLoadSuccess: false,
-        error: 'No bueno.',
-      });
-    });
-  });
-
-  describe('SUBMIT_FOR_APPROVAL', () => {
-    it('Should handle SUCCESS', () => {
-      const initialState = {};
-      const newState = moveReducer(initialState, {
-        type: SUBMIT_FOR_APPROVAL.success,
-        payload: { ...movePayload, status: 'APPROVED' },
-      });
-
-      expect(newState).toEqual({
-        currentMove: { ...expectedMove, status: 'APPROVED' },
-        submittedForApproval: true,
-      });
-    });
-
-    it('Should handle FAILURE', () => {
-      const initialState = {};
-
-      const newState = moveReducer(initialState, {
-        type: SUBMIT_FOR_APPROVAL.failure,
-        error: 'No bueno.',
-      });
-
-      expect(newState).toEqual({
-        submittedForApproval: false,
         error: 'No bueno.',
       });
     });

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { bindActionCreators } from 'redux';
-import PropTypes from 'prop-types';
 import { withLastLocation } from 'react-router-last-location';
-import { withContext } from 'shared/AppContext';
 
+import { withContext } from 'shared/AppContext';
 import { PpmSummary } from './PpmSummary';
-import { selectedMoveType, lastMoveIsCanceled, updateMove } from 'scenes/Moves/ducks';
+import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import { selectServiceMemberFromLoggedInUser, selectIsProfileComplete } from 'store/entities/selectors';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
@@ -108,7 +107,6 @@ export class PpmLanding extends Component {
       move,
       ppm,
       requestPaymentSuccess,
-      updateMove,
       location,
     } = this.props;
 
@@ -145,7 +143,6 @@ export class PpmLanding extends Component {
             resumeMove={this.resumeMove}
             reviewProfile={this.reviewProfile}
             requestPaymentSuccess={requestPaymentSuccess}
-            updateMove={updateMove}
           />
         )}
       </div>
@@ -197,11 +194,11 @@ const mapStateToProps = (state) => {
   return props;
 };
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { push, updateMove, loadPPMs, loadMTOShipments, showLoggedInUser: showLoggedInUserAction },
-    dispatch,
-  );
-}
+const mapDispatchToProps = {
+  push,
+  loadPPMs,
+  loadMTOShipments,
+  showLoggedInUser: showLoggedInUserAction,
+};
 
 export default withContext(withLastLocation(connect(mapStateToProps, mapDispatchToProps)(PpmLanding)));

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -146,3 +146,30 @@ export async function submitMoveForApproval(moveId, certificate) {
     },
   );
 }
+
+/** MTO SHIPMENTS */
+export async function createMTOShipment(mtoShipment) {
+  return makeInternalRequest(
+    'mtoShipment.createMTOShipment',
+    {
+      body: mtoShipment,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function patchMTOShipment(mtoShipmentId, mtoShipment, ifMatchETag) {
+  return makeInternalRequest(
+    'mtoShipment.updateMTOShipment',
+    {
+      mtoShipmentId,
+      'If-Match': ifMatchETag,
+      body: mtoShipment,
+    },
+    {
+      normalize: false,
+    },
+  );
+}

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -44,6 +44,8 @@ export async function getMTOShipmentsForMove(moveTaskOrderID, normalize = true) 
 }
 
 /** BELOW API CALLS ARE STILL USING DUCKS, NOT NORMALIZED BY DEFAULT */
+
+/** SERVICE MEMBERS */
 export async function createServiceMember(serviceMember = {}) {
   return makeInternalRequest(
     'service_members.createServiceMember',
@@ -77,6 +79,7 @@ export async function patchServiceMember(serviceMember) {
   );
 }
 
+/** BACKUP CONTACTS */
 export async function createBackupContactForServiceMember(serviceMemberId, backupContact) {
   return makeInternalRequest(
     'backup_contacts.createServiceMemberBackupContact',
@@ -96,6 +99,47 @@ export async function patchBackupContact(backupContact) {
     {
       backupContactId: backupContact.id,
       updateServiceMemberBackupContactPayload: backupContact,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+/** MOVES */
+export async function getMove(moveId) {
+  return makeInternalRequest(
+    'moves.showMove',
+    {
+      moveId,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function patchMove(move) {
+  return makeInternalRequest(
+    'moves.patchMove',
+    {
+      moveId: move.id,
+      patchMovePayload: move,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function submitMoveForApproval(moveId, certificate) {
+  return makeInternalRequest(
+    'moves.submitMoveForApproval',
+    {
+      moveId,
+      submitMoveForApprovalPayload: {
+        certificate,
+      },
     },
     {
       normalize: false,

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -11,6 +11,8 @@ import { getGHCClient } from 'shared/Swagger/api';
 import { filter } from 'lodash';
 import { fetchActive } from 'shared/utils';
 
+/** REMAINING EXPORTS ARE USED BY OFFICE */
+
 export const STATE_KEY = 'moves';
 const approveBasicsLabel = 'Moves.ApproveBasics';
 const cancelMoveLabel = 'Moves.CancelMove';

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -11,8 +11,6 @@ import { getGHCClient } from 'shared/Swagger/api';
 import { filter } from 'lodash';
 import { fetchActive } from 'shared/utils';
 
-/** REMAINING EXPORTS ARE USED BY OFFICE */
-
 export const STATE_KEY = 'moves';
 const approveBasicsLabel = 'Moves.ApproveBasics';
 const cancelMoveLabel = 'Moves.CancelMove';

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -17,7 +17,6 @@ const cancelMoveLabel = 'Moves.CancelMove';
 export const loadMoveLabel = 'Moves.loadMove';
 export const getMoveDatesSummaryLabel = 'Moves.getMoveDatesSummary';
 export const getMoveByLocatorOperation = 'move.getMove';
-export const submitMoveForApprovalLabel = 'move.submitMoveForApproval';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -95,19 +94,6 @@ export function selectActiveMoveByOrdersId(state, ordersId) {
 export function selectMoveStatus(state, moveId) {
   const move = selectMove(state, moveId);
   return move.status;
-}
-
-export function submitMoveForApproval(moveId, certificate, label = submitMoveForApprovalLabel) {
-  const swaggerTag = 'moves.submitMoveForApproval';
-  const submitMoveForApprovalPayload = { certificate: certificate };
-  return swaggerRequest(
-    getClient,
-    swaggerTag,
-    { moveId, submitMoveForApprovalPayload },
-    {
-      label,
-    },
-  );
 }
 
 export function selectActiveOrLatestMove(state) {

--- a/src/shared/Entities/modules/mtoShipments.js
+++ b/src/shared/Entities/modules/mtoShipments.js
@@ -5,8 +5,6 @@ import { filter } from 'lodash';
 import { denormalize } from 'normalizr';
 import { mtoShipments } from '../schema';
 
-/** REMAINING EXPORTS ARE USED BY OFFICE */
-
 const mtoShipmentsSchemaKey = 'mtoShipments';
 const getMTOShipmentsOperation = 'mtoShipment.listMTOShipments';
 export function getMTOShipments(moveTaskOrderID, label = getMTOShipmentsOperation, schemaKey = mtoShipmentsSchemaKey) {
@@ -33,27 +31,6 @@ export function patchMTOShipmentStatus(
       'If-Match': ifMatchETag,
       body: { status: shipmentStatus, rejectionReason },
     },
-    { label, schemaKey },
-  );
-}
-
-const createMTOShipmentOperation = 'mtoShipment.createMTOShipment';
-export function createMTOShipment(mtoShipment, label = createMTOShipmentOperation, schemaKey = mtoShipmentSchemaKey) {
-  return swaggerRequest(getClient, createMTOShipmentOperation, { body: mtoShipment }, { label, schemaKey });
-}
-
-const updateMTOShipmentOperation = 'mtoShipment.updateMTOShipment';
-export function updateMTOShipment(
-  mtoShipmentId,
-  mtoShipment,
-  ifMatchETag,
-  label = updateMTOShipmentOperation,
-  schemaKey = mtoShipmentSchemaKey,
-) {
-  return swaggerRequest(
-    getClient,
-    updateMTOShipmentOperation,
-    { mtoShipmentId, 'If-Match': ifMatchETag, body: mtoShipment },
     { label, schemaKey },
   );
 }

--- a/src/shared/Entities/modules/mtoShipments.js
+++ b/src/shared/Entities/modules/mtoShipments.js
@@ -5,6 +5,8 @@ import { filter } from 'lodash';
 import { denormalize } from 'normalizr';
 import { mtoShipments } from '../schema';
 
+/** REMAINING EXPORTS ARE USED BY OFFICE */
+
 const mtoShipmentsSchemaKey = 'mtoShipments';
 const getMTOShipmentsOperation = 'mtoShipment.listMTOShipments';
 export function getMTOShipments(moveTaskOrderID, label = getMTOShipmentsOperation, schemaKey = mtoShipmentsSchemaKey) {

--- a/src/store/entities/actions.js
+++ b/src/store/entities/actions.js
@@ -1,6 +1,7 @@
 export const UPDATE_SERVICE_MEMBER = 'UPDATE_SERVICE_MEMBER';
 export const UPDATE_BACKUP_CONTACT = 'UPDATE_BACKUP_CONTACT';
 export const UPDATE_MOVE = 'UPDATE_MOVE';
+export const UPDATE_MTO_SHIPMENT = 'UPDATE_MTO_SHIPMENT';
 
 export const updateServiceMember = (payload) => ({
   type: UPDATE_SERVICE_MEMBER,
@@ -14,5 +15,10 @@ export const updateBackupContact = (payload) => ({
 
 export const updateMove = (payload) => ({
   type: UPDATE_MOVE,
+  payload,
+});
+
+export const updateMTOShipment = (payload) => ({
+  type: UPDATE_MTO_SHIPMENT,
   payload,
 });

--- a/src/store/entities/actions.js
+++ b/src/store/entities/actions.js
@@ -1,5 +1,6 @@
 export const UPDATE_SERVICE_MEMBER = 'UPDATE_SERVICE_MEMBER';
 export const UPDATE_BACKUP_CONTACT = 'UPDATE_BACKUP_CONTACT';
+export const UPDATE_MOVE = 'UPDATE_MOVE';
 
 export const updateServiceMember = (payload) => ({
   type: UPDATE_SERVICE_MEMBER,
@@ -8,5 +9,10 @@ export const updateServiceMember = (payload) => ({
 
 export const updateBackupContact = (payload) => ({
   type: UPDATE_BACKUP_CONTACT,
+  payload,
+});
+
+export const updateMove = (payload) => ({
+  type: UPDATE_MOVE,
   payload,
 });


### PR DESCRIPTION
## Description

This PR completes the write portion of Redux refactor work for Moves & MTO Shipments. It migrates existing functions that make API calls to create or update moves & MTO shipments to use the newer saga + entities pattern:
- `patchMove` (used on Select Move Type page to save the `selected_move_type` field)
- `submitMoveForApproval` (used on Legalese page to submit the move)
- `createMTOShipment, patchMTOShipment` (used on the MTO Shipment form for HHG, NTS, NTS-R shipment types)

The work involved for each of the above functions is:
- Move the API call inline to the component's submit function, and add an error message state to display API errors (these are not standardized and so this work is mostly intended to lay groundwork for error UI in the future)
- On success of the API call, pass the response into the entities saga to be normalized and updated in Redux (both entities & legacy reducers if applicable)
- Delete legacy functions that are now redundant & no longer called anywhere

## Reviewer Notes

Flows to test are:
- Creating new shipments of all types
- Updating existing shipments
- Submitting a move for approval

I'm intending to branch off this and submit a second PR that completes the read portion of this work. Once both PRs are merged, the story can be delivered. The point of splitting the work up is so that the PRs can be smaller & easier to read, and because doing it in this order allows us to merge in portions of the work without introducing breaking changes.

## Setup

To run the application locally:
```
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3226) for this change