### PR TITLE
MB-5808: allow first_attempted_at to be nullable

### DIFF
--- a/cmd/webhook-client/webhook/webhook.go
+++ b/cmd/webhook-client/webhook/webhook.go
@@ -55,7 +55,13 @@ func (eng *Engine) processNotifications(notifications []models.WebhookNotificati
 				// If notification send failed, we need to log the severity
 				if err != nil {
 					eng.Logger.Error("Webhook Notification send failed", zap.Error(err))
-					sev = eng.GetSeverity(time.Now(), notif.FirstAttemptedAt)
+					var firstAttemptedAt time.Time
+					if notif.FirstAttemptedAt != nil {
+						firstAttemptedAt = *notif.FirstAttemptedAt
+					} else {
+						firstAttemptedAt = time.Now()
+					}
+					sev = eng.GetSeverity(time.Now(), firstAttemptedAt)
 					if sev != sub.Severity {
 						eng.Logger.Error("Raising severity of failure",
 							zap.String("subscriptionEvent", sub.EventKey),
@@ -192,7 +198,8 @@ func (eng *Engine) sendOneNotification(notif *models.WebhookNotification, sub *m
 		resp, body, err2 := eng.Client.Post(json, url)
 
 		if notif.Status == models.WebhookNotificationPending {
-			notif.FirstAttemptedAt = time.Now()
+			now := time.Now()
+			notif.FirstAttemptedAt = &now
 			// Not writing to db, but should be written within
 			// this function.
 		}

--- a/cmd/webhook-client/webhook/webhook_test.go
+++ b/cmd/webhook-client/webhook/webhook_test.go
@@ -614,7 +614,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 		//             After second failure one minute later - notif still marked as FAILING, subscription severity = 3
 
 		// Update firstAttemptedTime to be a minute ago
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-60 * time.Second)
+		firstAttemptedAt := notifications[0].FirstAttemptedAt
+		earlierThanFirstAttemptedAt := (*firstAttemptedAt).Add(-60 * time.Second)
+		notifications[0].FirstAttemptedAt = &earlierThanFirstAttemptedAt
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST
@@ -651,7 +653,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 
 		// Update firstAttemptedTime to be more than one threshold ago
 		durationOffset := time.Duration(engine.SeverityThresholds[0]) * time.Second
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-durationOffset)
+		firstAttemptedAt := notifications[0].FirstAttemptedAt
+		earlierThanFirstAttemptedAt := (*firstAttemptedAt).Add(-durationOffset)
+		notifications[0].FirstAttemptedAt = &earlierThanFirstAttemptedAt
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST
@@ -688,7 +692,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 
 		// Update firstAttemptedTime to be more than one threshold ago
 		durationOffset := time.Duration(engine.SeverityThresholds[1]) * time.Second
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-durationOffset)
+		firstAttemptedAt := notifications[0].FirstAttemptedAt
+		earlierThanFirstAttemptedAt := (*firstAttemptedAt).Add(-durationOffset)
+		notifications[0].FirstAttemptedAt = &earlierThanFirstAttemptedAt
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST

--- a/pkg/models/webhook_notification.go
+++ b/pkg/models/webhook_notification.go
@@ -42,7 +42,7 @@ type WebhookNotification struct {
 	Status           WebhookNotificationStatus `db:"status"`
 	CreatedAt        time.Time                 `db:"created_at"`
 	UpdatedAt        time.Time                 `db:"updated_at"`
-	FirstAttemptedAt time.Time                 `db:"first_attempted_at"`
+	FirstAttemptedAt *time.Time                `db:"first_attempted_at"`
 }
 
 // String is not required by pop and may be deleted


### PR DESCRIPTION
## Description

This makes the `first_attempted_at` field in the `WebhookNotification` model nullable. While attempting to deploy the webhook client to ECS, I encountered the following error:

```json
{
    "level": "error",
    "ts": "2021-01-27T20:10:54.567Z",
    "caller": "webhook/webhook.go:256",
    "msg": "Error:",
    "error": "sql: Scan error on column index 2, name \"first_attempted_at\": unsupported Scan, storing driver.Value type <nil> into type *time.Time",
    "stacktrace": "github.com/transcom/mymove/cmd/webhook-client/webhook.(*Engine).run\n\t/home/circleci/transcom/mymove/cmd/webhook-client/webhook/webhook.go:256\ngithub.com/transcom/mymove/cmd/webhook-client/webhook.(*Engine).Start\n\t/home/circleci/transcom/mymove/cmd/webhook-client/webhook/webhook.go:295"
}
```

After introducing the change in this PR, I no longer get that error. This brings the model into closer alignment with the database's schema, which indicates that `first_attempted_at` does _not_ have the `not null` constraint.

```text
dev_db=> \d webhook_notifications
                                        Table "public.webhook_notifications"
       Column       |             Type             | Collation | Nullable |                 Default                 
--------------------+------------------------------+-----------+----------+-----------------------------------------
 id                 | uuid                         |           | not null | 
 event_key          | text                         |           | not null | 
 trace_id           | uuid                         |           |          | 
 move_id            | uuid                         |           |          | 
 object_id          | uuid                         |           |          | 
 payload            | json                         |           | not null | 
 status             | webhook_notifications_status |           | not null | 'PENDING'::webhook_notifications_status
 created_at         | timestamp without time zone  |           | not null | 
 updated_at         | timestamp without time zone  |           | not null | 
 first_attempted_at | timestamp without time zone  |           |          | 
Indexes:
    "webhook_notifications_pkey" PRIMARY KEY, btree (id)
    "webhook_notifications_move_id_idx" btree (move_id)
    "webhook_notifications_unsent" btree (created_at) WHERE status <> 'SENT'::webhook_notifications_status AND status <> 'SKIPPED'::webhook_notifications_status
Foreign-key constraints:
    "webhook_notifications_move_id_fkey" FOREIGN KEY (move_id) REFERENCES moves(id)
```

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5808) for this change