### PR TITLE
[MB-6950] Add OTI segment and tests

### DIFF
--- a/pkg/edi/segment/oti.go
+++ b/pkg/edi/segment/oti.go
@@ -1,0 +1,73 @@
+package edisegment
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// OTI represents the OTI EDI segment
+type OTI struct {
+	ApplicationAcknowledgementCode   string `validate:"oneof=TA TE TR"`
+	ReferenceIdentificationQualifier string `validate:"oneof=BM CN"`
+	ReferenceIdentification          string `validate:"min=1,max=30"`
+	ApplicationSendersCode           string `validate:"omitempty,min=2,max=15"`
+	ApplicationReceiversCode         string `validate:"omitempty,min=2,max=15"`
+	Date                             string `validate:"omitempty,datetime=20060102"`
+	Time                             string `validate:"omitempty,datetime=1504"`
+	GroupControlNumber               int64  `validate:"required_with=TransactionSetControlNumber,omitempty,min=1,max=999999999"`
+	TransactionSetControlNumber      string `validate:"omitempty,min=4,max=9"`
+}
+
+// StringArray converts OTI to an array of strings
+func (s *OTI) StringArray() []string {
+	// For the optional int fields, make sure we map a zero to the empty string.
+	var strGroupControlNumber string
+	if s.GroupControlNumber != 0 {
+		strGroupControlNumber = strconv.FormatInt(s.GroupControlNumber, 10)
+	}
+
+	return []string{
+		"OTI",
+		s.ApplicationAcknowledgementCode,
+		s.ReferenceIdentificationQualifier,
+		s.ReferenceIdentification,
+		s.ApplicationSendersCode,
+		s.ApplicationReceiversCode,
+		s.Date,
+		s.Time,
+		strGroupControlNumber,
+		s.TransactionSetControlNumber,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the OTI struct
+func (s *OTI) Parse(elements []string) error {
+	expectedNumElements := 9
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("OTI: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	s.ApplicationAcknowledgementCode = elements[0]
+	s.ReferenceIdentificationQualifier = elements[1]
+	s.ReferenceIdentification = elements[2]
+	s.ApplicationSendersCode = elements[3]
+	s.ApplicationReceiversCode = elements[4]
+	s.Date = elements[5]
+	s.Time = elements[6]
+
+	// For the optional int fields, make sure we map an empty string to a zero.
+	var err error
+	strGroupControlNumber := elements[7]
+	if strGroupControlNumber == "" {
+		s.GroupControlNumber = 0
+	} else {
+		s.GroupControlNumber, err = strconv.ParseInt(strGroupControlNumber, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.TransactionSetControlNumber = elements[8]
+
+	return nil
+}

--- a/pkg/edi/segment/oti_test.go
+++ b/pkg/edi/segment/oti_test.go
@@ -1,0 +1,170 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateOTI() {
+	validOTI := OTI{
+		ApplicationAcknowledgementCode:   "TA",
+		ReferenceIdentificationQualifier: "BM",
+		ReferenceIdentification:          "ABC",
+		ApplicationSendersCode:           "MILMOVE",
+		ApplicationReceiversCode:         "RECEIVER",
+		Date:                             "20210311",
+		Time:                             "1057",
+		GroupControlNumber:               12345,
+		TransactionSetControlNumber:      "ABCDE",
+	}
+
+	suite.T().Run("validate success all fields", func(t *testing.T) {
+		err := suite.validator.Struct(validOTI)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success only required fields", func(t *testing.T) {
+		validOptionalOTI := OTI{
+			ApplicationAcknowledgementCode:   "TA",
+			ReferenceIdentificationQualifier: "BM",
+			ReferenceIdentification:          "ABC",
+		}
+		err := suite.validator.Struct(validOptionalOTI)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		oti := OTI{
+			ApplicationAcknowledgementCode:   "XX",       // oneof
+			ReferenceIdentificationQualifier: "XX",       // oneof
+			ReferenceIdentification:          "",         // min
+			ApplicationSendersCode:           "X",        // min
+			ApplicationReceiversCode:         "X",        // min
+			Date:                             "20211311", // datetime
+			Time:                             "2557",     // datetime
+			GroupControlNumber:               -1,         // min
+			TransactionSetControlNumber:      "ABC",      // min
+		}
+
+		err := suite.validator.Struct(oti)
+		suite.ValidateError(err, "ApplicationAcknowledgementCode", "oneof")
+		suite.ValidateError(err, "ReferenceIdentificationQualifier", "oneof")
+		suite.ValidateError(err, "ReferenceIdentification", "min")
+		suite.ValidateError(err, "ApplicationSendersCode", "min")
+		suite.ValidateError(err, "ApplicationReceiversCode", "min")
+		suite.ValidateError(err, "Date", "datetime")
+		suite.ValidateError(err, "Time", "datetime")
+		suite.ValidateError(err, "GroupControlNumber", "min")
+		suite.ValidateError(err, "TransactionSetControlNumber", "min")
+		suite.ValidateErrorLen(err, 9)
+	})
+
+	suite.T().Run("validate failure 2", func(t *testing.T) {
+		oti := validOTI
+		oti.ReferenceIdentification = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" // max
+		oti.ApplicationSendersCode = "MILMOVEMILMOVEMILMOVE"            // max
+		oti.ApplicationReceiversCode = "RECEIVERRECEIVER"               // max
+		oti.GroupControlNumber = 1000000000                             // max
+		oti.TransactionSetControlNumber = "ABCDEABCDE"                  // max
+
+		err := suite.validator.Struct(oti)
+		suite.ValidateError(err, "ReferenceIdentification", "max")
+		suite.ValidateError(err, "ApplicationSendersCode", "max")
+		suite.ValidateError(err, "ApplicationReceiversCode", "max")
+		suite.ValidateError(err, "GroupControlNumber", "max")
+		suite.ValidateError(err, "TransactionSetControlNumber", "max")
+		suite.ValidateErrorLen(err, 5)
+	})
+
+	suite.T().Run("validate failure 3", func(t *testing.T) {
+		oti := validOTI
+		oti.GroupControlNumber = 0 // required_with
+
+		err := suite.validator.Struct(oti)
+		suite.ValidateError(err, "GroupControlNumber", "required_with")
+		suite.ValidateErrorLen(err, 1)
+	})
+}
+
+func (suite *SegmentSuite) TestStringArrayOTI() {
+	suite.T().Run("string array all fields", func(t *testing.T) {
+		validOTI := OTI{
+			ApplicationAcknowledgementCode:   "TA",
+			ReferenceIdentificationQualifier: "BM",
+			ReferenceIdentification:          "ABC",
+			ApplicationSendersCode:           "MILMOVE",
+			ApplicationReceiversCode:         "RECEIVER",
+			Date:                             "20210311",
+			Time:                             "1057",
+			GroupControlNumber:               12345,
+			TransactionSetControlNumber:      "ABCDE",
+		}
+		arrayValidOTI := []string{"OTI", "TA", "BM", "ABC", "MILMOVE", "RECEIVER", "20210311", "1057", "12345", "ABCDE"}
+		suite.Equal(arrayValidOTI, validOTI.StringArray())
+	})
+
+	suite.T().Run("string array only required fields", func(t *testing.T) {
+		validOptionalOTI := OTI{
+			ApplicationAcknowledgementCode:   "TA",
+			ReferenceIdentificationQualifier: "BM",
+			ReferenceIdentification:          "ABC",
+		}
+		arrayValidOptionalOTI := []string{"OTI", "TA", "BM", "ABC", "", "", "", "", "", ""}
+		suite.Equal(arrayValidOptionalOTI, validOptionalOTI.StringArray())
+	})
+}
+
+func (suite *SegmentSuite) TestParseOTI() {
+	suite.T().Run("parse success all fields", func(t *testing.T) {
+		arrayValidOTI := []string{"TA", "BM", "ABC", "MILMOVE", "RECEIVER", "20210311", "1057", "12345", "ABCDE"}
+		expectedOTI := OTI{
+			ApplicationAcknowledgementCode:   "TA",
+			ReferenceIdentificationQualifier: "BM",
+			ReferenceIdentification:          "ABC",
+			ApplicationSendersCode:           "MILMOVE",
+			ApplicationReceiversCode:         "RECEIVER",
+			Date:                             "20210311",
+			Time:                             "1057",
+			GroupControlNumber:               12345,
+			TransactionSetControlNumber:      "ABCDE",
+		}
+
+		var validOTI OTI
+		err := validOTI.Parse(arrayValidOTI)
+		if suite.NoError(err) {
+			suite.Equal(expectedOTI, validOTI)
+		}
+	})
+
+	suite.T().Run("parse success only required fields", func(t *testing.T) {
+		arrayValidOptionalOTI := []string{"TA", "BM", "ABC", "", "", "", "", "", ""}
+		expectedOptionalOTI := OTI{
+			ApplicationAcknowledgementCode:   "TA",
+			ReferenceIdentificationQualifier: "BM",
+			ReferenceIdentification:          "ABC",
+		}
+
+		var validOptionalOTI OTI
+		err := validOptionalOTI.Parse(arrayValidOptionalOTI)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalOTI, validOptionalOTI)
+		}
+	})
+
+	suite.T().Run("wrong number of fields", func(t *testing.T) {
+		badArrayOTI := []string{"TA", "BM"}
+		var badOTI OTI
+		err := badOTI.Parse(badArrayOTI)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "Wrong number of fields")
+		}
+	})
+
+	suite.T().Run("invalid integers", func(t *testing.T) {
+		badArrayOTI := []string{"TA", "BM", "ABC", "MILMOVE", "RECEIVER", "20210311", "1057", "A12345", "ABCDE"}
+		var badOTI OTI
+		err := badOTI.Parse(badArrayOTI)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "invalid syntax")
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR adds the OTI segment and its validations as defined in this [mapping doc](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795).

## Reviewer Notes

- I added tests for `Parse` and `StringArray` that we don't seem to have in most other segments.  I'm getting 100% coverage (at least according to GoLand) where most of the other segments show 0% coverage.  That's perhaps a little misleading since we do test validations in all segments, but we aren't getting credit for those since those are are defined via struct tags.
- The OTI segment has a Date and Time field, but I'm storing them as `string` rather than `time.Time` to match what the other date/time fields do in other segments.  I'm not sure it matters much for this since it's got to be converted to a string anyway to create the EDI.

## Setup

There's no way to use this in the app yet, but `make server_test` will exercise the code.  Also, please verify the fields/validations against the mapping doc.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6950) for this change
* [Spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795)
* [824 specification](https://drive.google.com/file/d/144rKMw_aFFPgHwLfOhMKqvmkFO4SzJ2M/view?usp=sharing)