### PR TITLE
MB-6656 Support API: Update getMoveTaskOrder to return the IDs needed for createMoveTaskOrder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1366,7 +1366,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - integration_tests:
           requires:
@@ -1380,7 +1380,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: sw-upd-create-mto-for-load-testing
 
       - integration_tests_mtls:
           requires:
@@ -1393,7 +1393,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: sw-upd-create-mto-for-load-testing
 
       - client_test:
           requires:
@@ -1401,7 +1401,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: sw-upd-create-mto-for-load-testing
 
       - server_test:
           requires:
@@ -1409,7 +1409,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: sw-upd-create-mto-for-load-testing
 
       - build_app:
           requires:
@@ -1453,28 +1453,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - deploy_exp_migrations:
           requires:
@@ -1489,35 +1489,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: sw-upd-create-mto-for-load-testing
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1366,7 +1366,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:
@@ -1380,7 +1380,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: sw-upd-create-mto-for-load-testing
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1393,7 +1393,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: sw-upd-create-mto-for-load-testing
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1401,7 +1401,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: sw-upd-create-mto-for-load-testing
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1409,7 +1409,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: sw-upd-create-mto-for-load-testing
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1453,28 +1453,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1489,35 +1489,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: sw-upd-create-mto-for-load-testing
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -114,20 +114,22 @@ func MoveOrder(moveOrder *models.Order) *supportmessages.MoveOrder {
 	issueDate := strfmt.Date(moveOrder.IssueDate)
 
 	payload := supportmessages.MoveOrder{
-		DestinationDutyStation: destinationDutyStation,
-		Entitlement:            Entitlement(moveOrder.Entitlement),
-		Customer:               Customer(&moveOrder.ServiceMember),
-		OrderNumber:            moveOrder.OrdersNumber,
-		OrdersType:             supportmessages.OrdersType(moveOrder.OrdersType),
-		ID:                     strfmt.UUID(moveOrder.ID.String()),
-		OriginDutyStation:      originDutyStation,
-		ETag:                   etag.GenerateEtag(moveOrder.UpdatedAt),
-		Status:                 supportmessages.OrdersStatus(moveOrder.Status),
-		UploadedOrders:         uploadedOrders,
-		UploadedOrdersID:       uploadedOrders.ID,
-		ReportByDate:           &reportByDate,
-		IssueDate:              &issueDate,
-		Tac:                    moveOrder.TAC,
+		DestinationDutyStation:   destinationDutyStation,
+		DestinationDutyStationID: handlers.FmtUUID(moveOrder.NewDutyStationID),
+		Entitlement:              Entitlement(moveOrder.Entitlement),
+		Customer:                 Customer(&moveOrder.ServiceMember),
+		OrderNumber:              moveOrder.OrdersNumber,
+		OrdersType:               supportmessages.OrdersType(moveOrder.OrdersType),
+		ID:                       strfmt.UUID(moveOrder.ID.String()),
+		OriginDutyStation:        originDutyStation,
+		OriginDutyStationID:      handlers.FmtUUID(*moveOrder.OriginDutyStationID),
+		ETag:                     etag.GenerateEtag(moveOrder.UpdatedAt),
+		Status:                   supportmessages.OrdersStatus(moveOrder.Status),
+		UploadedOrders:           uploadedOrders,
+		UploadedOrdersID:         handlers.FmtUUID(moveOrder.UploadedOrdersID),
+		ReportByDate:             &reportByDate,
+		IssueDate:                &issueDate,
+		Tac:                      moveOrder.TAC,
 	}
 
 	if moveOrder.Grade != nil {

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -122,7 +122,6 @@ func MoveOrder(moveOrder *models.Order) *supportmessages.MoveOrder {
 		OrdersType:               supportmessages.OrdersType(moveOrder.OrdersType),
 		ID:                       strfmt.UUID(moveOrder.ID.String()),
 		OriginDutyStation:        originDutyStation,
-		OriginDutyStationID:      handlers.FmtUUID(*moveOrder.OriginDutyStationID),
 		ETag:                     etag.GenerateEtag(moveOrder.UpdatedAt),
 		Status:                   supportmessages.OrdersStatus(moveOrder.Status),
 		UploadedOrders:           uploadedOrders,
@@ -135,11 +134,8 @@ func MoveOrder(moveOrder *models.Order) *supportmessages.MoveOrder {
 	if moveOrder.Grade != nil {
 		payload.Rank = (supportmessages.Rank)(*moveOrder.Grade)
 	}
-	if destinationDutyStation != nil {
-		payload.DestinationDutyStationID = &(destinationDutyStation.ID)
-	}
-	if originDutyStation != nil {
-		payload.OriginDutyStationID = &(originDutyStation.ID)
+	if moveOrder.OriginDutyStationID != nil {
+		payload.OriginDutyStationID = handlers.FmtUUID(*moveOrder.OriginDutyStationID)
 	}
 	return &payload
 }


### PR DESCRIPTION
## Description

This PR updates the Support API endpoint `getMoveTaskOrder` to return the `UploadedOrdersID`, `DestinationDutyStationID`, and the `OriginDutyStationID` fields. This is primarily so Load Testing can hit this endpoint to get all the info it needs from a move to create more moves. This information was not getting populated previously.

## Setup

To test this endpoint, first set up your local dev environment:

```sh
make db_dev_e2e_populate server_run
```

Then, using your preferred Prime API testing method (Postman or the Prime API Client), test the following endpoints in order:

* Prime API: `fetchMTOUpdates`
  * You may think, "Hmm, why didn't we change this endpoint to return these ID values?" We have to be more discerning with what information we send to the Prime, and they don't need to see things like the uploaded orders ID. They also will never need to see the contractor ID (another value we need to get from the move for load testing) because they're the contractor! So we updated the Support API instead.
  * Grab a random move's ID from this list.

* Support API: `getMoveTaskOrder`
  * Hit this endpoint using the ID you grabbed from the previous step. In the response, verify that you see values for:
    * `contractorID`
    * `destinationDutyStationID`
    * `originDutyStationID`
    * `uploadedOrdersID`
  * You can also look up this record in your dev database using a DB viewer to triple-check that the returned values are correct.

And if you want to be super thorough:

* Support API: `createMoveTaskOrder`
  * Verify that you can create a new move using the values for `contractorID`, `destinationDutyStationID`, `originDutyStationID`, `uploadedOrdersID` that you saw in `getMoveTaskOrder`

