### PR TITLE
Fix flaky PPM office orders test

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -168,6 +168,12 @@ function officeUserVerifiesOrders(moveLocator) {
   // was ultimately saved when the page is refreshed (L190).
   // cy.get('span').contains('666666');
 
+  // Refresh browser and make sure changes persist
+  cy.patientReload();
+
+  cy.get('span').contains('666666');
+  cy.get('span').contains('Delayed Approval 20 Weeks or More');
+
   // Enter SAC
   cy.get('.combo-button button').should('be.disabled');
 


### PR DESCRIPTION
## Description

Quick follow up to the change made in: https://github.com/transcom/mymove/pull/5522

That PR addressed an issue in a PPM Office test where the timing of save API calls don't resolve in order, resulting in stale data persisting in the UI. The test continued to fail after merging that change because the test goes on to make a second edit/save elsewhere on the page, and since that second save includes the stale data, the data from the first change is actually reverted. This PR adds a page refresh in between the two edit/save interactions in order to prevent that.

I want to reiterate that the goal here is to make the tests pass more consistently, not to resolve the underlying bug (which will require reworking how the PPM Office forms save data to the API and update it in Redux)