### PR TITLE
Adjust sometimes-failing test to account for stubbed PPM discount rates

### DIFF
--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -806,6 +806,7 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 	moveDate := date(testdatagen.TestYear, time.May, 26)
 
 	tspPerformance1 := TransportationServiceProviderPerformance{
+		ID:                              uuid.FromStringOrNil("0b5fd285-84c2-450c-a614-585f61cdeff8"),
 		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
 		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
 		RateCycleStart:                  testdatagen.PeakRateCycleStart,
@@ -817,9 +818,10 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 		LinehaulRate:                    unit.NewDiscountRateFromPercent(50.5),
 		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
 	}
-	suite.MustSave(&tspPerformance1)
+	suite.MustCreate(suite.DB(), &tspPerformance1)
 
 	tspPerformance2 := TransportationServiceProviderPerformance{
+		ID:                              uuid.FromStringOrNil("5f5b3950-5962-4d54-a963-e508ef3f3252"),
 		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
 		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
 		RateCycleStart:                  testdatagen.PeakRateCycleStart,
@@ -831,13 +833,10 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 		LinehaulRate:                    unit.NewDiscountRateFromPercent(55.5),
 		SITRate:                         unit.NewDiscountRateFromPercent(52.0),
 	}
-	suite.MustSave(&tspPerformance2)
+	suite.MustCreate(suite.DB(), &tspPerformance2)
 
 	// Given matching BVS scores, the TSPP with the alphabetically first ID should be returned.  Make that our target.
 	targetTspPerformance := tspPerformance1
-	if tspPerformance1.ID.String() > tspPerformance2.ID.String() {
-		targetTspPerformance = tspPerformance2
-	}
 
 	discountRate, sitRate, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", moveDate)
 	if err != nil {


### PR DESCRIPTION
## Description

In #5699, the discount rates were hard-coded to account for the fact we aren't loading BVS rates anymore.  The test adjusted in this PR would dynamically pick one of two TSPP records (whichever's ID came first alphabetically) to use for the target of the test assertions.  But now that we've hard-coded the rates, the test would only pass if one of the two were picked.  This PR hard-codes the IDs in the test itself to make it always pick one of the two TSPP records as the target.

## Reviewer Notes

We may not ultimately need this test after the PPM rate engine is reworked in the future, but I didn't want to assume that yet.

## Setup

`make server_test`
