### PR TITLE
[MB-6089] Use ConflictError instead of InvalidInputError in updatePaymentRequestStatus

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -559,6 +559,9 @@ func init() {
           "404": {
             "$ref": "#/responses/NotFound"
           },
+          "409": {
+            "$ref": "#/responses/Conflict"
+          },
           "412": {
             "$ref": "#/responses/PreconditionFailed"
           },
@@ -2721,6 +2724,12 @@ func init() {
           },
           "404": {
             "description": "The requested resource wasn't found.",
+            "schema": {
+              "$ref": "#/definitions/ClientError"
+            }
+          },
+          "409": {
+            "description": "There was a conflict with the request.",
             "schema": {
               "$ref": "#/definitions/ClientError"
             }

--- a/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status_responses.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status_responses.go
@@ -233,6 +233,50 @@ func (o *UpdatePaymentRequestStatusNotFound) WriteResponse(rw http.ResponseWrite
 	}
 }
 
+// UpdatePaymentRequestStatusConflictCode is the HTTP code returned for type UpdatePaymentRequestStatusConflict
+const UpdatePaymentRequestStatusConflictCode int = 409
+
+/*UpdatePaymentRequestStatusConflict There was a conflict with the request.
+
+swagger:response updatePaymentRequestStatusConflict
+*/
+type UpdatePaymentRequestStatusConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *supportmessages.ClientError `json:"body,omitempty"`
+}
+
+// NewUpdatePaymentRequestStatusConflict creates UpdatePaymentRequestStatusConflict with default headers values
+func NewUpdatePaymentRequestStatusConflict() *UpdatePaymentRequestStatusConflict {
+
+	return &UpdatePaymentRequestStatusConflict{}
+}
+
+// WithPayload adds the payload to the update payment request status conflict response
+func (o *UpdatePaymentRequestStatusConflict) WithPayload(payload *supportmessages.ClientError) *UpdatePaymentRequestStatusConflict {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update payment request status conflict response
+func (o *UpdatePaymentRequestStatusConflict) SetPayload(payload *supportmessages.ClientError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdatePaymentRequestStatusConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(409)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // UpdatePaymentRequestStatusPreconditionFailedCode is the HTTP code returned for type UpdatePaymentRequestStatusPreconditionFailed
 const UpdatePaymentRequestStatusPreconditionFailedCode int = 412
 

--- a/pkg/gen/supportclient/payment_request/update_payment_request_status_responses.go
+++ b/pkg/gen/supportclient/payment_request/update_payment_request_status_responses.go
@@ -53,6 +53,12 @@ func (o *UpdatePaymentRequestStatusReader) ReadResponse(response runtime.ClientR
 			return nil, err
 		}
 		return nil, result
+	case 409:
+		result := NewUpdatePaymentRequestStatusConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 412:
 		result := NewUpdatePaymentRequestStatusPreconditionFailed()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -231,6 +237,39 @@ func (o *UpdatePaymentRequestStatusNotFound) GetPayload() *supportmessages.Clien
 }
 
 func (o *UpdatePaymentRequestStatusNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(supportmessages.ClientError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdatePaymentRequestStatusConflict creates a UpdatePaymentRequestStatusConflict with default headers values
+func NewUpdatePaymentRequestStatusConflict() *UpdatePaymentRequestStatusConflict {
+	return &UpdatePaymentRequestStatusConflict{}
+}
+
+/*UpdatePaymentRequestStatusConflict handles this case with default header values.
+
+There was a conflict with the request.
+*/
+type UpdatePaymentRequestStatusConflict struct {
+	Payload *supportmessages.ClientError
+}
+
+func (o *UpdatePaymentRequestStatusConflict) Error() string {
+	return fmt.Sprintf("[PATCH /payment-requests/{paymentRequestID}/status][%d] updatePaymentRequestStatusConflict  %+v", 409, o.Payload)
+}
+
+func (o *UpdatePaymentRequestStatusConflict) GetPayload() *supportmessages.ClientError {
+	return o.Payload
+}
+
+func (o *UpdatePaymentRequestStatusConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(supportmessages.ClientError)
 

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -114,6 +114,8 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 			return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
 		case services.PreconditionFailedError:
 			return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
+		case services.ConflictError:
+			return paymentrequestop.NewUpdatePaymentRequestStatusConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceID()))
 		default:
 			logger.Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
 			return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceID()))

