### PR TITLE
[MB-5846] Fix update move order interaction

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -2931,7 +2931,8 @@ func init() {
         "HHG_RESTRICTED_PROHIBITED": "Shipment of HHG Restricted or Prohibited",
         "INSTRUCTION_20_WEEKS": "Course of Instruction 20 Weeks or More",
         "PCS_TDY": "PCS with TDY Enroute"
-      }
+      },
+      "x-nullable": true
     },
     "PatchMTOServiceItemStatusPayload": {
       "properties": {
@@ -6940,7 +6941,8 @@ func init() {
         "HHG_RESTRICTED_PROHIBITED": "Shipment of HHG Restricted or Prohibited",
         "INSTRUCTION_20_WEEKS": "Course of Instruction 20 Weeks or More",
         "PCS_TDY": "PCS with TDY Enroute"
-      }
+      },
+      "x-nullable": true
     },
     "PatchMTOServiceItemStatusPayload": {
       "properties": {

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -2091,7 +2091,8 @@ func init() {
         "ARMY": "21 Army",
         "COAST_GUARD": "70 Coast Guard",
         "NAVY_AND_MARINES": "17 Navy and Marine Corps"
-      }
+      },
+      "x-nullable": true
     },
     "DimensionType": {
       "description": "Describes a dimension type for a MTOServiceItemDimension.",
@@ -3461,12 +3462,8 @@ func init() {
         "issueDate",
         "reportByDate",
         "ordersType",
-        "ordersTypeDetail",
         "newDutyStationId",
-        "originDutyStationId",
-        "ordersNumber",
-        "tac",
-        "departmentIndicator"
+        "originDutyStationId"
       ],
       "properties": {
         "authorizedWeight": {
@@ -3478,6 +3475,7 @@ func init() {
           "example": 2000
         },
         "departmentIndicator": {
+          "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
         },
         "grade": {
@@ -6102,7 +6100,8 @@ func init() {
         "ARMY": "21 Army",
         "COAST_GUARD": "70 Coast Guard",
         "NAVY_AND_MARINES": "17 Navy and Marine Corps"
-      }
+      },
+      "x-nullable": true
     },
     "DimensionType": {
       "description": "Describes a dimension type for a MTOServiceItemDimension.",
@@ -7475,12 +7474,8 @@ func init() {
         "issueDate",
         "reportByDate",
         "ordersType",
-        "ordersTypeDetail",
         "newDutyStationId",
-        "originDutyStationId",
-        "ordersNumber",
-        "tac",
-        "departmentIndicator"
+        "originDutyStationId"
       ],
       "properties": {
         "authorizedWeight": {
@@ -7492,6 +7487,7 @@ func init() {
           "example": 2000
         },
         "departmentIndicator": {
+          "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
         },
         "grade": {

--- a/pkg/gen/ghcmessages/move_order.go
+++ b/pkg/gen/ghcmessages/move_order.go
@@ -72,7 +72,7 @@ type MoveOrder struct {
 	OrderType OrdersType `json:"order_type,omitempty"`
 
 	// order type detail
-	OrderTypeDetail OrdersTypeDetail `json:"order_type_detail,omitempty"`
+	OrderTypeDetail *OrdersTypeDetail `json:"order_type_detail,omitempty"`
 
 	// origin duty station
 	OriginDutyStation *DutyStation `json:"originDutyStation,omitempty"`
@@ -303,11 +303,13 @@ func (m *MoveOrder) validateOrderTypeDetail(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := m.OrderTypeDetail.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("order_type_detail")
+	if m.OrderTypeDetail != nil {
+		if err := m.OrderTypeDetail.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("order_type_detail")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/gen/ghcmessages/move_order.go
+++ b/pkg/gen/ghcmessages/move_order.go
@@ -32,7 +32,7 @@ type MoveOrder struct {
 	DateIssued strfmt.Date `json:"date_issued,omitempty"`
 
 	// department indicator
-	DepartmentIndicator DeptIndicator `json:"department_indicator,omitempty"`
+	DepartmentIndicator *DeptIndicator `json:"department_indicator,omitempty"`
 
 	// destination duty station
 	DestinationDutyStation *DutyStation `json:"destinationDutyStation,omitempty"`
@@ -189,11 +189,13 @@ func (m *MoveOrder) validateDepartmentIndicator(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := m.DepartmentIndicator.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("department_indicator")
+	if m.DepartmentIndicator != nil {
+		if err := m.DepartmentIndicator.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("department_indicator")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/gen/ghcmessages/queue_move.go
+++ b/pkg/gen/ghcmessages/queue_move.go
@@ -21,7 +21,7 @@ type QueueMove struct {
 	Customer *Customer `json:"customer,omitempty"`
 
 	// department indicator
-	DepartmentIndicator DeptIndicator `json:"departmentIndicator,omitempty"`
+	DepartmentIndicator *DeptIndicator `json:"departmentIndicator,omitempty"`
 
 	// destination duty station
 	DestinationDutyStation *DutyStation `json:"destinationDutyStation,omitempty"`
@@ -101,11 +101,13 @@ func (m *QueueMove) validateDepartmentIndicator(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := m.DepartmentIndicator.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("departmentIndicator")
+	if m.DepartmentIndicator != nil {
+		if err := m.DepartmentIndicator.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("departmentIndicator")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/gen/ghcmessages/queue_payment_request.go
+++ b/pkg/gen/ghcmessages/queue_payment_request.go
@@ -24,7 +24,7 @@ type QueuePaymentRequest struct {
 	Customer *Customer `json:"customer,omitempty"`
 
 	// department indicator
-	DepartmentIndicator DeptIndicator `json:"departmentIndicator,omitempty"`
+	DepartmentIndicator *DeptIndicator `json:"departmentIndicator,omitempty"`
 
 	// id
 	// Format: uuid
@@ -110,11 +110,13 @@ func (m *QueuePaymentRequest) validateDepartmentIndicator(formats strfmt.Registr
 		return nil
 	}
 
-	if err := m.DepartmentIndicator.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("departmentIndicator")
+	if m.DepartmentIndicator != nil {
+		if err := m.DepartmentIndicator.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("departmentIndicator")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/gen/ghcmessages/update_move_order_payload.go
+++ b/pkg/gen/ghcmessages/update_move_order_payload.go
@@ -47,7 +47,7 @@ type UpdateMoveOrderPayload struct {
 	OrdersType OrdersType `json:"ordersType"`
 
 	// orders type detail
-	OrdersTypeDetail OrdersTypeDetail `json:"ordersTypeDetail,omitempty"`
+	OrdersTypeDetail *OrdersTypeDetail `json:"ordersTypeDetail,omitempty"`
 
 	// origin duty station Id
 	// Required: true
@@ -207,11 +207,13 @@ func (m *UpdateMoveOrderPayload) validateOrdersTypeDetail(formats strfmt.Registr
 		return nil
 	}
 
-	if err := m.OrdersTypeDetail.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("ordersTypeDetail")
+	if m.OrdersTypeDetail != nil {
+		if err := m.OrdersTypeDetail.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("ordersTypeDetail")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/pkg/gen/ghcmessages/update_move_order_payload.go
+++ b/pkg/gen/ghcmessages/update_move_order_payload.go
@@ -22,8 +22,7 @@ type UpdateMoveOrderPayload struct {
 	AuthorizedWeight *int64 `json:"authorizedWeight,omitempty"`
 
 	// department indicator
-	// Required: true
-	DepartmentIndicator DeptIndicator `json:"departmentIndicator"`
+	DepartmentIndicator *DeptIndicator `json:"departmentIndicator,omitempty"`
 
 	// grade
 	Grade *Grade `json:"grade,omitempty"`
@@ -41,16 +40,14 @@ type UpdateMoveOrderPayload struct {
 	NewDutyStationID *strfmt.UUID `json:"newDutyStationId"`
 
 	// Orders Number
-	// Required: true
-	OrdersNumber *string `json:"ordersNumber"`
+	OrdersNumber *string `json:"ordersNumber,omitempty"`
 
 	// orders type
 	// Required: true
 	OrdersType OrdersType `json:"ordersType"`
 
 	// orders type detail
-	// Required: true
-	OrdersTypeDetail OrdersTypeDetail `json:"ordersTypeDetail"`
+	OrdersTypeDetail OrdersTypeDetail `json:"ordersTypeDetail,omitempty"`
 
 	// origin duty station Id
 	// Required: true
@@ -68,8 +65,7 @@ type UpdateMoveOrderPayload struct {
 	Sac *string `json:"sac,omitempty"`
 
 	// TAC
-	// Required: true
-	Tac *string `json:"tac"`
+	Tac *string `json:"tac,omitempty"`
 }
 
 // Validate validates this update move order payload
@@ -96,10 +92,6 @@ func (m *UpdateMoveOrderPayload) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateOrdersNumber(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateOrdersType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -113,10 +105,6 @@ func (m *UpdateMoveOrderPayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReportByDate(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateTac(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -141,11 +129,17 @@ func (m *UpdateMoveOrderPayload) validateAuthorizedWeight(formats strfmt.Registr
 
 func (m *UpdateMoveOrderPayload) validateDepartmentIndicator(formats strfmt.Registry) error {
 
-	if err := m.DepartmentIndicator.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("departmentIndicator")
+	if swag.IsZero(m.DepartmentIndicator) { // not required
+		return nil
+	}
+
+	if m.DepartmentIndicator != nil {
+		if err := m.DepartmentIndicator.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("departmentIndicator")
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil
@@ -195,15 +189,6 @@ func (m *UpdateMoveOrderPayload) validateNewDutyStationID(formats strfmt.Registr
 	return nil
 }
 
-func (m *UpdateMoveOrderPayload) validateOrdersNumber(formats strfmt.Registry) error {
-
-	if err := validate.Required("ordersNumber", "body", m.OrdersNumber); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *UpdateMoveOrderPayload) validateOrdersType(formats strfmt.Registry) error {
 
 	if err := m.OrdersType.Validate(formats); err != nil {
@@ -217,6 +202,10 @@ func (m *UpdateMoveOrderPayload) validateOrdersType(formats strfmt.Registry) err
 }
 
 func (m *UpdateMoveOrderPayload) validateOrdersTypeDetail(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.OrdersTypeDetail) { // not required
+		return nil
+	}
 
 	if err := m.OrdersTypeDetail.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -248,15 +237,6 @@ func (m *UpdateMoveOrderPayload) validateReportByDate(formats strfmt.Registry) e
 	}
 
 	if err := validate.FormatOf("reportByDate", "body", "date", m.ReportByDate.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateMoveOrderPayload) validateTac(formats strfmt.Registry) error {
-
-	if err := validate.Required("tac", "body", m.Tac); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -115,7 +115,7 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 		ReportByDate:           strfmt.Date(moveOrder.ReportByDate),
 		DateIssued:             strfmt.Date(moveOrder.IssueDate),
 		OrderType:              ghcmessages.OrdersType(moveOrder.OrdersType),
-		DepartmentIndicator:    deptIndicator,
+		DepartmentIndicator:    &deptIndicator,
 		Tac:                    handlers.FmtStringPtr(moveOrder.TAC),
 		Sac:                    handlers.FmtStringPtr(moveOrder.SAC),
 		UploadedOrderID:        strfmt.UUID(moveOrder.UploadedOrdersID.String()),
@@ -499,9 +499,9 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 			}
 		}
 
-		deptIndicator := ""
+		var deptIndicator ghcmessages.DeptIndicator
 		if move.Orders.DepartmentIndicator != nil {
-			deptIndicator = *move.Orders.DepartmentIndicator
+			deptIndicator = ghcmessages.DeptIndicator(*move.Orders.DepartmentIndicator)
 		}
 
 		queueMoveOrders[i] = &ghcmessages.QueueMove{
@@ -509,7 +509,7 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 			Status:                 ghcmessages.QueueMoveStatus(move.Status),
 			ID:                     *handlers.FmtUUID(move.Orders.ID),
 			Locator:                move.Locator,
-			DepartmentIndicator:    ghcmessages.DeptIndicator(deptIndicator),
+			DepartmentIndicator:    &deptIndicator,
 			ShipmentsCount:         int64(len(validMTOShipments)),
 			DestinationDutyStation: DutyStation(&move.Orders.NewDutyStation),
 			OriginGBLOC:            ghcmessages.GBLOC(move.Orders.OriginDutyStation.TransportationOffice.Gbloc),
@@ -563,8 +563,9 @@ func QueuePaymentRequests(paymentRequests *models.PaymentRequests) *ghcmessages.
 			OriginGBLOC: ghcmessages.GBLOC(orders.OriginDutyStation.TransportationOffice.Gbloc),
 		}
 
-		if deptIndicator := orders.DepartmentIndicator; deptIndicator != nil {
-			queuePaymentRequests[i].DepartmentIndicator = ghcmessages.DeptIndicator(*deptIndicator)
+		if orders.DepartmentIndicator != nil {
+			deptIndicator := ghcmessages.DeptIndicator(*orders.DepartmentIndicator)
+			queuePaymentRequests[i].DepartmentIndicator = &deptIndicator
 		}
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -89,9 +89,9 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 		deptIndicator = ghcmessages.DeptIndicator(*moveOrder.DepartmentIndicator)
 	}
 
-	var orderTypeDetail ghcmessages.OrdersTypeDetail
+	var ordersTypeDetail ghcmessages.OrdersTypeDetail
 	if moveOrder.OrdersTypeDetail != nil {
-		orderTypeDetail = ghcmessages.OrdersTypeDetail(*moveOrder.OrdersTypeDetail)
+		ordersTypeDetail = ghcmessages.OrdersTypeDetail(*moveOrder.OrdersTypeDetail)
 	}
 
 	var grade ghcmessages.Grade
@@ -104,7 +104,7 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 		Entitlement:            entitlements,
 		Grade:                  &grade,
 		OrderNumber:            moveOrder.OrdersNumber,
-		OrderTypeDetail:        orderTypeDetail,
+		OrderTypeDetail:        &ordersTypeDetail,
 		ID:                     strfmt.UUID(moveOrder.ID.String()),
 		OriginDutyStation:      originDutyStation,
 		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -147,13 +147,14 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 	newAuthorizedWeight := int64(10000)
 	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 	grade := ghcmessages.GradeO5
+	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		AuthorizedWeight:    &newAuthorizedWeight,
 		Grade:               &grade,
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
-		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
+		OrdersTypeDetail:    &ordersTypeDetail,
 		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
@@ -209,12 +210,13 @@ func (suite *HandlerSuite) TestUpdateMoveOrderEventTrigger() {
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
 	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
+	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
-		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
+		OrdersTypeDetail:    &ordersTypeDetail,
 		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
@@ -258,6 +260,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerNotFound() {
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
 	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
+	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 
 	params := moveorderop.UpdateMoveOrderParams{
 		HTTPRequest: request,
@@ -267,7 +270,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerNotFound() {
 			IssueDate:           handlers.FmtDatePtr(&issueDate),
 			ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 			OrdersType:          "RETIREMENT",
-			OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
+			OrdersTypeDetail:    &ordersTypeDetail,
 			DepartmentIndicator: &deptIndicator,
 			OrdersNumber:        handlers.FmtString("ORDER100"),
 			NewDutyStationID:    handlers.FmtUUID(uuid.Nil),
@@ -300,12 +303,13 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerPreconditionsFailed() {
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
 	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
+	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
-		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
+		OrdersTypeDetail:    &ordersTypeDetail,
 		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
@@ -343,12 +347,13 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerBadRequest() {
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
 	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
+	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
-		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
+		OrdersTypeDetail:    &ordersTypeDetail,
 		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(uuid.Nil), // An unknown duty station will result in a invalid input error

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -145,6 +145,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
 
 	newAuthorizedWeight := int64(10000)
+	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 	grade := ghcmessages.GradeO5
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		AuthorizedWeight:    &newAuthorizedWeight,
@@ -153,7 +154,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
 		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
-		DepartmentIndicator: "COAST_GUARD",
+		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
@@ -207,13 +208,14 @@ func (suite *HandlerSuite) TestUpdateMoveOrderEventTrigger() {
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
+	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
 		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
-		DepartmentIndicator: "COAST_GUARD",
+		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
@@ -255,6 +257,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerNotFound() {
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
+	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 
 	params := moveorderop.UpdateMoveOrderParams{
 		HTTPRequest: request,
@@ -265,7 +268,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerNotFound() {
 			ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 			OrdersType:          "RETIREMENT",
 			OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
-			DepartmentIndicator: "COAST_GUARD",
+			DepartmentIndicator: &deptIndicator,
 			OrdersNumber:        handlers.FmtString("ORDER100"),
 			NewDutyStationID:    handlers.FmtUUID(uuid.Nil),
 			OriginDutyStationID: handlers.FmtUUID(uuid.Nil),
@@ -296,13 +299,14 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerPreconditionsFailed() {
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
+	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
 		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
-		DepartmentIndicator: "COAST_GUARD",
+		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
@@ -338,13 +342,14 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerBadRequest() {
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
+	deptIndicator := ghcmessages.DeptIndicator("COAST_GUARD")
 
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		IssueDate:           handlers.FmtDatePtr(&issueDate),
 		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
 		OrdersType:          "RETIREMENT",
 		OrdersTypeDetail:    "INSTRUCTION_20_WEEKS",
-		DepartmentIndicator: "COAST_GUARD",
+		DepartmentIndicator: &deptIndicator,
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(uuid.Nil), // An unknown duty station will result in a invalid input error
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -160,7 +160,10 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 		return models.Order{}, err
 	}
 
-	departmentIndicator := string(payload.DepartmentIndicator)
+	var departmentIndicator *string
+	if departmentIndicator != nil {
+		departmentIndicator = (*string)(payload.DepartmentIndicator)
+	}
 
 	var grade *string
 	if payload.Grade != nil {
@@ -173,7 +176,7 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 	}
 
 	return models.Order{
-		DepartmentIndicator: &departmentIndicator,
+		DepartmentIndicator: departmentIndicator,
 		Entitlement:         &entitlement,
 		Grade:               grade,
 		IssueDate:           time.Time(*payload.IssueDate),

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -148,8 +148,6 @@ func (h UpdateMoveOrderHandler) Handle(params moveorderop.UpdateMoveOrderParams)
 // MoveOrder transforms UpdateMoveOrderPayload to Order model
 func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error) {
 
-	ordersTypeDetail := internalmessages.OrdersTypeDetail(payload.OrdersTypeDetail)
-
 	var originDutyStationID uuid.UUID
 	if payload.OriginDutyStationID != nil {
 		originDutyStationID = uuid.FromStringOrNil(payload.OriginDutyStationID.String())
@@ -175,6 +173,12 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 		entitlement.DBAuthorizedWeight = swag.Int(int(*payload.AuthorizedWeight))
 	}
 
+	var ordersTypeDetail *internalmessages.OrdersTypeDetail
+	if payload.OrdersTypeDetail != nil {
+		orderTypeDetail := internalmessages.OrdersTypeDetail(*payload.OrdersTypeDetail)
+		ordersTypeDetail = &orderTypeDetail
+	}
+
 	return models.Order{
 		DepartmentIndicator: departmentIndicator,
 		Entitlement:         &entitlement,
@@ -183,7 +187,7 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 		NewDutyStationID:    newDutyStationID,
 		OrdersNumber:        payload.OrdersNumber,
 		OrdersType:          internalmessages.OrdersType(payload.OrdersType),
-		OrdersTypeDetail:    &ordersTypeDetail,
+		OrdersTypeDetail:    ordersTypeDetail,
 		OriginDutyStationID: &originDutyStationID,
 		ReportByDate:        time.Time(*payload.ReportByDate),
 		SAC:                 payload.Sac,

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -161,7 +161,7 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 	}
 
 	var departmentIndicator *string
-	if departmentIndicator != nil {
+	if payload.DepartmentIndicator != nil {
 		departmentIndicator = (*string)(payload.DepartmentIndicator)
 	}
 

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -78,10 +78,10 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandler() {
 
 	order := hhgMove.Orders
 	result := payload.QueueMoves[0]
-
+	deptIndicator := *result.DepartmentIndicator
 	suite.Len(payload.QueueMoves, 1)
 	suite.Equal(order.ServiceMember.ID.String(), result.Customer.ID.String())
-	suite.Equal(*order.DepartmentIndicator, string(result.DepartmentIndicator))
+	suite.Equal(*order.DepartmentIndicator, string(deptIndicator))
 	suite.Equal(order.OriginDutyStation.TransportationOffice.Gbloc, string(result.OriginGBLOC))
 	suite.Equal(order.NewDutyStation.ID.String(), result.DestinationDutyStation.ID.String())
 	suite.Equal(hhgMove.Locator, result.Locator)
@@ -819,12 +819,13 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 
 	createdAt := actualPaymentRequest.CreatedAt
 	age := int64(2)
+	deptIndicator := *paymentRequest.DepartmentIndicator
 
 	suite.Equal(age, paymentRequest.Age)
 	suite.Equal(createdAt.Format("2006-01-02T15:04:05.000Z07:00"), paymentRequest.SubmittedAt.String()) // swagger formats to milliseconds
 	suite.Equal(hhgMove.Locator, paymentRequest.Locator)
 
-	suite.Equal(*hhgMove.Orders.DepartmentIndicator, string(paymentRequest.DepartmentIndicator))
+	suite.Equal(*hhgMove.Orders.DepartmentIndicator, string(deptIndicator))
 }
 
 func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {

--- a/pkg/services/move_order/move_order_updater.go
+++ b/pkg/services/move_order/move_order_updater.go
@@ -73,14 +73,29 @@ func (s *moveOrderUpdater) UpdateMoveOrder(moveOrderID uuid.UUID, eTag string, m
 			existingOrder.Grade = moveOrder.Grade
 		}
 
+		if moveOrder.OrdersTypeDetail != nil {
+			existingOrder.OrdersTypeDetail = moveOrder.OrdersTypeDetail
+		}
+
+		if moveOrder.TAC != nil {
+			existingOrder.TAC = moveOrder.TAC
+		}
+
+		if moveOrder.SAC != nil {
+			existingOrder.SAC = moveOrder.SAC
+		}
+
+		if moveOrder.OrdersNumber != nil {
+			existingOrder.OrdersNumber = moveOrder.OrdersNumber
+		}
+
+		if moveOrder.DepartmentIndicator != nil {
+			existingOrder.DepartmentIndicator = moveOrder.DepartmentIndicator
+		}
+
 		existingOrder.IssueDate = moveOrder.IssueDate
 		existingOrder.ReportByDate = moveOrder.ReportByDate
 		existingOrder.OrdersType = moveOrder.OrdersType
-		existingOrder.OrdersTypeDetail = moveOrder.OrdersTypeDetail
-		existingOrder.OrdersNumber = moveOrder.OrdersNumber
-		existingOrder.TAC = moveOrder.TAC
-		existingOrder.SAC = moveOrder.SAC
-		existingOrder.DepartmentIndicator = moveOrder.DepartmentIndicator
 
 		verrs, updateErr := s.builder.UpdateOne(existingOrder, &eTag)
 

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -69,16 +69,12 @@ const MoveAllowances = () => {
   const onSubmit = (values) => {
     const { grade, authorizedWeight } = values;
     const body = {
-      departmentIndicator: moveOrder.department_indicator,
       issueDate: moveOrder.date_issued,
       newDutyStationId: moveOrder.destinationDutyStation.id,
       ordersNumber: moveOrder.order_number,
       ordersType: moveOrder.order_type,
-      ordersTypeDetail: moveOrder.order_type_detail,
       originDutyStationId: moveOrder.originDutyStation.id,
       reportByDate: moveOrder.report_by_date,
-      sac: moveOrder.sac,
-      tac: moveOrder.tac,
       grade,
       authorizedWeight: Number(authorizedWeight),
     };

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1616,6 +1616,7 @@ definitions:
   OrdersTypeDetail:
     type: string
     title: Orders type detail
+    x-nullable: true
     enum:
       - HHG_PERMITTED
       - PCS_TDY

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1591,6 +1591,7 @@ definitions:
   DeptIndicator:
     type: string
     title: Dept. indicator
+    x-nullable: true
     enum:
       - NAVY_AND_MARINES
       - ARMY
@@ -1756,6 +1757,7 @@ definitions:
         x-nullable: true
       departmentIndicator:
         $ref: '#/definitions/DeptIndicator'
+        x-nullable: true
       authorizedWeight:
         minimum: 1
         description: unit is in lbs
@@ -1769,12 +1771,8 @@ definitions:
       - issueDate
       - reportByDate
       - ordersType
-      - ordersTypeDetail
       - newDutyStationId
       - originDutyStationId
-      - ordersNumber
-      - tac
-      - departmentIndicator
   MoveTaskOrder:
     properties:
       id:


### PR DESCRIPTION
## Description

Fixed update move order endpoint by removing the requirement of fields deptIndivactor, tac, sac and orderTypeDetail and update any references to new nullable field. This also fixes the bug where it would blank out fields that were not provided in the payload

## Setup
`make server_run`
`make office_client_run`
Log in to TOO user
View a move that does not have fields deptIndicator, tac, sac and order type detail
Try editing allowances authorized weight and grade
Expected result: It should edit allowances correctly

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5846) for this change

