### PR TITLE
MB-4744 Add tag indicating pending service item approvals to move task order page

### DIFF
--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -52,7 +52,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   const [selectedServiceItem, setSelectedServiceItem] = useState(undefined);
   const [sections, setSections] = useState([]);
   const [activeSection, setActiveSection] = useState('');
-  const [unapprovedServiceItemsForShipment, setUnapprovedServiceItemsForShipment] = useState(new Map());
+  const [unapprovedServiceItemsForShipment, setUnapprovedServiceItemsForShipment] = useState({});
 
   const { moveCode } = match.params;
   const { setUnapprovedShipmentCount, setUnapprovedServiceItemCount, setMessage } = props;
@@ -180,14 +180,14 @@ export const MoveTaskOrder = ({ match, ...props }) => {
 
   useEffect(() => {
     let serviceItemCount = 0;
-    const serviceItemsCountForShipment = new Map();
+    const serviceItemsCountForShipment = {};
     mtoShipments?.forEach((mtoShipment) => {
       if (mtoShipment.status === shipmentStatuses.APPROVED) {
         const requestedServiceItemCount = shipmentServiceItems[`${mtoShipment.id}`]?.filter(
           (serviceItem) => serviceItem.status === SERVICE_ITEM_STATUSES.SUBMITTED,
         )?.length;
         serviceItemCount += requestedServiceItemCount || 0;
-        serviceItemsCountForShipment.set(mtoShipment.id, requestedServiceItemCount);
+        serviceItemsCountForShipment[`${mtoShipment.id}`] = requestedServiceItemCount;
       }
     });
     setUnapprovedServiceItemCount(serviceItemCount);
@@ -283,8 +283,8 @@ export const MoveTaskOrder = ({ match, ...props }) => {
             return (
               <a key={`sidenav_${s.id}`} href={`#shipment-${s.id}`} className={classes}>
                 {s.label}{' '}
-                {unapprovedServiceItemsForShipment.get(s.id) > 0 && (
-                  <Tag>{unapprovedServiceItemsForShipment.get(s.id)}</Tag>
+                {unapprovedServiceItemsForShipment[`${s.id}`] > 0 && (
+                  <Tag>{unapprovedServiceItemsForShipment[`${s.id}`]}</Tag>
                 )}
               </a>
             );

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -474,9 +474,11 @@ describe('MoveTaskOrder', () => {
 
       const navLinks = wrapper.find('LeftNav a');
       expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(0).contains('1'));
       expect(navLinks.at(0).prop('href')).toBe('#shipment-3');
 
       expect(navLinks.at(1).contains('NTS shipment')).toBe(true);
+      expect(navLinks.at(1).contains('1'));
       expect(navLinks.at(1).prop('href')).toBe('#shipment-4');
 
       expect(navLinks.at(2).contains('NTS-R shipment')).toBe(true);


### PR DESCRIPTION
## Description

Adds a visual cue to the move task order page informing the TOO of how many service items there are awaiting approval per shipment.

## Setup

Get your office app up and running

```sh
make server_run
make office_client_run
make db_dev_e2e_populate
```

Get a move into a state where there's a some service items on a shipment that need approval. One easy way to do that is to approve a new move and then go into the DB and flip the status over to SUBMITTED for a couple of them. Alternatively you can simulate the Prime requesting one using this tool: https://github.com/transcom/mymove/wiki/How-to-Test-the-Prime-API-(Local,-Staging,-and-Experimental)

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/4325613/112198799-ddcd7a00-8be3-11eb-9ab0-20971d62dbb7.png">

