### PR TITLE
[MB-4530] adding aditional UT to make sure payment request number is being test…

### DIFF
--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -435,7 +435,7 @@ func (p *paymentRequestCreator) makeUniqueIdentifier(tx *pop.Connection, mto mod
 		return "", 0, fmt.Errorf("max sequence_number for MoveTaskOrderID [%s] failed: %w", mto.ID, err)
 	}
 
-	if *mto.ReferenceID == "" {
+	if mto.ReferenceID == nil || *mto.ReferenceID == "" {
 		return "", 0, fmt.Errorf("could not find reference ID for MoveTaskOrderID [%s]", mto.ID)
 	}
 

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -258,7 +258,8 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 
 	uniqueIdentifier, sequenceNumber, err := p.makeUniqueIdentifier(tx, moveTaskOrder)
 	if err != nil {
-		return nil, fmt.Errorf("issue creating payment request unique identifier: %w", err)
+		errMsg := fmt.Sprintf("issue creating payment request unique identifier: %s", err.Error())
+		return nil, services.NewInvalidCreateInputError(nil, errMsg)
 	}
 	paymentRequest.PaymentRequestNumber = uniqueIdentifier
 	paymentRequest.SequenceNumber = sequenceNumber
@@ -436,7 +437,8 @@ func (p *paymentRequestCreator) makeUniqueIdentifier(tx *pop.Connection, mto mod
 	}
 
 	if mto.ReferenceID == nil || *mto.ReferenceID == "" {
-		return "", 0, fmt.Errorf("could not find reference ID for MoveTaskOrderID [%s]", mto.ID)
+		errMsg := fmt.Sprintf("MTO %s has missing ReferenceID", mto.ID.String())
+		return "", 0, errors.New(errMsg)
 	}
 
 	nextSequence := max + 1

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -428,17 +428,16 @@ func (p *paymentRequestCreator) createServiceItemParamFromLookup(tx *pop.Connect
 }
 
 func (p *paymentRequestCreator) makeUniqueIdentifier(tx *pop.Connection, mto models.Move) (string, int, error) {
+	if mto.ReferenceID == nil || *mto.ReferenceID == "" {
+		errMsg := fmt.Sprintf("MTO %s has missing ReferenceID", mto.ID.String())
+		return "", 0, errors.New(errMsg)
+	}
 	// Get the max sequence number that exists for the payment requests associated with the given MTO.
 	// Since we have a lock to prevent concurrent payment requests for this MTO, this should be safe.
 	var max int
 	err := tx.RawQuery("SELECT COALESCE(MAX(sequence_number),0) FROM payment_requests WHERE move_id = $1", mto.ID).First(&max)
 	if err != nil {
 		return "", 0, fmt.Errorf("max sequence_number for MoveTaskOrderID [%s] failed: %w", mto.ID, err)
-	}
-
-	if mto.ReferenceID == nil || *mto.ReferenceID == "" {
-		errMsg := fmt.Sprintf("MTO %s has missing ReferenceID", mto.ID.String())
-		return "", 0, errors.New(errMsg)
 	}
 
 	nextSequence := max + 1

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -671,4 +671,65 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 		suite.Equal(expectedPaymentRequestNumber2, paymentRequest2.PaymentRequestNumber)
 		suite.Equal(expectedSequenceNumber2, paymentRequest2.SequenceNumber)
 	})
