### PR TITLE
MB-5696 Fix bugs around updating a Move's status

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -587,3 +587,4 @@
 20201229155602_drop_confirmation_number_from_orders.up.sql
 20201230070814_fix_ecs_user_in_docker.up.sql
 20210104224106_add_reviewed_all_rejected_to_payment_request_status.up.sql
+20210107012144_update_comment_for_move_status.up.sql

--- a/migrations/app/schema/20210107012144_update_comment_for_move_status.up.sql
+++ b/migrations/app/schema/20210107012144_update_comment_for_move_status.up.sql
@@ -1,0 +1,10 @@
+COMMENT ON COLUMN moves.status IS 'The current status of the Move. Allowed values are:
+DRAFT, SUBMITTED, APPROVED, APPROVALS REQUESTED, CANCELED.
+A Move''s status gets set to APPROVALS REQUESTED when the Prime creates new service
+items. New service items can only be created if the Move''s previous status was
+APPROVED or APPROVALS REQUESTED. The APPROVALS REQUESTED status lets the TOO know
+they need to review the service items. As long as a Move has one or more service
+items in SUBMITTED status (i.e. they have not been reviewed yet by the TOO), the
+Move''s status remains APPROVALS REQUESTED. Once there aren''t any service items
+in SUBMITTED status (i.e the TOO has either rejected or approved them), the
+Move''s status goes back to APPROVED.';

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusSUBMITTED}})
+	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		MTOShipment: models.MTOShipment{

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -172,8 +172,12 @@ func (m *Move) Approve() error {
 
 // SetApprovalsRequested sets the move to approvals requested
 func (m *Move) SetApprovalsRequested() error {
+	// Do nothing if it's already in the desired state
+	if m.Status == MoveStatusAPPROVALSREQUESTED {
+		return nil
+	}
 	if m.Status != MoveStatusAPPROVED {
-		return errors.Wrap(ErrInvalidTransition, fmt.Sprintf("Cannot move to Approvals Requested when the Move is not in an Approved state for status: %s and ID: %s", m.Status, m.ID))
+		return errors.Wrap(ErrInvalidTransition, fmt.Sprintf("The status for the Move with ID %s can only be set to 'Approvals Requested' from the 'Approved' status, but its current status is %s.", m.ID, m.Status))
 	}
 	m.Status = MoveStatusAPPROVALSREQUESTED
 	return nil

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -187,21 +187,16 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 			}
 		}
 
-		// Once the service item is successfuly created, the Move's status needs to
+		// Once the service item is successfully created, the Move's status needs to
 		// be updated to 'Approvals Requested' if it's not already in that state,
 		// which will let the TOO know they need to review it.
-		if move.Status != models.MoveStatusAPPROVALSREQUESTED {
-			// We're not checking for an error here because this will only error if
-			// the move's status is not 'Approved', and it's not possible for a Move
-			// that's not 'Approved' to get to this line of code because at the
-			// beginning of this function, we only allow moves with status 'Approved'
-			// or 'Approvals Requested'.
-			move.SetApprovalsRequested()
-
-			verrs, err = txBuilder.UpdateOne(&move, nil)
-			if verrs != nil || err != nil {
-				return fmt.Errorf("%#v %e", verrs, err)
-			}
+		err = move.SetApprovalsRequested()
+		if err != nil {
+			return fmt.Errorf("%e", err)
+		}
+		verrs, err = txBuilder.UpdateOne(&move, nil)
+		if verrs != nil || err != nil {
+			return fmt.Errorf("%#v %e", verrs, err)
 		}
 
 		return nil

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -187,6 +187,23 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 			}
 		}
 
+		// Once the service item is successfuly created, the Move's status needs to
+		// be updated to 'Approvals Requested' if it's not already in that state,
+		// which will let the TOO know they need to review it.
+		if move.Status != models.MoveStatusAPPROVALSREQUESTED {
+			// We're not checking for an error here because this will only error if
+			// the move's status is not 'Approved', and it's not possible for a Move
+			// that's not 'Approved' to get to this line of code because at the
+			// beginning of this function, we only allow moves with status 'Approved'
+			// or 'Approvals Requested'.
+			move.SetApprovalsRequested()
+
+			verrs, err = txBuilder.UpdateOne(&move, nil)
+			if verrs != nil || err != nil {
+				return fmt.Errorf("%#v %e", verrs, err)
+			}
+		}
+
 		return nil
 	})
 
