### PR TITLE
[MB-4308] Move 101 page

### DIFF
--- a/cypress/integration/mymove/utilities/customer.js
+++ b/cypress/integration/mymove/utilities/customer.js
@@ -119,7 +119,7 @@ export function customerFillsOutOrdersInformation() {
   cy.upload_file('.filepond--root', 'top-secret.png');
   cy.get('button[data-testid="wizardNextButton"]', { timeout: fileUploadTimeout }).should('not.be.disabled').click();
 
-  cy.get('h1').contains('Figure out your shipments');
+  cy.get('h1').contains('Tips for planning your shipments');
   cy.nextPage();
 
   cy.visit('/');

--- a/src/components/Customer/MilmoveCard/MilmoveCard.jsx
+++ b/src/components/Customer/MilmoveCard/MilmoveCard.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Card } from '@trussworks/react-uswds';
 import { bool, node } from 'prop-types';
 
-import * as styles from './MilmoveCard.module.scss';
+import styles from './MilmoveCard.module.scss';
 
 const MilmoveCard = ({ children, headerFirst }) => (
-  <Card containerProps={{ className: styles.CardContainer }} headerFirst={headerFirst}>
+  <Card className={styles.MilmoveCard} containerProps={{ className: styles.CardContainer }} headerFirst={headerFirst}>
     {children}
   </Card>
 );

--- a/src/components/Customer/MilmoveCard/MilmoveCard.module.scss
+++ b/src/components/Customer/MilmoveCard/MilmoveCard.module.scss
@@ -1,7 +1,30 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
 @import 'shared/styles/_variables';
