### PR TITLE
MB-7327 Add y18n to resoultions to avoid high security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   "resolutions": {
     "kind-of": "^6.0.2",
     "selfsigned": "^1.10.8",
-    "immer": "^8.0.1"
+    "immer": "^8.0.1",
+    "y18n": "^5.0.5"
   },
   "name": "client",
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20368,12 +20368,7 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
-
-y18n@^5.0.5:
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0, y18n@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==


### PR DESCRIPTION
## Description

Ensure we avoid high security vulnerability on y18n pacakge. https://www.npmjs.com/advisories/1654

## Setup

```sh
make client_build
make client_run
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7327) for this change
* [this article](https://ustcdp3.slack.com/archives/CP6F568DC/p1617042052148800?thread_ts=1617041109.143900&cid=CP6F568DC) explains more about the approach used.