### PR TITLE
Kim mb 6374 add branch to header

### DIFF
--- a/src/components/CustomerHeader/CustomerHeader.stories.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.stories.jsx
@@ -14,7 +14,7 @@ export default {
 const props = {
   customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
   moveOrder: {
-    departmentIndicator: 'Navy',
+    agency: 'MARINES',
     grade: 'E-6',
     originDutyStation: {
       name: 'JBSA Lackland',

--- a/src/components/CustomerHeader/CustomerHeader.stories.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.stories.jsx
@@ -15,7 +15,7 @@ const props = {
   customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
   moveOrder: {
     agency: 'MARINES',
-    grade: 'E-6',
+    grade: 'E_6',
     originDutyStation: {
       name: 'JBSA Lackland',
     },

--- a/src/components/CustomerHeader/CustomerHeader.test.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.test.jsx
@@ -7,7 +7,7 @@ import CustomerHeader from './index';
 const props = {
   customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
   moveOrder: {
-    departmentIndicator: 'Navy',
+    agency: 'NAVY',
     grade: 'E_6',
     originDutyStation: {
       name: 'JBSA Lackland',

--- a/src/components/CustomerHeader/CustomerHeader.test.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.test.jsx
@@ -28,12 +28,12 @@ describe('CustomerHeader component', () => {
     expect(wrapper.find('CustomerHeader').length).toBe(1);
   });
   it('renders expected values', () => {
-    expect(wrapper.find('[data-test="nameBlock"]').text()).toContain('Kerry, Smith');
-    expect(wrapper.find('[data-test="nameBlock"]').text()).toContain('FKLCTR');
-    expect(wrapper.find('[data-test="deptRank"]').text()).toContain('Navy E-6');
-    expect(wrapper.find('[data-test="dodId"]').text()).toContain('DoD ID 999999999');
-    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('JBSA Lackland');
-    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('JB Lewis-McChord');
-    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('01 Aug 2018');
+    expect(wrapper.find('[data-testid="nameBlock"]').text()).toContain('Kerry, Smith');
+    expect(wrapper.find('[data-testid="nameBlock"]').text()).toContain('FKLCTR');
+    expect(wrapper.find('[data-testid="deptRank"]').text()).toContain('Navy E-6');
+    expect(wrapper.find('[data-testid="dodId"]').text()).toContain('DoD ID 999999999');
+    expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JBSA Lackland');
+    expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('JB Lewis-McChord');
+    expect(wrapper.find('[data-testid="infoBlock"]').text()).toContain('01 Aug 2018');
   });
 });

--- a/src/components/CustomerHeader/CustomerHeader.test.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.test.jsx
@@ -8,7 +8,7 @@ const props = {
   customer: { last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
   moveOrder: {
     departmentIndicator: 'Navy',
-    grade: 'E-6',
+    grade: 'E_6',
     originDutyStation: {
       name: 'JBSA Lackland',
     },
@@ -26,5 +26,14 @@ describe('CustomerHeader component', () => {
   const wrapper = mountCustomerHeader();
   it('renders without crashing', () => {
     expect(wrapper.find('CustomerHeader').length).toBe(1);
+  });
+  it('renders expected values', () => {
+    expect(wrapper.find('[data-test="nameBlock"]').text()).toContain('Kerry, Smith');
+    expect(wrapper.find('[data-test="nameBlock"]').text()).toContain('FKLCTR');
+    expect(wrapper.find('[data-test="deptRank"]').text()).toContain('Navy E-6');
+    expect(wrapper.find('[data-test="dodId"]').text()).toContain('DoD ID 999999999');
+    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('JBSA Lackland');
+    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('JB Lewis-McChord');
+    expect(wrapper.find('[data-test="infoBlock"]').text()).toContain('01 Aug 2018');
   });
 });

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -10,7 +10,7 @@ const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
   return (
     <div className={styles.custHeader}>
       <div>
-        <div className={styles.nameBlock}>
+        <div data-test="nameBlock" className={styles.nameBlock}>
           <h2>
             {customer.last_name}, {customer.first_name}
           </h2>
@@ -18,15 +18,17 @@ const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
         </div>
         <div>
           <p>
-            <span className={styles.details}>
+            <span data-test="deptRank" className={styles.details}>
               {moveOrder.departmentIndicator} {moveOrder.grade}
             </span>
             <span className={styles.verticalBar}>|</span>
-            <span className={styles.details}>DoD ID {customer.dodID}</span>
+            <span data-test="dodId" className={styles.details}>
+              DoD ID {customer.dodID}
+            </span>
           </p>
         </div>
       </div>
-      <div className={styles.infoBlock}>
+      <div data-test="infoBlock" className={styles.infoBlock}>
         <div>
           <p>Authorized origin</p>
           <h4>{moveOrder.originDutyStation.name}</h4>

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -4,7 +4,7 @@ import { string } from 'prop-types';
 import styles from './index.module.scss';
 
 import { MoveOrderShape, CustomerShape } from 'types/moveOrder';
-import { formatCustomerDate } from 'utils/formatters';
+import { formatCustomerDate, formatGrade } from 'utils/formatters';
 
 const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
   return (
@@ -19,7 +19,7 @@ const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
         <div>
           <p>
             <span data-test="deptRank" className={styles.details}>
-              {moveOrder.departmentIndicator} {moveOrder.grade}
+              {moveOrder.departmentIndicator} {formatGrade(moveOrder.grade)}
             </span>
             <span className={styles.verticalBar}>|</span>
             <span data-test="dodId" className={styles.details}>

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -4,7 +4,7 @@ import { string } from 'prop-types';
 import styles from './index.module.scss';
 
 import { MoveOrderShape, CustomerShape } from 'types/moveOrder';
-import { formatCustomerDate, formatGrade } from 'utils/formatters';
+import { formatCustomerDate, formatGrade, AGENCIES } from 'utils/formatters';
 
 const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
   return (
@@ -19,7 +19,7 @@ const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
         <div>
           <p>
             <span data-test="deptRank" className={styles.details}>
-              {moveOrder.departmentIndicator} {formatGrade(moveOrder.grade)}
+              {AGENCIES[`${moveOrder.agency}`]} {formatGrade(moveOrder.grade)}
             </span>
             <span className={styles.verticalBar}>|</span>
             <span data-test="dodId" className={styles.details}>

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -4,13 +4,14 @@ import { string } from 'prop-types';
 import styles from './index.module.scss';
 
 import { MoveOrderShape, CustomerShape } from 'types/moveOrder';
-import { formatCustomerDate, formatGrade, AGENCIES } from 'utils/formatters';
+import { formatCustomerDate } from 'utils/formatters';
+import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders.js';
 
 const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
   return (
     <div className={styles.custHeader}>
       <div>
-        <div data-test="nameBlock" className={styles.nameBlock}>
+        <div data-testid="nameBlock" className={styles.nameBlock}>
           <h2>
             {customer.last_name}, {customer.first_name}
           </h2>
@@ -18,17 +19,17 @@ const CustomerHeader = ({ customer, moveOrder, moveCode }) => {
         </div>
         <div>
           <p>
-            <span data-test="deptRank" className={styles.details}>
-              {AGENCIES[`${moveOrder.agency}`]} {formatGrade(moveOrder.grade)}
+            <span data-testid="deptRank" className={styles.details}>
+              {ORDERS_BRANCH_OPTIONS[`${moveOrder.agency}`]} {ORDERS_RANK_OPTIONS[`${moveOrder.grade}`]}
             </span>
             <span className={styles.verticalBar}>|</span>
-            <span data-test="dodId" className={styles.details}>
+            <span data-testid="dodId" className={styles.details}>
               DoD ID {customer.dodID}
             </span>
           </p>
         </div>
       </div>
-      <div data-test="infoBlock" className={styles.infoBlock}>
+      <div data-testid="infoBlock" className={styles.infoBlock}>
         <div>
           <p>Authorized origin</p>
           <h4>{moveOrder.originDutyStation.name}</h4>

--- a/src/constants/orders.js
+++ b/src/constants/orders.js
@@ -64,7 +64,7 @@ export const ORDERS_RANK_OPTIONS = {
 export const ORDERS_BRANCH_OPTIONS = {
   ARMY: 'Army',
   NAVY: 'Navy',
-  MARINES: 'Marines',
+  MARINES: 'Marine Corps',
   AIR_FORCE: 'Air Force',
   COAST_GUARD: 'Coast Guard',
   OTHER: 'Other',

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -13,6 +13,10 @@ export function formatOrderType(orderType) {
     .join(' ');
 }
 
+// Format the grade (rank) from underscore to dash (ex. E_1 to E-1)
+export function formatGrade(grade) {
+  return grade.split('_').join('-');
+}
 // Format dates for customer app (ex. 25 Dec 2020)
 export function formatCustomerDate(date) {
   return moment(date).format('DD MMM YYYY');

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -13,17 +13,6 @@ export function formatOrderType(orderType) {
     .join(' ');
 }
 
-export const AGENCIES = {
-  ARMY: 'Army',
-  NAVY: 'Navy',
-  MARINES: 'Marine Corps',
-  AIR_FORCE: 'Air Force',
-  COAST_GUARD: 'Coast Guard',
-};
-// Format the grade (rank) from underscore to dash (ex. E_1 to E-1)
-export function formatGrade(grade) {
-  return grade.split('_').join('-');
-}
 // Format dates for customer app (ex. 25 Dec 2020)
 export function formatCustomerDate(date) {
   return moment(date).format('DD MMM YYYY');

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -13,6 +13,13 @@ export function formatOrderType(orderType) {
     .join(' ');
 }
 
+export const AGENCIES = {
+  ARMY: 'Army',
+  NAVY: 'Navy',
+  MARINES: 'Marine Corps',
+  AIR_FORCE: 'Air Force',
+  COAST_GUARD: 'Coast Guard',
+};
 // Format the grade (rank) from underscore to dash (ex. E_1 to E-1)
 export function formatGrade(grade) {
   return grade.split('_').join('-');


### PR DESCRIPTION
## Description

The branch (aka affiliation aka agency) is not showing yet on the CustomerHeader.  This story adds the service member's branch name before the grade (aka rank).  Also reformats the displayed grade with a dash instead of underscore (E-6 instead of E_6).

## Reviewer Notes

The correct value to use is `agency` returned from the `moveOrder` payload which comes from the `ServiceMember` table's `Affiliation` field.  See [Slack discussion](https://ustcdp3.slack.com/archives/CP4979J0G/p1611097878028000)

## Setup

`make storybook` and look at the CustomerHeader

`make server_run`
`make client_run`
Go to the office user and click on a move.  View the header with the branch name.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/105108268-c0a6ee80-5a6e-11eb-8265-2162c7c7dbab.png)

