### PR TITLE
Fixes for Happo Github workflow

### DIFF
--- a/.github/workflows/happo-tests-master.yml
+++ b/.github/workflows/happo-tests-master.yml
@@ -1,4 +1,4 @@
-name: Happo CI
+name: Happo CI (master)
 
 on:
   push:

--- a/.github/workflows/happo-tests-master.yml
+++ b/.github/workflows/happo-tests-master.yml
@@ -2,7 +2,7 @@ name: Happo CI (master)
 
 on:
   push:
-    branches: [master, sr-happo-fix-gh]
+    branches: [master]
 
 jobs:
   happo:

--- a/.github/workflows/happo-tests-master.yml
+++ b/.github/workflows/happo-tests-master.yml
@@ -1,28 +1,11 @@
 name: Happo CI
 
 on:
-  pull_request:
-    branches: [master]
+  push:
+    branches: [master, sr-happo-fix-gh]
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-    steps:
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            frontend:
-              - 'src/**'
-              - '.storybook/**'
-              - '.happo.js'
-              - 'yarn.lock'
-
   happo:
-    needs: changes
-    if: ${{ needs.changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/happo-tests.yml
+++ b/.github/workflows/happo-tests.yml
@@ -17,7 +17,7 @@ jobs:
           echo ${{ github.ref }}
           echo ${{ github.base_ref }}
       - uses: dorny/paths-filter@v2
-        id: filter
+        id: filterfix-
         with:
           filters: |
             frontend:
@@ -36,6 +36,8 @@ jobs:
 
       - name: Set up node
         uses: actions/setup-node@v1
+        with:
+          node-version: '12.16.3'
 
       - name: Install dependencies
         run: yarn install

--- a/src/components/Customer/SelectableCard.jsx
+++ b/src/components/Customer/SelectableCard.jsx
@@ -7,7 +7,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './SelectableCard.module.scss';
 
 const SelectableCard = ({ id, label, name, value, cardText, onChange, disabled, checked, onHelpClick }) => {
-  // no op
   return (
     <div className={classnames(styles.cardContainer, { [styles.selected]: checked })}>
       <div className={styles.cardTitle}>

--- a/src/components/Customer/SelectableCard.jsx
+++ b/src/components/Customer/SelectableCard.jsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './SelectableCard.module.scss';
 
 const SelectableCard = ({ id, label, name, value, cardText, onChange, disabled, checked, onHelpClick }) => {
+  // no op
   return (
     <div className={classnames(styles.cardContainer, { [styles.selected]: checked })}>
       <div className={styles.cardTitle}>


### PR DESCRIPTION
Fixes the node version to our .node-version (12.16.3) when running the Happo Github workflow. Also splits the master Happo run into a separate workflow to bypass the paths-filter logic (so Happo runs on all master pushes).