### PR TITLE
MB-6044: db -> suite.DB()

### DIFF
--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -41,7 +41,6 @@ func cutoffDate() time.Time {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderFetchSomeFound() {
-	db := suite.DB()
 	date10DaysAgo := offsetDate(-10)
 	date9DaysAgo := offsetDate(-9)
 
@@ -112,7 +111,7 @@ func (suite *NotificationSuite) TestPaymentReminderFetchSomeFound() {
 
 	ppms := suite.createPaymentReminderMoves(moves)
 
-	PaymentReminder, err := NewPaymentReminder(db, suite.logger)
+	PaymentReminder, err := NewPaymentReminder(suite.DB(), suite.logger)
 	suite.NoError(err)
 	emailInfo, err := PaymentReminder.GetEmailInfo()
 	suite.NoError(err)
@@ -131,7 +130,6 @@ func (suite *NotificationSuite) TestPaymentReminderFetchSomeFound() {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderFetchNoneFound() {
-	db := suite.DB()
 	date10DaysAgo := offsetDate(-10)
 	date9DaysAgo := offsetDate(-9)
 	dateTooOld := cutoffDate()
@@ -158,7 +156,7 @@ func (suite *NotificationSuite) TestPaymentReminderFetchNoneFound() {
 
 	suite.createPaymentReminderMoves(moves)
 
-	PaymentReminder, err := NewPaymentReminder(db, suite.logger)
+	PaymentReminder, err := NewPaymentReminder(suite.DB(), suite.logger)
 	suite.NoError(err)
 	emailInfo, err := PaymentReminder.GetEmailInfo()
 
@@ -167,8 +165,6 @@ func (suite *NotificationSuite) TestPaymentReminderFetchNoneFound() {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderFetchAlreadySentEmail() {
-	db := suite.DB()
-
 	date10DaysAgo := offsetDate(-10)
 	dateTooOld := cutoffDate()
 
@@ -184,7 +180,7 @@ func (suite *NotificationSuite) TestPaymentReminderFetchAlreadySentEmail() {
 	}
 	suite.createPaymentReminderMoves(moves)
 
-	PaymentReminder, err := NewPaymentReminder(db, suite.logger)
+	PaymentReminder, err := NewPaymentReminder(suite.DB(), suite.logger)
 	suite.NoError(err)
 	emailInfoBeforeSending, err := PaymentReminder.GetEmailInfo()
 	suite.NoError(err)
@@ -198,19 +194,18 @@ func (suite *NotificationSuite) TestPaymentReminderFetchAlreadySentEmail() {
 }
 
 func (suite *NotificationSuite) TestPaymentReminderOnSuccess() {
-	db := suite.DB()
-	sm := testdatagen.MakeDefaultServiceMember(db)
+	sm := testdatagen.MakeDefaultServiceMember(suite.DB())
 	ei := PaymentReminderEmailInfo{
 		ServiceMemberID: sm.ID,
 	}
 
-	PaymentReminder, err := NewPaymentReminder(db, suite.logger)
+	PaymentReminder, err := NewPaymentReminder(suite.DB(), suite.logger)
 	suite.NoError(err)
 	err = PaymentReminder.OnSuccess(ei)("SESID")
 	suite.NoError(err)
 
 	n := models.Notification{}
-	err = db.First(&n)
+	err = suite.DB().First(&n)
 	suite.NoError(err)
 	suite.Equal(sm.ID, n.ServiceMemberID)
 	suite.Equal(models.MovePaymentReminderEmail, n.NotificationType)


### PR DESCRIPTION
## Description

This lays the groundwork for an upcoming change that will add the ability for the testing suite to change the database connection used by Pop (pkg/testingsuite/pop_suite.go). Because the underlying database connection will be able to be changed at will, it will require a disconnect/reconnect. When this occurs, references to the old connection will no longer remain valid. Therefore, this PR removes references to database connections, and instead references the current database connection at the time of usage.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
$ go test -failfast ./pkg/notifications/...
ok      github.com/transcom/mymove/pkg/notifications    11.396s
$
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6044) for this change