### PR TITLE
MB-6044: fix local ecs_user permissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1366,7 +1366,7 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-fix-local-ecs-user
 
       - push_tasks_exp:
           requires:
@@ -1394,7 +1394,7 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-fix-local-ecs-user
 
       - deploy_exp_tasks:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1366,7 +1366,7 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cj-fix-local-ecs-user
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
@@ -1394,7 +1394,7 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: cj-fix-local-ecs-user
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -584,3 +584,4 @@
 20201120174609_add_indexes_for_move_selected_type.up.sql
 20201207223002_create_zip3_distances.up.sql
 20201208215206_load_zip3_distances.up.sql
+20201230070814_fix_ecs_user_in_docker.up.sql

--- a/migrations/app/schema/20201230070814_fix_ecs_user_in_docker.up.sql
+++ b/migrations/app/schema/20201230070814_fix_ecs_user_in_docker.up.sql
@@ -1,0 +1,18 @@
+-- Fix the ecs_user permissions on tables for Docker-based databases, which
+-- uses the postgres user to run many operations.
+DO
+$do$
+BEGIN
+  IF EXISTS (
+    SELECT -- SELECT list can stay empty for this
+    FROM   pg_catalog.pg_roles
+    WHERE  rolname = 'postgres') THEN
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ecs_user;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ecs_user;
+    GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO ecs_user;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON TABLES TO ecs_user;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON SEQUENCES TO ecs_user;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres GRANT ALL PRIVILEGES ON FUNCTIONS TO ecs_user;
+  END IF;
+END
+$do$;


### PR DESCRIPTION
## Description

This PR brings our local development environment into closer parity with what is deployed to RDS.

The `ecs_user` PostgreSQL role was created in the 20190129115416_ecs_user_for_rds migration. However, it granted default privileges to the `master` role, which was only used on RDS for migrations. We now use `ecs_user` for migrations, so the `master` -> `ecs_user` grant is not utilized.

https://github.com/transcom/mymove/blob/c8465235bb4791e1fb1f2c2067d76d5aaf26772e/migrations/app/secure/20190129115416_ecs_user_for_rds.up.sql#L15-L18

The `GRANT` statements only apply to the `master` role. Therefore, when running migrations in Docker, none of the tables created after that migration grant any permissions to the `ecs_user` role because our Docker containers use the `postgres` role to run migrations rather than the `master` role.

This PR makes two changes when running on a PostgreSQL instance that has the `postgres` role (i.e.: our Docker containers, not RDS):
1. grants the expected privileges for all tables, sequences, and functions since the creation of the `ecs_user` role.
1. grants privileges to the `ecs_user` role to all tables, sequences, and functions going forward when running migrations as the `postgres` role, which is the role we use when running migrations in Docker containers.

## Reviewer Notes

I made this as a standard migration using `./bin/milmove gen migration -n fix_ecs_user_in_docker`. Should this be a secure migration instead? I see that the original `ecs_user` was created in a secure migration.

## Setup

Before the migration, creating a new table did not grant privileges to the `ecs_user` role.

```
$ docker kill $(docker ps --quiet --filter ancestor=postgres:12.2)
$ docker rm $(docker ps --all --quiet --filter ancestor=postgres:12.2)
$ make db_test_reset && make db_test_migrate && make db_e2e_up
$ psql 'postgres://postgres:mysecretpassword@localhost:5433/test_db?sslmode=disable'
psql (13.1, server 12.2 (Debian 12.2-2.pgdg100+1))
Type "help" for help.

test_db=# CREATE TABLE sample_01 (
    id bigint NOT NULL,
    example_number integer
);
CREATE TABLE
test_db=# SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE table_name='sample_01';
 grantee  | privilege_type 
----------+----------------
 postgres | INSERT
 postgres | SELECT
 postgres | UPDATE
 postgres | DELETE
 postgres | TRUNCATE
 postgres | REFERENCES
 postgres | TRIGGER
 master   | INSERT
 master   | SELECT
 master   | UPDATE
 master   | DELETE
 master   | TRUNCATE
 master   | REFERENCES
 master   | TRIGGER
(14 rows)

test_db=#
```

After the migration, creating a new table does grant privileges to the `ecs_user` role.

```
$ docker kill $(docker ps --quiet --filter ancestor=postgres:12.2)
$ docker rm $(docker ps --all --quiet --filter ancestor=postgres:12.2)
$ make db_test_reset && make db_test_migrate && make db_e2e_up
$ psql 'postgres://postgres:mysecretpassword@localhost:5433/test_db?sslmode=disable'
psql (13.1, server 12.2 (Debian 12.2-2.pgdg100+1))
Type "help" for help.

test_db=# CREATE TABLE sample_01 (
    id bigint NOT NULL,
    example_number integer
);
CREATE TABLE
test_db=# SELECT grantee, privilege_type FROM information_schema.role_table_grants WHERE table_name='sample_01';
 grantee  | privilege_type 
----------+----------------
 postgres | INSERT
 postgres | SELECT
 postgres | UPDATE
 postgres | DELETE
 postgres | TRUNCATE
 postgres | REFERENCES
 postgres | TRIGGER
 master   | INSERT
 master   | SELECT
 master   | UPDATE
 master   | DELETE
 master   | TRUNCATE
 master   | REFERENCES
 master   | TRIGGER
 ecs_user | INSERT
 ecs_user | SELECT
 ecs_user | UPDATE
 ecs_user | DELETE
 ecs_user | TRUNCATE
 ecs_user | REFERENCES
 ecs_user | TRIGGER
(21 rows)

test_db=# 
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [x] Have been communicated to #g-database
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6044) for this change