### PR TITLE
MB-6502 Add aria-label to close button on Modal

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -58,6 +58,7 @@ export const ModalClose = ({ handleClick, className, ...buttonProps }) => (
     unstyled
     className={classnames(styles.ModalClose, className)}
     data-testid="modalCloseButton"
+    aria-label="Close"
     {...buttonProps}
   >
     <FontAwesomeIcon icon="times" />


### PR DESCRIPTION
## Description

This branch adds an `aria label` of `Close` to the **Modal Close** component inside our **Modal** component.

## Reviewer Notes

n/a

## Setup

```sh
yarn storybook
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6502?atlOrigin=eyJpIjoiZDM3N2UxOGMxMzUyNDlmN2E4YzUzYTIxMWMxN2JlYzAiLCJwIjoiaiJ9) for this change
* [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.1/button-name?application=axeAPI) explains more about the approach used.

## Screenshots

<img width="557" alt="image" src="https://user-images.githubusercontent.com/59394696/107089704-13054080-67cd-11eb-9cc0-04f9b3bdd717.png">

<img width="1788" alt="image" src="https://user-images.githubusercontent.com/59394696/107089780-33cd9600-67cd-11eb-908b-b6d779bf7480.png">
