### PR TITLE
[MB-3912] Drop unused confirmation_number column, replace with move code in payloads

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -584,3 +584,4 @@
 20201120174609_add_indexes_for_move_selected_type.up.sql
 20201207223002_create_zip3_distances.up.sql
 20201208215206_load_zip3_distances.up.sql
+20201229155602_drop_confirmation_number_from_orders.up.sql

--- a/migrations/app/schema/20201229155602_drop_confirmation_number_from_orders.up.sql
+++ b/migrations/app/schema/20201229155602_drop_confirmation_number_from_orders.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+DROP COLUMN confirmation_number;

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -2767,10 +2767,6 @@ func init() {
           "type": "string",
           "$ref": "#/definitions/Branch"
         },
-        "confirmation_number": {
-          "type": "string",
-          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
-        },
         "customerID": {
           "type": "string",
           "format": "uuid",
@@ -2816,6 +2812,10 @@ func init() {
           "type": "string",
           "readOnly": true,
           "example": "Doe"
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "H2XFJF"
         },
         "moveTaskOrderID": {
           "type": "string",
@@ -6842,10 +6842,6 @@ func init() {
           "type": "string",
           "$ref": "#/definitions/Branch"
         },
-        "confirmation_number": {
-          "type": "string",
-          "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
-        },
         "customerID": {
           "type": "string",
           "format": "uuid",
@@ -6891,6 +6887,10 @@ func init() {
           "type": "string",
           "readOnly": true,
           "example": "Doe"
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "H2XFJF"
         },
         "moveTaskOrderID": {
           "type": "string",

--- a/pkg/gen/ghcmessages/move_order.go
+++ b/pkg/gen/ghcmessages/move_order.go
@@ -20,9 +20,6 @@ type MoveOrder struct {
 	// agency
 	Agency Branch `json:"agency,omitempty"`
 
-	// confirmation number
-	ConfirmationNumber string `json:"confirmation_number,omitempty"`
-
 	// customer ID
 	// Format: uuid
 	CustomerID strfmt.UUID `json:"customerID,omitempty"`
@@ -60,6 +57,9 @@ type MoveOrder struct {
 	// last name
 	// Read Only: true
 	LastName string `json:"last_name,omitempty"`
+
+	// move code
+	MoveCode string `json:"moveCode,omitempty"`
 
 	// move task order ID
 	// Format: uuid

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1675,10 +1675,6 @@ func init() {
         "linesOfAccounting": {
           "type": "string"
         },
-        "moveCode": {
-          "type": "string",
-          "example": "HYXFJF"
-        },
         "orderNumber": {
           "type": "string"
         },
@@ -1726,6 +1722,10 @@ func init() {
         "isCanceled": {
           "type": "boolean",
           "x-nullable": true
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "HYXFJF"
         },
         "moveOrder": {
           "$ref": "#/definitions/MoveOrder"
@@ -4134,10 +4134,6 @@ func init() {
         "linesOfAccounting": {
           "type": "string"
         },
-        "moveCode": {
-          "type": "string",
-          "example": "HYXFJF"
-        },
         "orderNumber": {
           "type": "string"
         },
@@ -4185,6 +4181,10 @@ func init() {
         "isCanceled": {
           "type": "boolean",
           "x-nullable": true
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "HYXFJF"
         },
         "moveOrder": {
           "$ref": "#/definitions/MoveOrder"

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1723,7 +1723,7 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "locator": {
+        "moveCode": {
           "type": "string",
           "readOnly": true,
           "example": "HYXFJF"
@@ -4183,7 +4183,7 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "locator": {
+        "moveCode": {
           "type": "string",
           "readOnly": true,
           "example": "HYXFJF"

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1723,8 +1723,9 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "moveCode": {
+        "locator": {
           "type": "string",
+          "readOnly": true,
           "example": "HYXFJF"
         },
         "moveOrder": {
@@ -4182,8 +4183,9 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "moveCode": {
+        "locator": {
           "type": "string",
+          "readOnly": true,
           "example": "HYXFJF"
         },
         "moveOrder": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1649,11 +1649,6 @@ func init() {
         "linesOfAccounting"
       ],
       "properties": {
-        "confirmationNumber": {
-          "type": "string",
-          "x-nullable": true,
-          "example": "HYXFJF"
-        },
         "customer": {
           "$ref": "#/definitions/Customer"
         },
@@ -1679,6 +1674,10 @@ func init() {
         },
         "linesOfAccounting": {
           "type": "string"
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "HYXFJF"
         },
         "orderNumber": {
           "type": "string"
@@ -4109,11 +4108,6 @@ func init() {
         "linesOfAccounting"
       ],
       "properties": {
-        "confirmationNumber": {
-          "type": "string",
-          "x-nullable": true,
-          "example": "HYXFJF"
-        },
         "customer": {
           "$ref": "#/definitions/Customer"
         },
@@ -4139,6 +4133,10 @@ func init() {
         },
         "linesOfAccounting": {
           "type": "string"
+        },
+        "moveCode": {
+          "type": "string",
+          "example": "HYXFJF"
         },
         "orderNumber": {
           "type": "string"

--- a/pkg/gen/primemessages/move_order.go
+++ b/pkg/gen/primemessages/move_order.go
@@ -42,9 +42,6 @@ type MoveOrder struct {
 	// Required: true
 	LinesOfAccounting *string `json:"linesOfAccounting"`
 
-	// move code
-	MoveCode string `json:"moveCode,omitempty"`
-
 	// order number
 	// Required: true
 	OrderNumber *string `json:"orderNumber"`

--- a/pkg/gen/primemessages/move_order.go
+++ b/pkg/gen/primemessages/move_order.go
@@ -17,9 +17,6 @@ import (
 // swagger:model MoveOrder
 type MoveOrder struct {
 
-	// confirmation number
-	ConfirmationNumber *string `json:"confirmationNumber,omitempty"`
-
 	// customer
 	Customer *Customer `json:"customer,omitempty"`
 
@@ -44,6 +41,9 @@ type MoveOrder struct {
 	// lines of accounting
 	// Required: true
 	LinesOfAccounting *string `json:"linesOfAccounting"`
+
+	// move code
+	MoveCode string `json:"moveCode,omitempty"`
 
 	// order number
 	// Required: true

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -44,6 +44,9 @@ type MoveTaskOrder struct {
 	// is canceled
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
+	// move code
+	MoveCode string `json:"moveCode,omitempty"`
+
 	// move order
 	MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
@@ -100,6 +103,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
+		MoveCode string `json:"moveCode,omitempty"`
+
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
 		MoveOrderID strfmt.UUID `json:"moveOrderID,omitempty"`
@@ -148,6 +153,9 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// isCanceled
 	result.IsCanceled = data.IsCanceled
 
+	// moveCode
+	result.MoveCode = data.MoveCode
+
 	// moveOrder
 	result.MoveOrder = data.MoveOrder
 
@@ -195,6 +203,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
+		MoveCode string `json:"moveCode,omitempty"`
+
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
 		MoveOrderID strfmt.UUID `json:"moveOrderID,omitempty"`
@@ -221,6 +231,8 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 		ID: m.ID,
 
 		IsCanceled: m.IsCanceled,
+
+		MoveCode: m.MoveCode,
 
 		MoveOrder: m.MoveOrder,
 

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -44,9 +44,9 @@ type MoveTaskOrder struct {
 	// is canceled
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
-	// locator
+	// move code
 	// Read Only: true
-	Locator string `json:"locator,omitempty"`
+	MoveCode string `json:"moveCode,omitempty"`
 
 	// move order
 	MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
@@ -104,7 +104,7 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		Locator string `json:"locator,omitempty"`
+		MoveCode string `json:"moveCode,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
@@ -154,8 +154,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// isCanceled
 	result.IsCanceled = data.IsCanceled
 
-	// locator
-	result.Locator = data.Locator
+	// moveCode
+	result.MoveCode = data.MoveCode
 
 	// moveOrder
 	result.MoveOrder = data.MoveOrder
@@ -204,7 +204,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		Locator string `json:"locator,omitempty"`
+		MoveCode string `json:"moveCode,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
@@ -233,7 +233,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled: m.IsCanceled,
 
-		Locator: m.Locator,
+		MoveCode: m.MoveCode,
 
 		MoveOrder: m.MoveOrder,
 

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -44,8 +44,9 @@ type MoveTaskOrder struct {
 	// is canceled
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
-	// move code
-	MoveCode string `json:"moveCode,omitempty"`
+	// locator
+	// Read Only: true
+	Locator string `json:"locator,omitempty"`
 
 	// move order
 	MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
@@ -103,7 +104,7 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		MoveCode string `json:"moveCode,omitempty"`
+		Locator string `json:"locator,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
@@ -153,8 +154,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// isCanceled
 	result.IsCanceled = data.IsCanceled
 
-	// moveCode
-	result.MoveCode = data.MoveCode
+	// locator
+	result.Locator = data.Locator
 
 	// moveOrder
 	result.MoveOrder = data.MoveOrder
@@ -203,7 +204,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		MoveCode string `json:"moveCode,omitempty"`
+		Locator string `json:"locator,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder,omitempty"`
 
@@ -232,7 +233,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled: m.IsCanceled,
 
-		MoveCode: m.MoveCode,
+		Locator: m.Locator,
 
 		MoveOrder: m.MoveOrder,
 

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1512,7 +1512,7 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "locator": {
+        "moveCode": {
           "description": "Unique 6-character code the customer can use to refer to their move",
           "type": "string",
           "readOnly": true,
@@ -3711,7 +3711,7 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
-        "locator": {
+        "moveCode": {
           "description": "Unique 6-character code the customer can use to refer to their move",
           "type": "string",
           "readOnly": true,

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1515,6 +1515,7 @@ func init() {
         "locator": {
           "description": "Unique 6-character code the customer can use to refer to their move",
           "type": "string",
+          "readOnly": true,
           "example": "ABC123"
         },
         "moveOrder": {
@@ -3713,6 +3714,7 @@ func init() {
         "locator": {
           "description": "Unique 6-character code the customer can use to refer to their move",
           "type": "string",
+          "readOnly": true,
           "example": "ABC123"
         },
         "moveOrder": {

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -59,7 +59,7 @@ type MoveTaskOrder struct {
 
 	// Unique 6-character code the customer can use to refer to their move
 	// Read Only: true
-	Locator string `json:"locator,omitempty"`
+	MoveCode string `json:"moveCode,omitempty"`
 
 	// move order
 	// Required: true
@@ -125,7 +125,7 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		Locator string `json:"locator,omitempty"`
+		MoveCode string `json:"moveCode,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder"`
 
@@ -184,8 +184,8 @@ func (m *MoveTaskOrder) UnmarshalJSON(raw []byte) error {
 	// isCanceled
 	result.IsCanceled = data.IsCanceled
 
-	// locator
-	result.Locator = data.Locator
+	// moveCode
+	result.MoveCode = data.MoveCode
 
 	// moveOrder
 	result.MoveOrder = data.MoveOrder
@@ -239,7 +239,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled *bool `json:"isCanceled,omitempty"`
 
-		Locator string `json:"locator,omitempty"`
+		MoveCode string `json:"moveCode,omitempty"`
 
 		MoveOrder *MoveOrder `json:"moveOrder"`
 
@@ -272,7 +272,7 @@ func (m MoveTaskOrder) MarshalJSON() ([]byte, error) {
 
 		IsCanceled: m.IsCanceled,
 
-		Locator: m.Locator,
+		MoveCode: m.MoveCode,
 
 		MoveOrder: m.MoveOrder,
 

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -58,6 +58,7 @@ type MoveTaskOrder struct {
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
 	// Unique 6-character code the customer can use to refer to their move
+	// Read Only: true
 	Locator string `json:"locator,omitempty"`
 
 	// move order

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -109,6 +109,11 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 		branch = ghcmessages.Branch(*moveOrder.ServiceMember.Affiliation)
 	}
 
+	var moveCode string
+	if moveOrder.Moves != nil && len(moveOrder.Moves) > 0 {
+		moveCode = moveOrder.Moves[0].Locator
+	}
+
 	payload := ghcmessages.MoveOrder{
 		DestinationDutyStation: destinationDutyStation,
 		Entitlement:            entitlements,
@@ -129,10 +134,7 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 		Tac:                    handlers.FmtStringPtr(moveOrder.TAC),
 		Sac:                    handlers.FmtStringPtr(moveOrder.SAC),
 		UploadedOrderID:        strfmt.UUID(moveOrder.UploadedOrdersID.String()),
-	}
-
-	if moveOrder.ConfirmationNumber != nil {
-		payload.ConfirmationNumber = *moveOrder.ConfirmationNumber
+		MoveCode:               moveCode,
 	}
 
 	return &payload

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -42,6 +42,7 @@ func (suite *HandlerSuite) TestGetMoveOrderHandlerIntegration() {
 
 	suite.Assertions.IsType(&moveorderop.GetMoveOrderOK{}, response)
 	suite.Equal(moveOrder.ID.String(), moveOrdersPayload.ID.String())
+	suite.Equal(moveTaskOrder.Locator, moveOrdersPayload.MoveCode)
 	suite.Equal(moveOrder.ServiceMemberID.String(), moveOrdersPayload.CustomerID.String())
 	suite.Equal(moveOrder.NewDutyStationID.String(), moveOrdersPayload.DestinationDutyStation.ID.String())
 	suite.NotNil(moveOrder.NewDutyStation)

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -24,7 +24,7 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *primemessages.MoveTaskOrder {
 	mtoShipments := MTOShipments(&moveTaskOrder.MTOShipments)
 	payload := &primemessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
-		Locator:            moveTaskOrder.Locator,
+		MoveCode:           moveTaskOrder.Locator,
 		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         moveTaskOrder.IsCanceled(),

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -24,6 +24,7 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *primemessages.MoveTaskOrder {
 	mtoShipments := MTOShipments(&moveTaskOrder.MTOShipments)
 	payload := &primemessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
+		MoveCode:           moveTaskOrder.Locator,
 		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         moveTaskOrder.IsCanceled(),
@@ -99,11 +100,6 @@ func MoveOrder(moveOrder *models.Order) *primemessages.MoveOrder {
 	}
 	entitlements := Entitlement(moveOrder.Entitlement)
 
-	var moveCode string
-	if moveOrder.Moves != nil && len(moveOrder.Moves) > 0 {
-		moveCode = moveOrder.Moves[0].Locator
-	}
-
 	payload := primemessages.MoveOrder{
 		CustomerID:             strfmt.UUID(moveOrder.ServiceMemberID.String()),
 		Customer:               Customer(&moveOrder.ServiceMember),
@@ -116,7 +112,6 @@ func MoveOrder(moveOrder *models.Order) *primemessages.MoveOrder {
 		Rank:                   moveOrder.Grade,
 		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),
 		ReportByDate:           strfmt.Date(moveOrder.ReportByDate),
-		MoveCode:               moveCode,
 	}
 
 	return &payload

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -24,7 +24,7 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *primemessages.MoveTaskOrder {
 	mtoShipments := MTOShipments(&moveTaskOrder.MTOShipments)
 	payload := &primemessages.MoveTaskOrder{
 		ID:                 strfmt.UUID(moveTaskOrder.ID.String()),
-		MoveCode:           moveTaskOrder.Locator,
+		Locator:            moveTaskOrder.Locator,
 		CreatedAt:          strfmt.DateTime(moveTaskOrder.CreatedAt),
 		AvailableToPrimeAt: handlers.FmtDateTimePtr(moveTaskOrder.AvailableToPrimeAt),
 		IsCanceled:         moveTaskOrder.IsCanceled(),

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -98,6 +98,12 @@ func MoveOrder(moveOrder *models.Order) *primemessages.MoveOrder {
 		moveOrder.Entitlement.SetWeightAllotment(*moveOrder.Grade)
 	}
 	entitlements := Entitlement(moveOrder.Entitlement)
+
+	var moveCode string
+	if moveOrder.Moves != nil && len(moveOrder.Moves) > 0 {
+		moveCode = moveOrder.Moves[0].Locator
+	}
+
 	payload := primemessages.MoveOrder{
 		CustomerID:             strfmt.UUID(moveOrder.ServiceMemberID.String()),
 		Customer:               Customer(&moveOrder.ServiceMember),
@@ -108,9 +114,9 @@ func MoveOrder(moveOrder *models.Order) *primemessages.MoveOrder {
 		OrderNumber:            moveOrder.OrdersNumber,
 		LinesOfAccounting:      moveOrder.TAC,
 		Rank:                   moveOrder.Grade,
-		ConfirmationNumber:     moveOrder.ConfirmationNumber,
 		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),
 		ReportByDate:           strfmt.Date(moveOrder.ReportByDate),
+		MoveCode:               moveCode,
 	}
 
 	return &payload

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -41,7 +41,7 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *supportmessages.MoveTaskOrder {
 		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
 		Status:             (supportmessages.MoveStatus)(moveTaskOrder.Status),
-		Locator:            moveTaskOrder.Locator,
+		MoveCode:           moveTaskOrder.Locator,
 	}
 
 	if moveTaskOrder.PPMEstimatedWeight != nil {

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -192,7 +192,7 @@ func (suite *HandlerSuite) moveTaskOrderPopulated(response *movetaskorderops.Cre
 
 	responsePayload := response.Payload
 
-	suite.NotNil(responsePayload.Locator)
+	suite.NotNil(responsePayload.MoveCode)
 	suite.NotNil(responsePayload.AvailableToPrimeAt)
 	suite.NotNil(responsePayload.MoveOrder.Customer.FirstName)
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -54,7 +54,6 @@ type Order struct {
 	SAC                 *string                            `json:"sac" db:"sac"`
 	DepartmentIndicator *string                            `json:"department_indicator" db:"department_indicator"`
 	Grade               *string                            `json:"grade" db:"grade"`
-	ConfirmationNumber  *string                            `json:"confirmation_number" db:"confirmation_number"`
 	Entitlement         *Entitlement                       `belongs_to:"entitlements"`
 	EntitlementID       *uuid.UUID                         `json:"entitlement_id" db:"entitlement_id"`
 	OriginDutyStation   *DutyStation                       `belongs_to:"duty_stations"`

--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -140,6 +140,7 @@ func (f moveOrderFetcher) FetchMoveOrder(moveOrderID uuid.UUID) (*models.Order, 
 		"NewDutyStation.Address",
 		"OriginDutyStation",
 		"Entitlement",
+		"Moves",
 	).Find(moveOrder, moveOrderID)
 
 	if err != nil {

--- a/pkg/services/move_order/move_order_fetcher_test.go
+++ b/pkg/services/move_order/move_order_fetcher_test.go
@@ -33,6 +33,7 @@ func (suite *MoveOrderServiceSuite) TestMoveOrderFetcher() {
 	suite.Equal(expectedMoveOrder.OriginDutyStation.AddressID, moveOrder.OriginDutyStation.AddressID)
 	suite.Equal(expectedMoveOrder.OriginDutyStation.Address.StreetAddress1, moveOrder.OriginDutyStation.Address.StreetAddress1)
 	suite.NotZero(moveOrder.OriginDutyStation)
+	suite.Equal(expectedMoveTaskOrder.Locator, moveOrder.Moves[0].Locator)
 }
 
 func (suite *MoveOrderServiceSuite) TestMoveOrderFetcherWithEmptyFields() {

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -336,7 +336,7 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 	contractorID := uuid.FromStringOrNil(mtoPayload.ContractorID.String())
 	model := &models.Move{
 		ReferenceID:        &mtoPayload.ReferenceID,
-		Locator:            mtoPayload.Locator,
+		Locator:            mtoPayload.MoveCode,
 		PPMEstimatedWeight: &ppmEstimatedWeight,
 		PPMType:            &mtoPayload.PpmType,
 		ContractorID:       &contractorID,

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1687,9 +1687,9 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         format: uuid
         type: string
-      confirmation_number:
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      moveCode:
         type: string
+        example: 'H2XFJF'
       first_name:
         type: string
         example: John

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -993,7 +993,7 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
-      locator:
+      moveCode:
         type: string
         example: 'HYXFJF'
         readOnly: true

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -993,9 +993,10 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
-      moveCode:
+      locator:
         type: string
         example: 'HYXFJF'
+        readOnly: true
       createdAt:
         format: date-time
         type: string

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -974,9 +974,6 @@ definitions:
       reportByDate:
         type: string
         format: date
-      moveCode:
-        type: string
-        example: 'HYXFJF'
       orderNumber:
         type: string
       linesOfAccounting:
@@ -996,6 +993,9 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+      moveCode:
+        type: string
+        example: 'HYXFJF'
       createdAt:
         format: date-time
         type: string
@@ -1286,7 +1286,7 @@ definitions:
           sitPostalCode:
             type: string
             format: zip
-            example: "90210"
+            example: '90210'
             pattern: '^(\d{5}([\-]\d{4})?)$'
           sitEntryDate:
             format: date
@@ -1462,7 +1462,7 @@ definitions:
       status:
         $ref: '#/definitions/PaymentRequestStatus'
       paymentRequestNumber:
-        example: "1234-5678-1"
+        example: '1234-5678-1'
         readOnly: true
         type: string
       proofOfServiceDocs:
@@ -1536,7 +1536,7 @@ definitions:
       key:
         $ref: '#/definitions/ServiceItemParamName'
       value:
-        example: "3025"
+        example: '3025'
         type: string
       type:
         $ref: '#/definitions/ServiceItemParamType'
@@ -1810,7 +1810,7 @@ responses:
     schema:
       $ref: '#/definitions/ClientError'
   Conflict:
-    description: "The request could not be processed because of conflict in the current state of the resource."
+    description: 'The request could not be processed because of conflict in the current state of the resource.'
     schema:
       $ref: '#/definitions/ClientError'
   PermissionDenied:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -974,10 +974,9 @@ definitions:
       reportByDate:
         type: string
         format: date
-      confirmationNumber:
+      moveCode:
         type: string
         example: 'HYXFJF'
-        x-nullable: true
       orderNumber:
         type: string
       linesOfAccounting:

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -456,9 +456,9 @@ paths:
                 description: Name of event triggered
                 example: paymentRequest.updated
               triggeredAt:
-                  type: string
-                  format: date-time
-                  description: Time representing when the event was triggered
+                type: string
+                format: date-time
+                description: Time representing when the event was triggered
               objectType:
                 type: string
                 description: The type of object that's being updated
@@ -481,9 +481,9 @@ paths:
                 description: Name of event triggered
                 example: paymentRequest.updated
               triggeredAt:
-                  type: string
-                  format: date-time
-                  description: Time representing when the event was triggered
+                type: string
+                format: date-time
+                description: Time representing when the event was triggered
               objectType:
                 type: string
                 description: The type of object that's being updated
@@ -924,7 +924,7 @@ definitions:
 
           If creating a MoveTaskOrder, this should match an existing duty station.
       rank:
-        $ref: "#/definitions/Rank"
+        $ref: '#/definitions/Rank'
       reportByDate:
         description: Date that the service member must report to the new DutyStation by.
         type: string
@@ -1071,6 +1071,7 @@ definitions:
         description: Unique 6-character code the customer can use to refer to their move
         type: string
         example: ABC123
+        readOnly: true
   MoveTaskOrders:
     items:
       $ref: '#/definitions/MoveTaskOrder'

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1067,7 +1067,7 @@ definitions:
         readOnly: true
       status:
         $ref: '#/definitions/MoveStatus'
-      locator:
+      moveCode:
         description: Unique 6-character code the customer can use to refer to their move
         type: string
         example: ABC123


### PR DESCRIPTION
## Description

The confirmation_number column wasn't being used on the orders table but was still being returned in payloads in the ghc and prime apis for MoveOrders.  This PR drops the column from the orders table and removes the field from the Orders model.

In the ghc api we include moveCode with the MoveOrder payload because this is often queried separately from the move.

In the prime api I'm adding MoveCode to the MoveTaskOrder payload because that is primarily what the prime queries as opposed to orders.  Since MoveCode is already a field on MoveTaskOrder/Move there is no need to add it to MoveOrder because you'll always have the parent MoveTaskOrder.

## Reviewer Notes

In theory an order could have many moves but this is not true in practice to my knowledge so it's okay to fetch the locator from the single move associated with the order.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make build_tools
make db_dev_e2e_populate
make server_run
make office_client_run
```

**Testing the GHC MoveOrder payload**
1. Login as the TOO user in the office app
2. Make an api request for an existing order in the database such as `http://officelocal:3000/ghc/v1/move-orders/1d49bb07-d9dd-4308-934d-baad94f2de9b`
3. The json payload response should include the moveCode property.

**Testing the Prime MoveTaskOrder payload**
1. Make an api request to the prime api to fetch data that includes a Move Task Order payload such as from your terminal `prime-api move-task-orders GET | jq .`
2. Verify that the moveCode property is part of the Move Task Order object response

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3912) for this change
* [ReDoc Prime API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/8607a1e3eb8ab3218f6a2b5334df941a9c036ab9/swagger/prime.yaml)

## Screenshots

![Screen Shot 2020-12-29 at 3 43 48 PM](https://user-images.githubusercontent.com/52669884/103313059-d2204c00-4a16-11eb-8e52-1d8b5f1cc2c5.png)

<img width="727" alt="Screen Shot 2020-12-30 at 1 36 58 PM" src="https://user-images.githubusercontent.com/52669884/103374215-e162d080-4ace-11eb-85da-56d9f4acfc9e.png">



