### PR TITLE
MB-6917 Add PaymentServiceItemParams to GHC API

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -390,18 +390,24 @@ func PaymentRequest(pr *models.PaymentRequest, storer storage.FileStorer) (*ghcm
 
 // PaymentServiceItem payload
 func PaymentServiceItem(ps *models.PaymentServiceItem) *ghcmessages.PaymentServiceItem {
+	if ps == nil {
+		return nil
+	}
+	paymentServiceItemParams := PaymentServiceItemParams(&ps.PaymentServiceItemParams)
+
 	return &ghcmessages.PaymentServiceItem{
-		ID:                 *handlers.FmtUUID(ps.ID),
-		MtoServiceItemID:   *handlers.FmtUUID(ps.MTOServiceItemID),
-		MtoServiceItemName: ps.MTOServiceItem.ReService.Name,
-		MtoShipmentType:    ghcmessages.MTOShipmentType(ps.MTOServiceItem.MTOShipment.ShipmentType),
-		MtoShipmentID:      handlers.FmtUUIDPtr(ps.MTOServiceItem.MTOShipmentID),
-		CreatedAt:          strfmt.DateTime(ps.CreatedAt),
-		PriceCents:         handlers.FmtCost(ps.PriceCents),
-		RejectionReason:    ps.RejectionReason,
-		Status:             ghcmessages.PaymentServiceItemStatus(ps.Status),
-		ReferenceID:        ps.ReferenceID,
-		ETag:               etag.GenerateEtag(ps.UpdatedAt),
+		ID:                       *handlers.FmtUUID(ps.ID),
+		MtoServiceItemID:         *handlers.FmtUUID(ps.MTOServiceItemID),
+		MtoServiceItemName:       ps.MTOServiceItem.ReService.Name,
+		MtoShipmentType:          ghcmessages.MTOShipmentType(ps.MTOServiceItem.MTOShipment.ShipmentType),
+		MtoShipmentID:            handlers.FmtUUIDPtr(ps.MTOServiceItem.MTOShipmentID),
+		CreatedAt:                strfmt.DateTime(ps.CreatedAt),
+		PriceCents:               handlers.FmtCost(ps.PriceCents),
+		RejectionReason:          ps.RejectionReason,
+		Status:                   ghcmessages.PaymentServiceItemStatus(ps.Status),
+		ReferenceID:              ps.ReferenceID,
+		ETag:                     etag.GenerateEtag(ps.UpdatedAt),
+		PaymentServiceItemParams: *paymentServiceItemParams,
 	}
 }
 
@@ -411,6 +417,33 @@ func PaymentServiceItems(paymentServiceItems *models.PaymentServiceItems) *ghcme
 	for i, m := range *paymentServiceItems {
 		copyOfPaymentServiceItem := m // Make copy to avoid implicit memory aliasing of items from a range statement.
 		payload[i] = PaymentServiceItem(&copyOfPaymentServiceItem)
+	}
+	return &payload
+}
+
+// PaymentServiceItemParam payload
+func PaymentServiceItemParam(paymentServiceItemParam models.PaymentServiceItemParam) *ghcmessages.PaymentServiceItemParam {
+	return &ghcmessages.PaymentServiceItemParam{
+		ID:                   strfmt.UUID(paymentServiceItemParam.ID.String()),
+		PaymentServiceItemID: strfmt.UUID(paymentServiceItemParam.PaymentServiceItemID.String()),
+		Key:                  ghcmessages.ServiceItemParamName(paymentServiceItemParam.ServiceItemParamKey.Key),
+		Value:                paymentServiceItemParam.Value,
+		Type:                 ghcmessages.ServiceItemParamType(paymentServiceItemParam.ServiceItemParamKey.Type),
+		Origin:               ghcmessages.ServiceItemParamOrigin(paymentServiceItemParam.ServiceItemParamKey.Origin),
+		ETag:                 etag.GenerateEtag(paymentServiceItemParam.UpdatedAt),
+	}
+}
+
+// PaymentServiceItemParams payload
+func PaymentServiceItemParams(paymentServiceItemParams *models.PaymentServiceItemParams) *ghcmessages.PaymentServiceItemParams {
+	if paymentServiceItemParams == nil {
+		return nil
+	}
+
+	payload := make(ghcmessages.PaymentServiceItemParams, len(*paymentServiceItemParams))
+
+	for i, p := range *paymentServiceItemParams {
+		payload[i] = PaymentServiceItemParam(p)
 	}
 	return &payload
 }
