### PR TITLE
[MB-5382] Remove exclusion of govet lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,12 +45,6 @@ linters:
   fast: false
 
 issues:
-  exclude-rules:
-    # skip analyzing dutystationsloader until repeated tags from embedded types are fixed https://github.com/golang/go/issues/30846
-    - path: internal/pkg/dutystationsloader/duty_stations_loader.go
-      linters:
-        - govet
-
   # Disable defaults for the exclude patterns and instead list them all out
   # TODO: Slowly remove these where they make sense and fix code
   exclude-use-default: false
@@ -71,4 +65,3 @@ run:
     - pkg/gen
     - mocks
   skip-dirs-use-default: true
-


### PR DESCRIPTION
## Description

Removing exclusion of a lint rule that has since been fixed by library maintainer. Furthermore, the exclusion is targeting a file that does not exist anymore

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5382) for this change