### PR TITLE
[MB-1585] SIT Schedule lookup for dest and origin

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/lookup_query_helpers.go
+++ b/pkg/payment_request/service_param_value_lookups/lookup_query_helpers.go
@@ -1,0 +1,24 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/pop/v5"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func fetchDomesticServiceArea(db *pop.Connection, contractCode string, zip3 string) (models.ReDomesticServiceArea, error) {
+	var domesticServiceArea models.ReDomesticServiceArea
+	err := db.Q().
+		Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
+		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
+		Where("re_zip3s.zip3 = ?", zip3).
+		Where("re_contracts.code = ?", contractCode).
+		First(&domesticServiceArea)
+	if err != nil {
+		return domesticServiceArea, fmt.Errorf("unable to find domestic service area for %s under contract code %s", zip3, contractCode)
+	}
+
+	return domesticServiceArea, nil
+}

--- a/pkg/payment_request/service_param_value_lookups/lookup_query_helpers_test.go
+++ b/pkg/payment_request/service_param_value_lookups/lookup_query_helpers_test.go
@@ -1,0 +1,29 @@
+package serviceparamvaluelookups
+
+import (
+	"github.com/go-openapi/strfmt"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestLookupQueryHelpers() {
+	domesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+		ReDomesticServiceArea: models.ReDomesticServiceArea{
+			ServiceArea:      "004",
+			ServicesSchedule: 2,
+		},
+	})
+
+	zip3 := testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+		ReZip3: models.ReZip3{
+			Contract:            domesticServiceArea.Contract,
+			DomesticServiceArea: domesticServiceArea,
+			Zip3:                "350",
+		},
+	})
+	dsa, err := fetchDomesticServiceArea(suite.DB(), zip3.Contract.Code, zip3.Zip3)
+	suite.FatalNoError(err)
+	suite.Equal(strfmt.UUID(domesticServiceArea.ID.String()), strfmt.UUID(dsa.ID.String()))
+
+}

