### PR TITLE
[MB-7053] Add domestic shorthaul support to service items calculator

### DIFF
--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
@@ -28,3 +28,16 @@ export const SmallTable = () => (
     tableSize="small"
   />
 );
+
+export const LargeDSHTable = () => (
+  <ServiceItemCalculations serviceItemParams={testParams.DomesticShortHaul} totalAmountRequested={642} itemCode="DSH" />
+);
+
+export const SmallDSHTable = () => (
+  <ServiceItemCalculations
+    serviceItemParams={testParams.DomesticShortHaul}
+    totalAmountRequested={642}
+    itemCode="DSH"
+    tableSize="small"
+  />
+);

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -58,7 +58,7 @@ const mileageZip5 = (params) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.DistanceZip5, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.Mileage;
   const detail = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress]} ${getParamValue(
-    SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress, // take the zip 3
+    SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress,
     params,
   )} to ${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipDestAddress]} ${getParamValue(
     SERVICE_ITEM_PARAM_KEYS.ZipDestAddress,

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -54,9 +54,41 @@ const mileage = (params) => {
   return calculation(value, label, detail);
 };
 
+const mileageZip5 = (params) => {
+  const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.DistanceZip5, params);
+  const label = SERVICE_ITEM_CALCULATION_LABELS.Mileage;
+  const detail = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress]} ${getParamValue(
+    SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress, // take the zip 3
+    params,
+  )} to ${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipDestAddress]} ${getParamValue(
+    SERVICE_ITEM_PARAM_KEYS.ZipDestAddress,
+    params,
+  )}`;
+
+  return calculation(value, label, detail);
+};
+
 const baselineLinehaulPrice = (params) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.PriceRateOrFactor, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.BaselineLinehaulPrice;
+  const detail1 = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.IsPeak]} ${
+    getParamValue(SERVICE_ITEM_PARAM_KEYS.IsPeak, params)?.toLowerCase() === 'true' ? 'peak' : 'non-peak'
+  }`;
+  const detail2 = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ServiceAreaOrigin]}: ${getParamValue(
+    SERVICE_ITEM_PARAM_KEYS.ServiceAreaOrigin,
+    params,
+  )}`;
+  const detail3 = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate]}: ${formatDate(
+    getParamValue(SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate, params),
+    'DD MMM YYYY',
+  )}`;
+
+  return calculation(value, label, detail1, detail2, detail3);
+};
+
+const baselineShorthaulPrice = (params) => {
+  const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.PriceRateOrFactor, params);
+  const label = SERVICE_ITEM_CALCULATION_LABELS.BaselineShorthaulPrice;
   const detail1 = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.IsPeak]} ${
     getParamValue(SERVICE_ITEM_PARAM_KEYS.IsPeak, params)?.toLowerCase() === 'true' ? 'peak' : 'non-peak'
   }`;
@@ -125,6 +157,16 @@ const makeCalculations = (itemCode, totalAmount, params) => {
         billableWeightFSC(params),
         mileage(params),
         fuelSurchargePrice(params),
+        totalAmountRequested(totalAmount),
+      ];
+      break;
+    // Domestic shorthaul
+    case SERVICE_ITEM_CODES.DSH:
+      result = [
+        billableWeight(params),
+        mileageZip5(params),
+        baselineShorthaulPrice(params),
+        priceEscalationFactor(params),
         totalAmountRequested(totalAmount),
       ];
       break;

--- a/src/constants/serviceItems.js
+++ b/src/constants/serviceItems.js
@@ -10,6 +10,7 @@ const SERVICE_ITEM_PARAM_KEYS = {
   WeightActual: 'WeightActual',
   WeightEstimated: 'WeightEstimated',
   DistanceZip3: 'DistanceZip3',
+  DistanceZip5: 'DistanceZip5',
   ZipDestAddress: 'ZipDestAddress',
   ZipPickupAddress: 'ZipPickupAddress',
   PriceRateOrFactor: 'PriceRateOrFactor',
@@ -26,6 +27,7 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   BillableWeight: 'Billable weight (cwt)',
   Mileage: 'Mileage',
   BaselineLinehaulPrice: 'Baseline linehaul price',
+  BaselineShorthaulPrice: 'Baseline shorthaul price',
   PriceEscalationFactor: 'Price escalation factor',
   TotalAmountRequested: 'Total amount requested',
   FuelSurchargePrice: 'Fuel surcharge price (per mi)',
@@ -46,10 +48,11 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
 const SERVICE_ITEM_CODES = {
   DLH: 'DLH',
   FSC: 'FSC',
+  DSH: 'DSH',
 };
 
 // TODO - temporary, will remove once all service item calculations are implemented
-const allowedServiceItemCalculations = [SERVICE_ITEM_CODES.DLH, SERVICE_ITEM_CODES.FSC];
+const allowedServiceItemCalculations = [SERVICE_ITEM_CODES.DLH, SERVICE_ITEM_CODES.FSC, SERVICE_ITEM_CODES.DSH];
 
 export {
   SERVICE_ITEM_STATUSES as default,


### PR DESCRIPTION
## Description

Add pricing details for Domestic shorthaul.

## Reviewer Notes

I'm fairly sure `PriceRateOrFactor` and `EscalationCompounded` params aren't implemented yet, so the baseline shorthaul price and price escalation factors are blank for now.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make client_run`

## Code Review Verification Steps

TIO role -> PARAMS move locator.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7053) for this change

## Screenshots

![Screen Shot 2021-03-24 at 7 36 29 PM](https://user-images.githubusercontent.com/3903208/112397331-43029780-8cd8-11eb-8332-45ef0d4070de.png)

