### PR TITLE
Create MoveDocument in createPPMWithAdvance scenario

### DIFF
--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -98,6 +98,18 @@ func createPPMWithAdvance(db *pop.Connection, userUploader *uploader.UserUploade
 		},
 		UserUploader: userUploader,
 	})
+	testdatagen.MakeMoveDocument(db, testdatagen.Assertions{
+		MoveDocument: models.MoveDocument{
+			MoveID:                   ppm0.Move.ID,
+			Move:                     ppm0.Move,
+			PersonallyProcuredMoveID: &ppm0.ID,
+		},
+		Document: models.Document{
+			ID:              uuid.FromStringOrNil("c26421b0-e4c3-446b-88f3-493bb25c1756"),
+			ServiceMemberID: ppm0.Move.Orders.ServiceMember.ID,
+			ServiceMember:   ppm0.Move.Orders.ServiceMember,
+		},
+	})
 	ppm0.Move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &ppm0.Move)
 }


### PR DESCRIPTION
## Description

This PR adds the creation of a Move Document with a specific UUID to the `devseed` test data scenario.

## Setup

Run:

```sh
make db_dev_e2e_populate
```

and verify that a record in the `documents` table with the UUID `c26421b0-e4c3-446b-88f3-493bb25c1756` exists. For those with load testing set up, you may also run `make server_run` and try the load tests against this update. If the support endpoint `/support/v1/move-task-orders` runs without failing, it's good to go! 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
