### PR TITLE
MB-6274: migrate images from legacy to gov-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -913,20 +913,6 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `push_app_legacy` pushes the app container to the legacy container repository
-  push_app_legacy:
-    executor: mymove_small
-    steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - aws_vars_legacy
-      - push_image:
-          ecr_env: legacy
-          image_name: ppp
-          tag: web-dev
-          repo: app
-      - announce_failure
-
   # `push_app_exp` pushes the app container to the milmove-exp container repository
   push_app_exp:
     executor: mymove_small
@@ -1019,20 +1005,6 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `push_migrations_legacy` pushes the migrations container to the legacy container repository
-  push_migrations_legacy:
-    executor: mymove_small
-    steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - aws_vars_legacy
-      - push_image:
-          ecr_env: legacy
-          image_name: ppp-migrations
-          tag: dev
-          repo: app-migrations
-      - announce_failure
-
   # `push_migrations_exp` pushes the migrations container to the milmove-exp container repository
   push_migrations_exp:
     executor: mymove_small
@@ -1095,20 +1067,6 @@ jobs:
           image_name: tasks
           tag: dev
           working_dir: ~/transcom/mymove
-      - announce_failure
-
-  # `push_tasks_legacy` pushes the tasks containers to the legacy container repository
-  push_tasks_legacy:
-    executor: mymove_small
-    steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - aws_vars_legacy
-      - push_image:
-          ecr_env: legacy
-          image_name: tasks
-          tag: dev
-          repo: app-tasks
       - announce_failure
 
   # `push_tasks_exp` pushes the tasks containers to the milmove-exp container repository
@@ -1373,9 +1331,7 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - check_generated_code
-            - push_app_legacy
             - push_app_stg
-            - push_migrations_legacy
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1386,9 +1342,7 @@ workflows:
           requires:
             - pre_deps_golang
             - check_generated_code
-            - push_app_legacy
             - push_app_stg
-            - push_migrations_legacy
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1417,10 +1371,6 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
-      - push_app_legacy:
-          requires:
-            - build_app
-
       - build_tools:
           requires:
             - anti_virus
@@ -1431,10 +1381,6 @@ workflows:
             - anti_virus
             - pre_deps_golang
 
-      - push_migrations_legacy:
-          requires:
-            - build_migrations
-
       - build_tasks:
           requires:
             - build_tools
@@ -1443,10 +1389,6 @@ workflows:
           requires:
             - anti_virus
             - pre_deps_golang
-
-      - push_tasks_legacy:
-          requires:
-            - build_tasks
 
       - push_app_exp:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,16 @@ commands:
             echo "export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY_ID" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_KEY" >> $BASH_ENV
             source $BASH_ENV
+  aws_vars_transcom_gov_dev:
+    steps:
+      - run:
+          name: 'Setting up AWS environment variables for prd env'
+          command: |
+            echo "export AWS_DEFAULT_REGION=$GOV_DEV_REGION" >> $BASH_ENV
+            echo "export AWS_ACCOUNT_ID=$GOV_DEV_ACCOUNT_ID" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$GOV_DEV_ACCESS_KEY_ID" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$GOV_DEV_SECRET_KEY" >> $BASH_ENV
+            source $BASH_ENV
   announce_failure:
     parameters:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,16 +98,6 @@ executors:
         command: '-c fsync=off -c full_page_writes=off -c max_connections=200'
 
 commands:
-  aws_vars_legacy:
-    steps:
-      - run:
-          name: 'Setting up AWS environment variables for legacy env'
-          command: |
-            echo "export AWS_DEFAULT_REGION=$LEGACY_REGION" >> $BASH_ENV
-            echo "export AWS_ACCOUNT_ID=$LEGACY_ACCOUNT_ID" >> $BASH_ENV
-            echo "export AWS_ACCESS_KEY_ID=$LEGACY_ACCESS_KEY_ID" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$LEGACY_SECRET_ACCESS_KEY" >> $BASH_ENV
-            source $BASH_ENV
   aws_vars_exp:
     steps:
       - run:
@@ -721,7 +711,7 @@ jobs:
     parallelism: 5
     executor: mymove_large
     steps:
-      - aws_vars_legacy
+      - aws_vars_transcom_gov_dev
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
@@ -768,7 +758,7 @@ jobs:
   integration_tests_mtls:
     executor: mymove_medium_plus
     steps:
-      - aws_vars_legacy
+      - aws_vars_transcom_gov_dev
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
@@ -923,15 +913,15 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `push_app_legacy` pushes the app container to the legacy container repository
-  push_app_legacy:
+  # `push_app_gov_dev` pushes the app container to the gov_dev container repository
+  push_app_gov_dev:
     executor: mymove_small
     steps:
       - setup_remote_docker:
           docker_layer_caching: false
-      - aws_vars_legacy
+      - aws_vars_transcom_gov_dev
       - push_image:
-          ecr_env: legacy
+          ecr_env: gov_dev
           image_name: ppp
           tag: web-dev
           repo: app
@@ -1029,15 +1019,15 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `push_migrations_legacy` pushes the migrations container to the legacy container repository
-  push_migrations_legacy:
+  # `push_migrations_gov_dev` pushes the migrations container to the gov_dev container repository
+  push_migrations_gov_dev:
     executor: mymove_small
     steps:
       - setup_remote_docker:
           docker_layer_caching: false
-      - aws_vars_legacy
+      - aws_vars_transcom_gov_dev
       - push_image:
-          ecr_env: legacy
+          ecr_env: gov_dev
           image_name: ppp-migrations
           tag: dev
           repo: app-migrations
@@ -1107,15 +1097,15 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
-  # `push_tasks_legacy` pushes the tasks containers to the legacy container repository
-  push_tasks_legacy:
+  # `push_tasks_gov_dev` pushes the tasks containers to the gov_dev container repository
+  push_tasks_gov_dev:
     executor: mymove_small
     steps:
       - setup_remote_docker:
           docker_layer_caching: false
-      - aws_vars_legacy
+      - aws_vars_transcom_gov_dev
       - push_image:
-          ecr_env: legacy
+          ecr_env: gov_dev
           image_name: tasks
           tag: dev
           repo: app-tasks
@@ -1383,9 +1373,9 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - check_generated_code
-            - push_app_legacy
+            - push_app_gov_dev
             - push_app_stg
-            - push_migrations_legacy
+            - push_migrations_gov_dev
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1396,9 +1386,9 @@ workflows:
           requires:
             - pre_deps_golang
             - check_generated_code
-            - push_app_legacy
+            - push_app_gov_dev
             - push_app_stg
-            - push_migrations_legacy
+            - push_migrations_gov_dev
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1427,7 +1417,7 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
-      - push_app_legacy:
+      - push_app_gov_dev:
           requires:
             - build_app
 
@@ -1441,7 +1431,7 @@ workflows:
             - anti_virus
             - pre_deps_golang
 
-      - push_migrations_legacy:
+      - push_migrations_gov_dev:
           requires:
             - build_migrations
 
@@ -1454,7 +1444,7 @@ workflows:
             - anti_virus
             - pre_deps_golang
 
-      - push_tasks_legacy:
+      - push_tasks_gov_dev:
           requires:
             - build_tasks
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
   aws_vars_transcom_com_dev:
     steps:
       - run:
-          name: 'Setting up AWS environment variables for prd env'
+          name: 'Setting up AWS environment variables for com-dev env'
           command: |
             echo "export AWS_DEFAULT_REGION=$COM_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV
@@ -141,7 +141,7 @@ commands:
   aws_vars_transcom_gov_dev:
     steps:
       - run:
-          name: 'Setting up AWS environment variables for prd env'
+          name: 'Setting up AWS environment variables for gov-dev env'
           command: |
             echo "export AWS_DEFAULT_REGION=$GOV_DEV_REGION" >> $BASH_ENV
             echo "export AWS_ACCOUNT_ID=$GOV_DEV_ACCOUNT_ID" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,6 +923,20 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