@@ -566,13 +599,13 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 
 var (
 	// QueuePaymentRequestPaymentRequested status payment requested
-	QueuePaymentRequestPaymentRequested string = "Payment requested"
+	QueuePaymentRequestPaymentRequested = "Payment requested"
 	// QueuePaymentRequestReviewed status Payment request reviewed
-	QueuePaymentRequestReviewed string = "Reviewed"
+	QueuePaymentRequestReviewed = "Reviewed"
 	// QueuePaymentRequestRejected status Payment request rejected
-	QueuePaymentRequestRejected string = "Rejected"
+	QueuePaymentRequestRejected = "Rejected"
 	// QueuePaymentRequestPaid status PaymentRequest paid
-	QueuePaymentRequestPaid string = "Paid"
+	QueuePaymentRequestPaid = "Paid"
 )
 
 // This is a helper function to calculate the inferred status needed for QueuePaymentRequest payload

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -117,52 +117,54 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 }
 
 func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
-	prUUID, _ := uuid.NewV4()
-	expectedServiceItemName := "Test Service Item Name"
+	expectedServiceItemName := "Test Service"
 	expectedShipmentType := models.MTOShipmentTypeHHG
-	paymentRequests := models.PaymentRequests{
-		models.PaymentRequest{
-			ID: prUUID,
-			PaymentServiceItems: models.PaymentServiceItems{
-				models.PaymentServiceItem{
-					MTOServiceItem: models.MTOServiceItem{
-						ReService: models.ReService{Name: expectedServiceItemName},
-						MTOShipment: models.MTOShipment{
-							ShipmentType: expectedShipmentType,
-						},
-					},
-				},
-			},
+
+	move := testdatagen.MakeAvailableMove(suite.DB())
+	// This should create all the other associated records we need.
+	paymentServiceItemParam := testdatagen.MakePaymentServiceItemParam(suite.DB(), testdatagen.Assertions{
+		Move: move,
+		ServiceItemParamKey: models.ServiceItemParamKey{
+			Key: models.ServiceItemParamNameRequestedPickupDate,
 		},
-	}
-	officeUserUUID, _ := uuid.NewV4()
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true, OfficeUser: models.OfficeUser{ID: officeUserUUID}})
+	})
+	paymentRequest := paymentServiceItemParam.PaymentServiceItem.PaymentRequest
+	paymentRequests := models.PaymentRequests{paymentRequest}
+
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
 		RoleType: roles.RoleTypeTIO,
 	})
 
 	suite.T().Run("Successful list fetch", func(t *testing.T) {
-		paymentRequestListFetcher := &mocks.PaymentRequestListFetcher{}
-		paymentRequestListFetcher.On("FetchPaymentRequestListByMove", mock.Anything,
-			mock.Anything).Return(&paymentRequests, nil).Once()
-
-		request := httptest.NewRequest("GET", fmt.Sprintf("/moves/%s/payment-requests/", "ABC123"), nil)
+		request := httptest.NewRequest("GET", fmt.Sprintf("/moves/%s/payment-requests/", move.Locator), nil)
 		request = suite.AuthenticateOfficeRequest(request, officeUser)
 		params := paymentrequestop.GetPaymentRequestsForMoveParams{
 			HTTPRequest: request,
-			Locator:     "ABC123",
+			Locator:     move.Locator,
 		}
 		context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerContext:            context,
-			PaymentRequestListFetcher: paymentRequestListFetcher,
+			PaymentRequestListFetcher: paymentrequest.NewPaymentRequestListFetcher(suite.DB()),
 		}
 		response := handler.Handle(params)
 		suite.Assertions.IsType(&paymentrequestop.GetPaymentRequestsForMoveOK{}, response)
-		okResponse := response.(*paymentrequestop.GetPaymentRequestsForMoveOK)
-		suite.Equal(prUUID.String(), okResponse.Payload[0].ID.String())
-		suite.Equal(expectedServiceItemName, okResponse.Payload[0].ServiceItems[0].MtoServiceItemName)
-		suite.EqualValues(expectedShipmentType, okResponse.Payload[0].ServiceItems[0].MtoShipmentType)
+		paymentRequestsResponse := response.(*paymentrequestop.GetPaymentRequestsForMoveOK)
+		paymentRequestsPayload := paymentRequestsResponse.Payload
+		paymentServiceItemParamPayload := paymentRequestsPayload[0].ServiceItems[0].PaymentServiceItemParams[0]
+
+		suite.Equal(1, len(paymentRequestsPayload))
+		suite.Equal(paymentRequests[0].ID.String(), paymentRequestsPayload[0].ID.String())
+		suite.Equal(expectedServiceItemName, paymentRequestsPayload[0].ServiceItems[0].MtoServiceItemName)
+		suite.EqualValues(expectedShipmentType, paymentRequestsPayload[0].ServiceItems[0].MtoShipmentType)
+
+		suite.Equal(1, len(paymentRequestsPayload[0].ServiceItems))
+		suite.Equal(paymentServiceItemParam.PaymentServiceItemID.String(), paymentRequestsPayload[0].ServiceItems[0].ID.String())
+		suite.Equal(1, len(paymentRequestsPayload[0].ServiceItems[0].PaymentServiceItemParams))
+		suite.Equal(paymentServiceItemParam.ID.String(), paymentServiceItemParamPayload.ID.String())
+		suite.EqualValues(models.ServiceItemParamNameRequestedPickupDate, paymentServiceItemParamPayload.Key)
+		suite.Equal(paymentServiceItemParam.Value, paymentServiceItemParamPayload.Value)
 	})
 
 	suite.T().Run("Failed list fetch - Not found error ", func(t *testing.T) {

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -117,7 +117,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 }
 
 func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
-	expectedServiceItemName := "Test Service"
+	expectedServiceItemName := "Move Management"
 	expectedShipmentType := models.MTOShipmentTypeHHG
 
 	move := testdatagen.MakeAvailableMove(suite.DB())
@@ -125,7 +125,12 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 	paymentServiceItemParam := testdatagen.MakePaymentServiceItemParam(suite.DB(), testdatagen.Assertions{
 		Move: move,
 		ServiceItemParamKey: models.ServiceItemParamKey{
-			Key: models.ServiceItemParamNameRequestedPickupDate,
+			Key:  models.ServiceItemParamNameRequestedPickupDate,
+			Type: models.ServiceItemParamTypeDate,
+		},
+		ReService: models.ReService{
+			Code: models.ReServiceCodeMS,
+			Name: "Move Management",
 		},
 	})
 	paymentRequest := paymentServiceItemParam.PaymentServiceItem.PaymentRequest

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -137,7 +137,12 @@ func (f *paymentRequestListFetcher) FetchPaymentRequestListByMove(officeUserID u
 	paymentRequests := models.PaymentRequests{}
 
 	// Replaced EagerPreload due to nullable fka on Contractor
-	query := f.db.Q().Eager("PaymentServiceItems.MTOServiceItem.ReService", "PaymentServiceItems.MTOServiceItem.MTOShipment", "MoveTaskOrder.Contractor", "MoveTaskOrder.Orders").
+	query := f.db.Q().Eager(
+		"PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
+		"PaymentServiceItems.MTOServiceItem.ReService",
+		"PaymentServiceItems.MTOServiceItem.MTOShipment",
+		"MoveTaskOrder.Contractor",
+		"MoveTaskOrder.Orders").
 		InnerJoin("moves", "payment_requests.move_id = moves.id").
 		InnerJoin("orders", "orders.id = moves.orders_id").
 		InnerJoin("service_members", "orders.service_member_id = service_members.id").

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -2292,8 +2292,10 @@ func createMoveWithServiceItems(db *pop.Connection, userUploader *uploader.UserU
 
 	move9 := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
-			ID:                 uuid.FromStringOrNil("7cbe57ba-fd3a-45a7-aa9a-1970f1908ae7"),
-			OrdersID:           orders9.ID,
+			ID:       uuid.FromStringOrNil("7cbe57ba-fd3a-45a7-aa9a-1970f1908ae7"),
+			OrdersID: orders9.ID,
+			// SelectedMoveType:   &hhgMoveType,
+			Status:             models.MoveStatusSUBMITTED,
 			AvailableToPrimeAt: swag.Time(time.Now()),
 		},
 	})


