### PR TITLE
MB 6520 Fix Crash For Trying To Validate Undefined TACs

### DIFF
--- a/src/pages/Office/MoveOrders/MoveOrders.jsx
+++ b/src/pages/Office/MoveOrders/MoveOrders.jsx
@@ -79,7 +79,7 @@ const MoveOrders = () => {
   });
 
   const handleTacValidation = (value) => {
-    if (value.length === 4) {
+    if (value && value.length === 4) {
       getTacValid({ tac: value }).then((response) => setIsValidTac(response.isValid));
     }
   };


### PR DESCRIPTION
## Description

Verify that the tac value exists before trying to get the length.

## Reviewer Notes



## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make client_run
make server run
```

Submit a move locally using the customer UI. 
I did this by going to local sign in, using the needs@orde.rs (milmove) user, and submitting a move. 

Go to the office UI, sign in as someone who can edit the orders. 
Select the order that was just submitted.
Edit the order.
Change the department indicator, or click in the TAC field.
Wait for a second or so. 
See the crash!
With these changes, it should no longer crash.

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6520) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
