### PR TITLE
[MB-5237] Return total sum of payment request's items

### DIFF
--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -262,10 +262,15 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 			Value:   "2424",
 		},
 	}
-	paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItemWithParams(
+	paymentServiceItem := testdatagen.MakePaymentServiceItemWithParams(
 		suite.DB(),
 		models.ReServiceCodeDLH,
 		basicPaymentServiceItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				Status: models.PaymentServiceItemStatusApproved,
+			},
+		},
 	)
 
 	// Add a price to the service item.

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -175,6 +175,7 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 	err = g.db.Q().
 		Eager("MTOServiceItem.ReService").
 		Where("payment_request_id = ?", paymentRequest.ID).
+		Where("status = ?", models.PaymentServiceItemStatusApproved).
 		All(&paymentServiceItems)
 	if err != nil {
 		if err.Error() == models.RecordNotFoundErrorString {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -184,6 +184,10 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		return ediinvoice.Invoice858C{}, services.NewQueryError("PaymentServiceItems", err, fmt.Sprintf("Could not find payment service items: %s", err))
 	}
 
+	if len(paymentServiceItems) == 0 {
+		return ediinvoice.Invoice858C{}, services.NewConflictError(paymentRequest.ID, "this payment request has no approved PaymentServiceItems")
+	}
+
 	if !msOrCsOnly(paymentServiceItems) {
 		err = g.createG62Segments(paymentRequest.ID, &edi858.Header)
 		if err != nil {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -107,6 +107,9 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		Move:           mto,
 		MTOShipment:    mtoShipment,
 		PaymentRequest: paymentRequest,
+		PaymentServiceItem: models.PaymentServiceItem{
+			Status: models.PaymentServiceItemStatusApproved,
+		},
 	}
 
 	var paymentServiceItems models.PaymentServiceItems
@@ -274,6 +277,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	suite.T().Run("adds actual pickup date to header", func(t *testing.T) {
 		g62Requested := result.Header.RequestedPickupDate
 		suite.IsType(&edisegment.G62{}, g62Requested)
+		suite.NotNil(g62Requested)
 		suite.Equal(10, g62Requested.DateQualifier)
 		suite.Equal(requestedPickupDate.Format(testDateFormat), g62Requested.Date)
 
@@ -504,6 +508,9 @@ func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {
 	assertions := testdatagen.Assertions{
 		Move:           mto,
 		PaymentRequest: paymentRequest,
+		PaymentServiceItem: models.PaymentServiceItem{
+			Status: models.PaymentServiceItemStatusApproved,
+		},
 	}
 
 	testdatagen.MakePaymentServiceItemWithParams(
@@ -563,6 +570,9 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 	assertions := testdatagen.Assertions{
 		Move:           nilMove,
 		PaymentRequest: nilPaymentRequest,
+		PaymentServiceItem: models.PaymentServiceItem{
+			Status: models.PaymentServiceItemStatusApproved,
+		},
 	}
 
 	testdatagen.MakePaymentServiceItemWithParams(

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -704,7 +704,7 @@ func (suite *GHCInvoiceSuite) TestNoApprovedPaymentServiceItems() {
 	)
 
 	result, err := generator.Generate(paymentRequest, false)
-	suite.NoError(err)
+	suite.Error(err)
 
 	suite.T().Run("Service items that are not approved should be not added to invoice", func(t *testing.T) {
 		suite.Empty(result.ServiceItems)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -478,7 +478,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds l3 service item segment", func(t *testing.T) {
 		l3 := result.L3
-		suite.Equal(int64(0), l3.PriceCents) // TODO: hard-coded to zero for now
+		suite.Equal(int64(7992), l3.PriceCents)
 	})
 }
 

--- a/pkg/services/payment_request/payment_request_reviewed_processor_test.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor_test.go
@@ -80,6 +80,9 @@ func (suite *PaymentRequestServiceSuite) createPaymentRequest(num int) models.Pa
 			Move:           mto,
 			MTOShipment:    mtoShipment,
 			PaymentRequest: paymentRequest,
+			PaymentServiceItem: models.PaymentServiceItem{
+				Status: models.PaymentServiceItemStatusApproved,
+			},
 		}
 
 		// dlh


### PR DESCRIPTION
## Description

I filled the L3 segment with the total cost of all the payment service items.
I also changed the query for payment service items to only include items with an approved status in the invoice.

## Reviewer Notes

- Tests set up PaymentServiceItems with the `REQUESTED` status by default, does this still make sense as the default?

## Setup

- Reset the dev DB
```sh
make db_dev_e2e_populate
```

- Create a file called `payload.json` containing the following text:
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```
- Create a payment request and get the payment request number from the output
```sh
prime-api-client --insecure create-payment-request --filename payload.json | jq '.paymentRequestNumber'
```
- Open http://officelocal:3000
- Log in as `too_tio_role@office.mil`
- Switch to the TIO role
- Click the request with the Move Code `RDY4PY`
- Review the request.
- Generate an EDI, using the payment request number you got from an earlier step
```sh
go run ./cmd/generate-payment-request-edi/ --payment-request-number <Your payment request number>
```
- If you didn't approve any items when reviewing the request, you should get an error. If you approved at least one item, verify that the total in the L3 segment matches the accepted amount you see in the web app.
    - For example, if the web app shows $12,325.52 , the L3 line in the EDI should look like this:
    ```
    L3*****1232552
    ```
## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5237)