### PR TITLE
use :latest instead of :alpine to fix 403 errors in clamav

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
   anti_virus:
     executor: av_medium
     steps:
-      - run: apt-get update && apt-get install -y curl git openssh
+      - run: apt-get update && apt-get install -y curl git ssh
       - checkout
       - run: clamscan --version
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,6 +560,7 @@ jobs:
       - run: apt-get update && apt-get install -y clamav curl git ssh
       - checkout
       - run: clamscan --version
+      - run: mkdir -p /store
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store
       - run:
           name: freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,8 +563,8 @@ jobs:
       - run: mkdir -p /store
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store
       - run:
-          name: freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store
-          command: for i in $(seq 1 5); do freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
+          name: sudo freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store
+          command: for i in $(seq 1 5); do sudo freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
       - run: >
           clamscan \
             --recursive \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
   anti_virus:
     executor: av_medium
     steps:
-      - run: apk update && apk add --no-cache git openssh
+      - run: sudo apt-get update && sudo apt-get install -y git openssh
       - checkout
       - run: clamscan --version
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1378,7 +1378,10 @@ workflows:
           requires:
             - pre_deps_golang
 
-      - anti_virus
+      - anti_virus:
+          filters:
+            branches:
+              only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
   anti_virus:
     executor: av_medium
     steps:
-      - run: apt-get update && apt-get install -y curl git ssh
+      - run: apt-get update && apt-get install -y clamav curl git ssh
       - checkout
       - run: clamscan --version
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1377,10 +1377,7 @@ workflows:
           requires:
             - pre_deps_golang
 
-      - anti_virus:
-          filters:
-            branches:
-              only: master
+      - anti_virus
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     resource_class: medium
     working_directory: /root/project
     docker:
-      - image: mk0x/docker-clamav:alpine
+      - image: mk0x/docker-clamav:latest
         # Authenticate with Docker Hub to avoid rate limit problems beginning on Nov 1st, 2020.
         # See https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/ for details
         # We'll need this until CircleCI and Docker Hub work out a deal to prevent rate limiting errors from CircleCI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,11 +560,11 @@ jobs:
       - run: apt-get update && apt-get install -y clamav curl git ssh
       - checkout
       - run: clamscan --version
-      - run: mkdir -p /store
+      - run: mkdir -p /store && chown clamav /store
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store
       - run:
-          name: sudo freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store
-          command: for i in $(seq 1 5); do sudo freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
+          name: freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store
+          command: for i in $(seq 1 5); do freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
       - run: >
           clamscan \
             --recursive \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ jobs:
   anti_virus:
     executor: av_medium
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y git openssh
+      - run: apt-get update && apt-get install -y curl git openssh
       - checkout
       - run: clamscan --version
       - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store

--- a/scripts/anti-virus
+++ b/scripts/anti-virus
@@ -14,7 +14,7 @@ set -eu -o pipefail
 #
 # - AV_IGNORE_DIR: The full path to the directory where new ignore files will be created (no default)
 # - AV_DATABASE_DIR: The directory inside the container to store AV database files (default: /tmp/store)
-# - AV_DOCKER_IMAGE: The docker image used which runs ClamAV (default: mk0x/docker-clamav:alpine)
+# - AV_DOCKER_IMAGE: The docker image used which runs ClamAV (default: mk0x/docker-clamav:latest)
 # - AV_MOUNT_DIR: The directory in the container used to mount files for scanning (default: /project)
 #
 
@@ -29,7 +29,7 @@ fi
 
 DATABASE_DIR=${AV_DATABASE_DIR:-/tmp/store}
 readonly DATABASE_DIR
-DOCKER_IMAGE=${AV_DOCKER_IMAGE:-mk0x/docker-clamav:alpine}
+DOCKER_IMAGE=${AV_DOCKER_IMAGE:-mk0x/docker-clamav:latest}
 readonly DOCKER_IMAGE
 MOUNT_DIR=${AV_MOUNT_DIR:-/root/project}
 readonly MOUNT_DIR

--- a/scripts/anti-virus-whitelists
+++ b/scripts/anti-virus-whitelists
@@ -18,7 +18,7 @@ set -eu -o pipefail
 # Environment Variables that modify behavior:
 #
 # - AV_DIR: The full path to the directory that will mounted (required, no default)
-# - AV_DOCKER_IMAGE: The docker image used which runs ClamAV (default: mk0x/docker-clamav:alpine)
+# - AV_DOCKER_IMAGE: The docker image used which runs ClamAV (default: mk0x/docker-clamav:latest)
 # - AV_IGNORE_DIR: The full path to the directory where new ignore files will be created (required, no default)
 # - AV_IGNORE_FILES: Specific files to ignore when scanning in a space-separated list
 # - AV_IGNORE_SIGS: Specific signatures to ignore when scanning in a space-separated list
