### PR TITLE
MB-6928 Get ServiceItemParams for payment request

### DIFF
--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
-	expectedServiceItemName := "Move Management"
+	expectedServiceItemName := "Test Service"
 	expectedShipmentType := models.MTOShipmentTypeHHG
 
 	move := testdatagen.MakeAvailableMove(suite.DB())
@@ -41,10 +41,6 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 			Key:  models.ServiceItemParamNameRequestedPickupDate,
 			Type: models.ServiceItemParamTypeDate,
 		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeMS,
-			Name: "Move Management",
-		},
 	})
 	paymentRequest := paymentServiceItemParam.PaymentServiceItem.PaymentRequest
 
@@ -54,7 +50,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 	})
 
 	suite.T().Run("successful fetch of payment request", func(t *testing.T) {
-		req := httptest.NewRequest("GET", fmt.Sprintf("/payment_request"), nil)
+		req := httptest.NewRequest("GET", fmt.Sprintf("/payment-requests/:paymentRequestID"), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
 
 		params := paymentrequestop.GetPaymentRequestParams{
@@ -93,7 +89,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
 
-		req := httptest.NewRequest("GET", fmt.Sprintf("/payment_request"), nil)
+		req := httptest.NewRequest("GET", fmt.Sprintf("/payment-requests/:paymentRequestID"), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUserTOO)
 
 		params := paymentrequestop.GetPaymentRequestParams{
@@ -114,7 +110,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(models.PaymentRequest{}, nil).Once()
 
-		req := httptest.NewRequest("GET", fmt.Sprintf("/payment_request"), nil)
+		req := httptest.NewRequest("GET", fmt.Sprintf("/payment-requests/:paymentRequestID"), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
 
 		params := paymentrequestop.GetPaymentRequestParams{
@@ -133,7 +129,7 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 }
 
 func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
-	expectedServiceItemName := "Move Management"
+	expectedServiceItemName := "Test Service"
 	expectedShipmentType := models.MTOShipmentTypeHHG
 
 	move := testdatagen.MakeAvailableMove(suite.DB())
@@ -143,10 +139,6 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 		ServiceItemParamKey: models.ServiceItemParamKey{
 			Key:  models.ServiceItemParamNameRequestedPickupDate,
 			Type: models.ServiceItemParamTypeDate,
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeMS,
-			Name: "Move Management",
 		},
 	})
 	paymentRequest := paymentServiceItemParam.PaymentServiceItem.PaymentRequest

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -23,7 +23,11 @@ func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) 
 
 	// fetch the payment request first with proof of service docs
 	// will error if payment request not found
-	err := p.db.Eager("PaymentServiceItems.MTOServiceItem.MTOShipment", "PaymentServiceItems.MTOServiceItem.ReService", "ProofOfServiceDocs").
+	err := p.db.Eager(
+		"PaymentServiceItems.MTOServiceItem.MTOShipment",
+		"PaymentServiceItems.MTOServiceItem.ReService",
+		"PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
+		"ProofOfServiceDocs").
 		Find(&paymentRequest, paymentRequestID)
 	if err != nil {
 		return models.PaymentRequest{}, err


### PR DESCRIPTION
**Description**

A TIO needs to see how weights factor into the pricing of service items
so that they can understand how the price was determined.

The payload was already modified in PR #6020 to include service item
params, so in this PR, all we needed to do was eager load the service
item params and key tables.

I used TDD to write a failing test first, and converted the existing
`TestFetchPaymentRequestHandler` test to an integration test that
hits the DB, as opposed to using mocks. I used the same test setup as
in PR #6020.

**Reviewer Notes**

Note that this PR only implements the backend portion of this feature.
There is a separate unscheduled story (in TTV's March Slice) for the
[frontend portion](https://dp3.atlassian.net/browse/MB-4800).

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. In TablePlus or other method of inspecting the dev DB, look up the Move with id "7cbe57ba-fd3a-45a7-aa9a-1970f1908ae7"
2. Find its `Locator`
3. As a TIO, click on the Payment Request with that Locator. 
4. Click on "View documents"
5. Open up the inspector tools and verify `paymentServiceItemParams` are present in the payload for that payment request.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6928) for this change

## Screenshots

<img width="1676" alt="Screen Shot 2021-03-09 at 4 38 43 PM" src="https://user-images.githubusercontent.com/811150/110542897-a1841f00-80f7-11eb-9ba3-3257aa5e29d7.png">

