### PR TITLE
MB-5952: add a command to run the webhook client in docker

### DIFF
--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -3,6 +3,4 @@ FROM gcr.io/distroless/static:latest
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/webhook-client /bin/webhook-client
 
-ENTRYPOINT ["/bin/webhook-client"]
-
-CMD ["db-webhook-notify"]
+CMD ["/bin/webhook-client", "db-webhook-notify"]

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -19,9 +19,14 @@ RUN make bin/webhook-client
 
 FROM gcr.io/distroless/static:latest
 
+# mTLS authentication self-signed certificate for use in development and test environments.
+COPY --from=builder --chown=root:root /home/circleci/project/config/tls/devlocal-mtls.cer /config/tls/devlocal-mtls.cer
+COPY --from=builder --chown=root:root /home/circleci/project/config/tls/devlocal-mtls.key /config/tls/devlocal-mtls.key
+
+# Public root certificate for RDS in us-gov-west-1.
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+
+# The main webhook-client binary.
 COPY --from=builder --chown=root:root /home/circleci/project/bin/webhook-client /bin/webhook-client
 
-ENTRYPOINT ["/bin/webhook-client"]
-
-CMD ["db-webhook-notify"]
+CMD ["/bin/webhook-client", "db-webhook-notify"]

--- a/Makefile
+++ b/Makefile
@@ -893,6 +893,25 @@ run_exp_migrations: bin/milmove db_deployed_migrations_reset ## Run GovCloud exp
 webhook_client_docker:
 	docker build -f Dockerfile.webhook_client_local -t $(WEBHOOK_CLIENT_DOCKER_CONTAINER):latest .
 
+.PHONY: webhook_client_start
+webhook_client_start: db_dev_e2e_populate webhook_client_start_standalone
+
+.PHONY: webhook_client_start_standalone
+webhook_client_start_standalone:
+	@echo "Starting the webhook client..."
+	# More environment variables can be added here that correlate with the command line options for
+	# the webhook-client binary.
+	docker run \
+		-e LOGGING_LEVEL=debug \
+		-e DB_HOST="database" \
+		-e DB_NAME \
+		-e DB_PORT \
+		-e DB_USER \
+		-e DB_PASSWORD \
+		-e PERIOD \
+		--link="$(DB_DOCKER_CONTAINER_DEV):database" \
+		$(WEBHOOK_CLIENT_DOCKER_CONTAINER):latest
+
 .PHONY: webhook_client_test
 webhook_client_test:
 	echo "This is a placeholder for webhook-client tests"


### PR DESCRIPTION
## Description

This adds two make commands to Makefile:

1. `make webhook_client_start`: this brings up the dev database, runs migrations, and prepares it to a state that the webhook-client container can use
1. `make webhook_client_start_standalone`: this runs a pre-existing webhook-client container, which can be generated using the pre-existing `make webhook_client_docker` command

## Reviewer Notes

I tried to follow the pattern regarding the mTLS certificate & key for local environments. I'm not exactly sure how to go about handling certificate & key in the non-local Docker image, since baking certificate keys into images isn't a best practice. So if there is a better pattern that should be used for the mTLS keys in this image, I am happy to follow it. I'm not concerned about secrecy for these specific certificates given that they are already public; I'm more concerned with the pattern of baking certificate keys into Docker images; it just feels like there is perhaps a better way. I brainstormed an approach where we would pass in the repo by using Docker volumes, but then that has the potential to get complex for users who are trying to use the container from outside of the repository. If anyone has opinions on how/if I should do things differently with all this, please let me know.

If there are any other commonly used environment variables (command line options converted into environment variables) that should be configured in the docker container, please let me know. There are a whole bunch of options in `bin/webhook-client`, but I'm not sure which ones should be included here when spinning up the Docker container locally.

## Setup

This demonstrates the default configuration:

```console
$ make webhook_client_start_standalone
Starting the webhook client...
docker run \
                -e LOGGING_LEVEL=debug \
                -e DB_HOST="database" \
                -e DB_NAME \
                -e DB_PORT \
                -e DB_USER \
                -e DB_PASSWORD \
                -e PERIOD \
                --link="milmove-db-dev:database" \
                webhook-client:latest
2020-12-15T02:14:14.129Z        INFO    webhook-client/main.go:50       Checking config and initializing
2020-12-15T02:14:14.129Z        INFO    cli/dbconn.go:258       Connecting to the database      {"url": "postgres://postgres:*****@database:5432/dev_db?sslmode=disable", "db-ssl-root-cert": ""}
2020-12-15T02:14:14.129Z        INFO    cli/dbconn.go:363       Starting database ping....
2020-12-15T02:14:14.132Z        INFO    cli/dbconn.go:370       ...DB ping successful!
2020-12-15T02:14:14.138Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
2020-12-15T02:14:19.136Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
^C2020/12/15 02:14:21 Shutdown Server ...
2020-12-15T02:14:21.000Z        INFO    webhook-client/db_webhook_notify.go:82  Db connection closed
2020/12/15 02:14:21 Listener exiting
```

This is a demonstration of environment variables in the laptop's shell being passed down into the Docker container. In this case, it is using the `PERIOD` environment variable and using that to determine how frequently to check the database for updates:

```text
$ PERIOD=1 make webhook_client_start_standalone
Starting the webhook client...
docker run \
                -e LOGGING_LEVEL=debug \
                -e DB_HOST="database" \
                -e DB_NAME \
                -e DB_PORT \
                -e DB_USER \
                -e DB_PASSWORD \
                -e PERIOD \
                --link="milmove-db-dev:database" \
                webhook-client:latest
2020-12-15T02:14:26.550Z        INFO    webhook-client/main.go:50       Checking config and initializing
2020-12-15T02:14:26.550Z        INFO    cli/dbconn.go:258       Connecting to the database      {"url": "postgres://postgres:*****@database:5432/dev_db?sslmode=disable", "db-ssl-root-cert": ""}
2020-12-15T02:14:26.551Z        INFO    cli/dbconn.go:363       Starting database ping....
2020-12-15T02:14:26.556Z        INFO    cli/dbconn.go:370       ...DB ping successful!
2020-12-15T02:14:26.564Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
2020-12-15T02:14:27.559Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
2020-12-15T02:14:28.559Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
2020-12-15T02:14:29.559Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
2020-12-15T02:14:30.559Z        DEBUG   webhook/webhook.go:258  Notification Check:     {"Num notifications found": 0}
^C2020/12/15 02:14:30 Shutdown Server ...
2020-12-15T02:14:30.977Z        INFO    webhook-client/db_webhook_notify.go:82  Db connection closed
2020/12/15 02:14:30 Listener exiting
```

## Code Review Verification Steps

* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5952) for this change