### PR TITLE
MB-6501 Add aria label to Document Viewer menu

### DIFF
--- a/src/components/DocumentViewer/DocumentViewer.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.jsx
@@ -75,8 +75,8 @@ const DocumentViewer = ({ files }) => {
   return (
     <div className={styles.DocumentViewer}>
       <div className={styles.titleBar}>
-        <Button data-testid="openMenu" type="button" onClick={openMenu} unstyled>
-          <FontAwesomeIcon icon="th-list" aria-label="Open menu" />
+        <Button data-testid="openMenu" type="button" onClick={openMenu} aria-label="Open menu" unstyled>
+          <FontAwesomeIcon icon="th-list" />
         </Button>
 
         <p title={selectedFilename}>{selectedFilename}</p>

--- a/src/components/DocumentViewer/DocumentViewer.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.jsx
@@ -76,7 +76,7 @@ const DocumentViewer = ({ files }) => {
     <div className={styles.DocumentViewer}>
       <div className={styles.titleBar}>
         <Button data-testid="openMenu" type="button" onClick={openMenu} unstyled>
-          <FontAwesomeIcon icon="th-list" />
+          <FontAwesomeIcon icon="th-list" aria-label="Open menu" />
         </Button>
 
         <p title={selectedFilename}>{selectedFilename}</p>


### PR DESCRIPTION
## Description

This branch adds an `aria-label` of `Open menu` to the menu button in the Document Viewer component.

## Reviewer Notes
n/a

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
yarn storybook
```

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6501?atlOrigin=eyJpIjoiNWM3ZDU1NDc0OTVhNGNiMGEzYjIwZDY2YjY1M2U1OWUiLCJwIjoiaiJ9) for this change
* [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.1/button-name?application=axeAPI)

## Screenshots
<img width="741" alt="image" src="https://user-images.githubusercontent.com/59394696/107088694-59f23680-67cb-11eb-8bea-98beb958a3f5.png">
<img width="1780" alt="image" src="https://user-images.githubusercontent.com/59394696/107088717-61b1db00-67cb-11eb-9202-dbce673c10c3.png">
