### PR TITLE
MB-7097 Admin API: Add optimistic locking to Webhook Subscriptions

### DIFF
--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_parameters.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_parameters.go
@@ -34,6 +34,12 @@ type UpdateWebhookSubscriptionParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Optimistic locking is implemented via the `If-Match` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a `412 Precondition Failed` error.
+
+	  Required: true
+	  In: header
+	*/
+	IfMatch string
 	/*Webhook subscription information
 	  Required: true
 	  In: body
@@ -54,6 +60,10 @@ func (o *UpdateWebhookSubscriptionParams) BindRequest(r *http.Request, route *mi
 	var res []error
 
 	o.HTTPRequest = r
+
+	if err := o.bindIfMatch(r.Header[http.CanonicalHeaderKey("If-Match")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -85,6 +95,27 @@ func (o *UpdateWebhookSubscriptionParams) BindRequest(r *http.Request, route *mi
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindIfMatch binds and validates parameter IfMatch from header.
+func (o *UpdateWebhookSubscriptionParams) bindIfMatch(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	if !hasKey {
+		return errors.Required("If-Match", "header", rawData)
+	}
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: true
+
+	if err := validate.RequiredString("If-Match", "header", raw); err != nil {
+		return err
+	}
+
+	o.IfMatch = raw
+
 	return nil
 }
 

--- a/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_responses.go
+++ b/pkg/gen/adminapi/adminoperations/webhook_subscriptions/update_webhook_subscription_responses.go
@@ -153,6 +153,30 @@ func (o *UpdateWebhookSubscriptionNotFound) WriteResponse(rw http.ResponseWriter
 	rw.WriteHeader(404)
 }
 
+// UpdateWebhookSubscriptionPreconditionFailedCode is the HTTP code returned for type UpdateWebhookSubscriptionPreconditionFailed
+const UpdateWebhookSubscriptionPreconditionFailedCode int = 412
+
+/*UpdateWebhookSubscriptionPreconditionFailed Precondition failed
+
+swagger:response updateWebhookSubscriptionPreconditionFailed
+*/
+type UpdateWebhookSubscriptionPreconditionFailed struct {
+}
+
+// NewUpdateWebhookSubscriptionPreconditionFailed creates UpdateWebhookSubscriptionPreconditionFailed with default headers values
+func NewUpdateWebhookSubscriptionPreconditionFailed() *UpdateWebhookSubscriptionPreconditionFailed {
+
+	return &UpdateWebhookSubscriptionPreconditionFailed{}
+}
+
+// WriteResponse to the client
+func (o *UpdateWebhookSubscriptionPreconditionFailed) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(412)
+}
+
 // UpdateWebhookSubscriptionUnprocessableEntityCode is the HTTP code returned for type UpdateWebhookSubscriptionUnprocessableEntity
 const UpdateWebhookSubscriptionUnprocessableEntityCode int = 422
 

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1384,6 +1384,13 @@ func init() {
             "schema": {
               "$ref": "#/definitions/WebhookSubscription"
             }
+          },
+          {
+            "type": "string",
+            "description": "Optimistic locking is implemented via the ` + "`" + `If-Match` + "`" + ` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a ` + "`" + `412 Precondition Failed` + "`" + ` error.\n",
+            "name": "If-Match",
+            "in": "header",
+            "required": true
           }
         ],
         "responses": {
@@ -3996,6 +4003,13 @@ func init() {
             "schema": {
               "$ref": "#/definitions/WebhookSubscription"
             }
+          },
+          {
+            "type": "string",
+            "description": "Optimistic locking is implemented via the ` + "`" + `If-Match` + "`" + ` header. If the ETag header does not match the value of the resource on the server, the server rejects the change with a ` + "`" + `412 Precondition Failed` + "`" + ` error.\n",
+            "name": "If-Match",
+            "in": "header",
+            "required": true
           }
         ],
         "responses": {

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -2571,6 +2571,10 @@ func init() {
           "type": "string",
           "format": "date-time"
         },
+        "eTag": {
+          "type": "string",
+          "readOnly": true
+        },
         "eventKey": {
           "description": "A string used to represent which events this subscriber expects to be notified about. Corresponds to the possible event_key values in webhook_notifications.",
           "type": "string",
@@ -5182,6 +5186,10 @@ func init() {
         "createdAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "eTag": {
+          "type": "string",
+          "readOnly": true
         },
         "eventKey": {
           "description": "A string used to represent which events this subscriber expects to be notified about. Corresponds to the possible event_key values in webhook_notifications.",

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1412,6 +1412,9 @@ func init() {
           "404": {
             "description": "subscription not found"
           },
+          "412": {
+            "description": "Precondition failed"
+          },
           "422": {
             "description": "Validation error",
             "schema": {
@@ -4030,6 +4033,9 @@ func init() {
           },
           "404": {
             "description": "subscription not found"
+          },
+          "412": {
+            "description": "Precondition failed"
           },
           "422": {
             "description": "Validation error",

--- a/pkg/gen/adminmessages/webhook_subscription.go
+++ b/pkg/gen/adminmessages/webhook_subscription.go
@@ -24,6 +24,10 @@ type WebhookSubscription struct {
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
+	// e tag
+	// Read Only: true
+	ETag string `json:"eTag,omitempty"`
+
 	// A string used to represent which events this subscriber expects to be notified about. Corresponds to the possible event_key values in webhook_notifications.
 	EventKey *string `json:"eventKey,omitempty"`
 

--- a/pkg/handlers/adminapi/payloads/model_to_payload.go
+++ b/pkg/handlers/adminapi/payloads/model_to_payload.go
@@ -1,0 +1,24 @@
+package payloads
+
+import (
+	"github.com/transcom/mymove/pkg/gen/adminmessages"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// WebhookSubscriptionPayload converts a webhook subscription payload to a model
+func WebhookSubscriptionPayload(sub models.WebhookSubscription) *adminmessages.WebhookSubscription {
+	severity := int64(sub.Severity)
+	status := adminmessages.WebhookSubscriptionStatus(sub.Status)
+
+	return &adminmessages.WebhookSubscription{
+		ID:           *handlers.FmtUUID(sub.ID),
+		SubscriberID: handlers.FmtUUID(sub.SubscriberID),
+		CallbackURL:  &sub.CallbackURL,
+		Severity:     &severity,
+		EventKey:     &sub.EventKey,
+		Status:       &status,
+		CreatedAt:    *handlers.FmtDateTime(sub.CreatedAt),
+		UpdatedAt:    *handlers.FmtDateTime(sub.UpdatedAt),
+	}
+}

--- a/pkg/handlers/adminapi/payloads/model_to_payload.go
+++ b/pkg/handlers/adminapi/payloads/model_to_payload.go
@@ -1,6 +1,9 @@
 package payloads
 
 import (
+	"github.com/go-openapi/strfmt"
+
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
@@ -18,7 +21,8 @@ func WebhookSubscriptionPayload(sub models.WebhookSubscription) *adminmessages.W
 		Severity:     &severity,
 		EventKey:     &sub.EventKey,
 		Status:       &status,
-		CreatedAt:    *handlers.FmtDateTime(sub.CreatedAt),
-		UpdatedAt:    *handlers.FmtDateTime(sub.UpdatedAt),
+		CreatedAt:    strfmt.DateTime(sub.CreatedAt),
+		UpdatedAt:    strfmt.DateTime(sub.UpdatedAt),
+		ETag:         etag.GenerateEtag(sub.UpdatedAt),
 	}
 }

--- a/pkg/handlers/adminapi/payloads/model_to_payload.go
+++ b/pkg/handlers/adminapi/payloads/model_to_payload.go
@@ -9,7 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// WebhookSubscriptionPayload converts a webhook subscription payload to a model
+// WebhookSubscriptionPayload converts a webhook subscription model to a payload
 func WebhookSubscriptionPayload(sub models.WebhookSubscription) *adminmessages.WebhookSubscription {
 	severity := int64(sub.Severity)
 	status := adminmessages.WebhookSubscriptionStatus(sub.Status)

--- a/pkg/handlers/adminapi/payloads/payload_to_model.go
+++ b/pkg/handlers/adminapi/payloads/payload_to_model.go
@@ -56,3 +56,16 @@ func WebhookSubscriptionModel(sub *adminmessages.WebhookSubscription) *models.We
 
 	return model
 }
+
+// WebhookSubscriptionModelFromCreate converts a payload for creating a webhook subscription to a model
+func WebhookSubscriptionModelFromCreate(sub *adminmessages.CreateWebhookSubscription) *models.WebhookSubscription {
+	model := &models.WebhookSubscription{
+		EventKey:     *sub.EventKey,
+		CallbackURL:  *sub.CallbackURL,
+		SubscriberID: uuid.FromStringOrNil(sub.SubscriberID.String()),
+	}
+	if sub.Status != nil {
+		model.Status = models.WebhookSubscriptionStatus(*sub.Status)
+	}
+	return model
+}

--- a/pkg/handlers/adminapi/payloads/payload_to_model.go
+++ b/pkg/handlers/adminapi/payloads/payload_to_model.go
@@ -30,7 +30,6 @@ func UserModel(user *adminmessages.UserUpdatePayload, id uuid.UUID) (*models.Use
 
 // WebhookSubscriptionModel converts a webhook subscription payload to a model
 func WebhookSubscriptionModel(sub *adminmessages.WebhookSubscription) *models.WebhookSubscription {
-
 	model := &models.WebhookSubscription{
 		ID: uuid.FromStringOrNil(sub.ID.String()),
 	}

--- a/pkg/handlers/adminapi/payloads/payload_to_model.go
+++ b/pkg/handlers/adminapi/payloads/payload_to_model.go
@@ -60,6 +60,8 @@ func WebhookSubscriptionModel(sub *adminmessages.WebhookSubscription) *models.We
 // WebhookSubscriptionModelFromCreate converts a payload for creating a webhook subscription to a model
 func WebhookSubscriptionModelFromCreate(sub *adminmessages.CreateWebhookSubscription) *models.WebhookSubscription {
 	model := &models.WebhookSubscription{
+		// EventKey and CallbackURL are required fields in the YAML, so we don't have to worry about the potential
+		// nil dereference errors here:
 		EventKey:     *sub.EventKey,
 		CallbackURL:  *sub.CallbackURL,
 		SubscriberID: uuid.FromStringOrNil(sub.SubscriberID.String()),

--- a/pkg/handlers/adminapi/webhook_subscriptions.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions.go
@@ -16,23 +16,6 @@ import (
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
-// payloadForWebhookSubscriptionModel converts from model to payload
-func payloadForWebhookSubscriptionModel(subscription models.WebhookSubscription) *adminmessages.WebhookSubscription {
-	severity := int64(subscription.Severity)
-
-	status := adminmessages.WebhookSubscriptionStatus(subscription.Status)
-	return &adminmessages.WebhookSubscription{
-		ID:           *handlers.FmtUUID(subscription.ID),
-		SubscriberID: handlers.FmtUUID(subscription.SubscriberID),
-		CallbackURL:  &subscription.CallbackURL,
-		Severity:     &severity,
-		EventKey:     &subscription.EventKey,
-		Status:       &status,
-		CreatedAt:    *handlers.FmtDateTime(subscription.CreatedAt),
-		UpdatedAt:    *handlers.FmtDateTime(subscription.UpdatedAt),
-	}
-}
-
 // payloadToWebhookSubscriptionModel converts from payload params to model
 func payloadToWebhookSubscriptionModel(params webhooksubscriptionop.CreateWebhookSubscriptionParams) models.WebhookSubscription {
 	subscription := params.WebhookSubscription
@@ -82,7 +65,7 @@ func (h IndexWebhookSubscriptionsHandler) Handle(params webhooksubscriptionop.In
 	payload := make(adminmessages.WebhookSubscriptions, queriedWebhookSubscriptionsCount)
 
 	for i, s := range webhookSubscriptions {
-		payload[i] = payloadForWebhookSubscriptionModel(s)
+		payload[i] = payloads.WebhookSubscriptionPayload(s)
 	}
 
 	return webhooksubscriptionop.NewIndexWebhookSubscriptionsOK().WithContentRange(fmt.Sprintf("webhookSubscriptions %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedWebhookSubscriptionsCount, totalWebhookSubscriptionsCount)).WithPayload(payload)
@@ -107,7 +90,7 @@ func (h GetWebhookSubscriptionHandler) Handle(params webhooksubscriptionop.GetWe
 		return handlers.ResponseForError(logger, err)
 	}
 
-	payload := payloadForWebhookSubscriptionModel(webhookSubscription)
+	payload := payloads.WebhookSubscriptionPayload(webhookSubscription)
 	return webhooksubscriptionop.NewGetWebhookSubscriptionOK().WithPayload(payload)
 }
 
@@ -149,7 +132,7 @@ func (h CreateWebhookSubscriptionHandler) Handle(params webhooksubscriptionop.Cr
 		}
 	}
 
-	returnPayload := payloadForWebhookSubscriptionModel(*createdWebhookSubscription)
+	returnPayload := payloads.WebhookSubscriptionPayload(*createdWebhookSubscription)
 	return webhooksubscriptionop.NewCreateWebhookSubscriptionCreated().WithPayload(returnPayload)
 }
 
@@ -191,6 +174,6 @@ func (h UpdateWebhookSubscriptionHandler) Handle(params webhooksubscriptionop.Up
 	}
 
 	// Convert model back to a payload and return to caller
-	payload = payloadForWebhookSubscriptionModel(*updatedWebhookSubscription)
+	payload = payloads.WebhookSubscriptionPayload(*updatedWebhookSubscription)
 	return webhooksubscriptionop.NewUpdateWebhookSubscriptionOK().WithPayload(payload)
 }

--- a/pkg/handlers/adminapi/webhook_subscriptions.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions.go
@@ -16,21 +16,6 @@ import (
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
-// payloadToWebhookSubscriptionModel converts from payload params to model
-func payloadToWebhookSubscriptionModel(params webhooksubscriptionop.CreateWebhookSubscriptionParams) models.WebhookSubscription {
-	subscription := params.WebhookSubscription
-
-	model := models.WebhookSubscription{
-		EventKey:     *subscription.EventKey,
-		CallbackURL:  *subscription.CallbackURL,
-		SubscriberID: uuid.FromStringOrNil(subscription.SubscriberID.String()),
-	}
-	if subscription.Status != nil {
-		model.Status = models.WebhookSubscriptionStatus(*subscription.Status)
-	}
-	return model
-}
-
 // IndexWebhookSubscriptionsHandler returns a list of webhook subscriptions via GET /webhook_subscriptions
 type IndexWebhookSubscriptionsHandler struct {
 	handlers.HandlerContext
@@ -104,12 +89,12 @@ type CreateWebhookSubscriptionHandler struct {
 // Handle creates an admin user
 func (h CreateWebhookSubscriptionHandler) Handle(params webhooksubscriptionop.CreateWebhookSubscriptionParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
-	subscription := payloadToWebhookSubscriptionModel(params)
+	subscription := payloads.WebhookSubscriptionModelFromCreate(params.WebhookSubscription)
 	subscriberIDFilter := []services.QueryFilter{
 		h.NewQueryFilter("id", "=", subscription.SubscriberID),
 	}
 
-	createdWebhookSubscription, verrs, err := h.WebhookSubscriptionCreator.CreateWebhookSubscription(&subscription, subscriberIDFilter)
+	createdWebhookSubscription, verrs, err := h.WebhookSubscriptionCreator.CreateWebhookSubscription(subscription, subscriberIDFilter)
 
 	if verrs != nil {
 		logger.Error("Error saving webhook subscription", zap.Error(verrs))

--- a/pkg/handlers/adminapi/webhook_subscriptions.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions.go
@@ -146,7 +146,7 @@ func (h UpdateWebhookSubscriptionHandler) Handle(params webhooksubscriptionop.Up
 	webhookSubscription := payloads.WebhookSubscriptionModel(payload)
 
 	// Note we are not checking etag as adminapi does not seem to use this
-	updatedWebhookSubscription, err := h.WebhookSubscriptionUpdater.UpdateWebhookSubscription(webhookSubscription, payload.Severity)
+	updatedWebhookSubscription, err := h.WebhookSubscriptionUpdater.UpdateWebhookSubscription(webhookSubscription, payload.Severity, &params.IfMatch)
 
 	// Return error response if not successful
 	if err != nil {

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/transcom/mymove/pkg/etag"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
@@ -232,6 +234,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 				EventKey:     swag.String("WebhookSubscription.Update"),
 				SubscriberID: &subscriberID,
 			},
+			IfMatch: etag.GenerateEtag(webhookSubscription.UpdatedAt),
 		}
 
 		queryBuilder := query.NewQueryBuilder(suite.DB())
@@ -268,6 +271,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 				CallbackURL: swag.String("somethingelse.com"),
 				EventKey:    swag.String("WebhookSubscription.Delete"),
 			},
+			IfMatch: etag.GenerateEtag(webhookSubscription2.UpdatedAt),
 		}
 
 		queryBuilder := query.NewQueryBuilder(suite.DB())
@@ -311,6 +315,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 				EventKey:     swag.String("WebhookSubscription.Update"),
 				SubscriberID: &subscriberID,
 			},
+			IfMatch: etag.GenerateEtag(webhookSubscription.UpdatedAt),
 		}
 
 		queryBuilder := query.NewQueryBuilder(suite.DB())

--- a/pkg/services/mocks/WebhookSubscriptionUpdater.go
+++ b/pkg/services/mocks/WebhookSubscriptionUpdater.go
@@ -12,13 +12,13 @@ type WebhookSubscriptionUpdater struct {
 	mock.Mock
 }
 
-// UpdateWebhookSubscription provides a mock function with given fields: webhooksubscription, severity
-func (_m *WebhookSubscriptionUpdater) UpdateWebhookSubscription(webhooksubscription *models.WebhookSubscription, severity *int64) (*models.WebhookSubscription, error) {
-	ret := _m.Called(webhooksubscription, severity)
+// UpdateWebhookSubscription provides a mock function with given fields: webhooksubscription, severity, eTag
+func (_m *WebhookSubscriptionUpdater) UpdateWebhookSubscription(webhooksubscription *models.WebhookSubscription, severity *int64, eTag *string) (*models.WebhookSubscription, error) {
+	ret := _m.Called(webhooksubscription, severity, eTag)
 
 	var r0 *models.WebhookSubscription
-	if rf, ok := ret.Get(0).(func(*models.WebhookSubscription, *int64) *models.WebhookSubscription); ok {
-		r0 = rf(webhooksubscription, severity)
+	if rf, ok := ret.Get(0).(func(*models.WebhookSubscription, *int64, *string) *models.WebhookSubscription); ok {
+		r0 = rf(webhooksubscription, severity, eTag)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.WebhookSubscription)
@@ -26,8 +26,8 @@ func (_m *WebhookSubscriptionUpdater) UpdateWebhookSubscription(webhooksubscript
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.WebhookSubscription, *int64) error); ok {
-		r1 = rf(webhooksubscription, severity)
+	if rf, ok := ret.Get(1).(func(*models.WebhookSubscription, *int64, *string) error); ok {
+		r1 = rf(webhooksubscription, severity, eTag)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/webhook_subscription.go
+++ b/pkg/services/webhook_subscription.go
@@ -21,5 +21,5 @@ type WebhookSubscriptionCreator interface {
 //WebhookSubscriptionUpdater is the service object interface for UpdateWebhookSubscription
 //go:generate mockery -name WebhookSubscriptionUpdater
 type WebhookSubscriptionUpdater interface {
-	UpdateWebhookSubscription(webhooksubscription *models.WebhookSubscription, severity *int64) (*models.WebhookSubscription, error)
+	UpdateWebhookSubscription(webhooksubscription *models.WebhookSubscription, severity *int64, eTag *string) (*models.WebhookSubscription, error)
 }

--- a/pkg/services/webhook_subscription/webhook_subscription_updater.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_updater.go
@@ -16,7 +16,7 @@ type webhookSubscriptionUpdater struct {
 // It uses the id in the passed in model to find the subscription.
 // For the severity field, it uses severity from the parameter not the model. If nil, severity will not be updated.
 // For all other fields, it uses the values found in the model.
-func (o *webhookSubscriptionUpdater) UpdateWebhookSubscription(requestedUpdate *models.WebhookSubscription, severity *int64) (*models.WebhookSubscription, error) {
+func (o *webhookSubscriptionUpdater) UpdateWebhookSubscription(requestedUpdate *models.WebhookSubscription, severity *int64, eTag *string) (*models.WebhookSubscription, error) {
 	webhookSubscriptionID := uuid.FromStringOrNil(requestedUpdate.ID.String())
 	queryFilters := []services.QueryFilter{query.NewQueryFilter("id", "=", webhookSubscriptionID)}
 
@@ -48,7 +48,7 @@ func (o *webhookSubscriptionUpdater) UpdateWebhookSubscription(requestedUpdate *
 		foundSub.CallbackURL = requestedUpdate.CallbackURL
 	}
 
-	verrs, err := o.builder.UpdateOne(&foundSub, nil)
+	verrs, err := o.builder.UpdateOne(&foundSub, eTag)
 
 	if verrs != nil && verrs.HasAny() {
 		return nil, services.NewInvalidInputError(webhookSubscriptionID, err, verrs, "")

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -34,14 +34,14 @@ import customRoutes from './CustomRoutes';
 import NotificationList from './Notifications/NotificationList';
 
 const httpClient = (url, options = {}) => {
+  if (!options.headers) {
+    options.headers = new Headers({ Accept: 'application/json' });
+  }
   const token = Cookies.get('masked_gorilla_csrf');
   if (!token) {
     console.warn('Unable to retrieve CSRF Token from cookie');
   }
-
-  if (!options.headers) {
-    options.headers = new Headers({ Accept: 'application/json', 'X-CSRF-TOKEN': token });
-  }
+  options.headers.set('X-CSRF-TOKEN', token);
   // send cookies in the request
   options.credentials = 'same-origin';
   return fetchUtils.fetchJson(url, options);

--- a/src/scenes/SystemAdmin/shared/rest_provider.js
+++ b/src/scenes/SystemAdmin/shared/rest_provider.js
@@ -2,16 +2,16 @@ import { stringify } from 'query-string';
 import { diff } from 'deep-object-diff';
 import { snakeCase } from 'lodash';
 import {
-  fetchUtils,
-  GET_LIST,
-  GET_ONE,
-  GET_MANY,
-  GET_MANY_REFERENCE,
   CREATE,
-  UPDATE,
-  UPDATE_MANY,
   DELETE,
   DELETE_MANY,
+  fetchUtils,
+  GET_LIST,
+  GET_MANY,
+  GET_MANY_REFERENCE,
+  GET_ONE,
+  UPDATE,
+  UPDATE_MANY,
 } from 'react-admin';
 
 /**
@@ -37,6 +37,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
   const convertDataRequestToHTTP = (type, resource, params) => {
     let url = '';
     const options = {};
+    options.headers = new Headers({ Accept: 'application/json' }); // required
     switch (type) {
       case GET_LIST: {
         const { page, perPage } = params.pagination;
@@ -93,6 +94,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
       case UPDATE:
         url = `${apiUrl}/${resource}/${params.id}`;
         options.method = 'PATCH';
+        options.headers.set('If-Match', params.data?.eTag); // for optimistic locking / concurrency control
         const paramsDiff = diff(params.previousData, params.data);
         if (paramsDiff.roles) {
           paramsDiff.roles = params.data.roles;

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -1835,6 +1835,13 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/WebhookSubscription'
+        - in: header
+          name: If-Match
+          type: string
+          required: true
+          description: >
+            Optimistic locking is implemented via the `If-Match` header. If the ETag header does not match
+            the value of the resource on the server, the server rejects the change with a `412 Precondition Failed` error.
       responses:
         200:
           description: Successfully updated webhook subscription

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -1855,6 +1855,8 @@ paths:
           description: Not authorized to update this webhook subscription
         404:
           description: subscription not found
+        412:
+          description: Precondition failed
         422:
           description: Validation error
           schema:

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -912,6 +912,9 @@ definitions:
       updatedAt:
         type: string
         format: date-time
+      eTag:
+        type: string
+        readOnly: true
   WebhookSubscriptions:
     type: array
     items:

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -873,22 +873,6 @@ definitions:
         type: string
         title: Last Name
         x-nullable: true
-  WebhookSubscriptionStatus:
-    type: string
-    title: Webhook subscription status
-    x-nullable: true
-    enum:
-      - ACTIVE
-      - FAILING
-      - DISABLED
-    x-display-value:
-      ACTIVE: Active
-      FAILING: Failing
-      DISABLED: Disabled
-  WebhookSubscriptions:
-    type: array
-    items:
-      $ref: '#/definitions/WebhookSubscription'
   WebhookSubscription:
     type: object
     description: >-
@@ -928,6 +912,22 @@ definitions:
       updatedAt:
         type: string
         format: date-time
+  WebhookSubscriptions:
+    type: array
+    items:
+      $ref: '#/definitions/WebhookSubscription'
+  WebhookSubscriptionStatus:
+    type: string
+    title: Webhook subscription status
+    x-nullable: true
+    enum:
+      - ACTIVE
+      - FAILING
+      - DISABLED
+    x-display-value:
+      ACTIVE: Active
+      FAILING: Failing
+      DISABLED: Disabled
   CreateWebhookSubscription:
     type: object
     properties:


### PR DESCRIPTION
## Description

This PR updates the `getWebhookSubscription` and `updateWebhookSubscription` Admin API endpoints to handle optimistic locking/concurrency control. This involved:

* returning an `eTag` value in the response for `getWebhookSubscription`
* adding a required `If-Match` header to the request for `updateWebhookSubscription`
* modifying the payload/model conversion functions to account for the `eTag` value
* passing the eTag into the `UpdateWebhookSubscription` service object
* modifying the `dataProvider` for the Admin UI to set an `If-Match` header for UPDATE requests
* updating tests

## Setup

We don't have an "Update Webhook Subscription" page in the Admin UI just yet, so this can only be manually tested through Postman. Please follow these instructions to set up your testing environment: https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman

Once you're all set up, follow these steps:

* Run your server and client with `make server_run` and `make admin_client_run`.
* Navigate to http://adminlocal:3000/system/webhook_subscriptions
* Pick a webhook subscription from the list. If there are none, create one using the "+ Create" button in the top right of the screen. 
   * The "Subscriber Id" needs to be `5db13bb4-6d29-4bdb-bc81-262f4513ecf6` (our fake Prime ID). The other fields can be whatever you fancy.
* Grab the ID for this webhook subscription and go to Postman. 
* Hit the `getWebhookSubscription` endpoint with your ID. Grab the `eTag` value from the output.
* Go to the `updateWebhookSubscription` endpoint. 
   * Put the ID in the url and the `eTag` in the "If-Match" header. You'll also need the "X-CSRF-Token" here (refer to https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman for more info).
   * Send a request body like:
```json
{
  "callbackUrl": "new.url.here"
}
```
* Verify that you got a 200 response code and that you see a new `eTag` in the response body.
* Send it again, with all the same info! This time you should see a 412 response code indicating that the `eTag` value was stale.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7097) for this change.
