### PR TITLE
[MB-6180] added truncation for city field in EDI

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -32,7 +32,7 @@ func NewGHCPaymentRequestInvoiceGenerator(db *pop.Connection, icnSequencer seque
 const dateFormat = "20060102"
 const isaDateFormat = "060102"
 const timeFormat = "1504"
-const maxCityLength = 27
+const maxCityLength = 30
 
 // Generate method takes a payment request and returns an Invoice858C
 func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.PaymentRequest, sendProductionInvoice bool) (ediinvoice.Invoice858C, error) {
@@ -713,7 +713,7 @@ func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 }
 
 func truncateStr(str string, cutoff int) string {
-	if len(str) >= cutoff {
+	if len(str) >= cutoff-3 {
 		return str[:cutoff] + "..."
 	}
 	return str

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -714,7 +714,10 @@ func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 
 func truncateStr(str string, cutoff int) string {
 	if len(str) >= cutoff {
-		return str[:cutoff-3] + "..."
+		if cutoff-3 > 0 {
+			return str[:cutoff-3] + "..."
+		}
+		return str[:cutoff]
 	}
 	return str
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -32,6 +32,7 @@ func NewGHCPaymentRequestInvoiceGenerator(db *pop.Connection, icnSequencer seque
 const dateFormat = "20060102"
 const isaDateFormat = "060102"
 const timeFormat = "1504"
+const maxCityLength = 27
 
 // Generate method takes a payment request and returns an Invoice858C
 func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.PaymentRequest, sendProductionInvoice bool) (ediinvoice.Invoice858C, error) {
@@ -402,7 +403,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 
 	// destination city/state/postal
 	header.DestinationPostalDetails = edisegment.N4{
-		CityName:            destinationDutyStation.Address.City,
+		CityName:            truncateStr(destinationDutyStation.Address.City, maxCityLength),
 		StateOrProvinceCode: destinationDutyStation.Address.State,
 		PostalCode:          destinationDutyStation.Address.PostalCode,
 	}
@@ -470,7 +471,7 @@ func (g ghcPaymentRequestInvoiceGenerator) createOriginAndDestinationSegments(pa
 
 	// origin city/state/postal
 	header.OriginPostalDetails = edisegment.N4{
-		CityName:            originDutyStation.Address.City,
+		CityName:            truncateStr(originDutyStation.Address.City, maxCityLength),
 		StateOrProvinceCode: originDutyStation.Address.State,
 		PostalCode:          originDutyStation.Address.PostalCode,
 	}
@@ -709,4 +710,11 @@ func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 	}
 
 	return true
+}
+
+func truncateStr(str string, cutoff int) string {
+	if len(str) >= cutoff {
+		return str[:cutoff] + "..."
+	}
+	return str
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -713,8 +713,8 @@ func msOrCsOnly(paymentServiceItems models.PaymentServiceItems) bool {
 }
 
 func truncateStr(str string, cutoff int) string {
-	if len(str) >= cutoff-3 {
-		return str[:cutoff] + "..."
+	if len(str) >= cutoff {
+		return str[:cutoff-3] + "..."
 	}
 	return str
 }

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -81,6 +81,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	}
 
 	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		PaymentRequest: models.PaymentRequest{
@@ -374,7 +375,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		// city state info
 		n4 := result.Header.OriginPostalDetails
 		suite.IsType(edisegment.N4{}, n4)
-		suite.Equal(address.City, n4.CityName)
+		if len(n4.CityName) >= maxCityLength {
+			suite.Equal(address.City[:maxCityLength]+"...", n4.CityName)
+		} else {
+			suite.Equal(address.City, n4.CityName)
+		}
 		suite.Equal(address.State, n4.StateOrProvinceCode)
 		suite.Equal(address.PostalCode, n4.PostalCode)
 		countryCode, err := address.CountryCode()

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -746,7 +746,7 @@ func (suite *GHCInvoiceSuite) TestNoApprovedPaymentServiceItems() {
 func (suite *GHCInvoiceSuite) TestTruncateStrFunc() {
 	longStr := "A super duper long string"
 	cutoff := 10
-	expectedTruncatedStr := "A super du..."
+	expectedTruncatedStr := "A super..."
 	suite.Equal(expectedTruncatedStr, truncateStr(longStr, cutoff))
 
 	shortStr := "Short"

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -742,3 +742,14 @@ func (suite *GHCInvoiceSuite) TestNoApprovedPaymentServiceItems() {
 		suite.Equal(int64(0), l3.PriceCents)
 	})
 }
+
+func (suite *GHCInvoiceSuite) TestTruncateStrFunc() {
+	longStr := "A super duper long string"
+	cutoff := 10
+	expectedTruncatedStr := "A super du..."
+	suite.Equal(expectedTruncatedStr, truncateStr(longStr, cutoff))
+
+	shortStr := "Short"
+	suite.Equal(shortStr, truncateStr(shortStr, cutoff))
+
+}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -745,11 +745,12 @@ func (suite *GHCInvoiceSuite) TestNoApprovedPaymentServiceItems() {
 
 func (suite *GHCInvoiceSuite) TestTruncateStrFunc() {
 	longStr := "A super duper long string"
-	cutoff := 10
 	expectedTruncatedStr := "A super..."
-	suite.Equal(expectedTruncatedStr, truncateStr(longStr, cutoff))
+	suite.Equal(expectedTruncatedStr, truncateStr(longStr, 10))
 
-	shortStr := "Short"
-	suite.Equal(shortStr, truncateStr(shortStr, cutoff))
-
+	suite.Equal("AB", truncateStr("ABCD", 2))
+	suite.Equal("ABC", truncateStr("ABCD", 3))
+	suite.Equal("A...", truncateStr("ABCDEFGHI", 4))
+	suite.Equal("ABC...", truncateStr("ABCDEFGHI", 6))
+	suite.Equal("Too short", truncateStr("Too short", 200))
 }


### PR DESCRIPTION
## Description

In the EDI the city name of the origin and destination duty stations can be a max of 30 characters in length. This PR updates the EDI generator to truncate the duty station city name's to be a max of 27 chars and adds an ellipsis ... 

## Reviewer Notes

I create a function called `truncateStr` in the generator file. Should it live somewhere else?

## Setup

```sh
make db_dev_e2e_populate
make server_run
```

Save json to file payload.json
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Update the either the origin or the destination duty station to have a city name longer than 27 characters 

For this mto, to update the destination duty station you can use this command exactly. To update the origin duty station replace the id with `ddb915e6-ae75-47a5-a153-2ddb2116027e`

```sh
update addresses set city='A super duper duper long city name' where id='5ac95be8-0230-47ea-90b4-b0f6f60de364';
```

Create payment request
```sh
prime-api-client --insecure create-payment-request --filename payload.json | tee output | jq '.id,.paymentRequestNumber'
```

Approve the payment request in the TIO interface http://officelocal:3000 Move Code `RDY4PY`

Generate EDI
```sh
bin/generate-payment-request-edi --payment-request-number [payment request number]
```
Expected Output
Notice the truncation in the first N4 segment for city name

```js
ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *210119*1839*U*00401*827201557*0*T*|
GS*SI*MILMOVE*8004171844*20210119*1839*100001251*X*004010
ST*858*0001
BX*00*J*PP*4116-3394*TRUS**4
N9*CN*4116-3394-1**
N9*CT*TRUSS_TEST**
N9*1W*Leo, Spacemen**
N9*ML*E_1**
N9*3L*ARMY**
G62*10*20210119**
G62*76*20210118**
G62*86*20200316**
N1*BY*JPPSO Testy McTest*92*LKNQ
N1*SE*Prime*2*PRME
N1*ST*Fort Gordon*10*CNNQ
N3*Fort Gordon*
N4*A super duper duper long ci...*GA*30813*USA** //Notice the truncation
PER*CN**TE*706-791-4184
N1*SF*3C99zB51T5*10*LKNQ
N3*987 Other Avenue*P.O. Box 1234
N4*Des Moines*IA*50309*USA**
PER*CN**TE*(510) 555-5555
HL*1**I
N9*PO*4116-3394-ad10cea7**
L5*1*DLH*TBD*D**
L0*1*354.000*DM*1349.000*B******L
L1*1*1349*LB*115948500
FA1*DY
FA2*TA*F8E1
HL*2**I
N9*PO*4116-3394-640c47d4**
L5*2*FSC*TBD*D**
L0*2*354.000*DM*1349.000*B******L
L1*2*1349*LB*34400
FA1*DY
FA2*TA*F8E1
HL*3**I
N9*PO*4116-3394-3b82e699**
L5*3*CS*TBD*D**
L0*3**********
L1*3*0**2235300
FA1*DY
FA2*TA*F8E1
L3*****1182182
SE*43*0001
GE*1*100001251
IEA*1*827201557
```
### Acceptance

* Generate an EDI on staging and ensure that the origin and destination duty station cities are truncated if they are over 27 chars long. I believe you won't be able to update the duty station city name in the database so you'll need to create a payment request for a move that has a long city name duty station in its orders

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6180) for this change

