### PR TITLE
[MB-4644] Toggle Show Request Details Button

### DIFF
--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1716,6 +1716,10 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 		},
 	})
 
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move10,
+	})
+
 	paymentRequest10 := testdatagen.MakePaymentRequest(db, testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
 			ID:            uuid.FromStringOrNil("cfd110d4-1f62-401c-a92c-39987a0b4229"),
@@ -1727,6 +1731,7 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 	})
 
 	serviceItemA := testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
+		MTOServiceItem: models.MTOServiceItem{Status: models.MTOServiceItemStatusApproved},
 		PaymentRequest: paymentRequest10,
 		ReService: models.ReService{
 			ID: uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"), // CS - Counseling Services
@@ -1734,6 +1739,7 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 	})
 
 	serviceItemB := testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
+		MTOServiceItem: models.MTOServiceItem{Status: models.MTOServiceItemStatusApproved},
 		PaymentRequest: paymentRequest10,
 		ReService: models.ReService{
 			ID: uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"), // MS - Move Management

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1652,10 +1652,6 @@ func createMoveWithServiceItems(db *pop.Connection, userUploader *uploader.UserU
 		PaymentRequest: paymentRequest9,
 	})
 
-	testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
-		PaymentRequest: paymentRequest9,
-	})
-
 	assertions9 := testdatagen.Assertions{
 		Move:           move9,
 		MTOShipment:    mtoShipment9,
@@ -1737,8 +1733,6 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 		PaymentRequest: paymentRequest10,
 	})
 
-	//serviceItem.MTOShipment.ShipmentType = models.MTOShipmentNull;
-
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
 			Status: models.PaymentServiceItemStatusApproved,
@@ -1746,6 +1740,7 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 		MTOServiceItem: serviceItemA,
 		PaymentRequest: paymentRequest10,
 	})
+
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
 		PaymentServiceItem: models.PaymentServiceItem{
 			Status: models.PaymentServiceItemStatusDenied,

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1712,6 +1712,7 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 		Move: models.Move{
 			ID:       uuid.FromStringOrNil("7cbe57ba-fd3a-45a7-aa9a-1970f1908ae8"),
 			OrdersID: orders10.ID,
+			Status:   models.MoveStatusAPPROVED,
 		},
 	})
 
@@ -1727,10 +1728,16 @@ func createMoveWithBasicServiceItems(db *pop.Connection, userUploader *uploader.
 
 	serviceItemA := testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
 		PaymentRequest: paymentRequest10,
+		ReService: models.ReService{
+			ID: uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"), // CS - Counseling Services
+		},
 	})
 
 	serviceItemB := testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
 		PaymentRequest: paymentRequest10,
+		ReService: models.ReService{
+			ID: uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"), // MS - Move Management
+		},
 	})
 
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -37,6 +37,7 @@ const PaymentRequestCard = ({ paymentRequest, history }) => {
   const defaultShowDetails = paymentRequest.status === 'PENDING' && basicServiceItems.length > 0;
   // only show button in reviewed/paid
   const showRequestDetailsButton = !defaultShowDetails && basicServiceItems.length > 0;
+
   // state to toggle between showing details or not
   const [showDetails, setShowDetails] = useState(defaultShowDetails);
   let handleClick = () => {};
@@ -64,6 +65,7 @@ const PaymentRequestCard = ({ paymentRequest, history }) => {
   }
 
   const showDetailsChevron = showDetails ? 'chevron-up' : 'chevron-down';
+  const showDetailsText = showDetails ? 'Hide request details' : 'Show request details';
   const handleToggleDetails = () => setShowDetails((prevState) => !prevState);
 
   return (
@@ -144,7 +146,7 @@ const PaymentRequestCard = ({ paymentRequest, history }) => {
           <div className={styles.toggleDrawer}>
             {showRequestDetailsButton && (
               <Button data-testid="showRequestDetailsButton" type="button" unstyled onClick={handleToggleDetails}>
-                <FontAwesomeIcon icon={showDetailsChevron} /> Show request details
+                <FontAwesomeIcon icon={showDetailsChevron} /> {showDetailsText}
               </Button>
             )}
           </div>

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -145,7 +145,13 @@ const PaymentRequestCard = ({ paymentRequest, history }) => {
           )}
           <div className={styles.toggleDrawer}>
             {showRequestDetailsButton && (
-              <Button data-testid="showRequestDetailsButton" type="button" unstyled onClick={handleToggleDetails}>
+              <Button
+                aria-expanded={showDetails}
+                data-testid="showRequestDetailsButton"
+                type="button"
+                unstyled
+                onClick={handleToggleDetails}
+              >
                 <FontAwesomeIcon icon={showDetailsChevron} /> {showDetailsText}
               </Button>
             )}


### PR DESCRIPTION
## Description
As a TIO viewing a **Reviewed Payment Request** I should be able to toggle the 'Show Request Details' when there are Service Items present

## Reviewer Notes

This button was previously set up in https://github.com/transcom/mymove/pull/5612, this corrects some of the seed data and makes small changes to the component
## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
