### PR TITLE
Updating to latest circleci-docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade
 
   postgres: &postgres postgres:12.4
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846 as builder
+FROM milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846 as builder
+FROM milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846 as builder
+FROM milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846 as builder
+FROM milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade as builder
 
 ENV CIRCLECI=true
 

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - database
       - redis
-    image: milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846
+    image: milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade
     deploy:
       resources:
         limits:

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846
+  image=milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -8,7 +8,7 @@ if [ -n "${CIRCLECI+x}" ]; then
   echo "CircleCI has swagger built in"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846
+  image=milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade
   docker pull -q "${image}"
 fi
 

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -14,7 +14,7 @@ if [ "$UNAME_S" == "Linux" ]; then
   /usr/local/bin/swagger validate "${filename}"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-2344eda297d5e8cefd3b6401275cd0cfd6086846
+  image=milmove/circleci-docker:milmove-app-411dc0acf41406c34eecdef5dfe6868e2aefeade
   docker pull -q "${image}"
   docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"
 fi


### PR DESCRIPTION
## Description

This PR updates us to the latest `milmove/circleci-docker` image to see if it helps with our `UnsupportedImageError` happening in the build.  The latest image uses an explicit `circleci/python:3.9.1-buster-node` tag as opposed to the more generic `circleci/python:3.9-buster-node`.
