### PR TITLE
MB-6673 Speed and clean up common Make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,6 +520,37 @@ db_dev_migrate: db_dev_migrate_standalone ## Migrate Dev DB
 db_dev_psql: ## Open PostgreSQL shell for Dev DB
 	scripts/psql-dev
 
+.PHONY: db_dev_fresh
+db_dev_fresh: db_dev_reset db_dev_migrate
+	@echo "Ensure that you're running the correct APPLICATION..."
+	./scripts/ensure-application app
+	@echo "Populate the ${DB_NAME_DEV} database..."
+	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development"
+
+.PHONY: db_dev_e2e_populate
+db_dev_e2e_populate: db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
+	@echo "Ensure that you're running the correct APPLICATION..."
+	./scripts/ensure-application app
+	@echo "Truncate the ${DB_NAME_DEV} database..."
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_DEV)/$(DB_NAME_DEV)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE;'
+	@echo "Populate the ${DB_NAME_DEV} database..."
+	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development"
+
+## Alias for db_dev_bandwidth_up
+## We started with `db_bandwidth_up`, which some folks are already using, and
+## then renamed it to `db_dev_bandwidth_up`. To allow folks to keep using the
+## name they're familiar with, we've added this alias to the renamed command.
+.PHONY: db_bandwidth_up
+db_bandwidth_up: db_dev_bandwidth_up
+
+.PHONY: db_dev_bandwidth_up
+db_dev_bandwidth_up: bin/generate-test-data	 ## Truncate Dev DB and Generate data for bandwidth tests
+	@echo "Ensure that you're running the correct APPLICATION..."
+	./scripts/ensure-application app
+	@echo "Truncate the ${DB_NAME_DEV} database..."
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_DEV)/$(DB_NAME_DEV)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE;'
+	@echo "Populate the ${DB_NAME_DEV} database..."
+	DB_PORT=$(DB_PORT_DEV) go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="bandwidth" --db-env="development"
 #
 # ----- END DB_DEV TARGETS -----
 #
@@ -661,7 +692,11 @@ db_test_psql: ## Open PostgreSQL shell for Test DB
 #
 
 .PHONY: e2e_test
-e2e_test: bin/gin server_generate server_build client_build db_e2e_init ## Run e2e (end-to-end) integration tests
+e2e_test: db_test_migrate db_e2e_up ## Run e2e (end-to-end) integration tests
+	$(AWS_VAULT) ./scripts/run-e2e-test
+
+.PHONY: e2e_test_fresh ## Build everything from scratch before running tests
+e2e_test_fresh: bin/gin server_generate server_build client_build db_e2e_init
 	$(AWS_VAULT) ./scripts/run-e2e-test
 
 .PHONY: e2e_mtls_test_docker
@@ -698,18 +733,9 @@ db_e2e_up: bin/generate-test-data ## Truncate Test DB and Generate e2e (end-to-e
 	@echo "Ensure that you're running the correct APPLICATION..."
 	./scripts/ensure-application app
 	@echo "Truncate the ${DB_NAME_TEST} database..."
-	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE;'
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE;'
 	@echo "Populate the ${DB_NAME_TEST} database..."
 	DB_PORT=$(DB_PORT_TEST) go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="e2e_basic" --db-env="test"
-
-.PHONY: db_bandwidth_up
-db_bandwidth_up: bin/generate-test-data	 ## Truncate Dev DB and Generate data for bandwidth tests
-	@echo "Ensure that you're running the correct APPLICATION..."
-	./scripts/ensure-application app
-	@echo "Truncate the ${DB_NAME_DEV} database..."
-	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_DEV)/$(DB_NAME_DEV)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE;'
-	@echo "Populate the ${DB_NAME_DEV} database..."
-	DB_PORT=$(DB_PORT_DEV) go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="bandwidth" --db-env="development"
 
 .PHONY: rerun_e2e_tests_with_new_data
 rerun_e2e_tests_with_new_data: db_e2e_up
@@ -717,16 +743,6 @@ rerun_e2e_tests_with_new_data: db_e2e_up
 
 .PHONY: db_e2e_init
 db_e2e_init: db_test_reset db_test_migrate redis_reset db_e2e_up ## Initialize e2e (end-to-end) DB (reset, migrate, up)
