### PR TITLE
Remove unused context function argument

### DIFF
--- a/cmd/milmove-tasks/send_payment_reminder_email.go
+++ b/cmd/milmove-tasks/send_payment_reminder_email.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -117,7 +116,6 @@ func sendPaymentReminder(cmd *cobra.Command, args []string) error {
 		logger.Fatal("Connecting to DB", zap.Error(err))
 	}
 
-	ctx := context.TODO()
 	notificationSender, notificationSenderErr := notifications.InitEmail(v, session, logger)
 	if notificationSenderErr != nil {
 		logger.Fatal("notification sender sending not enabled", zap.Error(notificationSenderErr))
@@ -128,7 +126,7 @@ func sendPaymentReminder(cmd *cobra.Command, args []string) error {
 		logger.Fatal("initializing MoveReviewed", zap.Error(err))
 	}
 
-	err = notificationSender.SendNotification(ctx, movePaymentReminderNotifier)
+	err = notificationSender.SendNotification(movePaymentReminderNotifier)
 	if err != nil {
 		logger.Fatal("Emails failed to send", zap.Error(err))
 	}

--- a/cmd/milmove-tasks/send_post_move_survey_email.go
+++ b/cmd/milmove-tasks/send_post_move_survey_email.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -127,7 +126,6 @@ func sendPostMoveSurvey(cmd *cobra.Command, args []string) error {
 		logger.Fatal("Connecting to DB", zap.Error(err))
 	}
 
-	ctx := context.TODO()
 	targetDate := time.Now().AddDate(0, 0, -offsetDays)
 	notificationSender, notificationSenderErr := notifications.InitEmail(v, session, logger)
 	if notificationSenderErr != nil {
@@ -138,7 +136,7 @@ func sendPostMoveSurvey(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		logger.Fatal("initializing MoveReviewed", zap.Error(err))
 	}
-	err = notificationSender.SendNotification(ctx, moveReviewedNotifier)
+	err = notificationSender.SendNotification(moveReviewedNotifier)
 	if err != nil {
 		logger.Fatal("Emails failed to send", zap.Error(err))
 	}

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -1,7 +1,6 @@
 package awardqueue
 
 import (
-	"context"
 	"log"
 	"testing"
 	"time"
@@ -69,7 +68,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 		}
 	}
 
-	err := queue.assignPerformanceBands(context.Background())
+	err := queue.assignPerformanceBands()
 
 	if err != nil {
 		t.Errorf("Failed to assign to performance bands: %v", err)
@@ -102,13 +101,12 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 }
 
 func (suite *AwardQueueSuite) Test_waitForLock() {
-	ctx := context.Background()
 	ret := make(chan int)
 	lockID := 1
 
 	go func() {
 		suite.DB().Transaction(func(tx *pop.Connection) error {
-			suite.Nil(waitForLock(ctx, tx, lockID))
+			suite.Nil(waitForLock(tx, lockID))
 			time.Sleep(time.Second)
 			ret <- 1
 			return nil
@@ -118,7 +116,7 @@ func (suite *AwardQueueSuite) Test_waitForLock() {
 	go func() {
 		suite.DB().Transaction(func(tx *pop.Connection) error {
 			time.Sleep(time.Millisecond * 500)
-			suite.Nil(waitForLock(ctx, tx, lockID))
+			suite.Nil(waitForLock(tx, lockID))
 			ret <- 2
 			return nil
 		})

--- a/pkg/handlers/ghcapi/documents.go
+++ b/pkg/handlers/ghcapi/documents.go
@@ -43,9 +43,6 @@ type GetDocumentHandler struct {
 
 // Handle creates a new Document from a request payload
 func (h GetDocumentHandler) Handle(params documentop.GetDocumentParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
@@ -53,7 +50,7 @@ func (h GetDocumentHandler) Handle(params documentop.GetDocumentParams) middlewa
 		return handlers.ResponseForError(logger, err)
 	}
 
-	document, err := models.FetchDocument(ctx, h.DB(), session, documentID, false)
+	document, err := models.FetchDocument(h.DB(), session, documentID, false)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/internalapi/backup_contacts.go
+++ b/pkg/handlers/internalapi/backup_contacts.go
@@ -38,7 +38,7 @@ func (h CreateBackupContactHandler) Handle(params backupop.CreateServiceMemberBa
 	session, logger := h.SessionAndLoggerFromContext(ctx)
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -63,13 +63,11 @@ type IndexBackupContactsHandler struct {
 
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexBackupContactsHandler) Handle(params backupop.IndexServiceMemberBackupContactsParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/internalapi/documents.go
+++ b/pkg/handlers/internalapi/documents.go
@@ -43,8 +43,6 @@ type CreateDocumentHandler struct {
 
 // Handle creates a new Document from a request payload
 func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	serviceMemberID, err := uuid.FromString(params.DocumentPayload.ServiceMemberID.String())
@@ -53,7 +51,7 @@ func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) mi
 	}
 
 	// Fetch to check auth
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -86,9 +84,6 @@ type ShowDocumentHandler struct {
 
 // Handle creates a new Document from a request payload
 func (h ShowDocumentHandler) Handle(params documentop.ShowDocumentParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
@@ -96,7 +91,7 @@ func (h ShowDocumentHandler) Handle(params documentop.ShowDocumentParams) middle
 		return handlers.ResponseForError(logger, err)
 	}
 
-	document, err := models.FetchDocument(ctx, h.DB(), session, documentID, false)
+	document, err := models.FetchDocument(h.DB(), session, documentID, false)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/internalapi/entitlements.go
+++ b/pkg/handlers/internalapi/entitlements.go
@@ -52,9 +52,6 @@ type ValidateEntitlementHandler struct {
 
 // Handle is the handler
 func (h ValidateEntitlementHandler) Handle(params entitlementop.ValidateEntitlementParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
@@ -67,7 +64,7 @@ func (h ValidateEntitlementHandler) Handle(params entitlementop.ValidateEntitlem
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, orders.ServiceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/internalapi/generic_move_documents.go
+++ b/pkg/handlers/internalapi/generic_move_documents.go
@@ -38,9 +38,6 @@ type CreateGenericMoveDocumentHandler struct {
 
 // Handle is the handler
 func (h CreateGenericMoveDocumentHandler) Handle(params movedocop.CreateGenericMoveDocumentParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
@@ -62,7 +59,7 @@ func (h CreateGenericMoveDocumentHandler) Handle(params movedocop.CreateGenericM
 	userUploads := models.UserUploads{}
 	for _, id := range uploadIds {
 		convertedUploadID := uuid.Must(uuid.FromString(id.String()))
-		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(ctx, h.DB(), session, convertedUploadID)
+		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(h.DB(), session, convertedUploadID)
 		if fetchUploadErr != nil {
 			return handlers.ResponseForError(logger, fetchUploadErr)
 		}

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -158,8 +158,6 @@ type SubmitMoveHandler struct {
 
 // Handle ... submit a move for approval
 func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	/* #nosec UUID is pattern matched by swagger which checks the format */
@@ -188,7 +186,6 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	err = h.NotificationSender().SendNotification(
-		ctx,
 		notifications.NewMoveSubmitted(h.DB(), logger, session, moveID),
 	)
 	if err != nil {

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -43,8 +43,6 @@ type CreateMovingExpenseDocumentHandler struct {
 
 // Handle is the handler
 func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMovingExpenseDocumentParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
@@ -69,7 +67,7 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 	userUploads := models.UserUploads{}
 	for _, id := range uploadIds {
 		convertedUploadID := uuid.Must(uuid.FromString(id.String()))
-		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(ctx, h.DB(), session, convertedUploadID)
+		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(h.DB(), session, convertedUploadID)
 		if fetchUploadErr != nil {
 			return handlers.ResponseForError(logger, fetchUploadErr)
 		}

--- a/pkg/handlers/internalapi/office.go
+++ b/pkg/handlers/internalapi/office.go
@@ -67,9 +67,6 @@ type CancelMoveHandler struct {
 
 // Handle ... cancels a Move from a request payload
 func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	if !session.IsOfficeUser() {
 		return officeop.NewCancelMoveForbidden()
@@ -97,7 +94,6 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	}
 
 	err = h.NotificationSender().SendNotification(
-		ctx,
 		notifications.NewMoveCanceled(h.DB(), logger, session, moveID),
 	)
 
@@ -120,8 +116,6 @@ type ApprovePPMHandler struct {
 
 // Handle ... approves a Personally Procured Move from a request payload
 func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	if !session.IsOfficeUser() {
 		return officeop.NewApprovePPMForbidden()
@@ -151,7 +145,6 @@ func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.R
 	}
 
 	err = h.NotificationSender().SendNotification(
-		ctx,
 		notifications.NewMoveApproved(h.DB(), logger, session, h.HandlerContext.AppNames().MilServername, moveID),
 	)
 	if err != nil {

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -67,9 +67,6 @@ type CreateOrdersHandler struct {
 
 // Handle ... creates new Orders from a request payload
 func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	payload := params.CreateOrders
@@ -78,7 +75,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -70,7 +70,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		}
 
 		// Fetch document to ensure user has access to it
-		document, docErr := models.FetchDocument(ctx, h.DB(), session, documentID, true)
+		document, docErr := models.FetchDocument(h.DB(), session, documentID, true)
 		if docErr != nil {
 			return handlers.ResponseForError(logger, docErr)
 		}
@@ -114,13 +114,10 @@ type DeleteUploadHandler struct {
 
 // Handle deletes an upload
 func (h DeleteUploadHandler) Handle(params uploadop.DeleteUploadParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	uploadID, _ := uuid.FromString(params.UploadID.String())
-	userUpload, err := models.FetchUserUploadFromUploadID(ctx, h.DB(), session, uploadID)
+	userUpload, err := models.FetchUserUploadFromUploadID(h.DB(), session, uploadID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -143,9 +140,6 @@ type DeleteUploadsHandler struct {
 
 // Handle deletes uploads
 func (h DeleteUploadsHandler) Handle(params uploadop.DeleteUploadsParams) middleware.Responder {
-
-	ctx := params.HTTPRequest.Context()
-
 	// User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	userUploader, err := uploaderpkg.NewUserUploader(h.DB(), logger, h.FileStorer(), 25*uploaderpkg.MB)
@@ -155,7 +149,7 @@ func (h DeleteUploadsHandler) Handle(params uploadop.DeleteUploadsParams) middle
 
 	for _, uploadID := range params.UploadIds {
 		uploadUUID, _ := uuid.FromString(uploadID.String())
-		userUpload, err := models.FetchUserUploadFromUploadID(ctx, h.DB(), session, uploadUUID)
+		userUpload, err := models.FetchUserUploadFromUploadID(h.DB(), session, uploadUUID)
 		if err != nil {
 			return handlers.ResponseForError(logger, err)
 		}

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -37,8 +37,6 @@ func decoratePayloadWithRoles(s *auth.Session, p *internalmessages.LoggedInUserP
 
 // Handle returns the logged in user
 func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) middleware.Responder {
-	ctx := params.HTTPRequest.Context()
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	if !session.IsServiceMember() {
@@ -63,7 +61,7 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 	}
 
 	// Load Servicemember and first level associations
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, session.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, session.ServiceMemberID)
 
 	if err != nil {
 		logger.Error("Error retrieving service_member", zap.Error(err))

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -85,10 +85,7 @@ type CreateWeightTicketSetDocumentHandler struct {
 
 // Handle is the handler for CreateWeightTicketSetDocumentHandler
 func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeightTicketDocumentParams) middleware.Responder {
-
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-
-	ctx := params.HTTPRequest.Context()
 
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
@@ -104,7 +101,7 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 	userUploads := models.UserUploads{}
 	for _, id := range uploadIds {
 		convertedUploadID := uuid.Must(uuid.FromString(id.String()))
-		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(ctx, h.DB(), session, convertedUploadID)
+		userUpload, fetchUploadErr := models.FetchUserUploadFromUploadID(h.DB(), session, convertedUploadID)
 		if fetchUploadErr != nil {
 			return handlers.ResponseForError(logger, fetchUploadErr)
 		}

--- a/pkg/handlers/ordersapi/post_revision.go
+++ b/pkg/handlers/ordersapi/post_revision.go
@@ -87,7 +87,7 @@ func (h PostRevisionHandler) Handle(params ordersoperations.PostRevisionParams) 
 			Revisions:    []models.ElectronicOrdersRevision{},
 		}
 		newRevision = toElectronicOrdersRevision(orders, params.Revision)
-		verrs, err = models.CreateElectronicOrderWithRevision(ctx, h.DB(), orders, newRevision)
+		verrs, err = models.CreateElectronicOrderWithRevision(h.DB(), orders, newRevision)
 	} else if err != nil {
 		return handlers.ResponseForError(logger, err)
 	} else if orders.Edipi != edipi {
@@ -110,7 +110,7 @@ func (h PostRevisionHandler) Handle(params ordersoperations.PostRevisionParams) 
 		}
 
 		newRevision = toElectronicOrdersRevision(orders, params.Revision)
-		verrs, err = models.CreateElectronicOrdersRevision(ctx, h.DB(), newRevision)
+		verrs, err = models.CreateElectronicOrdersRevision(h.DB(), newRevision)
 	}
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(logger, verrs, err)

--- a/pkg/handlers/ordersapi/post_revision_to_orders.go
+++ b/pkg/handlers/ordersapi/post_revision_to_orders.go
@@ -59,7 +59,7 @@ func (h PostRevisionToOrdersHandler) Handle(params ordersoperations.PostRevision
 	}
 
 	newRevision := toElectronicOrdersRevision(orders, params.Revision)
-	verrs, err := models.CreateElectronicOrdersRevision(ctx, h.DB(), newRevision)
+	verrs, err := models.CreateElectronicOrdersRevision(h.DB(), newRevision)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(logger, verrs, err)
 	}

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
@@ -37,7 +36,7 @@ func (d *Document) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchDocument returns a document if the user has access to that document
-func FetchDocument(ctx context.Context, db *pop.Connection, session *auth.Session, id uuid.UUID, includeDeletedDocs bool) (Document, error) {
+func FetchDocument(db *pop.Connection, session *auth.Session, id uuid.UUID, includeDeletedDocs bool) (Document, error) {
 	var document Document
 	query := db.Q()
 
@@ -58,7 +57,7 @@ func FetchDocument(ctx context.Context, db *pop.Connection, session *auth.Sessio
 		return Document{}, err
 	}
 
-	_, smErr := FetchServiceMemberForUser(ctx, db, session, document.ServiceMemberID)
+	_, smErr := FetchServiceMemberForUser(db, session, document.ServiceMemberID)
 	if smErr != nil {
 		return Document{}, smErr
 	}

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -44,8 +43,6 @@ func (suite *ModelSuite) Test_DocumentValidations() {
 func (suite *ModelSuite) TestFetchDocument() {
 	t := suite.T()
 
-	ctx := context.Background()
-
 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 	session := auth.Session{
 		UserID:          serviceMember.UserID,
@@ -65,14 +62,12 @@ func (suite *ModelSuite) TestFetchDocument() {
 		t.Errorf("did not expect validation errors: %v", verrs)
 	}
 
-	doc, _ := models.FetchDocument(ctx, suite.DB(), &session, document.ID, false)
+	doc, _ := models.FetchDocument(suite.DB(), &session, document.ID, false)
 	suite.Equal(doc.ID, document.ID)
 }
 
 func (suite *ModelSuite) TestFetchDeletedDocument() {
 	t := suite.T()
-
-	ctx := context.Background()
 
 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 	session := auth.Session{
@@ -96,13 +91,13 @@ func (suite *ModelSuite) TestFetchDeletedDocument() {
 		t.Errorf("did not expect validation errors: %v", verrs)
 	}
 
-	doc, _ := models.FetchDocument(ctx, suite.DB(), &session, document.ID, false)
+	doc, _ := models.FetchDocument(suite.DB(), &session, document.ID, false)
 
 	// fetches a nil document
 	suite.Equal(doc.ID, uuid.Nil)
 	suite.Equal(doc.ServiceMemberID, uuid.Nil)
 
-	doc2, _ := models.FetchDocument(ctx, suite.DB(), &session, document.ID, true)
+	doc2, _ := models.FetchDocument(suite.DB(), &session, document.ID, true)
 
 	// fetches a nil document
 	suite.Equal(doc2.ID, document.ID)

--- a/pkg/models/electronic_order.go
+++ b/pkg/models/electronic_order.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
@@ -84,7 +83,7 @@ func (e *ElectronicOrder) ValidateUpdate(tx *pop.Connection) (*validate.Errors, 
 }
 
 // CreateElectronicOrder inserts an empty set of electronic Orders into the database
-func CreateElectronicOrder(ctx context.Context, dbConnection *pop.Connection, order *ElectronicOrder) (*validate.Errors, error) {
+func CreateElectronicOrder(dbConnection *pop.Connection, order *ElectronicOrder) (*validate.Errors, error) {
 
 	responseVErrors := validate.NewErrors()
 	verrs, responseError := dbConnection.ValidateAndCreate(order)
@@ -96,7 +95,7 @@ func CreateElectronicOrder(ctx context.Context, dbConnection *pop.Connection, or
 }
 
 // CreateElectronicOrderWithRevision inserts a new set of electronic Orders into the database with its first Revision
-func CreateElectronicOrderWithRevision(ctx context.Context, dbConnection *pop.Connection, order *ElectronicOrder, firstRevision *ElectronicOrdersRevision) (*validate.Errors, error) {
+func CreateElectronicOrderWithRevision(dbConnection *pop.Connection, order *ElectronicOrder, firstRevision *ElectronicOrdersRevision) (*validate.Errors, error) {
 
 	responseVErrors := validate.NewErrors()
 	var responseError error
@@ -104,14 +103,14 @@ func CreateElectronicOrderWithRevision(ctx context.Context, dbConnection *pop.Co
 	// If the passed in function returns an error, the transaction is rolled back
 	errTransaction := dbConnection.Transaction(func(dbConnection *pop.Connection) error {
 		transactionError := errors.New("Rollback The transaction")
-		if verrs, err := CreateElectronicOrder(ctx, dbConnection, order); verrs.HasAny() || err != nil {
+		if verrs, err := CreateElectronicOrder(dbConnection, order); verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = err
 			return transactionError
 		}
 		firstRevision.ElectronicOrderID = order.ID
 		firstRevision.ElectronicOrder = *order
-		if verrs, err := CreateElectronicOrdersRevision(ctx, dbConnection, firstRevision); verrs.HasAny() || err != nil {
+		if verrs, err := CreateElectronicOrdersRevision(dbConnection, firstRevision); verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = err
 			return transactionError

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"context"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -44,7 +43,7 @@ func (suite *ModelSuite) TestCreateElectronicOrder() {
 		OrdersNumber: "8675309",
 	}
 
-	verrs, err := models.CreateElectronicOrder(context.Background(), suite.DB(), &newOrder)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &newOrder)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 }
@@ -69,7 +68,7 @@ func (suite *ModelSuite) TestCreateElectronicOrderWithRevision() {
 		OrdersType:    models.ElectronicOrdersTypeSeparation,
 		HasDependents: true,
 	}
-	verrs, err := models.CreateElectronicOrderWithRevision(context.Background(), suite.DB(), &newOrder, &rev)
+	verrs, err := models.CreateElectronicOrderWithRevision(suite.DB(), &newOrder, &rev)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 }
@@ -81,7 +80,7 @@ func (suite *ModelSuite) TestFetchElectronicOrderByID() {
 		OrdersNumber: "8675309",
 	}
 
-	verrs, err := models.CreateElectronicOrder(context.Background(), suite.DB(), &newOrder)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &newOrder)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -101,7 +100,7 @@ func (suite *ModelSuite) TestFetchElectronicOrderByIssuerAndOrdersNum() {
 		OrdersNumber: "8675309",
 	}
 
-	verrs, err := models.CreateElectronicOrder(context.Background(), suite.DB(), &newOrder)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &newOrder)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -121,8 +120,7 @@ func (suite *ModelSuite) TestFetchElectronicOrdersByEdipiAndIssuers() {
 		OrdersNumber: "8675309",
 	}
 
-	ctx := context.Background()
-	verrs, err := models.CreateElectronicOrder(ctx, suite.DB(), &newOrder1)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &newOrder1)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -132,7 +130,7 @@ func (suite *ModelSuite) TestFetchElectronicOrdersByEdipiAndIssuers() {
 		OrdersNumber: "5551234",
 	}
 
-	verrs, err = models.CreateElectronicOrder(ctx, suite.DB(), &newOrder2)
+	verrs, err = models.CreateElectronicOrder(suite.DB(), &newOrder2)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 

--- a/pkg/models/electronic_orders_revision.go
+++ b/pkg/models/electronic_orders_revision.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
@@ -337,7 +336,7 @@ func (e *ElectronicOrdersRevision) ValidateUpdate(tx *pop.Connection) (*validate
 }
 
 // CreateElectronicOrdersRevision inserts a revision into the database
-func CreateElectronicOrdersRevision(ctx context.Context, dbConnection *pop.Connection, revision *ElectronicOrdersRevision) (*validate.Errors, error) {
+func CreateElectronicOrdersRevision(dbConnection *pop.Connection, revision *ElectronicOrdersRevision) (*validate.Errors, error) {
 
 	responseVErrors := validate.NewErrors()
 	verrs, responseError := dbConnection.ValidateAndCreate(revision)

--- a/pkg/models/electronic_orders_revision_test.go
+++ b/pkg/models/electronic_orders_revision_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"context"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -15,7 +14,7 @@ func (suite *ModelSuite) TestElectronicOrdersRevisionValidateAndCreate() {
 		Issuer:       models.IssuerAirForce,
 		OrdersNumber: "8675309",
 	}
-	verrs, err := models.CreateElectronicOrder(context.Background(), suite.DB(), &order)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &order)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -129,7 +128,7 @@ func (suite *ModelSuite) TestCreateElectronicOrdersRevision() {
 		Issuer:       models.IssuerAirForce,
 		OrdersNumber: "8675309",
 	}
-	verrs, err := models.CreateElectronicOrder(context.Background(), suite.DB(), &order)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &order)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -150,7 +149,7 @@ func (suite *ModelSuite) TestCreateElectronicOrdersRevision() {
 		HasDependents:     true,
 	}
 
-	verrs, err = models.CreateElectronicOrdersRevision(context.Background(), suite.DB(), &rev)
+	verrs, err = models.CreateElectronicOrdersRevision(suite.DB(), &rev)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 }
@@ -161,8 +160,7 @@ func (suite *ModelSuite) TestCreateElectronicOrdersRevision_Amendment() {
 		Issuer:       models.IssuerAirForce,
 		OrdersNumber: "8675309",
 	}
-	ctx := context.Background()
-	verrs, err := models.CreateElectronicOrder(ctx, suite.DB(), &order)
+	verrs, err := models.CreateElectronicOrder(suite.DB(), &order)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -183,7 +181,7 @@ func (suite *ModelSuite) TestCreateElectronicOrdersRevision_Amendment() {
 		HasDependents:     true,
 	}
 
-	verrs, err = models.CreateElectronicOrdersRevision(ctx, suite.DB(), &rev0)
+	verrs, err = models.CreateElectronicOrdersRevision(suite.DB(), &rev0)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 
@@ -204,7 +202,7 @@ func (suite *ModelSuite) TestCreateElectronicOrdersRevision_Amendment() {
 		HasDependents:     true,
 	}
 
-	verrs, err = models.CreateElectronicOrdersRevision(ctx, suite.DB(), &rev1)
+	verrs, err = models.CreateElectronicOrdersRevision(suite.DB(), &rev1)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 

--- a/pkg/models/prime_upload.go
+++ b/pkg/models/prime_upload.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
@@ -57,7 +56,7 @@ func (u *PrimeUpload) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchPrimeUpload returns an PrimeUpload if the contractor has access to that upload
-func FetchPrimeUpload(ctx context.Context, db *pop.Connection, contractorID uuid.UUID, id uuid.UUID) (PrimeUpload, error) {
+func FetchPrimeUpload(db *pop.Connection, contractorID uuid.UUID, id uuid.UUID) (PrimeUpload, error) {
 	var primeUpload PrimeUpload
 	err := db.Q().
 		Join("uploads AS ups", "ups.id = prime_uploads.upload_id").

--- a/pkg/models/prime_upload_test.go
+++ b/pkg/models/prime_upload_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"context"
-
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/db/dberr"
@@ -125,7 +123,6 @@ func (suite *ModelSuite) TestFetchPrimeUploadWithNoUpload() {
 func (suite *ModelSuite) TestFetchPrimeUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
 	contractor := testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -160,7 +157,7 @@ func (suite *ModelSuite) TestFetchPrimeUpload() {
 		t.Errorf("did not expect PrimeUpload validation errors: %v", verrs)
 	}
 
-	primeUp, _ := models.FetchPrimeUpload(ctx, suite.DB(), contractor.ID, primeUpload.ID)
+	primeUp, _ := models.FetchPrimeUpload(suite.DB(), contractor.ID, primeUpload.ID)
 	suite.Equal(primeUp.ID, primeUpload.ID)
 	suite.Equal(upload.ID, primeUpload.Upload.ID)
 	suite.Equal(upload.ID, primeUpload.UploadID)
@@ -169,7 +166,6 @@ func (suite *ModelSuite) TestFetchPrimeUpload() {
 func (suite *ModelSuite) TestFetchDeletedPrimeUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
 	contractor := testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -208,7 +204,7 @@ func (suite *ModelSuite) TestFetchDeletedPrimeUpload() {
 
 	err = models.DeletePrimeUpload(suite.DB(), &primeUpload)
 	suite.Nil(err)
-	primeUp, err := models.FetchPrimeUpload(ctx, suite.DB(), contractor.ID, primeUpload.ID)
+	primeUp, err := models.FetchPrimeUpload(suite.DB(), contractor.ID, primeUpload.ID)
 	suite.Equal("error fetching prime_uploads: FETCH_NOT_FOUND", err.Error())
 
 	// fetches a nil primeupload

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -91,7 +90,7 @@ func (s *ServiceMember) ValidateUpdate(tx *pop.Connection) (*validate.Errors, er
 
 // FetchServiceMemberForUser returns a service member only if it is allowed for the given user to access that service member.
 // This method is thereby a useful way of performing access control checks.
-func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session *auth.Session, id uuid.UUID) (ServiceMember, error) {
+func FetchServiceMemberForUser(db *pop.Connection, session *auth.Session, id uuid.UUID) (ServiceMember, error) {
 
 	var serviceMember ServiceMember
 	err := db.Q().Eager("User",
@@ -145,7 +144,7 @@ func FetchServiceMember(db *pop.Connection, id uuid.UUID) (ServiceMember, error)
 }
 
 // SaveServiceMember takes a serviceMember with Address structs and coordinates saving it all in a transaction
-func SaveServiceMember(ctx context.Context, dbConnection *pop.Connection, serviceMember *ServiceMember) (*validate.Errors, error) {
+func SaveServiceMember(dbConnection *pop.Connection, serviceMember *ServiceMember) (*validate.Errors, error) {
 
 	responseVErrors := validate.NewErrors()
 	var responseError error

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"context"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -89,7 +87,6 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 }
 
 func (suite *ModelSuite) TestFetchServiceMemberForUser() {
-	ctx := context.Background()
 	user1 := testdatagen.MakeDefaultUser(suite.DB())
 	user2 := testdatagen.MakeDefaultUser(suite.DB())
 
@@ -110,7 +107,7 @@ func (suite *ModelSuite) TestFetchServiceMemberForUser() {
 		UserID:          user1.ID,
 		ServiceMemberID: sm.ID,
 	}
-	goodSm, err := FetchServiceMemberForUser(ctx, suite.DB(), session, sm.ID)
+	goodSm, err := FetchServiceMemberForUser(suite.DB(), session, sm.ID)
 	if suite.NoError(err) {
 		suite.Equal(sm.FirstName, goodSm.FirstName)
 		suite.Equal(sm.ResidentialAddress.ID, goodSm.ResidentialAddress.ID)
@@ -118,7 +115,7 @@ func (suite *ModelSuite) TestFetchServiceMemberForUser() {
 
 	// Wrong ServiceMember
 	wrongID, _ := uuid.NewV4()
-	_, err = FetchServiceMemberForUser(ctx, suite.DB(), session, wrongID)
+	_, err = FetchServiceMemberForUser(suite.DB(), session, wrongID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchNotFound, err)
 	}
@@ -126,7 +123,7 @@ func (suite *ModelSuite) TestFetchServiceMemberForUser() {
 	// User is forbidden from fetching order
 	session.UserID = user2.ID
 	session.ServiceMemberID = uuid.Nil
-	_, err = FetchServiceMemberForUser(ctx, suite.DB(), session, sm.ID)
+	_, err = FetchServiceMemberForUser(suite.DB(), session, sm.ID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchForbidden, err)
 	}

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -274,7 +273,7 @@ func FetchUnbandedTSPPerformanceGroups(db *pop.Connection) (TSPPerformanceGroups
 }
 
 // AssignQualityBandToTSPPerformance sets the QualityBand value for a TransportationServiceProviderPerformance.
-func AssignQualityBandToTSPPerformance(ctx context.Context, db *pop.Connection, band int, id uuid.UUID) error {
+func AssignQualityBandToTSPPerformance(db *pop.Connection, band int, id uuid.UUID) error {
 	performance := TransportationServiceProviderPerformance{}
 	if err := db.Find(&performance, id); err != nil {
 		return err

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -148,7 +147,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 	})
 	band := 1
 
-	err := AssignQualityBandToTSPPerformance(context.Background(), suite.DB(), band, perf.ID)
+	err := AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
 	if err != nil {
 		t.Fatalf("Did not update quality band: %v", err)
 	}

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"context"
-
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -77,7 +75,6 @@ func (suite *ModelSuite) Test_UploadValidations() {
 func (suite *ModelSuite) TestFetchUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	session := auth.Session{
@@ -116,12 +113,12 @@ func (suite *ModelSuite) TestFetchUpload() {
 		t.Errorf("did not expect UserUpload validation errors: %v", verrs)
 	}
 
-	upUser, _ := models.FetchUserUpload(ctx, suite.DB(), &session, uploadUser.ID)
+	upUser, _ := models.FetchUserUpload(suite.DB(), &session, uploadUser.ID)
 	suite.Equal(upUser.UploadID, upload.ID)
 	suite.Equal(upUser.Upload.ID, upload.ID)
 	suite.Equal(upUser.ID, uploadUser.ID)
 
-	upUser, _ = models.FetchUserUploadFromUploadID(ctx, suite.DB(), &session, upload.ID)
+	upUser, _ = models.FetchUserUploadFromUploadID(suite.DB(), &session, upload.ID)
 	suite.Equal(upUser.UploadID, upload.ID)
 	suite.Equal(upUser.Upload.ID, upload.ID)
 	suite.Equal(upUser.ID, uploadUser.ID)
@@ -130,7 +127,6 @@ func (suite *ModelSuite) TestFetchUpload() {
 func (suite *ModelSuite) TestFetchDeletedUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	session := auth.Session{
@@ -156,7 +152,7 @@ func (suite *ModelSuite) TestFetchDeletedUpload() {
 	}
 
 	models.DeleteUpload(suite.DB(), &upload)
-	up, _ := models.FetchUserUpload(ctx, suite.DB(), &session, upload.ID)
+	up, _ := models.FetchUserUpload(suite.DB(), &session, upload.ID)
 
 	// fetches a nil upload
 	suite.Equal(up.ID, uuid.Nil)

--- a/pkg/models/user_upload.go
+++ b/pkg/models/user_upload.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
@@ -69,7 +68,7 @@ func (u *UserUpload) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchUserUpload returns an UserUpload if the user has access to that upload
-func FetchUserUpload(ctx context.Context, db *pop.Connection, session *auth.Session, id uuid.UUID) (UserUpload, error) {
+func FetchUserUpload(db *pop.Connection, session *auth.Session, id uuid.UUID) (UserUpload, error) {
 	var userUpload UserUpload
 	err := db.Q().
 		Where("deleted_at is null").Eager("Document", "Upload").Find(&userUpload, id)
@@ -84,7 +83,7 @@ func FetchUserUpload(ctx context.Context, db *pop.Connection, session *auth.Sess
 	// If there's a document, check permissions. Otherwise user must
 	// have been the uploader
 	if userUpload.DocumentID != nil {
-		_, docErr := FetchDocument(ctx, db, session, *userUpload.DocumentID, false)
+		_, docErr := FetchDocument(db, session, *userUpload.DocumentID, false)
 		if docErr != nil {
 			return UserUpload{}, docErr
 		}
@@ -95,7 +94,7 @@ func FetchUserUpload(ctx context.Context, db *pop.Connection, session *auth.Sess
 }
 
 // FetchUserUploadFromUploadID returns an UserUpload if the user has access to that upload
-func FetchUserUploadFromUploadID(ctx context.Context, db *pop.Connection, session *auth.Session, uploadID uuid.UUID) (UserUpload, error) {
+func FetchUserUploadFromUploadID(db *pop.Connection, session *auth.Session, uploadID uuid.UUID) (UserUpload, error) {
 	var userUpload UserUpload
 	err := db.Q().
 		Join("uploads AS ups", "ups.id = user_uploads.upload_id").
@@ -111,7 +110,7 @@ func FetchUserUploadFromUploadID(ctx context.Context, db *pop.Connection, sessio
 	// If there's a document, check permissions. Otherwise user must
 	// have been the uploader
 	if userUpload.DocumentID != nil {
-		_, docErr := FetchDocument(ctx, db, session, *userUpload.DocumentID, false)
+		_, docErr := FetchDocument(db, session, *userUpload.DocumentID, false)
 		if docErr != nil {
 			return UserUpload{}, docErr
 		}

--- a/pkg/models/user_upload_test.go
+++ b/pkg/models/user_upload_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"context"
-
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -123,7 +121,6 @@ func (suite *ModelSuite) TestFetchUserUploadWithNoUpload() {
 func (suite *ModelSuite) TestFetchUserUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	session := auth.Session{
@@ -163,7 +160,7 @@ func (suite *ModelSuite) TestFetchUserUpload() {
 		t.Errorf("did not expect UserUpload validation errors: %v", verrs)
 	}
 
-	upUser, _ := models.FetchUserUpload(ctx, suite.DB(), &session, uploadUser.ID)
+	upUser, _ := models.FetchUserUpload(suite.DB(), &session, uploadUser.ID)
 	suite.Equal(upUser.ID, uploadUser.ID)
 	suite.Equal(upload.ID, uploadUser.Upload.ID)
 	suite.Equal(upload.ID, uploadUser.UploadID)
@@ -172,7 +169,6 @@ func (suite *ModelSuite) TestFetchUserUpload() {
 func (suite *ModelSuite) TestFetchDeletedUserUpload() {
 	t := suite.T()
 
-	ctx := context.Background()
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	session := auth.Session{
@@ -215,7 +211,7 @@ func (suite *ModelSuite) TestFetchDeletedUserUpload() {
 
 	err = models.DeleteUserUpload(suite.DB(), &uploadUser)
 	suite.Nil(err)
-	userUp, err := models.FetchUserUpload(ctx, suite.DB(), &session, uploadUser.ID)
+	userUp, err := models.FetchUserUpload(suite.DB(), &session, uploadUser.ID)
 	suite.Equal("error fetching user_uploads: FETCH_NOT_FOUND", err.Error())
 
 	// fetches a nil userupload

--- a/pkg/notifications/move_approved.go
+++ b/pkg/notifications/move_approved.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	html "html/template"
 	"net/url"
@@ -53,7 +52,7 @@ func NewMoveApproved(db *pop.Connection,
 	}
 }
 
-func (m MoveApproved) emails(ctx context.Context) ([]emailContent, error) {
+func (m MoveApproved) emails() ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -66,7 +65,7 @@ func (m MoveApproved) emails(ctx context.Context) ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}

--- a/pkg/notifications/move_approved_test.go
+++ b/pkg/notifications/move_approved_test.go
@@ -1,7 +1,6 @@
 package notifications
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -10,8 +9,6 @@ import (
 )
 
 func (suite *NotificationSuite) TestMoveApproved() {
-	ctx := context.Background()
-
 	approver := testdatagen.MakeStubbedUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
 
@@ -21,7 +18,7 @@ func (suite *NotificationSuite) TestMoveApproved() {
 	}, "milmovelocal", move.ID)
 	subject := fmt.Sprintf("[MilMove] Your Move is approved (move: %s)", move.Locator)
 
-	emails, err := notification.emails(ctx)
+	emails, err := notification.emails()
 	suite.NoError(err)
 	suite.Equal(len(emails), 1)
 

--- a/pkg/notifications/move_canceled.go
+++ b/pkg/notifications/move_canceled.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	html "html/template"
 	text "text/template"
@@ -46,7 +45,7 @@ func NewMoveCanceled(db *pop.Connection, logger Logger, session *auth.Session, m
 	}
 }
 
-func (m MoveCanceled) emails(ctx context.Context) ([]emailContent, error) {
+func (m MoveCanceled) emails() ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -59,7 +58,7 @@ func (m MoveCanceled) emails(ctx context.Context) ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	html "html/template"
 	text "text/template"
@@ -107,7 +106,7 @@ FROM personally_procured_moves ppm
 
 // NotificationSendingContext expects a `notification` with an `emails` method,
 // so we implement `email` to satisfy that interface
-func (m PaymentReminder) emails(ctx context.Context) ([]emailContent, error) {
+func (m PaymentReminder) emails() ([]emailContent, error) {
 	paymentReminderEmailInfos, err := m.GetEmailInfo()
 	if err != nil {
 		m.logger.Error("error retrieving email info")

--- a/pkg/notifications/move_reviewed.go
+++ b/pkg/notifications/move_reviewed.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	html "html/template"
 	text "text/template"
@@ -83,7 +82,7 @@ WHERE CAST(reviewed_date AS date) = $1
 
 // NotificationSendingContext expects a `notification` with an `emails` method,
 // so we implement `email` to satisfy that interface
-func (m MoveReviewed) emails(ctx context.Context) ([]emailContent, error) {
+func (m MoveReviewed) emails() ([]emailContent, error) {
 	emailInfos, err := m.GetEmailInfo(m.date)
 	if err != nil {
 		m.logger.Error("error retrieving email info", zap.String("date", m.date.String()))

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	html "html/template"
 	text "text/template"
@@ -46,7 +45,7 @@ func NewMoveSubmitted(db *pop.Connection, logger Logger, session *auth.Session, 
 	}
 }
 
-func (m MoveSubmitted) emails(ctx context.Context) ([]emailContent, error) {
+func (m MoveSubmitted) emails() ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -59,7 +58,7 @@ func (m MoveSubmitted) emails(ctx context.Context) ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}

--- a/pkg/notifications/move_submitted_test.go
+++ b/pkg/notifications/move_submitted_test.go
@@ -1,22 +1,18 @@
 package notifications
 
 import (
-	"context"
-
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *NotificationSuite) TestMoveSubmitted() {
-	ctx := context.Background()
-
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	notification := NewMoveSubmitted(suite.DB(), suite.logger, &auth.Session{
 		ServiceMemberID: move.Orders.ServiceMember.ID,
 		ApplicationName: auth.MilApp,
 	}, move.ID)
 
-	emails, err := notification.emails(ctx)
+	emails, err := notification.emails()
 	subject := "Thank you for submitting your move details"
 
 	suite.NoError(err)

--- a/pkg/notifications/notification_sender.go
+++ b/pkg/notifications/notification_sender.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"bytes"
-	"context"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,7 +17,7 @@ import (
 )
 
 type notification interface {
-	emails(ctx context.Context) ([]emailContent, error)
+	emails() ([]emailContent, error)
 }
 
 type emailContent struct {
@@ -32,7 +31,7 @@ type emailContent struct {
 
 // NotificationSender is an interface for sending notifications
 type NotificationSender interface {
-	SendNotification(ctx context.Context, notification notification) error
+	SendNotification(notification notification) error
 }
 
 // NotificationSendingContext provides context to a notification sender
@@ -52,8 +51,8 @@ func NewNotificationSender(svc sesiface.SESAPI, domain string, logger Logger) No
 }
 
 // SendNotification sends a one or more notifications for all supported mediums
-func (n NotificationSendingContext) SendNotification(ctx context.Context, notification notification) error {
-	emails, err := notification.emails(ctx)
+func (n NotificationSendingContext) SendNotification(notification notification) error {
+	emails, err := notification.emails()
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/notification_stub.go
+++ b/pkg/notifications/notification_stub.go
@@ -1,8 +1,6 @@
 package notifications
 
 import (
-	"context"
-
 	"github.com/gofrs/uuid"
 
 	"go.uber.org/zap"
@@ -20,8 +18,8 @@ func NewStubNotificationSender(domain string, logger Logger) StubNotificationSen
 }
 
 // SendNotification returns a dummy ID
-func (m StubNotificationSender) SendNotification(ctx context.Context, notification notification) error {
-	emails, err := notification.emails(ctx)
+func (m StubNotificationSender) SendNotification(notification notification) error {
+	emails, err := notification.emails()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
About 2 years ago, we added instrumentation via Honeycomb, which
required passing in the context to functions. Since then, we've removed
Honeycomb, but we didn't remove the context argument. Here are example
PRs that introduced the context argument:

https://github.com/transcom/mymove/pull/1269
https://github.com/transcom/mymove/pull/1326

This PR removes all unused code related to the context argument that
was added at the time Honeycomb was introduced.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