@@ -194,23 +211,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 		return nil, verrs, nil
 	} else if err != nil {
 		return nil, verrs, services.NewQueryError("unknown", err, "")
-	}
-
-	// Once the service item is successfuly created, the Move's status needs to
-	// be updated to 'Approvals Requested' if it's not already in that state,
-	// which will let the TOO know they need to review it.
-	if move.Status != models.MoveStatusAPPROVALSREQUESTED {
-		// We're not checking for an error here because this will only error if
-		// the move's status is not 'Approved', and it's not possible for a Move
-		// that's not 'Approved' to get to this line of code because at the
-		// beginning of this function, we only allow moves with status 'Approved'
-		// or 'Approvals Requested'.
-		move.SetApprovalsRequested()
-
-		verrs, err := o.builder.UpdateOne(&move, nil)
-		if verrs != nil || err != nil {
-			return nil, verrs, err
-		}
 	}
 
 	return &createdServiceItems, nil, nil

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -106,7 +106,6 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 
 	if serviceItem.ReService.Code == models.ReServiceCodeDOSHUT || serviceItem.ReService.Code == models.ReServiceCodeDDSHUT {
 		if mtoShipment.PrimeEstimatedWeight == nil {
-			fmt.Println("PrimeEstimatedWeight is nil")
 			return nil, verrs, services.NewConflictError(reService.ID, "for creating a service item. MTOShipment associated with this service item must have a valid PrimeEstimatedWeight.")
 		}
 	}

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -66,7 +66,7 @@ func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithInvalidMove() 
 		Move: move,
 	})
 
-	serviceItemForUnapprovedMTO := models.MTOServiceItem{
+	serviceItemForUnapprovedMove := models.MTOServiceItem{
 		MoveTaskOrderID: move.ID,
 		MoveTaskOrder:   move,
 		ReService:       reServiceDDFSIT,
@@ -74,7 +74,7 @@ func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithInvalidMove() 
 		MTOShipment:     shipment,
 	}
 
-	return serviceItemForUnapprovedMTO
+	return serviceItemForUnapprovedMove
 }
 
 func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithValidMove() models.MTOServiceItem {

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -42,55 +42,124 @@ func (t *testCreateMTOServiceItemQueryBuilder) Transaction(fn func(tx *pop.Conne
 	return t.fakeTransaction(fn)
 }
 
-func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
-	moveTaskOrder := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
-	dimension := testdatagen.MakeDefaultMTOServiceItemDimension(suite.DB())
-	serviceItem := models.MTOServiceItem{
-		MoveTaskOrderID: moveTaskOrder.ID,
-		MoveTaskOrder:   moveTaskOrder,
-		Dimensions: models.MTOServiceItemDimensions{
-			dimension,
+func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithInvalidMove() models.MTOServiceItem {
+	// Default move has status DRAFT, which is invalid for this test because
+	// service items can only be created if a Move's status is Approved or
+	// Approvals Requested
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDASIT,
 		},
+	})
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDDSIT,
+		},
+	})
+	reServiceDDFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDFSIT,
+		},
+	})
+	shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+		Move: move,
+	})
+
+	serviceItemForUnapprovedMTO := models.MTOServiceItem{
+		MoveTaskOrderID: move.ID,
+		MoveTaskOrder:   move,
+		ReService:       reServiceDDFSIT,
+		MTOShipmentID:   &shipment.ID,
+		MTOShipment:     shipment,
 	}
