### PR TITLE
Move root route back up above getWorkflowRoutes

### DIFF
--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -135,6 +135,10 @@ export class CustomerApp extends Component {
 
                   {/* auth required */}
                   <CustomerPrivateRoute exact path="/ppm" component={PpmLanding} />
+
+                  {/* ROOT */}
+                  <CustomerPrivateRoute path="/" exact component={Home} />
+
                   {getWorkflowRoutes(props)}
                   <CustomerPrivateRoute exact path="/moves/:moveId/edit" component={Edit} />
                   <CustomerPrivateRoute exact path="/moves/review/edit-profile" component={EditProfile} />
@@ -178,9 +182,6 @@ export class CustomerApp extends Component {
                       <h2>We are experiencing an internal server error</h2>
                     </div>
                   </Route>
-
-                  {/* ROOT */}
-                  <CustomerPrivateRoute path="/" exact component={Home} />
 
                   {/* 404 */}
                   <Route component={this.noMatch} />

--- a/src/scenes/MyMove/index.test.js
+++ b/src/scenes/MyMove/index.test.js
@@ -1,11 +1,61 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
-import { CustomerApp } from './index';
+import ConnectedCustomerApp, { CustomerApp } from './index';
 
 import Header from 'shared/Header/MyMove';
 import Footer from 'shared/Footer';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { MockProviders } from 'testUtils';
+import { AppContext } from 'shared/AppContext';
+
+describe('ConnectedCustomerApp tests', () => {
+  describe('with GHC/HHG feature flags turned off', () => {
+    const mockContext = {
+      flags: {
+        hhgFlow: false,
+        ghcFlow: false,
+      },
+    };
+
+    it('renders without crashing or erroring', () => {
+      const wrapper = mount(
+        <MockProviders initialEntries={['/']}>
+          <AppContext.Provider value={mockContext}>
+            <ConnectedCustomerApp />
+          </AppContext.Provider>
+        </MockProviders>,
+      );
+      const appWrapper = wrapper.find('#app-root');
+      expect(appWrapper).toBeDefined();
+      expect(appWrapper.find('PageNotInFlow')).toHaveLength(0);
+      expect(wrapper.find(SomethingWentWrong)).toHaveLength(0);
+    });
+  });
+
+  describe('with GHC/HHG feature flags turned on', () => {
+    const mockContext = {
+      flags: {
+        hhgFlow: true,
+        ghcFlow: true,
+      },
+    };
+
+    it('renders without crashing or erroring', () => {
+      const wrapper = mount(
+        <MockProviders initialEntries={['/']}>
+          <AppContext.Provider value={mockContext}>
+            <ConnectedCustomerApp />
+          </AppContext.Provider>
+        </MockProviders>,
+      );
+      const appWrapper = wrapper.find('#app-root');
+      expect(appWrapper).toBeDefined();
+      expect(appWrapper.find('PageNotInFlow')).toHaveLength(0);
+      expect(wrapper.find(SomethingWentWrong)).toHaveLength(0);
+    });
+  });
+});
 
 describe('CustomerApp tests', () => {
   let wrapper;


### PR DESCRIPTION
## Description

Fixes a bug evident in production where accessing the root URL (`/`) renders the "Missing Context" message. This is due to the `ghcFlow` feature flag being set to false. To test locally, change the `ghcFlow` flag to `false` for the development environment in `src/shared/featureFlags.js`: https://github.com/transcom/mymove/blob/master/src/shared/featureFlags.js#L26

On master you should see the Missing Context message, but on this branch you should see the sign in page.

I also added a [test to check for this going forward](https://github.com/transcom/mymove/pull/6081/files#diff-9779bd00b24ce4840a7623e4f77826c6ccd0d78383df518e7a0dbf4d259c1c11). You can test the test (!) locally by reverting the change I made to `MyMove/index.jsx` manually, and verifying the **ConnectedCustomerApp tests › with GHC/HHG feature flags turned off › renders without crashing or erroring** test fails.