### PR TITLE
[MB-6479] Changing region to US Gov West 1 rather than US West 1

### DIFF
--- a/pkg/cli/aws.go
+++ b/pkg/cli/aws.go
@@ -31,7 +31,7 @@ func (e *errUnknownPartition) Error() string {
 
 // InitAWSFlags initializes AWS command line flags
 func InitAWSFlags(flag *pflag.FlagSet) {
-	flag.String(AWSRegionFlag, endpoints.UsWest2RegionID, "The AWS Region")
+	flag.String(AWSRegionFlag, endpoints.UsGovWest1RegionID, "The AWS Region")
 }
 
 // CheckAWSRegion validates the AWS Region command line flags


### PR DESCRIPTION
## Description

It was pointed to US West 1, this points it to US Gov West 1. To test this, a person can deploy_ecs_task which uses this code. I don't have AWS configured on this temporary computer, so I can't do this today. 

Got the region from here https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/