### PR TITLE
MB-6665 migration model for saving ICN

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -616,3 +616,4 @@
 20210224203932_add_transportation_accounting_codes.up.sql
 20210301215522_add_cancellation_requested_shipment_status.up.sql
 20210318162232_create_edi_processing_table.up.sql
+20210323204715_add_payment_request_to_interchange_control_number.up.sql

--- a/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
+++ b/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE payment_request_to_interchange_control_numbers
+(
+    id uuid primary key,
+    payment_request_id uuid NOT NULL,
+    interchange_control_number int NOT NULL,
+    constraint payment_request_id_interchange_control_number_unique_key unique (payment_request_id, interchange_control_number)
+)
+
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.id is 'The id of this record';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.payment_request_id is 'The id of the associated payment request';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.interchange_control_number is 'The interchange control number generated in the out going EDI 858 invoice';

--- a/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
+++ b/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
@@ -1,9 +1,10 @@
 CREATE TABLE payment_request_to_interchange_control_numbers
 (
     id uuid primary key,
-    payment_request_id uuid NOT NULL,
+    payment_request_id uuid NOT NULL
+        constraint payment_request_to_interchange_control_numbers_payment_request_id_fkey references payment_requests,
     interchange_control_number int NOT NULL,
-    constraint payment_request_id_interchange_control_number_unique_key unique (payment_request_id, interchange_control_number)
+    constraint payment_request_id_interchange_control_number_unique_key unique (interchange_control_number, payment_request_id)
 );
 
 COMMENT ON COLUMN payment_request_to_interchange_control_numbers.id IS 'The id of this record';

--- a/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
+++ b/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
@@ -4,8 +4,8 @@ CREATE TABLE payment_request_to_interchange_control_numbers
     payment_request_id uuid NOT NULL,
     interchange_control_number int NOT NULL,
     constraint payment_request_id_interchange_control_number_unique_key unique (payment_request_id, interchange_control_number)
-)
+);
 
-COMMENT ON COLUMN payment_request_to_interchange_control_numbers.id is 'The id of this record';
-COMMENT ON COLUMN payment_request_to_interchange_control_numbers.payment_request_id is 'The id of the associated payment request';
-COMMENT ON COLUMN payment_request_to_interchange_control_numbers.interchange_control_number is 'The interchange control number generated in the out going EDI 858 invoice';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.id IS 'The id of this record';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.payment_request_id IS 'The id of the associated payment request';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.interchange_control_number IS 'The interchange control number generated in the out going EDI 858 invoice';

--- a/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
+++ b/migrations/app/schema/20210323204715_add_payment_request_to_interchange_control_number.up.sql
@@ -2,11 +2,11 @@ CREATE TABLE payment_request_to_interchange_control_numbers
 (
     id uuid primary key,
     payment_request_id uuid NOT NULL
-        constraint payment_request_to_interchange_control_numbers_payment_request_id_fkey references payment_requests,
+        constraint payment_request_to_icns_payment_request_id_fkey references payment_requests,
     interchange_control_number int NOT NULL,
-    constraint payment_request_id_interchange_control_number_unique_key unique (interchange_control_number, payment_request_id)
+    constraint interchange_control_number_payment_request_id_unique_key unique (interchange_control_number, payment_request_id)
 );
 
 COMMENT ON COLUMN payment_request_to_interchange_control_numbers.id IS 'The id of this record';
 COMMENT ON COLUMN payment_request_to_interchange_control_numbers.payment_request_id IS 'The id of the associated payment request';
-COMMENT ON COLUMN payment_request_to_interchange_control_numbers.interchange_control_number IS 'The interchange control number generated in the out going EDI 858 invoice';
+COMMENT ON COLUMN payment_request_to_interchange_control_numbers.interchange_control_number IS 'The interchange control number (ICN) generated in the out going EDI 858 invoice';

--- a/pkg/models/payment_request_to_interchange_control_number.go
+++ b/pkg/models/payment_request_to_interchange_control_number.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
+)
+
+// PaymentRequestToInterchangeControlNumber is an object that links payment requests to an Interchange Control Number used in the EDI 858 invoice
+type PaymentRequestToInterchangeControlNumber struct {
+	ID                       uuid.UUID `db:"id"`
+	PaymentRequestID         uuid.UUID `db:"payment_request_id"`
+	InterchangeControlNumber int       `db:"interchange_control_number"`
+
+	// Associations
+	PaymentRequest PaymentRequest `belongs_to:"payment_requests"`
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (p *PaymentRequestToInterchangeControlNumber) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.UUIDIsPresent{Field: p.PaymentRequestID, Name: "PaymentRequestID"},
+		// minimum interchange control number must be greater than 0
+		&validators.IntIsGreaterThan{Field: p.InterchangeControlNumber, Name: "InterchangeControlNumber", Compared: 0},
+		// max interchange control number must be less than 1000000000
+		&validators.IntIsLessThan{Field: p.InterchangeControlNumber, Name: "InterchangeControlNumber", Compared: 1000000000},
+	), nil
+}

