### PR TITLE
update busybox

### DIFF
--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,5 +1,7 @@
 FROM alpine:3.12.3
 
+RUN apk upgrade --no-cache busybox
+
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -21,6 +21,8 @@ RUN rm -f bin/milmove && make bin/milmove
 
 FROM alpine:3.12.3
 
+RUN apk upgrade --no-cache busybox
+
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/milmove /bin/milmove
 

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,5 +1,7 @@
 FROM alpine:3.12.3
 
+RUN apk upgrade --no-cache busybox
+
 COPY bin/generate-test-data /bin/generate-test-data
 COPY bin/prime-api-client /bin/prime-api-client
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -21,6 +21,8 @@ RUN rm -f bin/prime-api-client && make bin/prime-api-client
 
 FROM alpine:3.12.3
 
+RUN apk upgrade --no-cache busybox
+
 COPY --from=builder --chown=root:root /home/circleci/project/bin/generate-test-data /bin/generate-test-data
 COPY --from=builder --chown=root:root /home/circleci/project/bin/prime-api-client /bin/prime-api-client
 


### PR DESCRIPTION
## Description

This fixes [a vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-28831) with busybox that is present in alpine. This was [fixed in Alpine 3.13.4](https://alpinelinux.org/posts/Alpine-3.13.4-released.html). However, upon attempting to use the latest version, the following error is shown:

```
docker build -f Dockerfile.migrations -t app-migrations:dev .
mkdir -p /home/circleci/transcom/mymove/bin/images
docker save -o /home/circleci/transcom/mymove/bin/images/app-migrations app-migrations:dev
Sending build context to Docker daemon  805.6MB
Step 1/10 : FROM alpine:3.13.4
3.13.4: Pulling from library/alpine
no matching manifest for linux/amd64 in the manifest list entries
Exited with code exit status 1
```

So I'm upgrading busybox until we can upgrade to the latest version of Alpine.

## Setup

Watch CircleCI.