### PR TITLE
Yan MB-6376 Make Milmove Header Storybook Dynamic

### DIFF
--- a/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
+++ b/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
@@ -20,15 +20,8 @@ const props = {
 export const Milmove = () => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <MilMoveHeader {...props}>
-    {' '}
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
+    <a href="#">Navigation Link</a>
+    <a href="#">Navigation Link</a>
+    <a href="#">Navigation Link</a>
   </MilMoveHeader>
 );

--- a/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
+++ b/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
@@ -1,5 +1,8 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { MemoryRouter } from 'react-router';
 
 import MilMoveHeader from './index';
 
@@ -18,17 +21,18 @@ const props = {
 };
 
 export const Milmove = () => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <MilMoveHeader {...props}>
-    {' '}
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
-    <span>
-      <a href="#">Navigation Link</a>
-    </span>
-  </MilMoveHeader>
+  <MemoryRouter>
+    <MilMoveHeader {...props}>
+      {' '}
+      <span>
+        <a href="#">Navigation Link</a>
+      </span>
+      <span>
+        <a href="#">Navigation Link</a>
+      </span>
+      <span>
+        <a href="#">Navigation Link</a>
+      </span>
+    </MilMoveHeader>
+  </MemoryRouter>
 );

--- a/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
+++ b/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 import MilMoveHeader from './index';
 
@@ -13,7 +14,7 @@ export default {
 
 const props = {
   customer: { last_name: 'Baker', first_name: 'Riley', dodID: '999999999' },
-  handleLogout: () => {},
+  handleLogout: action('clicked'),
 };
 
 export const Milmove = () => (

--- a/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
+++ b/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
@@ -11,4 +11,23 @@ export default {
   },
 };
 
-export const Milmove = () => <MilMoveHeader />;
+const props = {
+  customer: { last_name: 'Baker', first_name: 'Riley', dodID: '999999999' },
+  handleLogout: () => {},
+};
+
+export const Milmove = () => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <MilMoveHeader {...props}>
+    {' '}
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+  </MilMoveHeader>
+);

--- a/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
+++ b/src/components/MilMoveHeader/MilMoveHeader.stories.jsx
@@ -1,8 +1,5 @@
-/* eslint-disable react/jsx-props-no-spreading */
-
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { MemoryRouter } from 'react-router';
 
 import MilMoveHeader from './index';
 
@@ -21,18 +18,17 @@ const props = {
 };
 
 export const Milmove = () => (
-  <MemoryRouter>
-    <MilMoveHeader {...props}>
-      {' '}
-      <span>
-        <a href="#">Navigation Link</a>
-      </span>
-      <span>
-        <a href="#">Navigation Link</a>
-      </span>
-      <span>
-        <a href="#">Navigation Link</a>
-      </span>
-    </MilMoveHeader>
-  </MemoryRouter>
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <MilMoveHeader {...props}>
+    {' '}
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+    <span>
+      <a href="#">Navigation Link</a>
+    </span>
+  </MilMoveHeader>
 );

--- a/src/components/MilMoveHeader/index.jsx
+++ b/src/components/MilMoveHeader/index.jsx
@@ -1,32 +1,35 @@
 import React from 'react';
-import classNames from 'classnames/bind';
+import { node, func } from 'prop-types';
+import { Button } from '@trussworks/react-uswds';
 
 import { ReactComponent as MmLogo } from '../../shared/images/milmove-logo.svg';
 
 import styles from './index.module.scss';
 
-const cx = classNames.bind(styles);
+import { CustomerShape } from 'types/moveOrder';
 
