### PR TITLE
Output yarn logs on install of Cypress

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -2,7 +2,7 @@ FROM cypress/base:12
 
 COPY package.json /package.json
 COPY yarn.lock /yarn.lock
-RUN yarn install --dev --silent
+RUN yarn install
 
 COPY . /cypress
 COPY cypress.json /cypress.json


### PR DESCRIPTION
## Description

Changes the `yarn install` command when setting up Cypress to run integration tests in Docker so it doesn't suppress logs. Making this change so we can find out more about why `yarn install` is occasionally failing in CI on all branches including master.