### PR TITLE
MB-6433 Benchmark TIO document viewer

### DIFF
--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -29,27 +29,33 @@ type bandwidthScenario NamedScenario
 var BandwidthScenario = bandwidthScenario{"bandwidth"}
 
 func createHHGMove150Kb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
+	filterFile := &[]string{"150Kb.png"}
 	serviceMember := makeServiceMember(db)
-	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, &[]string{"150Kb.png"})
+	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, filterFile)
 	move := makeMoveForOrders(orders, db, "S150KB")
 	shipment := makeShipmentForMove(move, db)
-	makePaymentRequestForShipment(move, shipment, db, primeUploader)
+	paymentRequestID := uuid.Must(uuid.FromString("68034aa3-831c-4d2d-9fd4-b66bc0cc5130"))
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
 }
 
 func createHHGMove2mb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
+	filterFile := &[]string{"2mb.png"}
 	serviceMember := makeServiceMember(db)
-	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, &[]string{"2mb.png"})
+	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, filterFile)
 	move := makeMoveForOrders(orders, db, "MED2MB")
 	shipment := makeShipmentForMove(move, db)
-	makePaymentRequestForShipment(move, shipment, db, primeUploader)
+	paymentRequestID := uuid.Must(uuid.FromString("4de88d57-9723-446b-904c-cf8d0a834687"))
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
 }
 
 func createHHGMove25mb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
+	filterFile := &[]string{"25mb.png"}
 	serviceMember := makeServiceMember(db)
-	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, &[]string{"25mb.png"})
+	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, filterFile)
 	move := makeMoveForOrders(orders, db, "LG25MB")
 	shipment := makeShipmentForMove(move, db)
-	makePaymentRequestForShipment(move, shipment, db, primeUploader)
+	paymentRequestID := uuid.Must(uuid.FromString("aca5cc9c-c266-4a7d-895d-dc3c9c0d9894"))
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
 }
 
 func makeServiceMember(db *pop.Connection) models.ServiceMember {
@@ -148,9 +154,10 @@ func makeShipmentForMove(move models.Move, db *pop.Connection) models.MTOShipmen
 	return MTOShipment
 }
 
-func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment, db *pop.Connection, primeUploader *uploader.PrimeUploader) {
+func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment, db *pop.Connection, primeUploader *uploader.PrimeUploader, fileNames *[]string, paymentRequestID uuid.UUID) {
 	paymentRequest := testdatagen.MakePaymentRequest(db, testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
+			ID:            paymentRequestID,
 			MoveTaskOrder: move,
 			IsFinal:       false,
 			Status:        models.PaymentRequestStatusPending,
@@ -192,7 +199,7 @@ func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment
 		MTOServiceItem: mtoServiceItemDUCRT,
 	})
 
