### PR TITLE
use latest milmove-cypress image: MB-6026

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-2c832f32e8dbd8afaaa5265e9c6ff59e8d536d11
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-ff8839d671dc164855c21255c40541bb23fa1e75
 
   postgres: &postgres postgres:12.4
 

--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-38cc39df3ee891652c472a6c731feecc63a1253b
+FROM milmove/circleci-docker:milmove-cypress-ff8839d671dc164855c21255c40541bb23fa1e75
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json


### PR DESCRIPTION
## Description

We have a repo `circleci-docker` that contains a build of cypress for our integration tests. When we update any packages in `circleci-docker`, we should pull the latest image of into `mymove`.

the `circleci-docker` pr: https://github.com/transcom/circleci-docker/pull/71

## Reviewer Notes

Did I get the correct hash from Dockerhub image?

## Setup

the integration tests should run w/o an issue on circle

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6026) for this change
