### PR TITLE
[MB-6951] Add TED segment and tests

### DIFF
--- a/pkg/edi/segment/ted.go
+++ b/pkg/edi/segment/ted.go
@@ -1,0 +1,33 @@
+package edisegment
+
+import (
+	"fmt"
+)
+
+// TED represents the TED EDI segment
+type TED struct {
+	ApplicationErrorConditionCode string `validate:"oneof=007 812 832 DUP IID INC K MJ PPD T ZZZ"`
+	FreeFormMessage               string `validate:"omitempty,max=60"`
+}
+
+// StringArray converts TED to an array of strings
+func (s *TED) StringArray() []string {
+	return []string{
+		"TED",
+		s.ApplicationErrorConditionCode,
+		s.FreeFormMessage,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the TED struct
+func (s *TED) Parse(elements []string) error {
+	expectedNumElements := 2
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("TED: Wrong number of fields, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	s.ApplicationErrorConditionCode = elements[0]
+	s.FreeFormMessage = elements[1]
+
+	return nil
+}

--- a/pkg/edi/segment/ted_test.go
+++ b/pkg/edi/segment/ted_test.go
@@ -1,0 +1,94 @@
+package edisegment
+
+import (
+	"strings"
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateTED() {
+	suite.T().Run("validate success all fields", func(t *testing.T) {
+		validTED := TED{
+			ApplicationErrorConditionCode: "007",
+			FreeFormMessage:               "free form message",
+		}
+		err := suite.validator.Struct(validTED)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success only required fields", func(t *testing.T) {
+		validOptionalTED := TED{
+			ApplicationErrorConditionCode: "007",
+		}
+		err := suite.validator.Struct(validOptionalTED)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure", func(t *testing.T) {
+		ted := TED{
+			ApplicationErrorConditionCode: "123",                   // oneof
+			FreeFormMessage:               strings.Repeat("x", 61), // max
+		}
+
+		err := suite.validator.Struct(ted)
+		suite.ValidateError(err, "ApplicationErrorConditionCode", "oneof")
+		suite.ValidateError(err, "FreeFormMessage", "max")
+		suite.ValidateErrorLen(err, 2)
+	})
+}
+
+func (suite *SegmentSuite) TestStringArrayTED() {
+	suite.T().Run("string array all fields", func(t *testing.T) {
+		validTED := TED{
+			ApplicationErrorConditionCode: "007",
+			FreeFormMessage:               "free form message",
+		}
+		arrayValidTED := []string{"TED", "007", "free form message"}
+		suite.Equal(arrayValidTED, validTED.StringArray())
+	})
+
+	suite.T().Run("string array only required fields", func(t *testing.T) {
+		validOptionalTED := TED{
+			ApplicationErrorConditionCode: "007",
+		}
+		arrayValidOptionalTED := []string{"TED", "007", ""}
+		suite.Equal(arrayValidOptionalTED, validOptionalTED.StringArray())
+	})
+}
+
+func (suite *SegmentSuite) TestParseTED() {
+	suite.T().Run("parse success all fields", func(t *testing.T) {
+		arrayValidTED := []string{"007", "free form message"}
+		expectedTED := TED{
+			ApplicationErrorConditionCode: "007",
+			FreeFormMessage:               "free form message",
+		}
+
+		var validTED TED
+		err := validTED.Parse(arrayValidTED)
+		if suite.NoError(err) {
+			suite.Equal(expectedTED, validTED)
+		}
+	})
+
+	suite.T().Run("parse success only required fields", func(t *testing.T) {
+		arrayValidOptionalTED := []string{"007", ""}
+		expectedOptionalTED := TED{
+			ApplicationErrorConditionCode: "007",
+		}
+
+		var validOptionalTED TED
+		err := validOptionalTED.Parse(arrayValidOptionalTED)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalTED, validOptionalTED)
+		}
+	})
+
+	suite.T().Run("wrong number of fields", func(t *testing.T) {
+		badArrayTED := []string{"007", "hello", "world"}
+		var badTED TED
+		err := badTED.Parse(badArrayTED)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "Wrong number of fields")
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR adds the TED segment and its validations as defined in this [mapping doc](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795).

## Reviewer Notes

- I added tests for `Parse` and `StringArray` that we don't seem to have in most other segments.  I'm getting 100% coverage (at least according to GoLand) where most of the other segments show 0% coverage.  That's perhaps a little misleading since we do test validations in all segments, but we aren't getting credit for those since those are are defined via struct tags.

## Setup

There's no way to use this in the app yet, but `make server_test` will exercise the code.  Also, please verify the fields/validations against the mapping doc.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6951) for this change
* [Spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=367426795)
* [824 specification](https://drive.google.com/file/d/144rKMw_aFFPgHwLfOhMKqvmkFO4SzJ2M/view?usp=sharing)