### PR TITLE
MB-6044: fmt -> log

### DIFF
--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -66,7 +66,6 @@ func dropDB(conn *pop.Connection, destination string) error {
 }
 
 func cloneDatabase(conn *pop.Connection, source, destination string) error {
-
 	// Now that the lock is available clone the DB
 	// Drop and then Create the DB
 	if dropErr := dropDB(conn, destination); dropErr != nil {
@@ -175,11 +174,11 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 
 	uniq := StringWithCharset(6, charset)
 	dbNamePackage := fmt.Sprintf("%s_%s_%s", dbNameTest, strings.Replace(packageName.String(), "/", "_", -1), uniq)
-	fmt.Printf("attempting to clone database %s to %s... ", dbNameTest, dbNamePackage)
+	log.Printf("attempting to clone database %s to %s... ", dbNameTest, dbNamePackage)
 	if err := cloneDatabase(primaryConn, dbNameTest, dbNamePackage); err != nil {
 		log.Panicf("failed to clone database '%s' to '%s': %#v", dbNameTest, dbNamePackage, err)
 	}
-	fmt.Println("success")
+	log.Println("success")
 
 	// disconnect from the primary DB
 	if err := primaryConn.Close(); err != nil {


### PR DESCRIPTION
## Description

This changes two `fmt.Printf` calls to `log.Printf` calls so that they follow the pattern established elsewhere in this file for using `log` rather than `fmt`.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6044) for this change