### PR TITLE
MB-4874 | Explicitly using AWS profile where it makes sense

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,10 @@ server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.sta
 server_run_debug: .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp .check_node_version.stamp check_log_dir build/index.html server_generate db_dev_run redis_run ## Debug the server
 	scripts/kill-process-on-port 8080
 	scripts/kill-process-on-port 9443
-	$(AWS_VAULT) dlv debug cmd/milmove/*.go -- serve 2>&1 | tee -a log/dev.log
+	DISABLE_AWS_VAULT_WRAPPER=1 \
+	AWS_REGION=us-gov-west-1 \
+	aws-vault exec transcom-gov-dev -- \
+	dlv debug cmd/milmove/*.go -- serve 2>&1 | tee -a log/dev.log
 
 .PHONY: build_tools
 build_tools: bin/gin \


### PR DESCRIPTION
## Description

`make server_run_debug` will only ever be ran against dev local, as such, we're explicitly calling `transcom-gov-dev` AWS profile rather than relying on `$AWS_PROFILE` that may or may not be `transcom-gov-dev` based on a person's environment variables when this target is called. 

`make e2e_test` is not called in CircleCI

`make e2e_mtls_test_docker` _is_ called in CircleCI but doesn't rely on `$AWS_PROFILE`

`make e2e_test_docker` _is_ called in CircleCI but doesn't rely on `$AWS_PROFILE`


`make e2e_test_docker_office`, `make e2e_test_docker_api`, and `make e2e_test_docker_mymove` are all variations of one another and not called in CircleCI

I'm torn on explicitly pointing these at `transcom-gov-dev` or continue to allow `$AWS_PROFILE` be whatever it might be on when the user runs this.

This PR is to get the work out there and to have a discussion around these remaining targets.