-const MilMoveHeader = () => (
-  <div className={cx('mm-header')}>
+const MilMoveHeader = ({ children, customer, handleLogout }) => (
+  <div className={styles.mmHeader}>
     <MmLogo />
-    <div className={cx('links')}>
+    <div className={styles.links}>
+      {children}
+      <span className={styles.lineAdd}>&nbsp;</span>
       <span>
-        <a href="#">Navigation Link</a>
+        {customer.last_name}, {customer.first_name}
       </span>
       <span>
-        <a href="#">Navigation Link</a>
-      </span>
-      <span>
-        <a href="#">Navigation Link</a>
-      </span>
-      <span className={cx('line-add')}>&nbsp;</span>
-      <span>Baker, Riley</span>
-      <span>
-        <a href="#">Sign out</a>
+        <Button className={styles.signOut} disabled={false} onClick={handleLogout}>
+          <span>Sign out</span>
+        </Button>
       </span>
     </div>
   </div>
 );
+
+MilMoveHeader.propTypes = {
+  children: node.isRequired,
+  customer: CustomerShape.isRequired,
+  handleLogout: func.isRequired,
+};
 
 export default MilMoveHeader;

--- a/src/components/MilMoveHeader/index.jsx
+++ b/src/components/MilMoveHeader/index.jsx
@@ -17,15 +17,13 @@ const MilMoveHeader = ({ children, customer, handleLogout }) => (
     </Title>
     <div className={styles.links}>
       {children}
-      <span className={styles.lineAdd}>&nbsp;</span>
+      <div className={styles.verticalLine} />
       <span>
         {customer.last_name}, {customer.first_name}
       </span>
-      <span>
-        <Button unstyled className={styles.signOut} onClick={handleLogout} type="button">
-          Sign out
-        </Button>
-      </span>
+      <Button unstyled className={styles.signOut} onClick={handleLogout} type="button">
+        Sign out
+      </Button>
     </div>
   </div>
 );

--- a/src/components/MilMoveHeader/index.jsx
+++ b/src/components/MilMoveHeader/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { node, func } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
+import { NavLink } from 'react-router-dom';
 
-import { ReactComponent as MmLogo } from '../../shared/images/milmove-logo.svg';
+import MmLogo from '../../shared/images/milmove-logo.svg';
 
 import styles from './index.module.scss';
 
@@ -10,7 +11,13 @@ import { CustomerShape } from 'types/moveOrder';
 
 const MilMoveHeader = ({ children, customer, handleLogout }) => (
   <div className={styles.mmHeader}>
-    <MmLogo />
+    <div className="usa-logo" id="basic-logo">
+      <em className="usa-logo__text">
+        <NavLink to="/" title="office.move.mil" aria-label="office.move.mil">
+          <img src={MmLogo} alt="MilMove Logo" />
+        </NavLink>
+      </em>
+    </div>
     <div className={styles.links}>
       {children}
       <span className={styles.lineAdd}>&nbsp;</span>

--- a/src/components/MilMoveHeader/index.jsx
+++ b/src/components/MilMoveHeader/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { node, func } from 'prop-types';
-import { Button } from '@trussworks/react-uswds';
-import { NavLink } from 'react-router-dom';
+import { Button, Title } from '@trussworks/react-uswds';
 
 import MmLogo from '../../shared/images/milmove-logo.svg';
 
@@ -11,13 +10,11 @@ import { CustomerShape } from 'types/moveOrder';
 
 const MilMoveHeader = ({ children, customer, handleLogout }) => (
   <div className={styles.mmHeader}>
-    <div className="usa-logo" id="basic-logo">
-      <em className="usa-logo__text">
-        <NavLink to="/" title="office.move.mil" aria-label="office.move.mil">
-          <img src={MmLogo} alt="MilMove Logo" />
-        </NavLink>
-      </em>
-    </div>
+    <Title>
+      <a href="/" title="office.move.mil" aria-label="office.move.mil">
+        <img src={MmLogo} alt="MilMove Logo" />
+      </a>
+    </Title>
     <div className={styles.links}>
       {children}
       <span className={styles.lineAdd}>&nbsp;</span>
@@ -25,8 +22,8 @@ const MilMoveHeader = ({ children, customer, handleLogout }) => (
         {customer.last_name}, {customer.first_name}
       </span>
       <span>
-        <Button className={styles.signOut} disabled={false} onClick={handleLogout}>
-          <span>Sign out</span>
+        <Button unstyled className={styles.signOut} onClick={handleLogout} type="button">
+          Sign out
         </Button>
       </span>
     </div>

--- a/src/components/MilMoveHeader/index.module.scss
+++ b/src/components/MilMoveHeader/index.module.scss
@@ -57,4 +57,9 @@
     padding: 0;
     margin: 0;
   }
+
+  :global(.usa-logo) {
+    margin: 0;
+    padding-top: 5px;
+  }
 }

--- a/src/components/MilMoveHeader/index.module.scss
+++ b/src/components/MilMoveHeader/index.module.scss
@@ -51,11 +51,9 @@
   }
 
   :global(.usa-button) {
-    background-color: transparent;
     display: inline-block;
-    height: 0;
+    font-weight: bold;
     padding: 0;
-    margin: 0;
   }
 
   :global(.usa-logo) {

--- a/src/components/MilMoveHeader/index.module.scss
+++ b/src/components/MilMoveHeader/index.module.scss
@@ -1,59 +1,59 @@
-// Mm Header styles
-
-@import '../../shared/styles/basics';
-@import '../../shared/styles/mixins';
-@import '../../shared/styles/colors';
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
 
 .mmHeader {
   background: $mm-blue;
-  width: 100vw;
-  padding: 10px;
+  width: 100%;
   @include u-padding-x(4);
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 50px;
+
   .links {
-    display: inline-block;
     color: $base-lightest;
     @include u-font-size('body', 'xs');
-    position: relative;
-  }
-  span {
-    @include u-padding-x(3);
-    &:first-child {
-      @include u-padding-left(0);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+
+    > * {
+      @include u-margin-right(3);
     }
-    &:last-child {
-      @include u-padding-right(0);
+
+    > * + * {
+      @include u-margin-left(3);
+    }
+
+    > :last-child {
+      @include u-margin-right(0);
     }
   }
-  a {
+
+  a,
+  .signOut {
     @include u-text('bold');
     color: $link-light;
+
     &:hover,
     &:focus {
       color: #b7caf0;
       @include u-text('no-underline');
     }
   }
-  .lineAdd {
-    padding: 0px;
+
+  .verticalLine {
+    margin: 0px;
     background: $base-dark;
     width: 1px;
-    height: 50px;
-    display: inline-block;
-    position: absolute;
-    top: -13px;
-  }
-  .signOut {
-    color: $link-light;
+    align-self: stretch;
   }
 
-  :global(.usa-button) {
-    display: inline-block;
-    font-weight: bold;
+  .signOut {
     padding: 0;
+    line-height: inherit;
   }
 
   :global(.usa-logo) {

--- a/src/components/MilMoveHeader/index.module.scss
+++ b/src/components/MilMoveHeader/index.module.scss
@@ -4,7 +4,7 @@
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/colors';
 
-.mm-header {
+.mmHeader {
   background: $mm-blue;
   width: 100vw;
   padding: 10px;
@@ -37,7 +37,7 @@
       @include u-text('no-underline');
     }
   }
-  .line-add {
+  .lineAdd {
     padding: 0px;
     background: $base-dark;
     width: 1px;
@@ -45,5 +45,16 @@
     display: inline-block;
     position: absolute;
     top: -13px;
+  }
+  .signOut {
+    color: $link-light;
+  }
+
+  :global(.usa-button) {
+    background-color: transparent;
+    display: inline-block;
+    height: 0;
+    padding: 0;
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Description

Edit the MilMove Header in Storybook to be Dynamic. 
Changes made:
- edit MilMoveHeader take in the links as children
- change MilMoveHeader to take in the customer as a prop to display the first and last name
- modify the sign out link to be a button instead and take in an on click handler as a prop
- change the MilMove logo to navigate back to the office
- update the storybook to use the new features and incorporate memory router for the NavLink used by the MilMove logo

## Reviewer Notes

Please verify that it is ok Memory Router the way I am using it.
Check my css please! 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```
Under Components, Headers, MilMove Header, Milmove

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6376) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/6477059/105260842-5d3ac080-5b43-11eb-8fe2-d3aac3af0d13.png)


If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
