### PR TITLE
Add support for move code (aka move locator) to prime-api-demo

### DIFF
--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -119,26 +119,22 @@ printf "\nThe prime will now fetch the new MTO.\n\n"
 
 printf "\n==========\n\n"
 
+# Find MTO By MTO ID
 if jq -e 'map(select(.id == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
-  # MTO found
   echo "Found by Move Task Order ID"
+# Find MTO By moveOrderID
+elif jq -e 'map(select(.moveOrderID == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
+  # extract the mtoid
+  mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
+  echo "Found by Move Order ID. Actual MTO ID is ${mtoid}"
+# Find MTO by moveCode aka locator
+elif jq -e 'map(select(.moveCode == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
+  # extract the mtoid
+  mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
+  echo "Found by Move Code. Actual MTO ID is ${mtoid}"
 else
-  # maybe we have a moveOrderID
-  if jq -e 'map(select(.moveOrderID == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
-    # great
-    mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
-    echo "Found by Move Order ID. Actual MTO ID is ${mtoid}"
-  else
-    # maybe we have a moveCode
-    if jq -e 'map(select(.moveCode == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
-      # great
-      mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
-      echo "Found by Move Code. Actual MTO ID is ${mtoid}"
-    else
-      echo "ID not found"
-      exit 1
-    fi
-  fi
+  echo "ID not found"
+  exit 1
 fi
 
 

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -7,7 +7,7 @@
 set -eu -o pipefail
 
 function usage() {
-  echo "Usage: $0 <moveTaskOrderID|moveOrderID> [[hostname] path/to/proof.pdf]"
+  echo "Usage: $0 <moveTaskOrderID|moveOrderID|moveCode> [[hostname] path/to/proof.pdf]"
   echo
   echo "If omitted, the optional parameters are set as follows:"
   echo "  hostname = local"
@@ -17,8 +17,9 @@ function usage() {
   echo "EXAMPLES:"
   echo "$0 --help # prints this help"
   echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d"
+  echo "$0 RDY4PY"
   echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d local path/to/proof.pdf path/to/proof.jpg"
-  echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d api.stg.move.mil"
+  echo "$0 RDY4PY api.stg.move.mil"
   echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d api.stg.move.mil path/to/proof.pdf path/to/proof.jpg"
 }
 
@@ -128,8 +129,15 @@ else
     mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
     echo "Found by Move Order ID. Actual MTO ID is ${mtoid}"
   else
-    echo "ID not found"
-    exit 1
+    # maybe we have a moveCode
+    if jq -e 'map(select(.moveCode == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
+      # great
+      mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
+      echo "Found by Move Code. Actual MTO ID is ${mtoid}"
+    else
+      echo "ID not found"
+      exit 1
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Description

I got tired of mapping move code to MTO id when I needed to run the `prime-api-demo` script. It now does that mapping for you because move code is returned in the `fetch-mto-updates` call.

## Reviewer Notes

The mto Id and move code in the script's help text are valid after running `make db_dev_e2e_populate` as they are in the devseed data.

## Setup

```sh
make db_dev_e2e_populate
make server_run
prime-api-demo RDY4PY
```

Expected output, feel free to continue passed the point below if you like but the change here is tested just by finding the mto id so you can ctrl c at that point

```sh
❯ prime-api-demo RDY4PY

Running against local server
server is running

==========

The prime is notified of a new move task order ID: RDY4PY

The prime will now fetch the new MTO.


==========

Found by Move Code. Actual MTO ID is 9c7b255c-2981-4bf8-839f-61c7458e2b4d

The prime updates the mto shipment with destination address as well the scheduled and actual pickup dates

Ready to continue? Hit enter...

```

### Acceptance

Run the demo script with the move code of a move on staging see that it finds the move.

## Code Review Verification Steps

* [X] Request review from a member of a different team.