### PR TITLE
Only create aws session if aws storage is set

### DIFF
--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -163,17 +163,19 @@ func main() {
 
 		// Initialize storage and uploader
 		var session *awssession.Session
+		storageBackend := v.GetString(cli.StorageBackendFlag)
+		if storageBackend == "s3" || storageBackend == "cdn" {
+			c := &aws.Config{
+				Region: aws.String(v.GetString(cli.AWSRegionFlag)),
+			}
+			s, errorSession := awssession.NewSession(c)
 
-		c := &aws.Config{
-			Region: aws.String(v.GetString(cli.AWSRegionFlag)),
+			if errorSession != nil {
+				logger.Fatal(errors.Wrap(errorSession, "error creating aws session").Error())
+			}
+
+			session = s
 		}
-		s, errorSession := awssession.NewSession(c)
-
-		if errorSession != nil {
-			logger.Fatal(errors.Wrap(errorSession, "error creating aws session").Error())
-		}
-
-		session = s
 		storer := storage.InitStorage(v, session, logger)
 
 		userUploader, uploaderErr := uploader.NewUserUploader(dbConnection, logger, storer, 25*uploader.MB)


### PR DESCRIPTION
`make db_dev_fresh` was failing if `STORAGE_BACKEND` was not set to "s3"
or "cdn". This part of the setup should only be run if `STORAGE_BACKEND`
uses aws.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
