### PR TITLE
MB-7015 Prevent Move approval if Order is invalid

### DIFF
--- a/cypress/integration/admin/webhookSubscriptions.js
+++ b/cypress/integration/admin/webhookSubscriptions.js
@@ -3,6 +3,7 @@ import { adminBaseURL } from '../../support/constants';
 describe('Webhook Subscriptions', function () {
   before(() => {
     cy.prepareAdminApp();
+    cy.clearAllCookies();
   });
 
   it('successfully navigates to the webhook subscriptions list page', function () {
@@ -47,6 +48,7 @@ describe('WebhookSubscriptions Details Show Page', function () {
 describe('WebhookSubscriptions Details Edit Page', function () {
   before(() => {
     cy.prepareAdminApp();
+    cy.clearAllCookies();
   });
 
   it('pulls up edit page for a webhook subscription', function () {
@@ -84,6 +86,7 @@ describe('WebhookSubscriptions Details Edit Page', function () {
 describe('Webhook Subscription Create Page', function () {
   before(() => {
     cy.prepareAdminApp();
+    cy.clearAllCookies();
   });
 
   it('pulls up create page for a webhook subscription', function () {

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -213,6 +213,7 @@ function officeUserVerifiesAccounting() {
 
   cy.get('button').contains('Save').click();
   cy.wait('@updateOrder');
+  cy.patientReload();
 
   cy.get('.tac > span').contains('ABC1');
   cy.get('span').contains('N002214CSW32Y9');

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -7,6 +7,7 @@ describe('office user finds the move', function () {
 
   beforeEach(() => {
     cy.clearAllCookies();
+    cy.intercept('PATCH', '**/ghc/v1/orders/**').as('patchOrder');
     cy.signInAsNewPPMOfficeUser();
   });
 
@@ -204,18 +205,16 @@ function officeUserVerifiesAccounting() {
   // Enter details in form and save
   cy.get('.editable-panel-header').contains('Accounting').siblings().click();
 
-  cy.get('input[name="tac"]').type('6789');
+  cy.get('input[name="tac"]').type('ABC1');
   cy.get('select[name="department_indicator"]').select('AIR_FORCE');
   cy.get('input[name="sac"]').type('N002214CSW32Y9');
 
   cy.get('button').contains('Save').should('be.enabled');
 
   cy.get('button').contains('Save').click();
+  cy.wait(['@patchOrder']);
 
-  // Verify data has been saved in the UI
-  // added '.tac' as an additional selector since
-  // '6789' is part of the DoD ID that was a false positive
-  cy.get('.tac > span').contains('6789');
+  cy.get('.tac > span').contains('ABC1');
   cy.get('span').contains('N002214CSW32Y9');
 
   // Refresh browser and make sure changes persist
@@ -224,7 +223,7 @@ function officeUserVerifiesAccounting() {
   cy.get('.combo-button .dropdown').contains('Approve PPM').should('have.class', 'disabled');
   cy.get('.combo-button').click();
 
-  cy.get('span').contains('6789');
+  cy.get('span').contains('ABC1');
   cy.get('span').contains('57 Air Force');
   cy.get('span').contains('N002214CSW32Y9');
 }

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -205,17 +205,16 @@ function officeUserVerifiesAccounting() {
   // Enter details in form and save
   cy.get('.editable-panel-header').contains('Accounting').siblings().click();
 
-  cy.get('input[name="tac"]').type('ABC1');
+  cy.get('input[name="tac"]').first().clear().type('7777');
   cy.get('select[name="department_indicator"]').select('AIR_FORCE');
-  cy.get('input[name="sac"]').type('N002214CSW32Y9');
+  cy.get('input[name="sac"]').first().clear().type('N002214CSW32Y9');
 
   cy.get('button').contains('Save').should('be.enabled');
 
   cy.get('button').contains('Save').click();
   cy.wait('@updateOrder');
-  cy.patientReload();
 
-  cy.get('.tac > span').contains('ABC1');
+  cy.get('.tac > span').contains('7777');
   cy.get('span').contains('N002214CSW32Y9');
 
   // Refresh browser and make sure changes persist
@@ -224,7 +223,7 @@ function officeUserVerifiesAccounting() {
   cy.get('.combo-button .dropdown').contains('Approve PPM').should('have.class', 'disabled');
   cy.get('.combo-button').click();
 
-  cy.get('span').contains('ABC1');
+  cy.get('span').contains('7777');
   cy.get('span').contains('57 Air Force');
   cy.get('span').contains('N002214CSW32Y9');
 }

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -7,7 +7,7 @@ describe('office user finds the move', function () {
 
   beforeEach(() => {
     cy.clearAllCookies();
-    cy.intercept('PATCH', '**/ghc/v1/orders/**').as('patchOrder');
+    cy.intercept('PUT', '**/internal/orders/**').as('updateOrder');
     cy.signInAsNewPPMOfficeUser();
   });
 
@@ -212,7 +212,7 @@ function officeUserVerifiesAccounting() {
   cy.get('button').contains('Save').should('be.enabled');
 
   cy.get('button').contains('Save').click();
-  cy.wait(['@patchOrder']);
+  cy.wait(['@updateOrder']);
 
   cy.get('.tac > span').contains('ABC1');
   cy.get('span').contains('N002214CSW32Y9');

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -7,7 +7,7 @@ describe('office user finds the move', function () {
 
   beforeEach(() => {
     cy.clearAllCookies();
-    cy.intercept('PUT', '**/internal/orders/**').as('updateOrder');
+    cy.intercept('**/internal/orders/**').as('updateOrder');
     cy.signInAsNewPPMOfficeUser();
   });
 
@@ -212,7 +212,7 @@ function officeUserVerifiesAccounting() {
   cy.get('button').contains('Save').should('be.enabled');
 
   cy.get('button').contains('Save').click();
-  cy.wait(['@updateOrder']);
+  cy.wait('@updateOrder');
 
   cy.get('.tac > span').contains('ABC1');
   cy.get('span').contains('N002214CSW32Y9');

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -9,8 +9,8 @@ describe('TOO user', () => {
     cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
     cy.intercept('**/ghc/v1/queues/moves?page=1&perPage=20&sort=status&order=asc').as('getSortedOrders');
     cy.intercept('**/ghc/v1/move/**').as('getMoves');
-    cy.intercept('**/ghc/v1/move-orders/**').as('getOrders');
-    cy.intercept('**/ghc/v1/move-orders/**/move-task-orders').as('getMoveTaskOrders');
+    cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/orders/**/move-task-orders').as('getMoveTaskOrders');
     cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
     cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
     cy.intercept('PATCH', '**/ghc/v1/move_task_orders/**/mto_shipments/**/status').as('patchMTOShipmentStatus');

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -167,199 +167,6 @@ func init() {
         }
       }
     },
-    "/move-orders/{orderID}": {
-      "get": {
-        "description": "Gets an order",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Gets an order by ID",
-        "operationId": "getOrder",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved order",
-            "schema": {
-              "$ref": "#/definitions/Order"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "$ref": "#/responses/InvalidRequest"
-            }
-          },
-          "401": {
-            "description": "The request was denied",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "403": {
-            "description": "The request was denied",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "$ref": "#/responses/NotFound"
-            }
-          },
-          "500": {
-            "description": "A server error occurred",
-            "schema": {
-              "$ref": "#/responses/ServerError"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "All fields sent in this request will be set on the order referenced",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Updates an order",
-        "operationId": "updateOrder",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateOrderPayload"
-            }
-          },
-          {
-            "type": "string",
-            "name": "If-Match",
-            "in": "header",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "updated instance of orders",
-            "schema": {
-              "$ref": "#/definitions/Order"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "$ref": "#/responses/InvalidRequest"
-            }
-          },
-          "401": {
-            "description": "The request was unauthenticated",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "403": {
-            "description": "The request was unauthorized",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "$ref": "#/responses/NotFound"
-            }
-          },
-          "412": {
-            "description": "Precondition failed",
-            "schema": {
-              "$ref": "#/responses/PreconditionFailed"
-            }
-          },
-          "500": {
-            "description": "internal server error"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "description": "ID of order to use",
-          "name": "orderID",
-          "in": "path",
-          "required": true
-        }
-      ]
-    },
-    "/move-orders/{orderID}/move-task-orders": {
-      "get": {
-        "description": "Gets move task orders associated with an order",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Gets move task orders associated with an order",
-        "operationId": "listMoveTaskOrders",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved all move task orders associated with an order",
-            "schema": {
-              "$ref": "#/definitions/MoveTaskOrders"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "$ref": "#/responses/InvalidRequest"
-            }
-          },
-          "401": {
-            "description": "The request was denied",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "403": {
-            "description": "The request was denied",
-            "schema": {
-              "$ref": "#/responses/PermissionDenied"
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "$ref": "#/responses/NotFound"
-            }
-          },
-          "500": {
-            "description": "A server error occurred",
-            "schema": {
-              "$ref": "#/responses/ServerError"
-            }
-          }
-        }
-      },
-      "parameters": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "description": "ID of order to use",
-          "name": "orderID",
-          "in": "path",
-          "required": true
-        }
-      ]
-    },
     "/move-task-orders/{moveTaskOrderID}": {
       "get": {
         "description": "Gets a move",
@@ -1422,6 +1229,205 @@ func init() {
           "format": "string",
           "description": "move code to identify a move for payment requests",
           "name": "locator",
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/orders/{orderID}": {
+      "get": {
+        "description": "Gets an order",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Gets an order by ID",
+        "operationId": "getOrder",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved order",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "$ref": "#/responses/InvalidRequest"
+            }
+          },
+          "401": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "403": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "$ref": "#/responses/NotFound"
+            }
+          },
+          "500": {
+            "description": "A server error occurred",
+            "schema": {
+              "$ref": "#/responses/ServerError"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "All fields sent in this request will be set on the order referenced",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Updates an order",
+        "operationId": "updateOrder",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrderPayload"
+            }
+          },
+          {
+            "type": "string",
+            "name": "If-Match",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated instance of orders",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "$ref": "#/responses/InvalidRequest"
+            }
+          },
+          "401": {
+            "description": "The request was unauthenticated",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "403": {
+            "description": "The request was unauthorized",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "$ref": "#/responses/NotFound"
+            }
+          },
+          "412": {
+            "description": "Precondition failed",
+            "schema": {
+              "$ref": "#/responses/PreconditionFailed"
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          },
+          "500": {
+            "description": "internal server error"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "description": "ID of order to use",
+          "name": "orderID",
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/orders/{orderID}/move-task-orders": {
+      "get": {
+        "description": "Gets move task orders associated with an order",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Gets move task orders associated with an order",
+        "operationId": "listMoveTaskOrders",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved all move task orders associated with an order",
+            "schema": {
+              "$ref": "#/definitions/MoveTaskOrders"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "$ref": "#/responses/InvalidRequest"
+            }
+          },
+          "401": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "403": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/responses/PermissionDenied"
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "$ref": "#/responses/NotFound"
+            }
+          },
+          "500": {
+            "description": "A server error occurred",
+            "schema": {
+              "$ref": "#/responses/ServerError"
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "description": "ID of order to use",
+          "name": "orderID",
           "in": "path",
           "required": true
         }
@@ -3967,244 +3973,6 @@ func init() {
         }
       }
     },
-    "/move-orders/{orderID}": {
-      "get": {
-        "description": "Gets an order",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Gets an order by ID",
-        "operationId": "getOrder",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved order",
-            "schema": {
-              "$ref": "#/definitions/Order"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "description": "The request payload is invalid",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "401": {
-            "description": "The request was denied",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "403": {
-            "description": "The request was denied",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "description": "The requested resource wasn't found",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "500": {
-            "description": "A server error occurred",
-            "schema": {
-              "description": "A server error occurred",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "All fields sent in this request will be set on the order referenced",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Updates an order",
-        "operationId": "updateOrder",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateOrderPayload"
-            }
-          },
-          {
-            "type": "string",
-            "name": "If-Match",
-            "in": "header",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "updated instance of orders",
-            "schema": {
-              "$ref": "#/definitions/Order"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "description": "The request payload is invalid",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "401": {
-            "description": "The request was unauthenticated",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "403": {
-            "description": "The request was unauthorized",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "description": "The requested resource wasn't found",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "412": {
-            "description": "Precondition failed",
-            "schema": {
-              "description": "Precondition failed",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "description": "ID of order to use",
-          "name": "orderID",
-          "in": "path",
-          "required": true
-        }
-      ]
-    },
-    "/move-orders/{orderID}/move-task-orders": {
-      "get": {
-        "description": "Gets move task orders associated with an order",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "order"
-        ],
-        "summary": "Gets move task orders associated with an order",
-        "operationId": "listMoveTaskOrders",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved all move task orders associated with an order",
-            "schema": {
-              "$ref": "#/definitions/MoveTaskOrders"
-            }
-          },
-          "400": {
-            "description": "The request payload is invalid",
-            "schema": {
-              "description": "The request payload is invalid",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "401": {
-            "description": "The request was denied",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "403": {
-            "description": "The request was denied",
-            "schema": {
-              "description": "The request was denied",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "404": {
-            "description": "The requested resource wasn't found",
-            "schema": {
-              "description": "The requested resource wasn't found",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          },
-          "500": {
-            "description": "A server error occurred",
-            "schema": {
-              "description": "A server error occurred",
-              "schema": {
-                "$ref": "#/definitions/Error"
-              }
-            }
-          }
-        }
-      },
-      "parameters": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "description": "ID of order to use",
-          "name": "orderID",
-          "in": "path",
-          "required": true
-        }
-      ]
-    },
     "/move-task-orders/{moveTaskOrderID}": {
       "get": {
         "description": "Gets a move",
@@ -5486,6 +5254,250 @@ func init() {
           "format": "string",
           "description": "move code to identify a move for payment requests",
           "name": "locator",
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/orders/{orderID}": {
+      "get": {
+        "description": "Gets an order",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Gets an order by ID",
+        "operationId": "getOrder",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved order",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "description": "The request payload is invalid",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "401": {
+            "description": "The request was denied",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was denied",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "description": "The requested resource wasn't found",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "500": {
+            "description": "A server error occurred",
+            "schema": {
+              "description": "A server error occurred",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "All fields sent in this request will be set on the order referenced",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Updates an order",
+        "operationId": "updateOrder",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrderPayload"
+            }
+          },
+          {
+            "type": "string",
+            "name": "If-Match",
+            "in": "header",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "updated instance of orders",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "description": "The request payload is invalid",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "401": {
+            "description": "The request was unauthenticated",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was unauthorized",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "description": "The requested resource wasn't found",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition failed",
+            "schema": {
+              "description": "Precondition failed",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          },
+          "500": {
+            "description": "internal server error"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "description": "ID of order to use",
+          "name": "orderID",
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/orders/{orderID}/move-task-orders": {
+      "get": {
+        "description": "Gets move task orders associated with an order",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "order"
+        ],
+        "summary": "Gets move task orders associated with an order",
+        "operationId": "listMoveTaskOrders",
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved all move task orders associated with an order",
+            "schema": {
+              "$ref": "#/definitions/MoveTaskOrders"
+            }
+          },
+          "400": {
+            "description": "The request payload is invalid",
+            "schema": {
+              "description": "The request payload is invalid",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "401": {
+            "description": "The request was denied",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was denied",
+            "schema": {
+              "description": "The request was denied",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource wasn't found",
+            "schema": {
+              "description": "The requested resource wasn't found",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          },
+          "500": {
+            "description": "A server error occurred",
+            "schema": {
+              "description": "A server error occurred",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "description": "ID of order to use",
+          "name": "orderID",
           "in": "path",
           "required": true
         }

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -332,6 +332,12 @@ func init() {
               "$ref": "#/responses/PreconditionFailed"
             }
           },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          },
           "500": {
             "description": "A server error occurred",
             "schema": {
@@ -868,6 +874,12 @@ func init() {
             "description": "Precondition Failed",
             "schema": {
               "$ref": "#/responses/PreconditionFailed"
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {
@@ -4183,6 +4195,12 @@ func init() {
               }
             }
           },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          },
           "500": {
             "description": "A server error occurred",
             "schema": {
@@ -4839,6 +4857,12 @@ func init() {
               "schema": {
                 "$ref": "#/definitions/Error"
               }
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
             }
           },
           "500": {

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_responses.go
@@ -267,6 +267,50 @@ func (o *UpdateMoveTaskOrderPreconditionFailed) WriteResponse(rw http.ResponseWr
 	}
 }
 
+// UpdateMoveTaskOrderUnprocessableEntityCode is the HTTP code returned for type UpdateMoveTaskOrderUnprocessableEntity
+const UpdateMoveTaskOrderUnprocessableEntityCode int = 422
+
+/*UpdateMoveTaskOrderUnprocessableEntity Validation error
+
+swagger:response updateMoveTaskOrderUnprocessableEntity
+*/
+type UpdateMoveTaskOrderUnprocessableEntity struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *ghcmessages.ValidationError `json:"body,omitempty"`
+}
+
+// NewUpdateMoveTaskOrderUnprocessableEntity creates UpdateMoveTaskOrderUnprocessableEntity with default headers values
+func NewUpdateMoveTaskOrderUnprocessableEntity() *UpdateMoveTaskOrderUnprocessableEntity {
+
+	return &UpdateMoveTaskOrderUnprocessableEntity{}
+}
+
+// WithPayload adds the payload to the update move task order unprocessable entity response
+func (o *UpdateMoveTaskOrderUnprocessableEntity) WithPayload(payload *ghcmessages.ValidationError) *UpdateMoveTaskOrderUnprocessableEntity {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update move task order unprocessable entity response
+func (o *UpdateMoveTaskOrderUnprocessableEntity) SetPayload(payload *ghcmessages.ValidationError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateMoveTaskOrderUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(422)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // UpdateMoveTaskOrderInternalServerErrorCode is the HTTP code returned for type UpdateMoveTaskOrderInternalServerError
 const UpdateMoveTaskOrderInternalServerErrorCode int = 500
 

--- a/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/move_task_order/update_move_task_order_status_responses.go
@@ -309,6 +309,50 @@ func (o *UpdateMoveTaskOrderStatusPreconditionFailed) WriteResponse(rw http.Resp
 	}
 }
 
+// UpdateMoveTaskOrderStatusUnprocessableEntityCode is the HTTP code returned for type UpdateMoveTaskOrderStatusUnprocessableEntity
+const UpdateMoveTaskOrderStatusUnprocessableEntityCode int = 422
+
+/*UpdateMoveTaskOrderStatusUnprocessableEntity Validation error
+
+swagger:response updateMoveTaskOrderStatusUnprocessableEntity
+*/
+type UpdateMoveTaskOrderStatusUnprocessableEntity struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *ghcmessages.ValidationError `json:"body,omitempty"`
+}
+
+// NewUpdateMoveTaskOrderStatusUnprocessableEntity creates UpdateMoveTaskOrderStatusUnprocessableEntity with default headers values
+func NewUpdateMoveTaskOrderStatusUnprocessableEntity() *UpdateMoveTaskOrderStatusUnprocessableEntity {
+
+	return &UpdateMoveTaskOrderStatusUnprocessableEntity{}
+}
+
+// WithPayload adds the payload to the update move task order status unprocessable entity response
+func (o *UpdateMoveTaskOrderStatusUnprocessableEntity) WithPayload(payload *ghcmessages.ValidationError) *UpdateMoveTaskOrderStatusUnprocessableEntity {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update move task order status unprocessable entity response
+func (o *UpdateMoveTaskOrderStatusUnprocessableEntity) SetPayload(payload *ghcmessages.ValidationError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateMoveTaskOrderStatusUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(422)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // UpdateMoveTaskOrderStatusInternalServerErrorCode is the HTTP code returned for type UpdateMoveTaskOrderStatusInternalServerError
 const UpdateMoveTaskOrderStatusInternalServerErrorCode int = 500
 

--- a/pkg/gen/ghcapi/ghcoperations/mymove_api.go
+++ b/pkg/gen/ghcapi/ghcoperations/mymove_api.go
@@ -492,7 +492,7 @@ func (o *MymoveAPI) initHandlerCache() {
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/move-orders/{orderID}"] = order.NewGetOrder(o.context, o.OrderGetOrderHandler)
+	o.handlers["GET"]["/orders/{orderID}"] = order.NewGetOrder(o.context, o.OrderGetOrderHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
@@ -516,7 +516,7 @@ func (o *MymoveAPI) initHandlerCache() {
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/move-orders/{orderID}/move-task-orders"] = order.NewListMoveTaskOrders(o.context, o.OrderListMoveTaskOrdersHandler)
+	o.handlers["GET"]["/orders/{orderID}/move-task-orders"] = order.NewListMoveTaskOrders(o.context, o.OrderListMoveTaskOrdersHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
@@ -544,7 +544,7 @@ func (o *MymoveAPI) initHandlerCache() {
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/move-orders/{orderID}"] = order.NewUpdateOrder(o.context, o.OrderUpdateOrderHandler)
+	o.handlers["PATCH"]["/orders/{orderID}"] = order.NewUpdateOrder(o.context, o.OrderUpdateOrderHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}

--- a/pkg/gen/ghcapi/ghcoperations/order/get_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/get_order.go
@@ -29,7 +29,7 @@ func NewGetOrder(ctx *middleware.Context, handler GetOrderHandler) *GetOrder {
 	return &GetOrder{Context: ctx, Handler: handler}
 }
 
-/*GetOrder swagger:route GET /move-orders/{orderID} order getOrder
+/*GetOrder swagger:route GET /orders/{orderID} order getOrder
 
 Gets an order by ID
 

--- a/pkg/gen/ghcapi/ghcoperations/order/get_order_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/get_order_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetOrderURL) SetBasePath(bp string) {
 func (o *GetOrderURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/move-orders/{orderID}"
+	var _path = "/orders/{orderID}"
 
 	orderID := o.OrderID.String()
 	if orderID != "" {

--- a/pkg/gen/ghcapi/ghcoperations/order/list_move_task_orders.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/list_move_task_orders.go
@@ -29,7 +29,7 @@ func NewListMoveTaskOrders(ctx *middleware.Context, handler ListMoveTaskOrdersHa
 	return &ListMoveTaskOrders{Context: ctx, Handler: handler}
 }
 
-/*ListMoveTaskOrders swagger:route GET /move-orders/{orderID}/move-task-orders order listMoveTaskOrders
+/*ListMoveTaskOrders swagger:route GET /orders/{orderID}/move-task-orders order listMoveTaskOrders
 
 Gets move task orders associated with an order
 

--- a/pkg/gen/ghcapi/ghcoperations/order/list_move_task_orders_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/list_move_task_orders_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *ListMoveTaskOrdersURL) SetBasePath(bp string) {
 func (o *ListMoveTaskOrdersURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/move-orders/{orderID}/move-task-orders"
+	var _path = "/orders/{orderID}/move-task-orders"
 
 	orderID := o.OrderID.String()
 	if orderID != "" {

--- a/pkg/gen/ghcapi/ghcoperations/order/update_order.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_order.go
@@ -29,7 +29,7 @@ func NewUpdateOrder(ctx *middleware.Context, handler UpdateOrderHandler) *Update
 	return &UpdateOrder{Context: ctx, Handler: handler}
 }
 
-/*UpdateOrder swagger:route PATCH /move-orders/{orderID} order updateOrder
+/*UpdateOrder swagger:route PATCH /orders/{orderID} order updateOrder
 
 Updates an order
 

--- a/pkg/gen/ghcapi/ghcoperations/order/update_order_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_order_responses.go
@@ -267,6 +267,50 @@ func (o *UpdateOrderPreconditionFailed) WriteResponse(rw http.ResponseWriter, pr
 	}
 }
 
+// UpdateOrderUnprocessableEntityCode is the HTTP code returned for type UpdateOrderUnprocessableEntity
+const UpdateOrderUnprocessableEntityCode int = 422
+
+/*UpdateOrderUnprocessableEntity Validation error
+
+swagger:response updateOrderUnprocessableEntity
+*/
+type UpdateOrderUnprocessableEntity struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *ghcmessages.ValidationError `json:"body,omitempty"`
+}
+
+// NewUpdateOrderUnprocessableEntity creates UpdateOrderUnprocessableEntity with default headers values
+func NewUpdateOrderUnprocessableEntity() *UpdateOrderUnprocessableEntity {
+
+	return &UpdateOrderUnprocessableEntity{}
+}
+
+// WithPayload adds the payload to the update order unprocessable entity response
+func (o *UpdateOrderUnprocessableEntity) WithPayload(payload *ghcmessages.ValidationError) *UpdateOrderUnprocessableEntity {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the update order unprocessable entity response
+func (o *UpdateOrderUnprocessableEntity) SetPayload(payload *ghcmessages.ValidationError) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *UpdateOrderUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(422)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // UpdateOrderInternalServerErrorCode is the HTTP code returned for type UpdateOrderInternalServerError
 const UpdateOrderInternalServerErrorCode int = 500
 

--- a/pkg/gen/ghcapi/ghcoperations/order/update_order_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/order/update_order_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UpdateOrderURL) SetBasePath(bp string) {
 func (o *UpdateOrderURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/move-orders/{orderID}"
+	var _path = "/orders/{orderID}"
 
 	orderID := o.OrderID.String()
 	if orderID != "" {

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -1,6 +1,7 @@
 package ghcapi
 
 import (
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
@@ -77,7 +78,8 @@ func (h UpdateMoveTaskOrderStatusHandlerFunc) Handle(params movetaskorderops.Upd
 		case services.NotFoundError:
 			return movetaskorderops.NewUpdateMoveTaskOrderStatusNotFound()
 		case services.InvalidInputError:
-			return movetaskorderops.NewUpdateMoveTaskOrderStatusBadRequest()
+			payload := payloadForValidationError("Unable to complete request", err.Error(), h.GetTraceID(), validate.NewErrors())
+			return movetaskorderops.NewUpdateMoveTaskOrderStatusUnprocessableEntity().WithPayload(payload)
 		case services.PreconditionFailedError:
 			return movetaskorderops.NewUpdateMoveTaskOrderStatusPreconditionFailed().WithPayload(&ghcmessages.Error{Message: handlers.FmtString(err.Error())})
 		case services.ConflictError:

--- a/pkg/handlers/ghcapi/order_test.go
+++ b/pkg/handlers/ghcapi/order_test.go
@@ -163,7 +163,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerIntegration() {
 		OrdersNumber:         handlers.FmtString("ORDER100"),
 		NewDutyStationID:     handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID:  handlers.FmtUUID(originDutyStation.ID),
-		Tac:                  handlers.FmtString("ABC1"),
+		Tac:                  handlers.FmtString("E19A"),
 		Sac:                  handlers.FmtString("987654321"),
 	}
 
@@ -226,7 +226,7 @@ func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
-		Tac:                 handlers.FmtString("ABC1"),
+		Tac:                 handlers.FmtString("E19A"),
 		Sac:                 handlers.FmtString("987654321"),
 	}
 
@@ -279,7 +279,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerNotFound() {
 			OrdersNumber:        handlers.FmtString("ORDER100"),
 			NewDutyStationID:    handlers.FmtUUID(uuid.Nil),
 			OriginDutyStationID: handlers.FmtUUID(uuid.Nil),
-			Tac:                 handlers.FmtString("ABC1"),
+			Tac:                 handlers.FmtString("E19A"),
 			Sac:                 handlers.FmtString("987654321"),
 		},
 	}
@@ -317,7 +317,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerPreconditionsFailed() {
 		OrdersNumber:        handlers.FmtString("ORDER100"),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
-		Tac:                 handlers.FmtString("ABC1"),
+		Tac:                 handlers.FmtString("E19A"),
 		Sac:                 handlers.FmtString("987654321"),
 	}
 
@@ -418,7 +418,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithoutTac() {
 		Sac:                 handlers.FmtString("987654321"),
 	}
 
-	request := httptest.NewRequest("PATCH", "/updatedOrder.OrdersNumber/{orderID}", nil)
+	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
 
 	suite.Run("When Move is still in draft status, TAC can be nil", func() {
 		params := orderop.UpdateOrderParams{
@@ -475,7 +475,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithoutTac() {
 		invalidResponse := response.(*orderop.UpdateOrderUnprocessableEntity).Payload
 		errorDetail := invalidResponse.Detail
 
-		suite.Contains(*errorDetail, "TAC cannot be empty.")
+		suite.Contains(*errorDetail, "TransportationAccountingCode cannot be blank.")
 	})
 
 	suite.Run("TAC can only contain 4 alphanumeric characters", func() {

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -41,7 +41,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 		NewDutyStationID:    handlers.FmtUUID(station.ID),
 		ServiceMemberID:     handlers.FmtUUID(sm.ID),
 		OrdersNumber:        handlers.FmtString("123456"),
-		Tac:                 handlers.FmtString("ABC1"),
+		Tac:                 handlers.FmtString("E19A"),
 		Sac:                 handlers.FmtString("SacNumber"),
 		DepartmentIndicator: &deptIndicator,
 	}
@@ -67,7 +67,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 	suite.Assertions.Len(okResponse.Payload.Moves, 1)
 	suite.Assertions.Equal(ordersType, okResponse.Payload.OrdersType)
 	suite.Assertions.Equal(handlers.FmtString("123456"), okResponse.Payload.OrdersNumber)
-	suite.Assertions.Equal(handlers.FmtString("ABC1"), okResponse.Payload.Tac)
+	suite.Assertions.Equal(handlers.FmtString("E19A"), okResponse.Payload.Tac)
 	suite.Assertions.Equal(handlers.FmtString("SacNumber"), okResponse.Payload.Sac)
 	suite.Assertions.Equal(&deptIndicator, okResponse.Payload.DepartmentIndicator)
 	suite.Equal(sm.DutyStationID, createdOrder.OriginDutyStationID)

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -41,7 +41,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 		NewDutyStationID:    handlers.FmtUUID(station.ID),
 		ServiceMemberID:     handlers.FmtUUID(sm.ID),
 		OrdersNumber:        handlers.FmtString("123456"),
-		Tac:                 handlers.FmtString("TacNumber"),
+		Tac:                 handlers.FmtString("ABC1"),
 		Sac:                 handlers.FmtString("SacNumber"),
 		DepartmentIndicator: &deptIndicator,
 	}
@@ -67,7 +67,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 	suite.Assertions.Len(okResponse.Payload.Moves, 1)
 	suite.Assertions.Equal(ordersType, okResponse.Payload.OrdersType)
 	suite.Assertions.Equal(handlers.FmtString("123456"), okResponse.Payload.OrdersNumber)
-	suite.Assertions.Equal(handlers.FmtString("TacNumber"), okResponse.Payload.Tac)
+	suite.Assertions.Equal(handlers.FmtString("ABC1"), okResponse.Payload.Tac)
 	suite.Assertions.Equal(handlers.FmtString("SacNumber"), okResponse.Payload.Sac)
 	suite.Assertions.Equal(&deptIndicator, okResponse.Payload.DepartmentIndicator)
 	suite.Equal(sm.DutyStationID, createdOrder.OriginDutyStationID)

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -251,7 +251,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 			OrdersType:       "PERMANENT_CHANGE_OF_STATION",
 			UploadedOrdersID: handlers.FmtUUID(document.ID),
 			Status:           (supportmessages.OrdersStatus)(models.OrderStatusDRAFT),
-			Tac:              swag.String("47475"),
+			Tac:              swag.String("ABC1"),
 		},
 	}
 

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -251,7 +251,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 			OrdersType:       "PERMANENT_CHANGE_OF_STATION",
 			UploadedOrdersID: handlers.FmtUUID(document.ID),
 			Status:           (supportmessages.OrdersStatus)(models.OrderStatusDRAFT),
-			Tac:              swag.String("ABC1"),
+			Tac:              swag.String("E19A"),
 		},
 	}
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -645,7 +645,9 @@ func SaveMoveDependencies(db *pop.Connection, move *Move) (*validate.Errors, err
 			}
 		}
 
-		if verrs, err := db.ValidateAndSave(&move.Orders); verrs.HasAny() || err != nil {
+		order := &move.Orders
+		db.Load(&order, "Moves")
+		if verrs, err := db.ValidateAndSave(order); verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error Saving Orders")
 			return transactionError

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -27,6 +27,99 @@ func (suite *ModelSuite) TestBasicOrderInstantiation() {
 	suite.verifyValidationErrors(order, expErrors)
 }
 
+func (suite *ModelSuite) TestTacNotNilAfterSubmission() {
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	order := move.Orders
+	order.TAC = nil
+	err := move.Submit(time.Now())
+	if err != nil {
+		suite.T().Fatal("Should transition.")
+	}
+	suite.MustSave(&move)
+	suite.DB().Load(&order, "Moves")
+
+	expErrors := map[string][]string{
+		"transportation_accounting_code": {"TransportationAccountingCode cannot be blank."},
+	}
+
+	suite.verifyValidationErrors(&order, expErrors)
+}
+
+func (suite *ModelSuite) TestOrdersNumberPresenceAfterSubmission() {
+	invalidCases := []struct {
+		desc  string
+		value *string
+	}{
+		{"EmptyString", swag.String("")},
+		{"Nil", nil},
+	}
+	for _, invalidCase := range invalidCases {
+		move := testdatagen.MakeDefaultMove(suite.DB())
+		order := move.Orders
+		order.OrdersNumber = invalidCase.value
+		err := move.Submit(time.Now())
+		if err != nil {
+			suite.T().Fatal("Should transition.")
+		}
+		suite.MustSave(&move)
+		suite.DB().Load(&order, "Moves")
+
+		expErrors := map[string][]string{
+			"orders_number": {"OrdersNumber cannot be blank."},
+		}
+
+		suite.verifyValidationErrors(&order, expErrors)
+	}
+}
+
+func (suite *ModelSuite) TestOrdersTypeDetailPresenceAfterSubmission() {
+	emptyString := internalmessages.OrdersTypeDetail("")
+
+	invalidCases := []struct {
+		desc  string
+		value *internalmessages.OrdersTypeDetail
+	}{
+		{"EmptyString", &emptyString},
+		{"Nil", nil},
+	}
+	for _, invalidCase := range invalidCases {
+		move := testdatagen.MakeDefaultMove(suite.DB())
+		order := move.Orders
+
+		order.OrdersTypeDetail = invalidCase.value
+		err := move.Submit(time.Now())
+		if err != nil {
+			suite.T().Fatal("Should transition.")
+		}
+		suite.MustSave(&move)
+		suite.DB().Load(&order, "Moves")
+
+		expErrors := map[string][]string{
+			"orders_type_detail": {"OrdersTypeDetail cannot be blank."},
+		}
+
+		suite.verifyValidationErrors(&order, expErrors)
+	}
+}
+
+func (suite *ModelSuite) TestDepartmentIndicatorNotNilAfterSubmission() {
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	order := move.Orders
+	order.DepartmentIndicator = nil
+	err := move.Submit(time.Now())
+	if err != nil {
+		suite.T().Fatal("Should transition.")
+	}
+	suite.MustSave(&move)
+	suite.DB().Load(&order, "Moves")
+
+	expErrors := map[string][]string{
+		"department_indicator": {"DepartmentIndicator cannot be blank."},
+	}
+
+	suite.verifyValidationErrors(&order, expErrors)
+}
+
 func (suite *ModelSuite) TestFetchOrderForUser() {
 
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -38,31 +38,38 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 	searchParams := services.FetchMoveTaskOrderParams{
 		IncludeHidden: false,
 	}
-	mto, err := o.FetchMoveTaskOrder(moveTaskOrderID, &searchParams)
+	move, err := o.FetchMoveTaskOrder(moveTaskOrderID, &searchParams)
 	if err != nil {
 		return &models.Move{}, err
 	}
 
-	if mto.AvailableToPrimeAt == nil {
-		// update field for mto
-		now := time.Now()
-		mto.AvailableToPrimeAt = &now
+	// Fail early if the Order is invalid due to missing required fields
+	order := move.Orders
+	o.db.Load(&order, "Moves")
+	if verrs, err = o.db.ValidateAndUpdate(&order); verrs.HasAny() || err != nil {
+		return &models.Move{}, services.NewInvalidInputError(move.ID, nil, verrs, "")
+	}
 
-		if mto.Status == models.MoveStatusSUBMITTED {
-			err = mto.Approve()
+	if move.AvailableToPrimeAt == nil {
+		// update field for move
+		now := time.Now()
+		move.AvailableToPrimeAt = &now
+
+		if move.Status == models.MoveStatusSUBMITTED {
+			err = move.Approve()
 			if err != nil {
-				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
 			}
 		}
 
-		verrs, err = o.builder.UpdateOne(mto, &eTag)
+		verrs, err = o.builder.UpdateOne(move, &eTag)
 		if verrs != nil && verrs.HasAny() {
-			return &models.Move{}, services.NewInvalidInputError(mto.ID, nil, verrs, "")
+			return &models.Move{}, services.NewInvalidInputError(move.ID, nil, verrs, "")
 		}
 		if err != nil {
 			switch err.(type) {
 			case query.StaleIdentifierError:
-				return nil, services.NewPreconditionFailedError(mto.ID, err)
+				return nil, services.NewPreconditionFailedError(move.ID, err)
 			default:
 				return &models.Move{}, err
 			}
@@ -84,7 +91,7 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 
 		if err != nil {
 			if errors.Is(err, models.ErrInvalidTransition) {
-				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
 			}
 			return &models.Move{}, err
 		}
@@ -105,7 +112,7 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 
 		if err != nil {
 			if errors.Is(err, models.ErrInvalidTransition) {
-				return &models.Move{}, services.NewConflictError(mto.ID, err.Error())
+				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
 			}
 			return &models.Move{}, err
 		}
@@ -113,15 +120,15 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 			return &models.Move{}, verrs
 		}
 
-		// CreateMTOServiceItem may have updated the mto status so refetch as to not return incorrect status
+		// CreateMTOServiceItem may have updated the move status so refetch as to not return incorrect status
 		// TODO: Modify CreateMTOServiceItem to return the updated move or refactor to operate on the passed in reference
-		mto, err = o.FetchMoveTaskOrder(moveTaskOrderID, nil)
+		move, err = o.FetchMoveTaskOrder(moveTaskOrderID, nil)
 		if err != nil {
 			return &models.Move{}, err
 		}
 	}
 
-	return mto, nil
+	return move, nil
 }
 
 // UpdateMoveTaskOrderQueryBuilder is the query builder for updating MTO

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -44,13 +44,6 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 		document.UserUploads = append(document.UserUploads, u)
 	}
 
-	// orderNumber := "ORDER3"
-	// ordersNumber := assertions.Order.OrdersNumber
-	// if ordersNumber != nil || ordersNumber != ""{
-	// 	 orderNumber = *ordersNumber
-	// }
-	// ordersNumber := orderNumber
-
 	defaultOrderNumber := "ORDER3"
 	ordersNumber := assertions.Order.OrdersNumber
 	if ordersNumber == nil {

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -191,7 +191,7 @@ func createPPMWithPaymentRequest(db *pop.Connection, userUploader *uploader.User
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("ABC1"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("0a2580ef-180a-44b2-a40b-291fa9cc13cc"),
@@ -685,7 +685,7 @@ func createPPMReadyToRequestPayment(db *pop.Connection, userUploader *uploader.U
 			OrdersNumber:        models.StringPointer("62149"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("ABC1"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("f9f10492-587e-43b3-af2a-9f67d2ac8757"),

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -135,7 +135,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 	ppm0.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &ppm0.Move)
+	verrs, err := models.SaveMoveDependencies(db, &ppm0.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with uploaded orders, a new ppm and no advance
@@ -170,7 +173,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 	ppmNoAdvance.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &ppmNoAdvance.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmNoAdvance.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * office user finds the move: office user completes storage panel
@@ -208,7 +214,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppmStorage.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppmStorage.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppmStorage.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmStorage.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmStorage.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * office user finds the move: office user cancels storage panel
@@ -246,7 +255,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppmNoStorage.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppmNoStorage.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppmNoStorage.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmNoStorage.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmNoStorage.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * A move, that will be canceled by the E2E test
@@ -281,7 +293,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 	ppmToCancel.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &ppmToCancel.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmToCancel.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm in progress
@@ -318,7 +333,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	})
 	ppm1.Move.Submit(time.Now())
 	ppm1.Move.Approve()
-	models.SaveMoveDependencies(db, &ppm1.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm1.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm move with payment requested
@@ -350,7 +368,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("ABC1"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("0a2580ef-180a-44b2-a40b-291fa9cc13cc"),
@@ -367,7 +385,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppm2.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm2.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppm2.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppm2.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm2.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm move that has requested payment
@@ -401,7 +422,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &moveTypeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("d6b8980d-6f88-41be-9ae2-1abcbd2574bc"),
@@ -434,7 +455,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppm3.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm3.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppm3.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppm3.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm3.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm move that has requested payment
@@ -469,7 +493,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &moveTypeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("687e3ee4-62ff-44b3-a5cb-73338c9fdf95"),
@@ -490,7 +514,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppmExcludedCalculations.Move.PersonallyProcuredMoves[0].RequestPayment()
-	models.SaveMoveDependencies(db, &ppmExcludedCalculations.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmExcludedCalculations.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	testdatagen.MakeMoveDocument(db, testdatagen.Assertions{
 		MoveDocument: models.MoveDocument{
@@ -546,9 +573,15 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 	ppmCanceled.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &ppmCanceled.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmCanceled.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 	ppmCanceled.Move.Cancel("reasons")
-	models.SaveMoveDependencies(db, &ppmCanceled.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmCanceled.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with orders and a move
@@ -708,7 +741,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 
 	move.PersonallyProcuredMoves = models.PersonallyProcuredMoves{ppm}
 	move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &move)
+	verrs, err = models.SaveMoveDependencies(db, &move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * A service member with an hhg only, unsubmitted move
@@ -929,7 +965,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62149"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("f9f10492-587e-43b3-af2a-9f67d2ac8757"),
@@ -944,7 +980,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppm6.Move.Approve()
 	ppm6.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm6.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppm6.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm6.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm ready to request payment
@@ -974,7 +1013,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62149"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("0581253d-0539-4a93-b1b6-ea4ad384f0c5"),
@@ -989,7 +1028,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	ppm7.Move.Approve()
 	ppm7.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm7.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppm7.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm7.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm ready to request payment
@@ -1019,7 +1061,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62341"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("946a5d40-0636-418f-b457-474915fb0149"),
@@ -1035,7 +1077,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	// This is the same PPM model as ppm5, but this is the one that will be saved by SaveMoveDependencies
 	ppm5.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppm5.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppm5.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppm5.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Service member with a ppm move approved, but not in progress
@@ -1067,7 +1112,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetails,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("4EVR"),
+			TAC:                 models.StringPointer("E19A"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("bd3d46b3-cb76-40d5-a622-6ada239e5504"),
@@ -1083,7 +1128,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	// This is the same PPM model as ppm2, but this is the one that will be saved by SaveMoveDependencies
 	ppmApproved.Move.PersonallyProcuredMoves[0].Submit(time.Now())
 	ppmApproved.Move.PersonallyProcuredMoves[0].Approve(time.Now())
-	models.SaveMoveDependencies(db, &ppmApproved.Move)
+	verrs, err = models.SaveMoveDependencies(db, &ppmApproved.Move)
+	if err != nil || verrs.HasAny() {
+		log.Panic(fmt.Errorf("Failed to save move and dependencies: %w", err))
+	}
 
 	/*
 	 * Another service member with orders and a move
@@ -1402,7 +1450,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 
 	// Creates custom test.jpg prime upload
 	file := testdatagen.Fixture("test.jpg")
-	_, verrs, err := primeUploader.CreatePrimeUploadForDocument(&posImage.ID, primeContractor, uploader.File{File: file}, uploader.AllowedTypesPaymentRequest)
+	_, verrs, err = primeUploader.CreatePrimeUploadForDocument(&posImage.ID, primeContractor, uploader.File{File: file}, uploader.AllowedTypesPaymentRequest)
 	if verrs.HasAny() || err != nil {
 		logger.Error("errors encountered saving test.jpg prime upload", zap.Error(err))
 	}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -350,7 +350,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("ABC1"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("0a2580ef-180a-44b2-a40b-291fa9cc13cc"),
@@ -401,7 +401,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &moveTypeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("d6b8980d-6f88-41be-9ae2-1abcbd2574bc"),
@@ -469,7 +469,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &moveTypeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("687e3ee4-62ff-44b3-a5cb-73338c9fdf95"),
@@ -929,7 +929,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62149"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("f9f10492-587e-43b3-af2a-9f67d2ac8757"),
@@ -974,7 +974,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62149"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("0581253d-0539-4a93-b1b6-ea4ad384f0c5"),
@@ -1019,7 +1019,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("62341"),
 			OrdersTypeDetail:    &typeDetail,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("946a5d40-0636-418f-b457-474915fb0149"),
@@ -1067,7 +1067,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetails,
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
+			TAC:                 models.StringPointer("4EVR"),
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("bd3d46b3-cb76-40d5-a622-6ada239e5504"),

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -202,12 +202,12 @@ printf "\n==========\n\n"
 
 # Find MTO By MTO ID
 if jq -e 'map(select(.id == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
-  echo "Found by Move Task Order ID"
+  echo "Found by Move ID"
 # Find MTO By orderID
 elif jq -e 'map(select(.orderID == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
   # extract the mtoid
   mtoid=$(jq '.id' tmp/pad_demo_mto.json | tr -d '"')
-  echo "Found by Move ID."
+  echo "Found by Order ID."
 # Find MTO by moveCode aka locator
 elif jq -e 'map(select(.moveCode == "'"${mtoid}"'")) | .[0]' tmp/pad_all_mtos.json > tmp/pad_demo_mto.json; then
   # extract the mtoid

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -104,7 +104,7 @@ paths:
       description: Returns a given move for a unique alphanumeric locator string
       summary: Returns a given move
       operationId: getMove
-  '/move-orders/{orderID}':
+  '/orders/{orderID}':
     parameters:
       - description: ID of order to use
         in: path
@@ -157,6 +157,10 @@ paths:
           description: Precondition failed
           schema:
             $ref: '#/responses/PreconditionFailed'
+        '422':
+          description: Validation error
+          schema:
+            $ref: '#/definitions/ValidationError'
         '500':
           description: internal server error
     get:
@@ -193,7 +197,7 @@ paths:
       description: Gets an order
       operationId: getOrder
       summary: Gets an order by ID
-  '/move-orders/{orderID}/move-task-orders':
+  '/orders/{orderID}/move-task-orders':
     parameters:
       - description: ID of order to use
         in: path

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -354,6 +354,10 @@ paths:
           description: Precondition failed
           schema:
             $ref: '#/responses/PreconditionFailed'
+        '422':
+          description: Validation error
+          schema:
+            $ref: '#/definitions/ValidationError'
         '500':
           description: A server error occurred
           schema:
@@ -776,6 +780,10 @@ paths:
           description: Precondition Failed
           schema:
             $ref: '#/responses/PreconditionFailed'
+        '422':
+          description: Validation error
+          schema:
+            $ref: '#/definitions/ValidationError'
         '500':
           description: A server error occurred
           schema:


### PR DESCRIPTION
## Description

A move cannot be approved unless the following fields are present
on the Order:

* TAC
* OrdersNumber
* DepartmentIndicator
* OrdersTypeDetail

There are other required Order fields, but those are required for the 
initial creation of the Order, so for this PR, we are only validating the 
fields that are initially optional, but need to be filled in before the TOO 
can approve the Move.

We also want to validate that the TAC must be exactly four 
alphanumeric characters.

To prevent the Move approval, we add an early check in 
`MakeAvailableToPrime` to see if the Order is valid.

To make sure the Order is valid, we add new model validations that
only run if the Move's status is no longer `DRAFT`.

Since I was touching code related to orders and moves, and in the
spirit of leaving code better than I found it, I also did some more
renaming of "move orders" to "orders" and "move task order" to
"move"

## Reviewer Notes

Please see if I missed any test cases.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7015) for this change