### PR TITLE
MB-6104 Set document viewer react-query to not refetch onFocus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1282,7 +1282,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-6104-document-viewer-cache-stale-time
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1295,7 +1295,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-6104-document-viewer-cache-stale-time
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1303,7 +1303,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-6104-document-viewer-cache-stale-time
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: ttv-6104-document-viewer-cache-stale-time
+              ignore: placeholder_branch_name
 
       - webhook_client_test:
           requires:
@@ -1359,28 +1359,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1394,28 +1394,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: ttv-6104-document-viewer-cache-stale-time
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1282,7 +1282,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-6104-document-viewer-cache-stale-time
 
       - integration_tests_mtls:
           requires:
@@ -1295,7 +1295,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-6104-document-viewer-cache-stale-time
 
       - client_test:
           requires:
@@ -1303,7 +1303,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-6104-document-viewer-cache-stale-time
 
       - server_test:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: ttv-6104-document-viewer-cache-stale-time
 
       - webhook_client_test:
           requires:
@@ -1359,28 +1359,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - deploy_exp_migrations:
           requires:
@@ -1394,28 +1394,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: ttv-6104-document-viewer-cache-stale-time
 
       - push_app_stg:
           requires:

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -164,11 +164,15 @@ export const useOrdersDocumentQueries = (moveCode) => {
 
   // Get a document
   // TODO - "upload" instead of "uploads" is because of the schema.js entity name. Change to "uploads"
+  const staleTime = 60 * 60000; // 60 * 60000 milliseconds = 1 hour
+  const cacheTime = staleTime;
   const { data: { documents, upload } = {}, ...ordersDocumentsQuery } = useQuery(
     [ORDERS_DOCUMENTS, documentId],
     getDocument,
     {
       enabled: !!documentId,
+      staleTime,
+      cacheTime,
     },
   );
 

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -164,15 +164,12 @@ export const useOrdersDocumentQueries = (moveCode) => {
 
   // Get a document
   // TODO - "upload" instead of "uploads" is because of the schema.js entity name. Change to "uploads"
-  const staleTime = 60 * 60000; // 60 * 60000 milliseconds = 1 hour
-  const cacheTime = staleTime;
   const { data: { documents, upload } = {}, ...ordersDocumentsQuery } = useQuery(
     [ORDERS_DOCUMENTS, documentId],
     getDocument,
     {
       enabled: !!documentId,
-      staleTime,
-      cacheTime,
+      refetchOnWindowFocus: false,
     },
   );
 

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -164,11 +164,15 @@ export const useOrdersDocumentQueries = (moveCode) => {
 
   // Get a document
   // TODO - "upload" instead of "uploads" is because of the schema.js entity name. Change to "uploads"
+  const staleTime = 15 * 60000; // 15 * 60000 milliseconds = 15 mins
+  const cacheTime = staleTime;
   const { data: { documents, upload } = {}, ...ordersDocumentsQuery } = useQuery(
     [ORDERS_DOCUMENTS, documentId],
     getDocument,
     {
       enabled: !!documentId,
+      staleTime,
+      cacheTime,
       refetchOnWindowFocus: false,
     },
   );

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React from 'react';
 import { useParams, matchPath, useLocation } from 'react-router-dom';
 
 import moveOrdersStyles from '../MoveOrders/MoveOrders.module.scss';
@@ -7,9 +7,8 @@ import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { useOrdersDocumentQueries } from 'hooks/queries';
-
-const MoveOrders = lazy(() => import('pages/Office/MoveOrders/MoveOrders'));
-const MoveAllowances = lazy(() => import('pages/Office/MoveAllowances/MoveAllowances'));
+import MoveOrders from 'pages/Office/MoveOrders/MoveOrders';
+import MoveAllowances from 'pages/Office/MoveAllowances/MoveAllowances';
 
 const MoveDocumentWrapper = () => {
   const { moveCode } = useParams();


### PR DESCRIPTION
## Description

> Motivation is to improve the user experience of not having to refetch document data.
> 
> AC: Disable refetch onFocus for document viewer & document doesn’t reload navigating to either orders/allowances page

## Reviewer Notes

- cache/stale time is set to 15 mins
- refetchOnFocus is set to false

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

Test on experimental:
1. Log in as TOO on `office.exp.move.mil`
2. Click on any move
3. Click on `View & edit orders`
4. Click on `View allowances` and notice that the document doesn't reload

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6104) for this change
* [this article](https://react-query.tanstack.com/reference/useQuery#_top) explains more about the approach used. `refetchOnWindowFocus` is set to disabled.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
