### PR TITLE
MB-6305: use the limited postgresql role in unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,9 @@ commands:
           environment:
             APPLICATION: '<< parameters.application >>'
             DB_PASSWORD: mysecretpassword
+            DB_PASSWORD_LOW_PRIV: mysecretpassword
             DB_USER: postgres
+            DB_USER_LOW_PRIV: crud
             DB_HOST: localhost
             DB_PORT_TEST: 5433
             DB_PORT: 5432
@@ -777,9 +779,11 @@ jobs:
             DB_NAME: test_db
             DB_NAME_TEST: test_db
             DB_PASSWORD: mysecretpassword
+            DB_PASSWORD_LOW_PRIV: mysecretpassword
             DB_PORT: 5432
             DB_PORT_TEST: 5432
             DB_USER: postgres
+            DB_USER_LOW_PRIV: crud
       - announce_failure
 
   # `build_tools` builds the mymove-specific CLI tools in `mymove/cmd`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,8 +716,6 @@ jobs:
       - run: make bin/milmove
       - server_tests_step:
           application: app
-      - server_tests_step:
-          application: orders
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results

--- a/.envrc
+++ b/.envrc
@@ -111,8 +111,10 @@ export MIGRATION_MANIFEST="${MYMOVE_DIR}/migrations/app/migrations_manifest.txt"
 
 # Default DB configuration
 export DB_PASSWORD=mysecretpassword
+export DB_PASSWORD_LOW_PRIV=mysecretpassword
 export PGPASSWORD=$DB_PASSWORD
 export DB_USER=postgres
+export DB_USER_LOW_PRIV=crud
 export DB_HOST=localhost
 export DB_PORT=5432
 export DB_PORT_DEPLOYED_MIGRATIONS=5434

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -42,10 +42,12 @@ services:
       - DB_NAME=test_db
       - DB_NAME_TEST=test_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_PORT_TEST=5432
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=true
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -60,11 +60,13 @@ services:
       - DB_HOST=database
       - DB_NAME=dev_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=1
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -51,11 +51,13 @@ services:
       - DB_HOST=database
       - DB_NAME=dev_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=1
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/docker-compose.mtls_local.yml
+++ b/docker-compose.mtls_local.yml
@@ -55,11 +55,13 @@ services:
       - DB_HOST=database
       - DB_NAME=dev_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=1
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/docker-compose.prime.yml
+++ b/docker-compose.prime.yml
@@ -56,11 +56,13 @@ services:
       - DB_HOST=database
       - DB_NAME=dev_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=1
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,13 @@ services:
       - DB_HOST=database
       - DB_NAME=dev_db
       - DB_PASSWORD=mysecretpassword
+      - DB_PASSWORD_LOW_PRIV=mysecretpassword
       - DB_PORT=5432
       - DB_REGION=us-west-2
       - DB_RETRY_INTERVAL=5s
       - DB_SSL_MODE=disable
       - DB_USER=postgres
+      - DB_USER_LOW_PRIV=crud
       - DEVLOCAL_AUTH=1
       - DEVLOCAL_CA=/config/tls/devlocal-ca.pem
       - DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -23,8 +23,11 @@ func TestMigrateSuite(t *testing.T) {
 	}
 
 	ms := &MigrateSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite("migrate"),
-		logger:       logger,
+		PopTestSuite: testingsuite.NewPopTestSuite(
+			"migrate",
+			testingsuite.WithHighPrivPSQLRole(),
+		),
+		logger: logger,
 	}
 	suite.Run(t, ms)
 	ms.PopTestSuite.TearDown()

--- a/pkg/services/ghcimport/ghc_rateengine_importer_test.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer_test.go
@@ -1,7 +1,6 @@
 package ghcimport
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -21,7 +20,7 @@ const testContractName = "Test Contract"
 
 var testContractStartDate = time.Date(2021, time.February, 01, 0, 0, 0, 0, time.UTC)
 
