### PR TITLE
MB-6159 error out if no cypress results

### DIFF
--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -161,8 +161,9 @@ docker logs -f ${CONTAINER_CYPRESS}
 # Stop the app container to release the DB connection
 docker stop ${CONTAINER}
 
-# Copy out the results
-docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/results cypress/ 2>/dev/null || echo "No cypress results copied"
+# Copy out the results, there are always xml result files so fail if we don't find them
+docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/results cypress/
+# Copy out screenshots, videos, and reports which may or may not be generated, hence we are hiding the errors
 docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/screenshots cypress/ 2>/dev/null || echo "No cypress screenshots copied"
 docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/videos cypress/ 2>/dev/null || echo "No cypress videos copied"
 docker cp ${CONTAINER_CYPRESS}:/home/circleci/cypress/reports cypress/ 2>/dev/null || echo "No cypress reports copied"


### PR DESCRIPTION
## Description

Cypress tests always generate results, whether tests pass or fail. The script running the tests should fail if none are found to let us know something is wrong.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6159) for this change
* [this article](https://ustcdp3.slack.com/archives/CP496B8DB/p1609958558007600) explains more about the approach used.
