### PR TITLE
no ticket: re-add acceptance tests that can be run conditionally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,72 @@ jobs:
           destination: test-results
       - announce_failure
 
+  # `acceptance_tests` runs acceptance tests for the webserver against the local, experimental, and staging environments.
+  acceptance_tests:
+    executor: mymove_medium
+    steps:
+      - aws_vars_legacy
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
+      - run:
+          name: Run Local acceptance tests
+          command: |
+            echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
+            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
+            echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
+            echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
+            echo 'export HERE_MAPS_APP_ID=$E2E_HERE_MAPS_APP_ID' >> $BASH_ENV
+            echo 'export HERE_MAPS_APP_CODE=$E2E_HERE_MAPS_APP_CODE' >> $BASH_ENV
+            source $BASH_ENV
+            make acceptance_test
+          environment:
+            CHAMBER_RETRIES: 20
+            DB_RETRY_INTERVAL: 5s
+            DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+            ENV: test
+            ENVIRONMENT: test
+            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/app/migrations_manifest.txt'
+            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
+            NO_TLS_ENABLED: true
+            PWD: /home/circleci/transcom/mymove
+      - aws_vars_exp
+      - run:
+          name: Prepare certificates
+          command: |
+            sudo cp /home/circleci/transcom/mymove/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+      - run:
+          name: Run Experimental acceptance tests
+          command: make acceptance_test
+          environment:
+            CHAMBER_RETRIES: 20
+            DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+            ENV: exp
+            ENVIRONMENT: exp
+            NO_TLS_ENABLED: true
+            PWD: /home/circleci/transcom/mymove
+            TEST_ACC_ENV: exp
+      - aws_vars_stg
+      - run:
+          name: Run Staging acceptance tests
+          command: make acceptance_test
+          environment:
+            CHAMBER_RETRIES: 20
+            DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+            ENV: stg
+            ENVIRONMENT: stg
+            NO_TLS_ENABLED: true
+            PWD: /home/circleci/transcom/mymove
+            TEST_ACC_ENV: stg
+      - run: echo "Prod acceptance tests are prohibited in CircleCI"
+      - announce_failure
+
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
     parallelism: 5
@@ -1271,6 +1337,13 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+
+      - acceptance_tests:
+          requires:
+            - pre_deps_golang
+          filters:
+            branches:
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1343,7 +1343,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: cj-re-add-ac-testing
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1343,7 +1343,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-re-add-ac-testing
 
       - integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1338,7 +1338,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: cj-re-add-ac-testing
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,7 +630,6 @@ jobs:
   acceptance_tests:
     executor: mymove_medium
     steps:
-      - aws_vars_legacy
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,11 +640,7 @@ jobs:
             echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
             echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
             echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
-            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
-            echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
-            echo 'export HERE_MAPS_APP_ID=$E2E_HERE_MAPS_APP_ID' >> $BASH_ENV
-            echo 'export HERE_MAPS_APP_CODE=$E2E_HERE_MAPS_APP_CODE' >> $BASH_ENV
             source $BASH_ENV
             make acceptance_test
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1338,7 +1338,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-re-add-ac-testing
 
       - integration_tests:
           requires:

--- a/cmd/milmove/main_test.go
+++ b/cmd/milmove/main_test.go
@@ -123,13 +123,20 @@ func (suite *webServerSuite) loadContext(variablesFile string) map[string]string
 func (suite *webServerSuite) patchContext(ctx map[string]string) map[string]string {
 	for k, v := range ctx {
 		if strings.HasPrefix(v, "/bin/") {
-			ctx[k] = filepath.Join(os.Getenv("TEST_ACC_CWD"), v[1:])
-		}
-		// Overwrite the migration path to something on the local system
-		if k == "MIGRATION_PATH" {
-			ctx[k] = "file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure"
+			newValue := filepath.Join(os.Getenv("TEST_ACC_CWD"), v[1:])
+			ctx[k] = newValue
 		}
 	}
+
+	// Always set the root cert to something on the local system.
+	newValue := filepath.Join(os.Getenv("TEST_ACC_CWD"), "bin/rds-ca-us-gov-west-1-2017-root.pem")
+	ctx["DB_SSL_ROOT_CERT"] = newValue
+
+	// Always set the migration path to something on the local system.
+	appSecure := filepath.Join(os.Getenv("TEST_ACC_CWD"), "migrations/app/secure")
+	appSchema := filepath.Join(os.Getenv("TEST_ACC_CWD"), "migrations/app/schema")
+	ctx["MIGRATION_PATH"] = fmt.Sprintf("file://%v;file://%v", appSchema, appSecure)
+
 	return ctx
 }
 

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -23,6 +23,10 @@ const (
 	EnvironmentDevelopment string = "development"
 	// EnvironmentExp is the GovCloud exp Environment name
 	EnvironmentExp string = "exp"
+	// EnvironmentStg is the GovCloud stg Environment name
+	EnvironmentStg string = "stg"
+	// EnvironmentPrd is the GovCloud prd Environment name
+	EnvironmentPrd string = "prd"
 )
 
 var environments = []string{
@@ -32,6 +36,8 @@ var environments = []string{
 	EnvironmentTest,
 	EnvironmentDevelopment,
 	EnvironmentExp,
+	EnvironmentStg,
+	EnvironmentPrd,
 }
 
 type errInvalidEnvironment struct {


### PR DESCRIPTION
## Description

As part of https://dp3.atlassian.net/browse/MB-4391 (https://github.com/transcom/mymove/pull/5443), I removed acceptance tests from CircleCI. However, acceptance tests are still useful, so I'm adding them back, but only making them run conditionally.

I worked on this while trying to get the `crud` role added. It seemed worth taking through to completion. There were a few changes I had to make in the code that appear to be very specifically designed to be run during these tests. I made a few modifications to that code. If there is a better way to make this work reliably, please feel free to let me know and I'll iterate on this.

## Setup

Replace placeholder_branch_name on the acceptance_tests filter to run acceptance tests in CircleCI.

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
* [x] User facing changes have been reviewed by design.