### PR TITLE
MB-5501-cancel-shipment

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1619,7 +1619,8 @@ func init() {
           "enum": [
             "APPROVED",
             "SUBMITTED",
-            "REJECTED"
+            "REJECTED",
+            "CANCELLATION_REQUESTED"
           ],
           "readOnly": true
         },
@@ -4103,7 +4104,8 @@ func init() {
           "enum": [
             "APPROVED",
             "SUBMITTED",
-            "REJECTED"
+            "REJECTED",
+            "CANCELLATION_REQUESTED"
           ],
           "readOnly": true
         },

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -113,7 +113,7 @@ type MTOShipment struct {
 
 	// status
 	// Read Only: true
-	// Enum: [APPROVED SUBMITTED REJECTED]
+	// Enum: [APPROVED SUBMITTED REJECTED CANCELLATION_REQUESTED]
 	Status string `json:"status,omitempty"`
 
 	// updated at
@@ -746,7 +746,7 @@ var mTOShipmentTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["APPROVED","SUBMITTED","REJECTED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["APPROVED","SUBMITTED","REJECTED","CANCELLATION_REQUESTED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -764,6 +764,9 @@ const (
 
 	// MTOShipmentStatusREJECTED captures enum value "REJECTED"
 	MTOShipmentStatusREJECTED string = "REJECTED"
+
+	// MTOShipmentStatusCANCELLATIONREQUESTED captures enum value "CANCELLATION_REQUESTED"
+	MTOShipmentStatusCANCELLATIONREQUESTED string = "CANCELLATION_REQUESTED"
 )
 
 // prop value enum

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -2173,7 +2173,8 @@ func init() {
           "enum": [
             "REJECTED",
             "APPROVED",
-            "SUBMITTED"
+            "SUBMITTED",
+            "CANCELLATION_REQUESTED"
           ]
         }
       }
@@ -4709,7 +4710,8 @@ func init() {
           "enum": [
             "REJECTED",
             "APPROVED",
-            "SUBMITTED"
+            "SUBMITTED",
+            "CANCELLATION_REQUESTED"
           ]
         }
       }

--- a/pkg/gen/supportmessages/update_m_t_o_shipment_status.go
+++ b/pkg/gen/supportmessages/update_m_t_o_shipment_status.go
@@ -23,7 +23,7 @@ type UpdateMTOShipmentStatus struct {
 	RejectionReason *string `json:"rejectionReason,omitempty"`
 
 	// status
-	// Enum: [REJECTED APPROVED SUBMITTED]
+	// Enum: [REJECTED APPROVED SUBMITTED CANCELLATION_REQUESTED]
 	Status string `json:"status,omitempty"`
 }
 
@@ -45,7 +45,7 @@ var updateMTOShipmentStatusTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["REJECTED","APPROVED","SUBMITTED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["REJECTED","APPROVED","SUBMITTED","CANCELLATION_REQUESTED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -63,6 +63,9 @@ const (
 
 	// UpdateMTOShipmentStatusStatusSUBMITTED captures enum value "SUBMITTED"
 	UpdateMTOShipmentStatusStatusSUBMITTED string = "SUBMITTED"
+
+	// UpdateMTOShipmentStatusStatusCANCELLATIONREQUESTED captures enum value "CANCELLATION_REQUESTED"
+	UpdateMTOShipmentStatusStatusCANCELLATIONREQUESTED string = "CANCELLATION_REQUESTED"
 )
 
 // prop value enum

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -170,8 +170,12 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	})
 
 	// Test Successful Cancellation Request
-
 	suite.T().Run("Successful patch - Integration Test for CANCELLATION_REQUESTED", func(t *testing.T) {
+		// Under test: updateMTOShipmentHandler function
+		// Mocked:     none
+		// Setup: We create a new mtoShipment, then try to update the status from Approved to Cancellation_Requested
+		// Expected outcome:
+		//             Successfully updated status to CANCELLATION_REQUESTED
 		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
 		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto,

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -193,6 +193,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			fetcher,
 			updater,
 		}
+
+		// NOTE: DEBUGGING to figure out what params is passing in.
+		// TODO: Fix Etag mismatch error
 		fmt.Println(params)
 		fmt.Println(params.Body)
 

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -173,6 +173,15 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 	suite.T().Run("Successful patch - Integration Test for CANCELLATION_REQUESTED", func(t *testing.T) {
 		//creator := mtoshipment.NewMTOShipmentStatusUpdater(builder)
+		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
+		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status:       models.MTOShipmentStatusSubmitted,
+				ShipmentType: models.MTOShipmentTypeHHGLongHaulDom,
+			},
+		})
+		eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
 		params := mtoshipmentops.UpdateMTOShipmentStatusParams{
 			HTTPRequest:   req,
 			MtoShipmentID: *handlers.FmtUUID(mtoShipment.ID),
@@ -198,7 +207,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		// TODO: Fix Etag mismatch error
 		fmt.Println(params)
 		fmt.Println(params.Body)
-
+		fmt.Println("DEBUG TEST")
+		fmt.Println(eTag)
 		suite.NoError(params.Body.Validate(strfmt.Default))
 		response := handler.Handle(params)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusOK{}, response)
@@ -206,5 +216,6 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusOK)
 		suite.NotEmpty(okResponse, supportmessages.UpdateMTOShipmentStatusStatusCANCELLATIONREQUESTED)
 		//suite.NotZero(okResponse.Payload.ID())
+		suite.NotZero(okResponse.Payload.ETag)
 	})
 }

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -197,7 +197,6 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusOK{}, response)
 
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusOK)
-		suite.NotEmpty(okResponse, supportmessages.UpdateMTOShipmentStatusStatusCANCELLATIONREQUESTED)
 		suite.Equal(supportmessages.UpdateMTOShipmentStatusStatusCANCELLATIONREQUESTED, okResponse.Payload.Status)
 		suite.NotZero(okResponse.Payload.ETag)
 	})

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1433,6 +1433,7 @@ definitions:
           - APPROVED
           - SUBMITTED
           - REJECTED
+          - CANCELLATION_REQUESTED
       rejectionReason:
         type: string
         readOnly: true

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1725,6 +1725,7 @@ definitions:
           - REJECTED
           - APPROVED
           - SUBMITTED
+          - CANCELLATION_REQUESTED
       rejectionReason:
         type: string
         example: MTO Shipment not good enough


### PR DESCRIPTION
## Description

Add CANCELLATION_REQUESTED to the enum definitions in support.yaml and prime.yaml for `UpdateMTOShipment`. 

Add a test to make sure that a mto_shipment status can be updated to cancellation_requested 

## Reviewer Notes

The eTag does not match the IfMatch header value and is returning a precondition failed. This is a blocker for me that I am trying to work through.

## Setup

To run the test:

```sh
go test ./pkg/handlers/supportapi --testify.m "TestUpdateMTOShipmentHandler"

```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5501) for this change

## Screenshots
