### PR TITLE
MB-6046: define db_user in environment variable files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1361,28 +1361,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1396,28 +1396,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-exp
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1361,28 +1361,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - deploy_exp_migrations:
           requires:
@@ -1396,28 +1396,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-exp
 
       - push_app_stg:
           requires:

--- a/cmd/ecs-deploy/task_def_test.go
+++ b/cmd/ecs-deploy/task_def_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
 func TestCreateAwsConfig(t *testing.T) {
@@ -12,5 +14,146 @@ func TestCreateAwsConfig(t *testing.T) {
 	awsConfig := createAwsConfig(awsRegionString)
 	if *awsConfig.Region != *aws.String(awsRegionString) {
 		t.Errorf("Expected AWS Config region to equal %v, instead is %v", *awsConfig.Region, *aws.String(awsRegionString))
+	}
+}
+
+func TestRemoveSecretsWithMatchingEnvironmentVariables(t *testing.T) {
+	cases := map[string]struct {
+		inSecrets  []*ecs.Secret
+		inEnvVars  []*ecs.KeyValuePair
+		expSecrets []*ecs.Secret
+	}{
+		"no secrets, no env vars": {
+			inSecrets:  []*ecs.Secret{},
+			inEnvVars:  []*ecs.KeyValuePair{},
+			expSecrets: []*ecs.Secret{},
+		},
+		"one secret, no env vars": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+		},
+		"no secrets, one env var": {
+			inSecrets: []*ecs.Secret{},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+			},
+			expSecrets: []*ecs.Secret{},
+		},
+		"one secret, one env var, not matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 2")},
+			},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+		},
+		"one secret, one env var, matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+			},
+			expSecrets: []*ecs.Secret{},
+		},
+		"two secrets, one env var, none matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting")},
+			},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+		},
+		"two secrets, one env var, one matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+			},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 2")},
+			},
+		},
+		"one secret, two env vars, none matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 2")},
+				{Name: aws.String("my setting 3")},
+			},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+		},
+		"one secret, two env vars, one matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			expSecrets: []*ecs.Secret{},
+		},
+		"two secrets, two env vars, both matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			expSecrets: []*ecs.Secret{},
+		},
+		"two secrets, three env vars, two matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+				{Name: aws.String("my setting 3")},
+			},
+			expSecrets: []*ecs.Secret{},
+		},
+		"three secrets, two env vars, two matching": {
+			inSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+				{Name: aws.String("my setting 3")},
+			},
+			inEnvVars: []*ecs.KeyValuePair{
+				{Name: aws.String("my setting 1")},
+				{Name: aws.String("my setting 2")},
+			},
+			expSecrets: []*ecs.Secret{
+				{Name: aws.String("my setting 3")},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		actual := removeSecretsWithMatchingEnvironmentVariables(tc.inSecrets, tc.inEnvVars)
+		if !reflect.DeepEqual(actual, tc.expSecrets) {
+			t.Errorf("%v: expected %v, but got %v", name, tc.expSecrets, actual)
+		}
 	}
 }

--- a/config/env/exp.app-client-tls.env
+++ b/config/env/exp.app-client-tls.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DPS_COOKIE_DOMAIN=.sddc.army.mil

--- a/config/env/exp.app.env
+++ b/config/env/exp.app.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEBUG_PPROF=false
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/config/env/exp.migrations.env
+++ b/config/env/exp.migrations.env
@@ -3,4 +3,5 @@ DB_NAME=app
 DB_PORT=5432
 DB_RETRY_INTERVAL=5s
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 MIGRATION_MANIFEST=/migrate/migrations_manifest.txt

--- a/config/env/exp.post-file-to-gex.env
+++ b/config/env/exp.post-file-to-gex.env
@@ -2,6 +2,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit?channel=TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM
 TRANSACTION_NAME=test

--- a/config/env/exp.save-ghc-fuel-price-data.env
+++ b/config/env/exp.save-ghc-fuel-price-data.env
@@ -2,3 +2,4 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user

--- a/config/env/exp.send-payment-reminder.env
+++ b/config/env/exp.send-payment-reminder.env
@@ -2,4 +2,5 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 EMAIL_BACKEND=ses

--- a/config/env/exp.send-post-move-survey.env
+++ b/config/env/exp.send-post-move-survey.env
@@ -2,5 +2,6 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 EMAIL_BACKEND=ses
 OFFSET_DAYS=15

--- a/config/env/prd.app-client-tls.env
+++ b/config/env/prd.app-client-tls.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DPS_COOKIE_DOMAIN=.sddc.army.mil

--- a/config/env/prd.app.env
+++ b/config/env/prd.app.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEBUG_PPROF=false
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/config/env/prd.migrations.env
+++ b/config/env/prd.migrations.env
@@ -3,4 +3,5 @@ DB_NAME=app
 DB_PORT=5432
 DB_RETRY_INTERVAL=5s
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 MIGRATION_MANIFEST=/migrate/migrations_manifest.txt

--- a/config/env/prd.post-file-to-gex.env
+++ b/config/env/prd.post-file-to-gex.env
@@ -2,6 +2,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit?channel=TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM
 TRANSACTION_NAME=test

--- a/config/env/prd.save-ghc-fuel-price-data.env
+++ b/config/env/prd.save-ghc-fuel-price-data.env
@@ -2,3 +2,4 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user

--- a/config/env/prd.send-payment-reminder.env
+++ b/config/env/prd.send-payment-reminder.env
@@ -2,4 +2,5 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 EMAIL_BACKEND=ses

--- a/config/env/prd.send-post-move-survey.env
+++ b/config/env/prd.send-post-move-survey.env
@@ -2,5 +2,6 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 EMAIL_BACKEND=ses
 OFFSET_DAYS=15

