### PR TITLE
use latest milmove-cypress image

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-5be9e7c630f5bbc4b04732d237ce4e25cf575601
+FROM milmove/circleci-docker:milmove-cypress-bb1f5f3cda6f88b178bdc4d5a439a09c9b7bfcf6
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json


### PR DESCRIPTION
## Description

We have a repo `circleci-docker` that contains a build of cypress for our integration tests. When we update any packages in `circleci-docker`, we should pull the latest image of into `mymove`.

## Reviewer Notes

Did I get the correct hash from Dockerhub image?

## Setup

the integration tests should run w/o an issue on circle

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5832) for this change

more info about the other repo: https://github.com/transcom/mymove/pull/5525