### PR TITLE
MB-6571 Update relevant Office & Admin statuses when User status is updated

### DIFF
--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -42,6 +42,9 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	adminAPI := adminops.NewMymoveAPI(adminSpec)
 	queryBuilder := query.NewQueryBuilder(context.DB())
+	officeUpdater := officeuser.NewOfficeUserUpdater(queryBuilder)
+	adminUpdater := adminuser.NewAdminUserUpdater(queryBuilder)
+
 	adminAPI.ServeError = handlers.ServeCustomError
 
 	adminAPI.OfficeUsersIndexOfficeUsersHandler = IndexOfficeUsersHandler{
@@ -129,7 +132,7 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 	adminAPI.UsersUpdateUserHandler = UpdateUserHandler{
 		context,
 		user.NewUserSessionRevocation(queryBuilder),
-		user.NewUserUpdater(queryBuilder),
+		user.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 		query.NewQueryFilter,
 	}
 

--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -70,7 +70,7 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	adminAPI.OfficeUsersUpdateOfficeUserHandler = UpdateOfficeUserHandler{
 		context,
-		officeuser.NewOfficeUserUpdater(queryBuilder),
+		officeUpdater,
 		query.NewQueryFilter,
 		userRolesCreator,
 	}
@@ -150,7 +150,7 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	adminAPI.AdminUsersUpdateAdminUserHandler = UpdateAdminUserHandler{
 		context,
-		adminuser.NewAdminUserUpdater(queryBuilder),
+		adminUpdater,
 		query.NewQueryFilter,
 	}
 

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	adminuser "github.com/transcom/mymove/pkg/services/admin_user"
 	fetch "github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	officeuser "github.com/transcom/mymove/pkg/services/office_user"
 	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	userservice "github.com/transcom/mymove/pkg/services/user"
@@ -248,6 +250,9 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 	sessionManagers := setupSessionManagers()
 	handlerContext := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 	handlerContext.SetSessionManagers(sessionManagers)
+	queryBuilder := query.NewQueryBuilder(suite.DB())
+	officeUpdater := officeuser.NewOfficeUserUpdater(queryBuilder)
+	adminUpdater := adminuser.NewAdminUserUpdater(queryBuilder)
 
 	suite.T().Run("Successful userSessionRevocation", func(t *testing.T) {
 		// Under test: UsereSessionRevocation, userUpdater
@@ -262,7 +267,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		handler := UpdateUserHandler{
 			handlerContext,
 			userservice.NewUserSessionRevocation(queryBuilder),
-			userservice.NewUserUpdater(queryBuilder),
+			userservice.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 			newQueryFilter,
 		}
 
@@ -315,7 +320,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		handler := UpdateUserHandler{
 			handlerContext,
 			userservice.NewUserSessionRevocation(queryBuilder),
-			userservice.NewUserUpdater(queryBuilder),
+			userservice.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 			newQueryFilter,
 		}
 
@@ -366,7 +371,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		handler := UpdateUserHandler{
 			handlerContext,
 			userservice.NewUserSessionRevocation(queryBuilder),
-			userservice.NewUserUpdater(queryBuilder),
+			userservice.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 			newQueryFilter,
 		}
 
@@ -422,7 +427,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		handler := UpdateUserHandler{
 			handlerContext,
 			userservice.NewUserSessionRevocation(queryBuilder),
-			userservice.NewUserUpdater(queryBuilder),
+			userservice.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 			newQueryFilter,
 		}
 
@@ -483,7 +488,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 		handler := UpdateUserHandler{
 			handlerContext,
 			userRevocation,
-			userservice.NewUserUpdater(queryBuilder),
+			userservice.NewUserUpdater(queryBuilder, officeUpdater, adminUpdater),
 			newQueryFilter,
 		}
 

--- a/pkg/services/office_user/office_user_updater.go
+++ b/pkg/services/office_user/office_user_updater.go
@@ -22,6 +22,7 @@ func (o *officeUserUpdater) UpdateOfficeUser(id uuid.UUID, payload *adminmessage
 
 	if err != nil {
 		return nil, nil, err
+
 	}
 
 	if payload.FirstName != nil {

--- a/pkg/services/user/user_updater.go
+++ b/pkg/services/user/user_updater.go
@@ -71,9 +71,9 @@ func (o *userUpdater) UpdateUser(id uuid.UUID, user *models.User) (*models.User,
 			_, verrs, err = o.officeUserUpdater.UpdateOfficeUser(foundOfficeUser.ID, &payload)
 
 			if verrs != nil {
-				logger.Info("Could not update office user", zap.Error(verrs))
+				logger.Error("Could not update office user", zap.Error(verrs))
 			} else if err != nil {
-				logger.Info("Could not update office user", zap.Error(err))
+				logger.Error("Could not update office user", zap.Error(err))
 			}
 		}
 
@@ -87,9 +87,9 @@ func (o *userUpdater) UpdateUser(id uuid.UUID, user *models.User) (*models.User,
 			}
 			_, verrs, err = o.adminUserUpdater.UpdateAdminUser(foundAdminUser.ID, &payload)
 			if verrs != nil {
-				logger.Info("Could not update admin user", zap.Error(verrs))
+				logger.Error("Could not update admin user", zap.Error(verrs))
 			} else if err != nil {
-				logger.Info("Could not update admin user", zap.Error(err))
+				logger.Error("Could not update admin user", zap.Error(err))
 			}
 		}
 	}

--- a/pkg/services/user/user_updater.go
+++ b/pkg/services/user/user_updater.go
@@ -4,18 +4,25 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
 type userUpdater struct {
-	builder userQueryBuilder
+	builder           userQueryBuilder
+	officeUserUpdater services.OfficeUserUpdater
+	adminUserUpdater  services.AdminUserUpdater
 }
 
 // NewUserUpdater returns a new admin user creator builder
-func NewUserUpdater(builder userQueryBuilder) services.UserUpdater {
-	return &userUpdater{builder}
+func NewUserUpdater(builder userQueryBuilder, officeUserUpdater services.OfficeUserUpdater, adminUserUpdater services.AdminUserUpdater) services.UserUpdater {
+	return &userUpdater{
+		builder,
+		officeUserUpdater,
+		adminUserUpdater,
+	}
 }
 
 // UpdateUser updates any user
@@ -42,6 +49,42 @@ func (o *userUpdater) UpdateUser(id uuid.UUID, user *models.User) (*models.User,
 	if verrs != nil || err != nil {
 		return nil, verrs, err
 	}
+
+	// If the update was successful and we are deactivating the user,
+	// update the office and admin statuses to match.
+
+	// Check if we are deactivating the user
+	if !user.Active {
+
+		// Check for Office User
+		foundOfficeUser := models.OfficeUser{}
+		filters = []services.QueryFilter{query.NewQueryFilter("user_id", "=", id.String())}
+		err = o.builder.FetchOne(&foundOfficeUser, filters)
+
+		// If we find a matching Office User, update their status
+		if err == nil {
+			payload := adminmessages.OfficeUserUpdatePayload{
+				Active: &user.Active,
+			}
+			_, verrs, err = o.officeUserUpdater.UpdateOfficeUser(foundOfficeUser.ID, &payload)
+			// TODO: Handle these errors at the end
+		}
+
+		// Check for Admin User
+		foundAdminUser := models.AdminUser{}
+		err = o.builder.FetchOne(&foundAdminUser, filters)
+		// If we find a matching Admin User, update their status
+		if err == nil {
+			payload := adminmessages.AdminUserUpdatePayload{
+				Active: &user.Active,
+			}
+			_, verrs, err = o.adminUserUpdater.UpdateAdminUser(foundAdminUser.ID, &payload)
+			// TODO: Handle these errors at the end
+		}
+
+	}
+
+	// if there are any errors, we should log them or return them. they may not be terminal.
 
 	return &foundUser, nil, nil
 

--- a/pkg/services/user/user_updater.go
+++ b/pkg/services/user/user_updater.go
@@ -70,7 +70,7 @@ func (o *userUpdater) UpdateUser(id uuid.UUID, user *models.User) (*models.User,
 			}
 			_, verrs, err = o.officeUserUpdater.UpdateOfficeUser(foundOfficeUser.ID, &payload)
 
-			if verrs.Count() > 0 {
+			if verrs != nil {
 				logger.Info("Could not update office user", zap.Error(verrs))
 			} else if err != nil {
 				logger.Info("Could not update office user", zap.Error(err))
@@ -86,7 +86,7 @@ func (o *userUpdater) UpdateUser(id uuid.UUID, user *models.User) (*models.User,
 				Active: &user.Active,
 			}
 			_, verrs, err = o.adminUserUpdater.UpdateAdminUser(foundAdminUser.ID, &payload)
-			if verrs.Count() > 0 {
+			if verrs != nil {
 				logger.Info("Could not update admin user", zap.Error(verrs))
 			} else if err != nil {
 				logger.Info("Could not update admin user", zap.Error(err))

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -37,7 +37,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 
 	})
 
-	suite.T().Run("Deactivate an Officer User successfully", func(t *testing.T) {
+	suite.T().Run("Deactivate an Office User successfully", func(t *testing.T) {
 		// Create an active office user
 		// deactivate the user
 		// check that their office user status is also set to false

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -5,13 +5,19 @@ import (
 
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers/adminapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
+	adminUser "github.com/transcom/mymove/pkg/services/admin_user"
+	officeUser "github.com/transcom/mymove/pkg/services/office_user"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *UserServiceSuite) TestUserUpdater() {
 	builder := query.NewQueryBuilder(suite.DB())
-	updater := NewUserUpdater(builder)
+	officeUserUpdater := officeUser.NewOfficeUserUpdater(builder)
+	adminUserUpdater := adminUser.NewAdminUserUpdater(builder)
+	updater := NewUserUpdater(builder, officeUserUpdater, adminUserUpdater)
+
 	active := true
 	inactive := false
 
@@ -27,6 +33,66 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 
 		suite.Nil(verr)
 		suite.Nil(err)
+		suite.False(updatedUser.Active)
+
+	})
+
+	suite.T().Run("Deactivate an Officer User successfully", func(t *testing.T) {
+		// Create an active office user
+		// deactivate the user
+		// check that their office user status is also set to false
+
+		activeOfficeUser := testdatagen.MakeActiveOfficeUser(suite.DB())
+
+		// Create the payload to update a user's active status. This should also
+		// update their officeUser status in parallel.
+		payload := adminmessages.UserUpdatePayload{
+			Active: &inactive,
+		}
+
+		modelToPayload, _ := payloads.UserModel(&payload, *activeOfficeUser.UserID)
+
+		// Deactivate user
+		updatedUser, verr, err := updater.UpdateUser(*activeOfficeUser.UserID, modelToPayload)
+
+		// Fetch updated office user to confirm status
+		updatedOfficeUser := models.OfficeUser{}
+		suite.DB().Eager("OfficeUser.User").Find(&updatedOfficeUser, activeOfficeUser.ID)
+
+		// Check that there are no errors and both statuses successfully updated
+		suite.Nil(verr)
+		suite.Nil(err)
+		suite.False(updatedOfficeUser.Active)
+		suite.False(updatedUser.Active)
+
+	})
+
+	suite.T().Run("Deactivate an Admin User successfully", func(t *testing.T) {
+		// Create an active office user
+		// deactivate the user
+		// check that their office user status is also set to false
+
+		activeAdminUser := testdatagen.MakeActiveAdminUser(suite.DB())
+
+		// Create the payload to update a user's active status. This should also
+		// update their officeUser status in parallel.
+		payload := adminmessages.UserUpdatePayload{
+			Active: &inactive,
+		}
+
+		modelToPayload, _ := payloads.UserModel(&payload, *activeAdminUser.UserID)
+
+		// Deactivate user
+		updatedUser, verr, err := updater.UpdateUser(*activeAdminUser.UserID, modelToPayload)
+
+		// Fetch updated office user to confirm status
+		updatedAdminUser := models.AdminUser{}
+		suite.DB().Eager("AdminUser.User").Find(&updatedAdminUser, activeAdminUser.ID)
+
+		// Check that there are no errors and both statuses successfully updated
+		suite.Nil(verr)
+		suite.Nil(err)
+		suite.False(updatedAdminUser.Active)
 		suite.False(updatedUser.Active)
 
 	})

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -38,9 +38,15 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 	})
 
 	suite.T().Run("Deactivate an Office User successfully", func(t *testing.T) {
-		// Create an active office user
-		// deactivate the user
-		// check that their office user status is also set to false
+		// Under test: updateUser, updateOfficeUser
+		//
+		// Set up:     We provide an ACTIVE user/office user, and then deactivate
+		//			   the user by calling updateUser.
+		//
+		// Expected outcome:
+		//           	updateUser updates the users table and calls updateOfficeUser
+		//            	to update the office_users table. Both tables have an ACTIVE
+		//				status set to False.
 
 		activeOfficeUser := testdatagen.MakeActiveOfficeUser(suite.DB())
 
@@ -68,14 +74,20 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 	})
 
 	suite.T().Run("Deactivate an Admin User successfully", func(t *testing.T) {
-		// Create an active office user
-		// deactivate the user
-		// check that their office user status is also set to false
+		// Under test: updateUser, updateAdminUser
+		//
+		// Set up:     We provide an ACTIVE user/admin user, and then deactivate
+		//			   the user by calling updateUser.
+		//
+		// Expected outcome:
+		//           	updateUser updates the users table and calls updateAdminUser
+		//            	to update the admin_users table. Both tables have an ACTIVE
+		//				status set to False.
 
 		activeAdminUser := testdatagen.MakeActiveAdminUser(suite.DB())
 
 		// Create the payload to update a user's active status. This should also
-		// update their officeUser status in parallel.
+		// update their adminUser status in parallel.
 		payload := adminmessages.UserUpdatePayload{
 			Active: &inactive,
 		}
@@ -85,7 +97,7 @@ func (suite *UserServiceSuite) TestUserUpdater() {
 		// Deactivate user
 		updatedUser, verr, err := updater.UpdateUser(*activeAdminUser.UserID, modelToPayload)
 
-		// Fetch updated office user to confirm status
+		// Fetch updated admin user to confirm status
 		updatedAdminUser := models.AdminUser{}
 		suite.DB().Eager("AdminUser.User").Find(&updatedAdminUser, activeAdminUser.ID)
 

--- a/pkg/testdatagen/make_admin_user.go
+++ b/pkg/testdatagen/make_admin_user.go
@@ -68,3 +68,15 @@ func MakeAdminUserWithNoUser(db *pop.Connection, assertions Assertions) models.A
 func MakeDefaultAdminUser(db *pop.Connection) models.AdminUser {
 	return MakeAdminUser(db, Assertions{})
 }
+
+// MakeActiveAdminUser makes an AdminUser that is active
+func MakeActiveAdminUser(db *pop.Connection) models.AdminUser {
+	adminUser := MakeDefaultAdminUser(db)
+
+	adminUser.Active = true
+
+	db.Update(&adminUser)
+
+	return adminUser
+
+}

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -107,6 +107,17 @@ func MakeTIOOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeU
 	return officeUser
 }
 
+// MakeActiveOfficeUser returns an active office user
+func MakeActiveOfficeUser(db *pop.Connection) models.OfficeUser {
+	officeUser := MakeDefaultOfficeUser(db)
+
+	officeUser.Active = true
+
+	db.Update(&officeUser)
+
+	return officeUser
+}
+
 // MakeTOOOfficeUser makes an OfficeUser with the TOO role
 func MakeTOOOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeUser {
 	tooRole := roles.Role{


### PR DESCRIPTION
## Description

This PR keeps the `office_users` and `admin_users` tables in sync with `users`. If a user is deactivated that is also an office or admin user, both `Active` statuses will update.

* `user_updater` service object now uses `admin_user_updater` and `office_user_updater` services objects to update as needed. By using these updaters, we can keep our error messages consistent.
* If there is an issue updating the `admin_users` or `office_users` tables, an error is logged. I decided to _not_ use a transaction, because if the code gets to this point, it means the user was successfully deactivated. Since one primary use case is security-related, we should always deactivate the user if we can.
* Two test functions added to create a new admin or office user that is active, and new tests added.



## Reviewer Notes

* Is the logging of errors around admin/office not updating sufficient?

## Setup

**Run tests**
`go test ./pkg/services/user --testify.m "TestUserUpdater" -v`

**Use UI to manuall test**
* Run the server and client, and go to http://adminlocal:3000
* Log in as an admin user. Go to the **Office Users** page and pick an active office user. Grab their email address.
* Go to the **Users** index page and search for the user by email. Edit the user and set Active to No. Save and confirm they are no longer active.
* Go back to the **Office Users** page and find the same user. Confirm their Active status is now false.
* Repeat this process for an Admin User.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6751) for this change

