### PR TITLE
MB-6604 Populate MilSessionID on first login

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
 )
@@ -383,6 +384,16 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 	}
 
 	switch userType {
+	case MilMoveUserType:
+		newServiceMember := models.ServiceMember{
+			UserID:             user.ID,
+			RequiresAccessCode: h.Context.GetFeatureFlag(cli.FeatureFlagAccessCode),
+		}
+		smVerrs, smErr := models.SaveServiceMember(h.db, &newServiceMember)
+		if smVerrs.HasAny() || smErr != nil {
+			h.logger.Error("Error creating service member for user", zap.Error(smErr))
+			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+		}
 	case PPMOfficeUserType:
 		// Now create the Truss JPPSO
 		address := models.Address{

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -8,8 +8,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
@@ -218,13 +220,24 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
 	req.ParseForm()
 
+	session := auth.Session{
+		ApplicationName: auth.MilApp,
+	}
+	ctx := auth.SetSessionInRequestContext(req, &session)
+
 	sessionManagers := setupSessionManagers()
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort, sessionManagers)
 	handler := NewCreateAndLoginUserHandler(authContext, suite.DB(), appnames)
-
 	rr := httptest.NewRecorder()
-	milSession.LoadAndSave(handler).ServeHTTP(rr, req)
+	milSession.LoadAndSave(handler).ServeHTTP(rr, req.WithContext(ctx))
+
+	serviceMemberID := session.ServiceMemberID
+	serviceMember, _ := models.FetchServiceMemberForUser(ctx, suite.DB(), &session, serviceMemberID)
+
+	suite.NotEqual(uuid.Nil, serviceMemberID)
+	suite.NotEqual(uuid.Nil, serviceMember.UserID)
+	suite.Equal(false, serviceMember.RequiresAccessCode)
 
 	suite.Equal(http.StatusSeeOther, rr.Code, "handler returned wrong status code")
 	if status := rr.Code; status != http.StatusSeeOther {

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -119,7 +119,7 @@ func (h CreateServiceMemberHandler) Handle(params servicememberop.CreateServiceM
 		RequiresAccessCode:   h.HandlerContext.GetFeatureFlag(cli.FeatureFlagAccessCode),
 		DutyStationID:        stationID,
 	}
-	smVerrs, err := models.SaveServiceMember(ctx, h.DB(), &newServiceMember)
+	smVerrs, err := models.SaveServiceMember(h.DB(), &newServiceMember)
 	if smVerrs.HasAny() || err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -189,7 +189,7 @@ func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMem
 	if verrs, err := h.patchServiceMemberWithPayload(ctx, &serviceMember, payload); verrs.HasAny() || err != nil {
 		return handlers.ResponseForVErrors(logger, verrs, err)
 	}
-	if verrs, err := models.SaveServiceMember(ctx, h.DB(), &serviceMember); verrs.HasAny() || err != nil {
+	if verrs, err := models.SaveServiceMember(h.DB(), &serviceMember); verrs.HasAny() || err != nil {
 		return handlers.ResponseForVErrors(logger, verrs, err)
 	}
 

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -145,7 +145,7 @@ func FetchServiceMember(db *pop.Connection, id uuid.UUID) (ServiceMember, error)
 }
 
 // SaveServiceMember takes a serviceMember with Address structs and coordinates saving it all in a transaction
-func SaveServiceMember(ctx context.Context, dbConnection *pop.Connection, serviceMember *ServiceMember) (*validate.Errors, error) {
+func SaveServiceMember(dbConnection *pop.Connection, serviceMember *ServiceMember) (*validate.Errors, error) {
 
 	responseVErrors := validate.NewErrors()
 	var responseError error


### PR DESCRIPTION
## Description

This PR fixes a bug where the `current_mil_session_id` field in the
Users table was not being populated on the very first sign in. That
meant that we couldn't revoke a User's session unless they signed out
and back in.

The reason why the field was not being populated is because this action
depended on `session.IsServiceMember()` being `true`. The Users table
has session fields for all three apps (mil, admin, office), and the
auth code determines which field to populate based on the type of user.

The problem was that `IsServiceMember` is only true if the session
contains the ID of the service member tied to the user, but the
service member was not created until after the authentication was
complete. The auth function only created the user, then redirected to
the onboarding home page, which then created the service member (this
happens in `src/sagas/onboarding.js`).

In this PR, the auth code now creates the service member right after
creating the user, and it populates the session with `ServiceMemberID`,
which allows `session.IsServiceMember()` to be `true`, and populates
the `current_mil_session_id` field.

## Reviewer Notes

To verify locally:

1. Run `psql-dev`
2. Run `TRUNCATE users CASCADE;`
3. Run `\q` to exit psql
4. Run `make server_run` and `make client_run`
5. Sign in using the regular sign in button that goes through login.gov
6. Enter your login.gov credentials
7. After successful sign in, using your preferred DB inspection method (psql, TablePlus, etc.), verify that your entry in the user's table has a `current_mil_session_id` field that is not empty.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6604) for this change