--- a/pkg/services/payment_request/payment_request_status_updater.go
+++ b/pkg/services/payment_request/payment_request_status_updater.go
@@ -42,7 +42,7 @@ func (p *paymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest 
 		}
 
 		if len(paymentServiceItems) > 0 {
-			return nil, services.NewInvalidInputError(id, nil, nil, "All PaymentServiceItems must be approved or denied to review this PaymentRequest")
+			return nil, services.NewConflictError(id, "All PaymentServiceItems must be approved or denied to review this PaymentRequest")
 		}
 	}
 

--- a/pkg/services/payment_request/payment_request_status_updater_test.go
+++ b/pkg/services/payment_request/payment_request_status_updater_test.go
@@ -25,7 +25,7 @@ func (suite *PaymentRequestServiceSuite) TestUpdatePaymentRequestStatus() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("Should return an InvalidInputError if the payment request has any service items that have not been reviewed", func(t *testing.T) {
+	suite.T().Run("Should return a ConflictError if the payment request has any service items that have not been reviewed", func(t *testing.T) {
 		paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 
 		psiCost := unit.Cents(10000)
@@ -49,7 +49,7 @@ func (suite *PaymentRequestServiceSuite) TestUpdatePaymentRequestStatus() {
 
 		_, err := updater.UpdatePaymentRequestStatus(&paymentRequest, etag.GenerateEtag(paymentRequest.UpdatedAt))
 		suite.Error(err)
-		suite.IsType(services.InvalidInputError{}, err)
+		suite.IsType(services.ConflictError{}, err)
 	})
 
 	suite.T().Run("Should update and return no error if the payment request has service items that have all been reviewed", func(t *testing.T) {

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -308,6 +308,8 @@ paths:
           $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
+        '409':
+          $ref: '#/responses/Conflict'
         '412':
           $ref: '#/responses/PreconditionFailed'
         '422':


### PR DESCRIPTION
## Description
I changed the error response you get when attempting to update the payment request status for a payment request that hasn't had all of its items approved or denied. 
We used to return an `InvalidInputError`, which was converted to an HTTP 500 response by the handler.

We only want 500s to happen when our code is broken, so I converted this to a `ConflictError`, which results in a 409 response.

## Setup

```sh
make bin/prime-api-client
make db_dev_e2e_populate
make server_run
```

Create an input file for creating a payment request. Let's call it `payment_request.json`.
*Note that, if there are any FSC or DSH service items in the payment request, the request will fail. (This is due to an issue with the DTOD API that is being investigated right now, and is unrelated to this PR.*
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "94bc8b44-fefe-469f-83a0-39b1e31116fb"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Create the payment request, and use `jq` to generate the input file for the next step
```sh
prime-api-client --insecure create-payment-request --filename payment_request.json | jq "{paymentRequestID: .paymentServiceItems[0].paymentRequestID, ifMatch: .eTag, body: {status: \"REVIEWED\"}}" > update_payment_request_status.json
```
Attempt to update the payment request status
```
prime-api-client --insecure support-update-payment-request-status --filename update_payment_request_status.json
```
Verify that you get a response with status code 409.
Example output:
```
HTTP/1.1 409 Conflict
Content-Length: 236
Cache-Control: no-cache, no-store, must-revalidate
Content-Security-Policy: frame-ancestors 'none'
Content-Type: application/json
Date: Tue, 05 Jan 2021 22:26:27 GMT
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Frame-Options: deny
X-Xss-Protection: 1; mode=block

{"detail":"id: 6260639e-b10d-4d84-bbed-b74597dfe355 is in a conflicting state All PaymentServiceItems must be approved or denied to review this PaymentRequest","instance":"ecf7627a-9fa8-4932-830d-5c508342d3a9","title":"Conflict Error"}

{"Payload":{"detail":"id: 6260639e-b10d-4d84-bbed-b74597dfe355 is in a conflicting state All PaymentServiceItems must be approved or denied to review this PaymentRequest","instance":"ecf7627a-9fa8-4932-830d-5c508342d3a9","title":"Conflict Error"}}%
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6089) for this change
