### PR TITLE
Use inmemory filesystem for postgres test db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,9 +636,8 @@ ifndef CIRCLECI
 			POSTGRES_PASSWORD=$(PGPASSWORD) \
 			-d \
 			-p $(DB_PORT_TEST):$(DB_PORT_DOCKER)\
-			$(DB_DOCKER_CONTAINER_IMAGE)\
-			-c fsync=off\
-			-c full_page_writes=off
+			--mount type=tmpfs,destination=/var/lib/postgresql/data \
+			$(DB_DOCKER_CONTAINER_IMAGE)
 else
 	@echo "Relying on CircleCI's database setup to start the DB."
 endif


### PR DESCRIPTION
## Description

Changes the `server_test` setup in the Makefile to use an in memory file system for the postgres db. This is fine since our tests do not preserve any data anyway, and in memory will gain us a speed improvement. I ran this locally and in CircleCI a couple times and looks like at least a 1-2 minute savings on each run of the server tests. 

## Reviewer Notes

What speed difference is this for you vs master?

## Setup

```sh
make server_tests
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.