### PR TITLE
MB-6299 TOO status queue filter shows SUBMITTED not New Move when selected

### DIFF
--- a/src/components/Table/Filters/MultiSelectCheckBoxFilter.jsx
+++ b/src/components/Table/Filters/MultiSelectCheckBoxFilter.jsx
@@ -36,19 +36,20 @@ const ValueContainer = ({ children, ...props }) => {
   );
 };
 
-const MultiValueContainer = ({ data: { value } }) => {
-  return <span>{value}</span>;
+const MultiValueContainer = ({ data: { label } }) => {
+  return <span data-testid="multi-value-container">{label}</span>;
 };
 
 const MultiSelectCheckBoxFilter = ({ options, column: { filterValue, setFilter } }) => {
   const selectFilterValue = useMemo(() => {
     return filterValue
       ? filterValue.split(',').map((val) => ({
-          label: val,
+          label: options.find((option) => option.value === val).label,
           value: val,
         }))
       : [];
-  }, [filterValue]);
+  }, [filterValue, options]);
+
   return (
     <div data-testid="MultiSelectCheckBoxFilter">
       <Select

--- a/src/components/Table/Filters/MultiSelectCheckBoxFilter.test.jsx
+++ b/src/components/Table/Filters/MultiSelectCheckBoxFilter.test.jsx
@@ -1,11 +1,59 @@
 import React from 'react';
+import Select from 'react-select';
 import { mount } from 'enzyme';
 
 import MultiSelectCheckBoxFilter from './MultiSelectCheckBoxFilter';
+
+const column = {
+  filterValue: '',
+  setFilter: jest.fn(),
+};
+const optionsConstants = [
+  { value: 'ARMY', label: 'Army' },
+  { value: 'NAVY', label: 'Navy' },
+];
+const optionsStrings = [
+  { value: 'approval requested', label: 'Approval Requested' },
+  { value: 'paid', label: 'Paid' },
+];
 
 describe('MultiSelectCheckBoxFilter', () => {
   it('renders without crashing', () => {
     const wrapper = mount(<MultiSelectCheckBoxFilter options={[{ label: 'test', value: 'test' }]} column={{}} />);
     expect(wrapper.find('[data-testid="MultiSelectCheckBoxFilter"]').length).toBe(1);
+    expect(wrapper.find('.MultiSelectCheckBoxFilter__placeholder').at(1).text('Select...')).toBeTruthy();
+  });
+
+  describe('It renders the expected placeholder text', () => {
+    it('from an array of constant valued objects when a value is chosen', () => {
+      const wrapper = mount(<MultiSelectCheckBoxFilter options={optionsConstants} column={column} />);
+      const input = wrapper.find(Select).find('input');
+      input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+      expect(wrapper.find('[data-testid="multi-value-container"]').text()).toEqual('Army');
+    });
+
+    it('from an array of string valued objects when a value is chosen', () => {
+      const wrapper = mount(<MultiSelectCheckBoxFilter options={optionsStrings} column={column} />);
+      const input = wrapper.find(Select).find('input');
+      input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+      expect(wrapper.find('[data-testid="multi-value-container"]').text()).toEqual('Approval Requested');
+    });
+
+    it('from an array of objects when multiple values are chosen', () => {
+      const wrapper = mount(<MultiSelectCheckBoxFilter options={optionsStrings} column={column} />);
+      const input = wrapper.find(Select).find('input');
+      input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+      input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+      expect(wrapper.find('[data-testid="multi-value-container"]').at(0).text()).toEqual('Approval Requested');
+      expect(wrapper.find('[data-testid="multi-value-container"]').at(1).text()).toEqual('Paid');
+    });
   });
 });

--- a/src/pages/Office/MoveQueue/MoveQueue.test.jsx
+++ b/src/pages/Office/MoveQueue/MoveQueue.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Select from 'react-select';
 import { mount } from 'enzyme';
 
 import MoveQueue from './MoveQueue';
@@ -129,5 +130,14 @@ describe('MoveQueue', () => {
     wrapper.update();
 
     expect(wrapper.find({ 'data-testid': 'lastName' }).at(0).hasClass('sortAscending')).toBe(true);
+  });
+
+  it('filters the queue', () => {
+    const input = wrapper.find(Select).at(0).find('input');
+    input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+    input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+    wrapper.update();
+    expect(wrapper.find('[data-testid="multi-value-container"]').text()).toEqual('New move');
   });
 });

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Select from 'react-select';
 import { mount } from 'enzyme';
 
 import PaymentRequestQueue from './PaymentRequestQueue';
@@ -122,5 +123,14 @@ describe('PaymentRequestQueue', () => {
     wrapper.update();
 
     expect(wrapper.find({ 'data-testid': 'lastName' }).at(0).hasClass('sortAscending')).toBe(true);
+  });
+
+  it('filters the queue', () => {
+    const input = wrapper.find(Select).at(0).find('input');
+    input.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+    input.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+
+    wrapper.update();
+    expect(wrapper.find('[data-testid="multi-value-container"]').text()).toEqual('Payment requested');
   });
 });


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```
1. Log in as TOO and view Move queue
2. Filter the queue by "New Move" status
3. Note Filter placeholder is "New Move", not SUBMITTED.

## Code Review Verification Steps


* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6299) for this change

## Screenshots

![Screen Shot 2021-01-28 at 9 33 29 AM](https://user-images.githubusercontent.com/1587316/106152880-ee192980-614b-11eb-827f-a1c3bd79525c.png)