-var tablesToTruncate = [...]string{
+var tablesToTruncate = []string{
 	"re_contract_years",
 	"re_contracts",
 	"re_domestic_accessorial_prices",
@@ -46,11 +45,9 @@ type GHCRateEngineImportSuite struct {
 
 func (suite *GHCRateEngineImportSuite) SetupTest() {
 	// Clean up only the rate engine tables we're going to be inserting into for the tests.
-	for _, table := range tablesToTruncate {
-		sql := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
-		err := suite.DB().RawQuery(sql).Exec()
-		suite.NoError(err)
-	}
+	err := suite.Truncate(tablesToTruncate)
+	suite.NoError(err)
+
 	// setup re_services which is normally a migration in other environments
 	suite.helperSetupReServicesTable()
 }

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -51,9 +51,25 @@ func StringWithCharset(length int, charset string) string {
 type PopTestSuite struct {
 	BaseTestSuite
 	PackageName
-	db                 *pop.Connection
-	dbConnDetails      *pop.ConnectionDetails
-	primaryConnDetails *pop.ConnectionDetails
+	origConn            *pop.Connection
+	lowPrivConn         *pop.Connection
+	highPrivConn        *pop.Connection
+	origConnDetails     *pop.ConnectionDetails
+	lowPrivConnDetails  *pop.ConnectionDetails
+	highPrivConnDetails *pop.ConnectionDetails
+
+	// Enable this flag to avoid the use of the DB_USER_LOW_PRIV and DB_PASSWORD_LOW_PRIV
+	// environment variables and instead fall back to the use of a single, high privileged
+	// PostgreSQL database role. This role used to commonly be called the "migrations user".
+	// However, this grants too many permissions to the database from the application. Therefore,
+	// we created a new user with fewer permissions that are used by most tests.
+	//
+	// There is one type of situation where we still want to use the PostgreSQL role: areas of the
+	// code that are testing migrations. In this situation, the following flag can be set to true
+	// to enable the use of the role with elevated permissions.
+	//
+	// For more details, please see https://dp3.atlassian.net/browse/MB-5197
+	useHighPrivsPSQLRole bool
 }
 
 func dropDB(conn *pop.Connection, destination string) error {
@@ -105,8 +121,29 @@ func CurrentPackage() PackageName {
 	return PackageName(pkg)
 }
 
+// PopTestSuiteOption is type intended to be used to change a PopTestSuite object.
+type PopTestSuiteOption func(*PopTestSuite)
+
+// WithHighPrivPSQLRole is a functional option that can be passed into the NewPopTestSuite
+// function to create a PopTestSuite that only uses the privileged SQL connection.
+func WithHighPrivPSQLRole() PopTestSuiteOption {
+	return func(pts *PopTestSuite) {
+		// Mark a flag that indicates that we are only using a single privileged role.
+		pts.useHighPrivsPSQLRole = true
+
+		// Disconnect the low privileged connection and replace its connection and connection
+		// details with those of the high privileged connection.
+		if err := pts.lowPrivConn.Close(); err != nil {
+			log.Panic(err)
+		}
+
+		pts.lowPrivConn = pts.highPrivConn
+		pts.lowPrivConnDetails = pts.highPrivConnDetails
+	}
+}
+
 // NewPopTestSuite returns a new PopTestSuite
-func NewPopTestSuite(packageName PackageName) PopTestSuite {
+func NewPopTestSuite(packageName PackageName, opts ...PopTestSuiteOption) PopTestSuite {
 	// Try to obtain the lock in this method within 10 minutes
 	lockCtx, cancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer cancel()
@@ -136,9 +173,17 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 	if dbUserErr != nil {
 		log.Panic(dbUserErr)
 	}
+	dbUserLowPriv, dbUserLowPrivErr := envy.MustGet("DB_USER_LOW_PRIV")
+	if dbUserLowPrivErr != nil {
+		log.Panic(dbUserLowPrivErr)
+	}
 	dbPassword, dbPasswordErr := envy.MustGet("DB_PASSWORD")
 	if dbPasswordErr != nil {
 		log.Panic(dbPasswordErr)
+	}
+	dbPasswordApp, dbPasswordAppErr := envy.MustGet("DB_PASSWORD_LOW_PRIV")
+	if dbPasswordAppErr != nil {
+		log.Panic(dbPasswordAppErr)
 	}
 	dbSSLMode := envy.Get("DB_SSL_MODE", "disable")
 
@@ -147,7 +192,7 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 	}
 
 	log.Printf("package %s is attempting to connect to database %s", packageName.String(), dbNameTest)
-	primaryConnDetails := pop.ConnectionDetails{
+	origConnDetails := pop.ConnectionDetails{
 		Dialect:  dbDialect,
 		Driver:   "postgres",
 		Database: dbNameTest,
@@ -157,17 +202,17 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 		Password: dbPassword,
 		Options:  dbOptions,
 	}
-	primaryConn, primaryConnErr := pop.NewConnection(&primaryConnDetails)
-	if primaryConnErr != nil {
-		log.Panic(primaryConnErr)
+	origConn, origConnErr := pop.NewConnection(&origConnDetails)
+	if origConnErr != nil {
+		log.Panic(origConnErr)
 	}
-	if openErr := primaryConn.Open(); openErr != nil {
+	if openErr := origConn.Open(); openErr != nil {
 		log.Panic(openErr)
 	}
 
 	// Doing this before cloning should pre-clean the DB for all tests
 	log.Printf("attempting to truncate the database %s", dbNameTest)
-	errTruncateAll := primaryConn.TruncateAll()
+	errTruncateAll := origConn.TruncateAll()
 	if errTruncateAll != nil {
 		log.Panicf("failed to truncate database '%s': %#v", dbNameTest, errTruncateAll)
 	}
@@ -175,13 +220,13 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 	uniq := StringWithCharset(6, charset)
 	dbNamePackage := fmt.Sprintf("%s_%s_%s", dbNameTest, strings.Replace(packageName.String(), "/", "_", -1), uniq)
 	log.Printf("attempting to clone database %s to %s... ", dbNameTest, dbNamePackage)
-	if err := cloneDatabase(primaryConn, dbNameTest, dbNamePackage); err != nil {
+	if err := cloneDatabase(origConn, dbNameTest, dbNamePackage); err != nil {
 		log.Panicf("failed to clone database '%s' to '%s': %#v", dbNameTest, dbNamePackage, err)
 	}
 	log.Println("success")
 
-	// disconnect from the primary DB
-	if err := primaryConn.Close(); err != nil {
+	// disconnect from the original DB
+	if err := origConn.Close(); err != nil {
 		log.Panic(err)
 	}
 
@@ -192,7 +237,10 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 
 	log.Printf("package %s is attempting to connect to database %s", packageName.String(), dbNamePackage)
 
-	packageConnDetails := pop.ConnectionDetails{
+	// Prepare a new connection to the temporary database with the same PostgreSQL role privileges
+	// as what the migrations task will have when running migrations. These privileges will be
+	// higher than the role that runs application.
+	highPrivConnDetails := pop.ConnectionDetails{
 		Dialect:  dbDialect,
 		Driver:   "postgres",
 		Database: dbNamePackage,
@@ -202,31 +250,75 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 		Password: dbPassword,
 		Options:  dbOptions,
 	}
-	packageConn, packageConnErr := pop.NewConnection(&packageConnDetails)
-	if packageConnErr != nil {
-		log.Panic(packageConnErr)
+	highPrivsConn, highPrivsConnErr := pop.NewConnection(&highPrivConnDetails)
+	if highPrivsConnErr != nil {
+		log.Panic(highPrivsConnErr)
 	}
-
-	if openErr := packageConn.Open(); openErr != nil {
+	if openErr := highPrivsConn.Open(); openErr != nil {
 		log.Panic(openErr)
 	}
 
-	return PopTestSuite{
-		db:                 packageConn,
-		dbConnDetails:      &packageConnDetails,
-		primaryConnDetails: &primaryConnDetails,
-		PackageName:        packageName}
+	// Prepare a new connection to the temporary database with the same PostgreSQL role privileges
+	// as what the application will have when running the server. These privileges will be lower
+	// than the role that runs database migrations.
+	lowPrivConnDetails := pop.ConnectionDetails{
+		Dialect:  dbDialect,
+		Driver:   "postgres",
+		Database: dbNamePackage,
+		Host:     dbHost,
+		Port:     dbPortTest,
+		User:     dbUserLowPriv,
+		Password: dbPasswordApp,
+		Options:  dbOptions,
+	}
+	lowPrivsConn, lowPrivsConnErr := pop.NewConnection(&lowPrivConnDetails)
+	if lowPrivsConnErr != nil {
+		log.Panic(lowPrivsConnErr)
+	}
+	if openErr := lowPrivsConn.Open(); openErr != nil {
+		log.Panic(openErr)
+	}
+
+	// Create a standardized PopTestSuite object.
+	pts := &PopTestSuite{
+		lowPrivConn:         lowPrivsConn,
+		highPrivConn:        highPrivsConn,
+		origConn:            origConn,
+		lowPrivConnDetails:  &lowPrivConnDetails,
+		highPrivConnDetails: &highPrivConnDetails,
+		origConnDetails:     &origConnDetails,
+		PackageName:         packageName,
+	}
+
+	// Apply the user-supplied options to the PopTestSuite object.
+	for _, opt := range opts {
+		opt(pts)
+	}
+
+	return *pts
 }
 
 // DB returns a db connection
 func (suite *PopTestSuite) DB() *pop.Connection {
-	return suite.db
+	return suite.lowPrivConn
+}
+
+// Truncate deletes all data from the specified tables.
+func (suite *PopTestSuite) Truncate(tables []string) error {
+	// Truncate the specified tables.
+	for _, table := range tables {
+		sql := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
+		if err := suite.highPrivConn.RawQuery(sql).Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // TruncateAll deletes all data from all tables that are owned by the user connected to the
 // database.
 func (suite *PopTestSuite) TruncateAll() error {
-	return suite.db.TruncateAll()
+	return suite.highPrivConn.TruncateAll()
 }
 
 // MustSave requires saving without errors
@@ -234,7 +326,7 @@ func (suite *PopTestSuite) MustSave(model interface{}) {
 	t := suite.T()
 	t.Helper()
 
-	verrs, err := suite.db.ValidateAndSave(model)
+	verrs, err := suite.lowPrivConn.ValidateAndSave(model)
 	if err != nil {
 		suite.T().Errorf("Errors encountered saving %v: %v", model, err)
 	}
@@ -262,7 +354,7 @@ func (suite *PopTestSuite) MustDestroy(model interface{}) {
 	t := suite.T()
 	t.Helper()
 
-	err := suite.db.Destroy(model)
+	err := suite.lowPrivConn.Destroy(model)
 	if err != nil {
 		suite.T().Errorf("Errors encountered destroying %v: %v", model, err)
 	}
@@ -280,8 +372,11 @@ func (suite *PopTestSuite) NoVerrs(verrs *validate.Errors) bool {
 // TearDown runs the teardown for step for the suite
 // Important steps are to close open DB connections and drop the DB
 func (suite *PopTestSuite) TearDown() {
-	// disconnect from the package DB conn
-	if err := suite.DB().Close(); err != nil {
+	// disconnect from the package DB connections
+	if err := suite.lowPrivConn.Close(); err != nil {
+		log.Panic(err)
+	}
+	if err := suite.highPrivConn.Close(); err != nil {
 		log.Panic(err)
 	}
 
@@ -295,20 +390,20 @@ func (suite *PopTestSuite) TearDown() {
 		log.Panic(lockErr)
 	}
 
-	// reconnect to the primary DB
-	primaryConn, primaryConnErr := pop.NewConnection(suite.primaryConnDetails)
-	if primaryConnErr != nil {
-		log.Panic(primaryConnErr)
+	// reconnect to the original DB
+	origConn, origConnErr := pop.NewConnection(suite.origConnDetails)
+	if origConnErr != nil {
+		log.Panic(origConnErr)
 	}
-	if openErr := primaryConn.Open(); openErr != nil {
+	if openErr := origConn.Open(); openErr != nil {
 		log.Panic(openErr)
 	}
 	// Remove the package DB
-	if err := dropDB(primaryConn, (*suite.dbConnDetails).Database); err != nil {
+	if err := dropDB(origConn, (*suite.lowPrivConnDetails).Database); err != nil {
 		log.Panic(err)
 	}
-	// disconnect from the primary DB
-	if err := primaryConn.Close(); err != nil {
+	// disconnect from the original DB
+	if err := origConn.Close(); err != nil {
 		log.Panic(err)
 	}
 


### PR DESCRIPTION
## Description

With the introduction of a [new low privileged database role](https://github.com/transcom/mymove/pull/5567), it would be useful to run unit tests with this new role. That's what this PR does:

1. Add the ability to utilize a low-privileged database role during testing. Make this the default. Make it so that the role with elevated privileges can also be used if desired, such as when testing migrations.
1. Start using the low privileged user throughout our various docker compose files and in CircleCI.
1. Remove testing of the `orders` API since it started throwing errors. We don't develop this portion of the codebase any more, so even if we did find bugs in it, we would devote any more time to developing it. Therefore, running tests against it (and in this PR's case, fixing code to make those errors go away) is not a good use of time and effort.

## Setup

```sh
docker kill $(docker ps --quiet --filter ancestor=postgres:12.4)
docker rm $(docker ps --all --quiet --filter ancestor=postgres:12.4)
make server_test
```

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6305) for this change
* [this article](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) explains more about the approach used for the functional options I added (`PopTestSuiteOption`).