### PR TITLE
[MB-7026] Parse EDI 824

### DIFF
--- a/pkg/edi/edi824/edi.go
+++ b/pkg/edi/edi824/edi.go
@@ -1,0 +1,28 @@
+package edi824
+
+import edisegment "github.com/transcom/mymove/pkg/edi/segment"
+
+type transactionSet struct {
+	ST   edisegment.ST    // transaction set header (bump up counter for "ST" and create new transactionSet)
+	BGN  edisegment.BGN   // beginning statement
+	OTIs []edisegment.OTI // original transaction identifications
+	TEDs []edisegment.TED // technical error descriptions
+	SE   edisegment.SE    // transaction set trailer
+}
+
+type functionalGroupEnvelope struct {
+	GS              edisegment.GS // functional group header (bump up counter for "GS" and create new functionalGroupEnvelope)
+	TransactionSets []transactionSet
+	GE              edisegment.GE // functional group trailer
+}
+
+type interchangeControlEnvelope struct {
+	ISA              edisegment.ISA // interchange control header
+	FunctionalGroups []functionalGroupEnvelope
+	IEA              edisegment.IEA // interchange control trailer
+}
+
+// EDI holds all the segments to parse an EDI 997
+type EDI struct {
+	InterchangeControlEnvelope interchangeControlEnvelope
+}

--- a/pkg/edi/edi824/edi.go
+++ b/pkg/edi/edi824/edi.go
@@ -22,7 +22,7 @@ type interchangeControlEnvelope struct {
 	IEA              edisegment.IEA // interchange control trailer
 }
 
-// EDI holds all the segments to parse an EDI 997
+// EDI holds all the segments to parse an EDI 824
 type EDI struct {
 	InterchangeControlEnvelope interchangeControlEnvelope
 }

--- a/pkg/edi/edi824/logger.go
+++ b/pkg/edi/edi824/logger.go
@@ -1,0 +1,15 @@
+package edi824
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+	WithOptions(opts ...zap.Option) *zap.Logger
+}

--- a/pkg/edi/edi824/parser.go
+++ b/pkg/edi/edi824/parser.go
@@ -1,0 +1,133 @@
+package edi824
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	edisegment "github.com/transcom/mymove/pkg/edi/segment"
+)
+
+type transactionSetCounter struct {
+	otiCounter int
+	tedCounter int
+}
+
+type functionalGroupCounter struct {
+	tsCounter int
+	ts        []transactionSetCounter
+}
+
+// 	ISA > FGs > TSs > OTI|TED
+type counterData struct {
+	fgCounter int
+	fg        []functionalGroupCounter
+}
+
+// Parse takes in a string representation of a 824 EDI file and reads it into a 824 EDI struct
+func (e *EDI) Parse(ediString string) error {
+	var err error
+	counter := counterData{}
+
+	scanner := bufio.NewScanner(strings.NewReader(ediString))
+	for scanner.Scan() {
+		record := strings.Split(scanner.Text(), "*")
+
+		if len(record) == 0 || len(strings.TrimSpace(record[0])) == 0 {
+			continue
+		}
+		switch record[0] {
+		case "ISA":
+			err = e.InterchangeControlEnvelope.ISA.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+		case "GS":
+			// functional group header
+			// bump up counter fgCounter
+			// create new functionalGroupEnvelope
+			// inside functional group
+			fg := functionalGroupEnvelope{}
+			err = fg.GS.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+			e.InterchangeControlEnvelope.FunctionalGroups = append(e.InterchangeControlEnvelope.FunctionalGroups, fg)
+			counter.fgCounter++
+			counter.fg = append(counter.fg, functionalGroupCounter{})
+		case "ST":
+			// bump up counter for tsCounter
+			// create new transactionSet
+			// inside functional group > transaction set
+			fgIndex := counter.fgCounter - 1
+			ts := transactionSet{}
+			err = ts.ST.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+			e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets = append(e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets, ts)
+			counter.fg[fgIndex].tsCounter++
+			counter.fg[fgIndex].ts = append(counter.fg[fgIndex].ts, transactionSetCounter{})
+		case "BGN":
+			// beginning statement
+			// inside functional group > transaction set
+			fgIndex := counter.fgCounter - 1
+			tsIndex := counter.fg[fgIndex].tsCounter - 1
+			err = e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].BGN.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+		case "OTI":
+			// bump up counter for otiCounter
+			// inside functional group > transaction set
+			fgIndex := counter.fgCounter - 1
+			tsIndex := counter.fg[fgIndex].tsCounter - 1
+			oti := edisegment.OTI{}
+			err = oti.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+			e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].OTIs = append(e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].OTIs, oti)
+			counter.fg[fgIndex].ts[tsIndex].otiCounter++
+		case "TED":
+			// bump up counter for tedCounter
+			// inside functional group > transaction set
+			fgIndex := counter.fgCounter - 1
+			tsIndex := counter.fg[fgIndex].tsCounter - 1
+
+			ted := edisegment.TED{}
+			err = ted.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+			e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].TEDs = append(e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].TEDs, ted)
+			counter.fg[fgIndex].ts[tsIndex].tedCounter++
+		case "SE": // trailer to ST
+			// transaction set trailer
+			// inside functional group > transaction set
+			fgIndex := counter.fgCounter - 1
+			tsIndex := counter.fg[fgIndex].tsCounter - 1
+			err = e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].TransactionSets[tsIndex].SE.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+		case "GE": // trailer to GS
+			// functional group trailer
+			// inside functional group
+			fgIndex := counter.fgCounter - 1
+			err = e.InterchangeControlEnvelope.FunctionalGroups[fgIndex].GE.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+		case "IEA": // trailer to ISA
+			err = e.InterchangeControlEnvelope.IEA.Parse(record[1:])
+			if err != nil {
+				return fmt.Errorf("824 failed to parse %w", err)
+			}
+		default:
+			return fmt.Errorf("unexpected row for EDI 824, do not know how to parse: %s with %d parts", strings.Join(record, " "), len(record))
+		}
+	} // end of scanner loop
+
+	return nil
+}

--- a/pkg/edi/edi824/parser_test.go
+++ b/pkg/edi/edi824/parser_test.go
@@ -50,27 +50,25 @@ IEA*1*000000001
 
 		// Check the ISA segments
 		// ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
