### PR TITLE
Remove toUpper call in EqualFold

### DIFF
--- a/pkg/migrate/SplitStatements.go
+++ b/pkg/migrate/SplitStatements.go
@@ -231,7 +231,7 @@ func SplitStatements(lines chan string, statements chan string, wait time.Durati
 				close(statements)
 				return
 			}
-			if strings.EqualFold(strings.ToUpper(str), strings.ToUpper(lastBlock)) {
+			if strings.EqualFold(str, lastBlock) {
 				i += len(lastBlock)
 				stmt.WriteString(blocks.Last())
 				blocks.Pop()


### PR DESCRIPTION
## Description

In addition to #5926, removing the toUpper call in EqualFold because EqualFold already does a case insensitive comparison