### PR TITLE
[MB-6913] Adding segment for AK5

### DIFF
--- a/pkg/edi/segment/ak5.go
+++ b/pkg/edi/segment/ak5.go
@@ -6,7 +6,7 @@ import (
 
 // AK5 represents the AK5 EDI segment
 // Purpose: To acknowledge acceptance or rejection and report errors in a transaction set (direct language
-// from the 997 spec, though we don't expect to process any errors, only expect to get acks here)
+// from the 997 spec, though we don't expect to process any errors in the 997, only expect to get acks here)
 type AK5 struct {
 	TransactionSetAcknowledgmentCode   string `validate:"min=1,max=1"`     // only expect to use this field
 	TransactionSetSyntaxErrorCodeAK502 string `validate:"omitempty,max=3"` // not expecting these fields to be set

--- a/pkg/edi/segment/ak5.go
+++ b/pkg/edi/segment/ak5.go
@@ -1,0 +1,47 @@
+package edisegment
+
+import (
+	"fmt"
+)
+
+// AK5 represents the AK5 EDI segment
+// Purpose: To acknowledge acceptance or rejection and report errors in a transaction set (direct language
+// from the 997 spec, though we don't expect to process any errors, only expect to get acks here)
+type AK5 struct {
+	TransactionSetAcknowledgmentCode   string `validate:"min=1,max=1"`     // only expect to use this field
+	TransactionSetSyntaxErrorCodeAK502 string `validate:"omitempty,max=3"` // not expecting these fields to be set
+	TransactionSetSyntaxErrorCodeAK503 string `validate:"omitempty,max=3"` // not expecting these fields to be set
+	TransactionSetSyntaxErrorCodeAK504 string `validate:"omitempty,max=3"` // not expecting these fields to be set
+	TransactionSetSyntaxErrorCodeAK505 string `validate:"omitempty,max=3"` // not expecting these fields to be set
+	TransactionSetSyntaxErrorCodeAK506 string `validate:"omitempty,max=3"` // not expecting these fields to be set
+}
+
+// StringArray converts AK5 to an array of strings
+func (s *AK5) StringArray() []string {
+	return []string{
+		"AK5",
+		s.TransactionSetAcknowledgmentCode,
+		s.TransactionSetSyntaxErrorCodeAK502,
+		s.TransactionSetSyntaxErrorCodeAK503,
+		s.TransactionSetSyntaxErrorCodeAK504,
+		s.TransactionSetSyntaxErrorCodeAK505,
+		s.TransactionSetSyntaxErrorCodeAK506,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the AK5 struct
+func (s *AK5) Parse(elements []string) error {
+	expectedNumElements := 6
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("AK5: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	s.TransactionSetAcknowledgmentCode = elements[0]
+	s.TransactionSetSyntaxErrorCodeAK502 = elements[1]
+	s.TransactionSetSyntaxErrorCodeAK503 = elements[2]
+	s.TransactionSetSyntaxErrorCodeAK504 = elements[3]
+	s.TransactionSetSyntaxErrorCodeAK505 = elements[4]
+	s.TransactionSetSyntaxErrorCodeAK506 = elements[5]
+
+	return nil
+}

--- a/pkg/edi/segment/ak5.go
+++ b/pkg/edi/segment/ak5.go
@@ -8,7 +8,7 @@ import (
 // Purpose: To acknowledge acceptance or rejection and report errors in a transaction set (direct language
 // from the 997 spec, though we don't expect to process any errors in the 997, only expect to get acks here)
 type AK5 struct {
-	TransactionSetAcknowledgmentCode   string `validate:"min=1,max=1"`     // only expect to use this field
+	TransactionSetAcknowledgmentCode   string `validate:"len=1"`           // only expect to use this field
 	TransactionSetSyntaxErrorCodeAK502 string `validate:"omitempty,max=3"` // not expecting these fields to be set
 	TransactionSetSyntaxErrorCodeAK503 string `validate:"omitempty,max=3"` // not expecting these fields to be set
 	TransactionSetSyntaxErrorCodeAK504 string `validate:"omitempty,max=3"` // not expecting these fields to be set

--- a/pkg/edi/segment/ak5_test.go
+++ b/pkg/edi/segment/ak5_test.go
@@ -45,7 +45,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "min")
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.T().Run("validate failure max", func(t *testing.T) {
 		// numbers of characters are more than max
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "AAAAA",
@@ -53,7 +53,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 			TransactionSetSyntaxErrorCodeAK503: "defz",
 			TransactionSetSyntaxErrorCodeAK504: "ghiz",
 			TransactionSetSyntaxErrorCodeAK505: "jklz",
-			TransactionSetSyntaxErrorCodeAK506: "mnoz", // min
+			TransactionSetSyntaxErrorCodeAK506: "mnoz",
 		}
 
 		err := suite.validator.Struct(ak5)
@@ -66,7 +66,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.ValidateErrorLen(err, 6)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.T().Run("validate failure min", func(t *testing.T) {
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "",
 			TransactionSetSyntaxErrorCodeAK502: "",

--- a/pkg/edi/segment/ak5_test.go
+++ b/pkg/edi/segment/ak5_test.go
@@ -36,7 +36,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 			TransactionSetSyntaxErrorCodeAK506: "mno",
 		}
 		err := suite.validator.Struct(ak5)
-		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "min")
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "len")
 	})
 
 	suite.T().Run("validate failure max", func(t *testing.T) {
@@ -51,7 +51,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		}
 
 		err := suite.validator.Struct(ak5)
-		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "max")
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "len")
 		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK502", "max")
 		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK503", "max")
 		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK504", "max")
@@ -72,7 +72,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		}
 
 		err := suite.validator.Struct(ak5)
-		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "min")
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "len")
 		suite.ValidateErrorLen(err, 1)
 	})
 }

