### PR TITLE
MB-7173 Update FlashMessage to only set heading attr if title is not empty

### DIFF
--- a/src/containers/FlashMessage/FlashMessage.jsx
+++ b/src/containers/FlashMessage/FlashMessage.jsx
@@ -14,7 +14,9 @@ export const FlashMessage = ({ flash, clearFlashMessage }) => {
   const { message, title, type, slim } = flash;
 
   return (
-    <Alert slim={slim} type={type} heading={title}>
+    // We use {title || undefined} here because an empty string as the title will render a blank header in Firefox,
+    // so we must pass in undefined if we want to see no header at all.
+    <Alert slim={slim} type={type} heading={title || undefined}>
       {message}
     </Alert>
   );


### PR DESCRIPTION
## Description

In Firefox, the FlashMessage Alert will render a blank header if the empty string is passed in. If we want to hide the space for the header, we need to pass `undefined` in instead. This PR fixes that logic in FlashMessage so renders in Firefox look as expected.

## Setup

Populate some fake data, and start your server and client:

```
make db_dev_e2e_populate server_run
make office_client_run
```

In Firefox, open the Office interface (http://officelocal:3000):

- Select "Local Sign In" and choose the TOO role.
- In the Move Queue page, select an approved move with at least 2 shipments, if possible.
- If there are any moves with multiple shipments that aren't yet approved, that's good too! Just approve the shipments as your first step.
- Once you're in the "Move Details" page, click on the "Move Task Order" tab.
- In this page, pick one of the shipments and select "Request Cancellation." You should see a success alert at the top of the page informing you that your request was submitted. **This alert should be slim, with no suspicious space.**

Now repeat the same process in Chrome. Verify that the UI looks the same.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7173) for this change.
