### PR TITLE
Benchmarking tool save reports and break out naming by measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@
 coverage.out
 __snapshots__
 cypress/cypress
-/puppeteer/lighthouse-report-fast.json
-/puppeteer/performance-trace-fast.json
+/puppeteer/reports
 
 # production
 /build

--- a/puppeteer/benchmarking.js
+++ b/puppeteer/benchmarking.js
@@ -27,6 +27,7 @@ const runNetworkComparison = async (scenario, host, saveReports, verbose) => {
     // eslint-disable-next-line no-await-in-loop
     results[`${speed}`] = await totalDuration({
       scenario,
+      measurement: measurementTypes.networkComparison,
       host,
       config: configStore,
       debug,
@@ -54,6 +55,7 @@ const runFileSizeComparison = async (scenario, host, saveReports, verbose) => {
     // eslint-disable-next-line no-await-in-loop
     const elapsedTimeResults = await totalDuration({
       scenario,
+      measurement: measurementTypes.fileDuration,
       host,
       config: configStore,
       debug,
@@ -79,7 +81,15 @@ const runAction = async ({ scenario, measurementType, host, verbose, saveReports
   let results = {};
   switch (measurementType) {
     case measurementTypes.totalDuration:
-      results = await totalDuration({ scenario, host, config: config.store, debug, saveReports, verbose }).catch(() => {
+      results = await totalDuration({
+        scenario,
+        measurementType,
+        host,
+        config: config.store,
+        debug,
+        saveReports,
+        verbose,
+      }).catch(() => {
         process.exit(1);
       });
 

--- a/puppeteer/benchmarking.js
+++ b/puppeteer/benchmarking.js
@@ -83,7 +83,7 @@ const runAction = async ({ scenario, measurementType, host, verbose, saveReports
     case measurementTypes.totalDuration:
       results = await totalDuration({
         scenario,
-        measurementType,
+        measurement: measurementType,
         host,
         config: config.store,
         debug,

--- a/puppeteer/config.json
+++ b/puppeteer/config.json
@@ -9,7 +9,6 @@
       "height": 900
     }
   },
-  "network": "fast",
-  "fileSize": "large",
-  "cpuSlowdownRate": 2
+  "fileSize": "small",
+  "cpuSlowdownRate": 1
 }

--- a/puppeteer/config.json
+++ b/puppeteer/config.json
@@ -9,6 +9,7 @@
       "height": 900
     }
   },
-  "fileSize": "small",
-  "cpuSlowdownRate": 1
+  "network": "fast",
+  "fileSize": "large",
+  "cpuSlowdownRate": 2
 }

--- a/puppeteer/constants.js
+++ b/puppeteer/constants.js
@@ -46,7 +46,7 @@ const networkProfiles = {
     upload: (10 * 1024 * 1024) / 8,
     latency: 20,
   },
-  medium: {
+  average: {
     offline: false,
     download: (5 * 1024 * 1024) / 8,
     upload: (5 * 1024 * 1024) / 8,
@@ -102,7 +102,7 @@ const fileSizePaymentRequestIds = {
 };
 
 // All speeds available
-const speeds = ['fast', 'medium', 'slow'];
+const speeds = ['fast', 'average', 'slow'];
 
 module.exports = {
   schema,

--- a/puppeteer/scenarios.js
+++ b/puppeteer/scenarios.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, security/detect-non-literal-fs-filename */
 const fs = require('fs');
 
 const lighthouse = require('lighthouse');
@@ -119,58 +119,36 @@ const lighthouseFromPuppeteer = async (
     let lhReportPath;
     let pTracePath;
 
+    const dateTime = new Date();
+    const dateString = [
+      dateTime.getFullYear(),
+      dateTime.getMonth() + 1,
+      dateTime.getDate(),
+      dateTime.getHours(),
+      dateTime.getMinutes(),
+      dateTime.getSeconds(),
+    ].join('');
+
     if (measurement === measurementTypes.networkComparison || measurement === measurementTypes.totalDuration) {
       lhReportPath = networkProfileName
-        ? `puppeteer/reports/lighthouse-report-${networkProfileName}.json`
-        : 'puppeteer/reports/lighthouse-report.json';
+        ? `puppeteer/reports/lighthouse-report-${networkProfileName}-${dateString}.json`
+        : `puppeteer/reports/lighthouse-report-${dateString}.json`;
       pTracePath = networkProfileName
-        ? `puppeteer/reports/performance-trace-${networkProfileName}.json`
-        : 'puppeteer/reports/performance-trace.json';
+        ? `puppeteer/reports/performance-trace-${networkProfileName}-${dateString}.json`
+        : `puppeteer/reports/performance-trace-${dateString}.json`;
 
-      // Need literal string to work around the detect-non-literal-fs-filename
-      switch (networkProfileName) {
-        case 'fast':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-fast.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-fast.json', trace);
-          break;
-        case 'average':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-average.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-average.json', trace);
-          break;
-        case 'slow':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-slow.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-slow.json', trace);
-          break;
-        default:
-          fs.writeFileSync('puppeteer/reports/lighthouse-report.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace.json', trace);
-      }
+      fs.writeFileSync(lhReportPath, json);
+      fs.writeFileSync(pTracePath, trace);
     } else if (measurement === measurementTypes.fileDuration) {
       lhReportPath = fileSizeName
-        ? `puppeteer/reports/lighthouse-report-${fileSizeName}.json`
-        : 'puppeteer/reports/lighthouse-report.json';
+        ? `puppeteer/reports/lighthouse-report-${fileSizeName}-${dateString}.json`
+        : `puppeteer/reports/lighthouse-report-${dateString}.json`;
       pTracePath = fileSizeName
-        ? `puppeteer/reports/performance-trace-${fileSizeName}.json`
-        : 'puppeteer/reports/performance-trace.json';
+        ? `puppeteer/reports/performance-trace-${fileSizeName}-${dateString}.json`
+        : `puppeteer/reports/performance-trace-${dateString}.json`;
 
-      // Need literal string to work around the detect-non-literal-fs-filename
-      switch (fileSizeName) {
-        case 'large':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-large.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-large.json', trace);
-          break;
-        case 'medium':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-medium.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-medium.json', trace);
-          break;
-        case 'small':
-          fs.writeFileSync('puppeteer/reports/lighthouse-report-small.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace-small.json', trace);
-          break;
-        default:
-          fs.writeFileSync('puppeteer/reports/lighthouse-report.json', json);
-          fs.writeFileSync('puppeteer/reports/performance-trace.json', trace);
-      }
+      fs.writeFileSync(lhReportPath, json);
+      fs.writeFileSync(pTracePath, trace);
     }
 
     // eslint-disable-next-line no-console
@@ -263,7 +241,7 @@ const totalDuration = async ({ scenario, measurement, host, config, debug, saveR
   const lhConfig = {
     extends: 'lighthouse:default',
     settings: {
-      maxWaitForLoad: 200000, // 200,000 ms. Increase max wait so lighthouse can gather metrics.
+      maxWaitForLoad: 300000, // 300,000 ms. Increase max wait so lighthouse can gather metrics.
       formFactor: 'desktop', // TODO - Will need to change once we do device emulation
       screenEmulation: {
         mobile: false,

--- a/puppeteer/scenarios.js
+++ b/puppeteer/scenarios.js
@@ -6,7 +6,13 @@ const puppeteer = require('puppeteer');
 const reportGenerator = require('lighthouse/lighthouse-core/report/report-generator');
 const { throttling } = require('lighthouse/lighthouse-core/config/constants');
 
-const { networkProfiles, fileSizeMoveCodes, fileSizePaymentRequestIds, scenarios } = require('./constants');
+const {
+  networkProfiles,
+  fileSizeMoveCodes,
+  fileSizePaymentRequestIds,
+  scenarios,
+  measurementTypes,
+} = require('./constants');
 
 // Gets the total request time based on the responseEnd - requestStart
 // in secs
@@ -84,42 +90,93 @@ const setupCPU = async (config, page) => {
       return Promise.resolve(rate);
     });
   }
-  return Promise.resolve();
+  return Promise.resolve(1);
 };
 
-const lighthouseFromPuppeteer = async (url, options, config = null, saveReports = false, networkProfileName = '') => {
+const lighthouseFromPuppeteer = async (
+  url,
+  options,
+  config = null,
+  saveReports = false,
+  networkProfileName = '',
+  fileSizeName = '',
+  measurement,
+) => {
   // Run Lighthouse
-  const { lhr, artifacts } = await lighthouse(url, options, config);
+  const { lhr, artifacts } = await lighthouse(url, options, config).catch((err) => {
+    console.error('lighthouse audit error \n', err);
+    process.exit(1);
+  });
+
+  if (!fs.existsSync('puppeteer/reports')) {
+    fs.mkdirSync('puppeteer/reports');
+  }
 
   // For debugging
   const json = reportGenerator.generateReport(lhr, 'json');
   if (saveReports) {
     const trace = reportGenerator.generateReport(artifacts, 'json');
-    const lhReportPath = `puppeteer/lighthouse-report-${networkProfileName}.json`;
-    const pTracePath = `puppeteer/performance-trace-${networkProfileName}.json`;
-    // eslint-disable-next-line no-console
-    console.debug(`\n
-    Generating lighthouse reports:
-      ${lhReportPath}
-      ${pTracePath}`);
-    // Need literal string to work around the detect-non-literal-fs-filename
-    switch (networkProfileName) {
-      case 'fast':
-        fs.writeFileSync('puppeteer/lighthouse-report-fast.json', json);
-        fs.writeFileSync('puppeteer/performance-trace-fast.json', trace);
-        break;
-      case 'medium':
-        fs.writeFileSync('puppeteer/lighthouse-report-medium.json', json);
-        fs.writeFileSync('puppeteer/performance-trace-medium.json', trace);
-        break;
-      case 'slow':
-        fs.writeFileSync('puppeteer/lighthouse-report-slow.json', json);
-        fs.writeFileSync('puppeteer/performance-trace-slow.json', trace);
-        break;
-      default:
-        fs.writeFileSync('puppeteer/lighthouse-report.json', json);
-        fs.writeFileSync('puppeteer/performance-trace.json', trace);
+    let lhReportPath;
+    let pTracePath;
+
+    if (measurement === measurementTypes.networkComparison || measurement === measurementTypes.totalDuration) {
+      lhReportPath = networkProfileName
+        ? `puppeteer/reports/lighthouse-report-${networkProfileName}.json`
+        : 'puppeteer/reports/lighthouse-report.json';
+      pTracePath = networkProfileName
+        ? `puppeteer/reports/performance-trace-${networkProfileName}.json`
+        : 'puppeteer/reports/performance-trace.json';
+
+      // Need literal string to work around the detect-non-literal-fs-filename
+      switch (networkProfileName) {
+        case 'fast':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-fast.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-fast.json', trace);
+          break;
+        case 'average':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-average.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-average.json', trace);
+          break;
+        case 'slow':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-slow.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-slow.json', trace);
+          break;
+        default:
+          fs.writeFileSync('puppeteer/reports/lighthouse-report.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace.json', trace);
+      }
+    } else if (measurement === measurementTypes.fileDuration) {
+      lhReportPath = fileSizeName
+        ? `puppeteer/reports/lighthouse-report-${fileSizeName}.json`
+        : 'puppeteer/reports/lighthouse-report.json';
+      pTracePath = fileSizeName
+        ? `puppeteer/reports/performance-trace-${fileSizeName}.json`
+        : 'puppeteer/reports/performance-trace.json';
+
+      // Need literal string to work around the detect-non-literal-fs-filename
+      switch (fileSizeName) {
+        case 'large':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-large.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-large.json', trace);
+          break;
+        case 'medium':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-medium.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-medium.json', trace);
+          break;
+        case 'small':
+          fs.writeFileSync('puppeteer/reports/lighthouse-report-small.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace-small.json', trace);
+          break;
+        default:
+          fs.writeFileSync('puppeteer/reports/lighthouse-report.json', json);
+          fs.writeFileSync('puppeteer/reports/performance-trace.json', trace);
+      }
     }
+
+    // eslint-disable-next-line no-console
+    console.debug(`Generating lighthouse reports:
+        ${lhReportPath}
+        ${pTracePath}`);
   }
 
   const { audits } = JSON.parse(json); // Lighthouse audits
@@ -134,7 +191,7 @@ const lighthouseFromPuppeteer = async (url, options, config = null, saveReports 
   };
 };
 
-const totalDuration = async ({ scenario, host, config, debug, saveReports, verbose }) => {
+const totalDuration = async ({ scenario, measurement, host, config, debug, saveReports, verbose }) => {
   const waitOptions = { timeout: 0, waitUntil: 'networkidle0' };
 
   const browser = await puppeteer.launch(config.launch);
@@ -175,38 +232,39 @@ const totalDuration = async ({ scenario, host, config, debug, saveReports, verbo
   }
 
   debug(`URL to gather metrics from: ${url}`);
-  await page.goto(url, waitOptions);
+  await page.goto(url, waitOptions).catch((err) => {
+    console.error(`failed to navigate to page ${url}\n`, err);
+    process.exit(1);
+  });
 
   const docViewerContentSelector = 'div[data-testid="DocViewerContent"]';
-  await page.waitForSelector(docViewerContentSelector);
+  await page.waitForSelector(docViewerContentSelector).catch((err) => {
+    console.error('waiting for document viewer selector timed out\n', err);
+    process.exit(1);
+  });
 
   // Will return all http requests and navigation performance on last navigation
   debug('Gathering performance timing metrics');
-  const navigationEntries = JSON.parse(
-    await page.evaluate(() => {
+  const performanceEntries = await page
+    .evaluate(() => {
       return JSON.stringify(performance.getEntries());
-    }),
-  );
+    })
+    .catch((err) => {
+      console.error('failed to fetch performance entries', err);
+    });
+  const navigationEntries = JSON.parse(performanceEntries);
 
   const lhOptions = {
     port: new URL(browser.wsEndpoint()).port,
     logLevel: verbose ? 'info' : 'error',
     chromeFlags: ['--disable-mobile-emulation'],
   };
+
   const lhConfig = {
     extends: 'lighthouse:default',
     settings: {
       maxWaitForLoad: 200000, // 200,000 ms. Increase max wait so lighthouse can gather metrics.
       formFactor: 'desktop', // TODO - Will need to change once we do device emulation
-      throttlingMethod: 'devtools',
-      throttling: {
-        // Lighthouse expects kilobits per sec instead of bytes per sec
-        // 1 byte = 0.008 kilobits
-        cpuSlowdownMultiplier: cpuRateConfig.rate,
-        requestLatencyMs: networkConfig.latency * throttling.DEVTOOLS_RTT_ADJUSTMENT_FACTOR,
-        downloadThroughputKbps: networkConfig.download * 0.008 * throttling.DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
-        uploadThroughputKbps: networkConfig.upload * 0.008 * throttling.DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
-      },
       screenEmulation: {
         mobile: false,
         width: deviceEmulationConfig.viewport.width,
@@ -215,11 +273,40 @@ const totalDuration = async ({ scenario, host, config, debug, saveReports, verbo
         disabled: false,
       },
       emulatedUserAgent: deviceEmulationConfig.userAgent,
+      throttlingMethod: 'devtools',
+      throttling: {
+        cpuSlowdownMultiplier: cpuRateConfig.rate,
+        requestLatencyMs: 0,
+        downloadThroughputKbps: 0,
+        uploadThroughputKbps: 0,
+      },
     },
   };
 
+  if (networkConfig) {
+    lhConfig.settings.throttling = {
+      ...lhConfig.settings.throttling,
+      // Lighthouse expects kilobits per sec instead of bytes per sec
+      // 1 byte = 0.008 kilobits
+      requestLatencyMs: networkConfig.latency * throttling.DEVTOOLS_RTT_ADJUSTMENT_FACTOR,
+      downloadThroughputKbps: networkConfig.download * 0.008 * throttling.DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
+      uploadThroughputKbps: networkConfig.upload * 0.008 * throttling.DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
+    };
+  }
+
   debug('Gathering lighthouse metrics');
-  const lhResults = await lighthouseFromPuppeteer(url, lhOptions, lhConfig, saveReports, config.network);
+  const lhResults = await lighthouseFromPuppeteer(
+    url,
+    lhOptions,
+    lhConfig,
+    saveReports,
+    config.network,
+    config.fileSize,
+    measurement,
+  ).catch((err) => {
+    console.error('error running lighthouse\n', err);
+  });
+
   const pfTimingResults = getTotalRequestTime(navigationEntries);
 
   await browser.close();


### PR DESCRIPTION
## Description

This PR adds a few more enhancements to the benchmarking tool:

- Organizes all reports to save in a reports/ directory that isn't tracked by git
- Adjusts the naming of network types to have distinct names from file size types
- Adds a timestamp to the reports to make it easier to archive and sort
- Allows running benchmark without network throttling
- Fix bug where CPU slowdown was set to default of 1

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
