### PR TITLE
MB-6935 Set access code flag in auth context

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -943,6 +943,12 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	authContext := authentication.NewAuthContext(logger, loginGovProvider, loginGovCallbackProtocol, loginGovCallbackPort, sessionManagers)
+	authContext.SetFeatureFlag(
+		authentication.FeatureFlag{
+			Name:   cli.FeatureFlagAccessCode,
+			Active: v.GetBool(cli.FeatureFlagAccessCode),
+		},
+	)
 	authMux := goji.SubMux()
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Handle(pat.Get("/login-gov"), authentication.RedirectHandler{Context: authContext})

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/alexedwards/scs/v2/memstore"
-	"github.com/markbates/goth"
-
+	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
+	"github.com/markbates/goth"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
@@ -656,6 +657,12 @@ func (suite *AuthSuite) TestAuthUnknownServiceMember() {
 	// Prepare the callback handler
 	callbackPort := 1234
 	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort, sessionManagers)
+	authContext.SetFeatureFlag(
+		FeatureFlag{
+			Name:   cli.FeatureFlagAccessCode,
+			Active: *swag.Bool(true),
+		},
+	)
 	h := CallbackHandler{
 		authContext,
 		suite.DB(),
@@ -705,9 +712,14 @@ func (suite *AuthSuite) TestAuthUnknownServiceMember() {
 	// that was created
 	suite.Equal(foundUser.ID, serviceMember.UserID)
 
-	// Verify that the service member's RequiresAccessCode field was created.
+	// Verify that the service member's RequiresAccessCode field was created
+	// and that it matches the `FEATURE_FLAG_ACCESS_CODE` env var as simulated
+	// above via `authContext.SetFeatureFlag`. Note that this only tests that
+	// if the feature flag is set in the authContext, that its value is used to
+	// set the `RequiresAccessCode` field. It does not test that the flag is
+	// set in the authContext in serve.go. For that, we need an end to end test.
 	// This is needed by the /users/logged_in endpoint.
-	suite.Equal(false, serviceMember.RequiresAccessCode)
+	suite.Equal(true, serviceMember.RequiresAccessCode)
 
 	// Verify handler redirects to landing URL
 	suite.Equal(http.StatusTemporaryRedirect, rr.Code, "handler did not redirect")


### PR DESCRIPTION
## Description

When the service member is first created upon their very first sign in,
we set their `requires_access_code` field to match the value of the
`FEATURE_FLAG_ACCESS_CODE` env var. This env var was not being properly
read in `auth.go`, and so it was always false, which meant customers
in prod could bypass the access code requirement.

The fix was to set the env var in the `context` that `auth.go` uses,
which is different from the `HandlerContext` that handlers use.

I looked into writing a Cypress test for this, but if I'm reading the [docs](https://docs.cypress.io/guides/guides/environment-variables.html#Option-3-CYPRESS)
correctly, this would have to be a separate standalone test that gets run with the env var.
For example:
```
FEATURE_FLAG_ACCESS_CODE=true yarn cypress run --spec cypress/integration/path/to/file.jsx
```
I don't think there's a way to set the env var within a test while running the entire test suite.

In Rails, you can easily set env vars on a per-test basis with Capybara and RSpec. For example:
```ruby
allow(ENV).to receive(:[]).with("FEATURE_FLAG_ACCESS_CODE").and_return(true)
```

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6935) for this change

## Screenshots

Before, a new user would go straight to the first onboarding page where they choose CONUS/OCONUS. Now, they see this if the feature flag is turned on:

<img width="611" alt="Screen Shot 2021-03-02 at 4 12 46 PM" src="https://user-images.githubusercontent.com/811150/109832008-f57d9800-7c0d-11eb-9ba1-cdd26b77258a.png">

Note that the field to enter the access code is missing. That's probably because the screenshot was taken before an access code was created for that service member. However, after I created a new access code, and made sure not to set the `claimed_at` field, the next time the user signed in, they weren't prompted for the code and went straight to the CONUS/OCONUS page.