+  # `push_app_legacy` pushes the app container to the legacy container repository
+  push_app_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          ecr_env: legacy
+          image_name: ppp
+          tag: web-dev
+          repo: app
+      - announce_failure
+
   # `push_app_exp` pushes the app container to the milmove-exp container repository
   push_app_exp:
     executor: mymove_small
@@ -1015,6 +1029,20 @@ jobs:
           working_dir: ~/transcom/mymove
       - announce_failure
 
+  # `push_migrations_legacy` pushes the migrations container to the legacy container repository
+  push_migrations_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          ecr_env: legacy
+          image_name: ppp-migrations
+          tag: dev
+          repo: app-migrations
+      - announce_failure
+
   # `push_migrations_exp` pushes the migrations container to the milmove-exp container repository
   push_migrations_exp:
     executor: mymove_small
@@ -1077,6 +1105,20 @@ jobs:
           image_name: tasks
           tag: dev
           working_dir: ~/transcom/mymove
+      - announce_failure
+
+  # `push_tasks_legacy` pushes the tasks containers to the legacy container repository
+  push_tasks_legacy:
+    executor: mymove_small
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - aws_vars_legacy
+      - push_image:
+          ecr_env: legacy
+          image_name: tasks
+          tag: dev
+          repo: app-tasks
       - announce_failure
 
   # `push_tasks_exp` pushes the tasks containers to the milmove-exp container repository
@@ -1341,7 +1383,9 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - check_generated_code
+            - push_app_legacy
             - push_app_stg
+            - push_migrations_legacy
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1352,7 +1396,9 @@ workflows:
           requires:
             - pre_deps_golang
             - check_generated_code
+            - push_app_legacy
             - push_app_stg
+            - push_migrations_legacy
             - push_migrations_stg
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
@@ -1381,6 +1427,10 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
+      - push_app_legacy:
+          requires:
+            - build_app
+
       - build_tools:
           requires:
             - anti_virus
@@ -1391,6 +1441,10 @@ workflows:
             - anti_virus
             - pre_deps_golang
 
+      - push_migrations_legacy:
+          requires:
+            - build_migrations
+
       - build_tasks:
           requires:
             - build_tools
@@ -1399,6 +1453,10 @@ workflows:
           requires:
             - anti_virus
             - pre_deps_golang
+
+      - push_tasks_legacy:
+          requires:
+            - build_tasks
 
       - push_app_exp:
           requires:

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -14,7 +14,7 @@ services:
   milmove_migrate:
     depends_on:
       - database
-    image: 923914045601.dkr.ecr.us-west-2.amazonaws.com/app-migrations:git-branch-placeholder_branch_name
+    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app-migrations:git-branch-placeholder_branch_name
     links:
       - database
     environment:
@@ -38,7 +38,7 @@ services:
     depends_on:
       - database
       - milmove_migrate
-    image: 923914045601.dkr.ecr.us-west-2.amazonaws.com/app:git-branch-placeholder_branch_name
+    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app:git-branch-placeholder_branch_name
     links:
       - database
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   milmove_migrate:
     depends_on:
       - database
-    image: 923914045601.dkr.ecr.us-west-2.amazonaws.com/app-migrations:git-branch-placeholder_branch_name
+    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app-migrations:git-branch-placeholder_branch_name
     links:
       - database
     environment:
@@ -42,7 +42,7 @@ services:
       - database
       - milmove_migrate
       - redis
-    image: 923914045601.dkr.ecr.us-west-2.amazonaws.com/app:git-branch-placeholder_branch_name
+    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app:git-branch-placeholder_branch_name
     links:
       - database
     ports:


### PR DESCRIPTION
## Description

Stop creating images in the legacy account. Create them in transcom-gov-dev.

In the course of making this PR, we tried to stop creating images in the legacy account. This failed because `make e2e_tests_docker` uses this image. Therefore, this PR migrated pushing images over to transcom-gov-dev.

## Setup

Watch CircleCI and ensure it passes.

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6274) for this change