### PR TITLE
use latest milmove-cypress image: MB-6647

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-2344eda297d5e8cefd3b6401275cd0cfd6086846
+FROM milmove/circleci-docker:milmove-cypress-411dc0acf41406c34eecdef5dfe6868e2aefeade
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json


### PR DESCRIPTION
## Description

We have a repo `circleci-docker` that contains a build of cypress for our integration tests. When we update any packages in `circleci-docker`, we should pull the latest image of into `mymove`.

the `circleci-docker` pr: https://github.com/transcom/circleci-docker/pull/86

## Reviewer Notes

Did I get the correct hash from Dockerhub image?

## Setup

the integration tests should run w/o an issue on circle

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6647) for this change
