### PR TITLE
[DRAFT for review] AK5 Description Helper

### DIFF
--- a/pkg/edi/segment/ak5.go
+++ b/pkg/edi/segment/ak5.go
@@ -45,3 +45,15 @@ func (s *AK5) Parse(elements []string) error {
 
 	return nil
 }
+
+// Accepted returns if the 997 was accepted as via the AK501 field using the 717 Definition
+func (s *AK5) Accepted() bool {
+	de := dataElement717{}
+	return de.Accepted(s.TransactionSetAcknowledgmentCode)
+}
+
+// AckDescription returns the 997 AK501 field description using the 717 Definition
+func (s *AK5) AckDescription() (string, error) {
+	de := dataElement717{}
+	return de.Description(s.TransactionSetAcknowledgmentCode)
+}

--- a/pkg/edi/segment/data_element_dictionary_edi997.go
+++ b/pkg/edi/segment/data_element_dictionary_edi997.go
@@ -1,0 +1,1 @@
+package edisegment

--- a/pkg/edi/segment/data_element_dictionary_edi997.go
+++ b/pkg/edi/segment/data_element_dictionary_edi997.go
@@ -7,7 +7,7 @@ import (
 // Helpful Data Element Dictionary definitions found in the 997 Function Acknowledgment spec
 // for use with Syncada application
 
-// 717 Transaction SEt Acknowledgement Code
+// 717 Transaction Set Acknowledgement Code
 // Code indicating accept or reject condition based on the syntax editing of the transaction set
 var transactionSetAckCode717 = map[string]string{
 	"A": "Accepted",

--- a/pkg/edi/segment/data_element_dictionary_edi997.go
+++ b/pkg/edi/segment/data_element_dictionary_edi997.go
@@ -1,1 +1,45 @@
 package edisegment
+
+import (
+	"fmt"
+)
+
+// Helpful Data Element Dictionary definitions found in the 997 Function Acknowledgment spec
+// for use with Syncada application
+
+// 717 Transaction SEt Acknowledgement Code
+// Code indicating accept or reject condition based on the syntax editing of the transaction set
+var transactionSetAckCode717 = map[string]string{
+	"A": "Accepted",
+	"E": "Accepted, But Errors Were Noted.",
+	"M": "Rejected, Message Authentication Code (MAC) Failed",
+	"P": "Partially Accepted, At Least One Transaction Set Was Rejected",
+	"R": "Rejected",
+	"W": "Rejected, Assurance Failed Validity Tests",
+	"X": "Rejected, Content After Decryption Could Not Be Analyzed",
+}
+
+var transactionSetAckCode717Accepted = []string{
+	"A",
+	"E",
+}
+
+type dataElement717 struct {
+}
+
+func (de dataElement717) Accepted(code string) bool {
+	for _, ackCode := range transactionSetAckCode717Accepted {
+		if code == ackCode {
+			return true
+		}
+	}
+	return false
+}
+
+func (de dataElement717) Description(code string) (string, error) {
+	description, ok := transactionSetAckCode717[code]
+	if ok {
+		return description, nil
+	}
+	return "", fmt.Errorf("code %s not found", code)
+}


### PR DESCRIPTION
## Description

This is a draft to consider if we want to have data elements defined when we know we'll be using them for certain segments. 

This is using the 717 Data Element Dictionary definition from the EDI 997 spec. 

https://drive.google.com/file/d/13cbg99nrrQP1PwkFYvBTlJjqD_b5ieGB/view


## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
