### PR TITLE
MB-7051: deploy connect-to-gex-via-sftp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1398,7 +1398,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:
@@ -1485,28 +1485,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1521,35 +1521,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: connect-to-gex-via-sftp
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,11 @@ commands:
           name: Get Digest from filesystem
           command: echo 'export ECR_DIGEST=$(cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_app-tasks_<< parameters.ecr_env >>)' | tee -a "${BASH_ENV}"
       - deploy:
+          name: Deploy connect to GEX via SFTP service
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container connect-to-gex-via-sftp "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT}"
+          no_output_timeout: 20m
+      - announce_failure
+      - deploy:
           name: Deploy GHC fuel price data task service
           command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container save-ghc-fuel-price-data "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT}"
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1398,7 +1398,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - integration_tests:
           requires:
@@ -1485,28 +1485,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - deploy_exp_migrations:
           requires:
@@ -1521,35 +1521,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: connect-to-gex-via-sftp
 
       - push_app_stg:
           requires:

--- a/Makefile
+++ b/Makefile
@@ -777,6 +777,22 @@ tasks_build_linux_docker:  ## Build Scheduled Task binaries (linux) and Docker i
 	@echo "Build the docker scheduled tasks container..."
 	docker build -f Dockerfile.tasks_local --tag $(TASKS_DOCKER_CONTAINER):latest .
 
+.PHONY: tasks_connect_to_gex_via_sftp
+tasks_connect_to_gex_via_sftp: tasks_build_linux_docker ## Run connect-to-gex-via-sftp from inside docker container
+	@echo "Connecting to GEX via SFTP with docker command..."
+	DB_NAME=$(DB_NAME_DEV) DB_DOCKER_CONTAINER=$(DB_DOCKER_CONTAINER_DEV) scripts/wait-for-db-docker
+	docker run \
+		-t \
+		-e DB_HOST="database" \
+		-e DB_NAME \
+		-e DB_PORT \
+		-e DB_USER \
+		-e DB_PASSWORD \
+		--link="$(DB_DOCKER_CONTAINER_DEV):database" \
+		--rm \
+		$(TASKS_DOCKER_CONTAINER):latest \
+		milmove-tasks connect-to-gex-via-sftp
+
 .PHONY: tasks_save_ghc_fuel_price_data
 tasks_save_ghc_fuel_price_data: tasks_build_linux_docker ## Run save-ghc-fuel-price-data from inside docker container
 	@echo "Saving the fuel price data to the ${DB_NAME_DEV} database with docker command..."

--- a/Makefile
+++ b/Makefile
@@ -788,6 +788,12 @@ tasks_connect_to_gex_via_sftp: tasks_build_linux_docker ## Run connect-to-gex-vi
 		-e DB_PORT \
 		-e DB_USER \
 		-e DB_PASSWORD \
+		-e GEX_SFTP_HOST \
+		-e GEX_SFTP_HOST_KEY \
+		-e GEX_SFTP_IP_ADDRESS \
+		-e GEX_SFTP_PASSWORD \
+		-e GEX_SFTP_PORT \
+		-e GEX_SFTP_USER_ID \
 		--link="$(DB_DOCKER_CONTAINER_DEV):database" \
 		--rm \
 		$(TASKS_DOCKER_CONTAINER):latest \

--- a/cmd/ecs-deploy/put_target.go
+++ b/cmd/ecs-deploy/put_target.go
@@ -26,7 +26,13 @@ const (
 	putTargetFlag  string = "put-target"
 )
 
