### PR TITLE
MB-6686 Do not return service member info for logged in user if move has been hidden

### DIFF
--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -169,6 +169,7 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 	// check if move task order exists first
 	queryFilters := []services.QueryFilter{
 		query.NewQueryFilter("id", "=", moveTaskOrderID.String()),
+		query.NewQueryFilter("show", "=", "TRUE"),
 	}
 
 	moveTaskOrder := &models.Move{}

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -98,15 +98,13 @@ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session 
 		"BackupMailingAddress",
 		"BackupContacts",
 		"DutyStation.Address",
-		"DutyStation.TransportationOffice",
 		"DutyStation.TransportationOffice.PhoneLines",
 		"Orders.NewDutyStation.TransportationOffice",
-		"Orders.Moves",
 		"Orders.UploadedOrders.UserUploads.Upload",
-		"ResidentialAddress",
-		"Orders.Moves").
+		"Orders.Moves",
+		"ResidentialAddress").
 		Join("orders", "orders.service_member_id = service_members.id").
-		Join("moves", "moves.orders_id = orders.id"). // We only want to return a move if it is visible to the user
+		Join("moves", "moves.orders_id = orders.id").
 		Where("show = TRUE").Find(&serviceMember, id)
 
 	if err != nil {

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -103,7 +103,12 @@ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session 
 		"Orders.NewDutyStation.TransportationOffice",
 		"Orders.Moves",
 		"Orders.UploadedOrders.UserUploads.Upload",
-		"ResidentialAddress").Find(&serviceMember, id)
+		"ResidentialAddress",
+		"Orders.Moves").
+		Join("orders", "orders.service_member_id = service_members.id").
+		Join("moves", "moves.orders_id = orders.id"). // We only want to return a move if it is visible to the user
+		Where("show = TRUE").Find(&serviceMember, id)
+
 	if err != nil {
 		if errors.Cause(err).Error() == RecordNotFoundErrorString {
 			return ServiceMember{}, ErrFetchNotFound


### PR DESCRIPTION
## Description

This PR is a part of the larger effort to not return moves if their `Show` status is marked as `False` in the db. If a move has been deactivated/hidden by an admin, we should not return it to the customer.

This bug was discovered during QA of MB-2558.

## Review

@sandy-wright, can you check out the change I made to mto_shipment? Am I correct in thinking we shouldn't use the returned move if it's hidden?

## Setup

**Test Flow**

* As a CUSTOMER: Create and submit a move.

* As an ADMIN: Edit the newly created move, and update "Show" to NO.

* As a CUSTOMER: Log in as customer and verify you can no longer see the move. 

* EXPECTED OUTCOME: The updated move should not be visible after updating "Show" to NO. When you refresh the screen as the logged-in user, you will see the logged out screen. You will not be able to log back in, but can see a 401 error in the network tab.

The lack of UI error handling is something to be addressed in future feature work.

## Code Review Verification Steps

* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6686) for this change
