### PR TITLE
MB-6503 Add aria-label to table pagination select

### DIFF
--- a/src/stories/tables.stories.jsx
+++ b/src/stories/tables.stories.jsx
@@ -190,19 +190,19 @@ export const TableElements = () => (
         <div className="tcontrol--pagination">
           <Button disabled className="usa-button--unstyled" onClick={action('clicked')}>
             <span className="icon">
-              <FontAwesomeIcon icon="chevron-left" />
+              <FontAwesomeIcon icon="chevron-left" aria-labelledby="prev-label" />
             </span>
-            <span>Prev</span>
+            <span id="prev-label">Prev</span>
           </Button>
-          <select className="usa-select" name="table-pagination">
+          <select className="usa-select" name="table-pagination" aria-label="select page">
             <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
           </select>
           <Button className="usa-button--unstyled" onClick={action('clicked')}>
-            <span>Next</span>
+            <span id="next-label">Next</span>
             <span className="icon">
-              <FontAwesomeIcon icon="chevron-right" />
+              <FontAwesomeIcon icon="chevron-right" aria-labelledby="next-label" />
             </span>
           </Button>
         </div>
@@ -210,7 +210,7 @@ export const TableElements = () => (
       <div className="sb-table-wrapper">
         <code>rows per page</code>
         <div className="tcontrol--rows-per-page">
-          <select className="usa-select" name="table-rows-per-page">
+          <select className="usa-select" name="table-rows-per-page" aria-label="select rows per page">
             <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>


### PR DESCRIPTION
## Description

This branch adds aria labels to the table pagination examples in Storybook, and the Queue Table component.

## Reviewer Notes

n/a

## Setup

```sh
yarn storybook
```

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6503?atlOrigin=eyJpIjoiOTYwOWFkZTBkM2Y3NDhkZDgxYzFlMDBhZjc5NTZkYjEiLCJwIjoiaiJ9) for this change
* [select element must have an accessible name](https://dequeuniversity.com/rules/axe/4.1/select-name?application=axeAPI) 

## Screenshots
<img width="731" alt="image" src="https://user-images.githubusercontent.com/59394696/107096572-10a8e380-67d9-11eb-8640-352f72b3d353.png">
<img width="1574" alt="image" src="https://user-images.githubusercontent.com/59394696/107096710-56fe4280-67d9-11eb-9de1-7a9e2fb466a5.png">

