### PR TITLE
MB-6675 Adjust header margins on Select Move Type Page

### DIFF
--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -174,7 +174,7 @@ export class SelectMoveType extends Component {
           canMoveNext={canMoveNext}
           error={errorMessage}
         >
-          <h6 data-testid="number-eyebrow" className="sm-heading">
+          <h6 data-testid="number-eyebrow" className="sm-heading margin-top-205 margin-bottom-0">
             Shipment {shipmentNumber}
           </h6>
           <h1 className={`${styles.selectTypeHeader} ${styles.header}`} data-testid="select-move-type-header">

--- a/src/pages/MyMove/SelectMoveType.jsx
+++ b/src/pages/MyMove/SelectMoveType.jsx
@@ -154,7 +154,7 @@ export class SelectMoveType extends Component {
     const footerText = (
       <div>
         {!hasShipment && (
-          <div data-testid="helper-footer" className={`${styles.footer} grid-col-12`}>
+          <div data-testid="helper-footer" className={`${styles.footer} grid-col-12 margin-top-0`}>
             It’s OK if you’re not sure about your choices. Your move counselor will go over all your options and can
             help make changes if necessary.
           </div>
@@ -186,7 +186,9 @@ export class SelectMoveType extends Component {
           <p>You can add more later</p>
           {isPpmSelectable ? ppmEnabledCard : ppmDisabledCard}
           {isHhgSelectable ? hhgEnabledCard : hhgDisabledCard}
-          <h3 data-testid="long-term-storage-heading">Long-term storage</h3>
+          <h3 className={styles.longTermStorageHeader} data-testid="long-term-storage-heading">
+            Long-term storage
+          </h3>
           {!isNtsSelectable && !isNtsrSelectable ? (
             <p className={styles.pSmall}>{noLongTermStorageCardsText}</p>
           ) : (

--- a/src/pages/MyMove/SelectMoveType.module.scss
+++ b/src/pages/MyMove/SelectMoveType.module.scss
@@ -14,7 +14,6 @@
 h1.selectTypeHeader.header {
   margin-top: 0;
   @include u-padding-top(1);
-  @include u-padding-bottom(4);
   & + * {
     margin-top: 0;
   }

--- a/src/pages/MyMove/SelectMoveType.module.scss
+++ b/src/pages/MyMove/SelectMoveType.module.scss
@@ -7,7 +7,7 @@
   font-size: 13px;
   color: $base;
   line-height: 16px;
-  @include u-padding-top(3);
+  @include u-padding-top(1);
   @include u-padding-bottom(3);
 }
 
@@ -17,6 +17,10 @@ h1.selectTypeHeader.header {
   & + * {
     margin-top: 0;
   }
+}
+
+h3.longTermStorageHeader {
+  @include u-margin-top(6);
 }
 
 .gridContainer {


### PR DESCRIPTION
## Description

This branch adjusts header margins on the Select Move Type Page. It's in progress- I still need to make sure the issues here, are not affecting other pages. From my initial look, it is not.

## Reviewer Notes
The ticket only called to adjust the h1, but I noticed a few more issues in the same file (with `.sm-heading`, the `h3`, and the footer text) that needed to be margins adjusted, and since it was all the same files, I felt it was in scope enough to include.

## Setup

```sh
make server_run
make client_run
```
Create New MilMove User
Upload Orders
This page is where you set your shipment type
http://milmovelocal:3000/moves/1d31a1b3-7828-4b4b-b7db-9350822834b2/shipment-type 

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6675?atlOrigin=eyJpIjoiODFhZmU2ZjYyMjhjNDFlZThiMWUxNTZkODgxNDJhMjciLCJwIjoiaiJ9) for this change
* [Zeplin comp](https://zpl.io/aXe0Ry8) for this page

## Screenshots

![milmovelocal_3000_moves_1d31a1b3-7828-4b4b-b7db-9350822834b2_shipment-type](https://user-images.githubusercontent.com/59394696/111522772-fac00400-8730-11eb-8238-bfaefaaed2a3.png)

