### PR TITLE
MB-6469 Add show=true filter and tests for MTOShipmentsMTOAvailableToPrime function

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -741,6 +741,7 @@ func (f mtoShipmentUpdater) MTOShipmentsMTOAvailableToPrime(mtoShipmentID uuid.U
 		Join("mto_shipments", "moves.id = mto_shipments.move_id").
 		Where("available_to_prime_at IS NOT NULL").
 		Where("mto_shipments.id = ?", mtoShipmentID).
+		Where("show = TRUE").
 		First(&mto)
 	if err != nil {
 		if err.Error() == models.RecordNotFoundErrorString {


### PR DESCRIPTION
## Description

This PR adds a filter to only find shipments connected to enabled, or show=True, moves in the `MTOShipmentsMTOAvailableToPrime` function. This service object's purpose is to verify that the shipment is connected to a Prime-available (and now, enabled) move, and it is used in the `updateMTOShipment` endpoint in the Prime API.

## Setup

To test this update, you will have to set up two tools:
1. Either the [Prime API Client](https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client) or [Postman with Prime API](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman)
2. Either [Postman with Admin API](https://github.com/transcom/mymove/pull/5717) or a [DB viewer connected to the MilMove dev DB](https://github.com/transcom/mymove/wiki/Configure-Postico-or-TablePlus-to-connect-to-mymove-DB) (<- these instructions are applicable to most DB viewers, not just the two listed there)

Once you have set up your testing environment, follow these steps:

* Hit the Prime API `fetchMTOUpdates` endpoint. Select a random MTO in the output, and grab these three bits of information:
  * the MTO's ID
  * the ID for one of the MTO's shipments
  * the eTag for the same shipment selected above
* Go to the Prime API `updateMTOShipment` endpoint and, using the same shipment ID and eTag selected previously, try an update with a simple request body like:
```json
{
  "firstAvailableDeliveryDate": "2021-02-02"
}
```
Verify that your update succeeded (200 response code) and grab the new eTag value for the shipment

* (If you set up the Admin API with Postman) Go to the Admin API `updateMove` endpoint and, using the MTO ID grabbed above, send this request body:
```json
{
  "show": false
}
```
Verify that your update succeeded (200 response code)

* (If you are using a DB viewer) Find the record in the `moves` table with `id='<the MTO ID you picked>'`. Go to the `show` column and change this value to `false`. Make sure you push and commit this change.
* Go back to the `updateMTOShipment` endpoint and submit the exact same request with the new eTag value. **You should get a 404 response saying the shipment was not found.** 

## Code Review Verification Steps

* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6469) for this change.