@@ -60,7 +60,7 @@ else
 fi
 
 
-DOCKER_IMAGE=${AV_DOCKER_IMAGE:-mk0x/docker-clamav:alpine}
+DOCKER_IMAGE=${AV_DOCKER_IMAGE:-mk0x/docker-clamav:latest}
 readonly DOCKER_IMAGE
 MOUNT_DIR=${AV_MOUNT_DIR:-/root/project}
 readonly MOUNT_DIR


### PR DESCRIPTION
## Description

This PR attempts to fix errors we are seeing with the mk0x/docker-clamav:alpine image indicated by https://github.com/mko-x/docker-clamav/issues/103#issuecomment-801787128.

Example failure: https://app.circleci.com/pipelines/github/transcom/mymove/28329/workflows/0e2827f9-116c-4c57-8149-b563d669ff21/jobs/435015

<details><summary>Sample output:</summary>

```text
#!/bin/bash -eo pipefail
for i in $(seq 1 5); do freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
Thu Mar 18 19:08:14 2021 -> ClamAV update process started at Thu Mar 18 19:08:14 2021
Thu Mar 18 19:08:14 2021 -> daily database available for download (remote version: 26112)
Time: 1.2s, ETA; 0.0s [=======================================>] 100.46MiB/100.46MiB  
Thu Mar 18 19:08:18 2021 -> Testing database: '/store/tmp/clamav-7f6a5f364aec941dd26e148feeb5daab.tmp-daily.cvd' ...
Thu Mar 18 19:08:39 2021 -> Database test passed.
Thu Mar 18 19:08:39 2021 -> daily.cvd updated (version: 26112, sigs: 3963581, f-level: 63, builder: raynman)
Thu Mar 18 19:08:39 2021 -> main database available for download (remote version: 59)
Time: 0.8s, ETA; 0.0s [=======================================>] 112.40MiB/112.40MiB  
Thu Mar 18 19:08:43 2021 -> Testing database: '/store/tmp/clamav-c219e642760fa4c3c4aee060763bf796.tmp-main.cvd' ...
Thu Mar 18 19:08:51 2021 -> Database test passed.
Thu Mar 18 19:08:51 2021 -> main.cvd updated (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
Thu Mar 18 19:08:51 2021 -> bytecode database available for download (remote version: 333)
Time: 0.1s, ETA; 0.0s [=======================================>] 0.28KiB/0.28KiB  
Thu Mar 18 19:08:52 2021 -> Testing database: '/store/tmp/clamav-264e41db57f738d1ed0a2d50f9b7d454.tmp-bytecode.cvd' ...
Thu Mar 18 19:08:52 2021 -> Database test passed.
Thu Mar 18 19:08:52 2021 -> bytecode.cvd updated (version: 333, sigs: 92, f-level: 63, builder: awillia2)
Thu Mar 18 19:08:52 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:08:52 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:08:52 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:08:52 2021 -> Trying again in 5 secs...
Thu Mar 18 19:08:57 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:08:57 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:08:57 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:08:57 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:02 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:02 2021 -> !downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:02 2021 -> !getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:02 2021 -> Giving up on https://database.clamav.net...
Thu Mar 18 19:09:02 2021 -> !Update failed for database: safebrowsing
Thu Mar 18 19:09:02 2021 -> ^fc_update_databases: fc_update_database failed: HTTP GET failed (11)
Thu Mar 18 19:09:02 2021 -> !Database update process failed: HTTP GET failed (11)
Thu Mar 18 19:09:02 2021 -> !Update failed.
Thu Mar 18 19:09:07 2021 -> ClamAV update process started at Thu Mar 18 19:09:07 2021
Thu Mar 18 19:09:07 2021 -> daily.cvd database is up to date (version: 26112, sigs: 3963581, f-level: 63, builder: raynman)
Thu Mar 18 19:09:07 2021 -> main.cvd database is up to date (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
Thu Mar 18 19:09:07 2021 -> bytecode.cvd database is up to date (version: 333, sigs: 92, f-level: 63, builder: awillia2)
Thu Mar 18 19:09:07 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:07 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:07 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:07 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:12 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.1s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:12 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:12 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:12 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:17 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.1s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:17 2021 -> !downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:17 2021 -> !getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:17 2021 -> Giving up on https://database.clamav.net...
Thu Mar 18 19:09:17 2021 -> !Update failed for database: safebrowsing
Thu Mar 18 19:09:17 2021 -> ^fc_update_databases: fc_update_database failed: HTTP GET failed (11)
Thu Mar 18 19:09:17 2021 -> !Database update process failed: HTTP GET failed (11)
Thu Mar 18 19:09:17 2021 -> !Update failed.
Thu Mar 18 19:09:22 2021 -> ClamAV update process started at Thu Mar 18 19:09:22 2021
Thu Mar 18 19:09:22 2021 -> daily.cvd database is up to date (version: 26112, sigs: 3963581, f-level: 63, builder: raynman)
Thu Mar 18 19:09:22 2021 -> main.cvd database is up to date (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
Thu Mar 18 19:09:22 2021 -> bytecode.cvd database is up to date (version: 333, sigs: 92, f-level: 63, builder: awillia2)
Thu Mar 18 19:09:22 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.1s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:22 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:22 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:22 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:27 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:27 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:27 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:27 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:32 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:32 2021 -> !downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:32 2021 -> !getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:32 2021 -> Giving up on https://database.clamav.net...
Thu Mar 18 19:09:32 2021 -> !Update failed for database: safebrowsing
Thu Mar 18 19:09:32 2021 -> ^fc_update_databases: fc_update_database failed: HTTP GET failed (11)
Thu Mar 18 19:09:32 2021 -> !Database update process failed: HTTP GET failed (11)
Thu Mar 18 19:09:32 2021 -> !Update failed.
Thu Mar 18 19:09:37 2021 -> ClamAV update process started at Thu Mar 18 19:09:37 2021
Thu Mar 18 19:09:37 2021 -> daily.cvd database is up to date (version: 26112, sigs: 3963581, f-level: 63, builder: raynman)
Thu Mar 18 19:09:37 2021 -> main.cvd database is up to date (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
Thu Mar 18 19:09:37 2021 -> bytecode.cvd database is up to date (version: 333, sigs: 92, f-level: 63, builder: awillia2)
Thu Mar 18 19:09:37 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:37 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:37 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:37 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:42 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:42 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:42 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:42 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:47 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.1s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:47 2021 -> !downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:47 2021 -> !getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:47 2021 -> Giving up on https://database.clamav.net...
Thu Mar 18 19:09:47 2021 -> !Update failed for database: safebrowsing
Thu Mar 18 19:09:47 2021 -> ^fc_update_databases: fc_update_database failed: HTTP GET failed (11)
Thu Mar 18 19:09:47 2021 -> !Database update process failed: HTTP GET failed (11)
Thu Mar 18 19:09:47 2021 -> !Update failed.
Thu Mar 18 19:09:52 2021 -> ClamAV update process started at Thu Mar 18 19:09:52 2021
Thu Mar 18 19:09:52 2021 -> daily.cvd database is up to date (version: 26112, sigs: 3963581, f-level: 63, builder: raynman)
Thu Mar 18 19:09:52 2021 -> main.cvd database is up to date (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
Thu Mar 18 19:09:52 2021 -> bytecode.cvd database is up to date (version: 333, sigs: 92, f-level: 63, builder: awillia2)
Thu Mar 18 19:09:52 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:52 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:52 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:52 2021 -> Trying again in 5 secs...
Thu Mar 18 19:09:57 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:09:57 2021 -> ^downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:57 2021 -> ^getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:09:57 2021 -> Trying again in 5 secs...
Thu Mar 18 19:10:02 2021 -> safebrowsing database available for download (remote version: 49191)
Time: 0.0s, ETA; 0.0s [=======================================>] 16B/16B  
Thu Mar 18 19:10:02 2021 -> !downloadFile: Unexpected response (403) from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:10:02 2021 -> !getcvd: Can't download safebrowsing.cvd from https://database.clamav.net/safebrowsing.cvd
Thu Mar 18 19:10:02 2021 -> Giving up on https://database.clamav.net...
Thu Mar 18 19:10:02 2021 -> !Update failed for database: safebrowsing
Thu Mar 18 19:10:02 2021 -> ^fc_update_databases: fc_update_database failed: HTTP GET failed (11)
Thu Mar 18 19:10:02 2021 -> !Database update process failed: HTTP GET failed (11)
Thu Mar 18 19:10:02 2021 -> !Update failed.

Exited with code exit status 11
CircleCI received exit code 11
```

</details>

While this should have nothing to do with alpine vs debian (the base for the `:latest` tag), switching over to `latest` ends up fixing the issue.

Another historical note for future archaeologists: I tried the `:buster-slim` and `:alpine-edge` tags. Both failed in unique ways. `:latest` was the only one that worked. This is further confusing because [according to the upstream author's push-manifest-all.sh file](https://github.com/mko-x/docker-clamav/blob/8f7e61995214f4e11b4fcf4cc68015ad80e41584/push-manifest-all.sh#L32-L33), `:latest` [appears to be the same as](https://github.com/mko-x/docker-clamav/blob/8f7e61995214f4e11b4fcf4cc68015ad80e41584/push-manifest-all.sh#L27-L28) `:buster-slim`.

## Setup

Watch CircleCI.

## Code Review Verification Steps

* [x] Request review from a member of a different team.