-var names = []string{"save-ghc-fuel-price-data", "send-post-move-survey", "send-payment-reminder", "post-file-to-gex"}
+var names = []string{
+	"connect-to-gex-via-sftp",
+	"post-file-to-gex",
+	"save-ghc-fuel-price-data",
+	"send-payment-reminder",
+	"send-post-move-survey",
+}
 
 type errInvalidName struct {
 	Name string

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -57,10 +57,11 @@ var servicesToEntryPoints = map[string][]string{
 	"app-client-tls": {fmt.Sprintf("%s serve", binMilMove)},
 	"app-migrations": {fmt.Sprintf("%s migrate", binMilMove)},
 	"app-tasks": {
-		fmt.Sprintf("%s save-ghc-fuel-price-data", binMilMoveTasks),
-		fmt.Sprintf("%s send-post-move-survey", binMilMoveTasks),
-		fmt.Sprintf("%s send-payment-reminder", binMilMoveTasks),
+		fmt.Sprintf("%s connect-to-gex-via-sftp", binMilMoveTasks),
 		fmt.Sprintf("%s post-file-to-gex", binMilMoveTasks),
+		fmt.Sprintf("%s save-ghc-fuel-price-data", binMilMoveTasks),
+		fmt.Sprintf("%s send-payment-reminder", binMilMoveTasks),
+		fmt.Sprintf("%s send-post-move-survey", binMilMoveTasks),
 	},
 	"app-webhook-client": {
 		fmt.Sprintf("%s webhook-notify", binWebhookClient),

--- a/config/env/prd.connect-to-gex-via-sftp.env
+++ b/config/env/prd.connect-to-gex-via-sftp.env
@@ -1,0 +1,6 @@
+DB_IAM=true
+DB_NAME=app
+DB_PORT=5432
+DB_RETRY_INTERVAL=5s
+DB_SSL_MODE=verify-full
+DB_USER=crud

--- a/scripts/deploy-app-tasks
+++ b/scripts/deploy-app-tasks
@@ -41,7 +41,8 @@ CIRCLE_SHA1=$(curl -s "https://${compare_host}/health" | jq -r .gitCommit)
 scripts/compare-deployed-commit "${compare_host}" "${CIRCLE_SHA1}"
 
 readonly image="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks:git-${CIRCLE_SHA1}"
-scripts/ecs-deploy-task-container save-ghc-fuel-price-data "${image}" "${APP_ENVIRONMENT}"
-scripts/ecs-deploy-task-container send-post-move-survey "${image}" "${APP_ENVIRONMENT}"
-scripts/ecs-deploy-task-container send-payment-reminder "${image}" "${APP_ENVIRONMENT}"
+scripts/ecs-deploy-task-container connect-to-gex-via-sftp "${image}" "${APP_ENVIRONMENT}"
 scripts/ecs-deploy-task-container post-file-to-gex "${image}" "${APP_ENVIRONMENT}"
+scripts/ecs-deploy-task-container save-ghc-fuel-price-data "${image}" "${APP_ENVIRONMENT}"
+scripts/ecs-deploy-task-container send-payment-reminder "${image}" "${APP_ENVIRONMENT}"
+scripts/ecs-deploy-task-container send-post-move-survey "${image}" "${APP_ENVIRONMENT}"

--- a/scripts/ecs-deploy-task-container
+++ b/scripts/ecs-deploy-task-container
@@ -25,6 +25,11 @@ readonly environment=$3
 readonly RESERVATION_CPU=256
 readonly RESERVATION_MEM=512
 
+if [[ "${name}" == "connect-to-gex-via-sftp" ]] && [[ "${environment}" != "prd" ]]; then
+  echo "We do not deploy connect-to-gex-via-sftp to non-prd environments. Skipping deployment."
+  exit 0
+fi
+
 echo "Checking for existence of variables file"
 
 variables_file="${DIR}/../config/env/${environment}.${name}.env"


### PR DESCRIPTION
## Description

This makes it so that the `connect-to-gex-via-sftp` task is deployed to a scheduled task during prod deployment. The cron schedule is currently set to `cron(0 0 1 1 ? 1970)`, so it will never run. Once this has been deployed to production, someone can change the cron schedule via the web console to trigger a single run.

I also added a gate to `scripts/ecs-deploy-task-container` to prevent it from attempting to deploy to any non-prd environment.

If this is approved, I'll do a test run to deploy to experimental to confirm that the gate works. No scheduled ECS task exists in exp or stg for `connect-to-gex-via-sftp`, so if the gate in `scripts/ecs-deploy-task-container` does not work, it will fail in other ways, but at least it won't try to connect.

## Setup

Everything is done via CircleCI.

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7051) for this change