+
+	return serviceItemForUnapprovedMTO
+}
+
+func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithValidMove() models.MTOServiceItem {
+	move := testdatagen.MakeAvailableMove(suite.DB())
+	dimension := models.MTOServiceItemDimension{
+		Type:      models.DimensionTypeItem,
+		Length:    12000,
+		Height:    12000,
+		Width:     12000,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDASIT,
+		},
+	})
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDDSIT,
+		},
+	})
+	reServiceDDFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDFSIT,
+		},
+	})
+	shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+		Move: move,
+	})
+
+	serviceItem := models.MTOServiceItem{
+		MoveTaskOrderID: move.ID,
+		MoveTaskOrder:   move,
+		ReService:       reServiceDDFSIT,
+		MTOShipmentID:   &shipment.ID,
+		MTOShipment:     shipment,
+		Dimensions:      models.MTOServiceItemDimensions{dimension},
+	}
+
+	return serviceItem
+}
+
+// Should return a message stating that service items can't be created if
+// the move is not in approved status.
+func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItemWithInvalidMove() {
+	builder := query.NewQueryBuilder(suite.DB())
+	creator := NewMTOServiceItemCreator(builder)
+	serviceItemForUnapprovedMove := suite.buildValidServiceItemWithInvalidMove()
+
+	createdServiceItem, _, err := creator.CreateMTOServiceItem(&serviceItemForUnapprovedMove)
+
+	suite.DB().Find(&serviceItemForUnapprovedMove, serviceItemForUnapprovedMove.ID)
+	move := serviceItemForUnapprovedMove.MoveTaskOrder
+	suite.DB().Find(&move, move.ID)
+
+	suite.Nil(createdServiceItem)
+	suite.Zero(serviceItemForUnapprovedMove.ID)
+	suite.Error(err)
+	suite.Contains(err.Error(), "Cannot create service items before a move has been approved")
+	suite.Equal(models.MoveStatusDRAFT, move.Status)
+}
+
+func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
+	serviceItem := suite.buildValidServiceItemWithValidMove()
+	moveTaskOrder := serviceItem.MoveTaskOrder
+	builder := query.NewQueryBuilder(suite.DB())
+	creator := NewMTOServiceItemCreator(builder)
 
 	// Happy path: If the service item is created successfully it should be returned
 	suite.T().Run("success", func(t *testing.T) {
-		fakeCreateOne := func(model interface{}) (*validate.Errors, error) {
-			return nil, nil
-		}
-		fakeFetchOne := func(model interface{}, filters []services.QueryFilter) error {
-			return nil
-		}
-		fakeTx := func(fn func(tx *pop.Connection) error) error {
-			return fn(&pop.Connection{})
-		}
-		fakeUpdateOne := func(model interface{}, etag *string) (*validate.Errors, error) {
-			return nil, nil
-		}
-
-		builder := &testCreateMTOServiceItemQueryBuilder{
-			fakeCreateOne:   fakeCreateOne,
-			fakeFetchOne:    fakeFetchOne,
-			fakeTransaction: fakeTx,
-			fakeUpdateOne:   fakeUpdateOne,
-		}
-
-		fakeCreateNewBuilder := func(db *pop.Connection) createMTOServiceItemQueryBuilder {
-			return builder
-		}
-
-		creator := mtoServiceItemCreator{
-			builder:          builder,
-			createNewBuilder: fakeCreateNewBuilder,
-		}
 		createdServiceItem, verrs, err := creator.CreateMTOServiceItem(&serviceItem)
+
+		move := serviceItem.MoveTaskOrder
+		suite.DB().Find(&move, move.ID)
 
 		suite.NoError(err)
 		suite.Nil(verrs)
 		suite.NotNil(createdServiceItem)
 
 		createdServiceItemList := *createdServiceItem
-		suite.NotEmpty(createdServiceItemList[0].Dimensions)
+		suite.Equal(len(createdServiceItemList), 3)
+		suite.NotEmpty(createdServiceItemList[2].Dimensions)
+		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, move.Status)
 	})
 
 	// If error when trying to create, the create should fail.