-
-.PHONY: db_dev_e2e_populate
-db_dev_e2e_populate: db_dev_reset db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
-	@echo "Ensure that you're running the correct APPLICATION..."
-	./scripts/ensure-application app
-	@echo "Populate the ${DB_NAME_DEV} database with docker command..."
-	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development"
-
-.PHONY: db_test_e2e_populate
-db_test_e2e_populate: db_test_reset db_test_migrate redis_reset build_tools db_e2e_up ## Populate Test DB with generated e2e (end-to-end) data
 
 .PHONY: db_test_e2e_backup
 db_test_e2e_backup: ## Backup Test DB as 'e2e_test'
@@ -909,7 +925,7 @@ webhook_client_start_standalone:
 		$(WEBHOOK_CLIENT_DOCKER_CONTAINER):latest
 
 .PHONY: webhook_client_test
-webhook_client_test: db_test_e2e_populate webhook_client_test_standalone
+webhook_client_test: db_e2e_init webhook_client_test_standalone
 
 .PHONY: webhook_client_test
 webhook_client_test_standalone:

--- a/README.md
+++ b/README.md
@@ -389,15 +389,18 @@ There are a few handy targets in the Makefile to help you run tests:
 
 * `make client_test`: Run front-end testing suites.
 * `make server_test`: Run back-end testing suites. [Additional info for running go tests](https://github.com/transcom/mymove/wiki/run-go-tests)
-* `make e2e_test`: Run e2e testing suite.
-  * Note: this will not necessarily reflect the same results as in the CI environment, run with caution. One of the reasons for this is it's pulling actual cypress latest, which as of this writing is `5.0.0`. Another reason is your `.envrc` is going to populate your dev environment with a bunch of values that `make e2e_test_docker` won't have.
-  * Note also: this runs with a full clean/rebuild, so it is not great for fast iteration. Use `yarn test:e2e` when working with individual tests
-* `yarn test:e2e`: Open the cypress test runner against your already running servers and inspect/run individual e2e tests. (Should better reflect CI environment than above, but not as well as below.)
-  * Note: You must already have the servers running for this to work! This may not reflect the same results as CI for the same reason as the above re: `.envrc` values. However, it is __significantly__ faster because you can run individual tests and not have to deal with the clean/rebuild.
-* `yarn test:e2e-clean`: Resets your dev DB to a clean state before opening the Cypress test runner.
+* `make e2e_test`: Run end-to-end testing suite. [Additional info for running E2E tests](https://github.com/transcom/mymove/wiki/run-e2e-tests)
+  * Note: this will not necessarily reflect the same results as in the CI
+  environment, run with caution. One is your `.envrc` is going to
+  populate your dev environment with a bunch of values that `make e2e_test_docker`
+  won't have.
 * `make e2e_test_docker`: Run e2e testing suite in the same docker container as is run in CircleCI.
-  * Note: this also runs with a full clean/rebuild, so it is not great for fast iteration. Use `yarn test:e2e` when working with individual tests.
+  * Note: this runs with a full clean/rebuild, so it is not great for fast iteration.
+  Use `make e2e_test` to pick individual tests from the Cypress UI.
 * `make test`: Run e2e, client- and server-side testing suites.
+* `yarn test:e2e`: Useful for debugging. This opens the cypress test runner
+against your already running dev servers and inspect/run individual e2e tests.
+  * Note: You must already have the servers running for this to work!
 
 #### Troubleshooting tips -- integration / e2e tests
 
@@ -431,25 +434,40 @@ A few commands exist for starting and stopping the DB docker container:
 
 #### Dev DB Commands
 
-There are a few handy targets in the Makefile to help you interact with the dev database:
+There are a few handy targets in the Makefile to help you interact with the dev
+database. During your day-to-day, the only one you will typically need regularly
+is `make db_dev_e2e_populate`. The others are for reference, or if something
+goes wrong.
 
-* `make db_dev_run`: Initializes a new database if it does not exist and runs it, or starts the previously initialized Docker container if it has been stopped.
-* `make db_dev_create`: Waits to connect to the DB and will create a DB if one doesn't already exist (run usually as part of `db_dev_run`).
-* `make db_dev_reset`: Destroys your database container. Useful if you want to start from scratch.
-* `make db_dev_migrate`: Applies database migrations against your running database container.
-* `make db_dev_migrate_standalone`: Applies database migrations against your running database container but will not check for server dependencies first.
-* `make db_dev_e2e_populate`: Populate data with data used to run e2e tests
+* `make db_dev_e2e_populate`: Populates the dev DB with data to facilitate
+verification of your work when using the app locally. It seeds the DB with various
+service members at different stages of the onboarding process, various office
+users, moves, payment requests, etc. The data is defined in the `devseed.go` file.
+* `make db_dev_run`: Initializes a new database if it does not exist and runs it,
+or starts the previously initialized Docker container if it has been stopped.
+You typically only need this after a computer restart, or if you manually quit
+Docker or otherwise stopped the DB.
+* `make db_dev_create`: Waits to connect to the DB and will create a DB if one
+doesn't already exist (this is automatically run as part of `db_dev_run`).
+* `make db_dev_fresh`: Destroys your database container, runs the DB, and
+applies the migrations. Useful if you want to start from scratch when the DB is
+not working properly. This runs `db_dev_reset` and `db_dev_migrate`.
+* `make db_dev_migrate_standalone`: Applies database migrations against your
+running database container but will not check for server dependencies first.
+
 
 #### Test DB Commands
 
-The Dev Commands are used to talk to the dev DB.  If you were working with the test DB you would use these commands:
+These commands are available for the Test DB. You will rarely need to use these
+individually since the commands to run tests already set up the test DB properly.
+One exception is `make db_test_run`, which you'll need to run after restarting
+your computer.
 
 * `make db_test_run`
 * `make db_test_create`
 * `make db_test_reset`
 * `make db_test_migrate`
 * `make db_test_migrate_standalone`
-* `make db_test_e2e_populate`
 * `make db_test_e2e_backup`
 * `make db_test_e2e_restore`
 * `make db_test_e2e_cleanup`

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "test:debug": "react-scripts --inspect-brk test --runInBand --env=jsdom",
     "test:coverage": "react-scripts test --coverage --env=jsdom --watchAll=false --coverageDirectory=coverage --runInBand",
     "test:e2e": "cypress open --config baseUrl=http://milmovelocal:3000 --env testClientPort=3000",
-    "test:e2e-clean": "make db_dev_e2e_populate; yarn test:e2e",
     "test:e2e-debug": "DEBUG=cypress:server:util:process_profiler cypress open --config baseUrl=http://milmovelocal:3000 --env testClientPort=3000",
     "test:e2e-clean-debug": "make db_dev_e2e_populate; DEBUG=cypress:server:util:process_profiler cypress open --config baseUrl=http://milmovelocal:3000 --env testClientPort=3000",
     "prettier": "prettier --write --loglevel warn 'src/**/*.{js,jsx}'",

--- a/scripts/make-test
+++ b/scripts/make-test
@@ -16,7 +16,6 @@ make clean build_tools
 # Test DB
 
 make db_dev_reset db_dev_migrate db_dev_e2e_populate
-make db_test_reset db_test_migrate db_test_e2e_populate
 make db_deployed_migrations_reset db_deployed_migrations_migrate
 
 # Test e2e Init

--- a/scripts/run-e2e-test
+++ b/scripts/run-e2e-test
@@ -5,9 +5,6 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
-# Make a backup of the e2e DB
-make db_test_e2e_backup
-
 CYPRESS_PORT=4000
 DB_ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_ENABLED=1 NO_TLS_PORT="$CYPRESS_PORT" \
     ./bin/gin \
@@ -21,6 +18,3 @@ npx cypress open || true
 
 # Terminate the background webserver
 kill %1
-
-# Remvoe the backup of the e2e DB
-make db_test_e2e_cleanup


### PR DESCRIPTION
## Description

This PR updates `db_dev_e2e_populate` so that instead of resetting and
migrating the DB from scratch, it runs only the missing migrations, if
any, then truncates the tables. This saves 3 minutes each time you
run it. The vast majority of the time that someone runs this command,
their local dev DB is already set up, so it doesn't make sense to
destroy the DB and rebuild it from scratch when all you need is to
clear the tables and repopulate them.

And in the case where you do need to start from scratch for some reason,
this PR introduces a `db_dev_fresh` command that will reset the DB and
run all the migrations.

To follow this pattern, I updated the existing `e2e_test` script so
that it only clears the test DB tables and repopulates them, which
makes it a whole lot faster to rerun end-to-end tests with fresh data.
And in the case where you do need to start from scratch, I introduced
the `e2e_fresh` script that does what `e2e_test` used to do.

I also moved `db_dev_e2e_populate` to the `DB_DEV TARGETS` section,
where it belongs since it's used to populate the Dev DB, and not for
running automated E2E tests.

## Reviewer Notes

Run `make db_dev_e2e_populate` and `make e2e_test`. They should take about 15 seconds to run, not 3 minutes+.

Run `make db_dev_fresh` and `make e2e_test_fresh`. These should destroy the DB and run all the migrations from scratch.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6673) for this change