### PR TITLE
[MB-7065] DangerJS allow eslint-disable with rules

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -100,15 +100,15 @@ function doesLineHaveProhibitedOverride(disablingString) {
     .split(/[\s,]+/)
     .map((item) => item.trim());
   // disablingStringParts format: ['eslint-disable-next-line', 'no-jsx', 'no-default']
-  if (disablingStringParts[0] === 'eslint-disable') {
-    // fail because don't disable whole file please!
-    prohibitedOverrideMsg =
-      'Found `eslint-disable`. This disables the whole file, which is bad practice because it can allow security issues to slip in unnoticed. Please specify exact rules on a line by line basis, eg `eslint-disable-next-line no-underscore-dangle`.';
-  }
 
   if (disablingStringParts.length === 1) {
-    // fail because rule should be specified
-    prohibitedOverrideMsg = 'Must specify the rule you are disabling';
+    if (disablingStringParts[0] === 'eslint-disable') {
+      prohibitedOverrideMsg =
+        'Found `eslint-disable`. This disables the whole file, which is bad practice because it can allow security issues to slip in unnoticed. Please specify exact rules on a line by line basis, eg `eslint-disable-next-line no-underscore-dangle`.';
+    } else {
+      // fail because rule should be specified
+      prohibitedOverrideMsg = 'Must specify the rule you are disabling';
+    }
     return prohibitedOverrideMsg;
   }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -98,7 +98,8 @@ function doesLineHaveProhibitedOverride(disablingString) {
   const disablingStringParts = disablingString
     .trim()
     .split(/[\s,]+/)
-    .map((item) => item.trim());
+    .map((item) => item.trim())
+    .filter((str) => !str.includes('*/')); // edgecase where string has a dangling */ or */}
   // disablingStringParts format: ['eslint-disable-next-line', 'no-jsx', 'no-default']
 
   if (disablingStringParts.length === 1) {

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -102,13 +102,8 @@ function doesLineHaveProhibitedOverride(disablingString) {
   // disablingStringParts format: ['eslint-disable-next-line', 'no-jsx', 'no-default']
 
   if (disablingStringParts.length === 1) {
-    if (disablingStringParts[0] === 'eslint-disable') {
-      prohibitedOverrideMsg =
-        'Found `eslint-disable`. This disables the whole file, which is bad practice because it can allow security issues to slip in unnoticed. Please specify exact rules on a line by line basis, eg `eslint-disable-next-line no-underscore-dangle`.';
-    } else {
-      // fail because rule should be specified
-      prohibitedOverrideMsg = 'Must specify the rule you are disabling';
-    }
+    // fail because rule should be specified
+    prohibitedOverrideMsg = 'Must specify the rule you are disabling';
     return prohibitedOverrideMsg;
   }
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "build-storybook": "build-storybook",
     "happo": "happo",
     "happo-ci-github-actions": "happo-ci-github-actions",
-    "spellcheck": "mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions"
+    "spellcheck": "mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions",
+    "dangerjs:local": "yarn danger local --dangerfile dangerfile.ts"
   },
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
## Description

Don't raise a warning when using eslint-disable as long as it has rules attached

## Reviewer Notes
- My code change removes the check for `eslint-disable` because dangerjs was linting itself and breaking 'eslint-disable' was being used in a context that was not in a comment. Normal circumstances, it would be a syntax error but in this file we're using `eslint-disable` as a string.


## Setup
1. Change variable to have a dangling `_` (eg. serviceMember_)
2. Add a valid eslint-disable to a file (eg. /* eslint-disable no-underscore-dangle */
3. Commit change
4. Run `npm run dangerjs:local`
Expected result: You should not get an error

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7065) for this change
