### PR TITLE
MB-6622 Make doc storage location configurable

### DIFF
--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -160,11 +162,20 @@ func main() {
 		}
 
 		// Initialize storage and uploader
-		zap.L().Info("Using local storage backend")
-		localStorageRoot := v.GetString(cli.LocalStorageRootFlag)
-		localStorageWebRoot := v.GetString(cli.LocalStorageWebRootFlag)
-		fsParams := storage.NewFilesystemParams(localStorageRoot, localStorageWebRoot, logger)
-		storer := storage.NewFilesystem(fsParams)
+		var session *awssession.Session
+
+		c := &aws.Config{
+			Region: aws.String(v.GetString(cli.AWSRegionFlag)),
+		}
+		s, errorSession := awssession.NewSession(c)
+
+		if errorSession != nil {
+			logger.Fatal(errors.Wrap(errorSession, "error creating aws session").Error())
+		}
+
+		session = s
+		storer := storage.InitStorage(v, session, logger)
+
 		userUploader, uploaderErr := uploader.NewUserUploader(dbConnection, logger, storer, 25*uploader.MB)
 		if uploaderErr != nil {
 			logger.Fatal("could not instantiate user uploader", zap.Error(err))
@@ -174,9 +185,9 @@ func main() {
 			logger.Fatal("could not instantiate prime uploader", zap.Error(err))
 		}
 		if namedScenario == tdgs.E2eBasicScenario.Name {
-			tdgs.E2eBasicScenario.Run(dbConnection, userUploader, primeUploader, logger, storer)
+			tdgs.E2eBasicScenario.Run(dbConnection, userUploader, primeUploader, logger)
 		} else if namedScenario == tdgs.DevSeedScenario.Name {
-			tdgs.DevSeedScenario.Run(dbConnection, userUploader, primeUploader, logger, storer)
+			tdgs.DevSeedScenario.Run(dbConnection, userUploader, primeUploader, logger)
 		} else if namedScenario == tdgs.BandwidthScenario.Name {
 			tdgs.BandwidthScenario.Run(dbConnection, userUploader, primeUploader)
 		}

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 	"github.com/transcom/mymove/pkg/uploader"
@@ -2483,7 +2482,7 @@ func createMoveWithUniqueDestinationAddress(db *pop.Connection) {
 }
 
 // Run does that data load thing
-func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, storer *storage.Filesystem) {
+func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger) {
 	// PPM Office Queue
 	createPPMOfficeUser(db)
 	createPPMWithAdvance(db, userUploader)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -16,7 +16,6 @@ import (
 	"github.com/transcom/mymove/pkg/dates"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 	"github.com/transcom/mymove/pkg/uploader"
@@ -36,7 +35,7 @@ var nextValidMoveDatePlusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate
 var nextValidMoveDateMinusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, -10), cal)
 
 // Run does that data load thing
-func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger, storer *storage.Filesystem) {
+func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, logger Logger) {
 	/*
 	 * Basic user with office access
 	 */


### PR DESCRIPTION
This allows uploading files to S3 for bandwidth/network/performance
testing. Read this Wiki article for pre-requisite setup:

https://github.com/transcom/mymove/wiki/Test-Storing-Data-in-S3-in-Devlocal

Then run this command:

```
aws-vault exec transcom-gov-dev -- make db_bandwidth_up
```

While it looks like the docs were uploaded successfully to S3, trying to
view them in the browser results in a 404. I'm not sure if there's a
missing step or some known permissions issue.

This PR is a follow-up to #5835 

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6622) for this change