### PR TITLE
Webhook subscription edit page: make name a string

### DIFF
--- a/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionEdit.jsx
+++ b/src/pages/Admin/WebhookSubscriptions/WebhookSubscriptionEdit.jsx
@@ -20,11 +20,11 @@ const WebhookSubscriptionEdit = (props) => (
       <SelectInput
         source="severity"
         choices={[
-          { id: 0, name: 0 },
-          { id: 1, name: 1 },
-          { id: 2, name: 2 },
-          { id: 3, name: 3 },
-          { id: 4, name: 4 },
+          { id: 0, name: '0' },
+          { id: 1, name: '1' },
+          { id: 2, name: '2' },
+          { id: 3, name: '3' },
+          { id: 4, name: '4' },
         ]}
       />
       <SelectInput


### PR DESCRIPTION
## Description

The integration tests were failing to pull up the webhook subscription page. To fix this the name values for a select were changes from int to string.

## Reviewer Notes

Why didn't the tests fail initially on the feature branch? 

## Setup

`make e2e_test`

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

