### PR TITLE
[MB-6422] Rank and Duty station should read from the Orders table on the Review page

### DIFF
--- a/src/components/Customer/Review/Summary/index.jsx
+++ b/src/components/Customer/Review/Summary/index.jsx
@@ -213,14 +213,14 @@ export class Summary extends Component {
           <ProfileTable
             affiliation={serviceMember.affiliation}
             city={serviceMember.residential_address.city}
-            currentDutyStationName={serviceMember.current_station.name}
+            currentDutyStationName={currentOrders.origin_duty_station.name}
             edipi={serviceMember.edipi}
             email={serviceMember.personal_email}
             firstName={serviceMember.first_name}
             onEditClick={this.handleEditClick}
             lastName={serviceMember.last_name}
             postalCode={serviceMember.residential_address.postal_code}
-            rank={serviceMember.rank}
+            rank={currentOrders.grade}
             state={serviceMember.residential_address.state}
             streetAddress1={serviceMember.residential_address.street_address_1}
             streetAddress2={serviceMember.residential_address.street_address_2}

--- a/src/components/Customer/Review/Summary/index.test.jsx
+++ b/src/components/Customer/Review/Summary/index.test.jsx
@@ -31,6 +31,12 @@ const defaultProps = {
     has_dependents: false,
     issue_date: '2020-08-11',
     moves: ['123'],
+    origin_duty_station: {
+      name: 'Test Duty Station',
+      address: {
+        postal_code: '123456',
+      },
+    },
     new_duty_station: {
       name: 'New Test Duty Station',
       address: {

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -137,9 +137,13 @@ class EditProfile extends Component {
   }
 
   render() {
-    const { schema, serviceMember, moveIsInDraft, schemaAffiliation, schemaRank } = this.props;
+    const { schema, serviceMember, moveIsInDraft, schemaAffiliation, schemaRank, currentOrders } = this.props;
     const { errorMessage } = this.state;
-
+    const initialValues = {
+      ...serviceMember,
+      rank: currentOrders ? currentOrders.grade : serviceMember.rank,
+      current_station: currentOrders ? currentOrders.origin_duty_station : serviceMember.current_station,
+    };
     return (
       <div className="usa-grid">
         {errorMessage && (
@@ -151,7 +155,7 @@ class EditProfile extends Component {
         )}
         <div className="usa-width-one-whole">
           <EditProfileForm
-            initialValues={serviceMember}
+            initialValues={initialValues}
             onSubmit={this.updateProfile}
             onCancel={this.returnToReview}
             schema={schema}
@@ -173,6 +177,7 @@ function mapStateToProps(state) {
     serviceMember,
     move: selectCurrentMove(state) || {},
     schema: get(state, 'swaggerInternal.spec.definitions.CreateServiceMemberPayload', {}),
+    currentOrders: selectCurrentOrders(state),
     // The move still counts as in draft if there are no orders.
     moveIsInDraft: selectMoveIsInDraft(state) || !selectCurrentOrders(state),
     isPpm: selectHasCurrentPPM(state),


### PR DESCRIPTION

## Description

On the review page, `Rank` and `Duty Station` should read from Orders instead of from Service Member

## Setup
`make server_run`
`make client_run`
1. Log into TOO user and go into a move
2. On an incognito tab, log into SM corresponding with move and go to `Review` page
3. On TOO app, Edit Order's Current Duty Station
4. On SM app, refresh. On the `Profile` table, Current duty station should be the new Current Duty Station
5. On TOO app, Edit Allowance's `Rank`
6. On SM app, refresh. On the `Profile` table, Rank should be the new Rank

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6422) for this change