--- a/pkg/edi/segment/ak5_test.go
+++ b/pkg/edi/segment/ak5_test.go
@@ -16,12 +16,6 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		}
 		err := suite.validator.Struct(validAK5)
 		suite.NoError(err)
-
-		validOptionalAK5 := AK5{
-			TransactionSetAcknowledgmentCode: "A",
-		}
-		err = suite.validator.Struct(validOptionalAK5)
-		suite.NoError(err)
 	})
 
 	suite.T().Run("validate success only required fields", func(t *testing.T) {
@@ -46,7 +40,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 	})
 
 	suite.T().Run("validate failure max", func(t *testing.T) {
-		// numbers of characters are more than max
+		// length of characters are more than max
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "AAAAA",
 			TransactionSetSyntaxErrorCodeAK502: "abcz",
@@ -67,6 +61,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 	})
 
 	suite.T().Run("validate failure min", func(t *testing.T) {
+		// length of characters are less than min
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "",
 			TransactionSetSyntaxErrorCodeAK502: "",

--- a/pkg/edi/segment/ak5_test.go
+++ b/pkg/edi/segment/ak5_test.go
@@ -1,0 +1,148 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateAK5() {
+	suite.T().Run("validate success all fields", func(t *testing.T) {
+		validAK5 := AK5{
+			TransactionSetAcknowledgmentCode:   "A",
+			TransactionSetSyntaxErrorCodeAK502: "abc",
+			TransactionSetSyntaxErrorCodeAK503: "def",
+			TransactionSetSyntaxErrorCodeAK504: "ghi",
+			TransactionSetSyntaxErrorCodeAK505: "jkl",
+			TransactionSetSyntaxErrorCodeAK506: "mno",
+		}
+		err := suite.validator.Struct(validAK5)
+		suite.NoError(err)
+
+		validOptionalAK5 := AK5{
+			TransactionSetAcknowledgmentCode: "A",
+		}
+		err = suite.validator.Struct(validOptionalAK5)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success only required fields", func(t *testing.T) {
+		validAK5 := AK5{
+			TransactionSetAcknowledgmentCode: "A",
+		}
+		err := suite.validator.Struct(validAK5)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("failure due to missing required fields", func(t *testing.T) {
+
+		ak5 := AK5{
+			TransactionSetSyntaxErrorCodeAK502: "abc",
+			TransactionSetSyntaxErrorCodeAK503: "def",
+			TransactionSetSyntaxErrorCodeAK504: "ghi",
+			TransactionSetSyntaxErrorCodeAK505: "jkl",
+			TransactionSetSyntaxErrorCodeAK506: "mno",
+		}
+		err := suite.validator.Struct(ak5)
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "min")
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		// numbers of characters are more than max
+		ak5 := AK5{
+			TransactionSetAcknowledgmentCode:   "AAAAA",
+			TransactionSetSyntaxErrorCodeAK502: "abcz",
+			TransactionSetSyntaxErrorCodeAK503: "defz",
+			TransactionSetSyntaxErrorCodeAK504: "ghiz",
+			TransactionSetSyntaxErrorCodeAK505: "jklz",
+			TransactionSetSyntaxErrorCodeAK506: "mnoz", // min
+		}
+
+		err := suite.validator.Struct(ak5)
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "max")
+		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK502", "max")
+		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK503", "max")
+		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK504", "max")
+		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK505", "max")
+		suite.ValidateError(err, "TransactionSetSyntaxErrorCodeAK506", "max")
+		suite.ValidateErrorLen(err, 6)
+	})
+
+	suite.T().Run("validate failure 2", func(t *testing.T) {
+		ak5 := AK5{
+			TransactionSetAcknowledgmentCode:   "",
+			TransactionSetSyntaxErrorCodeAK502: "",
+			TransactionSetSyntaxErrorCodeAK503: "",
+			TransactionSetSyntaxErrorCodeAK504: "",
+			TransactionSetSyntaxErrorCodeAK505: "",
+			TransactionSetSyntaxErrorCodeAK506: "",
+		}
+
+		err := suite.validator.Struct(ak5)
+		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "min")
+		suite.ValidateErrorLen(err, 1)
+	})
+}
+
+func (suite *SegmentSuite) TestStringArrayAK5() {
+	suite.T().Run("string array all fields", func(t *testing.T) {
+		validAK5 := AK5{
+			TransactionSetAcknowledgmentCode:   "A",
+			TransactionSetSyntaxErrorCodeAK502: "abc",
+			TransactionSetSyntaxErrorCodeAK503: "def",
+			TransactionSetSyntaxErrorCodeAK504: "ghi",
+			TransactionSetSyntaxErrorCodeAK505: "jkl",
+			TransactionSetSyntaxErrorCodeAK506: "mno",
+		}
+		arrayValidAK5 := []string{"AK5", "A", "abc", "def", "ghi", "jkl", "mno"}
+		suite.Equal(arrayValidAK5, validAK5.StringArray())
+	})
+
+	suite.T().Run("string array only required fields", func(t *testing.T) {
+		validOptionalAK5 := AK5{
+			TransactionSetAcknowledgmentCode: "A",
+		}
+		arrayValidOptionalAK5 := []string{"AK5", "A", "", "", "", "", ""}
+		suite.Equal(arrayValidOptionalAK5, validOptionalAK5.StringArray())
+	})
+}
+
+func (suite *SegmentSuite) TestParseAK5() {
+	suite.T().Run("parse success all fields", func(t *testing.T) {
+		arrayValidAK5 := []string{"A", "abc", "def", "ghi", "jkl", "mno"}
+		expectedAK5 := AK5{
+			TransactionSetAcknowledgmentCode:   "A",
+			TransactionSetSyntaxErrorCodeAK502: "abc",
+			TransactionSetSyntaxErrorCodeAK503: "def",
+			TransactionSetSyntaxErrorCodeAK504: "ghi",
+			TransactionSetSyntaxErrorCodeAK505: "jkl",
+			TransactionSetSyntaxErrorCodeAK506: "mno",
+		}
+
+		var validAK5 AK5
+		err := validAK5.Parse(arrayValidAK5)
+		if suite.NoError(err) {
+			suite.Equal(expectedAK5, validAK5)
+		}
+	})
+
+	suite.T().Run("parse success only required fields", func(t *testing.T) {
+		arrayValidOptionalAK5 := []string{"A", "", "", "", "", ""}
+		expectedOptionalAK5 := AK5{
+			TransactionSetAcknowledgmentCode: "A",
+		}
+
+		var validOptionalAK5 AK5
+		err := validOptionalAK5.Parse(arrayValidOptionalAK5)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalAK5, validOptionalAK5)
+		}
+	})
+
+	suite.T().Run("wrong number of fields", func(t *testing.T) {
+		badArrayAK5 := []string{"A", "abc"}
+		var badAK5 AK5
+		err := badAK5.Parse(badArrayAK5)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "Wrong number of fields")
+		}
+	})
+}

--- a/pkg/edi/segment/data_element_dictionary_997.go
+++ b/pkg/edi/segment/data_element_dictionary_997.go
@@ -1,0 +1,1 @@
+package edisegment

--- a/pkg/edi/segment/data_element_dictionary_997.go
+++ b/pkg/edi/segment/data_element_dictionary_997.go
@@ -1,1 +1,0 @@
-package edisegment


### PR DESCRIPTION
## Description

Mostly followed https://github.com/transcom/mymove/pull/6078 for guidance. 

This is the AK5 segment.  Which is used to get the `A` to indicate that a message was received by Syncada (that was previously sent from MilMove). 

## Reviewer Notes

n/a

## Setup

No testing for this other than running `make server_test`. 

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6913) for this change
* [Spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) explains more about the approach used.
* [997 specification](https://drive.google.com/file/d/13cbg99nrrQP1PwkFYvBTlJjqD_b5ieGB/view?usp=sharing)


## Screenshots

n/a
