### PR TITLE
[MB-5974] Optimize TOO switching between Orders sidebar and Allowances sidebar

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -169,7 +169,7 @@ describe('TOO user', () => {
     cy.wait(['@getMoveTaskOrders', '@getMTOShipments', '@getMTOServiceItems']);
 
     // Navigate to Edit orders page
-    cy.get('[data-testid="edit-orders"]').contains('View & Edit Orders').click();
+    cy.get('[data-testid="edit-orders"]').contains('View & edit orders').click();
 
     // Toggle between Edit Allowances and Edit Orders page
     cy.get('[data-testid="view-allowances"]').click();
@@ -225,7 +225,7 @@ describe('TOO user', () => {
     cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
 
     // Edit orders page | Cancel
-    cy.get('[data-testid="edit-orders"]').contains('View & Edit Orders').click();
+    cy.get('[data-testid="edit-orders"]').contains('View & edit orders').click();
     cy.get('button').contains('Cancel').click();
     cy.url().should('include', `/moves/${moveLocator}/details`);
   });

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -157,6 +157,78 @@ describe('TOO user', () => {
     cy.get('[data-testid="ApprovedServiceItemsTable"] tbody tr').should('have.length', 7);
   });
 
+  it('is able to edit orders', () => {
+    const moveLocator = 'TEST12';
+
+    // TOO Moves queue
+    cy.wait(['@getSortedMoveOrders']);
+    cy.contains(moveLocator).click();
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+
+    // Move Details page
+    cy.wait(['@getMoveTaskOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    // Navigate to Edit orders page
+    cy.get('[data-testid="edit-orders"]').contains('View & Edit Orders').click();
+
+    // Toggle between Edit Allowances and Edit Orders page
+    cy.get('[data-testid="view-allowances"]').click();
+    cy.url().should('include', `/moves/${moveLocator}/allowances`);
+    cy.get('[data-testid="view-orders"]').click();
+    cy.url().should('include', `/moves/${moveLocator}/orders`);
+
+    // Edit orders fields
+
+    // TODO Changing the originDutyStation value changes the moveLocator for the rest of the tests. Why?
+    // cy.get('[class*="-control"]')
+    //   .first()
+    //   .click(0, 0, { force: true })
+    //   .type('Fort Hood')
+    //   .get('[class*="-menu"]')
+    //   .find('[class*="-option"]')
+    //   .eq(1)
+    //   .click(0, 0, { force: true });
+
+    cy.get('[class*="-control"]')
+      .eq(1)
+      .click(0, 0, { force: true })
+      .type('JB McGuire-Dix-Lakehurst')
+      .get('[class*="-menu"]')
+      .find('[class*="-option"]')
+      .eq(1)
+      .click(0, 0, { force: true });
+
+    cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
+    cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
+    cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
+    cy.get('input[name="ordersNumber"]').click({ force: true }).clear().type('ORDER66');
+    cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
+    cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
+    cy.get('input[name="tac"]').click({ force: true }).clear().type('F123');
+    cy.get('input[name="sac"]').click({ force: true }).clear().type('4K988AS098F');
+
+    // Edit orders page | Save
+    cy.get('button').contains('Save').click();
+
+    // Verify edited values are saved
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // cy.get('[data-testid="currentDutyStation"]').contains('Fort Lee');
+    cy.get('[data-testid="newDutyStation"]').contains('JB Lewis-McChord');
+    cy.get('[data-testid="issuedDate"]').contains('16 Mar 2018');
+    cy.get('[data-testid="reportByDate"]').contains('22 Mar 2018');
+    cy.get('[data-testid="departmentIndicator"]').contains('Army');
+    cy.get('[data-testid="ordersNumber"]').contains('ORDER66');
+    cy.get('[data-testid="ordersType"]').contains('Permanent Change Of Station (PCS)');
+    cy.get('[data-testid="ordersTypeDetail"]').contains('Shipment of HHG Permitted');
+    cy.get('[data-testid="tacMDC"]').contains('F123');
+    cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
+
+    // Edit orders page | Cancel
+    cy.get('[data-testid="edit-orders"]').contains('View & Edit Orders').click();
+    cy.get('button').contains('Cancel').click();
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+  });
+
   it('is able to edit allowances', () => {
     const moveLocator = 'TEST12';
 

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -179,36 +179,38 @@ describe('TOO user', () => {
 
     // Edit orders fields
 
-    // TODO Changing the originDutyStation value changes the moveLocator for the rest of the tests. Why?
-    // cy.get('[class*="-control"]')
-    //   .first()
-    //   .click(0, 0, { force: true })
-    //   .type('Fort Hood')
-    //   .get('[class*="-menu"]')
-    //   .find('[class*="-option"]')
-    //   .eq(1)
-    //   .click(0, 0, { force: true });
+    cy.get('form').within(($form) => {
+      // TODO Changing the originDutyStation value changes the moveLocator for the rest of the tests. Why?
+      // cy.get('[class*="-control"]')
+      //   .first()
+      //   .click(0, 0, { force: true })
+      //   .type('Fort Hood')
+      //   .get('[class*="-menu"]')
+      //   .find('[class*="-option"]')
+      //   .eq(1)
+      //   .click(0, 0, { force: true });
 
-    cy.get('[class*="-control"]')
-      .eq(1)
-      .click(0, 0, { force: true })
-      .type('JB McGuire-Dix-Lakehurst')
-      .get('[class*="-menu"]')
-      .find('[class*="-option"]')
-      .eq(1)
-      .click(0, 0, { force: true });
+      cy.get('[class*="-control"]')
+        .eq(1)
+        .click(0, 0, { force: true })
+        .type('JB McGuire-Dix-Lakehurst')
+        .get('[class*="-menu"]')
+        .find('[class*="-option"]')
+        .eq(1)
+        .click(0, 0, { force: true });
 
-    cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
-    cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
-    cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
-    cy.get('input[name="ordersNumber"]').click({ force: true }).clear().type('ORDER66');
-    cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
-    cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
-    cy.get('input[name="tac"]').click({ force: true }).clear().type('F123');
-    cy.get('input[name="sac"]').click({ force: true }).clear().type('4K988AS098F');
+      cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
+      cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
+      cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
+      cy.get('input[name="ordersNumber"]').click({ force: true }).clear().type('ORDER66');
+      cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
+      cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
+      cy.get('input[name="tac"]').click({ force: true }).clear().type('F123');
+      cy.get('input[name="sac"]').click({ force: true }).clear().type('4K988AS098F');
 
-    // Edit orders page | Save
-    cy.get('button').contains('Save').click();
+      // Edit orders page | Save
+      cy.get('button').contains('Save').click();
+    });
 
     // Verify edited values are saved
     cy.url().should('include', `/moves/${moveLocator}/details`);
@@ -249,18 +251,21 @@ describe('TOO user', () => {
     cy.get('[data-testid="view-allowances"]').click();
     cy.url().should('include', `/moves/${moveLocator}/allowances`);
 
-    // Edit grade and authorized weight
-    cy.get('select[name=agency]').contains('Army');
-    cy.get('select[name=agency]').select('Navy');
-    cy.get('select[name="grade"]').contains('E-1');
-    cy.get('select[name="grade"]').select('W-2');
-    cy.get('input[name="authorizedWeight"]').clear().type('11111');
+    cy.get('form').within(($form) => {
+      // Edit grade and authorized weight
+      cy.get('select[name=agency]').contains('Army');
+      cy.get('select[name=agency]').select('Navy');
+      cy.get('select[name="grade"]').contains('E-1');
+      cy.get('select[name="grade"]').select('W-2');
+      cy.get('input[name="authorizedWeight"]').clear().type('11111');
 
-    //Edit DependentsAuthorized
-    cy.get('input[name="dependentsAuthorized"]').click();
+      //Edit DependentsAuthorized
+      cy.get('input[name="dependentsAuthorized"]').click();
 
-    // Edit allowances page | Save
-    cy.get('button').contains('Save').click();
+      // Edit allowances page | Save
+      cy.get('button').contains('Save').click();
+    });
+
     // Verify edited values are saved
     cy.url().should('include', `/moves/${moveLocator}/details`);
     cy.get('[data-testid="authorizedWeight"]').contains('11,111 lbs');

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -180,15 +180,14 @@ describe('TOO user', () => {
     // Edit orders fields
 
     cy.get('form').within(($form) => {
-      // TODO Changing the originDutyStation value changes the moveLocator for the rest of the tests. Why?
-      // cy.get('[class*="-control"]')
-      //   .first()
-      //   .click(0, 0, { force: true })
-      //   .type('Fort Hood')
-      //   .get('[class*="-menu"]')
-      //   .find('[class*="-option"]')
-      //   .eq(1)
-      //   .click(0, 0, { force: true });
+      cy.get('[class*="-control"]')
+        .first()
+        .click(0, 0, { force: true })
+        .type('Fort Irwin')
+        .get('[class*="-menu"]')
+        .find('[class*="-option"]')
+        .first()
+        .click(0, 0, { force: true });
 
       cy.get('[class*="-control"]')
         .eq(1)
@@ -214,7 +213,7 @@ describe('TOO user', () => {
 
     // Verify edited values are saved
     cy.url().should('include', `/moves/${moveLocator}/details`);
-    // cy.get('[data-testid="currentDutyStation"]').contains('Fort Lee');
+    cy.get('[data-testid="currentDutyStation"]').contains('Fort Irwin');
     cy.get('[data-testid="newDutyStation"]').contains('JB Lewis-McChord');
     cy.get('[data-testid="issuedDate"]').contains('16 Mar 2018');
     cy.get('[data-testid="reportByDate"]').contains('22 Mar 2018');

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -182,30 +182,30 @@ describe('TOO user', () => {
     cy.get('form').within(($form) => {
       cy.get('[class*="-control"]')
         .first()
-        .click(0, 0, { force: true })
+        .click(0, 0)
         .type('Fort Irwin')
         .get('[class*="-menu"]')
         .find('[class*="-option"]')
         .first()
-        .click(0, 0, { force: true });
+        .click(0, 0);
 
       cy.get('[class*="-control"]')
         .eq(1)
-        .click(0, 0, { force: true })
+        .click(0, 0)
         .type('JB McGuire-Dix-Lakehurst')
         .get('[class*="-menu"]')
         .find('[class*="-option"]')
         .eq(1)
-        .click(0, 0, { force: true });
+        .click(0, 0);
 
       cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
       cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
       cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
-      cy.get('input[name="ordersNumber"]').click({ force: true }).clear().type('ORDER66');
+      cy.get('input[name="ordersNumber"]').click().clear().type('ORDER66');
       cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
       cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
-      cy.get('input[name="tac"]').click({ force: true }).clear().type('F123');
-      cy.get('input[name="sac"]').click({ force: true }).clear().type('4K988AS098F');
+      cy.get('input[name="tac"]').click().clear().type('F123');
+      cy.get('input[name="sac"]').click().clear().type('4K988AS098F');
 
       // Edit orders page | Save
       cy.get('button').contains('Save').click();

--- a/src/components/Office/OrdersTable/OrdersTable.jsx
+++ b/src/components/Office/OrdersTable/OrdersTable.jsx
@@ -16,7 +16,7 @@ function OrdersTable({ ordersInfo }) {
         </div>
         <div>
           <Link className="usa-button usa-button--secondary" data-testid="edit-orders" to="orders">
-            View & Edit Orders
+            View & edit orders
           </Link>
         </div>
       </div>

--- a/src/components/Office/OrdersTable/OrdersTable.jsx
+++ b/src/components/Office/OrdersTable/OrdersTable.jsx
@@ -15,8 +15,8 @@ function OrdersTable({ ordersInfo }) {
           <h4>Orders</h4>
         </div>
         <div>
-          <Link className="usa-button usa-button--secondary" to="orders">
-            View & edit orders
+          <Link className="usa-button usa-button--secondary" data-testid="edit-orders" to="orders">
+            View & Edit Orders
           </Link>
         </div>
       </div>

--- a/src/components/Office/OrdersTable/OrdersTable.test.jsx
+++ b/src/components/Office/OrdersTable/OrdersTable.test.jsx
@@ -61,7 +61,7 @@ describe('Orders Table', () => {
         <OrdersTable ordersInfo={ordersInfoOptional} />
       </MockProviders>,
     );
-    expect(wrapper.find('Link').text()).toMatch('View & Edit Orders');
+    expect(wrapper.find('Link').text()).toMatch('View & edit orders');
     expect(wrapper.find('a').prop('href')).toMatch('/moves/TEST/orders');
   });
 });

--- a/src/components/Office/OrdersTable/OrdersTable.test.jsx
+++ b/src/components/Office/OrdersTable/OrdersTable.test.jsx
@@ -61,7 +61,7 @@ describe('Orders Table', () => {
         <OrdersTable ordersInfo={ordersInfoOptional} />
       </MockProviders>,
     );
-    expect(wrapper.find('Link').text()).toMatch('View & edit orders');
+    expect(wrapper.find('Link').text()).toMatch('View & Edit Orders');
     expect(wrapper.find('a').prop('href')).toMatch('/moves/TEST/orders');
   });
 });

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -11,7 +11,6 @@ import moveOrdersStyles from '../MoveOrders/MoveOrders.module.scss';
 import AllowancesDetailForm from '../../../components/Office/AllowancesDetailForm/AllowancesDetailForm';
 
 import { updateMoveOrder } from 'services/ghcApi';
-import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { useOrdersDocumentQueries } from 'hooks/queries';
@@ -31,7 +30,7 @@ const MoveAllowances = () => {
   const { moveCode } = useParams();
   const history = useHistory();
 
-  const { move, moveOrders, upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
+  const { move, moveOrders, isLoading, isError } = useOrdersDocumentQueries(moveCode);
   const moveOrderId = move?.ordersId;
 
   const handleClose = () => {
@@ -86,66 +85,57 @@ const MoveAllowances = () => {
     mutateOrders({ moveOrderID: moveOrderId, ifMatchETag: moveOrder.eTag, body });
   };
 
-  const documentsForViewer = Object.values(upload);
-
   const { entitlement, grade, agency } = moveOrder;
   const { authorizedWeight, dependentsAuthorized } = entitlement;
 
   const initialValues = { authorizedWeight: `${authorizedWeight}`, grade, agency, dependentsAuthorized };
 
   return (
-    <div className={moveOrdersStyles.MoveOrders}>
-      {documentsForViewer && (
-        <div className={moveOrdersStyles.embed}>
-          <DocumentViewer files={documentsForViewer} />
-        </div>
-      )}
-      <div className={moveOrdersStyles.sidebar}>
-        <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
-          {(formik) => (
-            <form onSubmit={formik.handleSubmit}>
-              <div className={moveOrdersStyles.orderDetails}>
-                <div className={moveOrdersStyles.top}>
-                  <Button
-                    className={moveOrdersStyles.closeButton}
-                    data-testid="closeSidebar"
-                    type="button"
-                    onClick={handleClose}
-                    unstyled
-                  >
-                    <FontAwesomeIcon icon="times" title="Close sidebar" aria-label="Close sidebar" />
-                  </Button>
-                  <h2 className={moveOrdersStyles.header} data-testid="allowances-header">
-                    View Allowances
-                  </h2>
-                  <div>
-                    <Link className={moveOrdersStyles.viewAllowances} data-testid="view-orders" to="orders">
-                      View Orders
-                    </Link>
-                  </div>
-                </div>
-                <div className={moveOrdersStyles.body}>
-                  <AllowancesDetailForm
-                    entitlements={moveOrder.entitlement}
-                    rankOptions={rankDropdownOptions}
-                    branchOptions={branchDropdownOption}
-                  />
-                </div>
-                <div className={moveOrdersStyles.bottom}>
-                  <div className={moveOrdersStyles.buttonGroup}>
-                    <Button disabled={formik.isSubmitting} type="submit">
-                      Save
-                    </Button>
-                    <Button type="button" secondary onClick={handleClose}>
-                      Cancel
-                    </Button>
-                  </div>
+    <div className={moveOrdersStyles.sidebar}>
+      <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
+        {(formik) => (
+          <form onSubmit={formik.handleSubmit}>
+            <div className={moveOrdersStyles.orderDetails}>
+              <div className={moveOrdersStyles.top}>
+                <Button
+                  className={moveOrdersStyles.closeButton}
+                  data-testid="closeSidebar"
+                  type="button"
+                  onClick={handleClose}
+                  unstyled
+                >
+                  <FontAwesomeIcon icon="times" title="Close sidebar" aria-label="Close sidebar" />
+                </Button>
+                <h2 className={moveOrdersStyles.header} data-testid="allowances-header">
+                  View Allowances
+                </h2>
+                <div>
+                  <Link className={moveOrdersStyles.viewAllowances} data-testid="view-orders" to="orders">
+                    View Orders
+                  </Link>
                 </div>
               </div>
-            </form>
-          )}
-        </Formik>
-      </div>
+              <div className={moveOrdersStyles.body}>
+                <AllowancesDetailForm
+                  entitlements={moveOrder.entitlement}
+                  rankOptions={rankDropdownOptions}
+                  branchOptions={branchDropdownOption}
+                />
+              </div>
+              <div className={moveOrdersStyles.bottom}>
+                <div className={moveOrdersStyles.buttonGroup}>
+                  <Button disabled={formik.isSubmitting} type="submit">
+                    Save
+                  </Button>
+                  <Button type="button" secondary onClick={handleClose}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </form>
+        )}
+      </Formik>
     </div>
   );
 };

--- a/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
@@ -77,27 +77,6 @@ jest.mock('hooks/queries', () => ({
           sac: 'E2P3',
         },
       },
-      documents: {
-        2: {
-          id: '2',
-          uploads: [
-            {
-              id: 'z',
-              filename: 'test.pdf',
-              contentType: 'application/pdf',
-              url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-            },
-          ],
-        },
-      },
-      upload: {
-        z: {
-          id: 'z',
-          filename: 'test.pdf',
-          contentType: 'application/pdf',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-      },
     };
   },
 }));
@@ -108,10 +87,6 @@ describe('MoveAllowances page', () => {
       <MoveAllowances />
     </MockProviders>,
   );
-
-  it('renders the orders document viewer', () => {
-    expect(wrapper.find('DocumentViewer').exists()).toBe(true);
-  });
 
   it('renders the sidebar elements', () => {
     expect(wrapper.find({ 'data-testid': 'allowances-header' }).text()).toBe('View Allowances');

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+import React, { lazy } from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+
+import moveOrdersStyles from '../MoveOrders/MoveOrders.module.scss';
+
+import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { useOrdersDocumentQueries } from 'hooks/queries';
+
+const MoveOrders = lazy(() => import('pages/Office/MoveOrders/MoveOrders'));
+const MoveAllowances = lazy(() => import('pages/Office/MoveAllowances/MoveAllowances'));
+
+const MoveDocumentWrapper = (props) => {
+  const { moveCode } = useParams();
+  const { formName } = props;
+  // console.log(formName);
+
+  const { upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
+
+  if (isLoading) return <LoadingPlaceholder />;
+  if (isError) return <SomethingWentWrong />;
+
+  const documentsForViewer = Object.values(upload);
+
+  return (
+    <div className={moveOrdersStyles.MoveOrders}>
+      {documentsForViewer && (
+        <div className={moveOrdersStyles.embed}>
+          <DocumentViewer files={documentsForViewer} />
+        </div>
+      )}
+      {formName === 'allowances' && <MoveAllowances moveCode={moveCode} />}
+      {formName === 'orders' && <MoveOrders moveCode={moveCode} />}
+    </div>
+  );
+};
+
+MoveDocumentWrapper.propTypes = {
+  formName: PropTypes.string.isRequired,
+};
+export default MoveDocumentWrapper;

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
@@ -16,7 +16,6 @@ const MoveAllowances = lazy(() => import('pages/Office/MoveAllowances/MoveAllowa
 const MoveDocumentWrapper = (props) => {
   const { moveCode } = useParams();
   const { formName } = props;
-  // console.log(formName);
 
   const { upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
 

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
@@ -1,7 +1,5 @@
-/* eslint-disable camelcase */
 import React, { lazy } from 'react';
-import PropTypes from 'prop-types';
-import { useParams } from 'react-router-dom';
+import { useParams, matchPath, useLocation } from 'react-router-dom';
 
 import moveOrdersStyles from '../MoveOrders/MoveOrders.module.scss';
 
@@ -13,14 +11,19 @@ import { useOrdersDocumentQueries } from 'hooks/queries';
 const MoveOrders = lazy(() => import('pages/Office/MoveOrders/MoveOrders'));
 const MoveAllowances = lazy(() => import('pages/Office/MoveAllowances/MoveAllowances'));
 
-const MoveDocumentWrapper = (props) => {
+const MoveDocumentWrapper = () => {
   const { moveCode } = useParams();
-  const { formName } = props;
+  const { pathname } = useLocation();
 
   const { upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
+
+  const showOrders = matchPath(pathname, {
+    path: '/moves/:moveCode/orders',
+    exact: true,
+  });
 
   const documentsForViewer = Object.values(upload);
 
@@ -31,13 +34,9 @@ const MoveDocumentWrapper = (props) => {
           <DocumentViewer files={documentsForViewer} />
         </div>
       )}
-      {formName === 'allowances' && <MoveAllowances moveCode={moveCode} />}
-      {formName === 'orders' && <MoveOrders moveCode={moveCode} />}
+      {showOrders ? <MoveOrders moveCode={moveCode} /> : <MoveAllowances moveCode={moveCode} />}
     </div>
   );
 };
 
-MoveDocumentWrapper.propTypes = {
-  formName: PropTypes.string.isRequired,
-};
 export default MoveDocumentWrapper;

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { Suspense } from 'react';
 import { mount } from 'enzyme';
 
@@ -102,11 +101,18 @@ jest.mock('hooks/queries', () => ({
   },
 }));
 
-describe('MoveOrders page', () => {
+const testMoveId = '10000';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn().mockReturnValue({ moveOrderId: testMoveId }),
+}));
+
+describe('MoveDocumentWrapper', () => {
   const wrapper = mount(
-    <MockProviders initialEntries={['moves/1000/orders']}>
+    <MockProviders initialEntries={[`/moves/${testMoveId}/orders`]}>
       <Suspense fallback={<div>Loading</div>}>
-        <MoveDocumentWrapper formName="orders" />
+        <MoveDocumentWrapper />
       </Suspense>
     </MockProviders>,
   );

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
+import React, { Suspense } from 'react';
 import { mount } from 'enzyme';
 
-import MoveOrders from './MoveOrders';
+import MoveDocumentWrapper from './MoveDocumentWrapper';
 
 import { MockProviders } from 'testUtils';
 
@@ -77,6 +77,27 @@ jest.mock('hooks/queries', () => ({
           sac: 'E2P3',
         },
       },
+      documents: {
+        2: {
+          id: '2',
+          uploads: [
+            {
+              id: 'z',
+              filename: 'test.pdf',
+              contentType: 'application/pdf',
+              url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+            },
+          ],
+        },
+      },
+      upload: {
+        z: {
+          id: 'z',
+          filename: 'test.pdf',
+          contentType: 'application/pdf',
+          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+        },
+      },
     };
   },
 }));
@@ -84,24 +105,18 @@ jest.mock('hooks/queries', () => ({
 describe('MoveOrders page', () => {
   const wrapper = mount(
     <MockProviders initialEntries={['moves/1000/orders']}>
-      <MoveOrders />
+      <Suspense fallback={<div>Loading</div>}>
+        <MoveDocumentWrapper formName="orders" />
+      </Suspense>
     </MockProviders>,
   );
 
-  it('renders the sidebar orders detail form', () => {
-    expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+  it('renders the orders document viewer', () => {
+    expect(wrapper.find('DocumentViewer').exists()).toBe(true);
   });
 
-  it('populates inital field values', () => {
-    expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
-    expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
-    expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
-    expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
-    expect(wrapper.find('select[name="departmentIndicator"]').prop('value')).toBe('AIR_FORCE');
-    expect(wrapper.find('input[name="ordersNumber"]').prop('value')).toBe('ORDER3');
-    expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
-    expect(wrapper.find('select[name="ordersTypeDetail"]').prop('value')).toBe('HHG_PERMITTED');
-    expect(wrapper.find('input[name="tac"]').prop('value')).toBe('F8E1');
-    expect(wrapper.find('input[name="sac"]').prop('value')).toBe('E2P3');
+  it('renders the sidebar orders detail form', async () => {
+    await wrapper.update();
+    expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
   });
 });

--- a/src/pages/Office/MoveOrders/MoveOrders.jsx
+++ b/src/pages/Office/MoveOrders/MoveOrders.jsx
@@ -136,7 +136,7 @@ const MoveOrders = () => {
               </div>
               <div className={styles.bottom}>
                 <div className={styles.buttonGroup}>
-                  <Button primary type="submit" disabled={formik.isSubmitting}>
+                  <Button type="submit" disabled={formik.isSubmitting}>
                     Save
                   </Button>
                   <Button type="button" secondary onClick={handleClose}>

--- a/src/pages/Office/MoveOrders/MoveOrders.jsx
+++ b/src/pages/Office/MoveOrders/MoveOrders.jsx
@@ -9,7 +9,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './MoveOrders.module.scss';
 
-import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
 import { updateMoveOrder } from 'services/ghcApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -40,7 +39,7 @@ const validationSchema = Yup.object({
 const MoveOrders = () => {
   const history = useHistory();
   const { moveCode } = useParams();
-  const { move, moveOrders, upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
+  const { move, moveOrders, isLoading, isError } = useOrdersDocumentQueries(moveCode);
   const moveOrderId = move?.ordersId;
 
   const handleClose = () => {
@@ -105,59 +104,50 @@ const MoveOrders = () => {
     sac: moveOrder?.sac,
   };
 
-  const documentsForViewer = Object.values(upload);
-
   return (
-    <div className={styles.MoveOrders}>
-      {documentsForViewer && (
-        <div className={styles.embed}>
-          <DocumentViewer files={documentsForViewer} />
-        </div>
-      )}
-      <div className={styles.sidebar}>
-        <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
-          {(formik) => (
-            <form onSubmit={formik.handleSubmit}>
-              <div className={styles.orderDetails}>
-                <div className={styles.top}>
-                  <Button
-                    className={styles.closeButton}
-                    data-testid="closeSidebar"
-                    type="button"
-                    onClick={handleClose}
-                    unstyled
-                  >
-                    <FontAwesomeIcon icon="times" title="Close sidebar" aria-label="Close sidebar" />
-                  </Button>
-                  <h2 className={styles.header}>View Orders</h2>
-                  <div>
-                    <Link className={styles.viewAllowances} data-testid="view-allowances" to="allowances">
-                      View Allowances
-                    </Link>
-                  </div>
-                </div>
-                <div className={styles.body}>
-                  <OrdersDetailForm
-                    deptIndicatorOptions={deptIndicatorDropdownOptions}
-                    ordersTypeOptions={ordersTypeDropdownOptions}
-                    ordersTypeDetailOptions={ordersTypeDetailsDropdownOptions}
-                  />
-                </div>
-                <div className={styles.bottom}>
-                  <div className={styles.buttonGroup}>
-                    <Button primary type="submit" disabled={formik.isSubmitting}>
-                      Save
-                    </Button>
-                    <Button type="button" secondary onClick={handleClose}>
-                      Cancel
-                    </Button>
-                  </div>
+    <div className={styles.sidebar}>
+      <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
+        {(formik) => (
+          <form onSubmit={formik.handleSubmit}>
+            <div className={styles.orderDetails}>
+              <div className={styles.top}>
+                <Button
+                  className={styles.closeButton}
+                  data-testid="closeSidebar"
+                  type="button"
+                  onClick={handleClose}
+                  unstyled
+                >
+                  <FontAwesomeIcon icon="times" title="Close sidebar" aria-label="Close sidebar" />
+                </Button>
+                <h2 className={styles.header}>View Orders</h2>
+                <div>
+                  <Link className={styles.viewAllowances} data-testid="view-allowances" to="allowances">
+                    View Allowances
+                  </Link>
                 </div>
               </div>
-            </form>
-          )}
-        </Formik>
-      </div>
+              <div className={styles.body}>
+                <OrdersDetailForm
+                  deptIndicatorOptions={deptIndicatorDropdownOptions}
+                  ordersTypeOptions={ordersTypeDropdownOptions}
+                  ordersTypeDetailOptions={ordersTypeDetailsDropdownOptions}
+                />
+              </div>
+              <div className={styles.bottom}>
+                <div className={styles.buttonGroup}>
+                  <Button primary type="submit" disabled={formik.isSubmitting}>
+                    Save
+                  </Button>
+                  <Button type="button" secondary onClick={handleClose}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </form>
+        )}
+      </Formik>
     </div>
   );
 };

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -7,9 +7,8 @@ import TabNav from 'components/TabNav';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 const MoveDetails = lazy(() => import('pages/Office/MoveDetails/MoveDetails'));
+const MoveDocumentWrapper = lazy(() => import('pages/Office/MoveDocumentWrapper/MoveDocumentWrapper'));
 const MoveTaskOrder = lazy(() => import('pages/Office/MoveTaskOrder/MoveTaskOrder'));
-const MoveOrders = lazy(() => import('pages/Office/MoveOrders/MoveOrders'));
-const MoveAllowances = lazy(() => import('pages/Office/MoveAllowances/MoveAllowances'));
 const PaymentRequestReview = lazy(() => import('pages/Office/PaymentRequestReview/PaymentRequestReview'));
 const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
 const MovePaymentRequests = lazy(() => import('pages/Office/MovePaymentRequests/MovePaymentRequests'));
@@ -71,11 +70,11 @@ const TXOMoveInfo = () => {
           </Route>
 
           <Route path="/moves/:moveCode/orders" exact>
-            <MoveOrders />
+            <MoveDocumentWrapper formName="orders" />
           </Route>
 
           <Route path="/moves/:moveCode/allowances" exact>
-            <MoveAllowances />
+            <MoveDocumentWrapper formName="allowances" />
           </Route>
 
           <Route path="/moves/:moveCode/mto" exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -69,12 +69,8 @@ const TXOMoveInfo = () => {
             <MoveDetails />
           </Route>
 
-          <Route path="/moves/:moveCode/orders" exact>
-            <MoveDocumentWrapper formName="orders" />
-          </Route>
-
-          <Route path="/moves/:moveCode/allowances" exact>
-            <MoveDocumentWrapper formName="allowances" />
+          <Route path={['/moves/:moveCode/allowances', '/moves/:moveCode/orders']} exact>
+            <MoveDocumentWrapper />
           </Route>
 
           <Route path="/moves/:moveCode/mto" exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -66,7 +66,7 @@ describe('TXO Move Info Container', () => {
 
       const renderedRoute = wrapper.find('Route');
       expect(renderedRoute).toHaveLength(1);
-      expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/orders');
+      expect(renderedRoute.prop('path')).toEqual(['/moves/:moveCode/allowances', '/moves/:moveCode/orders']);
     });
 
     it('should handle the Allowances route', () => {
@@ -78,7 +78,7 @@ describe('TXO Move Info Container', () => {
 
       const renderedRoute = wrapper.find('Route');
       expect(renderedRoute).toHaveLength(1);
-      expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/allowances');
+      expect(renderedRoute.prop('path')).toEqual(['/moves/:moveCode/allowances', '/moves/:moveCode/orders']);
     });
 
     it('should handle the Move Task Order route', () => {


### PR DESCRIPTION
## Description

A wrapper has been added to prevent re-rendering of the document viewer when switching between the Edit Orders and Edit Allowances forms.

Tests for the Edit Orders form have also been added.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
