### PR TITLE
MB-6198: rm vault from put_target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1282,7 +1282,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rek-mb-6198-rm-vault-put-target
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1295,7 +1295,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rek-mb-6198-rm-vault-put-target
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1303,7 +1303,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rek-mb-6198-rm-vault-put-target
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rek-mb-6198-rm-vault-put-target
+              ignore: placeholder_branch_name
 
       - webhook_client_test:
           requires:
@@ -1359,28 +1359,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1394,28 +1394,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rek-mb-6198-rm-vault-put-target
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1282,7 +1282,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rek-mb-6198-rm-vault-put-target
 
       - integration_tests_mtls:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1295,7 +1295,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rek-mb-6198-rm-vault-put-target
 
       - client_test:
           requires:
@@ -1303,7 +1303,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rek-mb-6198-rm-vault-put-target
 
       - server_test:
           requires:
@@ -1311,7 +1311,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rek-mb-6198-rm-vault-put-target
 
       - webhook_client_test:
           requires:
@@ -1359,28 +1359,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - deploy_exp_migrations:
           requires:
@@ -1394,28 +1394,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rek-mb-6198-rm-vault-put-target
 
       - push_app_stg:
           requires:

--- a/cmd/ecs-deploy/put_target.go
+++ b/cmd/ecs-deploy/put_target.go
@@ -52,9 +52,6 @@ func initPutTargetFlags(flag *pflag.FlagSet) {
 	// AWS Flags
 	cli.InitAWSFlags(flag)
 
-	// Vault Flags
-	cli.InitVaultFlags(flag)
-
 	// Put Targets Settings
 	flag.String(environmentFlag, "", fmt.Sprintf("The environment name (choose %q)", environments))
 	flag.String(nameFlag, "", fmt.Sprintf("The name of the rule"))
@@ -85,10 +82,6 @@ func checkPutTargetsConfig(v *viper.Viper) error {
 
 	if err := cli.CheckAWSRegionForService(region, cloudwatchevents.ServiceName); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("'%q' is invalid for service %s", cli.AWSRegionFlag, cloudwatchevents.ServiceName))
-	}
-
-	if err := cli.CheckVault(v); err != nil {
-		return err
 	}
 
 	environmentName := v.GetString(environmentFlag)
@@ -167,9 +160,8 @@ func putTargetFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the AWS configuration so we can build a session
-	awsConfig, err := cli.GetAWSConfig(v, verbose)
-	if err != nil {
-		quit(logger, nil, err)
+	awsConfig := &aws.Config{
+		Region: aws.String(v.GetString(cli.AWSRegionFlag)),
 	}
 	sess, err := awssession.NewSession(awsConfig)
 	if err != nil {

--- a/scripts/ecs-deploy-task-container
+++ b/scripts/ecs-deploy-task-container
@@ -54,7 +54,7 @@ dry_run_task_definition_date=$("${DIR}/../bin/ecs-deploy" task-def \
   --dry-run)
 
 dry_run_task_definition=$(echo "${dry_run_task_definition_date}" | cut -d ' ' -f 3)
-echo "${dry_run_task_definition} | jq ."
+echo "${dry_run_task_definition}" | jq .
 
 echo
 echo "Registering ECS task definition for ${name}"


### PR DESCRIPTION
## Description

This PR removes the commands from our version of the vault library from `cmd/ecs-deploy/put_target.go`.

## Reviewer Notes

Have run locally with no issues via the `deploy-app-tasks` cmd, which calls `ecs-deploy-task-container`, which in turn calls `"ecs-deploy" put-target`.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
 DISABLE_AWS_VAULT_WRAPPER=1 aws-vault exec transcom-gov-milmove-exp -- scripts/deploy-app-tasks exp
```

```sh
Successfully put new CloudWatch Event target for save-ghc-fuel-price-data with ECS task definition arn:aws-us-gov:ecs:us-gov-west-1:015681133840:task-definition/app-exp-save-ghc-fuel-price-data:65
Successfully put new CloudWatch Event target for send-post-move-survey with ECS task definition arn:aws-us-gov:ecs:us-gov-west-1:015681133840:task-definition/app-exp-send-post-move-survey:61
Successfully put new CloudWatch Event target for send-payment-reminder with ECS task definition arn:aws-us-gov:ecs:us-gov-west-1:015681133840:task-definition/app-exp-send-payment-reminder:61
Successfully put new CloudWatch Event target for post-file-to-gex with ECS task definition arn:aws-us-gov:ecs:us-gov-west-1:015681133840:task-definition/app-exp-post-file-to-gex:61
```

Here's proof of a successful run on CIRCLECI in the exp env:
<img width="705" alt="Screen Shot 2021-01-11 at 3 28 53 PM" src="https://user-images.githubusercontent.com/7401870/104250152-d63e6780-5421-11eb-875a-3ff90154e399.png">


## Code Review Verification Steps


* [x] If the change is risky, it has been tested in experimental before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6198) for this change