### PR TITLE
[MB-6909] Create AK1 EDI Segment for the 997 EDI Response

### DIFF
--- a/pkg/edi/segment/ak1.go
+++ b/pkg/edi/segment/ak1.go
@@ -7,8 +7,8 @@ import (
 
 // AK1 represents the AK1 EDI segment
 type AK1 struct {
-	FunctionalIdentifierCode string `validate:"required,eq=SI"`
-	GroupControlNumber       int64  `validate:"required,min=1,max=999999999"`
+	FunctionalIdentifierCode string `validate:"eq=SI"`
+	GroupControlNumber       int64  `validate:"min=1,max=999999999"`
 }
 
 // StringArray converts AK1 to an array of strings
@@ -30,5 +30,8 @@ func (s *AK1) Parse(elements []string) error {
 	var err error
 	s.FunctionalIdentifierCode = elements[0]
 	s.GroupControlNumber, err = strconv.ParseInt(elements[1], 10, 64)
-	return err
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/edi/segment/ak1.go
+++ b/pkg/edi/segment/ak1.go
@@ -1,0 +1,34 @@
+package edisegment
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// AK1 represents the AK1 EDI segment
+type AK1 struct {
+	FunctionalIdentifierCode string `validate:"required,eq=SI"`
+	GroupControlNumber       int64  `validate:"required,min=1,max=999999999"`
+}
+
+// StringArray converts AK1 to an array of strings
+func (s *AK1) StringArray() []string {
+	return []string{
+		"AK1",
+		s.FunctionalIdentifierCode,
+		strconv.FormatInt(s.GroupControlNumber, 10),
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the AK1 struct
+func (s *AK1) Parse(elements []string) error {
+	expectedNumElements := 2
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("AK1: Wrong number of elements, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	var err error
+	s.FunctionalIdentifierCode = elements[0]
+	s.GroupControlNumber, err = strconv.ParseInt(elements[1], 10, 64)
+	return err
+}

--- a/pkg/edi/segment/ak1_test.go
+++ b/pkg/edi/segment/ak1_test.go
@@ -1,0 +1,64 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateAK1() {
+	validAK1 := AK1{
+		FunctionalIdentifierCode: "SI",
+		GroupControlNumber:       1234567,
+	}
+
+	suite.T().Run("validate success", func(t *testing.T) {
+		err := suite.validator.Struct(validAK1)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		ak1 := AK1{
+			FunctionalIdentifierCode: "XX", // eq
+			GroupControlNumber:       -9,   // min
+		}
+
+		err := suite.validator.Struct(ak1)
+		suite.ValidateError(err, "FunctionalIdentifierCode", "eq")
+		suite.ValidateError(err, "GroupControlNumber", "min")
+		suite.ValidateErrorLen(err, 2)
+	})
+
+	suite.T().Run("validate failure 2", func(t *testing.T) {
+		ak1 := AK1{
+			FunctionalIdentifierCode: "XX", // eq
+			GroupControlNumber:       -9,   // min
+		}
+
+		err := suite.validator.Struct(ak1)
+		suite.ValidateError(err, "FunctionalIdentifierCode", "eq")
+		suite.ValidateError(err, "GroupControlNumber", "min")
+		suite.ValidateErrorLen(err, 2)
+	})
+
+	suite.T().Run("validate failure 3", func(t *testing.T) {
+		ak1 := AK1{
+			FunctionalIdentifierCode: "SI",
+			GroupControlNumber:       999999999999999, // max
+		}
+
+		err := suite.validator.Struct(ak1)
+		suite.ValidateError(err, "GroupControlNumber", "max")
+		suite.ValidateErrorLen(err, 1)
+	})
+
+	suite.T().Run("validate failure 4", func(t *testing.T) {
+		ak1 := AK1{
+			// FunctionalIdentifierCode: required
+			// GroupControlNumber:       required
+		}
+
+		err := suite.validator.Struct(ak1)
+		suite.ValidateError(err, "FunctionalIdentifierCode", "required")
+		suite.ValidateError(err, "GroupControlNumber", "required")
+		suite.ValidateErrorLen(err, 2)
+	})
+}

--- a/pkg/edi/segment/ak1_test.go
+++ b/pkg/edi/segment/ak1_test.go
@@ -18,7 +18,7 @@ func (suite *SegmentSuite) TestValidateAK1() {
 	suite.T().Run("validate failure 1", func(t *testing.T) {
 		ak1 := AK1{
 			FunctionalIdentifierCode: "XX", // eq
-			GroupControlNumber:       -9,   // min
+			GroupControlNumber:       0,    // min
 		}
 
 		err := suite.validator.Struct(ak1)
@@ -29,18 +29,6 @@ func (suite *SegmentSuite) TestValidateAK1() {
 
 	suite.T().Run("validate failure 2", func(t *testing.T) {
 		ak1 := AK1{
-			FunctionalIdentifierCode: "XX", // eq
-			GroupControlNumber:       -9,   // min
-		}
-
-		err := suite.validator.Struct(ak1)
-		suite.ValidateError(err, "FunctionalIdentifierCode", "eq")
-		suite.ValidateError(err, "GroupControlNumber", "min")
-		suite.ValidateErrorLen(err, 2)
-	})
-
-	suite.T().Run("validate failure 3", func(t *testing.T) {
-		ak1 := AK1{
 			FunctionalIdentifierCode: "SI",
 			GroupControlNumber:       999999999999999, // max
 		}
@@ -48,17 +36,5 @@ func (suite *SegmentSuite) TestValidateAK1() {
 		err := suite.validator.Struct(ak1)
 		suite.ValidateError(err, "GroupControlNumber", "max")
 		suite.ValidateErrorLen(err, 1)
-	})
-
-	suite.T().Run("validate failure 4", func(t *testing.T) {
-		ak1 := AK1{
-			// FunctionalIdentifierCode: required
-			// GroupControlNumber:       required
-		}
-
-		err := suite.validator.Struct(ak1)
-		suite.ValidateError(err, "FunctionalIdentifierCode", "required")
-		suite.ValidateError(err, "GroupControlNumber", "required")
-		suite.ValidateErrorLen(err, 2)
 	})
 }


### PR DESCRIPTION
## Description

This PR creates the AK1 segment and its validations as defined in this [mapping doc](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0)

## Reviewer Notes

 GroupControlNumber has a min set to 1. When I [tested the invalid min case](https://github.com/transcom/mymove/pull/6034/files#diff-6c8ef3d6f7e71f9d6ec5a720eb3ca3f81e6b45ff779cae5118e10001fd359aa1R21), I initially set the value to 0. However, this resulted in a "required" error instead of a min error. I'm not sure why that is

## Setup

There's no set up but please make sure the validations match what this [document](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) says they should be

## References

* [Jira story](tbd) for this change
* [this spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) 
