### PR TITLE
[MB-6072] Update TXO routes and params to use moveCode instead of moveOrderId key

### DIFF
--- a/src/pages/Office/MoveDetails/MoveDetails.test.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.test.jsx
@@ -58,7 +58,7 @@ describe('MoveDetails page', () => {
 
   const moveDetailsProps = {
     match: {
-      params: { moveOrderId: '123' },
+      params: { moveCode: '8UY81V' },
       isExact: true,
       path: '',
       url: '',
@@ -79,7 +79,8 @@ describe('MoveDetails page', () => {
   const wrapper = shallow(<MoveDetails {...moveDetailsProps} />);
 
   it('loads data from the API', () => {
-    expect(moveDetailsProps.getMoveOrder).toHaveBeenCalledWith(moveDetailsProps.match.params.moveOrderId);
+    expect(moveDetailsProps.getMoveByLocator).toHaveBeenCalledWith(moveDetailsProps.match.params.moveCode);
+    expect(moveDetailsProps.getMoveOrder).toHaveBeenCalledWith('123');
     expect(moveDetailsProps.getCustomer).toHaveBeenCalledWith(testMoveOrder.customerID);
     expect(moveDetailsProps.getAllMoveTaskOrders).toHaveBeenCalledWith(testMoveOrder.id);
     expect(moveDetailsProps.getMTOShipments).toHaveBeenCalledWith(testMoveTaskOrders[0].id);

--- a/src/pages/Office/MoveOrders/MoveOrders.test.jsx
+++ b/src/pages/Office/MoveOrders/MoveOrders.test.jsx
@@ -83,7 +83,7 @@ jest.mock('hooks/queries', () => ({
 
 describe('MoveOrders page', () => {
   const wrapper = mount(
-    <MockProviders initialEntries={['moves/1000/orders']}>
+    <MockProviders initialEntries={['moves/FP24I2/orders']}>
       <MoveOrders />
     </MockProviders>,
   );

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -10,8 +10,8 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { useMovePaymentRequestsQueries } from 'hooks/queries';
 
 const MovePaymentRequests = () => {
-  const { locator } = useParams();
-  const { paymentRequests, isLoading, isError } = useMovePaymentRequestsQueries(locator);
+  const { moveCode } = useParams();
+  const { paymentRequests, isLoading, isError } = useMovePaymentRequestsQueries(moveCode);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -63,9 +63,9 @@ jest.mock('hooks/queries', () => ({
 }));
 
 describe('MovePaymentRequests', () => {
-  const testMoveLocator = 'L2BKD6';
+  const testMoveCode = 'L2BKD6';
   const component = mount(
-    <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+    <MockProviders initialEntries={[`/moves/${testMoveCode}/payment-requests`]}>
       <MovePaymentRequests />
     </MockProviders>,
   );

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -69,9 +69,9 @@ jest.mock('hooks/queries', () => ({
 }));
 
 describe('MoveTaskOrder', () => {
-  const testId = 'test-id-123';
+  const moveCode = 'WE31AZ';
   const requiredProps = {
-    match: { params: { moveTaskOrderId: testId } },
+    match: { params: { moveCode } },
     history: { push: jest.fn() },
   };
 

--- a/src/pages/Office/PaymentRequestReview/PaymentRequestReview.jsx
+++ b/src/pages/Office/PaymentRequestReview/PaymentRequestReview.jsx
@@ -16,7 +16,7 @@ import { PAYMENT_REQUESTS } from 'constants/queryKeys';
 
 export const PaymentRequestReview = ({ history, match }) => {
   const [completeReviewError, setCompleteReviewError] = useState(undefined);
-  const { paymentRequestId, moveOrderId } = match.params;
+  const { paymentRequestId, moveCode } = match.params;
   const {
     paymentRequest,
     paymentRequests,
@@ -92,7 +92,7 @@ export const PaymentRequestReview = ({ history, match }) => {
   };
 
   const handleClose = () => {
-    history.push(`/moves/${moveOrderId}/payment-requests`);
+    history.push(`/moves/${moveCode}/payment-requests`);
   };
 
   const serviceItemCards = paymentServiceItemsArr.map((item) => {

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -14,13 +14,12 @@ const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
 const MovePaymentRequests = lazy(() => import('pages/Office/MovePaymentRequests/MovePaymentRequests'));
 
 const TXOMoveInfo = () => {
-  // TODO - Clean up path param moveOrderId. Should be moveCode.
-  const { moveOrderId } = useParams();
+  const { moveCode } = useParams();
   const { pathname } = useLocation();
 
   const hideNav =
     matchPath(pathname, {
-      path: '/moves/:moveOrderId/payment-requests/:id',
+      path: '/moves/:moveCode/payment-requests/:id',
       exact: true,
     }) ||
     matchPath(pathname, {
@@ -39,7 +38,7 @@ const TXOMoveInfo = () => {
           <div className="grid-container-desktop-lg">
             <TabNav
               items={[
-                <NavLink exact activeClassName="usa-current" to={`/moves/${moveOrderId}/details`} role="tab">
+                <NavLink exact activeClassName="usa-current" to={`/moves/${moveCode}/details`} role="tab">
                   <span className="tab-title">Move details</span>
                   <Tag>2</Tag>
                 </NavLink>,
@@ -47,15 +46,15 @@ const TXOMoveInfo = () => {
                   data-testid="MoveTaskOrder-Tab"
                   exact
                   activeClassName="usa-current"
-                  to={`/moves/${moveOrderId}/mto`}
+                  to={`/moves/${moveCode}/mto`}
                   role="tab"
                 >
                   <span className="tab-title">Move task order</span>
                 </NavLink>,
-                <NavLink exact activeClassName="usa-current" to={`/moves/${moveOrderId}/payment-requests`} role="tab">
+                <NavLink exact activeClassName="usa-current" to={`/moves/${moveCode}/payment-requests`} role="tab">
                   <span className="tab-title">Payment requests</span>
                 </NavLink>,
-                <NavLink exact activeClassName="usa-current" to={`/moves/${moveOrderId}/history`} role="tab">
+                <NavLink exact activeClassName="usa-current" to={`/moves/${moveCode}/history`} role="tab">
                   <span className="tab-title">History</span>
                 </NavLink>,
               ]}
@@ -77,15 +76,15 @@ const TXOMoveInfo = () => {
             <MoveTaskOrder />
           </Route>
 
-          <Route path="/moves/:moveOrderId/payment-requests/:paymentRequestId" exact>
+          <Route path="/moves/:moveCode/payment-requests/:paymentRequestId" exact>
             <PaymentRequestReview />
           </Route>
 
-          <Route path="/moves/:locator/payment-requests" exact>
+          <Route path="/moves/:moveCode/payment-requests" exact>
             <MovePaymentRequests />
           </Route>
 
-          <Route path="/moves/:moveOrderId/history" exact>
+          <Route path="/moves/:moveCode/history" exact>
             <MoveHistory />
           </Route>
 

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -5,17 +5,17 @@ import TXOMoveInfo from './TXOMoveInfo';
 
 import { MockProviders } from 'testUtils';
 
-const testMoveId = '10000';
+const testMoveCode = '1A5PM3';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn().mockReturnValue({ moveOrderId: '10000' }),
+  useParams: jest.fn().mockReturnValue({ moveCode: '1A5PM3' }),
 }));
 
 describe('TXO Move Info Container', () => {
   it('should render the move tab container', () => {
     const wrapper = mount(
-      <MockProviders initialEntries={[`/moves/${testMoveId}/details`]}>
+      <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
         <TXOMoveInfo />
       </MockProviders>,
     );
@@ -29,16 +29,16 @@ describe('TXO Move Info Container', () => {
     expect(wrapper.find('span.tab-title').at(2).text()).toContain('Payment requests');
     expect(wrapper.find('span.tab-title').at(3).text()).toContain('History');
 
-    expect(wrapper.find('li.tabItem a').at(0).prop('href')).toEqual(`/moves/${testMoveId}/details`);
-    expect(wrapper.find('li.tabItem a').at(1).prop('href')).toEqual(`/moves/${testMoveId}/mto`);
-    expect(wrapper.find('li.tabItem a').at(2).prop('href')).toEqual(`/moves/${testMoveId}/payment-requests`);
-    expect(wrapper.find('li.tabItem a').at(3).prop('href')).toEqual(`/moves/${testMoveId}/history`);
+    expect(wrapper.find('li.tabItem a').at(0).prop('href')).toEqual(`/moves/${testMoveCode}/details`);
+    expect(wrapper.find('li.tabItem a').at(1).prop('href')).toEqual(`/moves/${testMoveCode}/mto`);
+    expect(wrapper.find('li.tabItem a').at(2).prop('href')).toEqual(`/moves/${testMoveCode}/payment-requests`);
+    expect(wrapper.find('li.tabItem a').at(3).prop('href')).toEqual(`/moves/${testMoveCode}/history`);
   });
 
   describe('routing', () => {
     it('should handle the Move Details route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/details`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
@@ -48,7 +48,7 @@ describe('TXO Move Info Container', () => {
 
     it('should redirect from move info root to the Move Details route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
@@ -59,7 +59,7 @@ describe('TXO Move Info Container', () => {
 
     it('should handle the Move Orders route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/orders`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/orders`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
@@ -71,7 +71,7 @@ describe('TXO Move Info Container', () => {
 
     it('should handle the Allowances route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/allowances`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/allowances`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
@@ -83,7 +83,7 @@ describe('TXO Move Info Container', () => {
 
     it('should handle the Move Task Order route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/mto`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/mto`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
@@ -95,26 +95,26 @@ describe('TXO Move Info Container', () => {
 
     it('should handle the Move Payment Requests route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/payment-requests`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/payment-requests`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
 
       const renderedRoute = wrapper.find('Route');
       expect(renderedRoute).toHaveLength(1);
-      expect(renderedRoute.prop('path')).toEqual('/moves/:locator/payment-requests');
+      expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/payment-requests');
     });
 
     it('should handle the Move History route', () => {
       const wrapper = mount(
-        <MockProviders initialEntries={[`/moves/${testMoveId}/history`]}>
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/history`]}>
           <TXOMoveInfo />
         </MockProviders>,
       );
 
       const renderedRoute = wrapper.find('Route');
       expect(renderedRoute).toHaveLength(1);
-      expect(renderedRoute.prop('path')).toEqual('/moves/:moveOrderId/history');
+      expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/history');
     });
   });
 });

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -38,9 +38,8 @@ const OrdersInfo = lazy(() => import('scenes/Office/OrdersInfo'));
 const DocumentViewer = lazy(() => import('scenes/Office/DocumentViewer'));
 // TXO
 const TXOMoveInfo = lazy(() => import('pages/Office/TXOMoveInfo/TXOMoveInfo'));
-// TOO pages (TODO move into src/pages)
+// TOO pages
 const MoveQueue = lazy(() => import('pages/Office/MoveQueue/MoveQueue'));
-const CustomerDetails = lazy(() => import('scenes/Office/TOO/customerDetails'));
 // TIO pages
 const PaymentRequestQueue = lazy(() => import('pages/Office/PaymentRequestQueue/PaymentRequestQueue'));
 
@@ -125,14 +124,14 @@ export class OfficeApp extends Component {
     const txoRoutes = [
       <PrivateRoute
         key="txoMoveInfoRoute"
-        path="/moves/:moveOrderId"
+        path="/moves/:moveCode"
         component={TXOMoveInfo}
         requiredRoles={[roleTypes.TOO, roleTypes.TIO]}
       />,
     ];
 
     const isFullscreenPage = matchPath(pathname, {
-      path: '/moves/:moveOrderId/payment-requests/:id',
+      path: '/moves/:moveCode/payment-requests/:id',
     });
 
     const siteClasses = classnames('site', {
@@ -169,13 +168,6 @@ export class OfficeApp extends Component {
 
                 {/* PPM & TXO conflicting routes - select based on user role */}
                 {selectedRole === roleTypes.PPM ? ppmRoutes : txoRoutes}
-
-                {/* TEMP FOR DEV ONLY */}
-                <PrivateRoute
-                  path="/too/:moveOrderId/customer/:customerId"
-                  component={CustomerDetails}
-                  requiredRoles={[roleTypes.TOO]}
-                />
 
                 <PrivateRoute exact path="/select-application" component={ConnectedSelectApplication} />
                 {/* ROOT */}

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -270,26 +270,14 @@ describe('Office App', () => {
 
       it('handles the TXOMoveInfo URL', () => {
         const app = mount(
-          <MockProviders initialState={loggedInTOOState} initialEntries={['/moves/123']}>
+          <MockProviders initialState={loggedInTOOState} initialEntries={['/moves/AU67C6']}>
             <ConnectedOffice />
           </MockProviders>,
         );
 
         const renderedRoute = app.find('PrivateRoute');
         expect(renderedRoute).toHaveLength(1);
-        expect(renderedRoute.prop('path')).toEqual('/moves/:moveOrderId');
-      });
-
-      it('handles the CustomerDetails URL', () => {
-        const app = mount(
-          <MockProviders initialState={loggedInTOOState} initialEntries={['/too/123/customer/abc']}>
-            <ConnectedOffice />
-          </MockProviders>,
-        );
-
-        const renderedRoute = app.find('PrivateRoute');
-        expect(renderedRoute).toHaveLength(1);
-        expect(renderedRoute.prop('path')).toEqual('/too/:moveOrderId/customer/:customerId');
+        expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode');
       });
     });
 
@@ -325,14 +313,14 @@ describe('Office App', () => {
 
       it('handles the TXOMoveInfo URL', () => {
         const app = mount(
-          <MockProviders initialState={loggedInTIOState} initialEntries={['/moves/123']}>
+          <MockProviders initialState={loggedInTIOState} initialEntries={['/moves/AU67C6']}>
             <ConnectedOffice />
           </MockProviders>,
         );
 
         const renderedRoute = app.find('PrivateRoute');
         expect(renderedRoute).toHaveLength(1);
-        expect(renderedRoute.prop('path')).toEqual('/moves/:moveOrderId');
+        expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode');
       });
     });
   });


### PR DESCRIPTION
## Description

Now that all of the TXO URLs have been switched over to use the move locator code instead of the order id in the moves/* routes, let's rename all of our old usages of that param in the office components and tests.

I removed an old route for the customer that I believe was only for development purposes and seemed obsolete.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TOO/TIO user
2. Test the various moves routes:

moves/moveCode/details
moves/moveCode/mto
moves/moveCode/payment-requests
moves/moveCode/payment-requests/id
moves/moveCode/history

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6072) for this change

## Screenshots