-		/*
-			isa := edi824.InterchangeControlEnvelope.ISA
-			suite.Equal("00", strings.TrimSpace(isa.AuthorizationInformationQualifier))
-			suite.Equal("", strings.TrimSpace(isa.AuthorizationInformation))
-			suite.Equal("00", strings.TrimSpace(isa.SecurityInformationQualifier))
-			suite.Equal("", strings.TrimSpace(isa.SecurityInformation))
-			suite.Equal("12", strings.TrimSpace(isa.InterchangeSenderIDQualifier))
-			suite.Equal("8004171844", strings.TrimSpace(isa.InterchangeSenderID))
-			suite.Equal("ZZ", strings.TrimSpace(isa.InterchangeReceiverIDQualifier))
-			suite.Equal("MILMOVE", strings.TrimSpace(isa.InterchangeReceiverID))
-			suite.Equal("210217", strings.TrimSpace(isa.InterchangeDate))
-			suite.Equal("1530", strings.TrimSpace(isa.InterchangeTime))
-			suite.Equal("U", strings.TrimSpace(isa.InterchangeControlStandards))
-			suite.Equal("00401", strings.TrimSpace(isa.InterchangeControlVersionNumber))
-			suite.Equal(int64(22), isa.InterchangeControlNumber)
-			suite.Equal(0, isa.AcknowledgementRequested)
-			suite.Equal("T", strings.TrimSpace(isa.UsageIndicator))
-			suite.Equal(":", strings.TrimSpace(isa.ComponentElementSeparator))
-			isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
-			suite.validateISA(isaString, isa)
-		*/
+		isa := edi824.InterchangeControlEnvelope.ISA
+		suite.Equal("00", strings.TrimSpace(isa.AuthorizationInformationQualifier))
+		suite.Equal("", strings.TrimSpace(isa.AuthorizationInformation))
+		suite.Equal("00", strings.TrimSpace(isa.SecurityInformationQualifier))
+		suite.Equal("", strings.TrimSpace(isa.SecurityInformation))
+		suite.Equal("12", strings.TrimSpace(isa.InterchangeSenderIDQualifier))
+		suite.Equal("8004171844", strings.TrimSpace(isa.InterchangeSenderID))
+		suite.Equal("ZZ", strings.TrimSpace(isa.InterchangeReceiverIDQualifier))
+		suite.Equal("MILMOVE", strings.TrimSpace(isa.InterchangeReceiverID))
+		suite.Equal("210217", strings.TrimSpace(isa.InterchangeDate))
+		suite.Equal("1530", strings.TrimSpace(isa.InterchangeTime))
+		suite.Equal("U", strings.TrimSpace(isa.InterchangeControlStandards))
+		suite.Equal("00401", strings.TrimSpace(isa.InterchangeControlVersionNumber))
+		suite.Equal(int64(22), isa.InterchangeControlNumber)
+		suite.Equal(0, isa.AcknowledgementRequested)
+		suite.Equal("T", strings.TrimSpace(isa.UsageIndicator))
+		suite.Equal(":", strings.TrimSpace(isa.ComponentElementSeparator))
+		isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+		suite.validateISA(isaString, isa)
 
 		// Check the GS segments
 		// GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -170,14 +168,11 @@ IEA*1*000000001
 		err := edi824.Parse(sample824EDIString)
 		suite.NoError(err, "Successful parse of 824")
 
-		/*
-			// Check the ISA segments
-			// ISA*00*          00          12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T|
-			isa := edi824.InterchangeControlEnvelope.ISA
-			isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
-			suite.validateISA(isaString, isa)
-
-		*/
+		// Check the ISA segments
+		// ISA*00*          00          12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T|
+		isa := edi824.InterchangeControlEnvelope.ISA
+		isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+		suite.validateISA(isaString, isa)
 
 		// Check the GS segments
 		// GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -229,359 +224,451 @@ IEA*1*000000001
 		suite.validateIEA(ieaString, iea)
 	})
 
