### PR TITLE
MB-7308 Add createMTOAgent command to prime-api-client

### DIFF
--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -158,6 +158,27 @@ func main() {
 	prime.InitUpdateMTOAgentFlags(updateMTOAgentCommand.Flags())
 	root.AddCommand(updateMTOAgentCommand)
 
+	createMTOAgentCommand := &cobra.Command{
+		Use:   "create-mto-agent",
+		Short: "Create MTO agent",
+		Long: `
+  This command creates an agent associated with an MTO shipment.
+  It requires the caller to pass in a file using the --filename arg.
+  The file should contain path parameters and a body for the payload.
+
+  Endpoint path: /mto-shipments/{mtoShipmentID}/agents
+  The file should contain json as follows:
+  	{
+	  "mtoShipmentID": <uuid string>,
+      "body": <MTOAgent>
+  	}
+  Please see API documentation for full details on the endpoint definition.`,
+		RunE:         prime.CreateMTOAgent,
+		SilenceUsage: true,
+	}
+	prime.InitCreateMTOAgentFlags(createMTOAgentCommand.Flags())
+	root.AddCommand(createMTOAgentCommand)
+
 	updatePostCounselingInfo := &cobra.Command{
 		Use:          "update-mto-post-counseling-information",
 		Short:        "update post counseling info",

--- a/cmd/prime-api-client/prime/create_mto_agent.go
+++ b/cmd/prime-api-client/prime/create_mto_agent.go
@@ -1,0 +1,98 @@
+package prime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/transcom/mymove/cmd/prime-api-client/utils"
+	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
+)
+
+// InitCreateMTOAgentFlags declares which flags are enabled
+func InitCreateMTOAgentFlags(flag *pflag.FlagSet) {
+	flag.String(utils.FilenameFlag, "", "Name of the file being passed in")
+	flag.SortFlags = false
+}
+
+func checkCreateMTOAgentConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := utils.CheckRootConfig(v)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	if v.GetString(utils.FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !utils.ContainsDash(args)) {
+		logger.Fatal(errors.New("create-agents expects a file to be passed in"))
+	}
+
+	return nil
+}
+
+// CreateMTOAgent creates a gateway and sends the request to the endpoint
+func CreateMTOAgent(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	// Create the logger - remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := utils.ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkCreateMTOAgentConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// Decode json from file that was passed into MTOShipment
+	filename := v.GetString(utils.FilenameFlag)
+	var mtoAgentPayload mtoShipment.CreateMTOAgentParams // CreateMTOAgentParams Takes data out of JSon and puts it in struct
+	err = utils.DecodeJSONFileToPayload(filename, utils.ContainsDash(args), &mtoAgentPayload)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	mtoAgentPayload.SetTimeout(time.Second * 30)
+
+	// Create the client and open the cacStore
+	primeGateway, cacStore, errCreateClient := utils.CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer func() {
+			if closeErr := cacStore.Close(); closeErr != nil {
+				logger.Fatal(closeErr)
+			}
+		}()
+	}
+
+	// Make the API Call
+	resp, err := primeGateway.MtoShipment.CreateMTOAgent(&mtoAgentPayload) // Sends the request
+	if err != nil {
+		return utils.HandleGatewayError(err, logger)
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}

--- a/cmd/prime-api-client/support/create_move_task_order.go
+++ b/cmd/prime-api-client/support/create_move_task_order.go
@@ -32,7 +32,7 @@ func CheckCreateMTOConfig(v *viper.Viper, args []string) error {
 	}
 
 	if v.GetString(utils.FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !utils.ContainsDash(args)) {
-		return errors.New("create-payment-request expects a file to be passed in")
+		return errors.New("create-move-task-order expects a file to be passed in")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

* Adds `create-mto-agent` command to prime-api-client
* Hits `POST /mto-shipments/{mtoShipmentID}/agents` endpoint
* Fixes error message typo in `create_move_task_order`


## Setup

```sh
// Rebuild the client
rm -rf bin/prime-api-client
make bin/prime-api-client

// Run the command
prime-api-client create-mto-agent --filename data.json --insecure
```

Your data file should look similar to:

```
{
    "mtoShipmentID": "3a515895-cf37-4244-833d-f9ebfdd9352e",
    "body": {
        "firstName": "Jason",
        "lastName": "Ash",
        "agentType": "RECEIVING_AGENT",
        "phone": "415-555-5555",
        "email": "jason@example.com"
    }
}
```

**Notes:**
* The shipment cannot have an existing agent of the same type when creating a new one.



## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7308) for this change