### PR TITLE
[MB-6914] Create AK9 EDI segment

### DIFF
--- a/pkg/edi/segment/ak9.go
+++ b/pkg/edi/segment/ak9.go
@@ -1,0 +1,69 @@
+package edisegment
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// AK9 represents the AK9 EDI segment
+type AK9 struct {
+	FunctionalGroupAcknowledgeCode      string `validate:"oneof=A E P R"`
+	NumberOfTransactionSetsIncluded     int    `validate:"min=1,max=999999"`
+	NumberOfReceivedTransactionSets     int    `validate:"min=1,max=999999"`
+	NumberOfAcceptedTransactionSets     int    `validate:"min=1,max=999999"`
+	FunctionalGroupSyntaxErrorCodeAK905 string `validate:"omitempty,max=3"`
+	FunctionalGroupSyntaxErrorCodeAK906 string `validate:"omitempty,max=3"`
+	FunctionalGroupSyntaxErrorCodeAK907 string `validate:"omitempty,max=3"`
+	FunctionalGroupSyntaxErrorCodeAK908 string `validate:"omitempty,max=3"`
+	FunctionalGroupSyntaxErrorCodeAK909 string `validate:"omitempty,max=3"`
+}
+
+// StringArray converts AK9 to an array of strings
+func (s *AK9) StringArray() []string {
+	return []string{
+		"AK9",
+		s.FunctionalGroupAcknowledgeCode,
+		strconv.Itoa(s.NumberOfTransactionSetsIncluded),
+		strconv.Itoa(s.NumberOfReceivedTransactionSets),
+		strconv.Itoa(s.NumberOfAcceptedTransactionSets),
+		s.FunctionalGroupSyntaxErrorCodeAK905,
+		s.FunctionalGroupSyntaxErrorCodeAK906,
+		s.FunctionalGroupSyntaxErrorCodeAK907,
+		s.FunctionalGroupSyntaxErrorCodeAK908,
+		s.FunctionalGroupSyntaxErrorCodeAK909,
+	}
+}
+
+// Parse parses an X12 string that's split into an array into the AK9 struct
+func (s *AK9) Parse(elements []string) error {
+	expectedNumElements := 9
+	if len(elements) != expectedNumElements {
+		return fmt.Errorf("AK9: Wrong number of elements, expected %d, got %d", expectedNumElements, len(elements))
+	}
+
+	s.FunctionalGroupAcknowledgeCode = elements[0]
+
+	var err error
+	s.NumberOfTransactionSetsIncluded, err = strconv.Atoi(elements[1])
+	if err != nil {
+		return err
+	}
+
+	s.NumberOfReceivedTransactionSets, err = strconv.Atoi(elements[2])
+	if err != nil {
+		return err
+	}
+
+	s.NumberOfAcceptedTransactionSets, err = strconv.Atoi(elements[3])
+	if err != nil {
+		return err
+	}
+
+	s.FunctionalGroupSyntaxErrorCodeAK905 = elements[4]
+	s.FunctionalGroupSyntaxErrorCodeAK906 = elements[5]
+	s.FunctionalGroupSyntaxErrorCodeAK907 = elements[6]
+	s.FunctionalGroupSyntaxErrorCodeAK908 = elements[7]
+	s.FunctionalGroupSyntaxErrorCodeAK909 = elements[8]
+
+	return nil
+}

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -196,4 +196,29 @@ func (suite *SegmentSuite) TestParseAK9() {
 			suite.Contains(err.Error(), "Wrong number of elements")
 		}
 	})
+
+	suite.T().Run("parse fails for invalid ints", func(t *testing.T) {
+		var validOptionalAK9 AK9
+		arrayInvalidIntsAK9 := []string{"A", "g", "2", "3", "", "", "", "", ""}
+
+		err := validOptionalAK9.Parse(arrayInvalidIntsAK9)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "invalid syntax")
+		}
+
+		arrayInvalidIntsAK9[1] = "1"
+		arrayInvalidIntsAK9[2] = "AAA"
+
+		err = validOptionalAK9.Parse(arrayInvalidIntsAK9)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "invalid syntax")
+		}
+		arrayInvalidIntsAK9[2] = "2"
+		arrayInvalidIntsAK9[3] = "3.0"
+
+		err = validOptionalAK9.Parse(arrayInvalidIntsAK9)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "invalid syntax")
+		}
+	})
 }

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -80,9 +80,9 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		// length of characters are more than max
 		ak9 := AK9{
 			FunctionalGroupAcknowledgeCode:      "AA",
-			NumberOfTransactionSetsIncluded:     1,
-			NumberOfReceivedTransactionSets:     2,
-			NumberOfAcceptedTransactionSets:     3,
+			NumberOfTransactionSetsIncluded:     1000000,
+			NumberOfReceivedTransactionSets:     1000000,
+			NumberOfAcceptedTransactionSets:     1000000,
 			FunctionalGroupSyntaxErrorCodeAK905: "AAAA",
 			FunctionalGroupSyntaxErrorCodeAK906: "BBBB",
 			FunctionalGroupSyntaxErrorCodeAK907: "CCCC",
@@ -92,12 +92,15 @@ func (suite *SegmentSuite) TestValidateAK9() {
 
 		err := suite.validator.Struct(ak9)
 		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
+		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "max")
+		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "max")
+		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "max")
 		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK905", "max")
 		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK906", "max")
 		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK907", "max")
 		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK908", "max")
 		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK909", "max")
