### PR TITLE
MB-4392: Delete `docker_compose_up`🗑

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1030,12 +1030,6 @@ docker_compose_setup: .check_hosts.stamp ## Install requirements to use docker-c
 	brew install -f bash git docker docker-compose direnv || true
 	brew cask install -f aws-vault || true
 
-.PHONY: docker_compose_up
-docker_compose_up: ## Bring up docker-compose containers
-	aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-	scripts/update-docker-compose
-	docker-compose up
-
 .PHONY: docker_compose_down
 docker_compose_down: ## Destroy docker-compose containers
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1030,13 +1030,6 @@ docker_compose_setup: .check_hosts.stamp ## Install requirements to use docker-c
 	brew install -f bash git docker docker-compose direnv || true
 	brew cask install -f aws-vault || true
 
-.PHONY: docker_compose_down
-docker_compose_down: ## Destroy docker-compose containers
-	docker-compose down
-	# Instead of using `--rmi all` which might destroy postgres we just remove the AWS containers
-	docker rmi $(shell docker images --filter=reference='*amazonaws*/*:*' --format "{{.ID}}")
-	git checkout docker-compose.yml
-
 #
 # ----- END DOCKER COMPOSE TARGETS -----
 #


### PR DESCRIPTION
## [Delete `docker_compose_up`🗑](https://dp3.atlassian.net/browse/MB-4392)

So the original ticket said to delete the thing, but in the investigplimentory style which is in fashion nowadays, it seems like `docker-compose up` is also called here:

`run-e2e-test-docker`
- https://github.com/transcom/mymove/blob/master/scripts/run-e2e-test-docker#L52
- https://github.com/transcom/mymove/blob/master/scripts/run-e2e-test-docker#L59

Does this matter?