### PR TITLE
use latest milmove-cypress image: MB-6024

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-28346927e7aaa67c400858527a1c54b4baa71f32
+FROM milmove/circleci-docker:milmove-cypress-38cc39df3ee891652c472a6c731feecc63a1253b
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json

--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-bb1f5f3cda6f88b178bdc4d5a439a09c9b7bfcf6
+FROM milmove/circleci-docker:milmove-cypress-28346927e7aaa67c400858527a1c54b4baa71f32
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json


### PR DESCRIPTION
## Description

We have a repo circleci-docker that contains a build of cypress for our integration tests. When we update any packages in circleci-docker, we should pull the latest image of into mymove.

## Reviewer Notes

Make sure I have the correct hash: https://hub.docker.com/r/milmove/circleci-docker/tags?page=1&ordering=last_updated

## Setup

the integration tests should run w/o an issue on circle

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6024) for this change
