### PR TITLE
MB-6054 Pass customer's rank into ServiceMember model

### DIFF
--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -242,6 +242,7 @@ func CustomerModel(customer *supportmessages.Customer) *models.ServiceMember {
 		ID:            uuid.FromStringOrNil(customer.ID.String()),
 		Affiliation:   (*models.ServiceMemberAffiliation)(customer.Agency),
 		Edipi:         customer.DodID,
+		Rank:          (*models.ServiceMemberRank)(&customer.Rank),
 		FirstName:     customer.FirstName,
 		LastName:      customer.LastName,
 		PersonalEmail: customer.Email,


### PR DESCRIPTION
## Description

This PR updates the support service object to create an MTO to pass the `Rank` field from the `Customer` model into the new `ServiceMember` model. This field is required to create payment requests later on, so we needed to add it for load testing to succeed with all endpoints.

## Setup

Run the server with `make server_run` and hit the `createMoveTaskOrder` endpoint in the Support API using Postman or the Prime API Client. Check that the service member's rank was populated.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6054) for this change