-		suite.ValidateErrorLen(err, 6)
+		suite.ValidateErrorLen(err, 9)
 	})
 
 	suite.T().Run("validate failure min", func(t *testing.T) {

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -1,0 +1,196 @@
+package edisegment
+
+import (
+	"fmt"
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateAK9() {
+	suite.T().Run("validate success all fields", func(t *testing.T) {
+		validAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:      "A",
+			NumberOfTransactionSetsIncluded:     1,
+			NumberOfReceivedTransactionSets:     2,
+			NumberOfAcceptedTransactionSets:     3,
+			FunctionalGroupSyntaxErrorCodeAK905: "AAA",
+			FunctionalGroupSyntaxErrorCodeAK906: "BBB",
+			FunctionalGroupSyntaxErrorCodeAK907: "CCC",
+			FunctionalGroupSyntaxErrorCodeAK908: "DDD",
+			FunctionalGroupSyntaxErrorCodeAK909: "EEE",
+		}
+		err := suite.validator.Struct(validAK9)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success only required fields", func(t *testing.T) {
+		validAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "E",
+			NumberOfTransactionSetsIncluded: 1,
+			NumberOfReceivedTransactionSets: 2,
+			NumberOfAcceptedTransactionSets: 3,
+		}
+		err := suite.validator.Struct(validAK9)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate success for all valid FunctionalGroupAcknowledgeCode values", func(t *testing.T) {
+		validAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "A",
+			NumberOfTransactionSetsIncluded: 1,
+			NumberOfReceivedTransactionSets: 2,
+			NumberOfAcceptedTransactionSets: 3,
+		}
+		allowedValues := []string{"A", "E", "P", "R"}
+		for _, val := range allowedValues {
+			validAK9.FunctionalGroupAcknowledgeCode = val
+			err := suite.validator.Struct(validAK9)
+			suite.NoError(err, fmt.Sprintf("Failed to validate allowed value: \"%s\"", val))
+		}
+	})
+
+	suite.T().Run("validate failure for invalid FunctionalGroupAcknowledgeCode", func(t *testing.T) {
+		validAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "B",
+			NumberOfTransactionSetsIncluded: 1,
+			NumberOfReceivedTransactionSets: 2,
+			NumberOfAcceptedTransactionSets: 3,
+		}
+		err := suite.validator.Struct(validAK9)
+		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
+	})
+
+	suite.T().Run("failure due to missing required fields", func(t *testing.T) {
+
+		ak9 := AK9{
+			FunctionalGroupSyntaxErrorCodeAK905: "AAA",
+			FunctionalGroupSyntaxErrorCodeAK906: "BBB",
+			FunctionalGroupSyntaxErrorCodeAK907: "CCC",
+			FunctionalGroupSyntaxErrorCodeAK908: "DDD",
+			FunctionalGroupSyntaxErrorCodeAK909: "EEE",
+		}
+		err := suite.validator.Struct(ak9)
+		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
+		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
+		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
+		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
+		suite.ValidateErrorLen(err, 4)
+	})
+
+	suite.T().Run("validate failure max", func(t *testing.T) {
+		// length of characters are more than max
+		ak9 := AK9{
+			FunctionalGroupAcknowledgeCode:      "AA",
+			NumberOfTransactionSetsIncluded:     1,
+			NumberOfReceivedTransactionSets:     2,
+			NumberOfAcceptedTransactionSets:     3,
+			FunctionalGroupSyntaxErrorCodeAK905: "AAAA",
+			FunctionalGroupSyntaxErrorCodeAK906: "BBBB",
+			FunctionalGroupSyntaxErrorCodeAK907: "CCCC",
+			FunctionalGroupSyntaxErrorCodeAK908: "DDDD",
+			FunctionalGroupSyntaxErrorCodeAK909: "EEEE",
+		}
+
+		err := suite.validator.Struct(ak9)
+		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
+		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK905", "max")
+		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK906", "max")
+		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK907", "max")
+		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK908", "max")
+		suite.ValidateError(err, "FunctionalGroupSyntaxErrorCodeAK909", "max")
+		suite.ValidateErrorLen(err, 6)
+	})
+
+	suite.T().Run("validate failure min", func(t *testing.T) {
+		// length of characters are less than min
+		ak9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "",
+			NumberOfTransactionSetsIncluded: 0,
+			NumberOfReceivedTransactionSets: 0,
+			NumberOfAcceptedTransactionSets: 0,
+		}
+
+		err := suite.validator.Struct(ak9)
+		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
+		suite.ValidateError(err, "NumberOfTransactionSetsIncluded", "min")
+		suite.ValidateError(err, "NumberOfReceivedTransactionSets", "min")
+		suite.ValidateError(err, "NumberOfAcceptedTransactionSets", "min")
+		suite.ValidateErrorLen(err, 4)
+	})
+}
+
+func (suite *SegmentSuite) TestStringArrayAK9() {
+	suite.T().Run("string array all fields", func(t *testing.T) {
+		validAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:      "A",
+			NumberOfTransactionSetsIncluded:     1,
+			NumberOfReceivedTransactionSets:     2,
+			NumberOfAcceptedTransactionSets:     3,
+			FunctionalGroupSyntaxErrorCodeAK905: "AAA",
+			FunctionalGroupSyntaxErrorCodeAK906: "BBB",
+			FunctionalGroupSyntaxErrorCodeAK907: "CCC",
+			FunctionalGroupSyntaxErrorCodeAK908: "DDD",
+			FunctionalGroupSyntaxErrorCodeAK909: "EEE",
+		}
+		arrayValidAK9 := []string{"AK9", "A", "1", "2", "3", "AAA", "BBB", "CCC", "DDD", "EEE"}
+		suite.Equal(arrayValidAK9, validAK9.StringArray())
+	})
+
+	suite.T().Run("string array only required fields", func(t *testing.T) {
+		validOptionalAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "A",
+			NumberOfTransactionSetsIncluded: 1,
+			NumberOfReceivedTransactionSets: 2,
+			NumberOfAcceptedTransactionSets: 3,
+		}
+		arrayValidOptionalAK9 := []string{"AK9", "A", "1", "2", "3", "", "", "", "", ""}
+		suite.Equal(arrayValidOptionalAK9, validOptionalAK9.StringArray())
+	})
+}
+
+func (suite *SegmentSuite) TestParseAK9() {
+	suite.T().Run("parse success all fields", func(t *testing.T) {
+		arrayValidAK9 := []string{"A", "1", "2", "3", "AAA", "BBB", "CCC", "DDD", "EEE"}
+		expectedAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:      "A",
+			NumberOfTransactionSetsIncluded:     1,
+			NumberOfReceivedTransactionSets:     2,
+			NumberOfAcceptedTransactionSets:     3,
+			FunctionalGroupSyntaxErrorCodeAK905: "AAA",
+			FunctionalGroupSyntaxErrorCodeAK906: "BBB",
+			FunctionalGroupSyntaxErrorCodeAK907: "CCC",
+			FunctionalGroupSyntaxErrorCodeAK908: "DDD",
+			FunctionalGroupSyntaxErrorCodeAK909: "EEE",
+		}
+
+		var validAK9 AK9
+		err := validAK9.Parse(arrayValidAK9)
+		if suite.NoError(err) {
+			suite.Equal(expectedAK9, validAK9)
+		}
+	})
+
+	suite.T().Run("parse success only required fields", func(t *testing.T) {
+		arrayValidOptionalAK9 := []string{"A", "1", "2", "3", "", "", "", "", ""}
+		expectedOptionalAK9 := AK9{
+			FunctionalGroupAcknowledgeCode:  "A",
+			NumberOfTransactionSetsIncluded: 1,
+			NumberOfReceivedTransactionSets: 2,
+			NumberOfAcceptedTransactionSets: 3,
+		}
+
+		var validOptionalAK9 AK9
+		err := validOptionalAK9.Parse(arrayValidOptionalAK9)
+		if suite.NoError(err) {
+			suite.Equal(expectedOptionalAK9, validOptionalAK9)
+		}
+	})
+
+	suite.T().Run("wrong number of elements", func(t *testing.T) {
+		badArrayAK9 := []string{"A", "abc"}
+		var badAK9 AK9
+		err := badAK9.Parse(badArrayAK9)
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "Wrong number of elements")
+		}
+	})
+}


### PR DESCRIPTION
## Description
This PR creates the AK9 EDI segment with validations and tests.
I plagiarized a lot of this code from #6084 (thanks Jacquie!)

## Reviewer Notes

I couldn't find the potential values for the optional fields in this segment, AK905, AK906, AK907, AK908, or AK909,
They are supposed to be defined in Data Element 716, but that is missing from the data element dictionary section of the [997 spec](https://drive.google.com/file/d/13cbg99nrrQP1PwkFYvBTlJjqD_b5ieGB/view?usp=sharing).
I think this is fine, but if we ever find these definitions, we might be able to have tighter validations for these fields.

## Setup
Nothing in the app uses this segment yet, so we can only run its tests for now:
```sh
make server_test
```

Please also double check the fields and validations against [this spreadsheet](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0)


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6914) for this change
* [Spreadsheet of mapped values](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0) explains more about the approach used.
* [997 specification](https://drive.google.com/file/d/13cbg99nrrQP1PwkFYvBTlJjqD_b5ieGB/view?usp=sharing)
