### PR TITLE
MB-6500 remove the word "logo" from the MilMove alt text in the MilMove Header

### DIFF
--- a/public/static/maintenance.html
+++ b/public/static/maintenance.html
@@ -13,7 +13,7 @@
           <div class="usa-navbar">
             <div class="usa-logo" id="basic-logo">
               <em class="usa-logo__text">
-                <img src="logo.svg" alt="Milmove Logo">
+                <img src="logo.svg" alt="Milmove">
               </em>
             </div>
           </div>

--- a/src/components/MilMoveHeader/index.jsx
+++ b/src/components/MilMoveHeader/index.jsx
@@ -10,7 +10,7 @@ const MilMoveHeader = ({ children, handleLogout, firstName, lastName }) => (
   <div className={styles.mmHeader}>
     <Title>
       <a href="/" title="Home" aria-label="Home">
-        <img src={MmLogo} alt="MilMove Logo" />
+        <img src={MmLogo} alt="MilMove" />
       </a>
     </Title>
     <div className={styles.links}>

--- a/src/shared/Header/MyMove/index.jsx
+++ b/src/shared/Header/MyMove/index.jsx
@@ -72,7 +72,7 @@ function Header() {
               <div className="usa-logo" id="basic-logo">
                 <em className="usa-logo__text">
                   <NavLink to="/" title="my.move.mil" aria-label="my.move.mil">
-                    <img src={MilMoveLogo} alt="MilMove Logo" />
+                    <img src={MilMoveLogo} alt="MilMove" />
                   </NavLink>
                 </em>
               </div>


### PR DESCRIPTION
## Description

As stated in the "Images of Text" documentation in the WCAG, we have an acceptable case with the MilMove logotype. 
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/59394696/106324142-a925ed80-6246-11eb-8cd6-a75b7443d999.png">
We currently provide our users with the alt text of `Milmove Logo`, but the screen reader experience as well as degraded access experience (where low internet speeds could cause images to not load and show their alt text instead) is improved by removing the extraneous "logo" note.

## Reviewer Notes

This is a very low-impact change on the codebase and should have no visual or functional changes aside from what I mentioned above.

## Setup

in the app or storybook, you could inspect in the browser to see the changed alt text, or you could see it in our code changes in this PR.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6500?atlOrigin=eyJpIjoiZmI2ODk3OWIxYjc4NGMxZDllYTJkM2FjOWExNTk2ODciLCJwIjoiaiJ9) for this change
* [Writing Alt Text for Accessibility - Deque](https://www.deque.com/blog/great-alt-text-introduction/) explains more about the approach used.

## Screenshots
<img width="476" alt="image" src="https://user-images.githubusercontent.com/59394696/106324656-83e5af00-6247-11eb-8048-626472241f78.png">

