### PR TITLE
MB-6159 Correct the path where results will be found

### DIFF
--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -162,10 +162,10 @@ docker logs -f ${CONTAINER_CYPRESS}
 docker stop ${CONTAINER}
 
 # Copy out the results
-docker cp ${CONTAINER_CYPRESS}:/cypress/results cypress/ 2>/dev/null || echo "No cypress results copied"
-docker cp ${CONTAINER_CYPRESS}:/cypress/screenshots cypress/ 2>/dev/null || echo "No cypress screenshots copied"
-docker cp ${CONTAINER_CYPRESS}:/cypress/videos cypress/ 2>/dev/null || echo "No cypress videos copied"
-docker cp ${CONTAINER_CYPRESS}:/cypress/reports cypress/ 2>/dev/null || echo "No cypress reports copied"
+docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/results cypress/ 2>/dev/null || echo "No cypress results copied"
+docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/screenshots cypress/ 2>/dev/null || echo "No cypress screenshots copied"
+docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/videos cypress/ 2>/dev/null || echo "No cypress videos copied"
+docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/reports cypress/ 2>/dev/null || echo "No cypress reports copied"
 
 # Grab the exit code from the test container
 EXIT_STATUS=$(docker inspect ${CONTAINER_CYPRESS} --format='{{.State.ExitCode}}')


### PR DESCRIPTION
## Description

It was discovered recently that the cypress build job was not extracting the cypress test results correctly after a recent change to use the new circleci-docker base image. This PR fixes that.

## Reviewer Notes

Make sure some test result artifacts are stored after the `integration_tests` job

## Setup

Edit the file `cypress/integration/mymove/hhg.js` to introduce a failure. IE change line 27 to have `h5` instead of `h2`

Then run
```sh
SPEC=cypress/integration/mymove/hhg.js run-e2e-test-docker
```

Verify that output is in `cypress/results`, `cypress/screenshots`, and `cypress/videos`

## Code Review Verification Steps

* [X] Request review from a member of a different team.

## References

* [this slack thread](https://ustcdp3.slack.com/archives/CP496B8DB/p1609958558007600) explains more about the approach used.
* [Jira](https://dp3.atlassian.net/browse/MB-6159)