--- a/pkg/payment_request/service_param_value_lookups/service_area_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_lookup.go
@@ -15,15 +15,7 @@ func (r ServiceAreaLookup) lookup(keyData *ServiceItemParamKeyData) (string, err
 	zip := r.Address.PostalCode
 	zip3 := zip[0:3]
 
-	var domesticServiceArea models.ReDomesticServiceArea
-
-	query := db.Q().
-		Join("re_zip3s", "re_zip3s.domestic_service_area_id = re_domestic_service_areas.id").
-		Join("re_contracts", "re_contracts.id = re_domestic_service_areas.contract_id").
-		Where("zip3 = ?", zip3).
-		Where("re_contracts.code = ?", keyData.ContractCode)
-
-	err := query.First(&domesticServiceArea)
+	domesticServiceArea, err := fetchDomesticServiceArea(&db, keyData.ContractCode, zip3)
 
 	return domesticServiceArea.ServiceArea, err
 }

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -289,7 +289,6 @@ func ServiceParamLookupInitialize(
 
 	paramKey = models.ServiceItemParamNameSITScheduleOrigin
 	err = s.setLookup(serviceItemCode, paramKey, SITScheduleLookup{
-		// Will need to be updated after https://dp3.atlassian.net/browse/MB-6257#icft=MB-6257
 		Address: pickupAddress,
 	})
 	if err != nil {
@@ -298,7 +297,6 @@ func ServiceParamLookupInitialize(
 
 	paramKey = models.ServiceItemParamNameSITScheduleDest
 	err = s.setLookup(serviceItemCode, paramKey, SITScheduleLookup{
-		// Will need to be updated after https://dp3.atlassian.net/browse/MB-6257#icft=MB-6257
 		Address: destinationAddress,
 	})
 	if err != nil {

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -287,6 +287,24 @@ func ServiceParamLookupInitialize(
 		return nil, err
 	}
 
+	paramKey = models.ServiceItemParamNameSITScheduleOrigin
+	err = s.setLookup(serviceItemCode, paramKey, SITScheduleLookup{
+		// Will need to be updated after https://dp3.atlassian.net/browse/MB-6257#icft=MB-6257
+		Address: pickupAddress,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	paramKey = models.ServiceItemParamNameSITScheduleDest
+	err = s.setLookup(serviceItemCode, paramKey, SITScheduleLookup{
+		// Will need to be updated after https://dp3.atlassian.net/browse/MB-6257#icft=MB-6257
+		Address: destinationAddress,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &s, nil
 }
 

--- a/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup.go
@@ -6,12 +6,12 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// ServicesScheduleLookup does lookup on services schedule origin
-type ServicesScheduleLookup struct {
+// SITScheduleLookup does lookup on services schedule origin
+type SITScheduleLookup struct {
 	Address models.Address
 }
 
-func (s ServicesScheduleLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+func (s SITScheduleLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
 	db := *keyData.db
 
 	// find the service area by querying for the service area associated with the zip3
@@ -20,5 +20,5 @@ func (s ServicesScheduleLookup) lookup(keyData *ServiceItemParamKeyData) (string
 
 	domesticServiceArea, err := fetchDomesticServiceArea(&db, keyData.ContractCode, zip3)
 
-	return strconv.Itoa(domesticServiceArea.ServicesSchedule), err
+	return strconv.Itoa(domesticServiceArea.SITPDSchedule), err
 }

--- a/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
@@ -70,7 +70,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		},
 	})
 
-	suite.T().Run("lookup origin SITServicesSchedule", func(t *testing.T) {
+	suite.T().Run("lookup SITScheduleOrigin", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(originKey)
@@ -78,7 +78,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Equal(strconv.Itoa(originDomesticServiceArea.SITPDSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup dest SITServicesSchedule", func(t *testing.T) {
+	suite.T().Run("lookup SITScheduleOriginDest", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(destKey)
@@ -86,7 +86,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Equal(strconv.Itoa(destDomesticServiceArea.SITPDSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup origin SITServicesSchedule not found", func(t *testing.T) {
+	suite.T().Run("lookup SITScheduleOrigin not found", func(t *testing.T) {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
@@ -103,7 +103,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Contains(err.Error(), expected)
 	})
 
-	suite.T().Run("lookup dest SITServicesSchedule not found", func(t *testing.T) {
+	suite.T().Run("lookup SITScheduleDest not found", func(t *testing.T) {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),

--- a/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
@@ -1,0 +1,122 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
+	originKey := models.ServiceItemParamNameSITScheduleOrigin
+	destKey := models.ServiceItemParamNameSITScheduleDest
+
+	originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			PostalCode: "35007",
+		},
+	})
+	destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			PostalCode: "45007",
+		},
+	})
+
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			PickupAddressID:      &originAddress.ID,
+			PickupAddress:        &originAddress,
+			DestinationAddressID: &destAddress.ID,
+			DestinationAddress:   &destAddress,
+		},
+	})
+
+	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+		testdatagen.Assertions{
+			Move: mtoServiceItem.MoveTaskOrder,
+		})
+
+	originDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+		ReDomesticServiceArea: models.ReDomesticServiceArea{
+			ServiceArea:      "004",
+			ServicesSchedule: 2,
+		},
+	})
+
+	testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+		ReZip3: models.ReZip3{
+			Contract:            originDomesticServiceArea.Contract,
+			DomesticServiceArea: originDomesticServiceArea,
+			Zip3:                "350",
+		},
+	})
+
+	destDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+		ReDomesticServiceArea: models.ReDomesticServiceArea{
+			Contract:         originDomesticServiceArea.Contract,
+			ServiceArea:      "005",
+			ServicesSchedule: 3,
+		},
+	})
+
+	testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+		ReZip3: models.ReZip3{
+			Contract:            destDomesticServiceArea.Contract,
+			DomesticServiceArea: destDomesticServiceArea,
+			Zip3:                "450",
+		},
+	})
+
+	suite.T().Run("lookup origin ServicesSchedule", func(t *testing.T) {
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+		valueStr, err := paramLookup.ServiceParamValue(originKey)
+		suite.FatalNoError(err)
+		suite.Equal(strconv.Itoa(originDomesticServiceArea.SITPDSchedule), valueStr)
+	})
+
+	suite.T().Run("lookup dest ServicesSchedule", func(t *testing.T) {
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+		valueStr, err := paramLookup.ServiceParamValue(destKey)
+		suite.FatalNoError(err)
+		suite.Equal(strconv.Itoa(destDomesticServiceArea.SITPDSchedule), valueStr)
+	})
+
+	suite.T().Run("lookup origin ServicesSchedule not found", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+
+		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: mtoServiceItem.MoveTaskOrder,
+			})
+
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+		valueStr, err := paramLookup.ServiceParamValue(originKey)
+		suite.Equal("", valueStr)
+		suite.Error(err)
+		expected := fmt.Sprintf(" with error unable to find domestic service area for 902 under contract code %s", ghcrateengine.DefaultContractCode)
+		suite.Contains(err.Error(), expected)
+	})
+
+	suite.T().Run("lookup dest ServicesSchedule not found", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+
+		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: mtoServiceItem.MoveTaskOrder,
+			})
+
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+		valueStr, err := paramLookup.ServiceParamValue(destKey)
+		suite.Equal("", valueStr)
+		suite.Error(err)
+		expected := fmt.Sprintf(" with error unable to find domestic service area for 945 under contract code %s", ghcrateengine.DefaultContractCode)
+		suite.Contains(err.Error(), expected)
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/sit_schedule_lookup_test.go
@@ -41,8 +41,8 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 
 	originDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
 		ReDomesticServiceArea: models.ReDomesticServiceArea{
-			ServiceArea:      "004",
-			ServicesSchedule: 2,
+			ServiceArea:   "004",
+			SITPDSchedule: 2,
 		},
 	})
 
