### PR TITLE
[MB-6102] escape regex characters in duty station highlight library

### DIFF
--- a/src/components/form/fields/DutyStationInput.test.jsx
+++ b/src/components/form/fields/DutyStationInput.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import AsyncSelect from 'react-select/async';
 
 import { DutyStationInput } from './DutyStationInput';
@@ -43,6 +44,21 @@ describe('DutyStationInput', () => {
       const select = input.find(AsyncSelect);
       await select.simulate('change', { id: 1, address_id: 1 });
       expect(mockSetValue).toHaveBeenCalledWith({ address: 43, address_id: 1, id: 1 });
+    });
+
+    it('escapes regex special character input', async () => {
+      const mounted = mount(<DutyStationInput name="dutyStation" label="label" />);
+
+      await act(async () => {
+        // Only the hidden input that gets the final selected duty station has a name attribute
+        mounted
+          .find('input#react-select-2-input')
+          .simulate('change', { target: { id: 'react-select-2-input', value: '-][)(*+?.\\^$|' } });
+      });
+      mounted.update();
+
+      // The NoOptionsMessage component is only rendered when the 'No Options' message is displayed
+      expect(mounted.exists('NoOptionsMessage')).toBe(true);
     });
   });
 

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -91,7 +91,7 @@ export class DutyStationSearchBox extends Component {
     return (
       <div {...props.innerProps}>
         <components.Option {...props}>
-          <Highlighter searchWords={[this.state.inputValue]} textToHighlight={props.label} />
+          <Highlighter autoEscape searchWords={[this.state.inputValue]} textToHighlight={props.label} />
         </components.Option>
       </div>
     );


### PR DESCRIPTION
## Description

An accidental entering of non alphanumeric characters in the duty station input search would cause an unexpected Something went wrong error in the client.

It turns out we have a library react-highlighter-words that attempts to highlight the search string in the menu of results.  If you type any special character that has meaning in regular expressions `-][)(*+?.\^$|` it will cause the component to throw an error.

To fix this we just need to set the autoEscape prop to true on the Highlighter component that we're using.

https://github.com/bvaughn/react-highlight-words#props

https://github.com/bvaughn/highlight-words-core/blob/eb170f8a78c7926b613e72733267f3243696113c/src/utils.js#L172

## Reviewer Notes

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

On the Customer side:
1. Login as an existing service member
2. Edit the profile where it asks for current duty station
3. Click in the current duty station searchbox and enter 2 or more of the special characters
4. A No Options message should be displayed or some fuzzy matched results but no Something went wrong error.


On the office side:
1. Login as the TOO user and select a move from the queue
2. Navigate to the Edit Orders screen on the Move Details page
3. Edit either the origin duty station or the destination duty station by entering 2 or more of the special characters
4. A No Options message should be displayed or some fuzzy matched results but no Something went wrong error.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6102) for this change

## Screenshots

![regex mov](https://user-images.githubusercontent.com/52669884/103424507-9d41ff80-4ba4-11eb-8d52-c254525acb22.gif)

![regexsuccess mov](https://user-images.githubusercontent.com/52669884/103424563-f447d480-4ba4-11eb-8d39-cfacef591613.gif)