+
+:global(.usa-prose) .MilmoveCard {
+  margin-bottom: 0;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.MilmoveCard + .MilmoveCard {
+  @include u-margin-top(1);
+
+  @include at-media('desktop') {
+    @include u-margin-top(0);
+  }
+}
 
 .CardContainer {
   border-width: 0;
   border-bottom: 1px solid #dcdee0;
   border-radius: 0;
+
+  ul {
+    list-style: disc inside;
+  }
 }

--- a/src/components/Customer/SectionWrapper.module.scss
+++ b/src/components/Customer/SectionWrapper.module.scss
@@ -3,6 +3,11 @@
 @import 'shared/styles/_variables.scss';
 @import 'shared/styles/_basics.scss';
 
+// 24px margin in between Alert and SectionWrapper
+:global(.usa-alert) + .sectionWrapper {
+  @include u-margin-top(3);
+}
+
 .sectionWrapper {
   @media (min-width: $tablet) {
     @include u-bg('white');
@@ -30,6 +35,10 @@
     :global {
       .usa-form-group:first-of-type .usa-label {
         margin-top: 0;
+      }
+
+      .usa-card-group:first-child > .usa-card--header-first:first-child .usa-card__header {
+        @include u-padding-top(0);
       }
     }
   }

--- a/src/components/Customer/SectionWrapper.module.scss
+++ b/src/components/Customer/SectionWrapper.module.scss
@@ -40,6 +40,16 @@
       .usa-card-group:first-child > .usa-card--header-first:first-child .usa-card__header {
         @include u-padding-top(0);
       }
+
+      .usa-card-group:last-child > .usa-card:last-child {
+        .usa-card__container {
+          border-bottom: 0;
+        }
+
+        .usa-card__body {
+          @include u-padding-bottom(0);
+        }
+      }
     }
   }
 }

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -12,7 +12,7 @@ export const MovingInfo = () => {
   return (
     <>
       <h1 data-testid="shipmentsHeader">Tips for planning your shipments</h1>
-      <Alert type="info" heading="You can move 7,000 lbs for free">
+      <Alert type="info" heading="You can move 7,000 lbs for free" noIcon>
         The government will pay to move that much weight. Your whole move, no matter how many shipments it takes.
         <br />
         <br />
@@ -24,7 +24,7 @@ export const MovingInfo = () => {
             <CardHeader>
               <h3>Hold on to things you’ll need quickly</h3>
             </CardHeader>
-            <CardMedia>
+            <CardMedia inset>
               <img src={PPMShipmentImg} alt="PPM Shipment" />
             </CardMedia>
             <CardBody>
@@ -40,7 +40,7 @@ export const MovingInfo = () => {
             <CardHeader>
               <h3>One move, several parts</h3>
             </CardHeader>
-            <CardMedia>
+            <CardMedia inset>
               <img src={HHGShipmentImg} alt="HHG Shipment" />
             </CardMedia>
             <CardBody>
@@ -56,7 +56,7 @@ export const MovingInfo = () => {
             <CardHeader>
               <h3>Talk to your move counselor</h3>
             </CardHeader>
-            <CardMedia>
+            <CardMedia inset>
               <img src={MoveCounselorImg} alt="Move counselor" />
             </CardMedia>
             <CardBody>
@@ -76,7 +76,7 @@ export const MovingInfo = () => {
             <CardHeader>
               <h3>Talk to your movers</h3>
             </CardHeader>
-            <CardMedia>
+            <CardMedia inset>
               <img src={MovingTruckImg} alt="Moving truck" />
             </CardMedia>
             <CardBody>

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -22,7 +22,7 @@ export const MovingInfo = () => {
         <CardGroup>
           <MilmoveCard>
             <CardHeader>
-              <h3>Hold on to things you’ll need quickly</h3>
+              <h3 data-testid="shipmentsSubHeader">Hold on to things you’ll need quickly</h3>
             </CardHeader>
             <CardMedia inset>
               <img src={PPMShipmentImg} alt="PPM Shipment" />
@@ -38,7 +38,7 @@ export const MovingInfo = () => {
           </MilmoveCard>
           <MilmoveCard>
             <CardHeader>
-              <h3>One move, several parts</h3>
+              <h3 data-testid="shipmentsSubHeader">One move, several parts</h3>
             </CardHeader>
             <CardMedia inset>
               <img src={HHGShipmentImg} alt="HHG Shipment" />
@@ -54,7 +54,7 @@ export const MovingInfo = () => {
           </MilmoveCard>
           <MilmoveCard>
             <CardHeader>
-              <h3>Talk to your move counselor</h3>
+              <h3 data-testid="shipmentsSubHeader">Talk to your move counselor</h3>
             </CardHeader>
             <CardMedia inset>
               <img src={MoveCounselorImg} alt="Move counselor" />
@@ -74,7 +74,7 @@ export const MovingInfo = () => {
           </MilmoveCard>
           <MilmoveCard>
             <CardHeader>
-              <h3>Talk to your movers</h3>
+              <h3 data-testid="shipmentsSubHeader">Talk to your movers</h3>
             </CardHeader>
             <CardMedia inset>
               <img src={MovingTruckImg} alt="Moving truck" />

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { CardGroup, CardHeader, CardBody, CardMedia } from '@trussworks/react-uswds';
+import { Alert, CardGroup, CardHeader, CardBody, CardMedia } from '@trussworks/react-uswds';
 
-import PPMShipmentImg from '../../images/ppm-shipment.jpg';
-import HHGShipmentImg from '../../images/hhg-shipment.jpg';
-import MoveCounselorImg from '../../images/move-counselor.jpg';
-import MovingTruckImg from '../../images/moving-truck.jpg';
-
+import PPMShipmentImg from 'images/ppm-shipment.jpg';
+import HHGShipmentImg from 'images/hhg-shipment.jpg';
+import MoveCounselorImg from 'images/move-counselor.jpg';
+import MovingTruckImg from 'images/moving-truck.jpg';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import MilmoveCard from 'components/Customer/MilmoveCard/MilmoveCard';
 
@@ -13,6 +12,12 @@ export const MovingInfo = () => {
   return (
     <>
       <h1 data-testid="shipmentsHeader">Tips for planning your shipments</h1>
+      <Alert type="info" heading="You can move 7,000 lbs for free">
+        The government will pay to move that much weight. Your whole move, no matter how many shipments it takes.
+        <br />
+        <br />
+        If you move more weight, you’ll need to pay for the excess. We’ll tell you if it looks like that could happen.
+      </Alert>
       <SectionWrapper>
         <CardGroup>
           <MilmoveCard>
@@ -57,11 +62,11 @@ export const MovingInfo = () => {
             <CardBody>
               <p>
                 A session with a move counselor is free. Counselors have a lot of experience with military moves and can
-                steer you through complicated situations.{' '}
+                steer you through complicated situations.
               </p>
               <p>Your counselor can identify:</p>
               <ul>
-                <li>belongings that won&apos;t count against your weight allowance</li>
+                <li>belongings that won’t count against your weight allowance</li>
                 <li>excess weight, excess distance, and other things that can cost you money</li>
                 <li>things to make your move easier</li>
               </ul>
@@ -76,8 +81,8 @@ export const MovingInfo = () => {
             </CardMedia>
             <CardBody>
               <p>
-                If you have any shipments using professional movers, you&apos;ll be referred to a point of contact for
-                your move.
+                If you have any shipments using professional movers, you’ll be referred to a point of contact for your
+                move.
               </p>
               <p>When things get complicated or you have questions during your move, they are there to help.</p>
               <p>

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -1,31 +1,92 @@
 import React from 'react';
+import { CardGroup, CardHeader, CardBody, CardMedia } from '@trussworks/react-uswds';
+
+import PPMShipmentImg from '../../images/ppm-shipment.jpg';
+import HHGShipmentImg from '../../images/hhg-shipment.jpg';
+import MoveCounselorImg from '../../images/move-counselor.jpg';
+import MovingTruckImg from '../../images/moving-truck.jpg';
 
 import SectionWrapper from 'components/Customer/SectionWrapper';
+import MilmoveCard from 'components/Customer/MilmoveCard/MilmoveCard';
 
 export const MovingInfo = () => {
   return (
     <>
-      <h1 data-testid="shipmentsHeader">Figure out your shipments</h1>
-      <p>Handy tips as you decide how to move</p>
+      <h1 data-testid="shipmentsHeader">Tips for planning your shipments</h1>
       <SectionWrapper>
-        <h2 data-testid="shipmentsSubHeader">Move in one shipment or more</h2>
-        <p>
-          It’s common to move in a few shipments. Everything can go in one batch, or you can divide your belongings into
-          several shipments.
-        </p>
-        <hr />
-        <h2 className="margin-top-2" data-testid="shipmentsSubHeader">
-          Keep important things with you
-        </h2>
-        <p>
-          It’s a good idea to move things you’ll need right away and prized possessions yourself. Select a PPM
-          (personally procured move) shipment to do that.
-        </p>
-        <hr />
-        <h2 className="margin-top-2" data-testid="shipmentsSubHeader">
-          Spread out your pickup dates
-        </h2>
-        <p>It’s easier to coordinate multiple shipments if you don’t schedule all the pickups on the same day.</p>
+        <CardGroup>
+          <MilmoveCard>
+            <CardHeader>
+              <h3>Hold on to things you’ll need quickly</h3>
+            </CardHeader>
+            <CardMedia>
+              <img src={PPMShipmentImg} alt="PPM Shipment" />
+            </CardMedia>
+            <CardBody>
+              <p>Hand-carry important documents — ID, medical info, orders, school records, etc.</p>
+              <p>
+                Pack a set of things that you’ll need when you arrive — clothes, electronics, chargers, cleaning
+                supplies, etc. Valuables that can’t be replaced are also a good idea.
+              </p>
+              <p>To be paid for moving these things, select a PPM shipment.</p>
+            </CardBody>
+          </MilmoveCard>
+          <MilmoveCard>
+            <CardHeader>
+              <h3>One move, several parts</h3>
+            </CardHeader>
+            <CardMedia>
+              <img src={HHGShipmentImg} alt="HHG Shipment" />
+            </CardMedia>
+            <CardBody>
+              <p>It’s common to move a few things yourself and have professional movers pack and move the rest.</p>
+              <p>
+                You can have things picked up or delivered to more than one place — your home and an office, for
+                example. But multiple shipments make it easier to go over weight and end up paying for part of your move
+                yourself.
+              </p>
+            </CardBody>
+          </MilmoveCard>
+          <MilmoveCard>
+            <CardHeader>
+              <h3>Talk to your move counselor</h3>
+            </CardHeader>
+            <CardMedia>
+              <img src={MoveCounselorImg} alt="Move counselor" />
+            </CardMedia>
+            <CardBody>
+              <p>
+                A session with a move counselor is free. Counselors have a lot of experience with military moves and can
+                steer you through complicated situations.{' '}
+              </p>
+              <p>Your counselor can identify:</p>
+              <ul>
+                <li>belongings that won&apos;t count against your weight allowance</li>
+                <li>excess weight, excess distance, and other things that can cost you money</li>
+                <li>things to make your move easier</li>
+              </ul>
+            </CardBody>
+          </MilmoveCard>
+          <MilmoveCard>
+            <CardHeader>
+              <h3>Talk to your movers</h3>
+            </CardHeader>
+            <CardMedia>
+              <img src={MovingTruckImg} alt="Moving truck" />
+            </CardMedia>
+            <CardBody>
+              <p>
+                If you have any shipments using professional movers, you&apos;ll be referred to a point of contact for
+                your move.
+              </p>
+              <p>When things get complicated or you have questions during your move, they are there to help.</p>
+              <p>
+                It’s OK if things change after you submit your move info. Your movers or your counselor will make things
+                work.
+              </p>
+            </CardBody>
+          </MilmoveCard>
+        </CardGroup>
       </SectionWrapper>
     </>
   );

--- a/src/pages/MyMove/MovingInfo.test.jsx
+++ b/src/pages/MyMove/MovingInfo.test.jsx
@@ -8,7 +8,7 @@ const wrapper = mount(<MovingInfo />);
 describe('MovingInfo component', () => {
   it('renders', () => {
     expect(wrapper.find('MovingInfo').length).toBe(1);
-    expect(wrapper.text()).toContain('Figure out your shipments');
+    expect(wrapper.text()).toContain('Tips for planning your shipments');
     expect(wrapper.find('[data-testid="shipmentsHeader"]').length).toBe(1);
     expect(wrapper.find('[data-testid="shipmentsSubHeader"]').length).toBe(3);
   });

--- a/src/pages/MyMove/MovingInfo.test.jsx
+++ b/src/pages/MyMove/MovingInfo.test.jsx
@@ -10,6 +10,6 @@ describe('MovingInfo component', () => {
     expect(wrapper.find('MovingInfo').length).toBe(1);
     expect(wrapper.text()).toContain('Tips for planning your shipments');
     expect(wrapper.find('[data-testid="shipmentsHeader"]').length).toBe(1);
-    expect(wrapper.find('[data-testid="shipmentsSubHeader"]').length).toBe(3);
+    expect(wrapper.find('[data-testid="shipmentsSubHeader"]').length).toBe(4);
   });
 });


### PR DESCRIPTION
## Description

This PR uses the new MilmoveCard component and updates the Moving 101 page with new content.

## Reviewer Notes

To test, you will need to log in as a service member and add your first shipment. The Moving 101 page should display ahead of selecting the shipment type. Alternatively, you can log in as a service member who already has profile/orders info and navigate to: `/moves/<move ID>/moving-info`

## Setup

To start the application locally:
```
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4308) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/2723066/103695316-f40f5680-4f61-11eb-9021-40c3c527545f.png)

![image](https://user-images.githubusercontent.com/2723066/103695366-09848080-4f62-11eb-83b5-0c7f78ff6315.png)