--- a/config/env/stg.app-client-tls.env
+++ b/config/env/stg.app-client-tls.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DPS_COOKIE_DOMAIN=.sddc.army.mil

--- a/config/env/stg.app.env
+++ b/config/env/stg.app.env
@@ -4,6 +4,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DEBUG_PPROF=false
 DEVLOCAL_AUTH=false
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/config/env/stg.migrations.env
+++ b/config/env/stg.migrations.env
@@ -3,4 +3,5 @@ DB_NAME=app
 DB_PORT=5432
 DB_RETRY_INTERVAL=5s
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 MIGRATION_MANIFEST=/migrate/migrations_manifest.txt

--- a/config/env/stg.post-file-to-gex.env
+++ b/config/env/stg.post-file-to-gex.env
@@ -2,6 +2,7 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit?channel=TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM
 TRANSACTION_NAME=test

--- a/config/env/stg.save-ghc-fuel-price-data.env
+++ b/config/env/stg.save-ghc-fuel-price-data.env
@@ -2,3 +2,4 @@ DB_IAM=true
 DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
+DB_USER=ecs_user

--- a/config/env/stg.send-payment-reminder.env
+++ b/config/env/stg.send-payment-reminder.env
@@ -3,3 +3,4 @@ DB_NAME=app
 DB_PORT=5432
 DB_SSL_MODE=verify-full
 EMAIL_BACKEND=ses
+DB_USER=ecs_user

--- a/config/env/stg.send-post-move-survey.env
+++ b/config/env/stg.send-post-move-survey.env
@@ -4,3 +4,4 @@ DB_PORT=5432
 DB_SSL_MODE=verify-full
 EMAIL_BACKEND=ses
 OFFSET_DAYS=15
+DB_USER=ecs_user


### PR DESCRIPTION
## Description

This prepares for the roll-out of the low privileged PostgreSQL role to experimental. Up until now, we have used the same PostgreSQL role for all containers. However, in an upcoming PR, we intend to switch all containers except for the migrations container to use a lower privileged user. Currently, we define which role to use globally, via the `db_user` secret (set via chamber). This poses a problem: if the PostgreSQL role is defined globally, it impossible to set it on a per-container basis. I tried to set the `DB_USER` as an environment variable, but when I tried this, [AWS threw the following error](https://app.circleci.com/pipelines/github/transcom/mymove/25789/workflows/10136d83-d895-4a55-a9c4-23041f5765d8/jobs/398306):

```text
error registering new task definition: ClientException: The secret name must be unique and not shared with any new or existing environment variables set on the container, such as 'DB_USER'.
```

Therefore, this PR:

1. allows both an environment variable and a secret to share the same name. If this occurs, the value of the environment variable will be used and the value of the secret will be discarded. This will allow us to deploy the new approach of using environment variables (rather than secrets) to define the `DB_USER` value to lower environments, while still retaining the old behavior to exist. This should prevent failures during the transition. Once we have fully rolled out the approach of using the environment variables to all environments, we can delete the `db_user` secret from all environments, since it will then be obsolete.
1. explicitly defines the database role to use for each container that we deploy across all tiers. Another PR will migrate most containers from `ecs_user` to `crud`.
## Reviewer Notes

I am using `fmt.Fprintln(os.Stderr, ...)`, which is in direct contradiction to the guidelines laid out here: https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging

However, the guidelines appeared to be relevant to situations where engineers bubble up errors and need to show stack traces in server-type environments. The purpose of this `fmt.Println` statement is purely informational. I originally used a regular `fmt.Println` without sending to standard error, but it interfered with the output of the program, which caused downstream errors. No errors occurred when I sent it to standard error.
 
## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```text
$ go test -run TestRemoveSecretsWithMatchingEnvironmentVariables ./cmd/ecs-deploy
ok      github.com/transcom/mymove/cmd/ecs-deploy       0.294s
$
```

## Example behavior during deployments

The following line is an example of what is shown when a definition for a value exists as both a secret (usually set via chamber) and set as an environment variable:

```text
Found a secret with the same name as an environment variable. Discarding secret in favor of the environment variable: DB_USER
```

[Example with the migrations task](https://app.circleci.com/pipelines/github/transcom/mymove/25787/workflows/b6f8d63e-6cec-4cbd-978f-4c866c5fb618/jobs/398265):
```text
Checking for running builds...
Acquired lock
* Registering new task definition
Found a secret with the same name as an environment variable. Discarding secret in favor of the environment variable: DB_USER
Obtaining the current network configuration
Running migration with task definition arn:aws-us-gov:ecs:*************:************:task-definition/app-migrations-exp:120 ...
```

[Example with the app task](https://app.circleci.com/pipelines/github/transcom/mymove/25787/workflows/b6f8d63e-6cec-4cbd-978f-4c866c5fb618/jobs/398276)
```text
Checking for running builds...
Acquired lock
scripts/ecs-deploy-service-container app ************.dkr.ecr.*************.amazonaws.com/app@sha256:e0eb8d55fb29ebe070401cc77b735ec0fd42096aa306177056ce6bdbe01f9134 exp
* Registering new task definition
Found a secret with the same name as an environment variable. Discarding secret in favor of the environment variable: DB_USER
* Updating service app with ARN arn:aws-us-gov:ecs:*************:************:task-definition/app-exp:73
```

## Code Review Verification Steps

* [x] If the change is risky, [it has been tested in experimental](https://app.circleci.com/pipelines/github/transcom/mymove/25792/workflows/37242d5f-616d-47ec-95ac-dcde9d3d52bf) before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6046) for this change