### PR TITLE
MB-4639 TOO can change 'Dependents Authorized' in the allowances viewer

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -184,6 +184,9 @@ describe('TOO user', () => {
     cy.get('select[name="grade"]').select('W-2');
     cy.get('input[name="authorizedWeight"]').clear().type('11111');
 
+    //Edit DependentsAuthorized
+    cy.get('input[name="dependentsAuthorized"]').click();
+
     // Edit allowances page | Save
     cy.get('button').contains('Save').click();
     // Verify edited values are saved
@@ -191,6 +194,7 @@ describe('TOO user', () => {
     cy.get('[data-testid="authorizedWeight"]').contains('11,111 lbs');
     cy.get('[data-testid="branchRank"]').contains('Navy');
     cy.get('[data-testid="branchRank"]').contains('W-2');
+    cy.get('[data-testid="dependents"]').contains('Unauthorized');
 
     // Edit allowances page | Cancel
     cy.get('[data-testid="edit-allowances"]').contains('Edit Allowances').click();

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3537,8 +3537,9 @@ func init() {
           "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
         },
-        "entitlements": {
-          "$ref": "#/definitions/Entitlements"
+        "dependentsAuthorized": {
+          "type": "boolean",
+          "x-nullable": true
         },
         "grade": {
           "$ref": "#/definitions/Grade"
@@ -7614,8 +7615,9 @@ func init() {
           "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
         },
-        "entitlements": {
-          "$ref": "#/definitions/Entitlements"
+        "dependentsAuthorized": {
+          "type": "boolean",
+          "x-nullable": true
         },
         "grade": {
           "$ref": "#/definitions/Grade"

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3537,6 +3537,9 @@ func init() {
           "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
         },
+        "entitlements": {
+          "$ref": "#/definitions/Entitlements"
+        },
         "grade": {
           "$ref": "#/definitions/Grade"
         },
@@ -7610,6 +7613,9 @@ func init() {
         "departmentIndicator": {
           "x-nullable": true,
           "$ref": "#/definitions/DeptIndicator"
+        },
+        "entitlements": {
+          "$ref": "#/definitions/Entitlements"
         },
         "grade": {
           "$ref": "#/definitions/Grade"

--- a/pkg/gen/ghcmessages/update_move_order_payload.go
+++ b/pkg/gen/ghcmessages/update_move_order_payload.go
@@ -28,8 +28,8 @@ type UpdateMoveOrderPayload struct {
 	// department indicator
 	DepartmentIndicator *DeptIndicator `json:"departmentIndicator,omitempty"`
 
-	// entitlements
-	Entitlements *Entitlements `json:"entitlements,omitempty"`
+	// dependents authorized
+	DependentsAuthorized *bool `json:"dependentsAuthorized,omitempty"`
 
 	// grade
 	Grade *Grade `json:"grade,omitempty"`
@@ -88,10 +88,6 @@ func (m *UpdateMoveOrderPayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDepartmentIndicator(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateEntitlements(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -164,24 +160,6 @@ func (m *UpdateMoveOrderPayload) validateDepartmentIndicator(formats strfmt.Regi
 		if err := m.DepartmentIndicator.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("departmentIndicator")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *UpdateMoveOrderPayload) validateEntitlements(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.Entitlements) { // not required
-		return nil
-	}
-
-	if m.Entitlements != nil {
-		if err := m.Entitlements.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("entitlements")
 			}
 			return err
 		}

--- a/pkg/gen/ghcmessages/update_move_order_payload.go
+++ b/pkg/gen/ghcmessages/update_move_order_payload.go
@@ -28,6 +28,9 @@ type UpdateMoveOrderPayload struct {
 	// department indicator
 	DepartmentIndicator *DeptIndicator `json:"departmentIndicator,omitempty"`
 
+	// entitlements
+	Entitlements *Entitlements `json:"entitlements,omitempty"`
+
 	// grade
 	Grade *Grade `json:"grade,omitempty"`
 
@@ -85,6 +88,10 @@ func (m *UpdateMoveOrderPayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDepartmentIndicator(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateEntitlements(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -157,6 +164,24 @@ func (m *UpdateMoveOrderPayload) validateDepartmentIndicator(formats strfmt.Regi
 		if err := m.DepartmentIndicator.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("departmentIndicator")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *UpdateMoveOrderPayload) validateEntitlements(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Entitlements) { // not required
+		return nil
+	}
+
+	if m.Entitlements != nil {
+		if err := m.Entitlements.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("entitlements")
 			}
 			return err
 		}

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -149,8 +149,8 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 	grade := ghcmessages.GradeO5
 	ordersTypeDetail := ghcmessages.OrdersTypeDetail("INSTRUCTION_20_WEEKS")
 	body := &ghcmessages.UpdateMoveOrderPayload{
-		AuthorizedWeight:    &newAuthorizedWeight,
-		Agency:              affiliation,
+		AuthorizedWeight:     &newAuthorizedWeight,
+		Agency:               affiliation,
 		DependentsAuthorized: swag.Bool(true),
 		Grade:                &grade,
 		IssueDate:            handlers.FmtDatePtr(&issueDate),

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -151,17 +151,18 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 	body := &ghcmessages.UpdateMoveOrderPayload{
 		AuthorizedWeight:    &newAuthorizedWeight,
 		Agency:              affiliation,
-		Grade:               &grade,
-		IssueDate:           handlers.FmtDatePtr(&issueDate),
-		ReportByDate:        handlers.FmtDatePtr(&reportByDate),
-		OrdersType:          "RETIREMENT",
-		OrdersTypeDetail:    &ordersTypeDetail,
-		DepartmentIndicator: &deptIndicator,
-		OrdersNumber:        handlers.FmtString("ORDER100"),
-		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
-		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
-		Tac:                 handlers.FmtString("012345678"),
-		Sac:                 handlers.FmtString("987654321"),
+		DependentsAuthorized: swag.Bool(true),
+		Grade:                &grade,
+		IssueDate:            handlers.FmtDatePtr(&issueDate),
+		ReportByDate:         handlers.FmtDatePtr(&reportByDate),
+		OrdersType:           "RETIREMENT",
+		OrdersTypeDetail:     &ordersTypeDetail,
+		DepartmentIndicator:  &deptIndicator,
+		OrdersNumber:         handlers.FmtString("ORDER100"),
+		NewDutyStationID:     handlers.FmtUUID(destinationDutyStation.ID),
+		OriginDutyStationID:  handlers.FmtUUID(originDutyStation.ID),
+		Tac:                  handlers.FmtString("012345678"),
+		Sac:                  handlers.FmtString("987654321"),
 	}
 
 	params := moveorderop.UpdateMoveOrderParams{
@@ -198,6 +199,7 @@ func (suite *HandlerSuite) TestUpdateMoveOrderHandlerIntegration() {
 	suite.Equal(body.AuthorizedWeight, moveOrdersPayload.Entitlement.AuthorizedWeight)
 	suite.Equal(body.Grade, moveOrdersPayload.Grade)
 	suite.Equal(body.Agency, moveOrdersPayload.Agency)
+	suite.Equal(body.DependentsAuthorized, moveOrdersPayload.Entitlement.DependentsAuthorized)
 }
 
 // Test that a move order notification got stored Successfully

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -81,7 +81,6 @@ type UpdateMoveOrderHandler struct {
 
 // Handle ... updates an order from a request payload
 func (h UpdateMoveOrderHandler) Handle(params moveorderop.UpdateMoveOrderParams) middleware.Responder {
-
 	_, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	orderID, err := uuid.FromString(params.MoveOrderID.String())
@@ -172,6 +171,10 @@ func MoveOrder(payload ghcmessages.UpdateMoveOrderPayload) (models.Order, error)
 	var entitlement models.Entitlement
 	if payload.AuthorizedWeight != nil {
 		entitlement.DBAuthorizedWeight = swag.Int(int(*payload.AuthorizedWeight))
+	}
+
+	if payload.DependentsAuthorized != nil {
+		entitlement.DependentsAuthorized = payload.DependentsAuthorized
 	}
 
 	var ordersTypeDetail *internalmessages.OrdersTypeDetail

--- a/pkg/services/move_order/move_order_updater.go
+++ b/pkg/services/move_order/move_order_updater.go
@@ -30,7 +30,6 @@ type UpdateMoveOrderQueryBuilder interface {
 }
 
 func (s *moveOrderUpdater) UpdateMoveOrder(moveOrderID uuid.UUID, eTag string, moveOrder models.Order) (*models.Order, error) {
-
 	existingOrder, err := s.moveOrderFetcher.FetchMoveOrder(moveOrder.ID)
 	if err != nil {
 		return nil, services.NewNotFoundError(moveOrder.ID, "while looking for moveOrder")
@@ -51,14 +50,14 @@ func (s *moveOrderUpdater) UpdateMoveOrder(moveOrderID uuid.UUID, eTag string, m
 			}
 		}
 
-		if moveOrder.Entitlement.DBAuthorizedWeight != nil || moveOrder.Entitlement.DependentsAuthorized != nil {
+		if entitlement := moveOrder.Entitlement; entitlement != nil && (entitlement.DBAuthorizedWeight != nil || entitlement.DependentsAuthorized != nil) {
 
-			if moveOrder.Entitlement.DBAuthorizedWeight != nil {
-				existingOrder.Entitlement.DBAuthorizedWeight = moveOrder.Entitlement.DBAuthorizedWeight
+			if entitlement.DBAuthorizedWeight != nil {
+				existingOrder.Entitlement.DBAuthorizedWeight = entitlement.DBAuthorizedWeight
 			}
 
-			if moveOrder.Entitlement.DependentsAuthorized != nil {
-				existingOrder.Entitlement.DependentsAuthorized = moveOrder.Entitlement.DependentsAuthorized
+			if entitlement.DependentsAuthorized != nil {
+				existingOrder.Entitlement.DependentsAuthorized = entitlement.DependentsAuthorized
 			}
 
 			err = tx.Save(existingOrder.Entitlement)

--- a/pkg/services/move_order/move_order_updater.go
+++ b/pkg/services/move_order/move_order_updater.go
@@ -51,8 +51,16 @@ func (s *moveOrderUpdater) UpdateMoveOrder(moveOrderID uuid.UUID, eTag string, m
 			}
 		}
 
-		if moveOrder.Entitlement.DBAuthorizedWeight != nil {
-			existingOrder.Entitlement.DBAuthorizedWeight = moveOrder.Entitlement.DBAuthorizedWeight
+		if moveOrder.Entitlement.DBAuthorizedWeight != nil || moveOrder.Entitlement.DependentsAuthorized != nil {
+
+			if moveOrder.Entitlement.DBAuthorizedWeight != nil {
+				existingOrder.Entitlement.DBAuthorizedWeight = moveOrder.Entitlement.DBAuthorizedWeight
+			}
+
+			if moveOrder.Entitlement.DependentsAuthorized != nil {
+				existingOrder.Entitlement.DependentsAuthorized = moveOrder.Entitlement.DependentsAuthorized
+			}
+
 			err = tx.Save(existingOrder.Entitlement)
 			if err != nil {
 				return err

--- a/pkg/services/move_order/move_order_updater_test.go
+++ b/pkg/services/move_order/move_order_updater_test.go
@@ -1,0 +1,99 @@
+package moveorder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *MoveOrderServiceSuite) TestMoveOrderUpdater() {
+	expectedMoveTaskOrder := testdatagen.MakeDefaultMove(suite.DB())
+	expectedMoveOrder := expectedMoveTaskOrder.Orders
+
+	queryBuilder := query.NewQueryBuilder(suite.DB())
+	moveOrderUpdater := NewMoveOrderUpdater(suite.DB(), queryBuilder)
+
+	suite.T().Run("NotFoundError when order id doesn't exit", func(t *testing.T) {
+		_, err := moveOrderUpdater.UpdateMoveOrder(uuid.Nil, "", models.Order{})
+		suite.Error(err)
+		suite.IsType(services.NotFoundError{}, err)
+	})
+
+	suite.T().Run("PreconditionsError when etag is stale", func(t *testing.T) {
+		staleEtag := etag.GenerateEtag(expectedMoveOrder.UpdatedAt.Add(-1 * time.Minute))
+		_, err := moveOrderUpdater.UpdateMoveOrder(expectedMoveOrder.ID, staleEtag, models.Order{ID: expectedMoveOrder.ID})
+		suite.IsType(services.PreconditionFailedError{}, err)
+	})
+
+	suite.T().Run("Orders fields are updated without entitlement", func(t *testing.T) {
+		defaultMoveOrder := testdatagen.MakeDefaultMove(suite.DB()).Orders
+
+		newDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
+		issueDate := time.Now().Add(-48 * time.Hour)
+		reportByDate := time.Now().Add(72 * time.Hour)
+		ordersTypeDetail := internalmessages.OrdersTypeDetailINSTRUCTION20WEEKS
+		updatedMoveOrder := models.Order{
+			ID:                  defaultMoveOrder.ID,
+			OriginDutyStationID: &newDutyStation.ID,
+			NewDutyStationID:    newDutyStation.ID,
+			IssueDate:           issueDate,
+			ReportByDate:        reportByDate,
+			DepartmentIndicator: swag.String("COAST_GUARD"),
+			OrdersType:          internalmessages.OrdersTypeSEPARATION,
+			OrdersTypeDetail:    &ordersTypeDetail,
+			Grade:               swag.String(string(models.ServiceMemberRankO10)),
+			OrdersNumber:        swag.String("1122334455"),
+			TAC:                 swag.String("8843"),
+			SAC:                 swag.String("7766"),
+		}
+
+		expectedETag := etag.GenerateEtag(defaultMoveOrder.UpdatedAt)
+		actualOrder, err := moveOrderUpdater.UpdateMoveOrder(defaultMoveOrder.ID, expectedETag, updatedMoveOrder)
+
+		suite.NoError(err)
+		suite.Equal(updatedMoveOrder.ID, actualOrder.ID)
+		suite.Equal(updatedMoveOrder.NewDutyStationID, actualOrder.NewDutyStation.ID)
+		suite.Equal(updatedMoveOrder.OriginDutyStationID.String(), actualOrder.OriginDutyStation.ID.String())
+		suite.Equal(updatedMoveOrder.IssueDate, actualOrder.IssueDate)
+		suite.Equal(updatedMoveOrder.ReportByDate, actualOrder.ReportByDate)
+		suite.Equal(updatedMoveOrder.OrdersType, actualOrder.OrdersType)
+		suite.Equal(updatedMoveOrder.OrdersTypeDetail, actualOrder.OrdersTypeDetail)
+		suite.Equal(updatedMoveOrder.OrdersNumber, actualOrder.OrdersNumber)
+		suite.Equal(updatedMoveOrder.DepartmentIndicator, actualOrder.DepartmentIndicator)
+		suite.Equal(updatedMoveOrder.TAC, actualOrder.TAC)
+		suite.Equal(updatedMoveOrder.SAC, actualOrder.SAC)
+		suite.Equal(updatedMoveOrder.Grade, actualOrder.Grade)
+	})
+
+	suite.T().Run("Entitlement is updated with authorizedWeight or dependentsAuthorized", func(t *testing.T) {
+		defaultMoveOrder := testdatagen.MakeDefaultMove(suite.DB()).Orders
+		updatedMoveOrder := models.Order{
+			ID:                  defaultMoveOrder.ID,
+			OriginDutyStationID: defaultMoveOrder.OriginDutyStationID,
+			NewDutyStationID:    defaultMoveOrder.NewDutyStationID,
+			IssueDate:           defaultMoveOrder.IssueDate,
+			ReportByDate:        defaultMoveOrder.ReportByDate,
+			OrdersType:          defaultMoveOrder.OrdersType,
+			Entitlement: &models.Entitlement{
+				DBAuthorizedWeight:   swag.Int(20000),
+				DependentsAuthorized: swag.Bool(true),
+			},
+		}
+
+		expectedETag := etag.GenerateEtag(defaultMoveOrder.UpdatedAt)
+		actualOrder, err := moveOrderUpdater.UpdateMoveOrder(defaultMoveOrder.ID, expectedETag, updatedMoveOrder)
+
+		suite.NoError(err)
+		suite.Equal(swag.Int(20000), actualOrder.Entitlement.DBAuthorizedWeight)
+		suite.Equal(swag.Bool(true), actualOrder.Entitlement.DependentsAuthorized)
+	})
+}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1180,6 +1180,14 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b63"),
 		},
 	})
+
+	dependentsAuthorized := true
+
+	entitlements := testdatagen.MakeEntitlement(db, testdatagen.Assertions{
+		Entitlement: models.Entitlement{
+			DependentsAuthorized: &dependentsAuthorized,
+		},
+	})
 	orders := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
 			ID:              uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4988"),
@@ -1187,6 +1195,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			ServiceMember:   customer,
 		},
 		UserUploader: userUploader,
+		Entitlement:  entitlements,
 	})
 	mtoSelectedMoveType := models.SelectedMoveTypeHHG
 	mto := testdatagen.MakeMove(db, testdatagen.Assertions{

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Fieldset, Checkbox } from '@trussworks/react-uswds';
 
 import styles from './AllowancesDetailForm.module.scss';
 
@@ -40,6 +41,9 @@ const AllowancesDetailForm = ({ entitlements, rankOptions, branchOptions }) => {
         <dt>Storage in-transit</dt>
         <dd data-testid="storageInTransit">{formatDaysInTransit(entitlements.storageInTransit)}</dd>
       </dl>
+      <Fieldset>
+        <Checkbox data-testid="dependentsAuthorized" />
+      </Fieldset>
     </div>
   );
 };

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Fieldset, Checkbox } from '@trussworks/react-uswds';
+import { Field } from 'formik';
 
 import styles from './AllowancesDetailForm.module.scss';
 
@@ -42,14 +41,10 @@ const AllowancesDetailForm = ({ entitlements, rankOptions, branchOptions }) => {
         <dt>Storage in-transit</dt>
         <dd data-testid="storageInTransit">{formatDaysInTransit(entitlements.storageInTransit)}</dd>
       </dl>
-      <Fieldset>
-        <Checkbox
-          name="dependentsAuthorized"
-          label="Dependents authorized"
-          checked={entitlements.dependentsAuthorized}
-          onChange={onCheckboxChange}
-        />
-      </Fieldset>
+      <div className={styles.DependentsAuthorized}>
+        <Field type="checkbox" name="dependentsAuthorized" />
+        <label htmlFor="dependentsAuthorized"> Dependents Authorized</label>
+      </div>
     </div>
   );
 };

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Fieldset, Checkbox } from '@trussworks/react-uswds';
 
 import styles from './AllowancesDetailForm.module.scss';
@@ -42,7 +43,12 @@ const AllowancesDetailForm = ({ entitlements, rankOptions, branchOptions }) => {
         <dd data-testid="storageInTransit">{formatDaysInTransit(entitlements.storageInTransit)}</dd>
       </dl>
       <Fieldset>
-        <Checkbox data-testid="dependentsAuthorized" />
+        <Checkbox
+          name="dependentsAuthorized"
+          label="Dependents authorized"
+          checked={entitlements.dependentsAuthorized}
+          onChange={onCheckboxChange}
+        />
       </Fieldset>
     </div>
   );

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.module.scss
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.module.scss
@@ -24,7 +24,7 @@
     @include u-margin-bottom(3);
   }
 
-  fieldset {
+  .DependentsAuthorized {
     @include u-padding-top(1);
     @include u-padding-bottom(1);
     @include u-padding-left(2);

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.module.scss
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.module.scss
@@ -23,4 +23,12 @@
     @include u-margin-left(0);
     @include u-margin-bottom(3);
   }
+
+  fieldset {
+    @include u-padding-top(1);
+    @include u-padding-bottom(1);
+    @include u-padding-left(2);
+    border: 1px solid $base-lighter;
+    border-radius: 4px;
+  }
 }

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -75,5 +75,8 @@ describe('AllowancesDetailForm', () => {
 
     // Storage in-transit
     expect(wrapperNoProps.find('dd').at(3).text()).toBe('0 days');
+
+    // Dependents authorized
+    expect(wrapperNoProps.exists('dependentsAuthorized')).to.equal(true);
   });
 });

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -9,6 +9,18 @@ const initialValues = {
   authorizedWeight: '11000',
 };
 
+const rankOptions = [
+  { key: 'E_1', value: 'E-1' },
+  { key: 'E_2', value: 'E-2' },
+  { key: 'E_3', value: 'E-3' },
+  { key: 'E_4', value: 'E-4' },
+  { key: 'E_5', value: 'E-5' },
+  { key: 'E_6', value: 'E-6' },
+  { key: 'E_7', value: 'E-7' },
+  { key: 'E_8', value: 'E-8' },
+  { key: 'E_9', value: 'E-9' },
+];
+
 const entitlements = {
   authorizedWeight: 11000,
   dependentsAuthorized: true,
@@ -25,7 +37,7 @@ describe('AllowancesDetailForm', () => {
   const wrapper = mount(
     <Formik initialValues={initialValues} onSubmit={jest.fn()}>
       <form>
-        <AllowancesDetailForm entitlements={entitlements} />
+        <AllowancesDetailForm entitlements={entitlements} rankOptions={rankOptions} />
       </form>
     </Formik>,
   );
@@ -56,7 +68,7 @@ describe('AllowancesDetailForm', () => {
     const wrapperNoProps = mount(
       <Formik initialValues={{ authorizedWeight: null }} onSubmit={jest.fn()}>
         <form>
-          <AllowancesDetailForm entitlements={{}} />
+          <AllowancesDetailForm entitlements={{}} rankOptions={[]} />
         </form>
       </Formik>,
     );
@@ -77,6 +89,6 @@ describe('AllowancesDetailForm', () => {
     expect(wrapperNoProps.find('dd').at(3).text()).toBe('0 days');
 
     // Dependents authorized
-    expect(wrapperNoProps.exists('dependentsAuthorized')).to.equal(true);
+    expect(wrapperNoProps.find(`[name="dependentsAuthorized"]`)).toBeTruthy();
   });
 });

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -70,7 +70,7 @@ const MoveAllowances = () => {
 
   const moveOrder = Object.values(moveOrders)?.[0];
   const onSubmit = (values) => {
-    const { grade, authorizedWeight, agency } = values;
+    const { grade, authorizedWeight, agency, dependentsAuthorized } = values;
     const body = {
       issueDate: moveOrder.date_issued,
       newDutyStationId: moveOrder.destinationDutyStation.id,
@@ -81,6 +81,7 @@ const MoveAllowances = () => {
       grade,
       authorizedWeight: Number(authorizedWeight),
       agency,
+      dependentsAuthorized,
     };
     mutateOrders({ moveOrderID: moveOrderId, ifMatchETag: moveOrder.eTag, body });
   };
@@ -88,9 +89,9 @@ const MoveAllowances = () => {
   const documentsForViewer = Object.values(upload);
 
   const { entitlement, grade, agency } = moveOrder;
-  const { authorizedWeight } = entitlement;
+  const { authorizedWeight, dependentsAuthorized } = entitlement;
 
-  const initialValues = { authorizedWeight: `${authorizedWeight}`, grade, agency };
+  const initialValues = { authorizedWeight: `${authorizedWeight}`, grade, agency, dependentsAuthorized };
 
   return (
     <div className={moveOrdersStyles.MoveOrders}>

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1815,6 +1815,8 @@ definitions:
       agency:
         description: the branch that the service member belongs to
         $ref: '#/definitions/Branch'
+      entitlements:
+        $ref: '#/definitions/Entitlements'
     required:
       - issueDate
       - reportByDate

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1818,8 +1818,6 @@ definitions:
       agency:
         description: the branch that the service member belongs to
         $ref: '#/definitions/Branch'
-      entitlements:
-        $ref: '#/definitions/Entitlements'
     required:
       - issueDate
       - reportByDate

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1812,6 +1812,9 @@ definitions:
         x-nullable: true
       grade:
         $ref: '#/definitions/Grade'
+      dependentsAuthorized:
+        type: boolean
+        x-nullable: true
       agency:
         description: the branch that the service member belongs to
         $ref: '#/definitions/Branch'


### PR DESCRIPTION
## Description

Added the "Dependents Authorized" checkbox and functionality to the Weight Allowances form.

## Reviewer Notes

Due to a git issue, a thorough code review is needed to ensure all looks as expected.

## Code Review Verification Steps

While signed in as a TOO, view a move.
On the Allowances table, "Dependents Authorized" should be "Authorized"
Edit the Allowances
On the Allowances form, click the "Dependents Authorized" checkbox
Click Save
Dependents Authorized should now be "Unauthorized" 


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots

![Screen Shot 2020-12-23 at 6 42 59 PM](https://user-images.githubusercontent.com/1587316/103044489-af8dbf00-454e-11eb-8383-6ea59b60c784.png)

