### PR TITLE
MB-6189 Add cert for webhook client to use on stg and exp

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -592,3 +592,4 @@
 20210108004003_add_permissions_to_docker_roles.up.sql
 20210108174326_fix_city_and_state_data_in_addresses.up.sql
 20210113173236_create_crud_role.up.sql
+20210113234717_webhook_client_cert_stg_exp.up.sql

--- a/migrations/app/secure/20210113234717_webhook_client_cert_stg_exp.up.sql
+++ b/migrations/app/secure/20210113234717_webhook_client_cert_stg_exp.up.sql
@@ -1,0 +1,47 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.
+
+-- This migration allows a cert to have read/write access to all orders and the prime API.
+-- The Orders API and the Prime API use client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed.
+
+INSERT INTO public.client_certs (
+	id,
+	sha256_digest,
+	subject,
+	allow_dps_auth_api,
+	allow_orders_api,
+	created_at,
+	updated_at,
+	allow_air_force_orders_read,
+	allow_air_force_orders_write,
+	allow_army_orders_read,
+	allow_army_orders_write,
+	allow_coast_guard_orders_read,
+	allow_coast_guard_orders_write,
+	allow_marine_corps_orders_read,
+	allow_marine_corps_orders_write,
+	allow_navy_orders_read,
+	allow_navy_orders_write,
+	allow_prime)
+VALUES (
+	'9d7fa3b2-8896-4f10-a89c-e161003a3387',
+	'506f768e04ec3f0121929ba681ce001c20db71bf5f830c145b954ca2469e5724',
+	'CN=gex-client.move.mil,OU=USTRANSCOM,OU=PKI,OU=DoD,O=U.S. Government,C=US',
+	false,
+	true,
+	now(),
+	now(),
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true);


### PR DESCRIPTION
## Description

This PR adds a new certificate to the `client_certs` table for the webhook client to use in stg and exp.

In addition to this PR, the steps outlined in "[How to Migrate the Database](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations-for-one-environment)" have been followed, notably:

* secure migration was uploaded to stg and exp matching this PR
* stub file was uploaded to prod, as we won't need this cert on prod


## Setup

If you want to check the SHA256 of the cert or any other information, contact Roci for more details.


## Code Review Verification Steps
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6189) for this change

