### PR TITLE
[MB-6949] Add BGN EDI segment and tests

### DIFF
--- a/pkg/edi/segment/bgn.go
+++ b/pkg/edi/segment/bgn.go
@@ -1,0 +1,36 @@
+package edisegment
+
+import (
+	"fmt"
+)
+
+// BGN represents the BGN EDI segment
+type BGN struct {
+	TransactionSetPurposeCode string `validate:"eq=11"`
+	ReferenceIdentification   string `validate:"min=1,max=30"`
+	Date                      string `validate:"datetime=20060102"`
+}
+
+// StringArray converts BGN to an array of strings
+func (s *BGN) StringArray() []string {
+	return []string{
+		"BGN",
+		s.TransactionSetPurposeCode,
+		s.ReferenceIdentification,
+		s.Date,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the BGN struct
+func (s *BGN) Parse(elements []string) error {
+	expectedNumElements := 3
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("BGN: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	s.TransactionSetPurposeCode = elements[0]
+	s.ReferenceIdentification = elements[1]
+	s.Date = elements[2]
+
+	return nil
+}

--- a/pkg/edi/segment/bgn_test.go
+++ b/pkg/edi/segment/bgn_test.go
@@ -1,0 +1,81 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateBGN() {
+	suite.T().Run("validate success all fields", func(t *testing.T) {
+		validBGN := BGN{
+			TransactionSetPurposeCode: "11",
+			ReferenceIdentification:   "hello",
+			Date:                      "20210310",
+		}
+		err := suite.validator.Struct(validBGN)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		bgn := BGN{
+			TransactionSetPurposeCode: "10",       // eq
+			ReferenceIdentification:   "",         // min
+			Date:                      "20211313", // datetime
+		}
+
+		err := suite.validator.Struct(bgn)
+		suite.ValidateError(err, "TransactionSetPurposeCode", "eq")
+		suite.ValidateError(err, "ReferenceIdentification", "min")
+		suite.ValidateError(err, "Date", "datetime")
+		suite.ValidateErrorLen(err, 3)
+	})
+
+	suite.T().Run("validate failure 2", func(t *testing.T) {
+		bgn := BGN{
+			TransactionSetPurposeCode: "11",
+			ReferenceIdentification:   "long string that exceeds max length", // max
+			Date:                      "20210310",
+		}
+
+		err := suite.validator.Struct(bgn)
+		suite.ValidateError(err, "ReferenceIdentification", "max")
+		suite.ValidateErrorLen(err, 1)
+	})
+}
+
+func (suite *SegmentSuite) TestStringArrayBGN() {
+	suite.T().Run("string array all fields", func(t *testing.T) {
+		validBGN := BGN{
+			TransactionSetPurposeCode: "11",
+			ReferenceIdentification:   "hello",
+			Date:                      "20210310",
+		}
+		arrayValidBGN := []string{"BGN", "11", "hello", "20210310"}
+		suite.Equal(arrayValidBGN, validBGN.StringArray())
+	})
+}
+
+func (suite *SegmentSuite) TestParseBGN() {
+	suite.T().Run("parse success all fields", func(t *testing.T) {
+		arrayValidBGN := []string{"11", "hello", "20210310"}
+		expectedBGN := BGN{
+			TransactionSetPurposeCode: "11",
+			ReferenceIdentification:   "hello",
+			Date:                      "20210310",
+		}
+
+		var validBGN BGN
+		err := validBGN.Parse(arrayValidBGN)
+		if suite.NoError(err) {
+			suite.Equal(expectedBGN, validBGN)
+		}
+	})
+
+	suite.T().Run("wrong number of fields", func(t *testing.T) {
+		badArrayBGN := []string{"11", "hello"}
+		var badBGN BGN
+		err := badBGN.Parse(badArrayBGN)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "Wrong number of fields")
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR adds the BGN segment and its validations as defined in this [mapping doc](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795).

## Reviewer Notes

- I added tests for `Parse` and `StringArray` that we don't seem to have in most other segments.  I'm getting 100% coverage (at least according to GoLand) where most of the other segments show 0% coverage.  That's perhaps a little misleading since we do test validations in all segments, but we aren't getting credit for those since those are are defined via struct tags.
- The BGN segment has a Date field, but I'm storing it as a `string` rather than a `time.Time` to match what the other date/time fields do in other segments.  I'm not sure it matters much for this since it's got to be converted to a string anyway to create the EDI.

## Setup

There's no way to use this in the app yet, but `make server_test` will exercise the code.  Also, please verify the fields/validations against the mapping doc.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6949) for this change
* [Spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795)
* [824 specification](https://drive.google.com/file/d/144rKMw_aFFPgHwLfOhMKqvmkFO4SzJ2M/view?usp=sharing)