-	files := filesInBandwidthTestDirectory(nil)
+	files := filesInBandwidthTestDirectory(fileNames)
 	// Creates prime upload documents from the files in this directory:
 	// pkg/testdatagen/testdata/bandwidth_test_docs
 	for _, file := range files {

--- a/puppeteer/benchmarking.js
+++ b/puppeteer/benchmarking.js
@@ -13,7 +13,7 @@ const config = new Conf({
 
 const program = new commander.Command();
 
-const runNetworkComparison = async (host, saveReports, verbose) => {
+const runNetworkComparison = async (scenario, host, saveReports, verbose) => {
   const results = {};
 
   // await cannot be used inside of a forEach loop
@@ -25,7 +25,8 @@ const runNetworkComparison = async (host, saveReports, verbose) => {
 
     // Running these tests in parallel would likely skew the results
     // eslint-disable-next-line no-await-in-loop
-    const elapsedTimeResults = await totalDuration({
+    results[`${speed}`] = await totalDuration({
+      scenario,
       host,
       config: configStore,
       debug,
@@ -34,14 +35,12 @@ const runNetworkComparison = async (host, saveReports, verbose) => {
     }).catch(() => {
       process.exit(1);
     });
-
-    results[`${speed}`] = elapsedTimeResults;
   }
 
   return results;
 };
 
-const runFileSizeComparison = async (host, saveReports, verbose) => {
+const runFileSizeComparison = async (scenario, host, saveReports, verbose) => {
   const results = {};
 
   // await cannot be used inside of a forEach loop
@@ -54,6 +53,7 @@ const runFileSizeComparison = async (host, saveReports, verbose) => {
     // Running these tests in parallel would likely skew the results
     // eslint-disable-next-line no-await-in-loop
     const elapsedTimeResults = await totalDuration({
+      scenario,
       host,
       config: configStore,
       debug,
@@ -79,19 +79,19 @@ const runAction = async ({ scenario, measurementType, host, verbose, saveReports
   let results = {};
   switch (measurementType) {
     case measurementTypes.totalDuration:
-      results = await totalDuration({ host, config: config.store, debug, saveReports, verbose }).catch(() => {
+      results = await totalDuration({ scenario, host, config: config.store, debug, saveReports, verbose }).catch(() => {
         process.exit(1);
       });
 
       console.table(results);
       break;
     case measurementTypes.fileDuration:
-      results = await runFileSizeComparison(host, saveReports, verbose);
+      results = await runFileSizeComparison(scenario, host, saveReports, verbose);
 
       console.table(results);
       break;
     case measurementTypes.networkComparison:
-      results = await runNetworkComparison(host, saveReports, verbose);
+      results = await runNetworkComparison(scenario, host, saveReports, verbose);
 
       console.table(results);
       break;
@@ -106,7 +106,7 @@ program
   .addOption(
     new commander.Option('-s, --scenario <scenario>', 'scenario is the page or workflow being tested')
       .default('too-orders-document-viewer')
-      .choices(['too-orders-document-viewer'])
+      .choices(['too-orders-document-viewer', 'tio-payment-requests-document-viewer'])
       .makeOptionMandatory(),
   )
   .addOption(

--- a/puppeteer/constants.js
+++ b/puppeteer/constants.js
@@ -60,6 +60,11 @@ const networkProfiles = {
   },
 };
 
+const scenarios = {
+  too: 'too-orders-document-viewer',
+  tio: 'tio-payment-requests-document-viewer',
+};
+
 const measurementTypes = {
   totalDuration: 'total-duration',
   networkComparison: 'network-comparison',
@@ -89,6 +94,13 @@ const fileSizeMoveCodes = {
   large: 'LG25MB',
 };
 
+// File sizes associated to different payment requests by id
+const fileSizePaymentRequestIds = {
+  small: '68034aa3-831c-4d2d-9fd4-b66bc0cc5130',
+  medium: '4de88d57-9723-446b-904c-cf8d0a834687',
+  large: 'aca5cc9c-c266-4a7d-895d-dc3c9c0d9894',
+};
+
 // All speeds available
 const speeds = ['fast', 'medium', 'slow'];
 
@@ -100,5 +112,7 @@ module.exports = {
   fileSizeList,
   fileList,
   fileSizeMoveCodes,
+  fileSizePaymentRequestIds,
   speeds,
+  scenarios,
 };

--- a/puppeteer/scenarios.js
+++ b/puppeteer/scenarios.js
@@ -6,7 +6,7 @@ const puppeteer = require('puppeteer');
 const reportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
 const { throttling } = require('lighthouse/lighthouse-core/config/constants');
 
-const { networkProfiles, fileSizeMoveCodes } = require('./constants');
+const { networkProfiles, fileSizeMoveCodes, fileSizePaymentRequestIds, scenarios } = require('./constants');
 
 // Gets the total request time based on the responseEnd - requestStart
 // in secs
@@ -134,7 +134,7 @@ const lighthouseFromPuppeteer = async (url, options, config = null, saveReports 
   };
 };
 
-const totalDuration = async ({ host, config, debug, saveReports, verbose }) => {
+const totalDuration = async ({ scenario, host, config, debug, saveReports, verbose }) => {
   const waitOptions = { timeout: 0, waitUntil: 'networkidle0' };
 
   const browser = await puppeteer.launch(config.launch);
@@ -163,8 +163,17 @@ const totalDuration = async ({ host, config, debug, saveReports, verbose }) => {
   const networkConfig = await setupNetwork(config, page);
   const cpuRateConfig = await setupCPU(config, page);
 
-  // go to a document viewer, orders
-  const url = `${host}/moves/${fileSizeMoveCodes[config.fileSize]}/orders`;
+  // go to a document viewer
+  let url;
+  if (scenario === scenarios.tio) {
+    url = `${host}/moves/${fileSizeMoveCodes[config.fileSize]}/payment-requests/${
+      fileSizePaymentRequestIds[config.fileSize]
+    }`;
+  } else {
+    // default to TOO
+    url = `${host}/moves/${fileSizeMoveCodes[config.fileSize]}/orders`;
+  }
+
   debug(`URL to gather metrics from: ${url}`);
   await page.goto(url, waitOptions);
 


### PR DESCRIPTION
## Description

This PR builds off of JP's work: https://github.com/transcom/mymove/pull/5969

Adds an additional scenario `tio-payment-requests-document-viewer` to gather metrics from the TIO payment requests document viewer page for each measurement type.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_bandwidth_up
make server_run
make office_client_run

node puppeteer/benchmarking.js run -s tio-payment-requests-document-viewer -m network-comparison -v
node puppeteer/benchmarking.js run -s tio-payment-requests-document-viewer -m file-duration -v
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6433) for this change

## Screenshots

Results from the network comparison measurement type
![image](https://user-images.githubusercontent.com/1522549/109237763-131ead80-7787-11eb-8af2-9e10e1c61f02.png)
