### PR TITLE
Remove moose ownership of circleci config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,5 @@
 # Require team Pamplemoose to review changes to configs that may affect cATO static analysis compliancy
 .golangci.yaml @transcom/Truss-Pamplemoose
 .pre-commit-config.yaml @transcom/Truss-Pamplemoose
-.circleci/config.yml @transcom/Truss-Pamplemoose
 
 


### PR DESCRIPTION
## Description

Removes Pamplemoose as codeowners of circleci.  The original intention was related to adding friction to changes that 
 impact static analysis.  However, it doesn't seem to serve that purpose and moose gets tagged on many unrelated PRs.

## Setup

If you make changes to the circleci/config file and put in a PR, Pamplemoose should not show up as code owners that are required to approve.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

