### PR TITLE
MB-6901 Approve Move after TOO approves Shipment

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -262,16 +262,48 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 			}
 		}
 
-		// Once the service item is successfully created, the Move's status needs to
-		// be updated to 'Approvals Requested' if it's not already in that state,
-		// which will let the TOO know they need to review it.
-		err = move.SetApprovalsRequested()
-		if err != nil {
-			return fmt.Errorf("%e", err)
+		moveShouldBeApproved := true
+
+		// If any of the requested service items are in SUBMITTED status, then
+		// we need to change the move status to APPROVALS REQUESTED so the TOO
+		// can review them. Setting moveSouldBeApproved to false is how we know
+		// to set it to APPROVALS REQUESTED further down below.
+		for _, serviceItem := range requestedServiceItems {
+			if serviceItem.Status == models.MTOServiceItemStatusSubmitted {
+				moveShouldBeApproved = false
+				break
+			}
 		}
-		verrs, err = txBuilder.UpdateOne(&move, nil)
-		if verrs != nil || err != nil {
-			return fmt.Errorf("%#v %e", verrs, err)
+
+		// In case other service items have been created at the same time on this
+		// same move, we fetch the move from the DB and check if it has any
+		// submitted service items.
+		tx.Reload(&move)
+		for _, serviceItem := range move.MTOServiceItems {
+			if serviceItem.Status == models.MTOServiceItemStatusSubmitted {
+				moveShouldBeApproved = false
+				break
+			}
+		}
+
+		if moveShouldBeApproved {
+			err = move.Approve()
+			if err != nil {
+				return fmt.Errorf("%e", err)
+			}
+			verrs, err = txBuilder.UpdateOne(&move, nil)
+			if verrs != nil || err != nil {
+				return fmt.Errorf("%#v %e", verrs, err)
+			}
+		} else {
+			err = move.SetApprovalsRequested()
+			if err != nil {
+				return fmt.Errorf("%e", err)
+			}
+			verrs, err = txBuilder.UpdateOne(&move, nil)
+			if verrs != nil || err != nil {
+				return fmt.Errorf("%#v %e", verrs, err)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
## Description

When a TOO approves a shipment, there are default service items that get
created, and they are approved by default. When a move doesn't have any
service items in SUBMITTED status, the move's status should be
`Approved`, but in `mto_service_item_creator`, we were always setting
the move's status to `Approvals Requested`.

Instead, we should be iterating through all of the move's service items
to check their status, and only if at least one service item is in
`Submitted` status should we set the Move's status to
`Approvals Requested`. Otherwise, we should set it to `Approved`.

## Reviewer Notes

1. Sign in as a TOO
2. Click on a New Move in your queue
3. Approve the shipment and submit the move
4. Go back to your queue
5. Verify that the move's status is `Approved`

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6901) for this change
