### PR TITLE
MB-6461 Filter hidden moves from MTO availability checker, ListAllMoveTaskOrders, and ListMoveTaskOrders

### DIFF
--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -55,8 +55,7 @@ type ListMoveTaskOrdersHandler struct {
 func (h ListMoveTaskOrdersHandler) Handle(params moveorderop.ListMoveTaskOrdersParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	moveOrderID, _ := uuid.FromString(params.MoveOrderID.String())
-	searchParams := services.ListMoveTaskOrderParams{ExcludeHidden: true} // excludes disabled MTOs
-	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID, &searchParams)
+	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID, nil) // nil searchParams exclude disabled MTOs by default
 	if err != nil {
 		logger.Error("fetching all move orders", zap.Error(err))
 		switch err {

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -55,7 +55,8 @@ type ListMoveTaskOrdersHandler struct {
 func (h ListMoveTaskOrdersHandler) Handle(params moveorderop.ListMoveTaskOrdersParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	moveOrderID, _ := uuid.FromString(params.MoveOrderID.String())
-	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID, true)
+	searchParams := services.ListMoveTaskOrderParams{ExcludeHidden: true} // excludes disabled MTOs
+	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID, &searchParams)
 	if err != nil {
 		logger.Error("fetching all move orders", zap.Error(err))
 		switch err {

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -55,7 +55,7 @@ type ListMoveTaskOrdersHandler struct {
 func (h ListMoveTaskOrdersHandler) Handle(params moveorderop.ListMoveTaskOrdersParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	moveOrderID, _ := uuid.FromString(params.MoveOrderID.String())
-	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID)
+	moveTaskOrders, err := h.ListMoveTaskOrders(moveOrderID, true)
 	if err != nil {
 		logger.Error("fetching all move orders", zap.Error(err))
 		switch err {

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -26,7 +26,6 @@ func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesPa
 
 	searchParams := services.ListMoveTaskOrderParams{
 		IsAvailableToPrime: true,
-		ExcludeHidden:      true,
 		Since:              params.Since,
 	}
 	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(&searchParams)

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -24,7 +24,7 @@ type FetchMTOUpdatesHandler struct {
 func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(true, params.Since)
+	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(true, true, params.Since)
 
 	if err != nil {
 		logger.Error("Unexpected error while fetching records:", zap.Error(err))

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -24,7 +24,12 @@ type FetchMTOUpdatesHandler struct {
 func (h FetchMTOUpdatesHandler) Handle(params movetaskorderops.FetchMTOUpdatesParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(true, true, params.Since)
+	searchParams := services.ListMoveTaskOrderParams{
+		IsAvailableToPrime: true,
+		ExcludeHidden:      true,
+		Since:              params.Since,
+	}
+	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(&searchParams)
 
 	if err != nil {
 		logger.Error("Unexpected error while fetching records:", zap.Error(err))

--- a/pkg/handlers/supportapi/move_task_order.go
+++ b/pkg/handlers/supportapi/move_task_order.go
@@ -28,9 +28,8 @@ func (h ListMTOsHandler) Handle(params movetaskorderops.ListMTOsParams) middlewa
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
 	searchParams := services.ListMoveTaskOrderParams{
-		IsAvailableToPrime: false,
-		ExcludeHidden:      false,
-		Since:              params.Since,
+		IncludeHidden: true,
+		Since:         params.Since,
 	}
 	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(&searchParams)
 

--- a/pkg/handlers/supportapi/move_task_order.go
+++ b/pkg/handlers/supportapi/move_task_order.go
@@ -27,7 +27,12 @@ type ListMTOsHandler struct {
 func (h ListMTOsHandler) Handle(params movetaskorderops.ListMTOsParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(false, false, params.Since)
+	searchParams := services.ListMoveTaskOrderParams{
+		IsAvailableToPrime: false,
+		ExcludeHidden:      false,
+		Since:              params.Since,
+	}
+	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(&searchParams)
 
 	if err != nil {
 		logger.Error("Unable to fetch records:", zap.Error(err))

--- a/pkg/handlers/supportapi/move_task_order.go
+++ b/pkg/handlers/supportapi/move_task_order.go
@@ -27,7 +27,7 @@ type ListMTOsHandler struct {
 func (h ListMTOsHandler) Handle(params movetaskorderops.ListMTOsParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(false, params.Since)
+	mtos, err := h.MoveTaskOrderFetcher.ListAllMoveTaskOrders(false, false, params.Since)
 
 	if err != nil {
 		logger.Error("Unable to fetch records:", zap.Error(err))

--- a/pkg/services/mocks/MoveTaskOrderFetcher.go
+++ b/pkg/services/mocks/MoveTaskOrderFetcher.go
@@ -6,6 +6,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	models "github.com/transcom/mymove/pkg/models"
 
+	services "github.com/transcom/mymove/pkg/services"
+
 	uuid "github.com/gofrs/uuid"
 )
 
@@ -37,13 +39,13 @@ func (_m *MoveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*
 	return r0, r1
 }
 
-// ListAllMoveTaskOrders provides a mock function with given fields: isAvailableToPrime, excludeHidden, since
-func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, excludeHidden bool, since *int64) (models.Moves, error) {
-	ret := _m.Called(isAvailableToPrime, excludeHidden, since)
+// ListAllMoveTaskOrders provides a mock function with given fields: searchParams
+func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(searchParams *services.ListMoveTaskOrderParams) (models.Moves, error) {
+	ret := _m.Called(searchParams)
 
 	var r0 models.Moves
-	if rf, ok := ret.Get(0).(func(bool, bool, *int64) models.Moves); ok {
-		r0 = rf(isAvailableToPrime, excludeHidden, since)
+	if rf, ok := ret.Get(0).(func(*services.ListMoveTaskOrderParams) models.Moves); ok {
+		r0 = rf(searchParams)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.Moves)
@@ -51,8 +53,8 @@ func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, e
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(bool, bool, *int64) error); ok {
-		r1 = rf(isAvailableToPrime, excludeHidden, since)
+	if rf, ok := ret.Get(1).(func(*services.ListMoveTaskOrderParams) error); ok {
+		r1 = rf(searchParams)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,13 +62,13 @@ func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, e
 	return r0, r1
 }
 
-// ListMoveTaskOrders provides a mock function with given fields: moveOrderID, excludeHidden
-func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error) {
-	ret := _m.Called(moveOrderID, excludeHidden)
+// ListMoveTaskOrders provides a mock function with given fields: moveOrderID, searchParams
+func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, searchParams *services.ListMoveTaskOrderParams) ([]models.Move, error) {
+	ret := _m.Called(moveOrderID, searchParams)
 
 	var r0 []models.Move
-	if rf, ok := ret.Get(0).(func(uuid.UUID, bool) []models.Move); ok {
-		r0 = rf(moveOrderID, excludeHidden)
+	if rf, ok := ret.Get(0).(func(uuid.UUID, *services.ListMoveTaskOrderParams) []models.Move); ok {
+		r0 = rf(moveOrderID, searchParams)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.Move)
@@ -74,8 +76,8 @@ func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, exclud
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(uuid.UUID, bool) error); ok {
-		r1 = rf(moveOrderID, excludeHidden)
+	if rf, ok := ret.Get(1).(func(uuid.UUID, *services.ListMoveTaskOrderParams) error); ok {
+		r1 = rf(moveOrderID, searchParams)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/mocks/MoveTaskOrderFetcher.go
+++ b/pkg/services/mocks/MoveTaskOrderFetcher.go
@@ -37,13 +37,13 @@ func (_m *MoveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*
 	return r0, r1
 }
 
-// ListAllMoveTaskOrders provides a mock function with given fields: isAvailableToPrime, since
-func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.Moves, error) {
-	ret := _m.Called(isAvailableToPrime, since)
+// ListAllMoveTaskOrders provides a mock function with given fields: isAvailableToPrime, excludeHidden, since
+func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, excludeHidden bool, since *int64) (models.Moves, error) {
+	ret := _m.Called(isAvailableToPrime, excludeHidden, since)
 
 	var r0 models.Moves
-	if rf, ok := ret.Get(0).(func(bool, *int64) models.Moves); ok {
-		r0 = rf(isAvailableToPrime, since)
+	if rf, ok := ret.Get(0).(func(bool, bool, *int64) models.Moves); ok {
+		r0 = rf(isAvailableToPrime, excludeHidden, since)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.Moves)
@@ -51,8 +51,8 @@ func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(bool, *int64) error); ok {
-		r1 = rf(isAvailableToPrime, since)
+	if rf, ok := ret.Get(1).(func(bool, bool, *int64) error); ok {
+		r1 = rf(isAvailableToPrime, excludeHidden, since)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,13 +60,13 @@ func (_m *MoveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, s
 	return r0, r1
 }
 
-// ListMoveTaskOrders provides a mock function with given fields: moveOrderID
-func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.Move, error) {
-	ret := _m.Called(moveOrderID)
+// ListMoveTaskOrders provides a mock function with given fields: moveOrderID, excludeHidden
+func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error) {
+	ret := _m.Called(moveOrderID, excludeHidden)
 
 	var r0 []models.Move
-	if rf, ok := ret.Get(0).(func(uuid.UUID) []models.Move); ok {
-		r0 = rf(moveOrderID)
+	if rf, ok := ret.Get(0).(func(uuid.UUID, bool) []models.Move); ok {
+		r0 = rf(moveOrderID, excludeHidden)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.Move)
@@ -74,8 +74,8 @@ func (_m *MoveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]mod
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(uuid.UUID) error); ok {
-		r1 = rf(moveOrderID)
+	if rf, ok := ret.Get(1).(func(uuid.UUID, bool) error); ok {
+		r1 = rf(moveOrderID, excludeHidden)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -25,8 +25,8 @@ type MoveTaskOrderCreator interface {
 //go:generate mockery -name MoveTaskOrderFetcher
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*models.Move, error)
-	ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error)
-	ListAllMoveTaskOrders(isAvailableToPrime bool, excludeHidden bool, since *int64) (models.Moves, error)
+	ListMoveTaskOrders(moveOrderID uuid.UUID, searchParams *ListMoveTaskOrderParams) ([]models.Move, error)
+	ListAllMoveTaskOrders(searchParams *ListMoveTaskOrderParams) (models.Moves, error)
 }
 
 //MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder
@@ -41,4 +41,11 @@ type MoveTaskOrderUpdater interface {
 //go:generate mockery -name MoveTaskOrderChecker
 type MoveTaskOrderChecker interface {
 	MTOAvailableToPrime(moveTaskOrderID uuid.UUID) (bool, error)
+}
+
+// ListMoveTaskOrderParams is a public struct that's used to pass filter arguments to the ListMoveTaskOrders and ListAllMoveTaskOrders queries
+type ListMoveTaskOrderParams struct {
+	IsAvailableToPrime bool   // indicates if all MTOs returned must be Prime-available
+	ExcludeHidden      bool   // indicates if hidden/disabled MTOs should be included in the output
+	Since              *int64 // if filled, only MTOs that have been updated after this timestamp will be returned
 }

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -26,7 +26,7 @@ type MoveTaskOrderCreator interface {
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*models.Move, error)
 	ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.Move, error)
-	ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.Moves, error)
+	ListAllMoveTaskOrders(isAvailableToPrime bool, isVisible bool, since *int64) (models.Moves, error)
 }
 
 //MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -25,7 +25,7 @@ type MoveTaskOrderCreator interface {
 //go:generate mockery -name MoveTaskOrderFetcher
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*models.Move, error)
-	ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.Move, error)
+	ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error)
 	ListAllMoveTaskOrders(isAvailableToPrime bool, isVisible bool, since *int64) (models.Moves, error)
 }
 

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -45,7 +45,7 @@ type MoveTaskOrderChecker interface {
 
 // ListMoveTaskOrderParams is a public struct that's used to pass filter arguments to the ListMoveTaskOrders and ListAllMoveTaskOrders queries
 type ListMoveTaskOrderParams struct {
-	IsAvailableToPrime bool   // indicates if all MTOs returned must be Prime-available
+	IsAvailableToPrime bool   // indicates if all MTOs returned must be Prime-available (only used in ListAllMoveTaskOrders)
 	ExcludeHidden      bool   // indicates if hidden/disabled MTOs should be included in the output
-	Since              *int64 // if filled, only MTOs that have been updated after this timestamp will be returned
+	Since              *int64 // if filled, only MTOs that have been updated after this timestamp will be returned (only used in ListAllMoveTaskOrders)
 }

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -26,7 +26,7 @@ type MoveTaskOrderCreator interface {
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*models.Move, error)
 	ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error)
-	ListAllMoveTaskOrders(isAvailableToPrime bool, isVisible bool, since *int64) (models.Moves, error)
+	ListAllMoveTaskOrders(isAvailableToPrime bool, excludeHidden bool, since *int64) (models.Moves, error)
 }
 
 //MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -46,6 +46,6 @@ type MoveTaskOrderChecker interface {
 // ListMoveTaskOrderParams is a public struct that's used to pass filter arguments to the ListMoveTaskOrders and ListAllMoveTaskOrders queries
 type ListMoveTaskOrderParams struct {
 	IsAvailableToPrime bool   // indicates if all MTOs returned must be Prime-available (only used in ListAllMoveTaskOrders)
-	ExcludeHidden      bool   // indicates if hidden/disabled MTOs should be included in the output
+	IncludeHidden      bool   // indicates if hidden/disabled MTOs should be included in the output
 	Since              *int64 // if filled, only MTOs that have been updated after this timestamp will be returned (only used in ListAllMoveTaskOrders)
 }

--- a/pkg/services/move_task_order/move_task_order_checker.go
+++ b/pkg/services/move_task_order/move_task_order_checker.go
@@ -19,10 +19,10 @@ func NewMoveTaskOrderChecker(db *pop.Connection) services.MoveTaskOrderChecker {
 	return &moveTaskOrderChecker{db}
 }
 
-//MTOAvailableToPrime retrieves a Move for a given UUID and checks if it is available to prime
+//MTOAvailableToPrime retrieves a Move for a given UUID and checks if it is visible and available to prime
 func (f moveTaskOrderChecker) MTOAvailableToPrime(moveTaskOrderID uuid.UUID) (bool, error) {
 	mto := &models.Move{}
-	err := f.db.RawQuery("SELECT * from moves WHERE id = $1", moveTaskOrderID).First(mto)
+	err := f.db.RawQuery("SELECT * FROM moves WHERE id = $1 AND show = TRUE", moveTaskOrderID).First(mto)
 
 	if err != nil {
 		switch err {

--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -1,7 +1,12 @@
 package movetaskorder_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
 
 	"github.com/transcom/mymove/pkg/services"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
@@ -13,16 +18,41 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 	notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 	mtoChecker := NewMoveTaskOrderChecker(suite.DB())
 
-	availableToPrime, err := mtoChecker.MTOAvailableToPrime(availableMTO.ID)
-	suite.Equal(availableToPrime, true)
-	suite.NoError(err)
+	suite.T().Run("MTO is available and visible - success", func(t *testing.T) {
+		availableToPrime, err := mtoChecker.MTOAvailableToPrime(availableMTO.ID)
+		suite.Equal(availableToPrime, true)
+		suite.NoError(err)
+	})
 
-	availableToPrime2, err2 := mtoChecker.MTOAvailableToPrime(notAvailableMTO.ID)
-	suite.Equal(availableToPrime2, false)
-	suite.NoError(err2)
+	suite.T().Run("MTO is available but hidden - failure", func(t *testing.T) {
+		now := time.Now()
+		hide := false
+		availableHiddenMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+				Show:               &hide,
+			},
+		})
 
-	availableToPrime3, err3 := mtoChecker.MTOAvailableToPrime(uuid.Nil)
-	suite.Error(err3)
-	suite.IsType(err3, services.NotFoundError{})
-	suite.Equal(availableToPrime3, false)
+		availableToPrime, err := mtoChecker.MTOAvailableToPrime(availableHiddenMTO.ID)
+		suite.Error(err)
+		suite.IsType(err, services.NotFoundError{})
+		suite.Contains(err.Error(), availableHiddenMTO.ID.String())
+		suite.Equal(availableToPrime, false)
+	})
+
+	suite.T().Run("MTO is not available - no failure, but returns false", func(t *testing.T) {
+		availableToPrime, err := mtoChecker.MTOAvailableToPrime(notAvailableMTO.ID)
+		suite.Equal(availableToPrime, false)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("MTO ID is not valid - failure", func(t *testing.T) {
+		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
+		availableToPrime, err := mtoChecker.MTOAvailableToPrime(badUUID)
+		suite.Error(err)
+		suite.IsType(err, services.NotFoundError{})
+		suite.Contains(err.Error(), badUUID.String())
+		suite.Equal(availableToPrime, false)
+	})
 }

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -21,7 +21,7 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, searchPa
 	query := f.db.Where("orders_id = $1", moveOrderID)
 
 	// The default behavior of this query is to exclude any disabled moves:
-	if searchParams == nil || searchParams.ExcludeHidden {
+	if searchParams == nil || !searchParams.IncludeHidden {
 		query = query.Where("show = TRUE")
 	}
 
@@ -64,7 +64,8 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(searchParams *services.ListM
 			query = query.Where("available_to_prime_at IS NOT NULL")
 		}
 
-		if searchParams.ExcludeHidden {
+		// This value defaults to false - we want to make sure including hidden moves needs to be explicitly requested.
+		if !searchParams.IncludeHidden {
 			query = query.Where("show = TRUE")
 		}
 

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -36,7 +36,7 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, excludeH
 }
 
 //ListAllMoveTaskOrders retrieves all Move Task Orders that may or may not be available to prime, and may or may not be enabled.
-func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, isVisible bool, since *int64) (models.Moves, error) {
+func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, excludeHidden bool, since *int64) (models.Moves, error) {
 	var moveTaskOrders models.Moves
 	var err error
 	query := f.db.Q().Eager(
@@ -58,7 +58,7 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, isV
 		query = query.Where("available_to_prime_at IS NOT NULL")
 	}
 
-	if isVisible {
+	if excludeHidden {
 		query = query.Where("show = TRUE")
 	}
 

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -15,9 +15,15 @@ type moveTaskOrderFetcher struct {
 	db *pop.Connection
 }
 
-func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]models.Move, error) {
+//ListMoveTaskOrders retrieves all MTOs for a specific MoveOrder. Can filter out hidden MTOs (show=False)
+func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, excludeHidden bool) ([]models.Move, error) {
 	var moveTaskOrders []models.Move
-	err := f.db.Where("orders_id = $1", moveOrderID).Eager().All(&moveTaskOrders)
+	query := f.db.Where("orders_id = $1", moveOrderID)
+	if excludeHidden {
+		query = query.Where("show = TRUE")
+	}
+
+	err := query.Eager().All(&moveTaskOrders)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -29,8 +29,8 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID) ([]model
 	return moveTaskOrders, nil
 }
 
-//ListAllMoveTaskOrders retrieves all Move Task Orders that may or may not be available to prime
-func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, since *int64) (models.Moves, error) {
+//ListAllMoveTaskOrders retrieves all Move Task Orders that may or may not be available to prime, and may or may not be enabled.
+func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, isVisible bool, since *int64) (models.Moves, error) {
 	var moveTaskOrders models.Moves
 	var err error
 	query := f.db.Q().Eager(
@@ -50,6 +50,10 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(isAvailableToPrime bool, sin
 
 	if isAvailableToPrime {
 		query = query.Where("available_to_prime_at IS NOT NULL")
+	}
+
+	if isVisible {
+		query = query.Where("show = TRUE")
 	}
 
 	if since != nil {

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -22,7 +22,7 @@ func (f moveTaskOrderFetcher) ListMoveTaskOrders(moveOrderID uuid.UUID, searchPa
 
 	// The default behavior of this query is to exclude any disabled moves:
 	if searchParams == nil || !searchParams.IncludeHidden {
-		query = query.Where("show = TRUE")
+		query.Where("show = TRUE")
 	}
 
 	err := query.Eager().All(&moveTaskOrders)
@@ -58,20 +58,20 @@ func (f moveTaskOrderFetcher) ListAllMoveTaskOrders(searchParams *services.ListM
 
 	// Always exclude hidden moves by default:
 	if searchParams == nil {
-		query = query.Where("show = TRUE")
+		query.Where("show = TRUE")
 	} else {
 		if searchParams.IsAvailableToPrime {
-			query = query.Where("available_to_prime_at IS NOT NULL")
+			query.Where("available_to_prime_at IS NOT NULL")
 		}
 
 		// This value defaults to false - we want to make sure including hidden moves needs to be explicitly requested.
 		if !searchParams.IncludeHidden {
-			query = query.Where("show = TRUE")
+			query.Where("show = TRUE")
 		}
 
 		if searchParams.Since != nil {
 			since := time.Unix(*searchParams.Since, 0)
-			query = query.Where("updated_at > ?", since)
+			query.Where("updated_at > ?", since)
 		}
 	}
 

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -44,10 +44,8 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 	})
 	mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-	suite.T().Run("explicitly non-hidden move task orders", func(t *testing.T) {
-		searchParams := services.ListMoveTaskOrderParams{
-			ExcludeHidden: true,
-		}
+	suite.T().Run("implicitly non-hidden move task orders", func(t *testing.T) {
+		searchParams := services.ListMoveTaskOrderParams{} // should default to IncludeHidden being false
 		moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID, &searchParams)
 		suite.NoError(err)
 
@@ -69,7 +67,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 
 	suite.T().Run("include hidden move task orders", func(t *testing.T) {
 		searchParams := services.ListMoveTaskOrderParams{
-			ExcludeHidden: false,
+			IncludeHidden: true,
 		}
 		moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID, &searchParams)
 		suite.NoError(err)
@@ -116,7 +114,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 		searchParams := services.ListMoveTaskOrderParams{
 			IsAvailableToPrime: false,
-			ExcludeHidden:      false,
+			IncludeHidden:      true,
 			Since:              nil,
 		}
 
@@ -158,8 +156,8 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 		searchParams := services.ListMoveTaskOrderParams{
 			IsAvailableToPrime: true,
-			ExcludeHidden:      true,
-			Since:              nil,
+			// IncludeHidden should be false by default
+			Since: nil,
 		}
 
 		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(&searchParams)

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -57,7 +57,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 		mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(false, nil)
+		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(false, false, nil)
 		suite.NoError(err)
 
 		mto := moveTaskOrders[0]
@@ -77,7 +77,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 		mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(true, nil)
+		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(true, true, nil)
 		suite.NoError(err)
 		suite.Equal(len(moveTaskOrders), 3)
 
@@ -85,7 +85,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		suite.NoError(suite.DB().RawQuery("UPDATE moves SET updated_at=? WHERE id=?",
 			now.Add(-2*time.Second), oldMTO.ID).Exec())
 		since := now.Unix()
-		mtosWithSince, err := mtoFetcher.ListAllMoveTaskOrders(true, &since)
+		mtosWithSince, err := mtoFetcher.ListAllMoveTaskOrders(true, true, &since)
 		suite.NoError(err)
 		suite.Equal(len(mtosWithSince), 2)
 	})

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -33,10 +33,22 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 	expectedMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: expectedOrder,
 	})
+	hide := false
+	hiddenMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Order: expectedOrder,
+		Move: models.Move{
+			Show: &hide,
+		},
+	})
 	mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-	moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID)
+	moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID, true)
 	suite.NoError(err)
+
+	// The hidden move should be nowhere in the output list:
+	for _, move := range moveTaskOrders {
+		suite.NotEqual(move.ID, hiddenMTO.ID)
+	}
 
 	actualMTO := moveTaskOrders[0]
 


### PR DESCRIPTION
## Description

This PR updates the MTO Availability Checker to filter out all hidden (show=False) moves. I also updated `ListMoveTaskOrders` and `ListAllMoveTaskOrders` to add a parameter to toggle whether or not we want to include hidden moves. 

These changes will affect most Prime API endpoints (not all), and one GHC endpoint. The three that need to be tested to check that this is working as expected are:

- `fetchMTOUpdates` in the Prime API
- `createMTOShipment` in the Prime API
- `listMoveTaskOrders` in the GHC API

_Note: I completed the GHC one accidentally because I thought I was in the other function 🙊. It should technically be in the other ticket, but I didn't want to delete everything. @abbyoung, let me know if this will conflict with anything you've worked on for your ticket!_ 

## Setup

Testing this will involve three different APIs: Admin, GHC, and Prime. To set up the Admin and GHC APIs in Postman, see the instructions in this PR: https://github.com/transcom/mymove/pull/5717. (The instructions for the GHC API are exactly the same but with the `officelocal` domain.)

To test the Prime, you can use either the Prime API Client or Postman. See these instructions to get started: https://github.com/transcom/prime_api_deliverable/wiki/API-Endpoints#testing-the-api

Once your testing environment is all settled and running, follow these steps:

### Testing `listMoveTaskOrders`
1. Grab an ID for an Order (also called MoveOrder). You can get this by peeking at your database with a DB viewer (recommended), or by poking around in the office interface. 
2. Hit the `listMoveTaskOrders` endpoint with this Order ID. Grab a random MTO ID from this list.
3. Hit the `updateMove` endpoint in the Admin API. Use the MTO ID you grabbed previously, and pass in this request body:
```json
{
  "show": false
}
```
4. Rerun the `listMoveTaskOrders` endpoint with the same Order ID and verify that our now hidden MTO is nowhere to be seen.

### Testing `fetchMTOUpdates` and `createMTOShipment`
1. Hit the `fetchMTOUpdates` endpoint in the Prime API. Grab a random MTO ID from this list.
2. Hit the `updateMove` endpoint in the Admin API with this MTO ID and the payload described above.
3. Go back to the Prime API, and hit the `createMTOShipment` endpoint with a request like:
```json
{
  "moveTaskOrderID": "<the ID you grabbed above>",
  "shipmentType": "HHG",
  "requestedPickupDate": "2021-01-01",
  "pickupAddress": {
    "streetAddress1": "7 Q St",
    "city": "City",
    "state": "CA",
    "postalCode": "90210"
  },
  "destinationAddress": {
    "streetAddress1": "7 Q St",
    "city": "City",
    "state": "CA",
    "postalCode": "90210"
  }
}
```
You should receive a 404 response saying that the MTO was not found. 

4. Go back and hit `fetchMTOUpdates` again. Verify that the MTO you deactivated is no longer in the list.

## Code Review Verification Steps

* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6461) for this change.
