### PR TITLE
Kim mb 6839 redirect from profile wizards

### DIFF
--- a/src/constants/customerStates.js
+++ b/src/constants/customerStates.js
@@ -10,3 +10,14 @@ export const profileStates = {
   BACKUP_ADDRESS_COMPLETE: 'BACKUP_ADDRESS_COMPLETE',
   BACKUP_CONTACTS_COMPLETE: 'BACKUP_CONTACTS_COMPLETE',
 };
+
+export const orderedProfileStates = [
+  profileStates.EMPTY_PROFILE,
+  profileStates.DOD_INFO_COMPLETE,
+  profileStates.NAME_COMPLETE,
+  profileStates.CONTACT_INFO_COMPLETE,
+  profileStates.DUTY_STATION_COMPLETE,
+  profileStates.ADDRESS_COMPLETE,
+  profileStates.BACKUP_ADDRESS_COMPLETE,
+  profileStates.BACKUP_CONTACTS_COMPLETE,
+];

--- a/src/containers/requireCustomerState/requireCustomerState.jsx
+++ b/src/containers/requireCustomerState/requireCustomerState.jsx
@@ -4,6 +4,13 @@ import { push } from 'connected-react-router';
 
 import { selectServiceMemberProfileState } from 'store/entities/selectors';
 import { findNextServiceMemberStep } from 'utils/customer';
