### PR TITLE
[MB-6151] Error retrieving payment requests by move for USMC TIO user

### DIFF
--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -128,6 +128,7 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(officeUserID u
 	query := f.db.Q().EagerPreload("PaymentServiceItems").
 		InnerJoin("moves", "payment_requests.move_id = moves.id").
 		InnerJoin("orders", "orders.id = moves.orders_id").
+		InnerJoin("service_members", "orders.service_member_id = service_members.id").
 		InnerJoin("duty_stations", "duty_stations.id = orders.origin_duty_station_id").
 		InnerJoin("transportation_offices", "transportation_offices.id = duty_stations.transportation_office_id").
 		Where("moves.show = ?", swag.Bool(true))

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -173,46 +173,61 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListStatusFilter
 }
 
 func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() {
+	officeUUID, _ := uuid.NewV4()
+	marines := models.AffiliationMARINES
+	army := models.AffiliationARMY
+
+	paymentRequestUSMC := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "USMC",
+			ID:    officeUUID,
+		},
+		Move: models.Move{
+			Status: models.MoveStatusSUBMITTED,
+		},
+		ServiceMember: models.ServiceMember{Affiliation: &marines},
+	})
+
+	paymentRequestUSMC2 := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		PaymentRequest: models.PaymentRequest{
+			SequenceNumber: 2,
+		},
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "USMC",
+			ID:    officeUUID,
+		},
+		Move: paymentRequestUSMC.MoveTaskOrder,
+	})
+
+	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Move: models.Move{
+			Status: models.MoveStatusSUBMITTED,
+		},
+		ServiceMember: models.ServiceMember{Affiliation: &army},
+	})
+
+	officeUserOooRah := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{OfficeUser: models.OfficeUser{TransportationOfficeID: officeUUID}})
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
 	suite.T().Run("returns USMC payment requests", func(t *testing.T) {
-		officeUUID, _ := uuid.NewV4()
-		marines := models.AffiliationMARINES
-		army := models.AffiliationARMY
-
-		testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-			TransportationOffice: models.TransportationOffice{
-				Gbloc: "USMC",
-				ID:    officeUUID,
-			},
-			Move: models.Move{
-				Status: models.MoveStatusSUBMITTED,
-			},
-			ServiceMember: models.ServiceMember{Affiliation: &marines},
-		})
-
-		testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusSubmitted,
-			},
-			Move: models.Move{
-				Status: models.MoveStatusSUBMITTED,
-			},
-			ServiceMember: models.ServiceMember{Affiliation: &army},
-		})
-
-		officeUserOooRah := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{OfficeUser: models.OfficeUser{TransportationOfficeID: officeUUID}})
-		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-
 		paymentRequestListFetcher := NewPaymentRequestListFetcher(suite.DB())
 		expectedPaymentRequests, _, err := paymentRequestListFetcher.FetchPaymentRequestList(officeUserOooRah.ID,
 			&services.FetchPaymentRequestListParams{Page: swag.Int64(1), PerPage: swag.Int64(2)})
 		paymentRequests := *expectedPaymentRequests
 
 		suite.NoError(err)
-		suite.Equal(1, len(paymentRequests))
+		suite.Equal(2, len(paymentRequests))
 		suite.Equal(models.AffiliationMARINES, *paymentRequests[0].MoveTaskOrder.Orders.ServiceMember.Affiliation)
+		suite.Equal(models.AffiliationMARINES, *paymentRequests[1].MoveTaskOrder.Orders.ServiceMember.Affiliation)
 
 		expectedPaymentRequests, _, err = paymentRequestListFetcher.FetchPaymentRequestList(officeUser.ID,
 			&services.FetchPaymentRequestListParams{Page: swag.Int64(1), PerPage: swag.Int64(2)})
@@ -221,6 +236,17 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 		suite.NoError(err)
 		suite.Equal(1, len(paymentRequests))
 		suite.Equal(models.AffiliationARMY, *paymentRequests[0].MoveTaskOrder.Orders.ServiceMember.Affiliation)
+	})
+
+	suite.T().Run("returns USMC payment requests for move", func(t *testing.T) {
+		paymentRequestListFetcher := NewPaymentRequestListFetcher(suite.DB())
+		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(officeUserOooRah.ID, paymentRequestUSMC.MoveTaskOrder.Locator)
+		paymentRequests := *expectedPaymentRequests
+
+		suite.NoError(err)
+		suite.Equal(2, len(paymentRequests))
+		suite.Equal(paymentRequestUSMC.ID, paymentRequests[0].ID)
+		suite.Equal(paymentRequestUSMC2.ID, paymentRequests[1].ID)
 	})
 }
 

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -610,8 +610,12 @@ func createPPMReadyToRequestPayment(db *pop.Connection, userUploader *uploader.U
 	models.SaveMoveDependencies(db, &ppm6.Move)
 }
 
-func createHHGMoveWithPaymentRequest(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger) {
-	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{})
+func createHHGMoveWithPaymentRequest(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, affiliation models.ServiceMemberAffiliation) {
+	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			Affiliation: &affiliation,
+		},
+	})
 	orders := testdatagen.MakeOrder(db, testdatagen.Assertions{
 		Order: models.Order{
 			ServiceMemberID: customer.ID,
@@ -1741,8 +1745,10 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	// This allows testing the pagination feature in the TXO queues.
 	// Feel free to comment out the loop if you don't need this many moves.
 	for i := 1; i < 12; i++ {
-		createHHGMoveWithPaymentRequest(db, userUploader, primeUploader, logger)
+		createHHGMoveWithPaymentRequest(db, userUploader, primeUploader, logger, models.AffiliationAIRFORCE)
 	}
+	createHHGMoveWithPaymentRequest(db, userUploader, primeUploader, logger, models.AffiliationMARINES)
+
 	createMoveWithPPMAndHHG(db, userUploader)
 	createHHGMoveWith10ServiceItems(db, userUploader)
 	createHHGMoveWith2PaymentRequests(db, userUploader)


### PR DESCRIPTION
## Description

A 404 error was being returned when a TIO user assigned to the USMC GBLOC was trying to view all the payment requests for a particular move.

This case is handled differently in the backend because we don't filter payment requests by the GBLOC but by the service member's branch affiliation.  We didn't test this case for this query as it used to by part of the queues query but we broke it off and forgot to include a join to the service members table.

![Screen Shot 2021-01-05 at 12 32 55 PM](https://user-images.githubusercontent.com/52669884/103683158-d50bc700-4f57-11eb-9d46-7de0958c4bcc.png)

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TOO/TIO USMC user (too_tio_role_usmc@office.mil)
2. Switch to the TIO user role once logged in if necessary
4. Click on the payment request in the queue
5. Verify that the payment request card is shown for the move

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6151) for this change

## Screenshots

![Screen Shot 2021-01-05 at 1 38 24 PM](https://user-images.githubusercontent.com/52669884/103685830-dccd6a80-4f5b-11eb-9399-3249e89eb700.png)