--- a/pkg/models/payment_request_to_interchange_control_number_test.go
+++ b/pkg/models/payment_request_to_interchange_control_number_test.go
@@ -1,0 +1,53 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ModelSuite) TestPaymentRequestToInterchangeControlNumber() {
+	suite.T().Run("test PaymentRequest association", func(t *testing.T) {
+		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{})
+		validPR2ICN := testdatagen.MakePaymentRequestToInterchangeControlNumber(suite.DB(), testdatagen.Assertions{
+			PaymentRequestToInterchangeControlNumber: models.PaymentRequestToInterchangeControlNumber{PaymentRequestID: paymentRequest.ID}})
+		suite.Equal(paymentRequest.ID, validPR2ICN.PaymentRequestID)
+		suite.DB().Load(&validPR2ICN, "PaymentRequest")
+		suite.Equal(paymentRequest.ID, validPR2ICN.PaymentRequest.ID)
+	})
+
+	suite.T().Run("test valid PaymentRequestToInterchangeControlNumber", func(t *testing.T) {
+		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
+			PaymentRequestID:         uuid.Must(uuid.NewV4()),
+			InterchangeControlNumber: 1,
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validPR2ICN, expErrors)
+	})
+
+	suite.T().Run("test invalid PaymentRequestToInterchangeControlNumber", func(t *testing.T) {
+		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
+			PaymentRequestID:         uuid.Nil,
+			InterchangeControlNumber: 0,
+		}
+		expErrors := map[string][]string{
+			"payment_request_id":         {"PaymentRequestID can not be blank."},
+			"interchange_control_number": {"0 is not greater than 0."},
+		}
+		suite.verifyValidationErrors(&validPR2ICN, expErrors)
+	})
+
+	suite.T().Run("test invalid InterchangeControlNumber max", func(t *testing.T) {
+		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
+			PaymentRequestID:         uuid.Must(uuid.NewV4()),
+			InterchangeControlNumber: 1000000000,
+		}
+		expErrors := map[string][]string{
+			"interchange_control_number": {"1000000000 is not less than 1000000000."},
+		}
+		suite.verifyValidationErrors(&validPR2ICN, expErrors)
+	})
+}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -96,6 +96,18 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		return ediinvoice.Invoice858C{}, fmt.Errorf("Failed to get next Interchange Control Number: %w", err)
 	}
 
+	// save ICN
+	pr2icn := models.PaymentRequestToInterchangeControlNumber{
+		PaymentRequestID:         paymentRequest.ID,
+		InterchangeControlNumber: int(interchangeControlNumber),
+	}
+	verrs, err := g.db.ValidateAndSave(&pr2icn)
+	if err != nil {
+		return ediinvoice.Invoice858C{}, fmt.Errorf("Failed to save Interchange Control Number: %w", err)
+	} else if verrs != nil && verrs.HasAny() {
+		return ediinvoice.Invoice858C{}, fmt.Errorf("Failed to save Interchange Control Number: %s", verrs.String())
+	}
+
 	var usageIndicator string
 	if sendProductionInvoice {
 		usageIndicator = "P"

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -249,6 +249,14 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.EqualValues(result.ISA.InterchangeControlNumber, result.IEA.InterchangeControlNumber, result.GS.GroupControlNumber, result.GE.GroupControlNumber)
 	})
 
