### PR TITLE
[MB-7068] fix typo in AK3 test

### DIFF
--- a/pkg/edi/segment/ak3_test.go
+++ b/pkg/edi/segment/ak3_test.go
@@ -78,7 +78,7 @@ func (suite *SegmentSuite) TestStringArrayAK3() {
 	})
 }
 
-func (suite *SegmentSuite) TestParseAK5() {
+func (suite *SegmentSuite) TestParseAK3() {
 	suite.T().Run("parse success all fields", func(t *testing.T) {
 		arrayValidAK3 := []string{"ID", "12345", "CODE", "ERR"}
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the AK3 segment test that was causing server test failure in AK5

## Setup

server test should all pass

```sh
make server_test
```
