### PR TITLE
[MB-5920] Redux Refactor: Moves & MTOShipments (read)

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -8,7 +8,7 @@ describe('the PPM flow', function () {
   });
 
   it('can submit a PPM move', () => {
-    // profile@comple.te
+    // profile2@complete.draft
     const userId = '3b9360a3-3304-4c60-90f4-83d687884077';
     cy.apiSignInAsPpmUser(userId);
     SMSubmitsMove();

--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -5,6 +5,7 @@ import { adminReducer } from 'react-admin';
 import defaultMessages from 'ra-language-english';
 
 import authReducer from 'store/auth/reducer';
+import onboardingReducer from 'store/onboarding/reducer';
 import flashReducer from 'store/flash/reducer';
 import userReducer from 'shared/Data/users';
 import { swaggerReducerPublic, swaggerReducerInternal } from 'shared/Swagger/ducks';
@@ -38,6 +39,7 @@ const defaultReducers = {
 export const appReducer = (history) =>
   combineReducers({
     ...defaultReducers,
+    onboarding: onboardingReducer,
     router: connectRouter(history),
     swaggerInternal: swaggerReducerInternal,
     moves: moveReducer,

--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -14,11 +14,6 @@ import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
 import { loadMove } from 'shared/Entities/modules/moves';
 import { MOVE_STATUSES, SHIPMENT_OPTIONS, titleCase } from 'shared/constants';
-import {
-  moveIsApproved as selectMoveIsApproved,
-  lastMoveIsCanceled,
-  selectedMoveType as selectMoveType,
-} from 'scenes/Moves/ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatOrderType } from 'utils/formatters';
 import Alert from 'shared/Alert';
@@ -30,8 +25,15 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import NTSShipmentCard from 'components/Customer/Review/ShipmentCard/NTSShipmentCard';
 import NTSRShipmentCard from 'components/Customer/Review/ShipmentCard/NTSRShipmentCard';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
-import { selectMTOShipmentsByMoveId } from 'shared/Entities/modules/mtoShipments';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders, selectCurrentMove } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectCurrentOrders,
+  selectCurrentMove,
+  selectMoveIsApproved,
+  selectHasCanceledMove,
+  selectMoveType,
+  selectMTOShipmentsForCurrentMove,
+} from 'store/entities/selectors';
 import { OrdersShape, MoveShape, MtoShipmentShape, HistoryShape, MatchShape } from 'types/customerShapes';
 
 export class Summary extends Component {
@@ -301,7 +303,7 @@ function mapStateToProps(state, ownProps) {
 
   return {
     currentPPM: selectActivePPMForMove(state, moveID),
-    mtoShipments: selectMTOShipmentsByMoveId(state, moveID),
+    mtoShipments: selectMTOShipmentsForCurrentMove(state),
     serviceMember: selectServiceMemberFromLoggedInUser(state),
     currentMove: selectCurrentMove(state) || {},
     currentOrders,
@@ -310,7 +312,7 @@ function mapStateToProps(state, ownProps) {
     schemaOrdersType: getInternalSwaggerDefinition(state, 'OrdersType'),
     schemaAffiliation: getInternalSwaggerDefinition(state, 'Affiliation'),
     moveIsApproved: selectMoveIsApproved(state),
-    lastMoveIsCanceled: lastMoveIsCanceled(state),
+    lastMoveIsCanceled: selectHasCanceledMove(state),
     reviewState: state.review,
     entitlement: loadEntitlementsFromState(state),
   };

--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -12,7 +12,7 @@ import { checkEntitlement } from 'scenes/Review/ducks';
 import ConnectedPPMShipmentSummary from 'scenes/Review/PPMShipmentSummary';
 import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
-import { loadMove, selectMove } from 'shared/Entities/modules/moves';
+import { loadMove } from 'shared/Entities/modules/moves';
 import { MOVE_STATUSES, SHIPMENT_OPTIONS, titleCase } from 'shared/constants';
 import {
   moveIsApproved as selectMoveIsApproved,
@@ -31,7 +31,7 @@ import NTSShipmentCard from 'components/Customer/Review/ShipmentCard/NTSShipment
 import NTSRShipmentCard from 'components/Customer/Review/ShipmentCard/NTSRShipmentCard';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
 import { selectMTOShipmentsByMoveId } from 'shared/Entities/modules/mtoShipments';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders, selectCurrentMove } from 'store/entities/selectors';
 import { OrdersShape, MoveShape, MtoShipmentShape, HistoryShape, MatchShape } from 'types/customerShapes';
 
 export class Summary extends Component {
@@ -303,7 +303,7 @@ function mapStateToProps(state, ownProps) {
     currentPPM: selectActivePPMForMove(state, moveID),
     mtoShipments: selectMTOShipmentsByMoveId(state, moveID),
     serviceMember: selectServiceMemberFromLoggedInUser(state),
-    currentMove: selectMove(state, moveID),
+    currentMove: selectCurrentMove(state),
     currentOrders,
     selectedMoveType: selectMoveType(state),
     schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),

--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -303,7 +303,7 @@ function mapStateToProps(state, ownProps) {
     currentPPM: selectActivePPMForMove(state, moveID),
     mtoShipments: selectMTOShipmentsByMoveId(state, moveID),
     serviceMember: selectServiceMemberFromLoggedInUser(state),
-    currentMove: selectCurrentMove(state),
+    currentMove: selectCurrentMove(state) || {},
     currentOrders,
     selectedMoveType: selectMoveType(state),
     schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),

--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -299,14 +299,13 @@ Summary.defaultProps = {
 
 function mapStateToProps(state, ownProps) {
   const moveID = ownProps.match.params.moveId;
-  const currentOrders = selectCurrentOrders(state) || {};
 
   return {
     currentPPM: selectActivePPMForMove(state, moveID),
     mtoShipments: selectMTOShipmentsForCurrentMove(state),
     serviceMember: selectServiceMemberFromLoggedInUser(state),
     currentMove: selectCurrentMove(state) || {},
-    currentOrders,
+    currentOrders: selectCurrentOrders(state) || {},
     selectedMoveType: selectMoveType(state),
     schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),
     schemaOrdersType: getInternalSwaggerDefinition(state, 'OrdersType'),

--- a/src/components/OrdersUploader/index.jsx
+++ b/src/components/OrdersUploader/index.jsx
@@ -23,7 +23,7 @@ registerPlugin(FilePondImagePreview);
 
 const idleStatuses = [FileStatus.PROCESSING_COMPLETE, FileStatus.PROCESSING_ERROR];
 
-export class OrdersUploader extends Component {
+class OrdersUploader extends Component {
   constructor(props) {
     super(props);
 

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import { func, PropTypes } from 'prop-types';
 
 import SelectableCard from 'components/Customer/SelectableCard';
-import { setConusStatus } from 'scenes/Moves/ducks';
-import { selectConusStatus } from 'store/entities/selectors';
+import { setConusStatus } from 'store/onboarding/actions';
+import { selectConusStatus } from 'store/onboarding/selectors';
 import { CONUS_STATUS } from 'shared/constants';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { func, PropTypes } from 'prop-types';
 
 import SelectableCard from 'components/Customer/SelectableCard';
-import { setConusStatus, selectedConusStatus } from 'scenes/Moves/ducks';
+import { setConusStatus } from 'scenes/Moves/ducks';
+import { selectConusStatus } from 'store/entities/selectors';
 import { CONUS_STATUS } from 'shared/constants';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 
@@ -63,7 +64,7 @@ ConusOrNot.defaultProps = {
 
 const mapStateToProps = (state) => {
   const props = {
-    conusStatus: selectedConusStatus(state),
+    conusStatus: selectConusStatus(state),
   };
   return props;
 };

--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -8,8 +8,7 @@ import { updateMTOShipment as updateMTOShipmentAction } from 'store/entities/act
 import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import { HhgShipmentShape, HistoryShape, MatchShape, PageKeyShape, PageListShape } from 'types/customerShapes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 import { AddressShape, SimpleAddressShape } from 'types/address';
 
 export class CreateOrEditMtoShipment extends Component {
@@ -108,7 +107,7 @@ function mapStateToProps(state, ownProps) {
     serviceMember,
     mtoShipment: selectMTOShipmentById(state, ownProps.match.params.mtoShipmentId),
     currentResidence: serviceMember?.residential_address || {},
-    newDutyStationAddress: selectActiveOrLatestOrdersFromEntities(state)?.new_duty_station?.address || {},
+    newDutyStationAddress: selectCurrentOrders(state)?.new_duty_station?.address || {},
   };
 
   return props;

--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -3,12 +3,15 @@ import { connect } from 'react-redux';
 import { bool, string, func, shape, number } from 'prop-types';
 
 import MtoShipmentForm from 'components/Customer/MtoShipmentForm/MtoShipmentForm';
-import { selectMTOShipmentById } from 'shared/Entities/modules/mtoShipments';
 import { updateMTOShipment as updateMTOShipmentAction } from 'store/entities/actions';
 import { fetchCustomerData as fetchCustomerDataAction } from 'store/onboarding/actions';
 import { HhgShipmentShape, HistoryShape, MatchShape, PageKeyShape, PageListShape } from 'types/customerShapes';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectCurrentOrders,
+  selectMTOShipmentById,
+} from 'store/entities/selectors';
 import { AddressShape, SimpleAddressShape } from 'types/address';
 
 export class CreateOrEditMtoShipment extends Component {
@@ -105,7 +108,7 @@ function mapStateToProps(state, ownProps) {
 
   const props = {
     serviceMember,
-    mtoShipment: selectMTOShipmentById(state, ownProps.match.params.mtoShipmentId),
+    mtoShipment: selectMTOShipmentById(state, ownProps.match.params.mtoShipmentId) || {},
     currentResidence: serviceMember?.residential_address || {},
     newDutyStationAddress: selectCurrentOrders(state)?.new_duty_station?.address || {},
   };

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -29,13 +29,14 @@ import {
   selectIsProfileComplete,
   selectCurrentOrders,
   selectCurrentMove,
+  selectMTOShipmentsForCurrentMove,
 } from 'store/entities/selectors';
 import { selectUploadedOrders } from 'shared/Entities/modules/orders';
 import {
   getSignedCertification as getSignedCertificationAction,
   selectSignedCertification,
 } from 'shared/Entities/modules/signed_certifications';
-import { selectMTOShipmentsByMoveId, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
+import { selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
 import { SHIPMENT_OPTIONS, MOVE_STATUSES } from 'shared/constants';
 import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
@@ -497,9 +498,10 @@ const mapStateToProps = (state) => {
     backupContacts: serviceMember?.backup_contacts || [],
     signedCertification: selectSignedCertification(state),
     // TODO: change when we support PPM shipments as well
-    mtoShipments: selectMTOShipmentsByMoveId(state, move.id),
+    mtoShipments: selectMTOShipmentsForCurrentMove(state),
     // TODO: change when we support multiple moves
     move,
+    // TODO - deprecate this prop (need to refactor wizard flow)
     mtoShipment: selectMTOShipmentForMTO(state, get(move, 'id', '')),
   };
 };

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -24,8 +24,12 @@ import ShipmentList from 'components/Customer/Home/ShipmentList';
 import Contact from 'components/Customer/Home/Contact';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import PrintableLegalese from 'components/Customer/Home/PrintableLegalese';
-import { selectServiceMemberFromLoggedInUser, selectIsProfileComplete } from 'store/entities/selectors';
-import { selectUploadedOrders, selectActiveOrLatestOrdersFromEntities } from 'shared/Entities/modules/orders';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectIsProfileComplete,
+  selectCurrentOrders,
+} from 'store/entities/selectors';
+import { selectUploadedOrders } from 'shared/Entities/modules/orders';
 import {
   getSignedCertification as getSignedCertificationAction,
   selectSignedCertification,
@@ -37,6 +41,7 @@ import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
 import { formatCustomerDate } from 'utils/formatters';
 import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
+import { MtoShipmentShape, UploadShape, HistoryShape, MoveShape, OrdersShape } from 'types/customerShapes';
 
 const Description = ({ className, children, dataTestId }) => (
   <p className={`${styles.description} ${className}`} data-testid={dataTestId}>
@@ -425,28 +430,19 @@ class Home extends Component {
 }
 
 Home.propTypes = {
-  orders: shape({}).isRequired,
+  orders: OrdersShape.isRequired,
   serviceMember: shape({
     first_name: string,
     last_name: string,
   }),
-  mtoShipments: arrayOf(
-    shape({
-      id: string,
-      shipmentType: string,
-    }),
-  ).isRequired,
+  mtoShipments: arrayOf(MtoShipmentShape).isRequired,
   currentPpm: shape({
     id: string,
     shipmentType: string,
   }).isRequired,
-  uploadedOrderDocuments: arrayOf(
-    shape({
-      filename: string.isRequired,
-    }),
-  ).isRequired,
-  history: shape({}).isRequired,
-  move: shape({}).isRequired,
+  uploadedOrderDocuments: arrayOf(UploadShape).isRequired,
+  history: HistoryShape.isRequired,
+  move: MoveShape.isRequired,
   isLoggedIn: bool.isRequired,
   loggedInUserIsLoading: bool.isRequired,
   loggedInUserSuccess: bool.isRequired,
@@ -461,7 +457,7 @@ Home.propTypes = {
       ghcFlow: bool,
     }),
   }),
-  mtoShipment: shape({}).isRequired,
+  mtoShipment: MtoShipmentShape.isRequired,
   signedCertification: shape({
     signature: string,
     created_at: string,
@@ -494,7 +490,7 @@ const mapStateToProps = (state) => {
     loggedInUserIsLoading: selectGetCurrentUserIsLoading(state),
     loggedInUserSuccess: selectGetCurrentUserIsSuccess(state),
     isProfileComplete: selectIsProfileComplete(state),
-    orders: selectActiveOrLatestOrdersFromEntities(state),
+    orders: selectCurrentOrders(state),
     uploadedOrderDocuments: selectUploadedOrders(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -30,8 +30,8 @@ import {
   selectCurrentOrders,
   selectCurrentMove,
   selectMTOShipmentsForCurrentMove,
+  selectUploadsForCurrentOrders,
 } from 'store/entities/selectors';
-import { selectUploadedOrders } from 'shared/Entities/modules/orders';
 import {
   getSignedCertification as getSignedCertificationAction,
   selectSignedCertification,
@@ -493,7 +493,7 @@ const mapStateToProps = (state) => {
     loggedInUserSuccess: selectGetCurrentUserIsSuccess(state),
     isProfileComplete: selectIsProfileComplete(state),
     orders: selectCurrentOrders(state) || {},
-    uploadedOrderDocuments: selectUploadedOrders(state),
+    uploadedOrderDocuments: selectUploadsForCurrentOrders(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
     signedCertification: selectSignedCertification(state),

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -28,13 +28,13 @@ import {
   selectServiceMemberFromLoggedInUser,
   selectIsProfileComplete,
   selectCurrentOrders,
+  selectCurrentMove,
 } from 'store/entities/selectors';
 import { selectUploadedOrders } from 'shared/Entities/modules/orders';
 import {
   getSignedCertification as getSignedCertificationAction,
   selectSignedCertification,
 } from 'shared/Entities/modules/signed_certifications';
-import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
 import { selectMTOShipmentsByMoveId, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
 import { SHIPMENT_OPTIONS, MOVE_STATUSES } from 'shared/constants';
 import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
@@ -482,7 +482,7 @@ Home.defaultProps = {
 const mapStateToProps = (state) => {
   const user = selectCurrentUser(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
-  const move = selectActiveOrLatestMove(state);
+  const move = selectCurrentMove(state) || {};
 
   return {
     currentPpm: selectActivePPMForMove(state, move.id),

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -430,7 +430,7 @@ class Home extends Component {
 }
 
 Home.propTypes = {
-  orders: OrdersShape.isRequired,
+  orders: OrdersShape,
   serviceMember: shape({
     first_name: string,
     last_name: string,
@@ -466,6 +466,7 @@ Home.propTypes = {
 };
 
 Home.defaultProps = {
+  orders: null,
   serviceMember: null,
   selectedMoveType: '',
   lastMoveIsCanceled: false,
@@ -490,7 +491,7 @@ const mapStateToProps = (state) => {
     loggedInUserIsLoading: selectGetCurrentUserIsLoading(state),
     loggedInUserSuccess: selectGetCurrentUserIsSuccess(state),
     isProfileComplete: selectIsProfileComplete(state),
-    orders: selectCurrentOrders(state),
+    orders: selectCurrentOrders(state) || {},
     uploadedOrderDocuments: selectUploadedOrders(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -1,13 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
 import moment from 'moment';
 
 import Home from '.';
 
 import { MockProviders } from 'testUtils';
-import { store } from 'shared/store';
 import { formatCustomerDate } from 'utils/formatters';
 import { MOVE_STATUSES } from 'shared/constants';
 
@@ -34,9 +32,9 @@ const defaultProps = {
 
 function mountHome(props = {}) {
   return mount(
-    <Provider store={store}>
+    <MockProviders>
       <Home {...defaultProps} {...props} />
-    </Provider>,
+    </MockProviders>,
   );
 }
 

--- a/src/pages/MyMove/Orders.jsx
+++ b/src/pages/MyMove/Orders.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unused-prop-types */
-/* eslint-disable react/forbid-prop-types */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
@@ -11,18 +9,18 @@ import {
   createOrders as createOrdersAction,
   updateOrders as updateOrdersAction,
   fetchLatestOrders as fetchLatestOrdersAction,
-  selectActiveOrLatestOrders,
 } from 'shared/Entities/modules/orders';
 import { withContext } from 'shared/AppContext';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import OrdersInfoForm from 'components/Customer/OrdersInfoForm/OrdersInfoForm';
 import { WizardPage } from 'shared/WizardPage/index';
-import { HistoryShape, PageKeyShape, PageListShape } from 'types/customerShapes';
+import { HistoryShape, PageKeyShape, PageListShape, OrdersShape, MatchShape } from 'types/customerShapes';
 import { formatYesNoInputValue, formatYesNoAPIValue } from 'utils/formatters';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { ORDERS_TYPE_OPTIONS } from 'constants/orders';
 import { dropdownInputOptions } from 'shared/formatters';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import { DutyStationShape } from 'types';
 
 export class Orders extends Component {
   constructor(props) {
@@ -143,14 +141,12 @@ Orders.propTypes = {
     }).isRequired,
   }).isRequired,
   serviceMemberId: PropTypes.string.isRequired,
-  currentOrders: PropTypes.object,
+  currentOrders: OrdersShape,
   fetchLatestOrders: PropTypes.func,
   createOrders: PropTypes.func,
   updateOrders: PropTypes.func,
-  currentStation: PropTypes.object,
-  match: PropTypes.shape({
-    params: PropTypes.object,
-  }).isRequired,
+  currentStation: DutyStationShape,
+  match: MatchShape.isRequired,
   history: HistoryShape.isRequired,
   pages: PageListShape,
   pageKey: PageKeyShape,
@@ -171,7 +167,7 @@ const mapStateToProps = (state) => {
 
   return {
     serviceMemberId: serviceMember?.id,
-    currentOrders: selectActiveOrLatestOrders(state),
+    currentOrders: selectCurrentOrders(state),
     currentStation: serviceMember?.current_station || {},
   };
 };

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -71,9 +71,8 @@ describe('Orders page', () => {
     };
 
     const testProps = {
-      fetchLatestOrders: jest.fn(),
       updateOrders: jest.fn(),
-      createOrders: jest.fn(),
+      updateServiceMember: jest.fn(),
       history: mockHistory,
       pages: [],
       pageKey: '',
@@ -91,7 +90,7 @@ describe('Orders page', () => {
     });
 
     it('does not fetch latest orders on mount', () => {
-      expect(testProps.fetchLatestOrders).not.toHaveBeenCalled();
+      expect(testProps.updateOrders).not.toHaveBeenCalled();
     });
   });
 

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -6,13 +6,10 @@ import { string, bool, func, arrayOf, shape } from 'prop-types';
 import styles from './SelectMoveType.module.scss';
 
 import { SHIPMENT_OPTIONS, MOVE_STATUSES } from 'shared/constants';
-import { selectCurrentMove } from 'store/entities/selectors';
+import { selectCurrentMove, selectMTOShipmentsForCurrentMove } from 'store/entities/selectors';
 import { WizardPage } from 'shared/WizardPage';
 import SelectableCard from 'components/Customer/SelectableCard';
-import {
-  selectMTOShipmentsByMoveId,
-  loadMTOShipments as loadMTOShipmentsAction,
-} from 'shared/Entities/modules/mtoShipments';
+import { loadMTOShipments as loadMTOShipmentsAction } from 'shared/Entities/modules/mtoShipments';
 import { patchMove, getResponseError } from 'services/internalApi';
 import { updateMove as updateMoveAction } from 'store/entities/actions';
 import { MoveTaskOrderShape, MTOShipmentShape } from 'types/moveOrder';
@@ -245,7 +242,7 @@ SelectMoveType.propTypes = {
 
 const mapStateToProps = (state) => {
   const move = selectCurrentMove(state) || {};
-  const mtoShipments = selectMTOShipmentsByMoveId(state, move.id);
+  const mtoShipments = selectMTOShipmentsForCurrentMove(state);
 
   return {
     move,

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -6,7 +6,7 @@ import { string, bool, func, arrayOf, shape } from 'prop-types';
 import styles from './SelectMoveType.module.scss';
 
 import { SHIPMENT_OPTIONS, MOVE_STATUSES } from 'shared/constants';
-import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
+import { selectCurrentMove } from 'store/entities/selectors';
 import { WizardPage } from 'shared/WizardPage';
 import SelectableCard from 'components/Customer/SelectableCard';
 import {
@@ -243,16 +243,15 @@ SelectMoveType.propTypes = {
   mtoShipments: arrayOf(MTOShipmentShape).isRequired,
 };
 
-function mapStateToProps(state) {
-  const move = selectActiveOrLatestMove(state);
+const mapStateToProps = (state) => {
+  const move = selectCurrentMove(state);
   const mtoShipments = selectMTOShipmentsByMoveId(state, move.id);
 
-  const props = {
+  return {
     move,
     mtoShipments,
   };
-  return props;
-}
+};
 
 const mapDispatchToProps = {
   updateMove: updateMoveAction,

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -244,7 +244,7 @@ SelectMoveType.propTypes = {
 };
 
 const mapStateToProps = (state) => {
-  const move = selectCurrentMove(state);
+  const move = selectCurrentMove(state) || {};
   const mtoShipments = selectMTOShipmentsByMoveId(state, move.id);
 
   return {

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -1,24 +1,33 @@
-/* eslint-disable */
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { get } from 'lodash';
-
-import {
-  fetchLatestOrders,
-  selectActiveOrLatestOrders,
-  selectUploadsForActiveOrders,
-} from 'shared/Entities/modules/orders';
-import { createUpload, deleteUpload, selectDocument } from 'shared/Entities/modules/documents';
-import OrdersUploader from 'components/OrdersUploader';
-import UploadsTable from 'shared/Uploader/UploadsTable';
-import WizardPage from 'shared/WizardPage';
-import { documentSizeLimitMsg } from 'shared/constants';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 
 import './UploadOrders.css';
-import { no_op } from 'shared/utils';
+
+import {
+  fetchLatestOrders as fetchLatestOrdersAction,
+  selectUploadsForActiveOrders,
+} from 'shared/Entities/modules/orders';
+import {
+  createUpload as createUploadAction,
+  deleteUpload as deleteUploadAction,
+  selectDocument,
+} from 'shared/Entities/modules/documents';
+import OrdersUploader from 'components/OrdersUploader/index';
+import ConnectedUploadsTable from 'shared/Uploader/UploadsTable';
+import ConnectedWizardPage from 'shared/WizardPage/index';
+import { documentSizeLimitMsg } from 'shared/constants';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+// eslint-disable-next-line camelcase
+import { no_op as noop } from 'shared/utils';
+import {
+  PageListShape,
+  PageKeyShape,
+  AdditionalParamsShape,
+  OrdersShape,
+  UploadsShape,
+  DocumentShape,
+} from 'types/customerShapes';
 
 const uploaderLabelIdle = 'Drag & drop or <span class="filepond--label-action">click to upload orders</span>';
 
@@ -28,21 +37,15 @@ export class UploadOrders extends Component {
 
     this.state = {
       newUploads: [],
-      showAmendedOrders: false,
     };
 
     this.onChange = this.onChange.bind(this);
     this.deleteFile = this.deleteFile.bind(this);
-    this.setShowAmendedOrders = this.setShowAmendedOrders.bind(this);
   }
 
   componentDidMount() {
-    const { serviceMemberId } = this.props;
-    this.props.fetchLatestOrders(serviceMemberId);
-  }
-
-  setShowAmendedOrders(show) {
-    this.setState({ showAmendedOrders: show });
+    const { serviceMemberId, fetchLatestOrders } = this.props;
+    fetchLatestOrders(serviceMemberId);
   }
 
   onChange(files) {
@@ -53,21 +56,33 @@ export class UploadOrders extends Component {
 
   deleteFile(e, uploadId) {
     e.preventDefault();
-    if (this.props.currentOrders) {
-      this.props.deleteUpload(uploadId);
+    const { currentOrders, deleteUpload } = this.props;
+    if (currentOrders) {
+      deleteUpload(uploadId);
     }
   }
 
   render() {
-    const { pages, pageKey, error, currentOrders, uploads, document, additionalParams } = this.props;
-    const isValid = Boolean(uploads.length || this.state.newUploads.length);
-    const isDirty = Boolean(this.state.newUploads.length);
+    const {
+      pages,
+      pageKey,
+      error,
+      currentOrders,
+      uploads,
+      document,
+      additionalParams,
+      createUpload,
+      deleteUpload,
+    } = this.props;
+    const { newUploads } = this.state;
+    const isValid = Boolean(uploads.length || newUploads.length);
+    const isDirty = Boolean(newUploads.length);
     return (
-      <WizardPage
+      <ConnectedWizardPage
         additionalParams={additionalParams}
         dirty={isDirty}
         error={error}
-        handleSubmit={no_op}
+        handleSubmit={noop}
         pageIsValid={isValid}
         pageKey={pageKey}
         pageList={pages}
@@ -79,16 +94,16 @@ export class UploadOrders extends Component {
           <p>{documentSizeLimitMsg}</p>
         </div>
         {Boolean(uploads.length) && (
-          <Fragment>
+          <>
             <br />
-            <UploadsTable uploads={uploads} onDelete={this.deleteFile} />
-          </Fragment>
+            <ConnectedUploadsTable uploads={uploads} onDelete={this.deleteFile} />
+          </>
         )}
         {currentOrders && (
           <div className="uploader-box">
             <OrdersUploader
-              createUpload={this.props.createUpload}
-              deleteUpload={this.props.deleteUpload}
+              createUpload={createUpload}
+              deleteUpload={deleteUpload}
               document={document}
               onChange={this.onChange}
               options={{ labelIdle: uploaderLabelIdle }}
@@ -96,50 +111,52 @@ export class UploadOrders extends Component {
             <div className="hint">(Each page must be clear and legible.)</div>
           </div>
         )}
-
-        {/* TODO: Uncomment when we support upload of amended orders */}
-        {/* <div className="amended-orders">
-          <p>
-            Do you have amended orders? If so, you need to upload those as well.
-          </p>
-          <YesNoBoolean
-            value={showAmendedOrders}
-            onChange={this.setShowAmendedOrders}
-          />
-          {this.state.showAmendedOrders && (
-            <div className="uploader-box">
-              <h4>Upload amended orders</h4>
-              <Uploader document={{}} onChange={no_op} />
-              <div className="hint">(Each page must be clear and legible)</div>
-            </div>
-          )}
-        </div> */}
-      </WizardPage>
+      </ConnectedWizardPage>
     );
   }
 }
 
 UploadOrders.propTypes = {
+  serviceMemberId: PropTypes.string.isRequired,
+  fetchLatestOrders: PropTypes.func.isRequired,
+  createUpload: PropTypes.func.isRequired,
   deleteUpload: PropTypes.func.isRequired,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
+  currentOrders: OrdersShape,
+  error: PropTypes.string,
+  uploads: UploadsShape,
+  document: DocumentShape,
+  additionalParams: AdditionalParamsShape,
+};
+
+UploadOrders.defaultProps = {
+  currentOrders: null,
+  error: null,
+  additionalParams: null,
+  uploads: [],
+  document: null,
 };
 
 function mapStateToProps(state) {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
-  const currentOrders = selectActiveOrLatestOrders(state);
+  const currentOrders = selectCurrentOrders(state);
 
   const props = {
     serviceMemberId,
     currentOrders,
     uploads: selectUploadsForActiveOrders(state),
-    document: selectDocument(state, currentOrders.uploaded_orders),
+    document: selectDocument(state, currentOrders?.uploaded_orders),
   };
 
   return props;
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchLatestOrders, createUpload, deleteUpload }, dispatch);
-}
+const mapDispatchToProps = {
+  fetchLatestOrders: fetchLatestOrdersAction,
+  createUpload: createUploadAction,
+  deleteUpload: deleteUploadAction,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(UploadOrders);

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -4,10 +4,7 @@ import { connect } from 'react-redux';
 
 import './UploadOrders.css';
 
-import {
-  fetchLatestOrders as fetchLatestOrdersAction,
-  selectUploadsForActiveOrders,
-} from 'shared/Entities/modules/orders';
+import { fetchLatestOrders as fetchLatestOrdersAction } from 'shared/Entities/modules/orders';
 import {
   createUpload as createUploadAction,
   deleteUpload as deleteUploadAction,
@@ -17,7 +14,11 @@ import OrdersUploader from 'components/OrdersUploader/index';
 import ConnectedUploadsTable from 'shared/Uploader/UploadsTable';
 import ConnectedWizardPage from 'shared/WizardPage/index';
 import { documentSizeLimitMsg } from 'shared/constants';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectCurrentOrders,
+  selectUploadsForCurrentOrders,
+} from 'store/entities/selectors';
 // eslint-disable-next-line camelcase
 import { no_op as noop } from 'shared/utils';
 import {
@@ -146,7 +147,7 @@ function mapStateToProps(state) {
   const props = {
     serviceMemberId,
     currentOrders,
-    uploads: selectUploadsForActiveOrders(state),
+    uploads: selectUploadsForCurrentOrders(state),
     document: selectDocument(state, currentOrders?.uploaded_orders),
   };
 

--- a/src/sagas/entities.js
+++ b/src/sagas/entities.js
@@ -1,6 +1,12 @@
 import { all, takeLatest, put, call } from 'redux-saga/effects';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE, UPDATE_MTO_SHIPMENT } from 'store/entities/actions';
+import {
+  UPDATE_SERVICE_MEMBER,
+  UPDATE_BACKUP_CONTACT,
+  UPDATE_MOVE,
+  UPDATE_MTO_SHIPMENT,
+  UPDATE_ORDERS,
+} from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -26,6 +32,12 @@ export function* updateBackupContact(action) {
   });
 }
 
+export function* updateOrders(action) {
+  const { payload } = action;
+  const normalizedData = yield call(normalizeResponse, payload, 'orders');
+  yield put(addEntities(normalizedData));
+}
+
 export function* updateMove(action) {
   const { payload } = action;
 
@@ -47,6 +59,7 @@ export function* watchUpdateEntities() {
   yield all([
     takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
     takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
+    takeLatest(UPDATE_ORDERS, updateOrders),
     takeLatest(UPDATE_MOVE, updateMove),
     takeLatest(UPDATE_MTO_SHIPMENT, updateMTOShipment),
   ]);

--- a/src/sagas/entities.test.js
+++ b/src/sagas/entities.test.js
@@ -6,9 +6,16 @@ import {
   updateBackupContact,
   updateMove,
   updateMTOShipment,
+  updateOrders,
 } from './entities';
 
-import { UPDATE_SERVICE_MEMBER, UPDATE_BACKUP_CONTACT, UPDATE_MOVE, UPDATE_MTO_SHIPMENT } from 'store/entities/actions';
+import {
+  UPDATE_SERVICE_MEMBER,
+  UPDATE_BACKUP_CONTACT,
+  UPDATE_MOVE,
+  UPDATE_MTO_SHIPMENT,
+  UPDATE_ORDERS,
+} from 'store/entities/actions';
 import { normalizeResponse } from 'services/swaggerRequest';
 import { addEntities } from 'shared/Entities/actions';
 
@@ -20,6 +27,7 @@ describe('watchUpdateEntities', () => {
       all([
         takeLatest(UPDATE_SERVICE_MEMBER, updateServiceMember),
         takeLatest(UPDATE_BACKUP_CONTACT, updateBackupContact),
+        takeLatest(UPDATE_ORDERS, updateOrders),
         takeLatest(UPDATE_MOVE, updateMove),
         takeLatest(UPDATE_MTO_SHIPMENT, updateMTOShipment),
       ]),
@@ -180,6 +188,72 @@ describe('updateMTOShipment', () => {
 
   it('stores the normalized data in entities', () => {
     expect(generator.next(normalizedMove).value).toEqual(put(addEntities(normalizedMove)));
+  });
+
+  it('is done', () => {
+    expect(generator.next().done).toEqual(true);
+  });
+});
+
+describe('updateOrders', () => {
+  const testAction = {
+    payload: {
+      created_at: '2020-12-17T15:54:48.853Z',
+      has_dependents: false,
+      id: 'ef45eb5a-c1bf-4c60-9c22-990500b6badc',
+      issue_date: '2020-12-22',
+      moves: [
+        {
+          created_at: '2020-12-17T15:54:48.873Z',
+          id: '0ff5ec27-57be-4760-a87f-42998aa94caf',
+          locator: 'C8PFDW',
+          orders_id: 'ef45eb5a-c1bf-4c60-9c22-990500b6badc',
+          selected_move_type: '',
+          service_member_id: '15a17300-e1c6-4b3a-8e5d-9c47782a3961',
+          status: 'DRAFT',
+          updated_at: '2020-12-17T15:54:48.873Z',
+        },
+      ],
+      new_duty_station: {
+        address: {
+          city: 'Glendale Luke AFB',
+          country: 'United States',
+          id: 'ce6ec9a4-1bad-4fb3-8b3c-89ebee54e8cf',
+          postal_code: '85309',
+          state: 'AZ',
+          street_address_1: 'n/a',
+        },
+        address_id: 'ce6ec9a4-1bad-4fb3-8b3c-89ebee54e8cf',
+        affiliation: 'AIR_FORCE',
+        created_at: '2020-12-07T17:02:33.987Z',
+        id: '9e1b519e-6daa-4c3f-8cfe-413c582b6366',
+        name: 'Luke AFB',
+        updated_at: '2020-12-07T17:02:33.987Z',
+      },
+      orders_type: 'PERMANENT_CHANGE_OF_STATION',
+      report_by_date: '2020-12-28',
+      service_member_id: '15a17300-e1c6-4b3a-8e5d-9c47782a3961',
+      spouse_has_pro_gear: false,
+      status: 'DRAFT',
+      updated_at: '2020-12-17T15:54:48.853Z',
+      uploaded_orders: {
+        id: '251ea83d-4295-4105-9780-3ae2d6549872',
+        service_member_id: '15a17300-e1c6-4b3a-8e5d-9c47782a3961',
+        uploads: [],
+      },
+    },
+  };
+
+  const normalizedOrders = normalizeResponse(testAction.payload, 'orders');
+
+  const generator = updateOrders(testAction);
+
+  it('normalizes the payload', () => {
+    expect(generator.next().value).toEqual(call(normalizeResponse, testAction.payload, 'orders'));
+  });
+
+  it('stores the normalized data in entities', () => {
+    expect(generator.next(normalizedOrders).value).toEqual(put(addEntities(normalizedOrders)));
   });
 
   it('is done', () => {

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -21,7 +21,7 @@ import Alert from 'shared/Alert';
 import { ValidateZipRateData } from 'shared/api';
 import { setInitialFormValues } from './ducks';
 import SectionWrapper from 'components/Customer/SectionWrapper';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders, selectCurrentMove } from 'store/entities/selectors';
 
 import './DateAndLocation.css';
 
@@ -202,7 +202,7 @@ DateAndLocation.propTypes = {
 };
 
 function mapStateToProps(state) {
-  const moveID = state.moves.currentMove.id;
+  const currentMove = selectCurrentMove(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
 
   const defaultPickupZip = serviceMember?.residential_address?.postal_code;
@@ -212,7 +212,7 @@ function mapStateToProps(state) {
   const props = {
     serviceMemberId,
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
-    currentPPM: selectActivePPMForMove(state, moveID),
+    currentPPM: selectActivePPMForMove(state, currentMove?.id),
     currentOrders: selectCurrentOrders(state),
     formValues: getFormValues(formName)(state),
     entitlement: loadEntitlementsFromState(state),

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -16,12 +16,12 @@ import {
   updatePPM,
   updatePPMEstimate,
 } from 'shared/Entities/modules/ppms';
-import { fetchLatestOrders, selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
+import { fetchLatestOrders } from 'shared/Entities/modules/orders';
 import Alert from 'shared/Alert';
 import { ValidateZipRateData } from 'shared/api';
 import { setInitialFormValues } from './ducks';
 import SectionWrapper from 'components/Customer/SectionWrapper';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 import './DateAndLocation.css';
 
@@ -213,7 +213,7 @@ function mapStateToProps(state) {
     serviceMemberId,
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
     currentPPM: selectActivePPMForMove(state, moveID),
-    currentOrders: selectActiveOrLatestOrders(state),
+    currentOrders: selectCurrentOrders(state),
     formValues: getFormValues(formName)(state),
     entitlement: loadEntitlementsFromState(state),
     originDutyStationZip: serviceMember?.current_station?.address?.postal_code,

--- a/src/scenes/Moves/Ppm/PaymentReview/index.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import moment from 'moment';
 
 import Alert from 'shared/Alert';
@@ -16,7 +16,7 @@ import CustomerAgreement from 'scenes/Legalese/CustomerAgreement';
 import { ppmPaymentLegal } from 'scenes/Legalese/legaleseText';
 import PPMPaymentRequestActionBtns from 'scenes/Moves/Ppm/PPMPaymentRequestActionBtns';
 import { loadEntitlementsFromState } from 'shared/entitlements';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 import { submitExpenseDocs } from '../ducks';
 import DocumentsUploaded from './DocumentsUploaded';
@@ -212,7 +212,7 @@ const mapStateToProps = (state, props) => {
     incentiveEstimateMax: selectPPMEstimateRange(state).range_max,
     originDutyStationZip: serviceMember?.current_station?.address?.postal_code,
     entitlement: loadEntitlementsFromState(state),
-    orders: get(state, 'orders.currentOrders', {}),
+    orders: selectCurrentOrders(state) || {},
   };
 };
 

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -430,7 +430,7 @@ function mapStateToProps(state) {
     entitlement: loadEntitlementsFromState(state),
     schema: schema,
     originDutyStationZip,
-    orders: selectCurrentOrders(state),
+    orders: selectCurrentOrders(state) || {},
     // TODO this is a work around till we refactor more SM data...
     tempCurrentPPM: get(state, 'ppm.currentPpm'),
   };

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -28,7 +28,7 @@ import carGray from 'shared/icon/car-gray.svg';
 import trailerGray from 'shared/icon/trailer-gray.svg';
 import truckGray from 'shared/icon/truck-gray.svg';
 import SectionWrapper from 'components/Customer/SectionWrapper';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders, selectCurrentMove } from 'store/entities/selectors';
 
 const WeightWizardForm = reduxifyWizardForm('weight-wizard-form');
 
@@ -416,9 +416,10 @@ PpmWeight.propTypes = {
 };
 function mapStateToProps(state) {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
+  const currentMove = selectCurrentMove(state);
   const schema = get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {});
   const originDutyStationZip = serviceMember?.current_station?.address?.postal_code;
-  const moveID = state.moves.currentMove.id;
+  const moveID = currentMove?.id;
   const serviceMemberId = serviceMember?.id;
 
   const props = {

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -16,7 +16,7 @@ import {
   getPpmWeightEstimate,
   selectPPMEstimateRange,
 } from 'shared/Entities/modules/ppms';
-import { fetchLatestOrders, selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
+import { fetchLatestOrders } from 'shared/Entities/modules/orders';
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
 import RadioButton from 'shared/RadioButton';
 import 'react-rangeslider/lib/index.css';
@@ -28,7 +28,7 @@ import carGray from 'shared/icon/car-gray.svg';
 import trailerGray from 'shared/icon/trailer-gray.svg';
 import truckGray from 'shared/icon/truck-gray.svg';
 import SectionWrapper from 'components/Customer/SectionWrapper';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 const WeightWizardForm = reduxifyWizardForm('weight-wizard-form');
 
@@ -430,7 +430,7 @@ function mapStateToProps(state) {
     entitlement: loadEntitlementsFromState(state),
     schema: schema,
     originDutyStationZip,
-    orders: selectActiveOrLatestOrders(state),
+    orders: selectCurrentOrders(state),
     // TODO this is a work around till we refactor more SM data...
     tempCurrentPPM: get(state, 'ppm.currentPpm'),
   };

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -1,9 +1,12 @@
 import { get, isEmpty } from 'lodash';
+import { change } from 'redux-form';
+
 import { GetPpm, RequestPayment } from './api.js';
+
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
 import { fetchActive, fetchActivePPM } from 'shared/utils';
-import { change } from 'redux-form';
+import { selectCurrentMove } from 'store/entities/selectors';
 
 // Types
 export const CREATE_OR_UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes('CREATE_OR_UPDATE_PPM');
@@ -69,7 +72,7 @@ export function getMaxAdvance(state) {
 }
 
 export function getPPM(state) {
-  const move = state.moves.currentMove || state.moves.latestMove || {};
+  const move = selectCurrentMove(state) || {};
   const moveId = move.id;
   const ppmFromEntities = Object.values(state.entities.personallyProcuredMoves).find((ppm) => ppm.move_id === moveId);
   const tempPPM = state.ppm.currentPpm;

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -1,5 +1,4 @@
 import { get, head, pick } from 'lodash';
-import { GetMove } from './api.js';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
 import { fetchActive } from 'shared/utils';
 
@@ -16,6 +15,8 @@ export const createOrUpdateMoveType = 'CREATE_OR_UPDATE_MOVE';
 export const CREATE_OR_UPDATE_MOVE = ReduxHelpers.generateAsyncActionTypes(createOrUpdateMoveType);
 
 // Action creation
+
+// TODO - deprecate CONUS status state & use required field in form instead
 export function setConusStatus(moveType) {
   return { type: SET_CONUS_STATUS, moveType };
 }
@@ -25,18 +26,9 @@ export function setPendingMoveType(value) {
   return { type: SET_PENDING_MOVE_TYPE, payload: value };
 }
 
+// TODO - deprecate this action & field
 export function setSelectedMoveType(moveType) {
   return { type: SET_SELECTED_MOVE_TYPE, moveType };
-}
-
-export function loadMove(moveId) {
-  return function (dispatch, getState) {
-    const action = ReduxHelpers.generateAsyncActions(getMoveType);
-    dispatch(action.start());
-    return GetMove(moveId)
-      .then((item) => dispatch(action.success(item)))
-      .catch((error) => dispatch(action.error(error)));
-  };
 }
 
 //selector

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -15,13 +15,6 @@ export const createOrUpdateMoveType = 'CREATE_OR_UPDATE_MOVE';
 export const CREATE_OR_UPDATE_MOVE = ReduxHelpers.generateAsyncActionTypes(createOrUpdateMoveType);
 
 // Action creation
-
-// TODO - deprecate CONUS status state & use required field in form instead
-export function setConusStatus(moveType) {
-  return { type: SET_CONUS_STATUS, moveType };
-}
-
-// Action creation
 export function setPendingMoveType(value) {
   return { type: SET_PENDING_MOVE_TYPE, payload: value };
 }

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -32,14 +32,6 @@ export function setSelectedMoveType(moveType) {
 }
 
 //selector
-export const moveIsApproved = (state) => get(state, 'moves.currentMove.status') === 'APPROVED';
-
-export const lastMoveIsCanceled = (state) => get(state, 'moves.latestMove.status') === 'CANCELED';
-
-export const selectedMoveType = (state) => get(state, 'moves.currentMove.selected_move_type');
-
-export const selectedConusStatus = (state) => get(state, 'moves.currentMove.conus_status');
-
 export const isPpm = (state) => Boolean(get(state, 'ppm.currentPpm', false));
 
 // Reducer

--- a/src/scenes/Moves/ducks.test.js
+++ b/src/scenes/Moves/ducks.test.js
@@ -1,6 +1,6 @@
-import { CREATE_OR_UPDATE_MOVE, GET_MOVE, moveReducer, setConusStatus } from './ducks';
+import { CREATE_OR_UPDATE_MOVE, GET_MOVE, moveReducer } from './ducks';
 import loggedInUserPayload, { emptyPayload } from 'shared/User/sampleLoggedInUserPayload';
-import { SHIPMENT_OPTIONS, CONUS_STATUS } from 'shared/constants';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 const expectedMove = {
   id: '593cc830-1a3e-44b3-ba5a-8809f02dfa7d',
@@ -135,32 +135,6 @@ describe('move Reducer', () => {
         hasLoadError: true,
         hasLoadSuccess: false,
         error: 'No bueno.',
-      });
-    });
-  });
-
-  describe('SET_CONUS_STATUS', () => {
-    it('Should set conus status to CONUS', () => {
-      const initialState = {
-        currentMove: { conus_status: '' },
-      };
-
-      const newState = moveReducer(initialState, setConusStatus(CONUS_STATUS.CONUS));
-
-      expect(newState).toEqual({
-        currentMove: { conus_status: CONUS_STATUS.CONUS },
-      });
-    });
-
-    it('Should set selected conus status to OCONUS', () => {
-      const initialState = {
-        currentMove: { conus_status: '' },
-      };
-
-      const newState = moveReducer(initialState, setConusStatus(CONUS_STATUS.OCONUS));
-
-      expect(newState).toEqual({
-        currentMove: { conus_status: CONUS_STATUS.OCONUS },
       });
     });
   });

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -179,7 +179,7 @@ AppWrapper.propTypes = {
   loadInternalSchema: PropTypes.func,
   loadUser: PropTypes.func,
   initOnboarding: PropTypes.func,
-  conusStatus: PropTypes.string.isRequired,
+  conusStatus: PropTypes.string,
   context: PropTypes.shape({
     flags: PropTypes.shape({
       hhgFlow: PropTypes.bool,

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -37,7 +37,6 @@ import Footer from 'shared/Footer';
 import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivacyPolicyStatement from 'shared/Statements/PrivacyAndPolicyStatement';
 import AccessibilityStatement from 'shared/Statements/AccessibilityStatement';
-import { lastMoveIsCanceled, selectedConusStatus, selectedMoveType } from 'scenes/Moves/ducks';
 import { getWorkflowRoutes } from './getWorkflowRoutes';
 import { loadInternalSchema } from 'shared/Swagger/ducks';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -51,7 +50,13 @@ import ConnectedCreateOrEditMtoShipment from 'pages/MyMove/CreateOrEditMtoShipme
 import Home from 'pages/MyMove/Home';
 import { loadUser as loadUserAction } from 'store/auth/actions';
 import { initOnboarding as initOnboardingAction } from 'store/onboarding/actions';
-import { selectServiceMemberFromLoggedInUser, selectCurrentMove } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectCurrentMove,
+  selectHasCanceledMove,
+  selectMoveType,
+  selectConusStatus,
+} from 'store/entities/selectors';
 
 export class AppWrapper extends Component {
   state = { hasError: false };
@@ -204,11 +209,11 @@ const mapStateToProps = (state) => {
 
   return {
     currentServiceMemberId: serviceMemberId,
-    lastMoveIsCanceled: lastMoveIsCanceled(state),
+    lastMoveIsCanceled: selectHasCanceledMove(state),
     latestMove: get(state, 'moves.latestMove'),
     moveId: move?.id,
-    selectedMoveType: selectedMoveType(state),
-    conusStatus: selectedConusStatus(state),
+    selectedMoveType: selectMoveType(state),
+    conusStatus: selectConusStatus(state),
     swaggerError: state.swaggerInternal.hasErrored,
   };
 };

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -49,12 +49,12 @@ import ConnectedCreateOrEditMtoShipment from 'pages/MyMove/CreateOrEditMtoShipme
 import Home from 'pages/MyMove/Home';
 import { loadUser as loadUserAction } from 'store/auth/actions';
 import { initOnboarding as initOnboardingAction } from 'store/onboarding/actions';
+import { selectConusStatus } from 'store/onboarding/selectors';
 import {
   selectServiceMemberFromLoggedInUser,
   selectCurrentMove,
   selectHasCanceledMove,
   selectMoveType,
-  selectConusStatus,
 } from 'store/entities/selectors';
 
 export class AppWrapper extends Component {

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 import { LastLocationProvider } from 'react-router-last-location';
 
 import ValidatedPrivateRoute from 'shared/User/ValidatedPrivateRoute';
@@ -210,7 +209,6 @@ const mapStateToProps = (state) => {
   return {
     currentServiceMemberId: serviceMemberId,
     lastMoveIsCanceled: selectHasCanceledMove(state),
-    latestMove: get(state, 'moves.latestMove'),
     moveId: move?.id,
     selectedMoveType: selectMoveType(state),
     conusStatus: selectConusStatus(state),

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -200,13 +200,13 @@ AppWrapper.defaultProps = {
 const mapStateToProps = (state) => {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
-  const move = selectCurrentMove(state);
+  const move = selectCurrentMove(state) || {};
 
   return {
     currentServiceMemberId: serviceMemberId,
     lastMoveIsCanceled: lastMoveIsCanceled(state),
     latestMove: get(state, 'moves.latestMove'),
-    moveId: move.id,
+    moveId: move?.id,
     selectedMoveType: selectedMoveType(state),
     conusStatus: selectedConusStatus(state),
     swaggerError: state.swaggerInternal.hasErrored,

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -47,13 +47,11 @@ import TrailerCriteria from 'scenes/Moves/Ppm/TrailerCriteria';
 import PaymentReview from 'scenes/Moves/Ppm/PaymentReview/index';
 import CustomerAgreementLegalese from 'scenes/Moves/Ppm/CustomerAgreementLegalese';
 import { withContext } from 'shared/AppContext';
-import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
 import ConnectedCreateOrEditMtoShipment from 'pages/MyMove/CreateOrEditMtoShipment';
 import Home from 'pages/MyMove/Home';
-
 import { loadUser as loadUserAction } from 'store/auth/actions';
 import { initOnboarding as initOnboardingAction } from 'store/onboarding/actions';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentMove } from 'store/entities/selectors';
 
 export class AppWrapper extends Component {
   state = { hasError: false };
@@ -202,7 +200,7 @@ AppWrapper.defaultProps = {
 const mapStateToProps = (state) => {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
-  const move = selectActiveOrLatestMove(state);
+  const move = selectCurrentMove(state);
 
   return {
     currentServiceMemberId: serviceMemberId,

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -10,9 +10,10 @@ import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import { loadMove, selectMove } from 'shared/Entities/modules/moves';
-import { loadOrders, loadOrdersLabel, selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
+import { loadOrders, loadOrdersLabel } from 'shared/Entities/modules/orders';
 import { loadServiceMember, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { stringifyName } from 'shared/utils/serviceMember';
+import { selectOrdersById } from 'store/entities/selectors';
 
 import './office.scss';
 
@@ -80,7 +81,8 @@ const mapStateToProps = (state, ownProps) => {
   const moveId = ownProps.match.params.moveId;
   const move = selectMove(state, moveId);
   const ordersId = move.orders_id;
-  const uploads = selectUploadsForActiveOrders(state);
+  const orders = selectOrdersById(state, ordersId);
+  const uploads = orders?.uploaded_orders?.uploads || [];
   const serviceMemberId = move.service_member_id;
   const serviceMember = selectServiceMember(state, serviceMemberId);
   const loadOrdersRequest = getRequestStatus(state, loadOrdersLabel);

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -1,5 +1,5 @@
 import { pick, get } from 'lodash';
-import { GetOrders } from './api.js';
+
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
 import { fetchActive } from 'shared/utils';
@@ -10,8 +10,6 @@ export const GET_ORDERS = ReduxHelpers.generateAsyncActionTypes(getOrdersType);
 
 const showCurrentOrdersType = 'SHOW_CURRENT_ORDERS';
 export const SHOW_CURRENT_ORDERS = ReduxHelpers.generateAsyncActionTypes(showCurrentOrdersType);
-
-export const loadOrders = ReduxHelpers.generateAsyncActionCreator(getOrdersType, GetOrders);
 
 // Reducer
 const initialState = {

--- a/src/scenes/PpmLanding/MoveSummary/SubmittedPpmMoveDetails.jsx
+++ b/src/scenes/PpmLanding/MoveSummary/SubmittedPpmMoveDetails.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { get, isEmpty } from 'lodash';
+
+import styles from './PpmMoveDetails.module.scss';
+
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
 import { formatCents } from 'shared/formatters';
 import { formatIncentiveRange } from 'shared/incentive';
 import { selectPPMEstimateRange, selectReimbursement } from 'shared/Entities/modules/ppms';
 import { selectActivePPMForMove } from 'shared/Entities/modules/ppms';
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
-import styles from './PpmMoveDetails.module.scss';
+import { selectCurrentMove } from 'store/entities/selectors';
 
 const SubmittedPpmMoveDetails = (props) => {
   const { advance, ppm, currentPPM, tempCurrentPPM, hasEstimateError, estimateRange } = props;
@@ -46,12 +49,13 @@ const SubmittedPpmMoveDetails = (props) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
+  const currentMove = selectCurrentMove(state);
   const advance = selectReimbursement(state, ownProps.ppm.advance);
   const isMissingWeightTicketDocuments = selectPPMCloseoutDocumentsForMove(state, ownProps.ppm.move_id, [
     'WEIGHT_TICKET_SET',
   ]).some((doc) => doc.empty_weight_ticket_missing || doc.full_weight_ticket_missing);
-  const moveID = state.moves.currentMove.id;
-  let currentPPM = selectActivePPMForMove(state, moveID);
+
+  let currentPPM = selectActivePPMForMove(state, currentMove?.id);
   let tempCurrentPPM = get(state, 'ppm.currentPpm');
   if (isEmpty(currentPPM) && isEmpty(tempCurrentPPM)) {
     currentPPM = {};

--- a/src/scenes/PpmLanding/PPMStatusTimeline.js
+++ b/src/scenes/PpmLanding/PPMStatusTimeline.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import { get, includes } from 'lodash';
-import { StatusTimeline } from './StatusTimeline';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+
+import { StatusTimeline } from './StatusTimeline';
+
 import {
   getSignedCertification,
   selectPaymentRequestCertificationForMove,
 } from 'shared/Entities/modules/signed_certifications';
+import { selectCurrentMove } from 'store/entities/selectors';
 
 const PpmStatuses = {
   Submitted: 'SUBMITTED',
@@ -124,10 +127,11 @@ PPMStatusTimeline.propTypes = {
 };
 
 function mapStateToProps(state) {
-  const move = state.moves.currentMove || state.moves.latestMove || {};
-  const moveId = move.id || null;
+  const move = selectCurrentMove(state);
+  const moveId = move?.id;
+
   return {
-    signedCertification: selectPaymentRequestCertificationForMove(state, move.id),
+    signedCertification: selectPaymentRequestCertificationForMove(state, moveId),
     moveId,
   };
 }

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -8,7 +8,11 @@ import { withLastLocation } from 'react-router-last-location';
 import { withContext } from 'shared/AppContext';
 import { PpmSummary } from './PpmSummary';
 import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
-import { selectServiceMemberFromLoggedInUser, selectIsProfileComplete } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectIsProfileComplete,
+  selectCurrentOrders,
+} from 'store/entities/selectors';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
@@ -18,7 +22,7 @@ import scrollToTop from 'shared/scrollToTop';
 import { getPPM } from 'scenes/Moves/Ppm/ducks';
 import { loadPPMs } from 'shared/Entities/modules/ppms';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
-import { selectActiveOrLatestOrders, selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
+import { selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
 import { loadMTOShipments, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
 import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
 
@@ -181,7 +185,7 @@ const mapStateToProps = (state) => {
     isProfileComplete: selectIsProfileComplete(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
-    orders: selectActiveOrLatestOrders(state),
+    orders: selectCurrentOrders(state),
     uploads: selectUploadsForActiveOrders(state),
     move: move,
     ppm: getPPM(state),

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -23,7 +23,6 @@ import scrollToTop from 'shared/scrollToTop';
 import { getPPM } from 'scenes/Moves/Ppm/ducks';
 import { loadPPMs } from 'shared/Entities/modules/ppms';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
-import { selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
 import { loadMTOShipments } from 'shared/Entities/modules/mtoShipments';
 
 export class PpmLanding extends Component {
@@ -80,7 +79,6 @@ export class PpmLanding extends Component {
       lastMoveIsCanceled,
       serviceMember,
       orders,
-      uploads,
       move,
       ppm,
       backupContacts,
@@ -91,7 +89,6 @@ export class PpmLanding extends Component {
       lastMoveIsCanceled,
       serviceMember,
       orders,
-      uploads,
       move,
       ppm,
       backupContacts,
@@ -185,7 +182,6 @@ const mapStateToProps = (state) => {
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
     orders: selectCurrentOrders(state) || {},
-    uploads: selectUploadsForActiveOrders(state),
     move: move,
     ppm: getPPM(state),
     loggedInUser: user,

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -1,18 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { withLastLocation } from 'react-router-last-location';
 
 import { withContext } from 'shared/AppContext';
 import { PpmSummary } from './PpmSummary';
-import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import {
   selectServiceMemberFromLoggedInUser,
   selectIsProfileComplete,
   selectCurrentOrders,
   selectCurrentMove,
+  selectHasCanceledMove,
+  selectMoveType,
 } from 'store/entities/selectors';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
@@ -24,7 +24,7 @@ import { getPPM } from 'scenes/Moves/Ppm/ducks';
 import { loadPPMs } from 'shared/Entities/modules/ppms';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
 import { selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
-import { loadMTOShipments, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
+import { loadMTOShipments } from 'shared/Entities/modules/mtoShipments';
 
 export class PpmLanding extends Component {
   componentDidMount() {
@@ -178,9 +178,8 @@ const mapStateToProps = (state) => {
   const move = selectCurrentMove(state) || {};
 
   const props = {
-    mtoShipment: selectMTOShipmentForMTO(state, get(move, 'id', '')),
-    lastMoveIsCanceled: lastMoveIsCanceled(state),
-    selectedMoveType: selectedMoveType(state),
+    lastMoveIsCanceled: selectHasCanceledMove(state),
+    selectedMoveType: selectMoveType(state),
     isLoggedIn: user.isLoggedIn,
     isProfileComplete: selectIsProfileComplete(state),
     serviceMember,

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -12,6 +12,7 @@ import {
   selectServiceMemberFromLoggedInUser,
   selectIsProfileComplete,
   selectCurrentOrders,
+  selectCurrentMove,
 } from 'store/entities/selectors';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { selectCurrentUser, selectGetCurrentUserIsLoading, selectGetCurrentUserIsSuccess } from 'shared/Data/users';
@@ -24,7 +25,6 @@ import { loadPPMs } from 'shared/Entities/modules/ppms';
 import { showLoggedInUser as showLoggedInUserAction } from 'shared/Entities/modules/user';
 import { selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
 import { loadMTOShipments, selectMTOShipmentForMTO } from 'shared/Entities/modules/mtoShipments';
-import { selectActiveOrLatestMove } from 'shared/Entities/modules/moves';
 
 export class PpmLanding extends Component {
   componentDidMount() {
@@ -175,7 +175,7 @@ PpmLanding.defaultProps = {
 const mapStateToProps = (state) => {
   const user = selectCurrentUser(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
-  const move = selectActiveOrLatestMove(state);
+  const move = selectCurrentMove(state);
 
   const props = {
     mtoShipment: selectMTOShipmentForMTO(state, get(move, 'id', '')),

--- a/src/scenes/PpmLanding/index.jsx
+++ b/src/scenes/PpmLanding/index.jsx
@@ -175,7 +175,7 @@ PpmLanding.defaultProps = {
 const mapStateToProps = (state) => {
   const user = selectCurrentUser(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
-  const move = selectCurrentMove(state);
+  const move = selectCurrentMove(state) || {};
 
   const props = {
     mtoShipment: selectMTOShipmentForMTO(state, get(move, 'id', '')),
@@ -185,7 +185,7 @@ const mapStateToProps = (state) => {
     isProfileComplete: selectIsProfileComplete(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
-    orders: selectCurrentOrders(state),
+    orders: selectCurrentOrders(state) || {},
     uploads: selectUploadsForActiveOrders(state),
     move: move,
     ppm: getPPM(state),

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -183,7 +183,7 @@ class EditDateAndLocation extends Component {
         currentPPM.original_move_date,
         currentPPM.days_in_storage,
         currentPPM.pickup_postal_code,
-        this.currentOrders.id,
+        this.props.currentOrders.id,
         currentPPM.weight_estimate,
       );
     }

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -238,14 +238,13 @@ EditDateAndLocation.propTypes = {
 };
 function mapStateToProps(state) {
   const currentMove = selectCurrentMove(state) || {};
-  const currentOrders = selectCurrentOrders(state);
   const moveID = currentMove?.id;
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
 
   const props = {
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
     move: currentMove,
-    currentOrders,
+    currentOrders: selectCurrentOrders(state) || {},
     currentPPM: selectActivePPMForMove(state, moveID),
     formValues: getFormValues(editDateAndLocationFormName)(state),
     entitlement: loadEntitlementsFromState(state),

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -24,7 +24,7 @@ import {
 import { editBegin, editSuccessful, entitlementChangeBegin } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
 import { formatCents } from 'shared/formatters';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentMove, selectCurrentOrders } from 'store/entities/selectors';
 
 import 'scenes/Moves/Ppm/DateAndLocation.css';
 
@@ -237,24 +237,22 @@ EditDateAndLocation.propTypes = {
   error: PropTypes.object,
 };
 function mapStateToProps(state) {
-  const moveID = state.moves.currentMove.id;
+  const currentMove = selectCurrentMove(state) || {};
+  const currentOrders = selectCurrentOrders(state);
+  const moveID = currentMove?.id;
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
 
   const props = {
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
-    move: get(state, 'moves.currentMove'),
-    currentOrders: get(state.orders, 'currentOrders'),
+    move: currentMove,
+    currentOrders,
     currentPPM: selectActivePPMForMove(state, moveID),
     formValues: getFormValues(editDateAndLocationFormName)(state),
     entitlement: loadEntitlementsFromState(state),
     error: get(state, 'ppm.error'),
     hasSubmitError: get(state, 'ppm.hasSubmitError'),
     sitEstimate: selectPPMSitEstimate(state),
-    entitiesSitReimbursement: get(
-      selectActivePPMForMove(state, get(state, 'moves.currentMove.id')),
-      'estimated_storage_reimbursement',
-      '',
-    ),
+    entitiesSitReimbursement: get(selectActivePPMForMove(state, moveID), 'estimated_storage_reimbursement', ''),
   };
 
   const defaultPickupZip = serviceMember?.residential_address?.postal_code;

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -18,12 +18,16 @@ import SaveCancelButtons from './SaveCancelButtons';
 
 import { updateOrders, fetchLatestOrders, selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
 import { createUpload, deleteUpload, selectDocument } from 'shared/Entities/modules/documents';
-import { moveIsApproved, isPpm } from 'scenes/Moves/ducks';
+import { isPpm } from 'scenes/Moves/ducks';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
 import { documentSizeLimitMsg } from 'shared/constants';
 import { createModifiedSchemaForOrdersTypesFlag } from 'shared/featureFlags';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectCurrentOrders,
+  selectMoveIsApproved,
+} from 'store/entities/selectors';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -219,7 +223,7 @@ function mapStateToProps(state) {
     error: get(state, 'orders.error'),
     formValues: getFormValues(editOrdersFormName)(state),
     hasSubmitError: get(state, 'orders.hasSubmitError'),
-    moveIsApproved: moveIsApproved(state),
+    moveIsApproved: selectMoveIsApproved(state),
     isPpm: isPpm(state),
     schema: get(state, 'swaggerInternal.spec.definitions.CreateUpdateOrders', {}),
   };

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -6,7 +6,7 @@ import { get, includes, reject } from 'lodash';
 import { push } from 'connected-react-router';
 import { getFormValues, reduxForm, Field } from 'redux-form';
 
-import Alert from 'shared/Alert'; // eslint-disable-line
+import Alert from 'shared/Alert';
 import { withContext } from 'shared/AppContext';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
@@ -16,19 +16,14 @@ import UploadsTable from 'shared/Uploader/UploadsTable';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import SaveCancelButtons from './SaveCancelButtons';
 
-import {
-  updateOrders,
-  fetchLatestOrders,
-  selectActiveOrLatestOrders,
-  selectUploadsForActiveOrders,
-} from 'shared/Entities/modules/orders';
+import { updateOrders, fetchLatestOrders, selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
 import { createUpload, deleteUpload, selectDocument } from 'shared/Entities/modules/documents';
 import { moveIsApproved, isPpm } from 'scenes/Moves/ducks';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
 import { documentSizeLimitMsg } from 'shared/constants';
 import { createModifiedSchemaForOrdersTypesFlag } from 'shared/featureFlags';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -213,7 +208,7 @@ class EditOrders extends Component {
 function mapStateToProps(state) {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
-  const currentOrders = selectActiveOrLatestOrders(state);
+  const currentOrders = selectCurrentOrders(state);
   const uploads = selectUploadsForActiveOrders(state);
 
   const props = {

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -16,7 +16,7 @@ import UploadsTable from 'shared/Uploader/UploadsTable';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import SaveCancelButtons from './SaveCancelButtons';
 
-import { updateOrders, fetchLatestOrders, selectUploadsForActiveOrders } from 'shared/Entities/modules/orders';
+import { updateOrders, fetchLatestOrders } from 'shared/Entities/modules/orders';
 import { createUpload, deleteUpload, selectDocument } from 'shared/Entities/modules/documents';
 import { isPpm } from 'scenes/Moves/ducks';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
@@ -27,6 +27,7 @@ import {
   selectServiceMemberFromLoggedInUser,
   selectCurrentOrders,
   selectMoveIsApproved,
+  selectUploadsForCurrentOrders,
 } from 'store/entities/selectors';
 
 import './Review.css';
@@ -213,7 +214,7 @@ function mapStateToProps(state) {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
   const currentOrders = selectCurrentOrders(state) || {};
-  const uploads = selectUploadsForActiveOrders(state);
+  const uploads = selectUploadsForCurrentOrders(state);
 
   const props = {
     currentOrders,

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -208,7 +208,7 @@ class EditOrders extends Component {
 function mapStateToProps(state) {
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
-  const currentOrders = selectCurrentOrders(state);
+  const currentOrders = selectCurrentOrders(state) || {};
   const uploads = selectUploadsForActiveOrders(state);
 
   const props = {

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -16,7 +16,7 @@ import { isPpm } from 'scenes/Moves/ducks';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
-import { selectServiceMemberFromLoggedInUser, selectMoveIsApproved } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectMoveIsApproved, selectCurrentMove } from 'store/entities/selectors';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -181,7 +181,7 @@ function mapStateToProps(state) {
 
   return {
     serviceMember,
-    move: get(state, 'moves.currentMove'),
+    move: selectCurrentMove(state) || {},
     schema: get(state, 'swaggerInternal.spec.definitions.CreateServiceMemberPayload', {}),
     moveIsApproved: selectMoveIsApproved(state),
     isPpm: isPpm(state),

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -12,11 +12,11 @@ import Alert from 'shared/Alert';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { validateAdditionalFields } from 'shared/JsonSchemaForm';
 import SaveCancelButtons from './SaveCancelButtons';
-import { moveIsApproved, isPpm } from 'scenes/Moves/ducks';
+import { isPpm } from 'scenes/Moves/ducks';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectMoveIsApproved } from 'store/entities/selectors';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -183,7 +183,7 @@ function mapStateToProps(state) {
     serviceMember,
     move: get(state, 'moves.currentMove'),
     schema: get(state, 'swaggerInternal.spec.definitions.CreateServiceMemberPayload', {}),
-    moveIsApproved: moveIsApproved(state),
+    moveIsApproved: selectMoveIsApproved(state),
     isPpm: isPpm(state),
     schemaRank: get(state, 'swaggerInternal.spec.definitions.ServiceMemberRank', {}),
     schemaAffiliation: get(state, 'swaggerInternal.spec.definitions.Affiliation', {}),

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -6,7 +6,7 @@ import SaveCancelButtons from './SaveCancelButtons';
 import { push } from 'connected-react-router';
 import { reduxForm } from 'redux-form';
 
-import Alert from 'shared/Alert'; // eslint-disable-line
+import Alert from 'shared/Alert';
 import { formatCents } from 'shared/formatters';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import {
@@ -17,12 +17,12 @@ import {
   updatePPMEstimate,
   getPpmWeightEstimate,
 } from 'shared/Entities/modules/ppms';
-import { fetchLatestOrders, selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
+import { fetchLatestOrders } from 'shared/Entities/modules/orders';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCentsRange } from 'shared/formatters';
 import { editBegin, editSuccessful, entitlementChangeBegin, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 import EntitlementBar from 'scenes/EntitlementBar';
 import './Review.css';
@@ -344,7 +344,7 @@ function mapStateToProps(state) {
     entitlement: loadEntitlementsFromState(state),
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
     originDutyStationZip: serviceMember?.current_station?.address?.postal_code,
-    orders: selectActiveOrLatestOrders(state),
+    orders: selectCurrentOrders(state),
   };
 }
 

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -344,7 +344,7 @@ function mapStateToProps(state) {
     entitlement: loadEntitlementsFromState(state),
     schema: get(state, 'swaggerInternal.spec.definitions.UpdatePersonallyProcuredMovePayload', {}),
     originDutyStationZip: serviceMember?.current_station?.address?.postal_code,
-    orders: selectCurrentOrders(state),
+    orders: selectCurrentOrders(state) || {},
   };
 }
 

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -22,7 +22,7 @@ import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCentsRange } from 'shared/formatters';
 import { editBegin, editSuccessful, entitlementChangeBegin, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
-import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders, selectCurrentMove } from 'store/entities/selectors';
 
 import EntitlementBar from 'scenes/EntitlementBar';
 import './Review.css';
@@ -332,13 +332,13 @@ class EditWeight extends Component {
 }
 
 function mapStateToProps(state) {
-  const moveID = state.moves.currentMove.id;
+  const currentMove = selectCurrentMove(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
   const serviceMemberId = serviceMember?.id;
 
   return {
     serviceMemberId,
-    currentPPM: selectActivePPMForMove(state, moveID),
+    currentPPM: selectActivePPMForMove(state, currentMove?.id),
     incentiveEstimateMin: selectPPMEstimateRange(state).range_min,
     incentiveEstimateMax: selectPPMEstimateRange(state).range_max,
     entitlement: loadEntitlementsFromState(state),

--- a/src/scenes/Review/ProfileReview.jsx
+++ b/src/scenes/Review/ProfileReview.jsx
@@ -11,12 +11,8 @@ import WizardPage from 'shared/WizardPage';
 import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
 import scrollToTop from 'shared/scrollToTop';
-import {
-  selectServiceMemberFromLoggedInUser,
-  selectHasCanceledMove,
-  selectMoveType,
-  selectConusStatus,
-} from 'store/entities/selectors';
+import { selectConusStatus } from 'store/onboarding/selectors';
+import { selectServiceMemberFromLoggedInUser, selectHasCanceledMove, selectMoveType } from 'store/entities/selectors';
 
 class ProfileReview extends Component {
   componentDidMount() {

--- a/src/scenes/Review/ProfileReview.jsx
+++ b/src/scenes/Review/ProfileReview.jsx
@@ -1,18 +1,22 @@
-import PropTypes from 'prop-types';
-import WizardPage from 'shared/WizardPage';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'connected-react-router';
-import { withContext } from 'shared/AppContext';
-
-import { selectedMoveType, selectedConusStatus, lastMoveIsCanceled } from 'scenes/Moves/ducks';
-import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
 
 import ServiceMemberSummary from './ServiceMemberSummary';
+
+import { withContext } from 'shared/AppContext';
+import WizardPage from 'shared/WizardPage';
+import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
 import scrollToTop from 'shared/scrollToTop';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import {
+  selectServiceMemberFromLoggedInUser,
+  selectHasCanceledMove,
+  selectMoveType,
+  selectConusStatus,
+} from 'store/entities/selectors';
 
 class ProfileReview extends Component {
   componentDidMount() {
@@ -95,9 +99,9 @@ function mapStateToProps(state) {
 
   return {
     serviceMember,
-    lastMoveIsCanceled: lastMoveIsCanceled(state),
-    selectedMoveType: selectedMoveType(state),
-    conusStatus: selectedConusStatus(state),
+    lastMoveIsCanceled: selectHasCanceledMove(state),
+    selectedMoveType: selectMoveType(state),
+    conusStatus: selectConusStatus(state),
     schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),
     schemaOrdersType: getInternalSwaggerDefinition(state, 'OrdersType'),
     schemaAffiliation: getInternalSwaggerDefinition(state, 'Affiliation'),

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -121,7 +121,7 @@ function mapStateToProps(state) {
     existingStation: serviceMember?.current_station || {},
     currentServiceMember: serviceMember,
     currentStation: get(formValues, 'current_station', {}),
-    newDutyStation: get(orders, 'new_duty_station', {}),
+    newDutyStation: orders?.new_duty_station || {},
   };
 }
 

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -9,10 +9,9 @@ import { patchServiceMember, getResponseError } from 'services/internalApi';
 import { updateServiceMember as updateServiceMemberAction } from 'store/entities/actions';
 import { NULL_UUID } from 'shared/constants';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
-import { selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import SectionWrapper from 'components/Customer/SectionWrapper';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 import './DutyStation.css';
 
@@ -114,7 +113,7 @@ const mapDispatchToProps = {
 
 function mapStateToProps(state) {
   const formValues = getFormValues(dutyStationFormName)(state);
-  const orders = selectActiveOrLatestOrders(state);
+  const orders = selectCurrentOrders(state);
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
 
   return {

--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -106,6 +106,44 @@ export async function patchBackupContact(backupContact) {
   );
 }
 
+/** ORDERS */
+export async function getOrdersForServiceMember(serviceMemberId) {
+  return makeInternalRequest(
+    'service_members.showServiceMemberOrders',
+    {
+      serviceMemberId,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function createOrders(orders) {
+  return makeInternalRequest(
+    'orders.createOrders',
+    {
+      createOrders: orders,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
+export async function patchOrders(orders) {
+  return makeInternalRequest(
+    'orders.updateOrders',
+    {
+      ordersId: orders.id,
+      updateOrders: orders,
+    },
+    {
+      normalize: false,
+    },
+  );
+}
+
 /** MOVES */
 export async function getMove(moveId) {
   return makeInternalRequest(

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -1,14 +1,16 @@
-import { isNull, get, isEmpty } from 'lodash';
+import { isNull, get, isEmpty, filter } from 'lodash';
+import { denormalize } from 'normalizr';
+
 import { moves } from '../schema';
 import { ADD_ENTITIES } from '../actions';
-import { denormalize } from 'normalizr';
+
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient } from 'shared/Swagger/api';
 import { selectEntitlements } from 'shared/entitlements.js';
-import { selectOrdersForMove, selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
+import { selectOrdersForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForMove } from 'shared/Entities/modules/serviceMembers';
+import { selectCurrentOrders } from 'store/entities/selectors';
 import { getGHCClient } from 'shared/Swagger/api';
-import { filter } from 'lodash';
 import { fetchActive } from 'shared/utils';
 
 export const STATE_KEY = 'moves';
@@ -98,7 +100,7 @@ export function selectMoveStatus(state, moveId) {
 
 export function selectActiveOrLatestMove(state) {
   // temp until full redux refactor: gets active (or latest move) from entities if it exists.  If not, gets it from currentMove
-  let activeOrLatestOrders = selectActiveOrLatestOrders(state);
+  let activeOrLatestOrders = selectCurrentOrders(state);
   if (isEmpty(activeOrLatestOrders)) {
     return {};
   }

--- a/src/shared/Entities/modules/mtoShipments.js
+++ b/src/shared/Entities/modules/mtoShipments.js
@@ -2,8 +2,6 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { getGHCClient, getClient } from 'shared/Swagger/api';
 import { selectMoveTaskOrders } from 'shared/Entities/modules/moveTaskOrders';
 import { filter } from 'lodash';
-import { denormalize } from 'normalizr';
-import { mtoShipments } from '../schema';
 
 const mtoShipmentsSchemaKey = 'mtoShipments';
 const getMTOShipmentsOperation = 'mtoShipment.listMTOShipments';
@@ -49,20 +47,10 @@ export function selectMTOShipments(state, moveOrderId) {
   return filter(state.entities.mtoShipments, (item) => moveTaskOrders.find((mto) => mto.id === item.moveTaskOrderID));
 }
 
-export function selectMTOShipmentsByMoveId(state, moveId) {
-  const mtoShipments = filter(state.entities.mtoShipments, (mtoShipment) => mtoShipment.moveTaskOrderID === moveId);
-  return mtoShipments;
-}
-
+// TODO - deprecate this selector when we refactor the wizard flow
 export function selectMTOShipmentForMTO(state, moveTaskOrderId) {
   const mtoShipment = Object.values(state.entities.mtoShipments).find(
     (mtoShipment) => mtoShipment.moveTaskOrderID === moveTaskOrderId,
   );
   return mtoShipment || {};
-}
-
-export function selectMTOShipmentById(state, id) {
-  const emptyShipment = {};
-  if (!id) return emptyShipment;
-  return denormalize([id], mtoShipments, state.entities)[0] || emptyShipment;
 }

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -5,7 +5,6 @@ import { ADD_ENTITIES } from '../actions';
 import { swaggerRequest } from 'shared/Swagger/request';
 import { formatDateForSwagger } from 'shared/dates';
 import { getClient } from 'shared/Swagger/api';
-import { selectCurrentOrders } from 'store/entities/selectors';
 
 export const STATE_KEY = 'orders';
 export const loadOrdersLabel = 'Orders.loadOrders';
@@ -53,24 +52,5 @@ export function selectOrdersForMove(state, moveId) {
     return selectOrders(state, ordersId);
   } else {
     return {};
-  }
-}
-
-// TODO - migrate to selectors
-export function selectUploadsForActiveOrders(state) {
-  const orders = selectCurrentOrders(state);
-  const uploadedOrders = get(state, `entities.documents.${orders?.uploaded_orders}`);
-  if (uploadedOrders) {
-    return uploadedOrders.uploads
-      .map((uploadId) => get(state, `entities.uploads.${uploadId}`))
-      .filter((upload) => {
-        if (upload === undefined) {
-          console.warn('Upload not found in entities uploads');
-          return false;
-        }
-        return true;
-      });
-  } else {
-    return [];
   }
 }

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -8,7 +8,7 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { formatDateForSwagger } from 'shared/dates';
 import { getClient } from 'shared/Swagger/api';
 import { fetchActive } from 'shared/utils';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 export const STATE_KEY = 'orders';
 export const loadOrdersLabel = 'Orders.loadOrders';
@@ -72,8 +72,8 @@ export function selectOrdersForMove(state, moveId) {
 }
 
 export function selectUploadsForActiveOrders(state) {
-  const orders = selectActiveOrLatestOrders(state);
-  const uploadedOrders = get(state, `entities.documents.${orders.uploaded_orders}`);
+  const orders = selectCurrentOrders(state);
+  const uploadedOrders = get(state, `entities.documents.${orders?.uploaded_orders}`);
   if (uploadedOrders) {
     return uploadedOrders.uploads
       .map((uploadId) => get(state, `entities.uploads.${uploadId}`))

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -10,7 +10,6 @@ import { selectCurrentOrders } from 'store/entities/selectors';
 export const STATE_KEY = 'orders';
 export const loadOrdersLabel = 'Orders.loadOrders';
 const updateOrdersLabel = 'Orders.updateOrders';
-const createOrdersLabel = 'Orders.createOrders';
 export const getLatestOrdersLabel = 'Orders.showServiceMemberOrders';
 
 export default function reducer(state = {}, action) {
@@ -41,13 +40,6 @@ export function updateOrders(ordersId, orders, label = updateOrdersLabel) {
   orders.report_by_date = formatDateForSwagger(orders.report_by_date);
   orders.issue_date = formatDateForSwagger(orders.issue_date);
   return swaggerRequest(getClient, swaggerTag, { ordersId, updateOrders: orders }, { label });
-}
-
-export function createOrders(orders, label = createOrdersLabel) {
-  const swaggerTag = 'orders.createOrders';
-  orders.report_by_date = formatDateForSwagger(orders.report_by_date);
-  orders.issue_date = formatDateForSwagger(orders.issue_date);
-  return swaggerRequest(getClient, swaggerTag, { createOrders: orders }, { label });
 }
 
 // Selectors

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -82,9 +82,3 @@ export function selectUploadsForActiveOrders(state) {
     return [];
   }
 }
-
-// TODO - migrate to selectors
-export function selectUploadedOrders(state) {
-  const orders = selectCurrentOrders(state);
-  return orders ? orders.uploaded_orders.uploads : [];
-}

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -1,7 +1,6 @@
 import { get, isNull, sum, isEmpty } from 'lodash';
 
-import { selectActiveOrLatestOrders } from 'shared/Entities/modules/orders';
-import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
 
 export function selectEntitlements(rankEntitlement, hasDependents = false, spouseHasProGear = false) {
   if (!rankEntitlement) {
@@ -21,7 +20,7 @@ export function selectEntitlements(rankEntitlement, hasDependents = false, spous
 
 export function loadEntitlementsFromState(state) {
   // Temp fix until redux refactor finished - get orders from either entities or orders.currentOrders
-  let orders = selectActiveOrLatestOrders(state);
+  let orders = selectCurrentOrders(state);
   if (isEmpty(orders)) {
     return {};
   }

--- a/src/store/entities/actions.js
+++ b/src/store/entities/actions.js
@@ -2,6 +2,7 @@ export const UPDATE_SERVICE_MEMBER = 'UPDATE_SERVICE_MEMBER';
 export const UPDATE_BACKUP_CONTACT = 'UPDATE_BACKUP_CONTACT';
 export const UPDATE_MOVE = 'UPDATE_MOVE';
 export const UPDATE_MTO_SHIPMENT = 'UPDATE_MTO_SHIPMENT';
+export const UPDATE_ORDERS = 'UPDATE_ORDERS';
 
 export const updateServiceMember = (payload) => ({
   type: UPDATE_SERVICE_MEMBER,
@@ -20,5 +21,10 @@ export const updateMove = (payload) => ({
 
 export const updateMTOShipment = (payload) => ({
   type: UPDATE_MTO_SHIPMENT,
+  payload,
+});
+
+export const updateOrders = (payload) => ({
+  type: UPDATE_ORDERS,
   payload,
 });

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -68,6 +68,15 @@ export const selectCurrentOrders = (state) => {
 };
 
 /** Moves */
+export const selectMovesForLoggedInUser = (state) => {
+  const orders = selectOrdersForLoggedInUser(state);
+  const moves = orders?.reduce((prev, cur) => {
+    return prev.concat(cur.moves?.map((id) => state.entities.moves?.[`${id}`]) || []);
+  }, []);
+
+  return moves;
+};
+
 export const selectMovesForCurrentOrders = (state) => {
   const activeOrders = selectCurrentOrders(state);
   const moveIds = activeOrders?.moves || [];
@@ -82,4 +91,22 @@ export const selectCurrentMove = (state) => {
   return activeMove || null;
 };
 
+export const selectMoveIsApproved = createSelector(selectCurrentMove, (move) => move?.status === 'APPROVED');
+
+export const selectHasCanceledMove = createSelector(selectMovesForLoggedInUser, (moves) =>
+  moves.some((m) => m.status === 'CANCELED'),
+);
+
+export const selectMoveType = createSelector(selectCurrentMove, (move) => move?.selected_move_type);
+
+export const selectConusStatus = createSelector(selectCurrentMove, (move) => move?.conus_status);
+
 /** MTO Shipments */
+export const selectMTOShipmentsForCurrentMove = (state) => {
+  const currentMove = selectCurrentMove(state);
+  return Object.values(state.entities.mtoShipments)?.filter((m) => m.moveTaskOrderID === currentMove?.id);
+};
+
+export function selectMTOShipmentById(state, id) {
+  return state.entities?.mtoShipments?.[`${id}`] || null;
+}

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -50,3 +50,36 @@ export const selectBackupContacts = (state) => {
   const backupContactIds = serviceMember?.backup_contacts || [];
   return backupContactIds.map((id) => state.entities.backupContacts?.[`${id}`]);
 };
+
+/** Orders */
+export const selectOrdersForLoggedInUser = (state) => {
+  const serviceMember = selectServiceMemberFromLoggedInUser(state);
+  const ordersIds = serviceMember?.orders || [];
+  return ordersIds.map((id) => state.entities.orders?.[`${id}`]);
+};
+
+export const selectCurrentOrders = (state) => {
+  const orders = selectOrdersForLoggedInUser(state);
+  const [activeOrders] = orders.filter(
+    (o) => ['DRAFT', 'SUBMITTED', 'APPROVED', 'PAYMENT_REQUESTED'].indexOf(o?.status) > -1,
+  );
+
+  return activeOrders || orders[0] || null;
+};
+
+/** Moves */
+export const selectMovesForCurrentOrders = (state) => {
+  const activeOrders = selectCurrentOrders(state);
+  const moveIds = activeOrders?.moves || [];
+  return moveIds.map((id) => state.entities.moves?.[`${id}`]);
+};
+
+export const selectCurrentMove = (state) => {
+  const moves = selectMovesForCurrentOrders(state);
+  const [activeMove] = moves.filter(
+    (m) => ['DRAFT', 'SUBMITTED', 'APPROVED', 'PAYMENT_REQUESTED'].indexOf(m?.status) > -1,
+  );
+  return activeMove || null;
+};
+
+/** MTO Shipments */

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -67,6 +67,11 @@ export const selectCurrentOrders = (state) => {
   return activeOrders || orders[0] || null;
 };
 
+export const selectUploadsForCurrentOrders = (state) => {
+  const orders = selectCurrentOrders(state);
+  return orders ? orders.uploaded_orders?.uploads : [];
+};
+
 /** Moves */
 export const selectMovesForLoggedInUser = (state) => {
   const orders = selectOrdersForLoggedInUser(state);

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -97,7 +97,7 @@ export const selectCurrentMove = (state) => {
   const [activeMove] = moves.filter(
     (m) => ['DRAFT', 'SUBMITTED', 'APPROVED', 'PAYMENT_REQUESTED'].indexOf(m?.status) > -1,
   );
-  return activeMove || null;
+  return activeMove || moves[0] || null;
 };
 
 export const selectMoveIsApproved = createSelector(selectCurrentMove, (move) => move?.status === 'APPROVED');

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -104,8 +104,6 @@ export const selectHasCanceledMove = createSelector(selectMovesForLoggedInUser, 
 
 export const selectMoveType = createSelector(selectCurrentMove, (move) => move?.selected_move_type);
 
-export const selectConusStatus = createSelector(selectCurrentMove, (move) => move?.conus_status);
-
 /** MTO Shipments */
 export const selectMTOShipmentsForCurrentMove = (state) => {
   const currentMove = selectCurrentMove(state);

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -67,6 +67,10 @@ export const selectCurrentOrders = (state) => {
   return activeOrders || orders[0] || null;
 };
 
+export const selectOrdersById = (state, id) => {
+  return state.entities.orders?.[`${id}`] || null;
+};
+
 export const selectUploadsForCurrentOrders = (state) => {
   const orders = selectCurrentOrders(state);
   return orders ? orders.uploaded_orders?.uploads : [];

--- a/src/store/entities/selectors.test.js
+++ b/src/store/entities/selectors.test.js
@@ -6,6 +6,7 @@ import {
   selectCurrentDutyStation,
   selectOrdersForLoggedInUser,
   selectCurrentOrders,
+  selectMovesForLoggedInUser,
   selectMovesForCurrentOrders,
   selectCurrentMove,
 } from './selectors';
@@ -506,6 +507,89 @@ describe('selectCurrentOrders', () => {
     };
 
     expect(selectCurrentOrders(testState)).toEqual(null);
+  });
+});
+
+describe('selectMovesForLoggedInUser', () => {
+  it('returns the moves associated with the logged in user', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+            status: 'CANCELED',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'SUBMITTED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectMovesForLoggedInUser(testState)).toEqual([
+      testState.entities.moves.move1029,
+      testState.entities.moves.move2938,
+    ]);
+  });
+
+  it('returns an empty array if the logged in user has no moves', () => {
+    const testState = {
+      entities: {
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: [],
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            status: 'SUBMITTED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectMovesForLoggedInUser(testState)).toEqual([]);
   });
 });
 

--- a/src/store/entities/selectors.test.js
+++ b/src/store/entities/selectors.test.js
@@ -4,6 +4,10 @@ import {
   selectIsProfileComplete,
   selectBackupContacts,
   selectCurrentDutyStation,
+  selectOrdersForLoggedInUser,
+  selectCurrentOrders,
+  selectMovesForCurrentOrders,
+  selectCurrentMove,
 } from './selectors';
 
 describe('selectLoggedInUser', () => {
@@ -312,5 +316,428 @@ describe('selectIsProfileComplete', () => {
     };
 
     expect(selectIsProfileComplete(testState)).toEqual(true);
+  });
+});
+
+describe('selectOrdersForLoggedInUser', () => {
+  it('returns the orders associated with the logged in user', () => {
+    const testState = {
+      entities: {
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectOrdersForLoggedInUser(testState)).toEqual([
+      testState.entities.orders.orders789,
+      testState.entities.orders.orders8910,
+    ]);
+  });
+
+  it('returns an empty array if the service member has no orders', () => {
+    const testState = {
+      entities: {
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+          },
+        },
+      },
+    };
+
+    expect(selectOrdersForLoggedInUser(testState)).toEqual([]);
+  });
+});
+
+describe('selectCurrentOrders', () => {
+  it('returns the current orders associated with the logged in user', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+            status: 'CANCELED',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'APPROVED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentOrders(testState)).toEqual(testState.entities.orders.orders8910);
+  });
+
+  it('returns the first orders if none of the orders statuses are active', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+            status: 'CANCELED',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'CANCELED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentOrders(testState)).toEqual(testState.entities.orders.orders789);
+  });
+
+  it('returns null if there are no orders', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {},
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentOrders(testState)).toEqual(null);
+  });
+});
+
+describe('selectMovesForCurrentOrders', () => {
+  it('returns the moves associated with the current orders', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'SUBMITTED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectMovesForCurrentOrders(testState)).toEqual([testState.entities.moves.move2938]);
+  });
+
+  it('returns an empty array if the current orders have no moves', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: [],
+            status: 'SUBMITTED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectMovesForCurrentOrders(testState)).toEqual([]);
+  });
+});
+
+describe('selectCurrentMove', () => {
+  it('returns the current move associated with the current orders', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+            status: 'CANCELED',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+            status: 'DRAFT',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+            status: 'CANCELED',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'DRAFT',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentMove(testState)).toEqual(testState.entities.moves.move2938);
+  });
+
+  it('returns the current move associated with the first orders if none of the orders statuses are active', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+            status: 'SUBMITTED',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+            status: 'APPROVED',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+            status: 'CANCELED',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'CANCELED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentMove(testState)).toEqual(testState.entities.moves.move1029);
+  });
+
+  it('returns null if there are no active moves', () => {
+    const testState = {
+      entities: {
+        moves: {
+          move1029: {
+            id: 'move1029',
+            orders_id: 'orders789',
+            status: 'CANCELED',
+          },
+          move2938: {
+            id: 'move2938',
+            orders_id: 'orders8910',
+            status: 'CANCELED',
+          },
+        },
+        orders: {
+          orders789: {
+            id: 'orders789',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move1029'],
+            status: 'CANCELED',
+          },
+          orders8910: {
+            id: 'orders8910',
+            service_member_id: 'serviceMemberId456',
+            moves: ['move2938'],
+            status: 'CANCELED',
+          },
+        },
+        user: {
+          userId123: {
+            id: 'userId123',
+            service_member: 'serviceMemberId456',
+          },
+        },
+        serviceMembers: {
+          serviceMemberId456: {
+            id: 'serviceMemberId456',
+            orders: ['orders789', 'orders8910'],
+          },
+        },
+      },
+    };
+
+    expect(selectCurrentMove(testState)).toEqual(null);
   });
 });

--- a/src/store/entities/selectors.test.js
+++ b/src/store/entities/selectors.test.js
@@ -778,7 +778,7 @@ describe('selectCurrentMove', () => {
     expect(selectCurrentMove(testState)).toEqual(testState.entities.moves.move1029);
   });
 
-  it('returns null if there are no active moves', () => {
+  it('returns the first move if there are no active moves', () => {
     const testState = {
       entities: {
         moves: {
@@ -822,6 +822,6 @@ describe('selectCurrentMove', () => {
       },
     };
 
-    expect(selectCurrentMove(testState)).toEqual(null);
+    expect(selectCurrentMove(testState)).toEqual(testState.entities.moves.move1029);
   });
 });

--- a/src/store/onboarding/actions.js
+++ b/src/store/onboarding/actions.js
@@ -4,6 +4,8 @@ export const INIT_ONBOARDING_COMPLETE = 'INIT_ONBOARDING_COMPLETE';
 
 export const FETCH_CUSTOMER_DATA = 'FETCH_CUSTOMER_DATA';
 
+export const SET_CONUS_STATUS = 'SET_CONUS_STATUS';
+
 export const initOnboarding = () => ({
   type: INIT_ONBOARDING,
 });
@@ -19,4 +21,9 @@ export const initOnboardingComplete = () => ({
 
 export const fetchCustomerData = () => ({
   type: FETCH_CUSTOMER_DATA,
+});
+
+export const setConusStatus = (moveType) => ({
+  type: SET_CONUS_STATUS,
+  moveType,
 });

--- a/src/store/onboarding/actions.test.js
+++ b/src/store/onboarding/actions.test.js
@@ -1,4 +1,15 @@
-import { setConusStatus, SET_CONUS_STATUS } from './actions';
+import {
+  setConusStatus,
+  SET_CONUS_STATUS,
+  initOnboarding,
+  INIT_ONBOARDING,
+  initOnboardingFailed,
+  INIT_ONBOARDING_FAILED,
+  initOnboardingComplete,
+  INIT_ONBOARDING_COMPLETE,
+  fetchCustomerData,
+  FETCH_CUSTOMER_DATA,
+} from './actions';
 
 describe('Onboarding actions', () => {
   it('setConusStatus returns the expected action', () => {
@@ -8,5 +19,38 @@ describe('Onboarding actions', () => {
     };
 
     expect(setConusStatus('CONUS')).toEqual(expectedAction);
+  });
+
+  it('initOnboarding returns the expected action', () => {
+    const expectedAction = {
+      type: INIT_ONBOARDING,
+    };
+
+    expect(initOnboarding()).toEqual(expectedAction);
+  });
+
+  it('initOnboardingFailed returns the expected action', () => {
+    const expectedAction = {
+      type: INIT_ONBOARDING_FAILED,
+      error: 'Test Error',
+    };
+
+    expect(initOnboardingFailed('Test Error')).toEqual(expectedAction);
+  });
+
+  it('initOnboardingComplete returns the expected action', () => {
+    const expectedAction = {
+      type: INIT_ONBOARDING_COMPLETE,
+    };
+
+    expect(initOnboardingComplete()).toEqual(expectedAction);
+  });
+
+  it('fetchCustomerData returns the expected action', () => {
+    const expectedAction = {
+      type: FETCH_CUSTOMER_DATA,
+    };
+
+    expect(fetchCustomerData()).toEqual(expectedAction);
   });
 });

--- a/src/store/onboarding/actions.test.js
+++ b/src/store/onboarding/actions.test.js
@@ -1,0 +1,12 @@
+import { setConusStatus, SET_CONUS_STATUS } from './actions';
+
+describe('Onboarding actions', () => {
+  it('setConusStatus returns the expected action', () => {
+    const expectedAction = {
+      type: SET_CONUS_STATUS,
+      moveType: 'CONUS',
+    };
+
+    expect(setConusStatus('CONUS')).toEqual(expectedAction);
+  });
+});

--- a/src/store/onboarding/reducer.js
+++ b/src/store/onboarding/reducer.js
@@ -1,0 +1,23 @@
+import { SET_CONUS_STATUS } from './actions';
+
+export const initialState = {
+  conusStatus: null,
+};
+
+const onboardingReducer = (state = initialState, action) => {
+  switch (action?.type) {
+    case SET_CONUS_STATUS: {
+      const { moveType } = action;
+
+      return {
+        ...state,
+        conusStatus: moveType,
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default onboardingReducer;

--- a/src/store/onboarding/reducer.test.js
+++ b/src/store/onboarding/reducer.test.js
@@ -1,0 +1,15 @@
+import onboardingReducer, { initialState } from './reducer';
+import { setConusStatus } from './actions';
+
+describe('onboardingReducer', () => {
+  it('returns the initial state by default', () => {
+    expect(onboardingReducer(undefined, undefined)).toEqual(initialState);
+  });
+
+  it('handles the setConusStatus action', () => {
+    expect(onboardingReducer(initialState, setConusStatus('CONUS'))).toEqual({
+      ...initialState,
+      conusStatus: 'CONUS',
+    });
+  });
+});

--- a/src/store/onboarding/selectors.js
+++ b/src/store/onboarding/selectors.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
+export const selectConusStatus = (state) => {
+  return state.onboarding.conusStatus;
+};

--- a/src/store/onboarding/selectors.test.js
+++ b/src/store/onboarding/selectors.test.js
@@ -1,0 +1,13 @@
+import { selectConusStatus } from './selectors';
+
+describe('selectConusStatus', () => {
+  it('returns the conusStatus value', () => {
+    const testState = {
+      onboarding: {
+        conusStatus: 'CONUS',
+      },
+    };
+
+    expect(selectConusStatus(testState)).toEqual(testState.onboarding.conusStatus);
+  });
+});

--- a/src/types/customerShapes.js
+++ b/src/types/customerShapes.js
@@ -27,7 +27,7 @@ export const OrdersShape = shape({
   has_dependents: bool,
   id: string,
   issue_date: string,
-  moves: arrayOf(MoveShape),
+  moves: arrayOf(string),
   new_duty_station: DutyStationShape,
   orders_type: string,
   report_by_date: string,

--- a/src/types/customerShapes.js
+++ b/src/types/customerShapes.js
@@ -1,6 +1,47 @@
-import { arrayOf, bool, func, string, shape } from 'prop-types';
+import { arrayOf, bool, func, string, shape, object, number } from 'prop-types';
 
 import { AddressShape } from 'types/address';
+import { DutyStationShape } from 'types/dutyStation';
+
+export const MoveShape = shape({
+  id: string,
+  locator: string,
+  selected_move_type: string,
+  status: string,
+});
+
+export const UploadShape = shape({
+  filename: string,
+  content_type: string,
+  id: string,
+  status: string,
+  bytes: number,
+  created_at: string,
+  updated_at: string,
+  url: string,
+});
+
+export const UploadsShape = arrayOf(UploadShape);
+
+export const OrdersShape = shape({
+  has_dependents: bool,
+  id: string,
+  issue_date: string,
+  moves: arrayOf(MoveShape),
+  new_duty_station: DutyStationShape,
+  orders_type: string,
+  report_by_date: string,
+  service_member_id: string,
+  spouse_has_pro_gear: bool,
+  status: string,
+  updated_at: string,
+  uploaded_orders: shape({
+    id: string,
+    uploads: UploadsShape,
+  }),
+});
+
+export const DocumentShape = shape({});
 
 export const MtoAgentShape = shape({
   firstName: string,
@@ -68,6 +109,8 @@ export const PageListShape = arrayOf(string);
 
 export const PageKeyShape = string;
 
+export const AdditionalParamsShape = object;
+
 export const WizardPageShape = shape({
   pageList: PageListShape.isRequired,
   pageKey: PageKeyShape.isRequired,
@@ -87,4 +130,5 @@ export default {
   HhgShipmentShape,
   NtsShipmentShape,
   NtsrShipmentShape,
+  AdditionalParamsShape,
 };


### PR DESCRIPTION
## Description

This PR updates all code that selects a logged in service member's current move and current orders to select from `state.entities.moves, state.entities.orders` and not from the legacy reducers (`state.moves, state.orders`). This ended up being a bit larger than expected, due to some dependencies between moves and orders data. Changes include:
- Move selector functions into `store/entities/selectors` and renamed to be consistent:
    - `selectActiveOrLatestOrders, selectActiveOrLatestOrdersFromEntities >> selectCurrentOrders`
    - `selectActiveOrLatestMove >> selectCurrentMove`
    - `moveIsApproved` >> `selectMoveIsApproved`
    - `lastMoveIsCanceled` >> `selectHasCanceledMove`
    - `selectedMoveType` >> `selectMoveType`
    - `selectMTOShipmentsByMoveId` >> `selectMTOShipmentsForCurrentMove`
- Added an `onboarding` reducer in order to save the `conusStatus` value. This was because this value is not saved by the API at all, and should be stored separately from cached API data in Redux. I'm not sure that we need to save this value in Redux at all, but for now moving it into a different reducer felt like the path with the least friction.
    - Also migrated the selector: `selectedConusStatus` >> `selectConusStatus`
- I also needed to update the submit handler on the `Orders` step of onboarding, because it was navigating to the next page (Upload Orders) before the create request was completed. I took this opportunity to migrate the submit handler to use sagas (same as the other steps of onboarding now), and to update the service member if creating orders.
- Deprecated `selectUploadsForActiveOrders` - I don't think this selector was working as-is, resulting in existing uploads not showing up in the customer & office apps. It was looking for documents & uploads in entities, neither of which get populated as far as I can tell. I switched to alternative selectors that select the uploads nested within the orders object.
- Added some more customer prop types shapes
- Deleted legacy code that is no longer referenced anywhere
- Miscellaneous eslint fixes on touched files

## Reviewer Notes

After this PR, there should be no references made to Redux `state.moves` or `state.orders`. There are a few lingering methods used in the legacy ducks files, which can be migrated and/or deleted in the follow up stories to delete old reducers. To test, you can go through any service member flows and especially test that the add orders and add shipments work correctly. One note is that there are existing bugs related to _editing_ existing orders, so that is not expected to be fixed in this PR. There should be no new bugs introduced, and no visible changes to the user.

## Setup

To start the application:

```
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5920) for this change
