### PR TITLE
MB-7007 Update configuration of auto-approve plugin

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   approve:
     name: auto-approve dependabot PRs
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     steps:
       - name: approve

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -54,6 +54,6 @@ jobs:
     steps:
       - name: approve
         uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

Starting Mar 1 a change to github actions started causing inconsistent
failures in the auto-approve job. This commit applies a fix mentioned in
the github issue on the auto-approve repo.

See https://github.com/hmarr/auto-approve-action/issues/183

Thanks to a tip from @chrisgilmerproj 
https://github.com/transcom/mymove/pull/6098#issuecomment-797102346

## Reviewer Notes

Not sure there is anything we can do beyond see if the job builds and actions still trigger.

## Setup

None

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7007) for this change
* [this comment on a dependabot pr](https://github.com/transcom/mymove/pull/6098#issuecomment-797102346)
* [this github issue on auto-approve](https://github.com/hmarr/auto-approve-action/issues/183) explains more about the approach used.