### PR TITLE
MB-4403: adds gov accounts to allowed list

### DIFF
--- a/pkg/cli/vault.go
+++ b/pkg/cli/vault.go
@@ -34,6 +34,12 @@ const (
 	VaultAWSProfileTranscomPPP string = "transcom-ppp"
 	// VaultAWSProfileTranscomComLegacy is the aws-vault profile name for transcom-com-legacy
 	VaultAWSProfileTranscomComLegacy string = "transcom-com-legacy"
+	// VaultAWSProfileTranscomGovExp is the aws-vault profile name for transcom-gov-exp
+	VaultAWSProfileTranscomGovExp string = "transcom-gov-exp"
+	// VaultAWSProfileTranscomGovStg is the aws-vault profile name for transcom-gov-stg
+	VaultAWSProfileTranscomGovStg string = "transcom-gov-stg"
+	// VaultAWSProfileTranscomGovPrd is the aws-vault profile name for transcom-gov-prd
+	VaultAWSProfileTranscomGovPrd string = "transcom-gov-prd"
 )
 
 type errInvalidKeychainName struct {
@@ -91,6 +97,9 @@ func CheckVault(v *viper.Viper) error {
 		awsProfiles := []string{
 			VaultAWSProfileTranscomPPP,
 			VaultAWSProfileTranscomComLegacy,
+			VaultAWSProfileTranscomGovExp,
+			VaultAWSProfileTranscomGovStg,
+			VaultAWSProfileTranscomGovPrd,
 		}
 		if len(awsProfile) > 0 && !stringSliceContains(awsProfiles, awsProfile) {
 			return errors.Wrap(&errInvalidAWSProfile{Profile: awsProfile},

--- a/pkg/cli/vault.go
+++ b/pkg/cli/vault.go
@@ -34,12 +34,12 @@ const (
 	VaultAWSProfileTranscomPPP string = "transcom-ppp"
 	// VaultAWSProfileTranscomComLegacy is the aws-vault profile name for transcom-com-legacy
 	VaultAWSProfileTranscomComLegacy string = "transcom-com-legacy"
-	// VaultAWSProfileTranscomGovExp is the aws-vault profile name for transcom-gov-exp
-	VaultAWSProfileTranscomGovExp string = "transcom-gov-exp"
-	// VaultAWSProfileTranscomGovStg is the aws-vault profile name for transcom-gov-stg
-	VaultAWSProfileTranscomGovStg string = "transcom-gov-stg"
-	// VaultAWSProfileTranscomGovPrd is the aws-vault profile name for transcom-gov-prd
-	VaultAWSProfileTranscomGovPrd string = "transcom-gov-prd"
+	// VaultAWSProfileTranscomGovExp is the aws-vault profile name for transcom-gov-milmove-exp
+	VaultAWSProfileTranscomGovExp string = "transcom-gov-milmove-exp"
+	// VaultAWSProfileTranscomGovStg is the aws-vault profile name for transcom-gov-milmove-stg
+	VaultAWSProfileTranscomGovStg string = "transcom-gov-milmove-stg"
+	// VaultAWSProfileTranscomGovPrd is the aws-vault profile name for transcom-gov-milmove-prd
+	VaultAWSProfileTranscomGovPrd string = "transcom-gov-milmove-prd"
 )
 
 type errInvalidKeychainName struct {


### PR DESCRIPTION
## Description

This PR adds the gov accounts for MM app to the list of callable aws-vault profiles. It's one step towards making commands using aws-vault usable by other (gov) accounts.

## Reviewer Notes

I'm not sure this is necessary. It's part of an effort to make vault.go compatible with profiles (aka AWS accounts) besides transcom-ppp/transcom-com-legacy. I wonder, however, whether we won't end up removing the vault functions from scripts and commands that assume the legacy account.

## Code Review Verification Steps


* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4403) for this change\