### PR TITLE
[MB-6910] Created AK2 EDI segment 

### DIFF
--- a/pkg/edi/segment/ak2.go
+++ b/pkg/edi/segment/ak2.go
@@ -19,7 +19,7 @@ func (s *AK2) StringArray() []string {
 	}
 }
 
-// Parse parses an AK2 string that's split into an array into the AK2 struct
+// Parse parses an X12 string that's split into an array into the AK2 struct
 func (s *AK2) Parse(elements []string) error {
 	expectedNumElements := 2
 	if len(elements) != expectedNumElements {

--- a/pkg/edi/segment/ak2.go
+++ b/pkg/edi/segment/ak2.go
@@ -1,0 +1,31 @@
+package edisegment
+
+import (
+	"fmt"
+)
+
+// AK2 represents the AK2 EDI segment
+type AK2 struct {
+	TransactionSetIdentifierCode string `validate:"eq=858"`
+	TransactionSetControlNumber  string `validate:"min=4,max=9"`
+}
+
+// StringArray converts AK2 to an array of strings
+func (s *AK2) StringArray() []string {
+	return []string{
+		"AK2",
+		s.TransactionSetIdentifierCode,
+		s.TransactionSetControlNumber,
+	}
+}
+
+// Parse parses an AK2 string that's split into an array into the AK2 struct
+func (s *AK2) Parse(elements []string) error {
+	expectedNumElements := 2
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("AK2: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	}
+	s.TransactionSetIdentifierCode = elements[0]
+	s.TransactionSetControlNumber = elements[1]
+	return nil
+}

--- a/pkg/edi/segment/ak2_test.go
+++ b/pkg/edi/segment/ak2_test.go
@@ -1,0 +1,38 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateAK2() {
+	validAK2 := AK2{
+		TransactionSetIdentifierCode: "858",
+		TransactionSetControlNumber:  "ABCDE",
+	}
+
+	suite.T().Run("validate success", func(t *testing.T) {
+		err := suite.validator.Struct(validAK2)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		ak2 := AK2{
+			TransactionSetIdentifierCode: "123", // eq
+			TransactionSetControlNumber:  "123", // min
+		}
+
+		err := suite.validator.Struct(ak2)
+		suite.ValidateError(err, "TransactionSetIdentifierCode", "eq")
+		suite.ValidateError(err, "TransactionSetControlNumber", "min")
+		suite.ValidateErrorLen(err, 2)
+	})
+
+	suite.T().Run("validate failure 2", func(t *testing.T) {
+		ak2 := validAK2
+		ak2.TransactionSetControlNumber = "1234567890" // max
+
+		err := suite.validator.Struct(ak2)
+		suite.ValidateError(err, "TransactionSetControlNumber", "max")
+		suite.ValidateErrorLen(err, 1)
+	})
+}


### PR DESCRIPTION
## Description

This PR creates the AK2 segment and its validations as defined in this [mapping doc](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0)

## Reviewer Notes

The code and test for this segment is essentially identical to the ST segment. Because of the way our code is set up I didn't see a low-to-moderate way to make this more DRY. However, if I'm missing something please let me know!

## Setup

There's no set up but please make sure the validations match what this [document](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) says they should be

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6910) for this change
* [this spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) 
