### PR TITLE
[MB-5912] Payment request card storybook happo relative date fix

### DIFF
--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
@@ -1,27 +1,37 @@
 import React from 'react';
 import moment from 'moment';
+import MockDate from 'mockdate';
+import addons from '@storybook/addons';
 import { isHappoRun } from 'happo-plugin-storybook/register';
 
 import PaymentRequestCard from './PaymentRequestCard';
 
 import { MockProviders } from 'testUtils';
 
+const mockedDate = '2020-12-08T00:00:00.000Z';
+
 export default {
   title: 'TOO/TIO Components|PaymentRequestCard',
   component: PaymentRequestCard,
   decorators: [
-    (Story) => (
-      <div style={{ padding: '1em', backgroundColor: '#f9f9f9' }}>
-        <MockProviders initialEntries={['/moves/L0CATR/payment-requests']}>
-          <Story />
-        </MockProviders>
-      </div>
-    ),
+    (Story) => {
+      if (isHappoRun()) {
+        MockDate.set(mockedDate);
+        addons.getChannel().on('storyRendered', MockDate.reset);
+      }
+      return (
+        <div style={{ padding: '1em', backgroundColor: '#f9f9f9' }}>
+          <MockProviders initialEntries={['/moves/L0CATR/payment-requests']}>
+            <Story />
+          </MockProviders>
+        </div>
+      );
+    },
   ],
 };
 
-// Makes Happo diff consistently show PR submitted 7 days ago
-const itsBeenOneWeek = moment().subtract(7, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+// always show 7 days prior to mocked date time
+const itsBeenOneWeek = moment(mockedDate).subtract(7, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
 
 const pendingPaymentRequest = {
   id: '09474c6a-69b6-4501-8e08-670a12512e5f',

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import moment from 'moment';
+import { isHappoRun } from 'happo-plugin-storybook/register';
 
 import PaymentRequestCard from './PaymentRequestCard';
 
@@ -18,9 +20,12 @@ export default {
   ],
 };
 
+// Makes Happo diff consistently show PR submitted 7 days ago
+const itsBeenOneWeek = moment().subtract(7, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+
 const pendingPaymentRequest = {
   id: '09474c6a-69b6-4501-8e08-670a12512e5f',
-  createdAt: '2020-12-01T00:00:00.000Z',
+  createdAt: isHappoRun() ? itsBeenOneWeek : '2020-12-01T00:00:00.000Z',
   moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
   paymentRequestNumber: '1843-9061-1',
   status: 'PENDING',
@@ -38,7 +43,7 @@ const pendingPaymentRequest = {
 
 const reviewedPaymentRequest = {
   id: '09474c6a-69b6-4501-8e08-670a12512e5f',
-  createdAt: '2020-12-01T00:00:00.000Z',
+  createdAt: isHappoRun() ? itsBeenOneWeek : '2020-12-01T00:00:00.000Z',
   moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
   paymentRequestNumber: '1843-9061-1',
   status: 'REVIEWED',
@@ -64,7 +69,7 @@ const reviewedPaymentRequest = {
 
 const rejectedPaymentRequest = {
   id: '09474c6a-69b6-4501-8e08-670a12512e5f',
-  createdAt: '2020-12-01T00:00:00.000Z',
+  createdAt: isHappoRun() ? itsBeenOneWeek : '2020-12-01T00:00:00.000Z',
   moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
   paymentRequestNumber: '1843-9061-1',
   status: 'REVIEWED',

--- a/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.stories.jsx
+++ b/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.stories.jsx
@@ -20,7 +20,7 @@ const serviceItem = {
     description: 'Trombone',
     itemDimensions: { length: 1000, width: 2500, height: 3000 },
     crateDimensions: { length: 1000, width: 2500, height: 3000 },
-    imgURL: isHappoRun ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
+    imgURL: isHappoRun() ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
   },
 };
 

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
@@ -73,7 +73,7 @@ const serviceItems = [
       description: "Here's the description",
       itemDimensions: { length: 8400, width: 2600, height: 4200 },
       crateDimensions: { length: 110000, width: 36000, height: 54000 },
-      imgURL: isHappoRun ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
+      imgURL: isHappoRun() ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
     },
   },
 ];

--- a/src/stories/tables.stories.jsx
+++ b/src/stories/tables.stories.jsx
@@ -324,7 +324,7 @@ export const ServiceItemTables = () => (
             description: "Here's the description",
             itemDimensions: { length: 8400, width: 2600, height: 4200 },
             crateDimensions: { length: 110000, width: 36000, height: 54000 },
-            imgURL: isHappoRun ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
+            imgURL: isHappoRun() ? null : 'https://live.staticflickr.com/4735/24289917967_27840ed1af_b.jpg',
           },
         },
       ]}


### PR DESCRIPTION
## Description

The PaymentRequestCard component calculates a relative date for display based on when the payment request was created.  With a static creation date we would get new diffs in Happo everytime if we don't make it deterministic.  This uses the mockdate library to always set the creation date to 7 days ago and returns Dec 8th for the current date.

I am using the storybook callback for when a story is rendered to reset the mocked date to it's normal functionality.  I don't know if this is a great pattern but couldn't find a better solution for an after each type cleanup.

[Happo Doc on spurious diffs](https://docs.happo.io/docs/spurious-diffs)
[Storybook mocking imports](https://storybook.js.org/docs/react/workflows/build-pages-with-storybook#mocking-imports)

## Reviewer Notes

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

1. Replace isHappoRun() occurences in the PaymentRequestCard.stories.jsx file with true and refresh storybook
2. View the PaymentRequestCard stories at http://localhost:6006/?path=/story/too-tio-components-paymentrequestcard--needs-review
3. They should all read Submitted 7 days ago on 01 Dec 2020

Also verify the Happo diff on this PR

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5912) for this change

## Screenshots

<img width="1432" alt="Screen Shot 2020-12-11 at 11 07 15 AM" src="https://user-images.githubusercontent.com/52669884/101926411-07c9d600-3bcb-11eb-8298-0c3bb2ca414e.png">
<img width="1428" alt="Screen Shot 2020-12-11 at 11 07 24 AM" src="https://user-images.githubusercontent.com/52669884/101926417-0a2c3000-3bcb-11eb-9913-71d5c376fb31.png">
<img width="1426" alt="Screen Shot 2020-12-11 at 11 07 31 AM" src="https://user-images.githubusercontent.com/52669884/101926425-0c8e8a00-3bcb-11eb-9fba-7e19d8125c82.png">