### PR DESCRIPTION
## Description

A TIO needs to see how weights factor into the pricing of service items
so that they can understand how the price was determined.

This information comes from the `payment_service_item_params` and
`service_item_param_keys` tables.

The GHC YAML file already included the necessary fields in the
definition of the `getPaymentRequestsForMove` endpoint via the
definitions for
PaymentRequest->PaymentServiceItem->PaymentServiceItemParam

To add these to the payload, I copied the functions from the Prime API,
and then I updated the `FetchPaymentRequestListByMove` function to
perform the necessary joins and eager loading to fetch the data from the
DB.

I used TDD to write a failing test first, and converted the existing
`TestGetPaymentRequestsForMoveHandler` test to an integration test that
hits the DB, as opposed to using mocks. To figure out how to properly
set up the DB with all the necessary data, I looked up existing usage of
`paymentServiceItemParams` in our codebase, and found one in the Prime
API's `pkg/handlers/primeapi/move_task_order_test.go`. I copied that
over and added tests for the `Key` and `Value` fields in the payload.

It's not clear from the JIRA issue what the payload needs to contain for
the client to display the information to the TIO. If it needs the full
paylod as defined in the `PaymentServiceItemParam` section of the YAML,
then I'll add more tests for the rest of the payload.

## Reviewer Notes

Note that this PR only implements the backend portion of this feature. There is a separate unscheduled story (in TTV's March Slice) for the [frontend portion](https://dp3.atlassian.net/browse/MB-4800).

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6917) for this change

## Screenshots
<img width="1680" alt="Screen Shot 2021-03-04 at 1 06 38 PM" src="https://user-images.githubusercontent.com/811150/110011047-fcc7a300-7cec-11eb-974d-2aa69970fb4e.png">
