### PR TITLE
[MB-5435] CAT III: SA4009 Argument overwritten before first use

### DIFF
--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -29,7 +29,9 @@ func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember model
 	}
 
 	// if an existing service member, set requires access code to what they're already set
-	requiresAccessCode = serviceMember.RequiresAccessCode
+	if requiresAccessCode != serviceMember.RequiresAccessCode {
+		requiresAccessCode = serviceMember.RequiresAccessCode
+	}
 
 	var weightAllotment *internalmessages.WeightAllotment
 	if serviceMember.Rank != nil {


### PR DESCRIPTION
## Description

Check if there is a difference between serviceMember.requiresAccessCode and requiresAccessCode before overwriting it

## Setup
`make server_test`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References
* [Jira story](https://dp3.atlassian.net/browse/MB-5434) for this change
