### PR TITLE
[MB-5432] [CAT III] Property should not be marked as both required and readOnly

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2183,9 +2183,7 @@ func init() {
       "required": [
         "filename",
         "contentType",
-        "bytes",
-        "createdAt",
-        "updatedAt"
+        "bytes"
       ],
       "properties": {
         "bytes": {
@@ -4661,9 +4659,7 @@ func init() {
       "required": [
         "filename",
         "contentType",
-        "bytes",
-        "createdAt",
-        "updatedAt"
+        "bytes"
       ],
       "properties": {
         "bytes": {

--- a/pkg/gen/primemessages/upload.go
+++ b/pkg/gen/primemessages/upload.go
@@ -26,20 +26,18 @@ type Upload struct {
 	ContentType *string `json:"contentType"`
 
 	// created at
-	// Required: true
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"createdAt"`
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// filename
 	// Required: true
 	Filename *string `json:"filename"`
 
 	// updated at
-	// Required: true
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updatedAt"`
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this upload
@@ -92,8 +90,8 @@ func (m *Upload) validateContentType(formats strfmt.Registry) error {
 
 func (m *Upload) validateCreatedAt(formats strfmt.Registry) error {
 
-	if err := validate.Required("createdAt", "body", strfmt.DateTime(m.CreatedAt)); err != nil {
-		return err
+	if swag.IsZero(m.CreatedAt) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
@@ -114,8 +112,8 @@ func (m *Upload) validateFilename(formats strfmt.Registry) error {
 
 func (m *Upload) validateUpdatedAt(formats strfmt.Registry) error {
 
-	if err := validate.Required("updatedAt", "body", strfmt.DateTime(m.UpdatedAt)); err != nil {
-		return err
+	if swag.IsZero(m.UpdatedAt) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -2119,9 +2119,7 @@ func init() {
         "url",
         "filename",
         "contentType",
-        "bytes",
-        "createdAt",
-        "updatedAt"
+        "bytes"
       ],
       "properties": {
         "bytes": {
@@ -4572,9 +4570,7 @@ func init() {
         "url",
         "filename",
         "contentType",
-        "bytes",
-        "createdAt",
-        "updatedAt"
+        "bytes"
       ],
       "properties": {
         "bytes": {

--- a/pkg/gen/supportmessages/upload.go
+++ b/pkg/gen/supportmessages/upload.go
@@ -28,10 +28,9 @@ type Upload struct {
 	ContentType *string `json:"contentType"`
 
 	// created at
-	// Required: true
 	// Read Only: true
 	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"createdAt"`
+	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
 	// filename
 	// Required: true
@@ -47,10 +46,9 @@ type Upload struct {
 	Status string `json:"status,omitempty"`
 
 	// updated at
-	// Required: true
 	// Read Only: true
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updatedAt"`
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
 
 	// url
 	// Required: true
@@ -120,8 +118,8 @@ func (m *Upload) validateContentType(formats strfmt.Registry) error {
 
 func (m *Upload) validateCreatedAt(formats strfmt.Registry) error {
 
-	if err := validate.Required("createdAt", "body", strfmt.DateTime(m.CreatedAt)); err != nil {
-		return err
+	if swag.IsZero(m.CreatedAt) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("createdAt", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
@@ -201,8 +199,8 @@ func (m *Upload) validateStatus(formats strfmt.Registry) error {
 
 func (m *Upload) validateUpdatedAt(formats strfmt.Registry) error {
 
-	if err := validate.Required("updatedAt", "body", strfmt.DateTime(m.UpdatedAt)); err != nil {
-		return err
+	if swag.IsZero(m.UpdatedAt) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1796,8 +1796,6 @@ definitions:
       - filename
       - contentType
       - bytes
-      - createdAt
-      - updatedAt
   ValidationError:
     allOf:
       - $ref: '#/definitions/ClientError'

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1716,8 +1716,6 @@ definitions:
       - filename
       - contentType
       - bytes
-      - createdAt
-      - updatedAt
   ValidationError:
     allOf:
       - $ref: '#/definitions/ClientError'


### PR DESCRIPTION
## Description

Removed createdAt and updatedAt from the required fields on the Upload definition

## Reviewer Notes
- Is this correct? From what I understand, `readOnly` is configuration for responses and `required` is a configuration for requests so I can see why this validation warning exists but are there situations where we would want both?
 
## Setup
`make server_test`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5423) for this change
