### PR TITLE
Only set ServiceMemberID in session if app is mil 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,7 +704,11 @@ db_e2e_up: bin/generate-test-data ## Truncate Test DB and Generate e2e (end-to-e
 	@echo "Truncate the ${DB_NAME_TEST} database..."
 	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE;'
 	@echo "Populate the ${DB_NAME_TEST} database..."
-	DB_PORT=$(DB_PORT_TEST) bin/generate-test-data --named-scenario="e2e_basic" --db-env="test"
+	DB_PORT=$(DB_PORT_TEST) go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="e2e_basic" --db-env="test"
+
+.PHONY: rerun_e2e_tests_with_new_data
+rerun_e2e_tests_with_new_data: db_e2e_up
+	$(AWS_VAULT) ./scripts/run-e2e-test
 
 .PHONY: db_e2e_init
 db_e2e_init: db_test_reset db_test_migrate redis_reset db_e2e_up ## Initialize e2e (end-to-end) DB (reset, migrate, up)

--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -65,6 +65,8 @@ describe('Office authorization', () => {
       cy.signInAsMultiRoleOfficeUser();
       cy.wait(['@getGHCClient', '@getMoveOrders']);
       cy.contains('All moves'); // TOO home
+      cy.contains('Spaceman, Leo');
+      cy.contains('LKNQ moves');
 
       cy.contains('Change user role').click();
       cy.url().should('contain', '/select-application');

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -548,7 +548,7 @@ var authorizeKnownUser = func(userIdentity *models.UserIdentity, h CallbackHandl
 		session.Roles = append(session.Roles, role)
 	}
 	session.UserID = userIdentity.ID
-	if userIdentity.ServiceMemberID != nil {
+	if session.IsMilApp() && userIdentity.ServiceMemberID != nil {
 		session.ServiceMemberID = *(userIdentity.ServiceMemberID)
 	}
 

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -676,7 +676,7 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, w 
 		return nil, errors.New("Deactivated user requesting authentication")
 	}
 
-	if userIdentity.ServiceMemberID != nil {
+	if session.IsMilApp() && userIdentity.ServiceMemberID != nil {
 		session.ServiceMemberID = *(userIdentity.ServiceMemberID)
 	}
 

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4211,11 +4211,6 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "last_name": {
-          "type": "string",
-          "readOnly": true,
-          "example": "Doe"
-        },
         "office_user": {
           "x-nullable": true,
           "$ref": "#/definitions/OfficeUser"
@@ -10829,11 +10824,6 @@ func init() {
           "type": "string",
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
-        },
-        "last_name": {
-          "type": "string",
-          "readOnly": true,
-          "example": "Doe"
         },
         "office_user": {
           "x-nullable": true,

--- a/pkg/gen/internalmessages/logged_in_user_payload.go
+++ b/pkg/gen/internalmessages/logged_in_user_payload.go
@@ -33,10 +33,6 @@ type LoggedInUserPayload struct {
 	// Format: uuid
 	ID *strfmt.UUID `json:"id"`
 
-	// last name
-	// Read Only: true
-	LastName string `json:"last_name,omitempty"`
-
 	// office user
 	OfficeUser *OfficeUser `json:"office_user,omitempty"`
 

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -55,7 +55,6 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 		userPayload := internalmessages.LoggedInUserPayload{
 			ID:         handlers.FmtUUID(session.UserID),
 			FirstName:  session.FirstName,
-			LastName:   session.LastName,
 			Email:      session.Email,
 			OfficeUser: payloads.OfficeUser(&officeUser),
 		}

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1974,7 +1974,7 @@ func createTXO(db *pop.Connection) {
 
 	tooTioUUID := uuid.Must(uuid.FromString("9bda91d2-7a0c-4de1-ae02-b8cf8b4b858b"))
 	loginGovUUID := uuid.Must(uuid.NewV4())
-	testdatagen.MakeUser(db, testdatagen.Assertions{
+	user := testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            tooTioUUID,
 			LoginGovUUID:  &loginGovUUID,
@@ -1989,6 +1989,12 @@ func createTXO(db *pop.Connection) {
 			Email:  email,
 			Active: true,
 			UserID: &tooTioUUID,
+		},
+	})
+	testdatagen.MakeServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			User:   user,
+			UserID: user.ID,
 		},
 	})
 

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1945,7 +1945,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	email = "too_tio_role@office.mil"
 	tooTioUUID := uuid.Must(uuid.FromString("9bda91d2-7a0c-4de1-ae02-b8cf8b4b858b"))
 	loginGovID = uuid.Must(uuid.NewV4())
-	testdatagen.MakeUser(db, testdatagen.Assertions{
+	user := testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            tooTioUUID,
 			LoginGovUUID:  &loginGovID,
@@ -1960,6 +1960,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			Email:  email,
 			Active: true,
 			UserID: &tooTioUUID,
+		},
+	})
+	testdatagen.MakeServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			User:   user,
+			UserID: user.ID,
 		},
 	})
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -28,7 +28,7 @@ import { ConnectedSelectApplication } from 'pages/SelectApplication/SelectApplic
 import { roleTypes } from 'constants/userRoles';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
