### PR TITLE
MB-5922 Remove unused model type for sit departure

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1402,8 +1402,7 @@ func init() {
         "MTOServiceItemOriginSIT",
         "MTOServiceItemDestSIT",
         "MTOServiceItemShuttle",
-        "MTOServiceItemDomesticCrating",
-        "MTOServiceItemSITDeparture"
+        "MTOServiceItemDomesticCrating"
       ]
     },
     "MTOServiceItemOriginSIT": {
@@ -3863,8 +3862,7 @@ func init() {
         "MTOServiceItemOriginSIT",
         "MTOServiceItemDestSIT",
         "MTOServiceItemShuttle",
-        "MTOServiceItemDomesticCrating",
-        "MTOServiceItemSITDeparture"
+        "MTOServiceItemDomesticCrating"
       ]
     },
     "MTOServiceItemOriginSIT": {

--- a/pkg/gen/primemessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_model_type.go
@@ -43,9 +43,6 @@ const (
 
 	// MTOServiceItemModelTypeMTOServiceItemDomesticCrating captures enum value "MTOServiceItemDomesticCrating"
 	MTOServiceItemModelTypeMTOServiceItemDomesticCrating MTOServiceItemModelType = "MTOServiceItemDomesticCrating"
-
-	// MTOServiceItemModelTypeMTOServiceItemSITDeparture captures enum value "MTOServiceItemSITDeparture"
-	MTOServiceItemModelTypeMTOServiceItemSITDeparture MTOServiceItemModelType = "MTOServiceItemSITDeparture"
 )
 
 // for schema
@@ -53,7 +50,7 @@ var mTOServiceItemModelTypeEnum []interface{}
 
 func init() {
 	var res []MTOServiceItemModelType
-	if err := json.Unmarshal([]byte(`["MTOServiceItemBasic","MTOServiceItemOriginSIT","MTOServiceItemDestSIT","MTOServiceItemShuttle","MTOServiceItemDomesticCrating","MTOServiceItemSITDeparture"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["MTOServiceItemBasic","MTOServiceItemOriginSIT","MTOServiceItemDestSIT","MTOServiceItemShuttle","MTOServiceItemDomesticCrating"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1268,7 +1268,6 @@ definitions:
       - MTOServiceItemDestSIT
       - MTOServiceItemShuttle
       - MTOServiceItemDomesticCrating
-      - MTOServiceItemSITDeparture
   MTOServiceItemOriginSIT: # spectral oas2-unused-definition is OK here due to polymorphism
     description: Describes a domestic origin SIT service item. Subtype of a MTOServiceItem.
     allOf:


### PR DESCRIPTION
## Description

* Removes `MTOSeriveItemSITDepartur model type from prime.yaml

Cleaning up unused model type `MTOServiceItemSITDeparture` in `prime.yaml`.

The sitDepartureDate implementation changed and resulted in an `UpdateMTOServiceItemSIT` model type and endpoint, so we no longer need this previous model type.

Once we remove this unused model type, it will resolve a high volume of failures for the `createMTOServiceItem` endpoint in load testing.

## Setup

You can test the updated yaml with load testing by taking the url to the branch's `prime.yaml` and substituting it in the `parsers.py` file, like so:

```python
class PrimeAPIParser(APIParser):
    """ Parser class for the Prime API. """

    api_file = "https://raw.githubusercontent.com/transcom/mymove/mb-5922-remove-unused-model-type-sit/swagger/prime.yaml"
```

Then run `make load_test_prime`. The should be no 400 errors similar to:

```
{
    "title": "Bad Request",
    "instance": "2ebef0f0-57d3-404c-af0e-3a86121ffcec",
    "detail": "parsing body body from \"\" failed, because invalid modelType value: \"MTOServiceItemSITDeparture\""
}
```

## Code Review Verification Steps
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5922) for this change

