### PR TITLE
[MB-6148] format actual timestamps to 2 decimal place precision in getMove handler test

### DIFF
--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestGetMoveHandler() {
-	swaggerTimeFormat := "2006-01-02T15:04:05.999Z07:00"
+	swaggerTimeFormat := "2006-01-02T15:04:05.99Z07:00"
 	availableToPrimeAt := time.Now()
 	submittedAt := availableToPrimeAt.Add(-1 * time.Hour)
 
@@ -54,15 +54,15 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		payload := response.(*moveops.GetMoveOK).Payload
 
 		suite.Equal(move.ID.String(), payload.ID.String())
-		suite.Equal(move.AvailableToPrimeAt.Format(swaggerTimeFormat), payload.AvailableToPrimeAt.String())
+		suite.Equal(move.AvailableToPrimeAt.Format(swaggerTimeFormat), time.Time(*payload.AvailableToPrimeAt).Format(swaggerTimeFormat))
 		suite.Equal(move.ContractorID.String(), payload.ContractorID.String())
 		suite.Equal(move.Locator, payload.Locator)
 		suite.Equal(move.OrdersID.String(), payload.OrdersID.String())
 		suite.Equal(move.ReferenceID, payload.ReferenceID)
 		suite.Equal(string(move.Status), string(payload.Status))
-		suite.Equal(move.CreatedAt.Format(swaggerTimeFormat), payload.CreatedAt.String())
-		suite.Equal(move.SubmittedAt.Format(swaggerTimeFormat), payload.SubmittedAt.String())
-		suite.Equal(move.UpdatedAt.Format(swaggerTimeFormat), payload.UpdatedAt.String())
+		suite.Equal(move.CreatedAt.Format(swaggerTimeFormat), time.Time(payload.CreatedAt).Format(swaggerTimeFormat))
+		suite.Equal(move.SubmittedAt.Format(swaggerTimeFormat), time.Time(*payload.SubmittedAt).Format(swaggerTimeFormat))
+		suite.Equal(move.UpdatedAt.Format(swaggerTimeFormat), time.Time(payload.UpdatedAt).Format(swaggerTimeFormat))
 	})
 
 	suite.T().Run("Unsuccessful move fetch - empty string bad request", func(t *testing.T) {


### PR DESCRIPTION
## Description

I introduced a test a few sprints ago that checked the timestamp values in the getMove payload.  Our CI would intermittently fail on this test because sometimes the time precision would only be to 2 decimal places instead of 3 when the value was 0.  This caused the test to fail because the string formats would no longer match.

I changed the format to only check to 2 decimal places, which requires more work in the test since we can't just use the default String() ISO output which expects 3 places.

```
=== CONT  TestHandlerSuite/TestGetMoveHandler
    move_test.go:63: 
        	Error Trace:	move_test.go:63
        	Error:      	Not equal: 
        	            	expected: "2020-12-31T22:21:01.95Z"
        	            	actual  : "2020-12-31T22:21:01.950Z"
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-2020-12-31T22:21:01.95Z
        	            	+2020-12-31T22:21:01.950Z
        	Test:       	TestHandlerSuite/TestGetMoveHandler
    move_test.go:65: 
        	Error Trace:	move_test.go:65
        	Error:      	Not equal: 
        	            	expected: "2020-12-31T22:21:01.95Z"
        	            	actual  : "2020-12-31T22:21:01.950Z"
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-2020-12-31T22:21:01.95Z
        	            	+2020-12-31T22:21:01.950Z
```

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
go test ./pkg/handlers/ghcapi
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6148) for this change

## Screenshots
