### PR TITLE
Remove old automerge label from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - automerge
 - package-ecosystem: docker
   directory: "/cypress"
   schedule:
@@ -17,7 +16,6 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - automerge
 - package-ecosystem: npm
   directory: "/cypress"
   schedule:
@@ -26,7 +24,6 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - automerge
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -35,7 +32,6 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - automerge
 - package-ecosystem: gomod
   directory: "/"
   schedule:
@@ -44,4 +40,3 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - automerge


### PR DESCRIPTION
## Description

This PR removes the `automerge` label from the dependabot config since we no longer do any auto-merging of dependabot PRs.
