### PR TITLE
Update check-bash-version to use latest from brew

### DIFF
--- a/scripts/check-bash-version
+++ b/scripts/check-bash-version
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-VERSION="5.0"
+VERSION="5.1"
 
 # Script helps ensure that /etc/shells has all the correct entries in it
 


### PR DESCRIPTION
## Description

MilMove requires you install `bash` via `brew` [See Docs](https://github.com/transcom/mymove#setup-developer-setup). The latest install of brew installs version 5.1.4(1)-release which is newer than the 5.0 required by the `check-bash-version` script. This PR fixes that.

```sh
❯ bash --version
GNU bash, version 5.1.4(1)-release (x86_64-apple-darwin19.6.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

## Reviewer Notes

Try any of the make or script files you typically use to ensure they still work.

## Setup

Upgrade bash via brew and run `make prereqs` as below

```sh
❯ brew update
...
❯ brew upgrade bash
...
❯ rm -f .prereqs.stamp ; make prereqs
scripts/prereqs
/usr/local/bin/aws installed.
bash installed.
/usr/local/bin/chamber installed.
docker installed.
jq installed.
asdf installed.
.asdf/shims was found in path
go installed.
yarn installed.
pre-commit installed.
shellcheck installed.
psql installed.
nodenv installed.
.nodenv/shims was found in path
node installed.
pkcs11-tool installed.
pkcs15-tool installed.
circleci installed.
direnv installed.
entr installed.
aws-vault installed.
watchman installed.
OK: all prereqs found

aws-cli/2.1.15 Python/3.9.1 Darwin/19.6.0 source/x86_64 prompt/off installed
aws-vault /usr/local/bin/aws-vault v6.2.0 installed
Bash 5.1.4(1)-release installed
/Users/john/projects/dod/mymove/scripts/chamber
chamber v2.9.0 installed
Golang go version go1.15.5 darwin/amd64 installed
Node v12.16.3 installed
Warning: Treating opensc as a formula. For the cask, use homebrew/cask/opensc
opensc 0.21.0 installed
touch .prereqs.stamp
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.