+	// Test that the Interchange Control Number (ICN) is being saved to the db
+	suite.T().Run("the ICN is saved to the database", func(t *testing.T) {
+		var pr2icn models.PaymentRequestToInterchangeControlNumber
+		err := suite.DB().Where("payment_request_id = ?", paymentRequest.ID).First(&pr2icn)
+		suite.NoError(err)
+		suite.Equal(int(result.ISA.InterchangeControlNumber), pr2icn.InterchangeControlNumber)
+	})
+
 	// Test Invoice Start and End Segments
 	suite.T().Run("adds isa start segment", func(t *testing.T) {
 		suite.Equal("00", result.ISA.AuthorizationInformationQualifier)

--- a/pkg/testdatagen/make_payment_request_to_interchange_control_number.go
+++ b/pkg/testdatagen/make_payment_request_to_interchange_control_number.go
@@ -1,0 +1,42 @@
+package testdatagen
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gobuffalo/pop/v5"
+
+	"github.com/transcom/mymove/pkg/db/sequence"
+	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakePaymentRequestToInterchangeControlNumber creates a single PaymentRequest and PaymentRequestToInterchangeControlNumber
+func MakePaymentRequestToInterchangeControlNumber(db *pop.Connection, assertions Assertions) models.PaymentRequestToInterchangeControlNumber {
+	paymentRequestID := assertions.PaymentRequestToInterchangeControlNumber.PaymentRequestID
+	if isZeroUUID(paymentRequestID) {
+		paymentRequest := MakePaymentRequest(db, assertions)
+		paymentRequestID = paymentRequest.ID
+	}
+
+	icnSequencer, err := sequence.NewRandomSequencer(ediinvoice.ICNRandomMin, ediinvoice.ICNRandomMax)
+	if err != nil {
+		log.Panic(fmt.Errorf("Errors encountered creating random sequencer: %v", err))
+	}
+
+	icn, err := icnSequencer.NextVal()
+	if err != nil {
+		log.Panic(fmt.Errorf("Errors encountered getting random interchange control number: %v", err))
+	}
+
+	pr2icn := models.PaymentRequestToInterchangeControlNumber{
+		PaymentRequestID:         paymentRequestID,
+		InterchangeControlNumber: int(icn),
+	}
+
+	mergeModels(&pr2icn, assertions.PaymentRequestToInterchangeControlNumber)
+
+	mustCreate(db, &pr2icn, assertions.Stub)
+
+	return pr2icn
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -55,6 +55,7 @@ type Assertions struct {
 	Organization                             models.Organization
 	OriginDutyStation                        models.DutyStation
 	PaymentRequest                           models.PaymentRequest
+	PaymentRequestToInterchangeControlNumber models.PaymentRequestToInterchangeControlNumber
 	PaymentServiceItem                       models.PaymentServiceItem
 	PaymentServiceItemParam                  models.PaymentServiceItemParam
 	PaymentServiceItemParams                 models.PaymentServiceItemParams


### PR DESCRIPTION
## Description

The response EDI files (997, 824, & 810) use the Interchange Control Number (ICN) we initially sent in the original EDI 858. This number is used to correlate the response file to the original invoice order. This PR saves the generated ICN to a new table so that it can be referenced later when processing the response files. 

## Reviewer Notes

There was discussion of just adding a field to the payment request model, but this option leaves us with a little more flexibility if we need to change the relationship. For example if we ever put more than one payment request in a single 858, or if we have to send the same payment request again in a new 858. The flexibility seemed worth while and the difference was minimal to the implementation.

See [this slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1616770353096400)

## Setup

You will need to create a payment request and generate it's associated EDI 858.

### Local Dev

Setup the server and start it
```sh
make db_dev_reset db_dev_migrate db_dev_e2e_populate
make server_run
make office_client_run
```

Create a payment request using the following `payload.json` file
```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "serviceItems": [
      {
        "id": "ca9aeb58-e5a9-44b0-abe8-81d233dbdebf"
      },
      {
        "id": "6431e3e2-4ee4-41b5-b226-393f9133eb6c"
      },
      {
        "id": "fd6741a5-a92c-44d5-8303-1d7f5e60afbf"
      }
    ]
  }
}
```

And this command to create the payment request
```sh
prime-api-client --insecure create-payment-request --filename payload.json | jq '.id, .paymentRequestNumber'

"fda063aa-7e0e-4c45-9fa5-ea24de548048"
"5768-1974-1"
```

Approve the payment request in the http://officelocal:3000/ ui. Look for Move Code `RDY4PY`

Generate the EDI using the payment request number from the previous command
```sh
rm -f bin/generate-payment-request-edi
make bin/generate-payment-request-edi
bin/generate-payment-request-edi --payment-request-number 5768-1974-1

ISA*00*0084182369*00*0000000000*ZZ*MILMOVE        *12*8004171844     *210325*0604*U*00401*763222484*0*T*|
GS*SI*MILMOVE*8004171844*20210325*0604*763222484*X*004010
...
```

Verify that the ICN, which can be found near the end of the `ISA` segment eg `763222484`, was saved with the payment request id in the table as below:
```sql
select * from payment_request_to_interchange_control_numbers where payment_request_id = 'fda063aa-7e0e-4c45-9fa5-ea24de548048';
```
```sh
                  id                  |          payment_request_id          | interchange_control_number 
--------------------------------------+--------------------------------------+----------------------------
 39338278-812b-47ef-930c-de3a7b1ce10a | fda063aa-7e0e-4c45-9fa5-ea24de548048 |                  763222484
```

### Acceptance

In staging you can trigger the process payment requests to ensure that it still functions, however there is no way to look in the database to see if the record was saved.

To trigger the code that is changed on staging an EDI needs to be sent to Syncada.

Create or find a move that is ready for TIO to approve a payment request. You can use `prime-api-demo <move id>` to help get a new move ready.

Mark other edis as sent using this `payload.json`
```json
{
  "body": {
    "sendToSyncada": false
  }
}
```

and this command
```sh
prime-api-client --cac --hostname api.stg.move.mil --port 443 support-reviewed-payment-requests --filename payload.json | jq .
```

Approve the payment request you prepared earlier in the office ui. Then run the following payload to trigger the code
Mark other edis as sent using this `payload.json`
```json
{
  "body": {
    "sendToSyncada": true
  }
}
```

and this command
```sh
prime-api-client --cac --hostname api.stg.move.mil --port 443 support-reviewed-payment-requests --filename payload.json | jq .
```

Should get a similar response like below
```json
[
  {
    "eTag": "MjAyMS0wMy0yNVQwNToxOTowNi41ODkzMjda",
    "id": "fda063aa-7e0e-4c45-9fa5-ea24de548048",
    "isFinal": false,
    "moveTaskOrderID": "9c7b255c-2981-4bf8-839f-61c7458e2b4d",
    "paymentRequestNumber": "5768-1974-1",
    "status": "SENT_TO_GEX"
  }
]
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [X] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [X] Have been communicated to #g-database
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6665) for this change
* [this slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1616770353096400)