### PR TITLE
[MB-6615] uncommented out line in prime-api-demo script

### DIFF
--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -225,7 +225,7 @@ cat > tmp/pad_create_ddfsit_service_item.json <<- EOM
 }
 EOM
 
-#bin/prime-api-client "${primeapiopts[@]}" create-mto-service-item --filename ./tmp/pad_create_ddfsit_service_item.json > tmp/pad_create_ddfsit_response.json
+bin/prime-api-client "${primeapiopts[@]}" create-mto-service-item --filename ./tmp/pad_create_ddfsit_service_item.json > tmp/pad_create_ddfsit_response.json
 
 printf "The prime fetches mto updates to capture the newly created DDFSIT service item:\n\n"
 


### PR DESCRIPTION
## Description

This PR uncomments out a line in the script that creates the DDFSIT service item

## Setup

```sh
make db_dev_e2e_populate && make server_run
make client_run
prime-api-demo 9c7b255c-2981-4bf8-839f-61c7458e2b4d
```
Go through the flow up to the point where the service items are created. In the office app and the TOO view, find the move with the move code `RDY4PY`. Navigate to the Move Task Order tab and ensure that Dom. Destination First day SIT has been added to the move 

## Acceptance
Run in staging