+
+	suite.T().Run("Payment request number fails due to empty MTO ReferenceID", func(t *testing.T) {
+
+		saveReferenceID := moveTaskOrder.ReferenceID
+		*moveTaskOrder.ReferenceID = ""
+		suite.MustSave(&moveTaskOrder)
+
+		// Create new ones
+		paymentRequest1 := models.PaymentRequest{
+			MoveTaskOrderID: moveTaskOrder.ID,
+			IsFinal:         false,
+			PaymentServiceItems: models.PaymentServiceItems{
+				{
+					MTOServiceItemID: mtoServiceItem1.ID,
+					MTOServiceItem:   mtoServiceItem1,
+					PaymentServiceItemParams: models.PaymentServiceItemParams{
+						{
+							ServiceItemParamKeyID: serviceItemParamKey1.ID,
+							Value:                 "3254",
+						},
+					},
+				},
+			},
+		}
+		_, err := creator.CreatePaymentRequest(&paymentRequest1)
+		suite.Contains(err.Error(), "failure creating payment request: issue creating payment request unique identifier")
+
+		moveTaskOrder.ReferenceID = saveReferenceID
+		suite.MustSave(&moveTaskOrder)
+	})
+
+	suite.T().Run("Payment request number fails due to nil MTO ReferenceID", func(t *testing.T) {
+
+		saveReferenceID := moveTaskOrder.ReferenceID
+		moveTaskOrder.ReferenceID = nil
+		suite.MustSave(&moveTaskOrder)
+
+		// Create new one
+		paymentRequest1 := models.PaymentRequest{
+			MoveTaskOrderID: moveTaskOrder.ID,
+			IsFinal:         false,
+			PaymentServiceItems: models.PaymentServiceItems{
+				{
+					MTOServiceItemID: mtoServiceItem1.ID,
+					MTOServiceItem:   mtoServiceItem1,
+					PaymentServiceItemParams: models.PaymentServiceItemParams{
+						{
+							ServiceItemParamKeyID: serviceItemParamKey1.ID,
+							Value:                 "3254",
+						},
+					},
+				},
+			},
+		}
+		_, err := creator.CreatePaymentRequest(&paymentRequest1)
+		suite.Contains(err.Error(), "failure creating payment request: issue creating payment request unique identifier")
+
+		moveTaskOrder.ReferenceID = saveReferenceID
+		suite.MustSave(&moveTaskOrder)
+	})
+
 }

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -678,7 +678,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 		*moveTaskOrder.ReferenceID = ""
 		suite.MustSave(&moveTaskOrder)
 
