### PR TITLE
MB-6197: updates postgres from 12.2 to 12.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: '2.1'
 references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-2c832f32e8dbd8afaaa5265e9c6ff59e8d536d11
 
-  postgres: &postgres postgres:12.2
+  postgres: &postgres postgres:12.4
 
 executors:
   av_medium:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/transcom-infrasec-com/blob/c32c45078f29ea6fd58b0c246f994dbea91be372/transcom-com-legacy/app-prod/main.tf#L62
-DB_DOCKER_CONTAINER_IMAGE = postgres:12.2
+DB_DOCKER_CONTAINER_IMAGE = postgres:12.4
 REDIS_DOCKER_CONTAINER_IMAGE = redis:5.0.6
 REDIS_DOCKER_CONTAINER = milmove-redis
 TASKS_DOCKER_CONTAINER = tasks

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     deploy:
       resources:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls_local.yml
+++ b/docker-compose.mtls_local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.prime.yml
+++ b/docker-compose.prime.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.2
+    image: postgres:12.4
     restart: always
     ports:
       - '6432:5432'


### PR DESCRIPTION
## Description

Updates postgres from 12.2 to 12.4 for our docker containers to match our RDS instances (https://github.com/transcom/transcom-infrasec-gov/blob/11731c33d02fce90f74a270b4dc0af44bc5360fd/transcom-gov-milmove-exp/app-experimental/main.tf#L35
https://github.com/transcom/transcom-infrasec-gov/blob/11731c33d02fce90f74a270b4dc0af44bc5360fd/transcom-gov-milmove-prd/app-production/main.tf#L36
https://github.com/transcom/transcom-infrasec-gov/blob/11731c33d02fce90f74a270b4dc0af44bc5360fd/transcom-gov-milmove-stg/app-staging/main.tf#L34)

## Reviewer Notes

The same operation we did here: https://github.com/transcom/mymove/pull/3990/files for a newer version.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
docker pull postgres:12.2
```

## Code Review Verification Steps


* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6197) for this change