### PR TITLE
[MB-5887] Fix switch case statements for payment request card reviewed statuses

### DIFF
--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -17,10 +17,12 @@ const paymentRequestStatusLabel = (status) => {
   switch (status) {
     case 'PENDING':
       return 'Needs Review';
-    case ('REVIEWED', 'SENT_TO_GEX', 'RECEIVED_BY_GEX'):
+    case 'REVIEWED':
+    case 'SENT_TO_GEX':
+    case 'RECEIVED_BY_GEX':
       return 'Reviewed';
     case 'PAID':
-      return 'PAID';
+      return 'Paid';
     default:
       return status;
   }

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
@@ -169,7 +169,7 @@ describe('PaymentRequestCard', () => {
     );
 
     it('renders the reviewed status tag', () => {
-      expect(wrapper.find({ 'data-testid': 'tag' }).contains('REVIEWED')).toBe(true);
+      expect(wrapper.find({ 'data-testid': 'tag' }).contains('Reviewed')).toBe(true);
     });
 
     it('sums the approved service items total', () => {
@@ -196,6 +196,107 @@ describe('PaymentRequestCard', () => {
 
       expect(rejected.find('.amountRejected h2').contains('$60,000.02')).toBe(true);
       expect(rejected.find('.amountAccepted').exists()).toBe(false);
+    });
+  });
+
+  describe('payment request gex statuses', () => {
+    it('renders the reviewed status tag for sent_to_gex', () => {
+      const sentToGexPaymentRequest = {
+        id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+        createdAt: '2020-12-01T00:00:00.000Z',
+        moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+        paymentRequestNumber: '1843-9061-2',
+        status: 'SENT_TO_GEX',
+        serviceItems: [
+          {
+            id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 2000001,
+            status: 'DENIED',
+          },
+          {
+            id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 4000001,
+            status: 'DENIED',
+            rejectionReason: 'duplicate charge',
+          },
+        ],
+      };
+      const sentToGex = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+          <PaymentRequestCard paymentRequest={sentToGexPaymentRequest} />
+        </MockProviders>,
+      );
+      expect(sentToGex.find({ 'data-testid': 'tag' }).contains('Reviewed')).toBe(true);
+    });
+
+    it('renders the reviewed status tag for received_by_gex', () => {
+      const receivedByGexPaymentRequest = {
+        id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+        createdAt: '2020-12-01T00:00:00.000Z',
+        moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+        paymentRequestNumber: '1843-9061-2',
+        status: 'RECEIVED_BY_GEX',
+        serviceItems: [
+          {
+            id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 2000001,
+            status: 'DENIED',
+          },
+          {
+            id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 4000001,
+            status: 'DENIED',
+            rejectionReason: 'duplicate charge',
+          },
+        ],
+      };
+      const receivedByGex = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+          <PaymentRequestCard paymentRequest={receivedByGexPaymentRequest} />
+        </MockProviders>,
+      );
+      expect(receivedByGex.find({ 'data-testid': 'tag' }).contains('Reviewed')).toBe(true);
+    });
+
+    it('renders the paid status tag for paid request', () => {
+      const paidPaymentRequest = {
+        id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+        createdAt: '2020-12-01T00:00:00.000Z',
+        moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+        paymentRequestNumber: '1843-9061-2',
+        status: 'PAID',
+        serviceItems: [
+          {
+            id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 2000001,
+            status: 'DENIED',
+          },
+          {
+            id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+            createdAt: '2020-12-01T00:00:00.000Z',
+            mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+            priceCents: 4000001,
+            status: 'DENIED',
+            rejectionReason: 'duplicate charge',
+          },
+        ],
+      };
+      const paid = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+          <PaymentRequestCard paymentRequest={paidPaymentRequest} />
+        </MockProviders>,
+      );
+      expect(paid.find({ 'data-testid': 'tag' }).contains('Paid')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Description

This fixes the wrong case statement I wrote when adding the tag status to the payment request card.  SENT_TO_GEX and RECIEVED_BY_GEX statuses were displaying as is instead of Reviewed.

## Reviewer Notes

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

I don't see any SENT_TO_GEX or RECIEVED_BY_GEX statuses in our devseed so you may need to change them in your local db first from 'REVIEWED'

1. Login as the TIO
2. Find the reviewed payment request from the queue
3. The tag after the payment request number should display REVIEWED even if it is in the SENT_TO_GEX OR RECEIVED_BY_GEX statuses

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5887) for this change

## Screenshots

**Existing Behavior**
<img width="1239" alt="Screen Shot 2020-12-09 at 11 24 35 AM" src="https://user-images.githubusercontent.com/52669884/101656866-1f725480-3a3b-11eb-8c0a-1689c04238b5.png">

**Fixed Version**
<img width="1616" alt="Screen Shot 2020-12-09 at 11 21 48 AM" src="https://user-images.githubusercontent.com/52669884/101656511-b1c62880-3a3a-11eb-8112-3386e2d9d8e2.png">

