### PR TITLE
[MB-6010] create model for Rand McNally data

### DIFF
--- a/pkg/models/zip3_distance.go
+++ b/pkg/models/zip3_distance.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
+)
+
+// Zip3Distance model struct
+type Zip3Distance struct {
+	ID            uuid.UUID `json:"id" db:"id"`
+	FromZip3      string    `json:"from_zip3" db:"from_zip3"`
+	ToZip3        string    `json:"to_zip3" db:"to_zip3"`
+	DistanceMiles int       `json:"distance_miles" db:"distance_miles"`
+	CreatedAt     time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// Zip3Distances is not required by pop and may be deleted
+type Zip3Distances []Zip3Distances
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (z *Zip3Distance) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.StringLengthInRange{Field: z.FromZip3, Name: "FromZip3", Min: 3, Max: 3},
+		&validators.StringLengthInRange{Field: z.ToZip3, Name: "ToZip3", Min: 3, Max: 3},
+		&validators.IntIsPresent{Field: z.DistanceMiles, Name: "DistanceMiles"},
+	), nil
+}

--- a/pkg/models/zip3_distance.go
+++ b/pkg/models/zip3_distance.go
@@ -9,6 +9,9 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// Note: we’ll need to remove this in the future when we
+// integrate with the Rand McNally API instead of the database table.
+
 // Zip3Distance model struct
 type Zip3Distance struct {
 	ID            uuid.UUID `json:"id" db:"id"`
@@ -20,7 +23,7 @@ type Zip3Distance struct {
 }
 
 // Zip3Distances is not required by pop and may be deleted
-type Zip3Distances []Zip3Distances
+type Zip3Distances []Zip3Distance
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.

--- a/pkg/models/zip3_distance_test.go
+++ b/pkg/models/zip3_distance_test.go
@@ -1,0 +1,64 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestZip3DistanceValidations() {
+	suite.T().Run("test valid Zip3Distance", func(t *testing.T) {
+		validZip3Distance := models.Zip3Distance{
+			FromZip3:      "010",
+			ToZip3:        "011",
+			DistanceMiles: 24,
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validZip3Distance, expErrors)
+	})
+
+	suite.T().Run("test invalid Zip3Distance", func(t *testing.T) {
+		emptyZip3Distance := models.Zip3Distance{}
+		expErrors := map[string][]string{
+			"from_zip3":      {"FromZip3 not in range(3, 3)"},
+			"to_zip3":        {"ToZip3 not in range(3, 3)"},
+			"distance_miles": {"DistanceMiles can not be blank."},
+		}
+		suite.verifyValidationErrors(&emptyZip3Distance, expErrors)
+	})
+
+	suite.T().Run("test when from_zip3 is not a length of 3", func(t *testing.T) {
+		invalidFromZip3Distance := models.Zip3Distance{
+			FromZip3:      "01",
+			ToZip3:        "011",
+			DistanceMiles: 24,
+		}
+		expErrors := map[string][]string{
+			"from_zip3": {"FromZip3 not in range(3, 3)"},
+		}
+		suite.verifyValidationErrors(&invalidFromZip3Distance, expErrors)
+	})
+
+	suite.T().Run("test when to_zip3 is not a length of 3", func(t *testing.T) {
+		invalidToZip3Distance := models.Zip3Distance{
+			FromZip3:      "010",
+			ToZip3:        "0115",
+			DistanceMiles: 24,
+		}
+		expErrors := map[string][]string{
+			"to_zip3": {"ToZip3 not in range(3, 3)"},
+		}
+		suite.verifyValidationErrors(&invalidToZip3Distance, expErrors)
+	})
+
+	suite.T().Run("test when distance_miles is not provided", func(t *testing.T) {
+		invalidDistance := models.Zip3Distance{
+			FromZip3: "010",
+			ToZip3:   "011",
+		}
+		expErrors := map[string][]string{
+			"distance_miles": {"DistanceMiles can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidDistance, expErrors)
+	})
+}

--- a/pkg/testdatagen/make_zip3_distance.go
+++ b/pkg/testdatagen/make_zip3_distance.go
@@ -1,0 +1,28 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop/v5"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeZip3Distance creates a single Zip3Distance
+func MakeZip3Distance(db *pop.Connection, assertions Assertions) models.Zip3Distance {
+	Zip3Distance := models.Zip3Distance{
+		FromZip3:      "010",
+		ToZip3:        "011",
+		DistanceMiles: 24,
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&Zip3Distance, assertions.Zip3Distance)
+
+	mustCreate(db, &Zip3Distance, assertions.Stub)
+
+	return Zip3Distance
+}
+
+// MakeDefaultZip3Distance makes a single Zip3Distance with default values
+func MakeDefaultZip3Distance(db *pop.Connection) models.Zip3Distance {
+	return MakeZip3Distance(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -90,6 +90,7 @@ type Assertions struct {
 	User                                     models.User
 	WebhookNotification                      models.WebhookNotification
 	WebhookSubscription                      models.WebhookSubscription
+	Zip3Distance                             models.Zip3Distance
 }
 
 func stringPointer(s string) *string {


### PR DESCRIPTION
## Description

In order to integrate the Rand McNally database table (zip3_distances) with the GHC Planner, we need a model for the RM data. I used this [Rand McNally doc](https://docs.google.com/document/d/1RWh1hGYZltWKYpiejauoBambRL_REcZJVfBnLN3P0_M/edit#heading=h.xk6y5kr3aui9) to create the struct for the data model

## Set Up
Confirm that the server test in `./pkg/models` are passing. 

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6010) for this change
* [Rand McNally Data Doc](https://docs.google.com/document/d/1RWh1hGYZltWKYpiejauoBambRL_REcZJVfBnLN3P0_M/edit#) used as a basis for determining the schema 