@@ -56,9 +56,9 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 
 	destDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
 		ReDomesticServiceArea: models.ReDomesticServiceArea{
-			Contract:         originDomesticServiceArea.Contract,
-			ServiceArea:      "005",
-			ServicesSchedule: 3,
+			Contract:      originDomesticServiceArea.Contract,
+			ServiceArea:   "005",
+			SITPDSchedule: 3,
 		},
 	})
 
@@ -70,7 +70,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		},
 	})
 
-	suite.T().Run("lookup origin ServicesSchedule", func(t *testing.T) {
+	suite.T().Run("lookup origin SITServicesSchedule", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(originKey)
@@ -78,7 +78,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Equal(strconv.Itoa(originDomesticServiceArea.SITPDSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup dest ServicesSchedule", func(t *testing.T) {
+	suite.T().Run("lookup dest SITServicesSchedule", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(destKey)
@@ -86,7 +86,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Equal(strconv.Itoa(destDomesticServiceArea.SITPDSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup origin ServicesSchedule not found", func(t *testing.T) {
+	suite.T().Run("lookup origin SITServicesSchedule not found", func(t *testing.T) {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
@@ -103,7 +103,7 @@ func (suite *ServiceParamValueLookupsSuite) TestSITSchedule() {
 		suite.Contains(err.Error(), expected)
 	})
 
-	suite.T().Run("lookup dest ServicesSchedule not found", func(t *testing.T) {
+	suite.T().Run("lookup dest SITServicesSchedule not found", func(t *testing.T) {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),


### PR DESCRIPTION
## Description

This PR creates a lookup function that is used for both SITScheduleOrigin and SITScheduleDest

## Reviewer Notes

- I believe the sources for the pickup and destination addresses will need to be updated once those are no longer found on the MTO Service item (tickets to update this: https://dp3.atlassian.net/browse/MB-6279 and https://dp3.atlassian.net/browse/MB-6257))
- I broke out the query to find the domestic service area into a new file called `lookup_query_helper.go`. I based this off of the existing `pricer_query_helper.go` file. 
- There isn't any code set up (that I'm aware of for this ticket) but please double check that the query and unit test make sense


## Acceptance
- As noted in sprint planning, there's no acceptance for this ticket. Instead the lookup work can be accepted when the pricer is built

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1585) for this change