-	/*
-			suite.T().Run("successfully parse complex 824 with loops", func(t *testing.T) {
-				sample997EDIString := `
-		ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
-		GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
-		ST*824*0001
-		AK1*SI*100001251
-		AK2*858*0001
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 89
-		AK3*ab*124
-		AK4*1*2*3*4*MM*bad data goes here 100
-		AK5*A
-		AK9*A*1*1*1
-		SE*6*0001
-		ST*824*0002
-		AK1*SI*100001251
-		AK2*858*0001
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 90
-		AK5*A
-		AK2*858*0002
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 91
-		AK5*A
-		AK2*858*0003
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 92
-		AK5*A
-		AK9*A*1*1*1
-		SE*6*0002
-		GE*1*220001
-		GS*FA*8004171844*MILMOVE*20210217*152945*220002*X*004010
-		ST*824*0001
-		AK1*SI*100001251
-		AK2*858*0001
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 93
-		AK5*A
-		AK9*A*1*1*1
-		SE*6*0001
-		GE*1*220002
-		IEA*1*000000022
-		`
-				edi824 := EDI{}
-				err := edi824.Parse(sample997EDIString)
-				suite.NoError(err, "Successful parse of 824")
-
-				isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
-				isa := edi824.InterchangeControlEnvelope.ISA
-				suite.validateISA(isaString, isa)
-
-				// FunctionalGroup 1
-				fgIndex := 0
-				fg := edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
-
-				gsString := "GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010"
-				suite.Equal(2, len(edi824.InterchangeControlEnvelope.FunctionalGroups))
-				gs := fg.GS
-				suite.validateGS(gsString, gs)
-
-				// FunctionalGroup 1 > TransactionSet 1
-				tsIndex := 0
-				ts := fg.TransactionSets[tsIndex]
-
-				stString := "ST*824*0001"
-				suite.Equal(2, len(fg.TransactionSets))
-				st := ts.ST
-				suite.validateST(stString, st)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse
-				fgr := ts.FunctionalGroupResponse
-
-				ak1String := "AK1*SI*100001251"
-				ak1 := fgr.AK1
-				suite.validateAK1(ak1String, ak1)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1
-				suite.Equal(1, len(fgr.TransactionSetResponses))
-
-				tsrIndex := 0
-				tsr := fgr.TransactionSetResponses[tsrIndex]
-
-				ak2String := "AK2*858*0001"
-				ak2 := tsr.AK2
-				suite.validateAK2(ak2String, ak2)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 1
-				suite.Equal(2, len(tsr.dataSegments))
-				dsIndex := 0
-				ds := tsr.dataSegments[dsIndex]
-
-				ak3String := "AK3*ab*123"
-				ak3 := ds.AK3
-				suite.validateAK3(ak3String, ak3)
-
-				ak4String := "AK4*1*2*3*4*MM*bad data goes here 89"
-				ak4 := ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 2
-				dsIndex = 1
-				ds = tsr.dataSegments[dsIndex]
-
-				ak3String = "AK3*ab*124"
-				ak3 = ds.AK3
-				suite.validateAK3(ak3String, ak3)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 2
-				ak4String = "AK4*1*2*3*4*MM*bad data goes here 100"
-				ak4 = ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 END
-				ak5String := "AK5*A"
-				ak5 := tsr.AK5
-				suite.validateAK5(ak5String, ak5)
-
-				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse END
-				ak9String := "AK9*A*1*1*1"
-				ak9 := fgr.AK9
-				suite.validateAK9(ak9String, ak9)
-
-				// FunctionalGroup 1 > TransactionSet 1 END
-				seString := "SE*6*0001"
-				se := ts.SE
-				suite.validateSE(seString, se)
-
-				// FunctionalGroup 1 > TransactionSet 2
-				tsIndex = 1
-				ts = fg.TransactionSets[tsIndex]
-
-				stString = "ST*824*0002"
-				st = ts.ST
-				suite.validateST(stString, st)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse
-				fgr = ts.FunctionalGroupResponse
-
-				ak1String = "AK1*SI*100001251"
-				ak1 = fgr.AK1
-				suite.validateAK1(ak1String, ak1)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1
-				suite.Equal(3, len(fgr.TransactionSetResponses))
-
-				tsrIndex = 0
-				tsr = fgr.TransactionSetResponses[tsrIndex]
-
-				ak2String = "AK2*858*0001"
-				ak2 = tsr.AK2
-				suite.validateAK2(ak2String, ak2)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segment 1
-				dsIndex = 0
-				ds = tsr.dataSegments[dsIndex]
-
-				ak3String = "AK3*ab*123"
-				ak3 = ds.AK3
-				suite.validateAK3(ak3String, ak3)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segment 1
-				ak4String = "AK4*1*2*3*4*MM*bad data goes here 90"
-				ak4 = ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 END
-				ak5String = "AK5*A"
-				ak5 = tsr.AK5
-				suite.validateAK5(ak5String, ak5)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2
-				tsrIndex = 1
-				tsr = fgr.TransactionSetResponses[tsrIndex]
-
-				ak2String = "AK2*858*0002"
-				ak2 = tsr.AK2
-				suite.validateAK2(ak2String, ak2)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 > Data Segment 1
-				suite.Equal(1, len(tsr.dataSegments))
-
-				dsIndex = 0
-				ds = tsr.dataSegments[dsIndex]
-
-				ak3String = "AK3*ab*123"
-				ak3 = ds.AK3
-				suite.validateAK3(ak3String, ak3)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 > Data Segment 1
-				ak4String = "AK4*1*2*3*4*MM*bad data goes here 91"
-				ak4 = ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 END
-				ak5String = "AK5*A"
-				ak5 = tsr.AK5
-				suite.validateAK5(ak5String, ak5)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3
-				tsrIndex = 2
-				tsr = fgr.TransactionSetResponses[tsrIndex]
-
-				ak2 = tsr.AK2
-				ak2String = "AK2*858*0003"
-				suite.validateAK2(ak2String, ak2)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 > Data Segment 1
-				dsIndex = 0
-				ds = tsr.dataSegments[dsIndex]
-
-				ak3 = ds.AK3
-				ak3String = "AK3*ab*123"
-				suite.validateAK3(ak3String, ak3)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 > Data Segment 1
-				ak4String = "AK4*1*2*3*4*MM*bad data goes here 92"
-				ak4 = ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 END
-				ak5 = tsr.AK5
-				ak5String = "AK5*A"
-				suite.validateAK5(ak5String, ak5)
-
-				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse END
-				ak9String = "AK9*A*1*1*1"
-				ak9 = fgr.AK9
-				suite.validateAK9(ak9String, ak9)
-
-				// FunctionalGroup 1 > TransactionSet 2 END
-				seString = "SE*6*0002"
-				se = ts.SE
-				suite.validateSE(seString, se)
-
-				// FunctionalGroup 1 END
-				geString := "GE*1*220001"
-				ge := fg.GE
-				suite.validateGE(geString, ge)
-
-				// FunctionalGroup 2
-				fgIndex = 1
-				fg = edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
-
-				gsString = "GS*FA*8004171844*MILMOVE*20210217*152945*220002*X*004010"
-				gs = fg.GS
-				suite.validateGS(gsString, gs)
-
-				// FunctionalGroup 2 > TransactionSet 1
-				tsIndex = 0
-				ts = fg.TransactionSets[tsIndex]
-				st = fg.TransactionSets[tsIndex].ST
-
-				stString = "ST*824*0001"
-				suite.validateST(stString, st)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse
-				fgr = ts.FunctionalGroupResponse
-
-				ak1String = "AK1*SI*100001251"
-				ak1 = fgr.AK1
-				suite.validateAK1(ak1String, ak1)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1
-				tsrIndex = 0
-				tsr = fgr.TransactionSetResponses[tsrIndex]
-
-				ak2String = "AK2*858*0001"
-				ak2 = tsr.AK2
-				suite.validateAK2(ak2String, ak2)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segments
-				dsIndex = 0
-				ds = tsr.dataSegments[dsIndex]
-
-				ak3String = "AK3*ab*123"
-				ak3 = ds.AK3
-				suite.validateAK3(ak3String, ak3)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segments
-				ak4String = "AK4*1*2*3*4*MM*bad data goes here 93"
-				ak4 = ds.AK4
-				suite.validateAK4(ak4String, ak4)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 END
-				ak5String = "AK5*A"
-				ak5 = tsr.AK5
-				suite.validateAK5(ak5String, ak5)
-
-				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse END
-				ak9String = "AK9*A*1*1*1"
-				ak9 = fgr.AK9
-				suite.validateAK9(ak9String, ak9)
-
-				// FunctionalGroup 2 > TransactionSet 1 END
-				seString = "SE*6*0001"
-				se = ts.SE
-				suite.validateSE(seString, se)
-
-				// FunctionalGroup 2 END
-				geString = "GE*1*220002"
-				ge = fg.GE
-				suite.validateGE(geString, ge)
-
-				iea := edi824.InterchangeControlEnvelope.IEA
-				ieaString := "IEA*1*000000022"
-				suite.validateIEA(ieaString, iea)
-
-			})
-
-			suite.T().Run("fail to parse 824 with unknown segment", func(t *testing.T) {
-				sample997EDIString := `
-		ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
-		GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
-		ST*824*0001
-		AK18*SI*100001251
-		AK2*858*0001
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 89
-		AK5*A
-		AK9*A*1*1*1
-		SE*6*0001
-		GE*1*220001
-		IEA*1*000000022
-		`
-				edi824 := EDI{}
-				err := edi824.Parse(sample997EDIString)
-				suite.Error(err, "fail to parse 824")
-				suite.Contains(err.Error(), "unexpected row for EDI 824")
-			})
-
-			suite.T().Run("fail to parse 824 with bad format", func(t *testing.T) {
-				sample997EDIString := `
-		ISA*00
-		GS
-		ST
-		AK1*SI*100001251
-		AK2*858*0001
-		AK3*ab*123
-		AK4*1*2*3*4*MM*bad data goes here 89
-		AK5*A
-		AK9*A*1*1*1
-		SE*6*0001
-		GE*1*220001
-		IEA*1*000000022
-		`
-				edi824 := EDI{}
-				err := edi824.Parse(sample997EDIString)
-				suite.Error(err, "fail to parse 824")
-				suite.Contains(err.Error(), "824 failed to parse")
-			})
-
-	*/
+	suite.T().Run("successfully parse complex 824 with loops", func(t *testing.T) {
+		sample824EDIString := `
+ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+ST*824*000000001
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0005
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+TED*007*Missing Data
+TED*812*Missing Transaction Reference or Trace Number
+TED*PPD*Previously Paid
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+SE*5*000000001
+ST*824*000000002
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0005
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+TED*007*Missing Data
+TED*INC*Incomplete Transaction
+TED*IID*Invalid Identification Code
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+SE*5*000000002
+GE*2*1
+GS*AG*8004171844*MILMOVE*20210217*1544*2*X*004010
+ST*824*000000001
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+TED*007*Missing Data
+TED*812*Missing Transaction Reference or Trace Number
+TED*PPD*Previously Paid
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+SE*5*000000001
+ST*824*000000002
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+TED*007*Missing Data
+TED*INC*Incomplete Transaction
+TED*IID*Invalid Identification Code
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+SE*5*000000002
+GE*2*2
+IEA*1*000000001
+`
+		edi824 := EDI{}
+		err := edi824.Parse(sample824EDIString)
+		suite.NoError(err, "Successful parse of 824")
+
+		/*
+			// Check the ISA segments
+			// ISA*00*          00          12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T|
+			isa := edi824.InterchangeControlEnvelope.ISA
+			isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+			suite.validateISA(isaString, isa)
+
+		*/
+
+		// Functional Group 1
+		suite.Equal(2, len(edi824.InterchangeControlEnvelope.FunctionalGroups))
+		fgIndex := 0
+		fg := edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
+
+		// Check the GS segments
+		gs := fg.GS
+		gsString := "GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010"
+		suite.validateGS(gsString, gs)
+
+		// Functional Group 1 > Transactional Set 1
+		suite.Equal(2, len(fg.TransactionSets))
+		tsIndex := 0
+		ts := fg.TransactionSets[tsIndex]
+
+		// Check the ST segments
+		st := ts.ST
+		stString := "ST*824*000000001"
+		suite.validateST(stString, st)
+
+		// Functional Group 1 > Transactional Set 1 > Beginning Segment
+
+		// Check the BGN segments
+		bgn := ts.BGN
+		bgnString := "BGN*11*1126-9404*20210217"
+		suite.validateBGN(bgnString, bgn)
+
+		// Functional Group 1 > Transactional Set 1 > Beginning Segment > OTI
+
+		// Check the OTI segments
+		suite.Equal(5, len(ts.OTIs))
+		otiIndex := 0
+		oti := ts.OTIs[otiIndex]
+		otiString := "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 1
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 2
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 3
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 4
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0005"
+		suite.validateOTI(otiString, oti)
+
+		// Functional Group 1 > Transactional Set 1 > Beginning Segment > TED
+
+		// Check the TED segments
+		// n/a
+		suite.Equal(5, len(ts.TEDs))
+		tedIndex := 0
+		ted := ts.TEDs[tedIndex]
+		tedString := "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 1
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*007*Missing Data"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 2
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*812*Missing Transaction Reference or Trace Number"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 3
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*PPD*Previously Paid"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 4
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		// Functional Group 1 > Transactional Set 1
+
+		// Checking SE segments
+		// SE*5*000000001
+		se := ts.SE
+		seString := "SE*5*000000001"
+		suite.validateSE(seString, se)
+
+		// Functional Group 1 > Transactional Set 2
+		tsIndex = 1
+		ts = fg.TransactionSets[tsIndex]
+
+		// Check the ST segments
+		st = ts.ST
+		stString = "ST*824*000000002"
+		suite.validateST(stString, st)
+
+		// Functional Group 1 > Transactional Set 2 > Beginning Segment
+
+		// Check the BGN segments
+		// BGN*11*1126-9404*20210217
+		bgn = ts.BGN
+		bgnString = "BGN*11*1126-9404*20210217"
+		suite.validateBGN(bgnString, bgn)
+
+		// Functional Group 1 > Transactional Set 2 > Beginning Segment > OTI
+
+		// Check the OTI segments
+		suite.Equal(5, len(ts.OTIs))
+		otiIndex = 0
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 1
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 2
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 3
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 4
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0005"
+		suite.validateOTI(otiString, oti)
+
+		// Functional Group 1 > Transactional Set 2 > Beginning Segment > TED
+
+		// Check the TED segments
+		suite.Equal(5, len(ts.TEDs))
+		tedIndex = 0
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 1
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*007*Missing Data"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 2
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*INC*Incomplete Transaction"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 3
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*IID*Invalid Identification Code"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 4
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		// Functional Group 1 > Transactional Set 2
+
+		// Checking SE segments
+		// SE*5*000000001
+		se = ts.SE
+		seString = "SE*5*000000002"
+		suite.validateSE(seString, se)
+
+		// Functional Group 1
+
+		// Checking GE segments
+		ge := fg.GE
+		geString := "GE*2*1"
+		suite.validateGE(geString, ge)
+
+		// Functional Group 2
+		fgIndex = 1
+		fg = edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
+
+		// Check the GS segments
+		gs = fg.GS
+		gsString = "GS*AG*8004171844*MILMOVE*20210217*1544*2*X*004010"
+		suite.validateGS(gsString, gs)
+
+		// Functional Group 2 > Transactional Set 1
+		suite.Equal(2, len(fg.TransactionSets))
+		tsIndex = 0
+		ts = fg.TransactionSets[tsIndex]
+
+		// Check the ST segments
+		st = ts.ST
+		stString = "ST*824*000000001"
+		suite.validateST(stString, st)
+
+		// Functional Group 2 > Transactional Set 1 > Beginning Segment
+
+		// Check the BGN segments
+		// BGN*11*1126-9404*20210217
+		bgn = ts.BGN
+		bgnString = "BGN*11*1126-9404*20210217"
+		suite.validateBGN(bgnString, bgn)
+
+		// Functional Group 2 > Transactional Set 1 > Beginning Segment > OTI
+
+		// Check the OTI segments
+		suite.Equal(2, len(ts.OTIs))
+		otiIndex = 0
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 1
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0002"
+		suite.validateOTI(otiString, oti)
+
+		// Functional Group 2 > Transactional Set 1 > Beginning Segment > TED
+
+		// Check the TED segments
+		suite.Equal(5, len(ts.TEDs))
+		tedIndex = 0
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 1
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*007*Missing Data"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 2
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*812*Missing Transaction Reference or Trace Number"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 3
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*PPD*Previously Paid"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 4
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		// Functional Group 2 > Transactional Set 1
+
+		// Checking SE segments
+		// SE*5*000000001
+		se = ts.SE
+		seString = "SE*5*000000001"
+		suite.validateSE(seString, se)
+
+		// Functional Group 2 > Transactional Set 2
+		tsIndex = 1
+		ts = fg.TransactionSets[tsIndex]
+
+		// Check the ST segments
+		st = ts.ST
+		stString = "ST*824*000000002"
+		suite.validateST(stString, st)
+
+		// Functional Group 2 > Transactional Set 2 > Beginning Segment
+
+		// Check the BGN segments
+		bgn = ts.BGN
+		bgnString = "BGN*11*1126-9404*20210217"
+		suite.validateBGN(bgnString, bgn)
+
+		// Functional Group 2 > Transactional Set 2 > Beginning Segment > OTI
+
+		// Check the OTI segments
+		suite.Equal(2, len(ts.OTIs))
+		otiIndex = 0
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0003"
+		suite.validateOTI(otiString, oti)
+
+		otiIndex = 1
+		oti = ts.OTIs[otiIndex]
+		otiString = "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0004"
+		suite.validateOTI(otiString, oti)
+
+		// Functional Group 2 > Transactional Set 2 > Beginning Segment > TED
+
+		// Check the TED segments
+		// n/a
+		suite.Equal(5, len(ts.TEDs))
+		tedIndex = 0
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 1
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*007*Missing Data"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 2
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*INC*Incomplete Transaction"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 3
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*IID*Invalid Identification Code"
+		suite.validateTED(tedString, ted)
+
+		tedIndex = 4
+		ted = ts.TEDs[tedIndex]
+		tedString = "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		// Functional Group 2 > Transactional Set 2
+
+		// Checking SE segments
+		se = ts.SE
+		seString = "SE*5*000000002"
+		suite.validateSE(seString, se)
+
+		// Functional Group 2
+
+		// Checking GE segments
+		ge = fg.GE
+		geString = "GE*2*2"
+		suite.validateGE(geString, ge)
+
+		// Checking the IEA segments
+		iea := edi824.InterchangeControlEnvelope.IEA
+		ieaString := "IEA*1*000000001"
+		suite.validateIEA(ieaString, iea)
+	})
+
+	suite.T().Run("fail to parse 824 with unknown segment", func(t *testing.T) {
+		sample824EDIString := `
+	ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+	GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+	ST*824*000000001
+	BGN*11*1126-9404*20210217
+	OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+	TEN*1*2*2
+	SE*5*000000001
+	GE*1*1
+	IEA*1*000000001
+	`
+		edi824 := EDI{}
+		err := edi824.Parse(sample824EDIString)
+		suite.Error(err, "fail to parse 824")
+		suite.Contains(err.Error(), "unexpected row for EDI 824")
+	})
+
+	suite.T().Run("fail to parse 824 with bad format", func(t *testing.T) {
+		sample824EDIString := `
+ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+ST*824*000000001
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001*ZZ
+
+SE*5*000000001
+GE*1*1
+IEA*1*000000001
+`
+		edi824 := EDI{}
+		err := edi824.Parse(sample824EDIString)
+		suite.Error(err, "fail to parse 824")
+		suite.Contains(err.Error(), "824 failed to parse")
+	})
 }
 
 func (suite *EDI824Suite) validateISA(row string, isa edisegment.ISA) {

--- a/pkg/edi/edi824/parser_test.go
+++ b/pkg/edi/edi824/parser_test.go
@@ -1,0 +1,684 @@
+package edi824
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	edisegment "github.com/transcom/mymove/pkg/edi/segment"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type EDI824Suite struct {
+	testingsuite.PopTestSuite
+	logger Logger
+}
+
+func TestEDI997Suite(t *testing.T) {
+	// Use a no-op logger during testing
+	logger := zap.NewNop()
+
+	hs := &EDI824Suite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		logger:       logger,
+	}
+
+	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
+}
+
+func (suite *EDI824Suite) TestParse() {
+
+	suite.T().Run("successfully parse simple 824 string", func(t *testing.T) {
+		sample824EDIString := `
+ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+ST*824*000000001
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+SE*5*000000001
+GE*1*1
+IEA*1*000000001
+`
+		edi824 := EDI{}
+		err := edi824.Parse(sample824EDIString)
+		suite.NoError(err, "Successful parse of 824")
+
+		// Check the ISA segments
+		// ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+		/*
+			isa := edi824.InterchangeControlEnvelope.ISA
+			suite.Equal("00", strings.TrimSpace(isa.AuthorizationInformationQualifier))
+			suite.Equal("", strings.TrimSpace(isa.AuthorizationInformation))
+			suite.Equal("00", strings.TrimSpace(isa.SecurityInformationQualifier))
+			suite.Equal("", strings.TrimSpace(isa.SecurityInformation))
+			suite.Equal("12", strings.TrimSpace(isa.InterchangeSenderIDQualifier))
+			suite.Equal("8004171844", strings.TrimSpace(isa.InterchangeSenderID))
+			suite.Equal("ZZ", strings.TrimSpace(isa.InterchangeReceiverIDQualifier))
+			suite.Equal("MILMOVE", strings.TrimSpace(isa.InterchangeReceiverID))
+			suite.Equal("210217", strings.TrimSpace(isa.InterchangeDate))
+			suite.Equal("1530", strings.TrimSpace(isa.InterchangeTime))
+			suite.Equal("U", strings.TrimSpace(isa.InterchangeControlStandards))
+			suite.Equal("00401", strings.TrimSpace(isa.InterchangeControlVersionNumber))
+			suite.Equal(int64(22), isa.InterchangeControlNumber)
+			suite.Equal(0, isa.AcknowledgementRequested)
+			suite.Equal("T", strings.TrimSpace(isa.UsageIndicator))
+			suite.Equal(":", strings.TrimSpace(isa.ComponentElementSeparator))
+			isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+			suite.validateISA(isaString, isa)
+		*/
+
+		// Check the GS segments
+		// GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups))
+		gs := edi824.InterchangeControlEnvelope.FunctionalGroups[0].GS
+		suite.Equal("AG", strings.TrimSpace(gs.FunctionalIdentifierCode))
+		suite.Equal("8004171844", strings.TrimSpace(gs.ApplicationSendersCode))
+		suite.Equal("MILMOVE", strings.TrimSpace(gs.ApplicationReceiversCode))
+		suite.Equal("20210217", strings.TrimSpace(gs.Date))
+		suite.Equal("1544", strings.TrimSpace(gs.Time))
+		suite.Equal(int64(1), gs.GroupControlNumber)
+		suite.Equal("X", strings.TrimSpace(gs.ResponsibleAgencyCode))
+		suite.Equal("004010", strings.TrimSpace(gs.Version))
+		gsString := "GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010"
+		suite.validateGS(gsString, gs)
+
+		// Check the ST segments
+		// ST*824*000000001
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets))
+		st := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].ST
+		suite.Equal("824", strings.TrimSpace(st.TransactionSetIdentifierCode))
+		suite.Equal("000000001", strings.TrimSpace(st.TransactionSetControlNumber))
+		stString := "ST*824*000000001"
+		suite.validateST(stString, st)
+
+		// Check the BGN segments
+		// BGN*11*1126-9404*20210217
+		bgn := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].BGN
+		suite.Equal("11", strings.TrimSpace(bgn.TransactionSetPurposeCode))
+		suite.Equal("1126-9404", strings.TrimSpace(bgn.ReferenceIdentification))
+		suite.Equal("20210217", strings.TrimSpace(bgn.Date))
+		bgnString := "BGN*11*1126-9404*20210217\n"
+		suite.validateBGN(bgnString, bgn)
+
+		// Check the OTI segments
+		// OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].OTIs))
+		oti := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].OTIs[0]
+		suite.Equal("TR", strings.TrimSpace(oti.ApplicationAcknowledgementCode))
+		suite.Equal("BM", strings.TrimSpace(oti.ReferenceIdentificationQualifier))
+		suite.Equal("1126-9404", strings.TrimSpace(oti.ReferenceIdentification))
+		suite.Equal("MILMOVE", strings.TrimSpace(oti.ApplicationSendersCode))
+		suite.Equal("8004171844", strings.TrimSpace(oti.ApplicationReceiversCode))
+		suite.Equal("20210217", strings.TrimSpace(oti.Date))
+		suite.Equal(int64(100001251), oti.GroupControlNumber)
+		suite.Equal("0001", strings.TrimSpace(oti.TransactionSetControlNumber))
+		otiString := "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001"
+		suite.validateOTI(otiString, oti)
+
+		// Check the TED segments
+		// TED*K*DOCUMENT OWNER CANNOT BE DETERMINED
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].TEDs))
+		ted := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].TEDs[0]
+		suite.Equal("K", strings.TrimSpace(ted.ApplicationErrorConditionCode))
+		suite.Equal("DOCUMENT OWNER CANNOT BE DETERMINED", strings.TrimSpace(ted.FreeFormMessage))
+		tedString := "TED*K*DOCUMENT OWNER CANNOT BE DETERMINED"
+		suite.validateTED(tedString, ted)
+
+		// Checking SE segments
+		// SE*5*000000001
+		se := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].SE
+		suite.Equal(5, se.NumberOfIncludedSegments)
+		suite.Equal("000000001", strings.TrimSpace(se.TransactionSetControlNumber))
+		seString := "SE*5*000000001"
+		suite.validateSE(seString, se)
+
+		// Checking GE segments
+		// GE*1*1
+		ge := edi824.InterchangeControlEnvelope.FunctionalGroups[0].GE
+		suite.Equal(1, ge.NumberOfTransactionSetsIncluded)
+		suite.Equal(int64(1), ge.GroupControlNumber)
+		geString := "GE*1*1"
+		suite.validateGE(geString, ge)
+
+		// Checking the IEA segments
+		// IEA*1*000000001
+		iea := edi824.InterchangeControlEnvelope.IEA
+		suite.Equal(1, iea.NumberOfIncludedFunctionalGroups)
+		suite.Equal(int64(000000001), iea.InterchangeControlNumber)
+		ieaString := "IEA*1*000000001"
+		suite.validateIEA(ieaString, iea)
+	})
+
+	suite.T().Run("successfully parse simple 824 string with missing optional TED", func(t *testing.T) {
+		sample824EDIString := `
+ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+ST*824*000000001
+BGN*11*1126-9404*20210217
+OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+
+SE*5*000000001
+GE*1*1
+IEA*1*000000001
+`
+		edi824 := EDI{}
+		err := edi824.Parse(sample824EDIString)
+		suite.NoError(err, "Successful parse of 824")
+
+		/*
+			// Check the ISA segments
+			// ISA*00*          00          12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T|
+			isa := edi824.InterchangeControlEnvelope.ISA
+			isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+			suite.validateISA(isaString, isa)
+
+		*/
+
+		// Check the GS segments
+		// GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups))
+		gs := edi824.InterchangeControlEnvelope.FunctionalGroups[0].GS
+		gsString := "GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010"
+		suite.validateGS(gsString, gs)
+
+		// Check the ST segments
+		// ST*824*000000001
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets))
+		st := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].ST
+		stString := "ST*824*000000001"
+		suite.validateST(stString, st)
+
+		// Check the BGN segments
+		// BGN*11*1126-9404*20210217
+		bgn := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].BGN
+		bgnString := "BGN*11*1126-9404*20210217"
+		suite.validateBGN(bgnString, bgn)
+
+		// Check the OTI segments
+		// OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001
+		suite.Equal(1, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].OTIs))
+		oti := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].OTIs[0]
+		otiString := "OTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001"
+		suite.validateOTI(otiString, oti)
+
+		// Check the TED segments
+		// n/a
+		suite.Equal(0, len(edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].TEDs))
+
+		// Checking SE segments
+		// SE*5*000000001
+		se := edi824.InterchangeControlEnvelope.FunctionalGroups[0].TransactionSets[0].SE
+		seString := "SE*5*000000001"
+		suite.validateSE(seString, se)
+
+		// Checking GE segments
+		// GE*1*1
+		ge := edi824.InterchangeControlEnvelope.FunctionalGroups[0].GE
+		geString := "GE*1*1"
+		suite.validateGE(geString, ge)
+
+		// Checking the IEA segments
+		// IEA*1*000000001
+		iea := edi824.InterchangeControlEnvelope.IEA
+		ieaString := "IEA*1*000000001"
+		suite.validateIEA(ieaString, iea)
+	})
+
+	/*
+			suite.T().Run("successfully parse complex 824 with loops", func(t *testing.T) {
+				sample997EDIString := `
+		ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+		GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
+		ST*824*0001
+		AK1*SI*100001251
+		AK2*858*0001
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 89
+		AK3*ab*124
+		AK4*1*2*3*4*MM*bad data goes here 100
+		AK5*A
+		AK9*A*1*1*1
+		SE*6*0001
+		ST*824*0002
+		AK1*SI*100001251
+		AK2*858*0001
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 90
+		AK5*A
+		AK2*858*0002
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 91
+		AK5*A
+		AK2*858*0003
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 92
+		AK5*A
+		AK9*A*1*1*1
+		SE*6*0002
+		GE*1*220001
+		GS*FA*8004171844*MILMOVE*20210217*152945*220002*X*004010
+		ST*824*0001
+		AK1*SI*100001251
+		AK2*858*0001
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 93
+		AK5*A
+		AK9*A*1*1*1
+		SE*6*0001
+		GE*1*220002
+		IEA*1*000000022
+		`
+				edi824 := EDI{}
+				err := edi824.Parse(sample997EDIString)
+				suite.NoError(err, "Successful parse of 824")
+
+				isaString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:"
+				isa := edi824.InterchangeControlEnvelope.ISA
+				suite.validateISA(isaString, isa)
+
+				// FunctionalGroup 1
+				fgIndex := 0
+				fg := edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
+
+				gsString := "GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010"
+				suite.Equal(2, len(edi824.InterchangeControlEnvelope.FunctionalGroups))
+				gs := fg.GS
+				suite.validateGS(gsString, gs)
+
+				// FunctionalGroup 1 > TransactionSet 1
+				tsIndex := 0
+				ts := fg.TransactionSets[tsIndex]
+
+				stString := "ST*824*0001"
+				suite.Equal(2, len(fg.TransactionSets))
+				st := ts.ST
+				suite.validateST(stString, st)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse
+				fgr := ts.FunctionalGroupResponse
+
+				ak1String := "AK1*SI*100001251"
+				ak1 := fgr.AK1
+				suite.validateAK1(ak1String, ak1)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1
+				suite.Equal(1, len(fgr.TransactionSetResponses))
+
+				tsrIndex := 0
+				tsr := fgr.TransactionSetResponses[tsrIndex]
+
+				ak2String := "AK2*858*0001"
+				ak2 := tsr.AK2
+				suite.validateAK2(ak2String, ak2)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 1
+				suite.Equal(2, len(tsr.dataSegments))
+				dsIndex := 0
+				ds := tsr.dataSegments[dsIndex]
+
+				ak3String := "AK3*ab*123"
+				ak3 := ds.AK3
+				suite.validateAK3(ak3String, ak3)
+
+				ak4String := "AK4*1*2*3*4*MM*bad data goes here 89"
+				ak4 := ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 2
+				dsIndex = 1
+				ds = tsr.dataSegments[dsIndex]
+
+				ak3String = "AK3*ab*124"
+				ak3 = ds.AK3
+				suite.validateAK3(ak3String, ak3)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 > Data Segment 2
+				ak4String = "AK4*1*2*3*4*MM*bad data goes here 100"
+				ak4 = ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponses 1 END
+				ak5String := "AK5*A"
+				ak5 := tsr.AK5
+				suite.validateAK5(ak5String, ak5)
+
+				// FunctionalGroup 1 > TransactionSet 1 > FunctionalGroupResponse END
+				ak9String := "AK9*A*1*1*1"
+				ak9 := fgr.AK9
+				suite.validateAK9(ak9String, ak9)
+
+				// FunctionalGroup 1 > TransactionSet 1 END
+				seString := "SE*6*0001"
+				se := ts.SE
+				suite.validateSE(seString, se)
+
+				// FunctionalGroup 1 > TransactionSet 2
+				tsIndex = 1
+				ts = fg.TransactionSets[tsIndex]
+
+				stString = "ST*824*0002"
+				st = ts.ST
+				suite.validateST(stString, st)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse
+				fgr = ts.FunctionalGroupResponse
+
+				ak1String = "AK1*SI*100001251"
+				ak1 = fgr.AK1
+				suite.validateAK1(ak1String, ak1)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1
+				suite.Equal(3, len(fgr.TransactionSetResponses))
+
+				tsrIndex = 0
+				tsr = fgr.TransactionSetResponses[tsrIndex]
+
+				ak2String = "AK2*858*0001"
+				ak2 = tsr.AK2
+				suite.validateAK2(ak2String, ak2)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segment 1
+				dsIndex = 0
+				ds = tsr.dataSegments[dsIndex]
+
+				ak3String = "AK3*ab*123"
+				ak3 = ds.AK3
+				suite.validateAK3(ak3String, ak3)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segment 1
+				ak4String = "AK4*1*2*3*4*MM*bad data goes here 90"
+				ak4 = ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 1 END
+				ak5String = "AK5*A"
+				ak5 = tsr.AK5
+				suite.validateAK5(ak5String, ak5)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2
+				tsrIndex = 1
+				tsr = fgr.TransactionSetResponses[tsrIndex]
+
+				ak2String = "AK2*858*0002"
+				ak2 = tsr.AK2
+				suite.validateAK2(ak2String, ak2)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 > Data Segment 1
+				suite.Equal(1, len(tsr.dataSegments))
+
+				dsIndex = 0
+				ds = tsr.dataSegments[dsIndex]
+
+				ak3String = "AK3*ab*123"
+				ak3 = ds.AK3
+				suite.validateAK3(ak3String, ak3)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 > Data Segment 1
+				ak4String = "AK4*1*2*3*4*MM*bad data goes here 91"
+				ak4 = ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 2 END
+				ak5String = "AK5*A"
+				ak5 = tsr.AK5
+				suite.validateAK5(ak5String, ak5)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3
+				tsrIndex = 2
+				tsr = fgr.TransactionSetResponses[tsrIndex]
+
+				ak2 = tsr.AK2
+				ak2String = "AK2*858*0003"
+				suite.validateAK2(ak2String, ak2)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 > Data Segment 1
+				dsIndex = 0
+				ds = tsr.dataSegments[dsIndex]
+
+				ak3 = ds.AK3
+				ak3String = "AK3*ab*123"
+				suite.validateAK3(ak3String, ak3)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 > Data Segment 1
+				ak4String = "AK4*1*2*3*4*MM*bad data goes here 92"
+				ak4 = ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse > TransactionSetResponse 3 END
+				ak5 = tsr.AK5
+				ak5String = "AK5*A"
+				suite.validateAK5(ak5String, ak5)
+
+				// FunctionalGroup 1 > TransactionSet 2 > FunctionalGroupResponse END
+				ak9String = "AK9*A*1*1*1"
+				ak9 = fgr.AK9
+				suite.validateAK9(ak9String, ak9)
+
+				// FunctionalGroup 1 > TransactionSet 2 END
+				seString = "SE*6*0002"
+				se = ts.SE
+				suite.validateSE(seString, se)
+
+				// FunctionalGroup 1 END
+				geString := "GE*1*220001"
+				ge := fg.GE
+				suite.validateGE(geString, ge)
+
+				// FunctionalGroup 2
+				fgIndex = 1
+				fg = edi824.InterchangeControlEnvelope.FunctionalGroups[fgIndex]
+
+				gsString = "GS*FA*8004171844*MILMOVE*20210217*152945*220002*X*004010"
+				gs = fg.GS
+				suite.validateGS(gsString, gs)
+
+				// FunctionalGroup 2 > TransactionSet 1
+				tsIndex = 0
+				ts = fg.TransactionSets[tsIndex]
+				st = fg.TransactionSets[tsIndex].ST
+
+				stString = "ST*824*0001"
+				suite.validateST(stString, st)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse
+				fgr = ts.FunctionalGroupResponse
+
+				ak1String = "AK1*SI*100001251"
+				ak1 = fgr.AK1
+				suite.validateAK1(ak1String, ak1)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1
+				tsrIndex = 0
+				tsr = fgr.TransactionSetResponses[tsrIndex]
+
+				ak2String = "AK2*858*0001"
+				ak2 = tsr.AK2
+				suite.validateAK2(ak2String, ak2)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segments
+				dsIndex = 0
+				ds = tsr.dataSegments[dsIndex]
+
+				ak3String = "AK3*ab*123"
+				ak3 = ds.AK3
+				suite.validateAK3(ak3String, ak3)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 > Data Segments
+				ak4String = "AK4*1*2*3*4*MM*bad data goes here 93"
+				ak4 = ds.AK4
+				suite.validateAK4(ak4String, ak4)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse > TransactionSetResponse 1 END
+				ak5String = "AK5*A"
+				ak5 = tsr.AK5
+				suite.validateAK5(ak5String, ak5)
+
+				// FunctionalGroup 2 > TransactionSet 1 > FunctionalGroupResponse END
+				ak9String = "AK9*A*1*1*1"
+				ak9 = fgr.AK9
+				suite.validateAK9(ak9String, ak9)
+
+				// FunctionalGroup 2 > TransactionSet 1 END
+				seString = "SE*6*0001"
+				se = ts.SE
+				suite.validateSE(seString, se)
+
+				// FunctionalGroup 2 END
+				geString = "GE*1*220002"
+				ge = fg.GE
+				suite.validateGE(geString, ge)
+
+				iea := edi824.InterchangeControlEnvelope.IEA
+				ieaString := "IEA*1*000000022"
+				suite.validateIEA(ieaString, iea)
+
+			})
+
+			suite.T().Run("fail to parse 824 with unknown segment", func(t *testing.T) {
+				sample997EDIString := `
+		ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
+		GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
+		ST*824*0001
+		AK18*SI*100001251
+		AK2*858*0001
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 89
+		AK5*A
+		AK9*A*1*1*1
+		SE*6*0001
+		GE*1*220001
+		IEA*1*000000022
+		`
+				edi824 := EDI{}
+				err := edi824.Parse(sample997EDIString)
+				suite.Error(err, "fail to parse 824")
+				suite.Contains(err.Error(), "unexpected row for EDI 824")
+			})
+
+			suite.T().Run("fail to parse 824 with bad format", func(t *testing.T) {
+				sample997EDIString := `
+		ISA*00
+		GS
+		ST
+		AK1*SI*100001251
+		AK2*858*0001
+		AK3*ab*123
+		AK4*1*2*3*4*MM*bad data goes here 89
+		AK5*A
+		AK9*A*1*1*1
+		SE*6*0001
+		GE*1*220001
+		IEA*1*000000022
+		`
+				edi824 := EDI{}
+				err := edi824.Parse(sample997EDIString)
+				suite.Error(err, "fail to parse 824")
+				suite.Contains(err.Error(), "824 failed to parse")
+			})
+
+	*/
+}
+
+func (suite *EDI824Suite) validateISA(row string, isa edisegment.ISA) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(isa.AuthorizationInformationQualifier), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(isa.AuthorizationInformation), row)
+	suite.Equal(strings.TrimSpace(elements[3]), strings.TrimSpace(isa.SecurityInformationQualifier), row)
+	suite.Equal(strings.TrimSpace(elements[4]), strings.TrimSpace(isa.SecurityInformation), row)
+	suite.Equal(strings.TrimSpace(elements[5]), strings.TrimSpace(isa.InterchangeSenderIDQualifier), row)
+	suite.Equal(strings.TrimSpace(elements[6]), strings.TrimSpace(isa.InterchangeSenderID), row)
+	suite.Equal(strings.TrimSpace(elements[7]), strings.TrimSpace(isa.InterchangeReceiverIDQualifier), row)
+	suite.Equal(strings.TrimSpace(elements[8]), strings.TrimSpace(isa.InterchangeReceiverID), row)
+	suite.Equal(strings.TrimSpace(elements[9]), strings.TrimSpace(isa.InterchangeDate), row)
+	suite.Equal(strings.TrimSpace(elements[10]), strings.TrimSpace(isa.InterchangeTime), row)
+	suite.Equal(strings.TrimSpace(elements[11]), strings.TrimSpace(isa.InterchangeControlStandards), row)
+	suite.Equal(strings.TrimSpace(elements[12]), strings.TrimSpace(isa.InterchangeControlVersionNumber), row)
+	intValue, err := strconv.Atoi(elements[13])
+	suite.NoError(err, row)
+	suite.Equal(int64(intValue), isa.InterchangeControlNumber, row)
+	intValue, err = strconv.Atoi(elements[14])
+	suite.NoError(err, row)
+	suite.Equal(intValue, isa.AcknowledgementRequested, row)
+	suite.Equal(strings.TrimSpace(elements[15]), strings.TrimSpace(isa.UsageIndicator), row)
+	suite.Equal(strings.TrimSpace(elements[16]), strings.TrimSpace(isa.ComponentElementSeparator), row)
+}
+
+func (suite *EDI824Suite) validateGS(row string, gs edisegment.GS) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(gs.FunctionalIdentifierCode), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(gs.ApplicationSendersCode), row)
+	suite.Equal(strings.TrimSpace(elements[3]), strings.TrimSpace(gs.ApplicationReceiversCode), row)
+	suite.Equal(strings.TrimSpace(elements[4]), strings.TrimSpace(gs.Date), row)
+	suite.Equal(strings.TrimSpace(elements[5]), strings.TrimSpace(gs.Time), row)
+	intValue, err := strconv.Atoi(elements[6])
+	suite.NoError(err, row)
+	suite.Equal(int64(intValue), gs.GroupControlNumber, row)
+	suite.Equal(strings.TrimSpace(elements[7]), strings.TrimSpace(gs.ResponsibleAgencyCode), row)
+	suite.Equal(strings.TrimSpace(elements[8]), strings.TrimSpace(gs.Version), row)
+}
+
+func (suite *EDI824Suite) validateST(row string, st edisegment.ST) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(st.TransactionSetIdentifierCode), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(st.TransactionSetControlNumber), row)
+}
+
+func (suite *EDI824Suite) validateBGN(row string, bgn edisegment.BGN) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(bgn.TransactionSetPurposeCode), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(bgn.ReferenceIdentification), row)
+	suite.Equal(strings.TrimSpace(elements[3]), strings.TrimSpace(bgn.Date), row)
+}
+
+func (suite *EDI824Suite) validateOTI(row string, oti edisegment.OTI) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(oti.ApplicationAcknowledgementCode), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(oti.ReferenceIdentificationQualifier), row)
+	suite.Equal(strings.TrimSpace(elements[3]), strings.TrimSpace(oti.ReferenceIdentification), row)
+	suite.Equal(strings.TrimSpace(elements[4]), strings.TrimSpace(oti.ApplicationSendersCode), row)
+	suite.Equal(strings.TrimSpace(elements[5]), strings.TrimSpace(oti.ApplicationReceiversCode), row)
+	suite.Equal(strings.TrimSpace(elements[6]), strings.TrimSpace(oti.Date), row)
+	intValue, err := strconv.Atoi(elements[8])
+	suite.NoError(err, row)
+	suite.Equal(int64(intValue), oti.GroupControlNumber, row)
+	suite.Equal(strings.TrimSpace(elements[9]), strings.TrimSpace(oti.TransactionSetControlNumber), row)
+}
+
+func (suite *EDI824Suite) validateTED(row string, ted edisegment.TED) {
+	elements := strings.Split(row, "*")
+	suite.Equal(strings.TrimSpace(elements[1]), strings.TrimSpace(ted.ApplicationErrorConditionCode), row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(ted.FreeFormMessage), row)
+}
+
+func (suite *EDI824Suite) validateSE(row string, se edisegment.SE) {
+	elements := strings.Split(row, "*")
+	intValue, err := strconv.Atoi(elements[1])
+	suite.NoError(err, row)
+	suite.Equal(intValue, se.NumberOfIncludedSegments, row)
+	suite.Equal(strings.TrimSpace(elements[2]), strings.TrimSpace(se.TransactionSetControlNumber), row)
+}
+
+func (suite *EDI824Suite) validateGE(row string, ge edisegment.GE) {
+	elements := strings.Split(row, "*")
+	intValue, err := strconv.Atoi(elements[1])
+	suite.NoError(err, row)
+	suite.Equal(intValue, ge.NumberOfTransactionSetsIncluded, row)
+	intValue, err = strconv.Atoi(elements[2])
+	suite.NoError(err, row)
+	suite.Equal(int64(intValue), ge.GroupControlNumber, row)
+}
+
+func (suite *EDI824Suite) validateIEA(row string, iea edisegment.IEA) {
+	elements := strings.Split(row, "*")
+	intValue, err := strconv.Atoi(elements[1])
+	suite.NoError(err, row)
+	suite.Equal(intValue, iea.NumberOfIncludedFunctionalGroups, row)
+	intValue, err = strconv.Atoi(elements[2])
+	suite.NoError(err, row)
+	suite.Equal(int64(intValue), iea.InterchangeControlNumber, row)
+}


