### PR TITLE
MB-6138: set the default database user to crud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1352,21 +1352,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1380,28 +1380,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: cj-crud-default
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1352,21 +1352,21 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - deploy_exp_migrations:
           requires:
@@ -1380,28 +1380,28 @@ workflows:
             - push_migrations_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cj-crud-default
 
       - push_app_stg:
           requires:

--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -146,7 +146,7 @@ func InitDatabaseFlags(flag *pflag.FlagSet) {
 	flag.String(DbNameFlag, "dev_db", "Database Name")
 	flag.String(DbHostFlag, "localhost", "Database Hostname")
 	flag.Int(DbPortFlag, 5432, "Database Port")
-	flag.String(DbUserFlag, "postgres", "Database Username")
+	flag.String(DbUserFlag, "crud", "Database Username")
 	flag.String(DbPasswordFlag, "", "Database Password")
 	flag.Int(DbPoolFlag, DbPoolDefault, "Database Pool or max DB connections")
 	flag.Int(DbIdlePoolFlag, DbIdlePoolDefault, "Database Idle Pool or max DB idle connections")


### PR DESCRIPTION
## Description

This PR sets the default for which database role to user for connections. This will apply in the event that a user has not been explicitly defined, such as with the exp/stg/prd environments:

* exp: https://github.com/transcom/mymove/pull/5701
* stg: https://github.com/transcom/mymove/pull/5702
* prd: https://github.com/transcom/mymove/pull/5704

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [x] If the change is risky, it has been [tested in experimental](https://app.circleci.com/pipelines/github/transcom/mymove/26533/workflows/db9a60a1-a3bb-454c-b163-f744efac89d5) before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6138) for this change