### PR TITLE
[MB-6213] Non-USMC TIO user should not see Marine Corps PRs in queue

### DIFF
--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -199,7 +199,10 @@ func sortOrder(sort *string, order *string) QueryOption {
 
 func branchFilter(branch *string) QueryOption {
 	return func(query *pop.Query) {
-		if branch != nil {
+		// When no branch filter is selected we want to filter out Marine Corps payment requests
+		if branch == nil {
+			query = query.Where("service_members.affiliation != ?", models.AffiliationMARINES)
+		} else {
 			query = query.Where("service_members.affiliation = ?", *branch)
 		}
 	}

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -60,6 +60,21 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestList() {
 			Show: swag.Bool(false),
 		},
 	})
+	// Marine Corps payment requests should be excluded even if in the same GBLOC
+	marines := models.AffiliationMARINES
+	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			Status: models.MTOShipmentStatusSubmitted,
+		},
+		Move: models.Move{
+			Status: models.MoveStatusSUBMITTED,
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "LKNQ",
+			ID:    uuid.Must(uuid.NewV4()),
+		},
+		ServiceMember: models.ServiceMember{Affiliation: &marines},
+	})
 
 	suite.T().Run("Only returns visible (where Move.Show is not false) payment requests matching office user GBLOC", func(t *testing.T) {
 		expectedPaymentRequests, _, err := paymentRequestListFetcher.FetchPaymentRequestList(officeUser.ID,
@@ -182,7 +197,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 			Status: models.MTOShipmentStatusSubmitted,
 		},
 		TransportationOffice: models.TransportationOffice{
-			Gbloc: "USMC",
+			Gbloc: "LKNQ",
 			ID:    officeUUID,
 		},
 		Move: models.Move{
@@ -199,10 +214,11 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 			Status: models.MTOShipmentStatusSubmitted,
 		},
 		TransportationOffice: models.TransportationOffice{
-			Gbloc: "USMC",
+			Gbloc: "LKNQ",
 			ID:    officeUUID,
 		},
-		Move: paymentRequestUSMC.MoveTaskOrder,
+		Move:          paymentRequestUSMC.MoveTaskOrder,
+		ServiceMember: models.ServiceMember{Affiliation: &marines},
 	})
 
 	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
@@ -215,12 +231,12 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 		ServiceMember: models.ServiceMember{Affiliation: &army},
 	})
 
-	officeUserOooRah := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{OfficeUser: models.OfficeUser{TransportationOfficeID: officeUUID}})
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	officeUserUSMC := testdatagen.MakeOfficeUserWithUSMCGBLOC(suite.DB())
 
 	suite.T().Run("returns USMC payment requests", func(t *testing.T) {
 		paymentRequestListFetcher := NewPaymentRequestListFetcher(suite.DB())
-		expectedPaymentRequests, _, err := paymentRequestListFetcher.FetchPaymentRequestList(officeUserOooRah.ID,
+		expectedPaymentRequests, _, err := paymentRequestListFetcher.FetchPaymentRequestList(officeUserUSMC.ID,
 			&services.FetchPaymentRequestListParams{Page: swag.Int64(1), PerPage: swag.Int64(2)})
 		paymentRequests := *expectedPaymentRequests
 
@@ -240,7 +256,7 @@ func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequestListUSMCGBLOC() 
 
 	suite.T().Run("returns USMC payment requests for move", func(t *testing.T) {
 		paymentRequestListFetcher := NewPaymentRequestListFetcher(suite.DB())
-		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(officeUserOooRah.ID, paymentRequestUSMC.MoveTaskOrder.Locator)
+		expectedPaymentRequests, err := paymentRequestListFetcher.FetchPaymentRequestListByMove(officeUserUSMC.ID, paymentRequestUSMC.MoveTaskOrder.Locator)
 		paymentRequests := *expectedPaymentRequests
 
 		suite.NoError(err)


### PR DESCRIPTION
## Description

Marine Corps payment requests were still showing up in a TIO's queue if the origin duty station matched the TIO's transportation office GBLOC.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the non-USMC TIO user
2. Click on a payment request in the queue in the 'Payment Requested' status note the move code.
3. Click on the View Orders link on the Payment Request Card.
4. Switch to the View Allowances view and change the branch to Marine Corps
5. Save the changes
6. Navigate back to the payment requests queue and the payment request should no longer appear

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6213) for this change

## Screenshots