### PR TITLE
[MB-6474] Migration to remove Alexi's CAC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1284,7 +1284,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rr-MB-6474-remove-alexi-cac-access
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1297,7 +1297,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rr-MB-6474-remove-alexi-cac-access
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1305,7 +1305,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rr-MB-6474-remove-alexi-cac-access
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1313,7 +1313,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: rr-MB-6474-remove-alexi-cac-access
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1352,21 +1352,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1380,28 +1380,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rr-MB-6474-remove-alexi-cac-access
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1284,7 +1284,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rr-MB-6474-remove-alexi-cac-access
 
       - integration_tests_mtls:
           requires:
@@ -1297,7 +1297,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rr-MB-6474-remove-alexi-cac-access
 
       - client_test:
           requires:
@@ -1305,7 +1305,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rr-MB-6474-remove-alexi-cac-access
 
       - server_test:
           requires:
@@ -1313,7 +1313,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: rr-MB-6474-remove-alexi-cac-access
 
       - build_app:
           requires:
@@ -1352,21 +1352,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - deploy_exp_migrations:
           requires:
@@ -1380,28 +1380,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-MB-6474-remove-alexi-cac-access
 
       - push_app_stg:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -603,3 +603,4 @@
 20210121193254_remove_zipSITAddress_association_with_DOPSIT.up.sql
 20210121212236_add_ZipSITOriginHHGOriginal_and_ZipSITOriginHHGActual_param_keys.up.sql
 20210121214111_add_ZipSITOriginHHG_params_for_DOPSIT.up.sql
+20210125221259_remove_alexi_cac.up.sql

--- a/migrations/app/schema/20210125221259_remove_alexi_cac.up.sql
+++ b/migrations/app/schema/20210125221259_remove_alexi_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove akostibas CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='a5922b65a90304385b83f8a01983e8ad312c4e08c2c9322ebcf54cfd35e61fda';


### PR DESCRIPTION
## Description

Removes CAC access. This doesn't have to be a secure migration because we're only identifying the sha256 digest in dev/experimental/staging/prod. And if it doesn't exist in those environments this is a noop.

## Reviewer Notes

This needs to be deployed manually to experimental to apply in that environment.  I will do that after getting initial approval on the PR.

## Setup

- `make db_dev_run db_dev_migrate`
- Verify that CAC record no longer appears in `client_certs` table.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6474) for this change
