### PR TITLE
MB-6683: remove orders.x.move.mil and orders.move.mil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,7 +1223,7 @@ jobs:
       - aws_vars_exp
       - deploy_app_client_tls_steps:
           compare_host: '' # leave blank since we want exp to be able to roll back
-          health_check_hosts: gex.exp.move.mil,orders.exp.move.mil
+          health_check_hosts: gex.exp.move.mil
           ecr_env: exp
 
   deploy_exp_webhook_client:
@@ -1284,7 +1284,7 @@ jobs:
       - aws_vars_stg
       - deploy_app_client_tls_steps:
           compare_host: gex.stg.move.mil
-          health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
+          health_check_hosts: gex.stg.move.mil
           ecr_env: stg
 
   deploy_storybook_dp3:
@@ -1335,7 +1335,7 @@ jobs:
       - aws_vars_prd
       - deploy_app_client_tls_steps:
           compare_host: gex.move.mil
-          health_check_hosts: gex.move.mil,orders.move.mil
+          health_check_hosts: gex.move.mil
           ecr_env: prd
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1453,28 +1453,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - deploy_exp_migrations:
           requires:
@@ -1489,35 +1489,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rm-orders
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1453,28 +1453,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1489,35 +1489,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: rm-orders
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:


### PR DESCRIPTION
## Description

Remove references to orders.x.move.mil and orders.move.mil.

## Reviewer Notes

The ticket only specifies orders.x.move.mil. I also removed orders.move.mil. If I should not have done that, please let me know.

## Setup

This is run entirely in CircleCI.

## Code Review Verification Steps

* [x] If the change is risky, it has been [tested in experimental](https://app.circleci.com/pipelines/github/transcom/mymove/27166/workflows/ce08befe-4fe2-446e-989f-be73730ff61c) before merging.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6683) for this change