+import { orderedProfileStates } from 'constants/customerStates';
+
+const getIsAllowedProfileState = (requiredState, currentProfileState) => {
+  const requiredStatePosition = orderedProfileStates.indexOf(requiredState);
+  const currentStatePosition = orderedProfileStates.indexOf(currentProfileState);
+  return requiredStatePosition <= currentStatePosition;
+};
 
 const requireCustomerState = (Component, requiredState) => {
   const RequireCustomerState = (props) => {
@@ -12,7 +19,8 @@ const requireCustomerState = (Component, requiredState) => {
 
     useEffect(() => {
       // Only verify state on mount (once)
-      if (requiredState !== currentProfileState) {
+      const isAllowedState = getIsAllowedProfileState(requiredState, currentProfileState);
+      if (!isAllowedState) {
         const redirectTo = findNextServiceMemberStep(currentProfileState);
         dispatch(push(redirectTo));
       }

--- a/src/containers/requireCustomerState/requireCustomerState.jsx
+++ b/src/containers/requireCustomerState/requireCustomerState.jsx
@@ -9,6 +9,11 @@ import { orderedProfileStates } from 'constants/customerStates';
 const getIsAllowedProfileState = (requiredState, currentProfileState) => {
   const requiredStatePosition = orderedProfileStates.indexOf(requiredState);
   const currentStatePosition = orderedProfileStates.indexOf(currentProfileState);
+  const isProfileComplete = currentStatePosition === orderedProfileStates.length - 1;
+
+  if (isProfileComplete) {
+    return currentStatePosition === requiredStatePosition;
+  }
   return requiredStatePosition <= currentStatePosition;
 };
 
@@ -20,6 +25,7 @@ const requireCustomerState = (Component, requiredState) => {
     useEffect(() => {
       // Only verify state on mount (once)
       const isAllowedState = getIsAllowedProfileState(requiredState, currentProfileState);
+
       if (!isAllowedState) {
         const redirectTo = findNextServiceMemberStep(currentProfileState);
         dispatch(push(redirectTo));

--- a/src/containers/requireCustomerState/requireCustomerState.test.jsx
+++ b/src/containers/requireCustomerState/requireCustomerState.test.jsx
@@ -19,9 +19,9 @@ describe('requireCustomerState HOC', () => {
   });
 
   const TestComponent = () => <div>My test component</div>;
-  const TestComponentWithHOC = requireCustomerState(TestComponent, profileStates.BACKUP_CONTACTS_COMPLETE);
+  const TestComponentWithHOC = requireCustomerState(TestComponent, profileStates.ADDRESS_COMPLETE);
 
-  it('dispatches a redirect if the current state does not equal the required state', () => {
+  it('dispatches a redirect if the current state is earlier than the required state', () => {
     const mockState = {
       entities: {
         user: {
@@ -76,6 +76,92 @@ describe('requireCustomerState HOC', () => {
             residential_address: {
               street: '123 Main St',
             },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <TestComponentWithHOC />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the required state but profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <TestComponentWithHOC />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if profile is complete and required state is not the completed profile state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
             backup_mailing_address: {
               street: '456 Main St',
             },
@@ -92,6 +178,60 @@ describe('requireCustomerState HOC', () => {
     const wrapper = mount(
       <MockProviders initialState={mockState}>
         <TestComponentWithHOC />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+
+  it('does not redirect if profile is complete and required state is the completed profile state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const TestComponentCompletedProfileWithHOC = requireCustomerState(
+      TestComponent,
+      profileStates.BACKUP_CONTACTS_COMPLETE,
+    );
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <TestComponentCompletedProfileWithHOC />
       </MockProviders>,
     );
 

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -20,6 +20,9 @@ import { no_op } from 'shared/utils';
 import WizardPage from 'shared/WizardPage';
 import scrollToTop from 'shared/scrollToTop';
 import { selectServiceMemberFromLoggedInUser, selectBackupContacts } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 import SectionWrapper from 'components/Customer/SectionWrapper';
 
@@ -191,6 +194,8 @@ export class BackupContact extends Component {
 
 BackupContact.propTypes = {
   schema: PropTypes.object.isRequired,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -207,4 +212,7 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(BackupContact);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(BackupContact, profileStates.BACKUP_ADDRESS_COMPLETE));

--- a/src/scenes/ServiceMembers/BackupContact.test.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.test.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import BackupContact from './BackupContact';
+
+describe('requireCustomerState BackupContact', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "BACKUP MAILING ADDRESS COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupContact {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/backup-address'));
+  });
+
+  it('does not redirect if the current state equals the "BACKUP MAILING ADDRESS COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupContact {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupContact {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -9,6 +9,9 @@ import { updateServiceMember as updateServiceMemberAction } from 'store/entities
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import AddressForm from 'shared/AddressForm';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 import SectionWrapper from 'components/Customer/SectionWrapper';
 
@@ -82,6 +85,8 @@ BackupMailingAddress.propTypes = {
   schema: PropTypes.object.isRequired,
   updateServiceMember: PropTypes.func.isRequired,
   currentServiceMember: PropTypes.object,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -97,4 +102,7 @@ function mapStateToProps(state) {
     currentServiceMember: serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(BackupMailingAddress);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(BackupMailingAddress, profileStates.ADDRESS_COMPLETE));

--- a/src/scenes/ServiceMembers/BackupMailingAddress.test.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.test.jsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import BackupMailingAddress from './BackupMailingAddress';
+
+describe('requireCustomerState BackupMailingAddress', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "ADDRESS COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupMailingAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/current-address'));
+  });
+
+  it('does not redirect if the current state equals the "ADDRESS COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupMailingAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "ADDRESS COMPLETE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupMailingAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <BackupMailingAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -14,7 +14,7 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
 import { profileStates } from 'constants/customerStates';
-import { PageKeyShape, PageListShape } from '../../types/customerShapes';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 const subsetOfFields = [
   'telephone',

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -12,6 +12,9 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from '../../types/customerShapes';
 
 const subsetOfFields = [
   'telephone',
@@ -112,6 +115,8 @@ ContactInfo.propTypes = {
   schema: PropTypes.object.isRequired,
   updateServiceMember: PropTypes.func.isRequired,
   currentServiceMember: PropTypes.object,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -130,4 +135,7 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ContactInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(ContactInfo, profileStates.NAME_COMPLETE));

--- a/src/scenes/ServiceMembers/ContactInfo.test.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.test.jsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import ContactInfo from './ContactInfo';
+
+describe('requireCustomerState ContactInfo', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "NAME COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ContactInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/name'));
+  });
+
+  it('does not redirect if the current state equals the "NAME COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ContactInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "NAME COMPLETE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ContactInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ContactInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -10,6 +10,9 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 const subsetOfFields = ['affiliation', 'edipi', 'rank'];
 
@@ -87,6 +90,8 @@ DodInfo.propTypes = {
   schema: PropTypes.object.isRequired,
   updateServiceMember: PropTypes.func.isRequired,
   currentServiceMember: PropTypes.object,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -104,4 +109,4 @@ function mapStateToProps(state) {
   return props;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DodInfo);
+export default connect(mapStateToProps, mapDispatchToProps)(requireCustomerState(DodInfo, profileStates.EMPTY_PROFILE));

--- a/src/scenes/ServiceMembers/DodInfo.test.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.test.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import DodInfo from './DodInfo';
+
+describe('requireCustomerState DodInfo', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('does not redirect if the current state equals the "EMPTY PROFILE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DodInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "EMPTY PROFILE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DodInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DodInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -12,6 +12,9 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { selectServiceMemberFromLoggedInUser, selectCurrentOrders } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 import './DutyStation.css';
 
@@ -105,6 +108,8 @@ export class DutyStation extends Component {
 }
 DutyStation.propTypes = {
   updateServiceMember: PropTypes.func.isRequired,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -125,4 +130,7 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DutyStation);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(DutyStation, profileStates.CONTACT_INFO_COMPLETE));

--- a/src/scenes/ServiceMembers/DutyStation.test.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.test.jsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import DutyStation from './DutyStation';
+
+describe('requireCustomerState DutyStation', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "CONTACT INFO COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DutyStation {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/contact-info'));
+  });
+
+  it('does not redirect if the current state equals the "CONTACT INFO COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DutyStation {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "CONTACT INFO COMPLETE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DutyStation {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <DutyStation {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -9,6 +9,9 @@ import { updateServiceMember as updateServiceMemberAction } from 'store/entities
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 import SectionWrapper from 'components/Customer/SectionWrapper';
 
@@ -89,6 +92,8 @@ Name.propTypes = {
   schema: PropTypes.object.isRequired,
   updateServiceMember: PropTypes.func.isRequired,
   currentServiceMember: PropTypes.object,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -104,4 +109,7 @@ function mapStateToProps(state) {
     currentServiceMember: serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Name);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(Name, profileStates.DOD_INFO_COMPLETE));

--- a/src/scenes/ServiceMembers/Name.test.jsx
+++ b/src/scenes/ServiceMembers/Name.test.jsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import Name from './Name';
+import ContactInfo from './ContactInfo';
+
+describe('requireCustomerState Name', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "DOD INFO COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ContactInfo {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/conus-oconus'));
+  });
+
+  it('does not redirect if the current state equals the "DOD INFO COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <Name {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "DOD INFO COMPLETE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <Name {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <Name {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -10,6 +10,9 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { ValidateZipRateData } from 'shared/api';
 import AddressForm from 'shared/AddressForm';
 import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
+import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
+import { profileStates } from 'constants/customerStates';
+import { PageKeyShape, PageListShape } from 'types/customerShapes';
 
 import SectionWrapper from 'components/Customer/SectionWrapper';
 
@@ -92,6 +95,8 @@ ResidentialAddress.propTypes = {
   schema: PropTypes.object.isRequired,
   updateServiceMember: PropTypes.func.isRequired,
   currentServiceMember: PropTypes.object,
+  pages: PageListShape.isRequired,
+  pageKey: PageKeyShape.isRequired,
 };
 
 const mapDispatchToProps = {
@@ -107,4 +112,7 @@ function mapStateToProps(state) {
     currentServiceMember: serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(ResidentialAddress);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(requireCustomerState(ResidentialAddress, profileStates.DUTY_STATION_COMPLETE));

--- a/src/scenes/ServiceMembers/ResidentialAddress.test.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.test.jsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import * as reactRedux from 'react-redux';
+import { push } from 'connected-react-router';
+
+import { MockProviders } from 'testUtils';
+import ResidentialAddress from './ResidentialAddress';
+
+describe('requireCustomerState ResidentialAddress', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatchMock.mockClear();
+    mockDispatch.mockClear();
+    useDispatchMock.mockReturnValue(mockDispatch);
+  });
+
+  const props = {
+    pages: ['first'],
+    pageKey: '1',
+    userEmail: 'my@email.com',
+    schema: { my: 'schema' },
+    updateServiceMember: jest.fn(),
+  };
+
+  it('dispatches a redirect if the current state is earlier than the "DUTY STATION COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ResidentialAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/current-duty'));
+  });
+
+  it('does not redirect if the current state equals the "DUTY STATION COMPLETE" state', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ResidentialAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+  it('does not redirect if the current state is after the "DUTY STATION COMPLETE" state and profile is not complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ResidentialAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('does redirect if the profile is complete', () => {
+    const mockState = {
+      entities: {
+        user: {
+          testUserId: {
+            id: 'testUserId',
+            email: 'testuser@example.com',
+            service_member: 'testServiceMemberId',
+          },
+        },
+        serviceMembers: {
+          testServiceMemberId: {
+            id: 'testServiceMemberId',
+            rank: 'test rank',
+            edipi: '1234567890',
+            affiliation: 'ARMY',
+            first_name: 'Tester',
+            last_name: 'Testperson',
+            telephone: '1234567890',
+            personal_email: 'test@example.com',
+            email_is_preferred: true,
+            current_station: {
+              id: 'testDutyStationId',
+            },
+            residential_address: {
+              street: '123 Main St',
+            },
+            backup_mailing_address: {
+              street: '456 Main St',
+            },
+            backup_contacts: [
+              {
+                id: 'testBackupContact',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <MockProviders initialState={mockState}>
+        <ResidentialAddress {...props} />
+      </MockProviders>,
+    );
+
+    expect(wrapper.exists()).toBe(true);
+    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+  });
+});


### PR DESCRIPTION
## Description

If a customer has completed their profile, and visits a url in the profile Wizard, they are redirected to the Home page. If they visit a page beyond where they are in the profile Wizard flow, it redirects them to the last page they need to fill out. 
 
## Reviewer Notes

Adjusts the HOC (Higher-Order Component) `requireCustomerState` to redirect to the page available to them based on their current state, and if they have completed their profile, they are redirected to the Home page.

I wrote a `getIsAllowedProfileState` to determine if they are allowed to be on the page they are on or not.  Does this needs its own test?  If so, its own file?

## Setup

The allowed pages are based on the `profileStates`.  

`service-member/dod-info` --> DodInfo.jsx —> EMPTY_PROFILE
`service-member/name` --> Name.jsx —> DOD_INFO_COMPLETE
`service-member/contact-info` --> ContactInfo.jsx —> NAME_COMPLETE
`service-member/current-duty` --> DutyStation.jsx —> CONTACT_INFO_COMPLETE
`service-member/current-address` --> ResidentialAddress.jsx —> DUTY_STATION_COMPLETE
`service-member/backup-address` --> BackupMailingAddress.jsx —> ADDRESS_COMPLETE
`service-member/backup-contact` --> BackupContact.jsx —> BACKUP_ADDRESS_COMPLETE
`/` --> Home/index.jsx —> BACKUP_CONTACTS_COMPLETE (this one already was implemented)


## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6839) for this change

## Screenshots


