### PR TITLE
MB-4629 TIO can see basic service item details on the current payment request card

### DIFF
--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -45,7 +45,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
                   {item.status === PAYMENT_SERVICE_ITEM_STATUS.REQUESTED && (
                     <div className={styles.needsReview}>
                       <FontAwesomeIcon icon="exclamation-circle" />
-                      <span>Needs Review</span>
+                      <span>Needs review</span>
                     </div>
                   )}
                   {item.status === PAYMENT_SERVICE_ITEM_STATUS.APPROVED && (

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -17,7 +17,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
         <div className={styles.shipmentType}>
           <div className={styles.basicServiceType} />
           <h3>
-            Basic Service Items ({serviceItems.length} {serviceItems.length > 1 ? 'items' : 'item'})
+            Basic service items ({serviceItems.length} {serviceItems.length > 1 ? 'items' : 'item'})
           </h3>
         </div>
       </div>
@@ -29,7 +29,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
         </colgroup>
         <thead>
           <tr>
-            <th>Service Item</th>
+            <th>Service item</th>
             <th className="align-right">Amount</th>
             <th className="align-right">Status</th>
           </tr>

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { ShipmentOptionsOneOf } from '../../../types/shipment';
+import { PaymentServiceItemShape } from '../../../types/index';
 
 import styles from './PaymentRequestDetails.module.scss';
 
+import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 import { formatCents, toDollarString } from 'shared/formatters';
 
 const PaymentRequestDetails = ({ serviceItems }) => {
@@ -15,7 +15,9 @@ const PaymentRequestDetails = ({ serviceItems }) => {
         {/* TODO this div will become dynamic based on different shipment types */}
         <div className={styles.shipmentType}>
           <div className={styles.basicServiceType} />
-          <h3>Basic Service Items ({serviceItems.length} items)</h3>
+          <h3>
+            Basic Service Items ({serviceItems.length} {serviceItems.length > 1 ? 'items' : 'item'})
+          </h3>
         </div>
       </div>
       <table className="table--stacked">
@@ -32,26 +34,26 @@ const PaymentRequestDetails = ({ serviceItems }) => {
           </tr>
         </thead>
         <tbody>
-          {serviceItems.map((item, i) => {
+          {serviceItems.map((item) => {
             return (
               // eslint-disable-next-line react/no-array-index-key
-              <tr key={i}>
+              <tr key={item.id}>
                 <td>{item.serviceItemName}</td>
                 <td>{toDollarString(formatCents(item.priceCents))}</td>
                 <td>
-                  {item.status === 'PENDING' && (
+                  {item.status === PAYMENT_SERVICE_ITEM_STATUS.PENDING && (
                     <div className={styles.needsReview}>
                       <FontAwesomeIcon icon="exclamation-circle" />
                       <span>Needs Review</span>
                     </div>
                   )}
-                  {item.status === 'APPROVED' && (
+                  {item.status === PAYMENT_SERVICE_ITEM_STATUS.APPROVED && (
                     <div className={styles.accepted}>
                       <FontAwesomeIcon icon="check" />
                       <span>Accepted</span>
                     </div>
                   )}
-                  {item.status === 'DENIED' && (
+                  {item.status === PAYMENT_SERVICE_ITEM_STATUS.DENIED && (
                     <div className={styles.rejected}>
                       <FontAwesomeIcon icon="times" />
                       <span>Rejected</span>
@@ -68,16 +70,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
 };
 
 PaymentRequestDetails.propTypes = {
-  serviceItems: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      createAt: PropTypes.string,
-      mtoServiceItemID: PropTypes.string,
-      priceCents: PropTypes.number,
-      status: PropTypes.string,
-      shipmentType: ShipmentOptionsOneOf,
-    }),
-  ).isRequired,
+  serviceItems: PaymentServiceItemShape.isRequired,
 };
 
 export default PaymentRequestDetails;

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { ShipmentOptionsOneOf } from '../../../types/shipment';
+
+import styles from './PaymentRequestDetails.module.scss';
+
+import { formatCents, toDollarString } from 'shared/formatters';
+
+const PaymentRequestDetails = ({ serviceItems }) => {
+  return (
+    <div className={styles.PaymentRequestDetails}>
+      <div className="stackedtable-header">
+        {/* TODO this div will become dynamic based on different shipment types */}
+        <div className={styles.shipmentType}>
+          <div className={styles.basicServiceType} />
+          <h3>Basic Service Items ({serviceItems.length} items)</h3>
+        </div>
+      </div>
+      <table className="table--stacked">
+        <colgroup>
+          <col style={{ width: '50%' }} />
+          <col style={{ width: '25%' }} />
+          <col style={{ width: '25%' }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>Service Item</th>
+            <th className="align-right">Amount</th>
+            <th className="align-right">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {serviceItems.map((item, i) => {
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <tr key={i}>
+                <td>{item.serviceItemName}</td>
+                <td>{toDollarString(formatCents(item.priceCents))}</td>
+                <td>
+                  {item.status === 'PENDING' && (
+                    <div className={styles.needsReview}>
+                      <FontAwesomeIcon icon="exclamation-circle" />
+                      <span>Needs Review</span>
+                    </div>
+                  )}
+                  {item.status === 'APPROVED' && (
+                    <div className={styles.accepted}>
+                      <FontAwesomeIcon icon="check" />
+                      <span>Accepted</span>
+                    </div>
+                  )}
+                  {item.status === 'DENIED' && (
+                    <div className={styles.rejected}>
+                      <FontAwesomeIcon icon="times" />
+                      <span>Rejected</span>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+PaymentRequestDetails.propTypes = {
+  serviceItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      createAt: PropTypes.string,
+      mtoServiceItemID: PropTypes.string,
+      priceCents: PropTypes.number,
+      status: PropTypes.string,
+      shipmentType: ShipmentOptionsOneOf,
+    }),
+  ).isRequired,
+};
+
+export default PaymentRequestDetails;

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { PaymentServiceItemShape } from '../../../types/index';
@@ -41,7 +42,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
                 <td>{item.serviceItemName}</td>
                 <td>{toDollarString(formatCents(item.priceCents))}</td>
                 <td>
-                  {item.status === PAYMENT_SERVICE_ITEM_STATUS.PENDING && (
+                  {item.status === PAYMENT_SERVICE_ITEM_STATUS.REQUESTED && (
                     <div className={styles.needsReview}>
                       <FontAwesomeIcon icon="exclamation-circle" />
                       <span>Needs Review</span>
@@ -70,7 +71,7 @@ const PaymentRequestDetails = ({ serviceItems }) => {
 };
 
 PaymentRequestDetails.propTypes = {
-  serviceItems: PaymentServiceItemShape.isRequired,
+  serviceItems: PropTypes.arrayOf(PaymentServiceItemShape).isRequired,
 };
 
 export default PaymentRequestDetails;

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.module.scss
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.module.scss
@@ -1,0 +1,92 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+@import 'shared/styles/_custom';
+
+.PaymentRequestDetails {
+  @include u-padding-y(2);
+  :global .stackedtable-header {
+    max-width: unset;
+    h3 {
+      margin-top: 10px;
+    }
+  }
+
+  :global .table--stacked {
+    width: 100%;
+
+    th {
+      @include u-font-weight(bold);
+      @include u-font-size('body', '3xs');
+      color: $base-darker;
+      border-top: 0;
+
+      &:not(:first-child) {
+        text-align: right;
+      }
+    }
+
+    td:not(:first-child) {
+      @include u-font-weight(bold);
+      text-align: right;
+    }
+  }
+
+  .accepted {
+    svg {
+      @include u-margin-right(1);
+      height: 18px;
+      width: 18px;
+      display: inline-block;
+      position: relative;
+      top: 2px;
+
+      path {
+        fill: $success;
+      }
+    }
+  }
+
+  .rejected {
+    svg {
+      @include u-margin-right(1);
+      height: 18px;
+      width: 18px;
+      display: inline-block;
+      position: relative;
+      top: 2px;
+
+      path {
+        fill: $error;
+      }
+    }
+  }
+
+  .needsReview {
+    svg {
+      @include u-margin-right(1);
+      height: 18px;
+      width: 18px;
+      display: inline-block;
+      position: relative;
+      top: 2px;
+
+      path {
+        fill: $warning;
+      }
+    }
+  }
+}
+
+.shipmentType {
+  .basicServiceType {
+    width: 34px;
+    height: 6px;
+    background-color: $base-light;
+  }
+  .householdServiceType {
+    width: 34px;
+    height: 6px;
+    background-color: $accent-hhg;
+  }
+}

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
@@ -4,6 +4,34 @@ import PaymentRequestDetails from './PaymentRequestDetails';
 
 import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 
+const unreviewedPaymentRequest = {
+  id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+  createdAt: '2020-12-01T00:00:00.000Z',
+  moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+  paymentRequestNumber: '1843-9061-2',
+  status: 'PENDING',
+  serviceItems: [
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+  ],
+};
 const reviewedPaymentRequest = {
   id: '29474c6a-69b6-4501-8e08-670a12512e5f',
   createdAt: '2020-12-01T00:00:00.000Z',
@@ -30,16 +58,15 @@ const reviewedPaymentRequest = {
       shipmentType: null,
       serviceItemName: 'Counseling',
     },
-    {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
-      createdAt: '2020-12-01T00:00:00.000Z',
-      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
-      priceCents: 4000001,
-      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
-      rejectionReason: 'duplicate charge',
-      shipmentType: null,
-      serviceItemName: 'Counseling',
-    },
+  ],
+};
+const singleServicePaymentRequest = {
+  id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+  createdAt: '2020-12-01T00:00:00.000Z',
+  moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+  paymentRequestNumber: '1843-9061-2',
+  status: 'REVIEWED',
+  serviceItems: [
     {
       id: '09474c6a-69b6-4501-8e08-670a12512a5f',
       createdAt: '2020-12-01T00:00:00.000Z',
@@ -49,26 +76,6 @@ const reviewedPaymentRequest = {
       shipmentType: null,
       serviceItemName: 'Move management',
     },
-    {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
-      createdAt: '2020-12-01T00:00:00.000Z',
-      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
-      priceCents: 4000001,
-      status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
-      rejectionReason: 'duplicate charge',
-      shipmentType: null,
-      serviceItemName: 'Counseling',
-    },
-    {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
-      createdAt: '2020-12-01T00:00:00.000Z',
-      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
-      priceCents: 4000001,
-      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
-      rejectionReason: 'duplicate charge',
-      shipmentType: null,
-      serviceItemName: 'Counseling',
-    },
   ],
 };
 
@@ -76,8 +83,18 @@ export default {
   title: 'Office Components/PaymentRequestDetails',
 };
 
-export const withBasicServiceItems = () => (
+export const withUnreviewedBasicServiceItems = () => (
+  <div style={{ padding: '20px' }}>
+    <PaymentRequestDetails serviceItems={unreviewedPaymentRequest.serviceItems} />
+  </div>
+);
+export const withReviewedBasicServiceItems = () => (
   <div style={{ padding: '20px' }}>
     <PaymentRequestDetails serviceItems={reviewedPaymentRequest.serviceItems} />
+  </div>
+);
+export const withSingleBasicServiceItem = () => (
+  <div style={{ padding: '20px' }}>
+    <PaymentRequestDetails serviceItems={singleServicePaymentRequest.serviceItems} />
   </div>
 );

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-// TODO Future work adds more shipmentType indicators
-// import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 import PaymentRequestDetails from './PaymentRequestDetails';
+
+import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 
 const reviewedPaymentRequest = {
   id: '29474c6a-69b6-4501-8e08-670a12512e5f',
@@ -16,7 +16,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 2000001,
-      status: 'APPROVED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.APPROVED,
       shipmentType: null,
       serviceItemName: 'Move management',
     },
@@ -25,7 +25,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'DENIED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
@@ -35,7 +35,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'PENDING',
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
@@ -45,7 +45,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 2000001,
-      status: 'APPROVED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.APPROVED,
       shipmentType: null,
       serviceItemName: 'Move management',
     },
@@ -54,7 +54,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'DENIED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
@@ -64,7 +64,7 @@ const reviewedPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'PENDING',
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.stories.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+// TODO Future work adds more shipmentType indicators
+// import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+import PaymentRequestDetails from './PaymentRequestDetails';
+
+const reviewedPaymentRequest = {
+  id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+  createdAt: '2020-12-01T00:00:00.000Z',
+  moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+  paymentRequestNumber: '1843-9061-2',
+  status: 'REVIEWED',
+  serviceItems: [
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: 'APPROVED',
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'DENIED',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'PENDING',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: 'APPROVED',
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'DENIED',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'PENDING',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+  ],
+};
+
+export default {
+  title: 'Office Components/PaymentRequestDetails',
+};
+
+export const withBasicServiceItems = () => (
+  <div style={{ padding: '20px' }}>
+    <PaymentRequestDetails serviceItems={reviewedPaymentRequest.serviceItems} />
+  </div>
+);

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
@@ -73,6 +73,25 @@ const basicPaymentRequest = {
   ],
 };
 
+const basicPaymentRequestOneServiceItem = {
+  id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+  createdAt: '2020-12-01T00:00:00.000Z',
+  moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+  paymentRequestNumber: '1843-9061-2',
+  status: 'REVIEWED',
+  serviceItems: [
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: 'APPROVED',
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+  ],
+};
+
 const testMoveLocator = 'AF7K1P';
 
 describe('PaymentRequestDetails', () => {
@@ -84,8 +103,23 @@ describe('PaymentRequestDetails', () => {
     );
 
     it('renders the service items', async () => {
-      await wrapper.update();
       expect(wrapper.find('td')).toBeTruthy();
+    });
+
+    it('renders the expected table title', () => {
+      expect(wrapper.text().includes('Basic Service Items (6 items)')).toBeTruthy();
+    });
+  });
+
+  describe('When given a single basic service item', () => {
+    const wrapper = mount(
+      <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+        <PaymentRequestDetails serviceItems={basicPaymentRequestOneServiceItem.serviceItems} />
+      </MockProviders>,
+    );
+
+    it('renders the expected table title', () => {
+      expect(wrapper.text().includes('Basic Service Items (1 item)')).toBeTruthy();
     });
   });
 });

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import PaymentRequestDetails from './PaymentRequestDetails';
+
+import { MockProviders } from 'testUtils';
+
+const basicPaymentRequest = {
+  id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+  createdAt: '2020-12-01T00:00:00.000Z',
+  moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+  paymentRequestNumber: '1843-9061-2',
+  status: 'REVIEWED',
+  serviceItems: [
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: 'APPROVED',
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'DENIED',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'PENDING',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 2000001,
+      status: 'APPROVED',
+      shipmentType: null,
+      serviceItemName: 'Move management',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'DENIED',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+    {
+      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+      priceCents: 4000001,
+      status: 'PENDING',
+      rejectionReason: 'duplicate charge',
+      shipmentType: null,
+      serviceItemName: 'Counseling',
+    },
+  ],
+};
+
+const testMoveLocator = 'AF7K1P';
+
+describe('PaymentRequestDetails', () => {
+  describe('When given basic service items', () => {
+    const wrapper = mount(
+      <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+        <PaymentRequestDetails serviceItems={basicPaymentRequest.serviceItems} />
+      </MockProviders>,
+    );
+
+    it('renders the service items', async () => {
+      await wrapper.update();
+      expect(wrapper.find('td')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
@@ -108,7 +108,7 @@ describe('PaymentRequestDetails', () => {
     });
 
     it('renders the expected table title', () => {
-      expect(wrapper.text().includes('Basic Service Items (6 items)')).toBeTruthy();
+      expect(wrapper.text().includes('Basic service items (6 items)')).toBeTruthy();
     });
   });
 
@@ -120,7 +120,7 @@ describe('PaymentRequestDetails', () => {
     );
 
     it('renders the expected table title', () => {
-      expect(wrapper.text().includes('Basic Service Items (1 item)')).toBeTruthy();
+      expect(wrapper.text().includes('Basic service items (1 item)')).toBeTruthy();
     });
   });
 });

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.test.jsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import PaymentRequestDetails from './PaymentRequestDetails';
 
+import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 import { MockProviders } from 'testUtils';
 
 const basicPaymentRequest = {
@@ -17,16 +18,16 @@ const basicPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 2000001,
-      status: 'APPROVED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.APPROVED,
       shipmentType: null,
       serviceItemName: 'Move management',
     },
     {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      id: '39474c6a-69b6-4501-8e08-670a12512a5e',
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'DENIED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
@@ -36,36 +37,36 @@ const basicPaymentRequest = {
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'PENDING',
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
     },
     {
-      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      id: '09474c6a-69b6-4501-8e08-670a12512a5g',
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 2000001,
-      status: 'APPROVED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.APPROVED,
       shipmentType: null,
       serviceItemName: 'Move management',
     },
     {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      id: '39474c6a-69b6-4501-8e08-670a12512a5h',
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'DENIED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
     },
     {
-      id: '39474c6a-69b6-4501-8e08-670a12512a5f',
+      id: '39474c6a-69b6-4501-8e08-670a12512a5i',
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'a8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 4000001,
-      status: 'PENDING',
+      status: PAYMENT_SERVICE_ITEM_STATUS.REQUESTED,
       rejectionReason: 'duplicate charge',
       shipmentType: null,
       serviceItemName: 'Counseling',
@@ -81,11 +82,11 @@ const basicPaymentRequestOneServiceItem = {
   status: 'REVIEWED',
   serviceItems: [
     {
-      id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+      id: '09474c6a-69b6-4501-8e08-670a12512a5e',
       createdAt: '2020-12-01T00:00:00.000Z',
       mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
       priceCents: 2000001,
-      status: 'APPROVED',
+      status: PAYMENT_SERVICE_ITEM_STATUS.APPROVED,
       shipmentType: null,
       serviceItemName: 'Move management',
     },


### PR DESCRIPTION
## Description

This PR adds the Storybook component, styling, and basic unit tests for the Payment Request details.

## Reviewer Notes

Please take a look at the CSS. Are there units that should be pulled from elsewhere? Are there declarations that should be moved to a more global stylesheet?

In particular, should the icons be pulled into a global icons stylesheet? Same with the color indicator above the table header.

Any other feedback is welcome!

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [x] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?


## Screenshots

![Screen Shot 2021-01-07 at 11 04 44 AM](https://user-images.githubusercontent.com/1587316/103914676-335fb380-50d8-11eb-84f0-3e28eaf2c2ec.png)

