### PR TITLE
MB-6678 Align subcopy size in CONUS / OCONUS card options

### DIFF
--- a/src/components/Customer/SelectableCard.module.scss
+++ b/src/components/Customer/SelectableCard.module.scss
@@ -55,6 +55,9 @@ p + .cardContainer {
   @media (min-width: $tablet) {
     padding-left: 2rem;
   }
+  div {
+    @include u-margin-bottom(1);
+  }
 }
 
 .helpButton {

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -14,9 +14,7 @@ export class ConusOrNot extends Component {
     const { setLocation, conusStatus } = this.props;
     const oconusCardText = (
       <>
-        <div>
-        Starts or ends in Alaska, Hawaii, or International locations
-        </div>
+        <div>Starts or ends in Alaska, Hawaii, or International locations</div>
         <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set up
         your move.
       </>

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -14,11 +14,10 @@ export class ConusOrNot extends Component {
     const { setLocation, conusStatus } = this.props;
     const oconusCardText = (
       <>
-        <p>Starts or ends in Alaska, Hawaii, or International locations</p>
-        <p>
-          <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set
-          up your move.
-        </p>
+        Starts or ends in Alaska, Hawaii, or International locations
+        <br /> <br />
+        <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set up
+        your move.
       </>
     );
 

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -14,8 +14,9 @@ export class ConusOrNot extends Component {
     const { setLocation, conusStatus } = this.props;
     const oconusCardText = (
       <>
+        <div>
         Starts or ends in Alaska, Hawaii, or International locations
-        <hr className="bg-white border-0" />
+        </div>
         <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set up
         your move.
       </>

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -15,7 +15,7 @@ export class ConusOrNot extends Component {
     const oconusCardText = (
       <>
         Starts or ends in Alaska, Hawaii, or International locations
-        <hr className="text-white border-0" />
+        <hr className="bg-white border-0" />
         <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set up
         your move.
       </>

--- a/src/pages/MyMove/ConusOrNot.jsx
+++ b/src/pages/MyMove/ConusOrNot.jsx
@@ -15,7 +15,7 @@ export class ConusOrNot extends Component {
     const oconusCardText = (
       <>
         Starts or ends in Alaska, Hawaii, or International locations
-        <br /> <br />
+        <hr className="text-white border-0" />
         <strong>MilMove does not support OCONUS moves yet.</strong> Contact your current transportation office to set up
         your move.
       </>


### PR DESCRIPTION
## Description
This branch removes the wrapping `<p>` elements from around the OCONUS **Selectable Card** text to eliminate the visual differences between it and the CONUS card above it on the `Where are you moving` page in the customer onboarding process.

## Reviewer Notes
~I used an `<hr>` to get the desired line break without the use of a `<p>` element, which was what was causing the the visual difference between the text in the top card and the bottom.~ I changed approaches to use a div with some margin bottom instead.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
http://milmovelocal:3000/service-member/8311b7ea-5f31-432e-8077-a3a5babb63e3/conus-status

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6678?atlOrigin=eyJpIjoiNzlhMmVlYTNhYWJlNDJhZWEwNGU5ZGEyMjk2MGY2ZTciLCJwIjoiaiJ9) for this change

## Screenshots

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/59394696/109187069-8ca2a580-775f-11eb-8ce1-973ad9b3a68f.png">
<img width="315" alt="image" src="https://user-images.githubusercontent.com/59394696/109187138-9b895800-775f-11eb-95c2-668037757666.png">

