### PR TITLE
[MB-6663] Update BX04 to use payment request number

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -137,7 +137,7 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		TransactionSetPurposeCode:    "00",
 		TransactionMethodTypeCode:    "J",
 		ShipmentMethodOfPayment:      "PP",
-		ShipmentIdentificationNumber: *moveTaskOrder.ReferenceID,
+		ShipmentIdentificationNumber: paymentRequest.PaymentRequestNumber,
 		StandardCarrierAlphaCode:     "TRUS",
 		ShipmentQualifier:            "4",
 	}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -295,7 +295,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.Equal("00", bx.TransactionSetPurposeCode)
 		suite.Equal("J", bx.TransactionMethodTypeCode)
 		suite.Equal("PP", bx.ShipmentMethodOfPayment)
-		suite.Equal(*paymentRequest.MoveTaskOrder.ReferenceID, bx.ShipmentIdentificationNumber)
+		suite.Equal(paymentRequest.PaymentRequestNumber, bx.ShipmentIdentificationNumber)
 		suite.Equal("TRUS", bx.StandardCarrierAlphaCode)
 		suite.Equal("4", bx.ShipmentQualifier)
 	})


### PR DESCRIPTION
## Description

I changed field BX04 (ShipmentIdentificationNumber) to save the payment request number instead of the MTO reference id.

## Setup
### Generate an EDI and check field 4 on the BX segment
```sh
make bin/generate-payment-request-edi
make db_dev_e2e_populate
make server_run

# in another terminal
make office_client_run
```

Create `payload.json`
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

Create a payment request:
```sh
prime-api-client --insecure create-payment-request --filename payload.json | jq '.id,.paymentRequestNumber'
```

Approve the payment request in the TIO interface http://officelocal:3000 (the Move Code is RDY4PY)

Use the payment request number to generate an EDI:
```sh
bin/generate-payment-request-edi --payment-request-number [payment request number] | grep BX
```
Check the BX segment to make sure the payment request number is in there.
For example, if your payment request number was `5555-5555-5` then the BX line should look like this:
```
BX*00*J*PP*5555-5555-5*TRUS**4
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6663) for this change