@@ -132,9 +201,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 
 	// Should return a "NotFoundError" if the MTO ID is nil
 	suite.T().Run("moveTaskOrderID not found", func(t *testing.T) {
-		builder := query.NewQueryBuilder(suite.DB())
-		creator := NewMTOServiceItemCreator(builder)
-
 		notFoundID := uuid.Must(uuid.NewV4())
 		serviceItemNoMTO := models.MTOServiceItem{
 			MoveTaskOrderID: notFoundID,
@@ -149,9 +215,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 
 	// Should return a "NotFoundError" if the reServiceCode passed in isn't found on the table
 	suite.T().Run("reServiceCode not found", func(t *testing.T) {
-		builder := query.NewQueryBuilder(suite.DB())
-		creator := NewMTOServiceItemCreator(builder)
-
 		fakeCode := models.ReServiceCode("FAKE")
 		serviceItemBadCode := models.MTOServiceItem{
 			MoveTaskOrderID: moveTaskOrder.ID,
@@ -171,9 +234,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 	// Should be able to create a service item with code ReServiceCodeMS or ReServiceCodeCS without a shipment,
 	// and it should come back as "APPROVED"
 	suite.T().Run("ReServiceCodeCS creation approved", func(t *testing.T) {
-		builder := query.NewQueryBuilder(suite.DB())
-		creator := NewMTOServiceItemCreator(builder)
-
 		reServiceCS := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeCS,
@@ -196,9 +256,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 	// Should return a "NotFoundError" if the mtoShipmentID passed in isn't found
 	// OR if it isn't linked to the mtoID passed in
 	suite.T().Run("mtoShipmentID not found", func(t *testing.T) {
-		builder := query.NewQueryBuilder(suite.DB())
-		creator := NewMTOServiceItemCreator(builder)
-
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 		reService := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
@@ -223,31 +280,24 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 
 	// If the service item we're trying to create is shuttle service and there is no estimated weight, it fails.
 	suite.T().Run("MTOServiceItemShuttle no prime weight", func(t *testing.T) {
-		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrder,
+		})
+
+		reService := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDSHUT,
+			},
+		})
 
 		serviceItemNoWeight := models.MTOServiceItem{
 			MoveTaskOrderID: moveTaskOrder.ID,
 			MoveTaskOrder:   moveTaskOrder,
 			MTOShipment:     shipment,
 			MTOShipmentID:   &shipment.ID,
-			ReService: models.ReService{
-				Code: models.ReServiceCodeDDSHUT,
-			},
+			ReService:       reService,
 		}
 
-		fakeCreateOne := func(model interface{}) (*validate.Errors, error) {
-			return nil, nil
-		}
-		fakeFetchOne := func(model interface{}, filters []services.QueryFilter) error {
-			return nil
-		}
-
-		builder := &testCreateMTOServiceItemQueryBuilder{
-			fakeCreateOne: fakeCreateOne,
-			fakeFetchOne:  fakeFetchOne,
-		}
-
-		creator := NewMTOServiceItemCreator(builder)
 		createdServiceItem, _, err := creator.CreateMTOServiceItem(&serviceItemNoWeight)
 		suite.Nil(createdServiceItem)
 		suite.Error(err)
@@ -256,7 +306,9 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 
 	// The timeMilitary fields need to be in the correct format.
 	suite.T().Run("timeMilitary formatting for DDFSIT", func(t *testing.T) {
-		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{MTOShipment: models.MTOShipment{MoveTaskOrder: moveTaskOrder}})
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrder,
+		})
 		contact := models.MTOServiceItemCustomerContact{
 			Type:                       models.CustomerContactTypeFirst,
 			FirstAvailableDeliveryDate: time.Now(),
@@ -269,28 +321,6 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDDFSIT,
 			},
-		}
-
-		fakeCreateOne := func(model interface{}) (*validate.Errors, error) {
-			return nil, nil
-		}
-		fakeFetchOne := func(model interface{}, filters []services.QueryFilter) error {
-			return nil
-		}
-		fakeTx := func(fn func(tx *pop.Connection) error) error {
-			return fn(&pop.Connection{})
-		}
-		builder := &testCreateMTOServiceItemQueryBuilder{
-			fakeCreateOne:   fakeCreateOne,
-			fakeFetchOne:    fakeFetchOne,
-			fakeTransaction: fakeTx,
-		}
-		fakeCreateNewBuilder := func(db *pop.Connection) createMTOServiceItemQueryBuilder {
-			return builder
-		}
-		creator := mtoServiceItemCreator{
-			builder:          builder,
-			createNewBuilder: fakeCreateNewBuilder,
 		}
 
 		suite.T().Run("timeMilitary=HH:MMZ", func(t *testing.T) {

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -302,7 +302,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 	// Test that the move's status changes to Approved when the service item's
 	// status is no longer SUBMITTED
 	suite.T().Run("When TOO reviews move and approves service item", func(t *testing.T) {
-		suite.DB().TruncateAll()
+		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItem()
 
 		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
@@ -320,8 +320,10 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 	// Test that the move's status changes to Approvals Requested if any of its service
 	// items' status is SUBMITTED
 	suite.T().Run("When move is approved and service item is submitted", func(t *testing.T) {
-		suite.DB().TruncateAll()
+		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItem()
+		move.Status = models.MoveStatusAPPROVED
+		suite.MustSave(&move)
 
 		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
 			serviceItem.ID, models.MTOServiceItemStatusSubmitted, rejectionReason, eTag)
@@ -341,7 +343,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 	// Test that the move's status changes to Approved if the service item is
 	// rejected
 	suite.T().Run("When TOO reviews move and rejects service item", func(t *testing.T) {
-		suite.DB().TruncateAll()
+		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItem()
 		rejectionReason = swag.String("incomplete")
 
@@ -364,7 +366,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 	// is either Approved or Approvals Requested. Neither the Move's status nor
 	// the service item's status should be changed if the requirements aren't met.
 	suite.T().Run("When the Move has not been approved yet", func(t *testing.T) {
-		suite.DB().TruncateAll()
+		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItemForUnapprovedMove()
 
 		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -2,7 +2,6 @@ package mtoshipment
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -566,15 +565,18 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Nil(shipment3.ApprovedDate)
 	})
 
-	suite.T().Run("When move status is not already approved", func(t *testing.T) {
+	suite.T().Run("When move is not yet approved, cannot approve shipment", func(t *testing.T) {
 		submittedMTO := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 		mtoShipment := submittedMTO.MTOShipments[0]
 		eTag = etag.GenerateEtag(mtoShipment.UpdatedAt)
 
 		updatedShipment, err := updater.UpdateMTOShipmentStatus(mtoShipment.ID, models.MTOShipmentStatusApproved, nil, eTag)
+		suite.DB().Find(&mtoShipment, mtoShipment.ID)
+
 		suite.Nil(updatedShipment)
+		suite.Equal(models.MTOShipmentStatusSubmitted, mtoShipment.Status)
 		suite.Error(err)
 		suite.IsType(services.ConflictError{}, err)
-		suite.True(strings.Contains(err.Error(), "Cannot move to Approvals Requested when the Move is not in an Approved state"))
+		suite.Contains(err.Error(), "Cannot approve a shipment if the move isn't approved.")
 	})
 }

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -118,6 +118,18 @@ func MakeAvailableMove(db *pop.Connection) models.Move {
 	return move
 }
 
+// MakeApprovalsRequestedMove makes a Move with status 'Approvals Requested'
+func MakeApprovalsRequestedMove(db *pop.Connection) models.Move {
+	now := time.Now()
+	move := MakeMove(db, Assertions{
+		Move: models.Move{
+			AvailableToPrimeAt: &now,
+			Status:             models.MoveStatusAPPROVALSREQUESTED,
+		},
+	})
+	return move
+}
+
 // MakeDefaultMove makes a Move with default values
 func MakeDefaultMove(db *pop.Connection) models.Move {
 	return MakeMove(db, Assertions{})


### PR DESCRIPTION
## Description
Service items can only be created on a Move whose status is either
Approved or Approvals Requested. However, this was not properly
enforced in `mto_service_item_creator`. The status update on the move
was performed outside of the transaction that created the service
items. So if service items were created on an invalid move, even
though the status update failed, the service items were still created.

I also found a bug in `mto_service_item_updater`, where if a service
item's status was set back to SUBMITTED, the move's status wouldn't
get reset to APPROVALS REQUESTED, and so the TOO wouldn't know to
review it.

To fix the first bug, I added a check at the beginning of the
service item creation function to check and fail early if the move's
status is not 'Approved' or 'Approvals Requested', because if it's
not, nothing in the rest of the function matters. I also updated the
error message to be more friendly for the Prime.

I added several missing tests around these two bugs, and I plan on
adding more, as well as doing some refactoring to make the code
easier to understand.

## Reviewer Notes

1. Using the Prime API, try to create a service item on a Move whose status is neither `Approved` nor `Approvals Requested`. You should get an error of type ConflictError (status code 409) with message `Cannot create service items before a move has been approved` and the Move's ID and current status for debugging. No service items should be created on this move.

2. Using the Prime API, create a service item on an approved Move. Verify that after the operation is successful, the Move's status has changed to `Approvals Requested`.

3. Using the Support API, update the status of an existing service item (where the Move is in Approved Status) to `SUBMITTED`. Verify that the Move's status is changed to `Approvals Requested`.

4. Using the Support API, update the status of an existing shipment (where the Move is NOT in Approved Status, such as `Submitted`) to `Approved`. Verify that you get an error saying you can't approve a shipment if the move is not approved. This is because approving a shipment automatically creates service items on the moves, but since you can't create service items on a move that isn't approved, updating the shipment status should fail.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5696) for this change
