### PR TITLE
Added test for send to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1315,10 +1315,6 @@ workflows:
             branches:
               ignore: placeholder_branch_name
 
-      - webhook_client_test:
-          requires:
-            - build_tools
-
       - build_app:
           requires:
             - anti_virus
@@ -1351,11 +1347,6 @@ workflows:
           requires:
             - build_tasks
 
-      - build_webhook_client:
-          requires:
-            - anti_virus
-            - webhook_client_test
-
       - push_app_exp:
           requires:
             - build_app
@@ -1373,13 +1364,6 @@ workflows:
       - push_tasks_exp:
           requires:
             - build_tasks
-          filters:
-            branches:
-              only: placeholder_branch_name
-
-      - push_webhook_client_exp:
-          requires:
-            - build_webhook_client
           filters:
             branches:
               only: placeholder_branch_name

--- a/cmd/webhook-client/main.go
+++ b/cmd/webhook-client/main.go
@@ -99,17 +99,18 @@ func main() {
 	initPostWebhookNotifyFlags(postWebhookNotifyCommand.Flags())
 	root.AddCommand(postWebhookNotifyCommand)
 
-	dbWebhookNotifyCommand := &cobra.Command{
-		Use:   "db-webhook-notify",
-		Short: "Database Webhook Notify",
+	webhookNotifyCommand := &cobra.Command{
+		Use:   "webhook-notify",
+		Short: "Webhook Notify",
 		Long: `
-	Database Webhook Notify checks the webhook_notification
-	table and sends the first notification it finds there.`,
-		RunE:         dbWebhookNotify,
+	Webhook Notify launches the engine for webhook notifications.
+	This repeatedly checks the webhook_notification and webhook_subscription tables and
+	sends the notifications every minute.`,
+		RunE:         webhookNotify,
 		SilenceUsage: true,
 	}
-	initDbWebhookNotifyFlags(dbWebhookNotifyCommand.Flags())
-	root.AddCommand(dbWebhookNotifyCommand)
+	initWebhookNotifyFlags(webhookNotifyCommand.Flags())
+	root.AddCommand(webhookNotifyCommand)
 
 	dbConnectionCommand := &cobra.Command{
 		Use:   "db-connection-test",

--- a/cmd/webhook-client/utils/connection.go
+++ b/cmd/webhook-client/utils/connection.go
@@ -16,6 +16,13 @@ import (
 	"github.com/transcom/mymove/pkg/cli"
 )
 
+const (
+	// RecipientMTLSCert is the client cert to connect to the subscriber
+	RecipientMTLSCert string = "gex-mtls-client-cert"
+	// RecipientMTLSKey is the client key to connect to the subscriber
+	RecipientMTLSKey string = "gex-mtls-client-key"
+)
+
 // WebhookClientPoster is an interface that WebhookRuntime implements
 type WebhookClientPoster interface {
 	SetupClient(cert *tls.Certificate) (*WebhookRuntime, error)
@@ -156,35 +163,47 @@ func CreateClient(v *viper.Viper) (*WebhookRuntime, *pksigner.Store, error) {
 
 	// Get the tls certificate
 	// If using a CAC, the client cert comes from the card
-	// Otherwise, use the certpath and keypath values
+	// Otherwise, it comes from a file or env variable
 	if v.GetBool(cli.CACFlag) {
 		cert, store, err = GetCacCertificate(v)
-
 		if err != nil {
 			return nil, nil, err
 		}
 
-	} else if !v.GetBool(cli.CACFlag) {
-		var loadCert tls.Certificate
-
-		certPath := v.GetString(utils.CertPathFlag)
-		keyPath := v.GetString(utils.KeyPathFlag)
-		loadCert, err = tls.LoadX509KeyPair(certPath, keyPath)
-
+	} else {
+		cert, err = loadCertificate(v)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		cert = &loadCert
 	}
 
 	runtimeClient := NewWebhookRuntime(contentType, insecure, verbose)
-
 	rc, err = runtimeClient.SetupClient(cert)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return rc, store, nil
+}
+
+func loadCertificate(v *viper.Viper) (*tls.Certificate, error) {
+	var loadCert tls.Certificate
+	var err error
+	// Cert can be provided as a filepath or directly as an string
+	// Note that the path can also be passed in as a flag or environment
+	// variable.
+	if v.GetString(utils.CertPathFlag) != "" {
+		certPath := v.GetString(utils.CertPathFlag)
+		keyPath := v.GetString(utils.KeyPathFlag)
+		loadCert, err = tls.LoadX509KeyPair(certPath, keyPath)
+	} else {
+		certString := v.GetString(RecipientMTLSCert)
+		key := v.GetString(RecipientMTLSKey)
+		loadCert, err = tls.X509KeyPair([]byte(certString), []byte(key))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return &loadCert, nil
 }

--- a/cmd/webhook-client/utils/connection.go
+++ b/cmd/webhook-client/utils/connection.go
@@ -93,11 +93,10 @@ func (wr *WebhookRuntime) Post(data []byte, url string) (*http.Response, []byte,
 		url,
 		bufferData,
 	)
-	req.Header.Set("Content-type", wr.ContentType)
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Content-type", wr.ContentType)
 
 	// Print out the request when debug mode is on
 	if wr.Debug {

--- a/cmd/webhook-client/webhook/webhook.go
+++ b/cmd/webhook-client/webhook/webhook.go
@@ -218,8 +218,9 @@ func (eng *Engine) sendOneNotification(notif *models.WebhookNotification, sub *m
 		}
 		// If there was an error response from server, log error and continue
 		if resp.StatusCode != 200 {
-			errmsg := fmt.Sprintf("Failed to send. Response Status: %s. Body: %s", resp.Status, string(body))
-			logger.Debug("Received error on sending webhook", zap.String("Error", errmsg),
+			logger.Debug("Received error on sending notification",
+				zap.String("Response Status", resp.Status),
+				zap.String("Response Body", string(body)),
 				zap.String("notificationID", notif.ID.String()),
 				zap.Int("Retry #", try))
 		}

--- a/cmd/webhook-client/webhook/webhook_test.go
+++ b/cmd/webhook-client/webhook/webhook_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -40,6 +42,77 @@ func TestWebhookClientTestingSuite(t *testing.T) {
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()
+}
+
+func (suite *WebhookClientTestingSuite) Test_SendStgNotification() {
+	defer teardownEngineRun(suite)
+
+	// Create a client
+	v := viper.New()
+	// Parse flags from environemnt
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+	client, _, err := utils.CreateClient(v)
+	suite.Nil(err)
+
+	// Create the engine
+	engine := Engine{
+		DB:                  suite.DB(),
+		Logger:              suite.logger,
+		Client:              client,
+		MaxImmediateRetries: 3,
+	}
+	// Create a notification
+	notification := testdatagen.MakeWebhookNotification(suite.DB(), testdatagen.Assertions{
+		WebhookNotification: models.WebhookNotification{
+			Status:  models.WebhookNotificationSent,
+			Payload: swag.String("{\"message\":\"This is an updated notification #1\"}"),
+		},
+	})
+	// Create a subscription
+	subscription := testdatagen.MakeWebhookSubscription(suite.DB(), testdatagen.Assertions{
+		WebhookSubscription: models.WebhookSubscription{
+			CallbackURL: "https://api.stg.move.mil/support/v1/webhook-notify",
+		},
+	})
+
+	// TESTCASE SCENARIO
+	// What is being tested: sendOneNotification function
+	// Mocked: None
+	// Behaviour: The function gets passed in 2 models, one for notification
+	// and one for subscription.
+	// It should create a payload from the notification and send it to the url
+	// listed in the subscription. On success or failure, it should update the
+	// notification.Status with SENT or FAILED accordingly
+
+	suite.T().Run("Successful post, updated notification", func(t *testing.T) {
+
+		// Under test: sendOneNotification function
+		// Mocked:     Client
+		// Set up:     We provide a PENDING webhook notification, and point the
+		//             subscription at Staging
+		// Expected outcome:
+		//             Notification would be updated as SENT
+
+		// Set beginning status as pending
+		suite.DB().Find(&notification, notification.ID)
+		notification.Status = models.WebhookNotificationPending
+		suite.DB().ValidateAndUpdate(&notification)
+
+		// Call the engine function.
+		err := engine.sendOneNotification(&notification, &subscription)
+
+		// Check that there was no error
+		suite.Nil(err)
+		// Check that notification Status was set to Sent in the model
+		notif := models.WebhookNotification{}
+		suite.DB().Find(&notif, notification.ID)
+		suite.Equal(models.WebhookNotificationSent, notif.Status)
+		// Check that first attempted at date was set
+		suite.False(notif.FirstAttemptedAt.IsZero())
+
+	})
+
 }
 
 func (suite *WebhookClientTestingSuite) Test_SendOneNotification() {
@@ -81,6 +154,7 @@ func (suite *WebhookClientTestingSuite) Test_SendOneNotification() {
 
 	// TESTCASE SCENARIO
 	// What is being tested: sendOneNotification function
+	// Mocked: Client
 	// Behaviour: The function gets passed in 2 models, one for notification
 	// and one for subscription.
 	// It should create a payload from the notification and send it to the url

--- a/cmd/webhook-client/webhook_notify.go
+++ b/cmd/webhook-client/webhook_notify.go
@@ -23,13 +23,13 @@ const (
 )
 
 // Init flags specific to this command
-func initDbWebhookNotifyFlags(flag *pflag.FlagSet) {
+func initWebhookNotifyFlags(flag *pflag.FlagSet) {
 	flag.Int(PeriodFlag, 5, "Period in secs to check for notifications")
 	flag.Int(MaxRetriesFlag, 3, "Number of times to immediately retry")
 	flag.SortFlags = false
 }
 
-func dbWebhookNotify(cmd *cobra.Command, args []string) error {
+func webhookNotify(cmd *cobra.Command, args []string) error {
 	v := viper.New()
 
 	// Parse flags from command line


### PR DESCRIPTION
## Description

There is a new test called `Test_SendStgNotification` that sends a real notification to the live staging environment.
You can run the test by running all webhook tests
`go test ./cmd/webhook-client/webhook -v`

But do check for the successful passing of `Test_SendStgNotification`

Since we now have a "real" test in there, I had to remove the webhook client tests from circleci. It's a bit of a catch-22, we are writing this test to help infra get a working version in staging. Currently that is not working. That also means this test won't work until we complete that effort, and therefore we're not ready to run all our webhook tests in staging. 

## Reviewer Notes

I also renamed db-webhook-notify to just webhook-notify as db was unnecessary. 

## Reference
* [MB-6193 Push Deploy: Write e2e test for webhook client - Jira](https://dp3.atlassian.net/browse/MB-6193)

