### PR TITLE
MB-3621 MTO status mutation for move details

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1024,7 +1024,7 @@ func init() {
           "200": {
             "description": "Successfully updated move task order status",
             "schema": {
-              "$ref": "#/definitions/MoveTaskOrder"
+              "$ref": "#/definitions/Move"
             }
           },
           "400": {
@@ -2971,6 +2971,10 @@ func init() {
         "isCanceled": {
           "type": "boolean",
           "x-nullable": true
+        },
+        "locator": {
+          "type": "string",
+          "example": "1K43AR"
         },
         "moveOrderID": {
           "type": "string",
@@ -5054,7 +5058,7 @@ func init() {
           "200": {
             "description": "Successfully updated move task order status",
             "schema": {
-              "$ref": "#/definitions/MoveTaskOrder"
+              "$ref": "#/definitions/Move"
             }
           },
           "400": {
@@ -7118,6 +7122,10 @@ func init() {
         "isCanceled": {
           "type": "boolean",
           "x-nullable": true
+        },
+        "locator": {
+          "type": "string",
+          "example": "1K43AR"
         },
         "moveOrderID": {
           "type": "string",

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
@@ -25,7 +25,7 @@ type UpdateMoveTaskOrderStatusOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *ghcmessages.MoveTaskOrder `json:"body,omitempty"`
+	Payload *ghcmessages.Move `json:"body,omitempty"`
 }
 
 // NewUpdateMoveTaskOrderStatusOK creates UpdateMoveTaskOrderStatusOK with default headers values
@@ -35,13 +35,13 @@ func NewUpdateMoveTaskOrderStatusOK() *UpdateMoveTaskOrderStatusOK {
 }
 
 // WithPayload adds the payload to the update move task order status o k response
-func (o *UpdateMoveTaskOrderStatusOK) WithPayload(payload *ghcmessages.MoveTaskOrder) *UpdateMoveTaskOrderStatusOK {
+func (o *UpdateMoveTaskOrderStatusOK) WithPayload(payload *ghcmessages.Move) *UpdateMoveTaskOrderStatusOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the update move task order status o k response
-func (o *UpdateMoveTaskOrderStatusOK) SetPayload(payload *ghcmessages.MoveTaskOrder) {
+func (o *UpdateMoveTaskOrderStatusOK) SetPayload(payload *ghcmessages.Move) {
 	o.Payload = payload
 }
 

--- a/pkg/gen/ghcmessages/move_task_order.go
+++ b/pkg/gen/ghcmessages/move_task_order.go
@@ -45,6 +45,9 @@ type MoveTaskOrder struct {
 	// is canceled
 	IsCanceled *bool `json:"isCanceled,omitempty"`
 
+	// locator
+	Locator string `json:"locator,omitempty"`
+
 	// move order ID
 	// Format: uuid
 	MoveOrderID strfmt.UUID `json:"moveOrderID,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
@@ -102,6 +104,10 @@ func MoveOrder(moveOrder *models.Order) *ghcmessages.MoveOrder {
 	if moveOrder == nil {
 		return nil
 	}
+	if moveOrder.ID == uuid.Nil {
+		return nil
+	}
+
 	destinationDutyStation := DutyStation(&moveOrder.NewDutyStation)
 	originDutyStation := DutyStation(moveOrder.OriginDutyStation)
 	if moveOrder.Grade != nil && moveOrder.Entitlement != nil {

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -70,6 +70,7 @@ func MoveTaskOrder(moveTaskOrder *models.Move) *ghcmessages.MoveTaskOrder {
 		ReferenceID:        *moveTaskOrder.ReferenceID,
 		UpdatedAt:          strfmt.DateTime(moveTaskOrder.UpdatedAt),
 		ETag:               etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+		Locator:            moveTaskOrder.Locator,
 	}
 	return payload
 }

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -59,6 +59,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Stub: true,
 			Order: models.Order{
+				ID:            uuid.Must(uuid.NewV4()),
 				HasDependents: *swag.Bool(false),
 			},
 			Entitlement: models.Entitlement{
@@ -99,6 +100,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
 			Stub: true,
 			Order: models.Order{
+				ID:            uuid.Must(uuid.NewV4()),
 				HasDependents: *swag.Bool(true),
 			},
 		})

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -83,7 +83,7 @@ func (h UpdateMoveTaskOrderStatusHandlerFunc) Handle(params movetaskorderops.Upd
 		}
 	}
 
-	moveTaskOrderPayload := payloads.MoveTaskOrder(mto)
+	moveTaskOrderPayload := payloads.Move(mto)
 
 	// Audit attempt to make MTO available to prime
 	_, err = audit.Capture(mto, moveTaskOrderPayload, logger, session, params.HTTPRequest)

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
@@ -20,11 +22,13 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	availableToPrimeAt := time.Now()
 	submittedAt := availableToPrimeAt.Add(-1 * time.Hour)
 
+	ordersID := uuid.Must(uuid.NewV4())
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Move: models.Move{
 			Status:             models.MoveStatusAPPROVED,
 			AvailableToPrimeAt: &availableToPrimeAt,
 			SubmittedAt:        &submittedAt,
+			Orders:             models.Order{ID: ordersID},
 		},
 	})
 
@@ -63,6 +67,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 		suite.Equal(move.CreatedAt.Format(swaggerTimeFormat), time.Time(payload.CreatedAt).Format(swaggerTimeFormat))
 		suite.Equal(move.SubmittedAt.Format(swaggerTimeFormat), time.Time(*payload.SubmittedAt).Format(swaggerTimeFormat))
 		suite.Equal(move.UpdatedAt.Format(swaggerTimeFormat), time.Time(payload.UpdatedAt).Format(swaggerTimeFormat))
+		suite.Equal(ordersID, move.Orders.ID)
 	})
 
 	suite.T().Run("Unsuccessful move fetch - empty string bad request", func(t *testing.T) {

--- a/src/components/Office/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview.jsx
@@ -179,11 +179,11 @@ ShipmentApprovalPreview.propTypes = {
       state: PropTypes.string,
       postal_code: PropTypes.string,
     }),
-    backupContact: {
+    backupContact: PropTypes.shape({
       name: PropTypes.string,
       phone: PropTypes.string,
       email: PropTypes.string,
-    },
+    }),
   }).isRequired,
   setIsModalVisible: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { useParams } from 'react-router-dom';
 import { GridContainer, Grid } from '@trussworks/react-uswds';
+import { queryCache, useMutation } from 'react-query';
 
 import styles from '../TXOMoveInfo/TXOTab.module.scss';
 
@@ -15,6 +16,7 @@ import OrdersTable from 'components/Office/OrdersTable/OrdersTable';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { MOVES } from 'constants/queryKeys';
 
 const sectionLabels = {
   'requested-shipments': 'Requested shipments',
@@ -57,6 +59,13 @@ const MoveDetails = () => {
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
+  });
+
+  // use mutation calls
+  const [mutateMoveStatus] = useMutation(updateMoveTaskOrderStatus, {
+    onSuccess: (data) => {
+      queryCache.setQueryData([MOVES, data.locator], data);
+    },
   });
 
   if (isLoading) return <LoadingPlaceholder />;
@@ -132,7 +141,7 @@ const MoveDetails = () => {
                 customerInfo={customerInfo}
                 mtoServiceItems={mtoServiceItems}
                 shipmentsStatus="SUBMITTED"
-                approveMTO={updateMoveTaskOrderStatus}
+                approveMTO={mutateMoveStatus}
                 approveMTOShipment={patchMTOShipmentStatus}
                 moveTaskOrder={move}
               />

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -7,7 +7,7 @@ import { queryCache, useMutation } from 'react-query';
 import styles from '../TXOMoveInfo/TXOTab.module.scss';
 
 import 'styles/office.scss';
-import { updateMoveTaskOrderStatus, patchMTOShipmentStatus } from 'services/ghcApi';
+import { updateMoveStatus, patchMTOShipmentStatus } from 'services/ghcApi';
 import LeftNav from 'components/LeftNav';
 import CustomerInfoTable from 'components/Office/CustomerInfoTable';
 import RequestedShipments from 'components/Office/RequestedShipments/RequestedShipments';
@@ -62,7 +62,7 @@ const MoveDetails = () => {
   });
 
   // use mutation calls
-  const [mutateMoveStatus] = useMutation(updateMoveTaskOrderStatus, {
+  const [mutateMoveStatus] = useMutation(updateMoveStatus, {
     onSuccess: (data) => {
       queryCache.setQueryData([MOVES, data.locator], data);
     },

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -115,12 +115,7 @@ export async function updateMoveOrder({ moveOrderID, ifMatchETag, body }) {
   return makeGHCRequest(operationPath, { moveOrderID, 'If-Match': ifMatchETag, body });
 }
 
-export function updateMoveTaskOrderStatus({
-  moveTaskOrderID,
-  ifMatchETag,
-  mtoApprovalServiceItemCodes,
-  normalize = true,
-}) {
+export function updateMoveStatus({ moveTaskOrderID, ifMatchETag, mtoApprovalServiceItemCodes, normalize = true }) {
   const operationPath = 'moveTaskOrder.updateMoveTaskOrderStatus';
   return makeGHCRequest(
     operationPath,

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -739,7 +739,7 @@ paths:
         '200':
           description: Successfully updated move task order status
           schema:
-            $ref: '#/definitions/MoveTaskOrder'
+            $ref: '#/definitions/Move'
         '400':
           description: The request payload is invalid
           schema:
@@ -1858,6 +1858,9 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         format: uuid
         type: string
+      locator:
+        type: string
+        example: '1K43AR'
       referenceId:
         example: 1001-3456
         type: string


### PR DESCRIPTION
## Description

This PR updates the call to update the move status to use `useMutation` from react-query. `useMutation` is used to update the react query cache with the keys `[Moves, Locator]`.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- Didn't see any unit tests to update or add. Although, I was thinking of moving the mutation calls into it's own file to make it testable. Not sure though since we currently aren't doing that now for other mutation calls.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

Test
1. Log in as TOO
2. Click on any `New move`
3. Select any shipment
4. Select any basic service items
5. Click on `Approve selected shipments`
6. Everything should still work!

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3621) for this change