### PR TITLE
Add estimated weight to createMTOShipment and make isCanceled read-only

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1725,7 +1725,8 @@ func init() {
         },
         "isCanceled": {
           "type": "boolean",
-          "x-nullable": true
+          "x-nullable": true,
+          "readOnly": true
         },
         "moveCode": {
           "type": "string",
@@ -4189,7 +4190,8 @@ func init() {
         },
         "isCanceled": {
           "type": "boolean",
-          "x-nullable": true
+          "x-nullable": true,
+          "readOnly": true
         },
         "moveCode": {
           "type": "string",

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -919,6 +919,10 @@ func init() {
           "description": "Email or id of a contact person for this update",
           "type": "string"
         },
+        "primeEstimatedWeight": {
+          "type": "integer",
+          "example": 4500
+        },
         "requestedPickupDate": {
           "description": "The date the customer requested that this shipment be picked up.",
           "type": "string",
@@ -3378,6 +3382,10 @@ func init() {
         "pointOfContact": {
           "description": "Email or id of a contact person for this update",
           "type": "string"
+        },
+        "primeEstimatedWeight": {
+          "type": "integer",
+          "example": 4500
         },
         "requestedPickupDate": {
           "description": "The date the customer requested that this shipment be picked up.",

--- a/pkg/gen/primemessages/create_m_t_o_shipment.go
+++ b/pkg/gen/primemessages/create_m_t_o_shipment.go
@@ -47,6 +47,9 @@ type CreateMTOShipment struct {
 	// Email or id of a contact person for this update
 	PointOfContact string `json:"pointOfContact,omitempty"`
 
+	// prime estimated weight
+	PrimeEstimatedWeight int64 `json:"primeEstimatedWeight,omitempty"`
+
 	// The date the customer requested that this shipment be picked up.
 	// Required: true
 	// Format: date
@@ -83,6 +86,8 @@ func (m *CreateMTOShipment) UnmarshalJSON(raw []byte) error {
 		PickupAddress *Address `json:"pickupAddress"`
 
 		PointOfContact string `json:"pointOfContact,omitempty"`
+
+		PrimeEstimatedWeight int64 `json:"primeEstimatedWeight,omitempty"`
 
 		RequestedPickupDate *strfmt.Date `json:"requestedPickupDate"`
 
@@ -128,6 +133,9 @@ func (m *CreateMTOShipment) UnmarshalJSON(raw []byte) error {
 	// pointOfContact
 	result.PointOfContact = data.PointOfContact
 
+	// primeEstimatedWeight
+	result.PrimeEstimatedWeight = data.PrimeEstimatedWeight
+
 	// requestedPickupDate
 	result.RequestedPickupDate = data.RequestedPickupDate
 
@@ -156,6 +164,8 @@ func (m CreateMTOShipment) MarshalJSON() ([]byte, error) {
 
 		PointOfContact string `json:"pointOfContact,omitempty"`
 
+		PrimeEstimatedWeight int64 `json:"primeEstimatedWeight,omitempty"`
+
 		RequestedPickupDate *strfmt.Date `json:"requestedPickupDate"`
 
 		ShipmentType MTOShipmentType `json:"shipmentType"`
@@ -172,6 +182,8 @@ func (m CreateMTOShipment) MarshalJSON() ([]byte, error) {
 		PickupAddress: m.PickupAddress,
 
 		PointOfContact: m.PointOfContact,
+
+		PrimeEstimatedWeight: m.PrimeEstimatedWeight,
 
 		RequestedPickupDate: m.RequestedPickupDate,
 

--- a/pkg/gen/primemessages/move_task_order.go
+++ b/pkg/gen/primemessages/move_task_order.go
@@ -42,6 +42,7 @@ type MoveTaskOrder struct {
 	ID strfmt.UUID `json:"id,omitempty"`
 
 	// is canceled
+	// Read Only: true
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
 	// move code

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1510,7 +1510,8 @@ func init() {
         "isCanceled": {
           "description": "Indicated this MoveTaskOrder has been canceled.",
           "type": "boolean",
-          "x-nullable": true
+          "x-nullable": true,
+          "readOnly": true
         },
         "moveCode": {
           "description": "Unique 6-character code the customer can use to refer to their move",
@@ -3709,7 +3710,8 @@ func init() {
         "isCanceled": {
           "description": "Indicated this MoveTaskOrder has been canceled.",
           "type": "boolean",
-          "x-nullable": true
+          "x-nullable": true,
+          "readOnly": true
         },
         "moveCode": {
           "description": "Unique 6-character code the customer can use to refer to their move",

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -55,6 +55,7 @@ type MoveTaskOrder struct {
 	ID strfmt.UUID `json:"id,omitempty"`
 
 	// Indicated this MoveTaskOrder has been canceled.
+	// Read Only: true
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
 	// Unique 6-character code the customer can use to refer to their move

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -77,9 +77,10 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 				StreetAddress2: pickupAddress.StreetAddress2,
 				StreetAddress3: pickupAddress.StreetAddress3,
 			},
-			PointOfContact:      "John Doe",
-			RequestedPickupDate: handlers.FmtDatePtr(mtoShipment.RequestedPickupDate),
-			ShipmentType:        primemessages.MTOShipmentTypeHHG,
+			PointOfContact:       "John Doe",
+			PrimeEstimatedWeight: 1200,
+			RequestedPickupDate:  handlers.FmtDatePtr(mtoShipment.RequestedPickupDate),
+			ShipmentType:         primemessages.MTOShipmentTypeHHG,
 		},
 	}
 
@@ -97,6 +98,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentOK{}, response)
 		// check that the mto shipment status is Submitted
 		suite.Require().Equal(createMTOShipmentPayload.Status, primemessages.MTOShipmentStatusSUBMITTED, "MTO Shipment should have been submitted")
+		suite.Require().Equal(createMTOShipmentPayload.PrimeEstimatedWeight, params.Body.PrimeEstimatedWeight)
 	})
 
 	suite.T().Run("POST failure - 500", func(t *testing.T) {

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -98,6 +98,13 @@ func MTOShipmentModelFromCreate(mtoShipment *primemessages.CreateMTOShipment) *m
 		CustomerRemarks: mtoShipment.CustomerRemarks,
 	}
 
+	if mtoShipment.PrimeEstimatedWeight > 0 {
+		estimatedWeight := unit.Pound(mtoShipment.PrimeEstimatedWeight)
+		model.PrimeEstimatedWeight = &estimatedWeight
+		recordedDate := time.Now()
+		model.PrimeEstimatedWeightRecordedDate = &recordedDate
+	}
+
 	if mtoShipment.RequestedPickupDate != nil {
 		model.RequestedPickupDate = swag.Time(time.Time(*mtoShipment.RequestedPickupDate))
 	}

--- a/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
@@ -108,9 +108,5 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 		model.AvailableToPrimeAt = &availableToPrimeAt
 	}
 
-	if mtoPayload.IsCanceled != nil && *mtoPayload.IsCanceled == true {
-		model.Status = models.MoveStatusCANCELED
-	}
-
 	return model
 }

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -220,7 +220,6 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		AvailableToPrimeAt: handlers.FmtDateTime(time.Now()),
 		PpmType:            "FULL",
 		ContractorID:       handlers.FmtUUID(contractor.ID),
-		IsCanceled:         swag.Bool(false),
 		MoveOrder: &supportmessages.MoveOrder{
 			Rank:                     (supportmessages.Rank)("E_6"),
 			OrderNumber:              swag.String("4554"),
@@ -255,7 +254,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		//             existing duty stations and existing uploaded orders document
 		// Expected outcome:
 		//             New MTO and orders are created. Customer data and duty station data are pulled in.
-		//			   isCanceled should be default value which is draft
+		//			   Status should be default value which is DRAFT
 
 		// We only provide an existing customerID not the whole object.
 		// We expect the handler to link the correct objects
@@ -302,8 +301,8 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// We only provide an existing customerID not the whole object.
 		mtoPayload.MoveOrder.CustomerID = handlers.FmtUUID(dbCustomer.ID)
 
-		// Set IsCanceled to true to set the Move's status to CANCELED
-		mtoPayload.IsCanceled = swag.Bool(true)
+		// Set the status to CANCELED
+		mtoPayload.Status = supportmessages.MoveStatusCANCELED
 
 		params := movetaskorderops.CreateMoveTaskOrderParams{
 			HTTPRequest: request,

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -349,9 +349,5 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 		model.AvailableToPrimeAt = &availableToPrimeAt
 	}
 
-	if mtoPayload.IsCanceled != nil && *mtoPayload.IsCanceled == true {
-		model.Status = models.MoveStatusCANCELED
-	}
-
 	return model
 }

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1021,6 +1021,7 @@ definitions:
       isCanceled:
         type: boolean
         x-nullable: true
+        readOnly: true
       updatedAt:
         format: date-time
         type: string

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -784,6 +784,9 @@ definitions:
         format: date
         type: string
         description: The date the customer requested that this shipment be picked up.
+      primeEstimatedWeight:
+        type: integer
+        example: 4500
       customerRemarks:
         type: string
         example: handle with care

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1027,6 +1027,7 @@ definitions:
       isCanceled:
         type: boolean
         x-nullable: true
+        readOnly: true
         description: Indicated this MoveTaskOrder has been canceled.
       contractorID:
         type: string


### PR DESCRIPTION
## Description

This PR updates the Prime API endpoint `createMTOShipment` to accept a value for the `primeEstimatedWeight` field, and it marks the `isCanceled` field in the MTO definition in both the Prime and Support APIs as "readOnly". This is so the status is only changed using the "status" field and we won't get any unexpectedly canceled moves from load testing.

## Setup

Populate your database with test data and run your server:

```sh
make db_dev_e2e_populate server_run
```

Once your server is running, please test the `createMTOShipment` endpoint and verify that you can add a value for `primeEstimatedWeight`. You may use the method of your choice, [Postman](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman) or the [Prime API Client](https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client). Please verify that you see the correct `primeEstimatedWeight` value and the correct date for `primeEstimatedWeightRecordedAt` in the response payload.

For the change to `isCanceled`, please verify in the ReDoc documentation that it shows up in the response for MTO endpoints, but not in the requests:

* [Prime API ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/add-estimated-weight-to-create-shipment/swagger/prime.yaml)
* [Support API ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/add-estimated-weight-to-create-shipment/swagger/support.yaml)

Then you can try to hit the endpoint `createMoveTaskOrder` in the Support API with `"isCanceled": true` and verify that the response still shows an MTO with DRAFT/SUBMITTED/APPROVED status (whichever one you pass in). 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

