### PR TITLE
[MB-7056] DOFSIT payment service item calculations

### DIFF
--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
@@ -14,17 +14,31 @@ export default {
       );
     },
   ],
+  argTypes: {
+    tableSize: {
+      defaultValue: 'large',
+      control: {
+        type: 'select',
+        options: ['small', 'large'],
+      },
+    },
+  },
 };
 
-export const LargeTable = () => (
-  <ServiceItemCalculations serviceItemParams={testParams.DomesticLongHaul} totalAmountRequested={642} itemCode="DLH" />
-);
-
-export const SmallTable = () => (
+export const DLH = (data) => (
   <ServiceItemCalculations
     serviceItemParams={testParams.DomesticLongHaul}
     totalAmountRequested={642}
     itemCode="DLH"
-    tableSize="small"
+    tableSize={data.tableSize}
+  />
+);
+
+export const DOFSIT = (data) => (
+  <ServiceItemCalculations
+    serviceItemParams={testParams.DomesticOrigin1stSIT}
+    totalAmountRequested={833}
+    itemCode="DOFSIT"
+    tableSize={data.tableSize}
   />
 );

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
@@ -121,7 +121,7 @@ describe('ServiceItemCalculations', () => {
     {
       value: '85 cwt',
       label: 'Billable weight (cwt)',
-      details: ['Shipment weight: 8,500 lbs'],
+      details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
     },
     {
       value: '210',

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -75,8 +75,29 @@ describe('makeCalculations', () => {
   });
 
   it('returns correct data for DomesticOrigin1stSIT', () => {
-    const result = makeCalculations('?', 99999, testParams.DomesticOrigin1stSIT);
-    expect(result).toEqual([]);
+    const result = makeCalculations('DOFSIT', 99999, testParams.DomesticOrigin1stSIT);
+    expect(result).toEqual([
+      {
+        value: '85 cwt',
+        label: 'Billable weight (cwt)',
+        details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
+      },
+      {
+        value: '1.033',
+        label: 'Origin price',
+        details: ['Service area: 176', 'Pickup date: 11 Mar 2020', 'Domestic non-peak'],
+      },
+      {
+        value: '1.033',
+        label: 'Price escalation factor',
+        details: ['Base year: 2'],
+      },
+      {
+        value: '$999.99',
+        label: 'Total amount requested',
+        details: [''],
+      },
+    ]);
   });
 
   it('returns correct data for DomesticDestination1stSIT', () => {
@@ -155,7 +176,7 @@ describe('makeCalculations', () => {
       {
         value: '85 cwt',
         label: 'Billable weight (cwt)',
-        details: ['Shipment weight: 8,500 lbs'],
+        details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
       },
       {
         value: '210',

--- a/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
+++ b/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
@@ -132,7 +132,7 @@ const ContractYearName = {
   origin: 'PRICER',
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'STRING',
-  value: 'Contract Year Name',
+  value: '2',
 };
 const NumberDaysSIT = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
@@ -249,7 +249,7 @@ const ServicesScheduleOrigin = {
   origin: 'SYSTEM',
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'STRING',
-  value: '',
+  value: '2',
 };
 const ServicesScheduleDest = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
@@ -330,7 +330,7 @@ const PSIPriceDomOriginPrice = {
   origin: 'SYSTEM',
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'DECIMAL',
-  value: '',
+  value: '10',
 };
 const PSIPriceDomDest = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
@@ -402,11 +402,14 @@ const testParams = {
   ],
   DomesticOriginPrice: [
     RequestedPickupDate,
-    ServiceAreaOrigin,
     WeightActual,
     WeightBilledActual,
     WeightEstimated,
     ZipPickupAddress,
+    PriceRateOrFactor,
+    ServiceAreaOrigin,
+    EscalationCompounded,
+    ContractYearName,
   ],
   DomesticDestinationPrice: [
     RequestedPickupDate,
@@ -417,12 +420,15 @@ const testParams = {
     ZipDestAddress,
   ],
   DomesticOrigin1stSIT: [
-    RequestedPickupDate,
-    ServiceAreaOrigin,
     WeightActual,
     WeightBilledActual,
     WeightEstimated,
+    PriceRateOrFactor,
+    ServiceAreaOrigin,
+    RequestedPickupDate,
     ZipPickupAddress,
+    EscalationCompounded,
+    ContractYearName,
   ],
   DomesticDestination1stSIT: [
     RequestedPickupDate,
@@ -555,6 +561,7 @@ const testParams = {
     EIAFuelPrice,
     FSCWeightBasedDistanceMultiplier,
     WeightBilledActual,
+    WeightEstimated,
     ZipDestAddress,
     ZipPickupAddress,
   ],

--- a/src/constants/serviceItems.js
+++ b/src/constants/serviceItems.js
@@ -20,6 +20,9 @@ const SERVICE_ITEM_PARAM_KEYS = {
   EscalationCompounded: 'EscalationCompounded',
   EIAFuelPrice: 'EIAFuelPrice',
   FSCWeightBasedDistanceMultiplier: 'FSCWeightBasedDistanceMultiplier',
+  OriginPrice: 'OriginPrice',
+  ServiceSchedule: 'ServiceSchedule',
+  ContractYearName: 'ContractYearName',
 };
 
 const SERVICE_ITEM_CALCULATION_LABELS = {
@@ -29,6 +32,10 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   PriceEscalationFactor: 'Price escalation factor',
   TotalAmountRequested: 'Total amount requested',
   FuelSurchargePrice: 'Fuel surcharge price (per mi)',
+  ServiceSchedule: 'Service schedule',
+  ServiceArea: 'Service area',
+  RequestedPickup: 'Requested pickup',
+  [SERVICE_ITEM_PARAM_KEYS.ContractYearName]: 'Base year',
   [SERVICE_ITEM_PARAM_KEYS.WeightBilledActual]: 'Shipment weight',
   [SERVICE_ITEM_PARAM_KEYS.WeightActual]: 'Shipment weight',
   [SERVICE_ITEM_PARAM_KEYS.WeightEstimated]: 'Estimated',
@@ -41,15 +48,17 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   [SERVICE_ITEM_PARAM_KEYS.ActualPickupDate]: 'Pickup date',
   [SERVICE_ITEM_PARAM_KEYS.EIAFuelPrice]: 'EIA diesel',
   [SERVICE_ITEM_PARAM_KEYS.FSCWeightBasedDistanceMultiplier]: 'Weight-based distance multiplier',
+  [SERVICE_ITEM_PARAM_KEYS.OriginPrice]: 'Origin price',
 };
 
 const SERVICE_ITEM_CODES = {
   DLH: 'DLH',
   FSC: 'FSC',
+  DOFSIT: 'DOFSIT',
 };
 
 // TODO - temporary, will remove once all service item calculations are implemented
-const allowedServiceItemCalculations = [SERVICE_ITEM_CODES.DLH, SERVICE_ITEM_CODES.FSC];
+const allowedServiceItemCalculations = [SERVICE_ITEM_CODES.DLH, SERVICE_ITEM_CODES.FSC, SERVICE_ITEM_CODES.DOFSIT];
 
 export {
   SERVICE_ITEM_STATUSES as default,


### PR DESCRIPTION
## Description

This adds the Domestic Origin 1st Day SIT service item calculations for the TIO service item pricing params work.  This should be very similar to the Domestic Origin Price service item component.

Some things we learned from A-team was that the service schedule maps 1:1 with the service area, non-peak/peak, and contract base period so it can be dropped from the details in Origin Price.  It wasn't being returned as a param for the DOP and DOFSIT service items so it was going to be blank in display anyway.

We're still waiting for the origin price value itself which will be coming as the `PriceRateOrFactor` param when the pricer params are implemented.  The price escalation factor and base year value will also be blank because the `EscalationCompounded` and `ContractYearName` params are also unimplemented.

## Reviewer Notes

I used the controls add-on in storybook to let us toggle between large and small table sizes instead of creating independent stories for each service item.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

1. Login as the TIO user
2. Search for the payment request with move locator `PARAMS` and click on it in the queue.
3. Approve or reject all of the payment request service items because it needs to be in the reviewed state to see the calculations.
4. Expand the Domestic Origin 1st Day SIT by clicking on it to reveal the calculations

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7056) for this change

## Screenshots

<img width="1333" alt="Screen Shot 2021-03-26 at 10 22 57 AM" src="https://user-images.githubusercontent.com/52669884/112645901-5bc89580-8e1d-11eb-8be7-fa61ff5d7088.png">
<img width="1355" alt="Screen Shot 2021-03-26 at 10 22 34 AM" src="https://user-images.githubusercontent.com/52669884/112645902-5bc89580-8e1d-11eb-821c-0402644227b4.png">
<img width="317" alt="Screen Shot 2021-03-26 at 10 21 49 AM" src="https://user-images.githubusercontent.com/52669884/112645904-5c612c00-8e1d-11eb-859f-9fb95d8d5474.png">
<img width="1295" alt="Screen Shot 2021-03-26 at 10 21 25 AM" src="https://user-images.githubusercontent.com/52669884/112645905-5c612c00-8e1d-11eb-9642-7cceca9c1ae8.png">
