### PR TITLE
[MB-6753] Removed referenceID from createMoveTaskOrder

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1893,6 +1893,7 @@ func init() {
         "referenceId": {
           "description": "Unique ID associated with this MoveOrder.\n\nNo two MoveTaskOrders may have the same ID.\nAttempting to create a MoveTaskOrder may fail if this referenceId has been used already.\n",
           "type": "string",
+          "readOnly": true,
           "example": "1001-3456"
         },
         "status": {
@@ -4428,6 +4429,7 @@ func init() {
         "referenceId": {
           "description": "Unique ID associated with this MoveOrder.\n\nNo two MoveTaskOrders may have the same ID.\nAttempting to create a MoveTaskOrder may fail if this referenceId has been used already.\n",
           "type": "string",
+          "readOnly": true,
           "example": "1001-3456"
         },
         "status": {

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -90,6 +90,7 @@ type MoveTaskOrder struct {
 	// No two MoveTaskOrders may have the same ID.
 	// Attempting to create a MoveTaskOrder may fail if this referenceId has been used already.
 	//
+	// Read Only: true
 	ReferenceID string `json:"referenceId,omitempty"`
 
 	// status

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -49,14 +49,13 @@ func (f moveTaskOrderCreator) InternalCreateMoveTaskOrder(payload supportmessage
 
 		// Convert payload to model for moveTaskOrder
 		moveTaskOrder = MoveTaskOrderModel(&payload)
-		// Fill in defaults if not provided in payload
-		if *moveTaskOrder.ReferenceID == "" {
-			refID, err = models.GenerateReferenceID(tx)
-			moveTaskOrder.ReferenceID = &refID
-		}
+		// referenceID cannot be set by user so generate it
+		refID, err = models.GenerateReferenceID(tx)
 		if err != nil {
 			return err
 		}
+		moveTaskOrder.ReferenceID = &refID
+
 		if moveTaskOrder.Locator == "" {
 			moveTaskOrder.Locator = models.GenerateLocator()
 		}

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1019,6 +1019,7 @@ definitions:
       referenceId:
         example: 1001-3456
         type: string
+        readOnly: true
         description: |
           Unique ID associated with this MoveOrder.
 


### PR DESCRIPTION
## Description

During load testing we found we can set the referenceID to anything. This shouldn't be the case, referenceID is supposed to be generated by the server and fits a pattern `dddd-dddd`. So this feature of the createMoveTaskOrder endpoint breaks other parts of the flow. This is a fix. 

Changed support api endpoint `createMoveTaskOrder` to make this field `readOnly`. And then made sure we discard the value that gets sent in in favor of a generated ID.

## Setup

Create a move in Postman using createMoveTaskOrder, send in a referenceID, result should not use what you sent but have a valid referenceID.

Also tests were updated, you can run with:

```sh
go test ./pkg/handlers/supportapi/ --testify.m TestCreateMoveTaskOrderRequestHandler -v
```

## References

* [Jira story](https://dp3.atlassian.net/browse/mb-6753) for this change
* [Postman Setup](https://github.com/transcom/mymove/wiki/setup-postman-to-make-mutual-tls-api-calls) for mtls calls
* [Support Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/master/swagger/support.yaml#operation/updateMoveTaskOrderStatus) in master
* [Updated Support Redoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/718124137dd139b7dd4cd6601084039c88f13fb6/swagger/support.yaml#operation/createMoveTaskOrder) for this branch
