### PR TITLE
MB-6460 Add light link to Storybook

### DIFF
--- a/src/shared/styles/_typography.scss
+++ b/src/shared/styles/_typography.scss
@@ -92,6 +92,10 @@ a,
     &.focus {
       @include u-outline('05', 'blue-40v');
     }
+    &:visited,
+    &.visited {
+      color: $link-light;
+    }
   }
 }
 

--- a/src/shared/styles/_typography.scss
+++ b/src/shared/styles/_typography.scss
@@ -80,6 +80,19 @@ a,
   &.focus {
     @include u-outline('05', 'blue-40v');
   }
+  &-light {
+    @include u-text('bold');
+    color: $link-light;
+    &:hover,
+    &.hover {
+      color: #b7caf0;
+      @include u-text('no-underline');
+    }
+    &:focus,
+    &.focus {
+      @include u-outline('05', 'blue-40v');
+    }
+  }
 }
 
 ul {

--- a/src/stories/typography.stories.jsx
+++ b/src/stories/typography.stories.jsx
@@ -79,5 +79,12 @@ export const links = () => (
     <small>
       <a href="https://materializecss.com/sass.html">USWDS blue-warm-60v 14/16</a>
     </small>
+
+    <p>a link light</p>
+    <div style={{ background: '#000' }}>
+      <a href="#" className="usa-link-light">
+        This is link is on a dark background
+      </a>
+    </div>
   </div>
 );


### PR DESCRIPTION
## Description

This branch adds the light link styling to the links page in storybook. It also adds styling to the `overrides.scss` file where the other default link styles reside.

## Reviewer Notes

If anyone has specific opinions on how the class was named for this, I would appreciate feedbac on that. Setting global styles can be risky and I want to assure we are all in alignment on how global styles are called.

## Setup

```sh
yarn storybook
```
**Global > Typography > Links**

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6460?atlOrigin=eyJpIjoiNTE1MGRlNTQ5NjFiNGMxMmI0NjU4MWUzYjQ0MzNkZjUiLCJwIjoiaiJ9) for this change

## Screenshots
default state:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/59394696/105766360-a44ff980-5f27-11eb-9451-cde04f8b3c6a.png">

hover:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/59394696/105766383-aca83480-5f27-11eb-8b9a-16a67c6e3076.png">

focus:
<img width="325" alt="image" src="https://user-images.githubusercontent.com/59394696/105766443-c184c800-5f27-11eb-9978-988cd4fff3da.png">

