### PR TITLE
Fix firstAttemptedAt model due to nullable db field

### DIFF
--- a/cmd/webhook-client/webhook/webhook_test.go
+++ b/cmd/webhook-client/webhook/webhook_test.go
@@ -104,7 +104,7 @@ func (suite *WebhookClientTestingSuite) Test_SendStgNotification() {
 		suite.DB().Find(&notif, notification.ID)
 		suite.Equal(models.WebhookNotificationSent, notif.Status)
 		// Check that first attempted at date was set
-		suite.False(notif.FirstAttemptedAt.IsZero())
+		suite.NotNil(notif.FirstAttemptedAt)
 
 	})
 
@@ -187,7 +187,7 @@ func (suite *WebhookClientTestingSuite) Test_SendOneNotification() {
 		suite.DB().Find(&notif, notification.ID)
 		suite.Equal(models.WebhookNotificationSent, notif.Status)
 		// Check that first attempted at date was set
-		suite.False(notif.FirstAttemptedAt.IsZero())
+		suite.NotNil(notif.FirstAttemptedAt)
 
 	})
 
@@ -447,7 +447,7 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunInactiveSub() {
 			// if there's no subscription, we except status to be skipped
 			suite.Equal(models.WebhookNotificationSkipped, notif.Status)
 			// And we except firstAttemptedAt to be unset
-			suite.True(notif.FirstAttemptedAt.IsZero())
+			suite.Nil(notif.FirstAttemptedAt)
 		} else {
 			suite.Equal(models.WebhookNotificationSent, notif.Status)
 			suite.False(notif.FirstAttemptedAt.IsZero())
@@ -537,7 +537,7 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailingSub() {
 
 	// Third notification should be PENDING
 	suite.Equal(models.WebhookNotificationPending, updatedNotifs[2].Status)
-	suite.True(updatedNotifs[2].FirstAttemptedAt.IsZero())
+	suite.Nil(updatedNotifs[2].FirstAttemptedAt)
 
 }
 
@@ -614,7 +614,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 		//             After second failure one minute later - notif still marked as FAILING, subscription severity = 3
 
 		// Update firstAttemptedTime to be a minute ago
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-60 * time.Second)
+		timestamp := *(notifications[0].FirstAttemptedAt)
+		timestamp = timestamp.Add(-60 * time.Second)
+		notifications[0].FirstAttemptedAt = &timestamp
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST
@@ -651,7 +653,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 
 		// Update firstAttemptedTime to be more than one threshold ago
 		durationOffset := time.Duration(engine.SeverityThresholds[0]) * time.Second
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-durationOffset)
+		timestamp := *(notifications[0].FirstAttemptedAt)
+		timestamp = timestamp.Add(-durationOffset)
+		notifications[0].FirstAttemptedAt = &timestamp
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST
@@ -688,7 +692,9 @@ func (suite *WebhookClientTestingSuite) Test_EngineRunFailedSubWithSeverity() {
 
 		// Update firstAttemptedTime to be more than one threshold ago
 		durationOffset := time.Duration(engine.SeverityThresholds[1]) * time.Second
-		notifications[0].FirstAttemptedAt = notifications[0].FirstAttemptedAt.Add(-durationOffset)
+		timestamp := *(notifications[0].FirstAttemptedAt)
+		timestamp = timestamp.Add(-durationOffset)
+		notifications[0].FirstAttemptedAt = &timestamp
 		suite.DB().ValidateAndUpdate(&notifications[0])
 
 		// RUN TEST

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -37,6 +37,21 @@ type FeatureFlag struct {
 	Active bool
 }
 
+func (suite *HandlerSuite) TestTruncateAll() {
+
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	fmt.Println("created move", move.ID, move.ContractorID)
+
+	err := suite.DB().TruncateAll()
+	fmt.Println(err)
+	fmt.Println("truncated db")
+
+	foundMove := models.Move{}
+	err = suite.DB().Find(&foundMove, move.ID.String())
+	fmt.Println(err)
+	fmt.Println("found move", foundMove.ID, foundMove.ContractorID)
+}
+
 func (suite *HandlerSuite) TestFetchMTOUpdatesHandler() {
 	// unavailable MTO
 	testdatagen.MakeDefaultMove(suite.DB())

--- a/pkg/models/webhook_notification.go
+++ b/pkg/models/webhook_notification.go
@@ -42,7 +42,7 @@ type WebhookNotification struct {
 	Status           WebhookNotificationStatus `db:"status"`
 	CreatedAt        time.Time                 `db:"created_at"`
 	UpdatedAt        time.Time                 `db:"updated_at"`
-	FirstAttemptedAt time.Time                 `db:"first_attempted_at"`
+	FirstAttemptedAt *time.Time                `db:"first_attempted_at"`
 }
 
 // String is not required by pop and may be deleted


### PR DESCRIPTION
## Description

@carterjones reported that the model did not match the db. Model-vet concurred. 
The db says `firstAttemptedAt` is nullable, but the model had a non-pointer type. 
Fixed by switching model to pointer and cleaning tests. 


## Setup

You can run the tests located here
```
go test ./cmd/webhook-client/webhook -v
```

## References

* [Retry mechanism is documented here](https://docs.google.com/document/d/1tq2jWvuLXEv30Bab2S-nSj9V1bAzLrPk7DZo3xLX9-o/edit#heading=h.fd69p5h0bm30) 

