### PR TITLE
[MB-2455] Deny payment requests if previous final payment request was already sent for the move order

### DIFF
--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -110,6 +110,13 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 			logger.Error("Payment Request",
 				zap.Any("payload", payload))
 			return paymentrequestop.NewCreatePaymentRequestUnprocessableEntity().WithPayload(payload)
+		case services.QueryError:
+			if e.Unwrap() != nil {
+				// If you can unwrap, log the internal error (usually a pq error) for better debugging
+				logger.Error("primeapi.CreatePaymentRequestHandler query error", zap.Error(e.Unwrap()))
+			}
+			return paymentrequestop.NewCreatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+
 		case *services.BadDataError:
 			payload := payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceID())
 

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -104,6 +104,12 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 			logger.Error("Payment Request",
 				zap.Any("payload", payload))
 			return paymentrequestop.NewCreatePaymentRequestConflict().WithPayload(payload)
+		case services.InvalidInputError:
+			payload := payloads.ValidationError(err.Error(), h.GetTraceID(), &validate.Errors{})
+
+			logger.Error("Payment Request",
+				zap.Any("payload", payload))
+			return paymentrequestop.NewCreatePaymentRequestUnprocessableEntity().WithPayload(payload)
 		case *services.BadDataError:
 			payload := payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceID())
 

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -59,6 +59,9 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 			if _, ok := err.(services.InvalidInputError); ok {
 				return err
 			}
+			if _, ok := err.(services.QueryError); ok {
+				return err
+			}
 			if errors.As(err, &badDataError) {
 				return err
 			}
@@ -254,10 +257,10 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 
 	// Verify that there were no previous requests that were marked as final
 	var finalPaymentRequests models.PaymentRequests
-	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
+	count, err := tx.Q().Where("move_i = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
 
 	if err != nil {
-		return nil, err
+		return nil, services.NewQueryError("PaymentRequests", err, fmt.Sprintf("Error while querying final payment request for MTO %s: %s", paymentRequest.MoveTaskOrderID, err))
 	}
 
 	if count != 0 {

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -257,7 +257,7 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 
 	// Verify that there were no previous requests that were marked as final
 	var finalPaymentRequests models.PaymentRequests
-	count, err := tx.Q().Where("move_i = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
+	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
 
 	if err != nil {
 		return nil, services.NewQueryError("PaymentRequests", err, fmt.Sprintf("Error while querying final payment request for MTO %s: %s", paymentRequest.MoveTaskOrderID, err))

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -256,6 +256,10 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 	var finalPaymentRequests models.PaymentRequests
 	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
 
+	if err != nil {
+		return nil, err
+	}
+
 	if count != 0 {
 		return nil, services.NewInvalidInputError(moveTaskOrder.ID, nil, nil, fmt.Sprintf("Cannot create PaymentRequest because a final PaymentRequest has already been submitted for MoveTaskOrder (ID: %s)", moveTaskOrder.ID))
 	}

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -56,6 +56,9 @@ func (p *paymentRequestCreator) CreatePaymentRequest(paymentRequestArg *models.P
 			if _, ok := err.(services.ConflictError); ok {
 				return err
 			}
+			if _, ok := err.(services.InvalidInputError); ok {
+				return err
+			}
 			if errors.As(err, &badDataError) {
 				return err
 			}
@@ -247,6 +250,14 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 	// Verify Affiliation
 	if serviceMember.Affiliation == nil || *serviceMember.Affiliation == "" {
 		return nil, services.NewConflictError(moveTaskOrder.Orders.ServiceMemberID, fmt.Sprintf("ServiceMember on MoveTaskOrder (ID: %s) missing Affiliation", moveTaskOrder.ID))
+	}
+
+	// Verify that there were no previous requests that were marked as final
+	var finalPaymentRequests models.PaymentRequests
+	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
+
+	if count != 0 {
+		return nil, services.NewInvalidInputError(moveTaskOrder.ID, nil, nil, fmt.Sprintf("Cannot create PaymentRequest because a final PaymentRequest has already been submitted for MoveTaskOrder (ID: %s)", moveTaskOrder.ID))
 	}
 
 	// Update PaymentRequest

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -257,10 +257,10 @@ func (p *paymentRequestCreator) createPaymentRequestSaveToDB(tx *pop.Connection,
 
 	// Verify that there were no previous requests that were marked as final
 	var finalPaymentRequests models.PaymentRequests
-	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE", paymentRequest.MoveTaskOrderID).Count(&finalPaymentRequests)
+	count, err := tx.Q().Where("move_id = $1 AND is_final = TRUE AND status <> $2", paymentRequest.MoveTaskOrderID, models.PaymentRequestStatusReviewedAllRejected).Count(&finalPaymentRequests)
 
 	if err != nil {
-		return nil, services.NewQueryError("PaymentRequests", err, fmt.Sprintf("Error while querying final payment request for MTO %s: %s", paymentRequest.MoveTaskOrderID, err))
+		return nil, services.NewQueryError("PaymentRequests", err, fmt.Sprintf("Error while querying final payment request for MTO %s: %s", paymentRequest.MoveTaskOrderID, err.Error()))
 	}
 
 	if count != 0 {


### PR DESCRIPTION
## Description

After a final payment request has been submitted for a move, we should not accept any more payment requests for that move.

In this PR, I added a check when creating a payment request to see if there are any payment requests for the same move that already have IsFinal = true. If we find any, we return `InvalidInputError`.

I also a small bug in two tests that prevented them from properly cleaning up after themselves, and broke my test when I tried to put it after them.
They both were backing up a pointer to a string (instead of its value) with the intention of restoring it at the end of the test, which did nothing.

## Reviewer Notes
- I'm never sure if I'm doing pop queries in the classiest way possible.
- I left `verrs` blank because the error doesn't really pertain to specific fields. I think this is probably OK, but I'm wondering if it means we're using the wrong flavor of error here.
 
## Setup
To test this, we have to create a `PaymentRequest` with `isFinal=true` and then create another payment request for the same MTO and verify that the second request fails.

- initial setup
```sh
rm bin/prime-api-client && make bin/prime-api-client
make server_run
```

- create final payment request
`create_final_payment_request.json`
```json
{
  "body": {
    "isFinal": true,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      }
    ]
  }
}
```
```sh
prime-api-client --insecure create-payment-request --filename create_final_payment_request.json
```

- Send another create-payment-request for the same MTO (this one should fail).
`create_next_payment_request.json`
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      }
    ]
  }
}
```
```sh
prime-api-client --insecure create-payment-request --filename create_next_payment_request.json
```
Verify that this command fails with a status code of 422 and the correct error message:
```
HTTP/1.1 422 Unprocessable Entity
...
{"detail":"Cannot create PaymentRequest because a final PaymentRequest has already been submitted for MoveTaskOrder (ID: 9c7b255c-2981-4bf8-839f-61c7458e2b4d)","instance":"1fc03161-bd85-467d-8eaf-a3fb39b281f3","title":"Validation Error","invalidFields":{}}
...
```
## Acceptance
Should be essentially the same as for local, you will just need to find or create a move that has at least 2 service items that you can create payment requests for,
Then create a payment request for one of its service items with `"isFinal": true`,
and then create another payment request for the other service item, and verify that it fails.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2455) for this change