-import { LocationShape, UserRolesShape, UserShape } from 'types/index';
+import { LocationShape, UserRolesShape, OfficeUserInfoShape } from 'types/index';
 import { LogoutUser } from 'utils/api';
 
 // Lazy load these dependencies (they correspond to unique routes & only need to be loaded when that URL is accessed)
@@ -80,7 +80,7 @@ export class OfficeApp extends Component {
       activeRole,
       userIsLoggedIn,
       userRoles,
-      user,
+      officeUser,
       location: { pathname },
       logOut,
     } = this.props;
@@ -158,16 +158,16 @@ export class OfficeApp extends Component {
               <QueueHeader />
             ) : (
               <MilmoveHeader
-                lastName={user.last_name}
-                firstName={user.first_name}
+                lastName={officeUser.last_name}
+                firstName={officeUser.first_name}
                 handleLogout={() => {
                   logOut();
                   LogoutUser();
                 }}
               >
-                {user?.office_user?.transportation_office && (
+                {officeUser.transportation_office && (
                   <Link to="/">
-                    {user?.office_user?.transportation_office.gbloc} {queueText}
+                    {officeUser.transportation_office.gbloc} {queueText}
                   </Link>
                 )}
               </MilmoveHeader>
@@ -236,7 +236,7 @@ OfficeApp.propTypes = {
   userIsLoggedIn: PropTypes.bool,
   userRoles: UserRolesShape,
   activeRole: PropTypes.string,
-  user: UserShape,
+  officeUser: OfficeUserInfoShape,
   logOut: PropTypes.func.isRequired,
 };
 
@@ -245,7 +245,7 @@ OfficeApp.defaultProps = {
   userIsLoggedIn: false,
   userRoles: [],
   activeRole: null,
-  user: {},
+  officeUser: {},
 };
 
 const mapStateToProps = (state) => {
@@ -255,7 +255,7 @@ const mapStateToProps = (state) => {
     userIsLoggedIn: user.isLoggedIn,
     userRoles: user.roles,
     activeRole: state.auth.activeRole,
-    user,
+    officeUser: user.office_user,
   };
 };
 

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -47,6 +47,84 @@ describe('Office App', () => {
     });
   });
 
+  describe('header with TOO user name and GBLOC', () => {
+    const officeUserState = {
+      auth: {
+        activeRole: roleTypes.TOO,
+      },
+      user: {
+        isLoading: false,
+        userInfo: {
+          isLoggedIn: true,
+          roles: [
+            {
+              roleType: roleTypes.TOO,
+            },
+          ],
+          office_user: {
+            first_name: 'Amanda',
+            last_name: 'Gorman',
+            transportation_office: {
+              gbloc: 'ABCD',
+            },
+          },
+        },
+      },
+    };
+
+    describe('after signing in', () => {
+      it('renders the header with the office user name and GBLOC', () => {
+        const app = mount(
+          <MockProviders initialState={officeUserState} initialEntries={['/moves/queue']}>
+            <ConnectedOffice />
+          </MockProviders>,
+        );
+
+        expect(app.containsMatchingElement(<a href="/">ABCD moves</a>)).toEqual(true);
+        expect(app.containsMatchingElement(<span>Gorman, Amanda</span>)).toEqual(true);
+      });
+    });
+  });
+
+  describe('header with TIO user name and GBLOC', () => {
+    const officeUserState = {
+      auth: {
+        activeRole: roleTypes.TIO,
+      },
+      user: {
+        isLoading: false,
+        userInfo: {
+          isLoggedIn: true,
+          roles: [
+            {
+              roleType: roleTypes.TIO,
+            },
+          ],
+          office_user: {
+            first_name: 'Amanda',
+            last_name: 'Gorman',
+            transportation_office: {
+              gbloc: 'ABCD',
+            },
+          },
+        },
+      },
+    };
+
+    describe('after signing in', () => {
+      it('renders the header with the office user name and GBLOC', () => {
+        const app = mount(
+          <MockProviders initialState={officeUserState} initialEntries={['/moves/queue']}>
+            <ConnectedOffice />
+          </MockProviders>,
+        );
+
+        expect(app.containsMatchingElement(<a href="/">ABCD payment requests</a>)).toEqual(true);
+        expect(app.containsMatchingElement(<span>Gorman, Amanda</span>)).toEqual(true);
+      });
+    });
+  });
+
   describe('if the user is logged in with multiple roles', () => {
     const multiRoleState = {
       auth: {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,4 +1,4 @@
-export { UserRoleShape, UserRolesShape, OfficeUserInfoShape, TransportationOfficeShape, UserShape } from './user';
+export { UserRoleShape, UserRolesShape, OfficeUserInfoShape, TransportationOfficeShape } from './user';
 export { AddressShape } from './address';
 export { DutyStationShape } from './dutyStation';
 export { DropdownArrayOf } from './form';

--- a/src/types/user.js
+++ b/src/types/user.js
@@ -23,9 +23,3 @@ export const OfficeUserInfoShape = PropTypes.shape({
   telephone: PropTypes.string,
   transportation_office: TransportationOfficeShape,
 });
-
-export const UserShape = PropTypes.shape({
-  first_name: PropTypes.string,
-  last_name: PropTypes.string,
-  office_user: OfficeUserInfoShape,
-});

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -31,10 +31,6 @@ definitions:
         type: string
         example: John
         readOnly: true
-      last_name:
-        type: string
-        example: Doe
-        readOnly: true
       service_member:
         $ref: '#/definitions/ServiceMemberPayload'
         x-nullable: true


### PR DESCRIPTION
## Description

Recently, we added a header on the Office App to display the Office
User's name and GBLOC. When this was first implemented, the
information was only displaying for some users, but not others. This
information comes from the payload of the `/users/logged_in` endpoint.

The reason why the header wasn't working for some people, namely those
who existed as both service members and office users, is because the
`ShowLoggedInUserHandler` was only returning the Office User info if
`!session.IsServiceMember()`. Unfortunately, this only worked if the
current user had never signed into the service member application.
This is because when an office user signs in (and if they also have a
service member account), we populated the session with their Service
Member ID, which makes `session.IsServiceMember()` return `true`.

So, one reasonable solution, and the simplest one, is to only set the
ServiceMember ID in the session if the current app is the `mil` app.

This essentially reverts #5788 

## Reviewer Notes

This fix should work with existing users. If you already have a user that has both a service member and office user account, sign into the office app, and you should see the banner with your GBLOC and first and last names.

You should also make sure that brand new accounts still work, as well as signing in via devlocal-auth. 

To test with new accounts, follow the steps below:

1. Sign in via login.gov to milmovelocal:3000
- [ ] Verify that you see the OCONUS/CONUS form
2. In a separate terminal tab or window, run `make admin_client_run`. This will launch the admin app
3. Click on `Local Sign In` in the top right
4. Click on `Login` next to any admin user listed
5. Click on Office users in the left sidebar if it's not already selected
6. Click on `+ CREATE` in the top right
7. Fill out your details, making sure to use the same email as the one you used in step 1
8. Select both the `Transportation Ordering Officer` and `Transportation Invoicing Officer` roles
9. Save the user
10. Sign out of the admin app
11. In a separate terminal tab or window, run `make office_client_run`. This will launch the office app
12. Sign in via login.gov
Verify that you see the header with your name and GBLOC

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run # in a separate tab
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

_Please frame screenshots to show enough useful context but also highlight the affected regions._