### PR DESCRIPTION
## Description

EDI 824 is an Application Advice message that is sent to the MilMove system to report errors found by Syncada when processing the EDI 858.

This story was to test parsing the 824 which is basically having to write a 824 `Parse` function and test it. I tested with with 3 version of 824s.
1. This is the sample that we received via SFTP when @gidjin  was doing the USBank testing.
2. Is a mod of the the first one, omitting optional segment `TED`.
3. This is another mod of the first, seeing if the `Parse` function can handle loops for different segments. E.g., the functional group, transaction sets, OTIs and TEDs, etc allow for multiple loops (arrays) of data.

The 824 spec can be found [here](https://drive.google.com/file/d/144rKMw_aFFPgHwLfOhMKqvmkFO4SzJ2M/view). 

A-Team detailed mapping out the fields [here](https://docs.google.com/spreadsheets/d/1OYYgAp6GD0wG6SKx61De2VRZFkAPHBHZV2BpyvD0nMc/edit#gid=0). 

There is a [EDI Responses design document](https://docs.google.com/document/d/1e8Zq2dkqZ1nWxJNTI5V-w1iZo0ccVTunmWEAr61F4MA/edit#heading=h.pydiodiv30kf) which talks about how the 997 EDI is used in the MilMove system.


## Reviewer Notes

n/a

## Setup

nothing to do for acceptance or testing until the final process EDI story for the 824 is completed

```sh
make server_test
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7026) for this change

## Screenshots
n/a