-		// Create new ones
+		// Create new one
 		paymentRequest1 := models.PaymentRequest{
 			MoveTaskOrderID: moveTaskOrder.ID,
 			IsFinal:         false,
@@ -696,7 +696,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 		_, err := creator.CreatePaymentRequest(&paymentRequest1)
-		suite.Contains(err.Error(), "failure creating payment request: issue creating payment request unique identifier")
+		suite.Contains(err.Error(), "has missing ReferenceID")
 
 		moveTaskOrder.ReferenceID = saveReferenceID
 		suite.MustSave(&moveTaskOrder)
@@ -726,7 +726,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 		_, err := creator.CreatePaymentRequest(&paymentRequest1)
-		suite.Contains(err.Error(), "failure creating payment request: issue creating payment request unique identifier")
+		suite.Contains(err.Error(), "has missing ReferenceID")
 
 		moveTaskOrder.ReferenceID = saveReferenceID
 		suite.MustSave(&moveTaskOrder)

--- a/pkg/testdatagen/make_re_domestic_linehaul_price.go
+++ b/pkg/testdatagen/make_re_domestic_linehaul_price.go
@@ -1,0 +1,59 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeReDomesticLinehaulPrice creates a single ReDomesticLinehaulPrice
+func MakeReDomesticLinehaulPrice(db *pop.Connection, assertions Assertions) models.ReDomesticLinehaulPrice {
+
+	serviceArea := assertions.ReDomesticLinehaulPrice.DomesticServiceArea
+	serviceAreaID := assertions.ReDomesticLinehaulPrice.DomesticServiceAreaID
+	if isZeroUUID(serviceAreaID) {
+		if isZeroUUID(serviceArea.ID) {
+			serviceArea = MakeReDomesticServiceArea(db, assertions)
+			assertions.ReDomesticLinehaulPrice.DomesticServiceAreaID = serviceArea.ID
+		} else {
+			assertions.ReDomesticLinehaulPrice.DomesticServiceAreaID = serviceArea.ID
+		}
+	}
+
+	reContract := assertions.ReDomesticLinehaulPrice.Contract
+	reContractID := assertions.ReDomesticLinehaulPrice.ContractID
+	if isZeroUUID(reContractID) {
+		if isZeroUUID(reContract.ID) {
+			reContract = MakeReContract(db, assertions)
+			assertions.ReDomesticLinehaulPrice.ContractID = reContract.ID
+		} else {
+			assertions.ReDomesticLinehaulPrice.ContractID = reContract.ID
+		}
+	}
+
+	id, _ := uuid.NewV4()
+	reDomesticLinehaulPrice := models.ReDomesticLinehaulPrice{
+		ID:                    id,
+		ContractID:            reContract.ID,
+		WeightLower:           500,
+		WeightUpper:           4999,
+		MilesLower:            1001,
+		MilesUpper:            1500,
+		IsPeakPeriod:          false,
+		DomesticServiceAreaID: serviceArea.ID,
+		PriceMillicents:       5000, // $0.050
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&reDomesticLinehaulPrice, assertions.ReDomesticLinehaulPrice)
+
+	mustCreate(db, &reDomesticLinehaulPrice, assertions.Stub)
+
+	return reDomesticLinehaulPrice
+}
+
+// MakeDefaultReDomesticLinehaulPrice makes a single ReDomesticLinehaulPrice with default values
+func MakeDefaultReDomesticLinehaulPrice(db *pop.Connection) models.ReDomesticLinehaulPrice {
+	return MakeReDomesticLinehaulPrice(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -64,6 +64,7 @@ type Assertions struct {
 	ReContract                               models.ReContract
 	ReContractYear                           models.ReContractYear
 	ReDomesticServiceArea                    models.ReDomesticServiceArea
+	ReDomesticLinehaulPrice                  models.ReDomesticLinehaulPrice
 	Reimbursement                            models.Reimbursement
 	ReService                                models.ReService
 	ReZip3                                   models.ReZip3


### PR DESCRIPTION
…ed and returns an error if there is a failure to create the payment request number. Additional testing around the handler for payment request creator from the prime API call, also for good error messaging when payment request cannot be generated due to the MTO Reference ID missing.

## Description

UT to check error message when payment request fails to generated due to missing MTO Reference ID.

## Reviewer Notes

n/a

## Setup

### Local Dev Setup

#### Run the local server 

```sh
make  db_dev_e2e_populate && make server_run
```

#### Remove ReferenceID in dev database

Open up your favorite db editor. And locate MTO with 

```
id='9c7b255c-2981-4bf8-839f-61c7458e2b4d'
```
and remove the `reference_id` value and update the database.

#### (optional) Run fetch-mto-updates

```sh
prime-api-client --insecure fetch-mto-updates | jq 'map(select(.id == "9c7b255c-2981-4bf8-839f-61c7458e2b4d")) | .[0]'
```

#### Create payload 
filename : payload.json

```json
{                                                                                                                           
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {   
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },  
      {   
        "id": "eee4b555-2475-4e67-a5b8-102f28d950f8"
      },  
      {   
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },  
      {   
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }   
    ]   
  }
}
```

#### Run CLI to create payment request

```sh
prime-api-client --insecure create-payment-request --filename payload.json | jq
``` 

#### Verify output

```json
{
  "Payload": {
    "detail": "issue creating payment request unique identifier: MTO 9c7b255c-2981-4bf8-839f-61c7458e2b4d has missing ReferenceID",
    "instance": "098d5095-ffae-4fe4-85e1-57e7142a633a",
    "title": "Validation Error",
    "invalidFields": null
  }
}
```

### Staging Setup

If you can find an MTO with a missing ReferenceID, then run the create payment request CLI in staging. Otherwise, just run a regular create payment request and verify that everything works without issue.

Look at demo wiki page for running CLI to create payment requests. https://github.com/transcom/mymove/wiki/Manually-run-Prime-API-for-Slice-demo

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4530) for this change


## Screenshots

n/a