### PR TITLE
MB-7022 create storybook component for backup contact

### DIFF
--- a/src/components/form/BackupContactInfoFields/BackupContactInfoFields.stories.jsx
+++ b/src/components/form/BackupContactInfoFields/BackupContactInfoFields.stories.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import { BackupContactInfoFields } from './index';
+
+import { Form } from 'components/form/Form';
+import formStyles from 'styles/form.module.scss';
+
+export default {
+  title: 'Components/Fieldsets/BackupContactInfoFields',
+};
+
+export const Basic = () => (
+  <Formik
+    initialValues={{
+      backupContact: {
+        phone: '',
+        alternatePhone: '',
+        email: '',
+      },
+    }}
+  >
+    {() => (
+      <Form className={formStyles.form}>
+        <BackupContactInfoFields name="backupContact" legend="Backup contact" />
+      </Form>
+    )}
+  </Formik>
+);
+
+export const WithAdditionalText = () => (
+  <Formik
+    initialValues={{
+      backupContact: {
+        phone: '',
+        alternatePhone: '',
+        email: '',
+      },
+    }}
+  >
+    {() => (
+      <Form className={formStyles.form}>
+        <BackupContactInfoFields
+          name="backupContact"
+          legend="Backup contact"
+          render={(fields) => (
+            <>
+              <p>
+                If we can&apos;t reach you, who can we contact? Any person you assign as a backup contact must be 18
+                years of age or older.
+              </p>
+              {fields}
+            </>
+          )}
+        />
+      </Form>
+    )}
+  </Formik>
+);

--- a/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
+++ b/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Formik } from 'formik';
+
+import { BackupContactInfoFields } from './index';
+
+describe('BackupContactInfoFields component', () => {
+  it('renders a legend and all backup contact info inputs', () => {
+    const { getByText, getByLabelText } = render(
+      <Formik>
+        <BackupContactInfoFields legend="Backup contact" name="backupContact" />
+      </Formik>,
+    );
+    expect(getByText('Backup contact')).toBeInstanceOf(HTMLLegendElement);
+    expect(getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
+    expect(getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
+    expect(getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
+  });
+
+  describe('with pre-filled values', () => {
+    it('renders a legend and all backup contact info inputs', () => {
+      const initialValues = {
+        backupContact: {
+          email: 'test@example.com',
+          name: 'test',
+          phone: '555-123-4567',
+        },
+      };
+
+      const { getByLabelText } = render(
+        <Formik initialValues={initialValues}>
+          <BackupContactInfoFields legend="Backup contact" name="backupContact" />
+        </Formik>,
+      );
+      expect(getByLabelText('Name')).toHaveValue(initialValues.backupContact.name);
+      expect(getByLabelText('Email')).toHaveValue(initialValues.backupContact.email);
+      expect(getByLabelText('Phone')).toHaveValue(initialValues.backupContact.phone);
+    });
+  });
+});

--- a/src/components/form/BackupContactInfoFields/index.jsx
+++ b/src/components/form/BackupContactInfoFields/index.jsx
@@ -6,23 +6,23 @@ import { Fieldset } from '@trussworks/react-uswds';
 import TextField from 'components/form/fields/TextField';
 
 export const BackupContactInfoFields = ({ legend, className, name, render }) => {
-  const BackupContactInfoFieldsUUID = useRef(uuidv4());
+  const backupContactInfoFieldsUUID = useRef(uuidv4());
 
   return (
     <Fieldset legend={legend} className={className}>
       {render(
         <>
-          <TextField label="Name" id={`name_${BackupContactInfoFieldsUUID}`} name={`${name}.name`} />
+          <TextField label="Name" id={`name_${backupContactInfoFieldsUUID}`} name={`${name}.name`} />
           <div className="grid-row grid-gap">
             <div className="mobile-lg:grid-col-7">
-              <TextField label="Email" id={`email_${BackupContactInfoFieldsUUID}`} name={`${name}.email`} />
+              <TextField label="Email" id={`email_${backupContactInfoFieldsUUID}`} name={`${name}.email`} />
             </div>
           </div>
           <div className="grid-row grid-gap">
             <div className="mobile-lg:grid-col-4">
               <TextField
                 label="Phone"
-                id={`phone_${BackupContactInfoFieldsUUID}`}
+                id={`phone_${backupContactInfoFieldsUUID}`}
                 name={`${name}.phone`}
                 type="tel"
                 maxLength="10"

--- a/src/components/form/BackupContactInfoFields/index.jsx
+++ b/src/components/form/BackupContactInfoFields/index.jsx
@@ -1,0 +1,51 @@
+import React, { useRef } from 'react';
+import { func, node, string } from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import { Fieldset } from '@trussworks/react-uswds';
+
+import TextField from 'components/form/fields/TextField';
+
+export const BackupContactInfoFields = ({ legend, className, name, render }) => {
+  const BackupContactInfoFieldsUUID = useRef(uuidv4());
+
+  return (
+    <Fieldset legend={legend} className={className}>
+      {render(
+        <>
+          <TextField label="Name" id={`name_${BackupContactInfoFieldsUUID}`} name={`${name}.name`} />
+          <div className="grid-row grid-gap">
+            <div className="mobile-lg:grid-col-7">
+              <TextField label="Email" id={`email_${BackupContactInfoFieldsUUID}`} name={`${name}.email`} />
+            </div>
+          </div>
+          <div className="grid-row grid-gap">
+            <div className="mobile-lg:grid-col-4">
+              <TextField
+                label="Phone"
+                id={`phone_${BackupContactInfoFieldsUUID}`}
+                name={`${name}.phone`}
+                type="tel"
+                maxLength="10"
+              />
+            </div>
+          </div>
+        </>,
+      )}
+    </Fieldset>
+  );
+};
+
+BackupContactInfoFields.propTypes = {
+  legend: node,
+  className: string,
+  name: string.isRequired,
+  render: func,
+};
+
+BackupContactInfoFields.defaultProps = {
+  legend: '',
+  className: '',
+  render: (fields) => fields,
+};
+
+export default BackupContactInfoFields;


### PR DESCRIPTION
## Description

Add a new component for the backup contact fields.

## Reviewer Notes
This PR is getting merged into `sr-7020-residential-address-fieldset` branch since this work builds off of some of those changes.

Is the Formik hooked up correctly?

Storybook also has a basic version, which does not have the additional text of "If we can't reach you....."

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7022) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._

![image](https://user-images.githubusercontent.com/6477059/111558042-310a7d00-874b-11eb-9404-2cfbfc03a4b4.png)
![image](https://user-images.githubusercontent.com/6477059/111558065-3c5da880-874b-11eb-825c-f967bb9b5ea8.png)
