### PR TITLE
Rename PricingParam to PricingDisplayParam

### DIFF
--- a/pkg/services/ghc_rate_engine.go
+++ b/pkg/services/ghc_rate_engine.go
@@ -16,121 +16,121 @@ type ServiceItemPricer interface {
 	UsingConnection(db *pop.Connection) ServiceItemPricer
 }
 
-// PricingParam represents a parameter (key/value pair) returned from a pricer
-type PricingParam struct {
+// PricingDisplayParam represents a parameter (key/value pair) returned from a pricer
+type PricingDisplayParam struct {
 	Key   models.ServiceItemParamName
 	Value interface{}
 }
 
-// PricingParams represents a slice of pricing parameters
-type PricingParams []PricingParam
+// PricingDisplayParams represents a slice of pricing parameters
+type PricingDisplayParams []PricingDisplayParam
 
 // ParamsPricer is an interface that all param-aware pricers implement
 type ParamsPricer interface {
-	PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, PricingParams, error)
+	PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, PricingDisplayParams, error)
 }
 
 // ManagementServicesPricer prices management services for a GHC move
 //go:generate mockery -name ManagementServicesPricer
 type ManagementServicesPricer interface {
-	Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingParams, error)
+	Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // CounselingServicesPricer prices counseling services for a GHC move
 //go:generate mockery -name CounselingServicesPricer
 type CounselingServicesPricer interface {
-	Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingParams, error)
+	Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticLinehaulPricer prices domestic linehaul for a GHC move
 //go:generate mockery -name DomesticLinehaulPricer
 type DomesticLinehaulPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticShorthaulPricer prices the domestic shorthaul for a GHC Move
 //go:generate mockery -name DomesticShorthaulPricer
 type DomesticShorthaulPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticOriginPricer prices the domestic origin for a GHC Move
 //go:generate mockery -name DomesticOriginPricer
 type DomesticOriginPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticDestinationPricer prices the domestic destination price for a GHC Move
 //go:generate mockery -name DomesticDestinationPricer
 type DomesticDestinationPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticPackPricer prices the domestic packing and unpacking for a GHC Move
 //go:generate mockery -name DomesticPackPricer
 type DomesticPackPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticUnpackPricer prices the domestic unpacking for a GHC Move
 //go:generate mockery -name DomesticUnpackPricer
 type DomesticUnpackPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // FuelSurchargePricer prices the fuel surcharge price for a GHC Move
 //go:generate mockery -name FuelSurchargePricer
 type FuelSurchargePricer interface {
-	Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, PricingParams, error)
+	Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticOriginFirstDaySITPricer prices domestic origin first day SIT for a GHC move
 //go:generate mockery -name DomesticOriginFirstDaySITPricer
 type DomesticOriginFirstDaySITPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticDestinationFirstDaySITPricer prices domestic destination first day SIT for a GHC move
 //go:generate mockery -name DomesticDestinationFirstDaySITPricer
 type DomesticDestinationFirstDaySITPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticOriginAdditionalDaysSITPricer prices domestic origin additional days SIT for a GHC move
 //go:generate mockery -name DomesticOriginAdditionalDaysSITPricer
 type DomesticOriginAdditionalDaysSITPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticDestinationAdditionalDaysSITPricer prices domestic destination additional days SIT for a GHC move
 //go:generate mockery -name DomesticDestinationAdditionalDaysSITPricer
 type DomesticDestinationAdditionalDaysSITPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticOriginSITPickupPricer prices domestic origin SIT pickup for a GHC move
 //go:generate mockery -name DomesticOriginSITPickupPricer
 type DomesticOriginSITPickupPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }
 
 // DomesticDestinationSITDeliveryPricer prices domestic destination SIT delivery for a GHC move
 //go:generate mockery -name DomesticDestinationSITDeliveryPricer
 type DomesticDestinationSITDeliveryPricer interface {
-	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, PricingParams, error)
+	Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, PricingDisplayParams, error)
 	ParamsPricer
 }

--- a/pkg/services/ghcrateengine/counseling_services_pricer.go
+++ b/pkg/services/ghcrateengine/counseling_services_pricer.go
@@ -23,7 +23,7 @@ func NewCounselingServicesPricer(db *pop.Connection) services.CounselingServices
 }
 
 // Price determines the price for a counseling service
-func (p counselingServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingParams, error) {
+func (p counselingServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingDisplayParams, error) {
 	taskOrderFee, err := fetchTaskOrderFee(p.db, contractCode, models.ReServiceCodeCS, mtoAvailableToPrimeAt)
 	if err != nil {
 		return unit.Cents(0), nil, fmt.Errorf("could not fetch task order fee: %w", err)
@@ -33,7 +33,7 @@ func (p counselingServicesPricer) Price(contractCode string, mtoAvailableToPrime
 }
 
 // PriceUsingParams determines the price for a counseling service given PaymentServiceItemParams
-func (p counselingServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p counselingServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_destination_additional_days_sit_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_additional_days_sit_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticDestinationAdditionalDaysSITPricer(db *pop.Connection) services.
 }
 
 // Price determines the price for domestic destination additional days SIT
-func (p domesticDestinationAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticAdditionalDaysSIT(p.db, models.ReServiceCodeDDASIT, contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 }
 
 // PriceUsingParams determines the price for domestic destination first day SIT given PaymentServiceItemParams
-func (p domesticDestinationAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_destination_first_day_sit_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_first_day_sit_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticDestinationFirstDaySITPricer(db *pop.Connection) services.Domest
 }
 
 // Price determines the price for domestic destination first day SIT
-func (p domesticDestinationFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticFirstDaySIT(p.db, models.ReServiceCodeDDFSIT, contractCode, requestedPickupDate, weight, serviceArea)
 }
 
 // PriceUsingParams determines the price for domestic destination first day SIT given PaymentServiceItemParams
-func (p domesticDestinationFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -25,7 +25,7 @@ func NewDomesticDestinationPricer(db *pop.Connection) services.DomesticDestinati
 }
 
 // Price determines the price for the destination service area
-func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -60,7 +60,7 @@ func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDat
 	return totalCost, nil, nil
 }
 
-func (p domesticDestinationPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticDestinationSITDeliveryPricer(db *pop.Connection) services.Domest
 }
 
 // Price determines the price for domestic destination SIT delivery
-func (p domesticDestinationSITDeliveryPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationSITDeliveryPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticPickupDeliverySIT(p.db, models.ReServiceCodeDDDSIT, contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipDest, zipSITDest, distance)
 }
 
 // PriceUsingParams determines the price for domestic destination SIT delivery given PaymentServiceItemParams
-func (p domesticDestinationSITDeliveryPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticDestinationSITDeliveryPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
@@ -32,7 +32,7 @@ func NewDomesticLinehaulPricer(db *pop.Connection) services.DomesticLinehaulPric
 }
 
 // Price determines the price for a domestic linehaul
-func (p domesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (p domesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	isPeakPeriod := IsPeakPeriod(requestedPickupDate)
 	priceAndEscalation, err := fetchDomesticLinehaulPrice(p.db, contractCode, requestedPickupDate, isPeakPeriod, distance, weight, serviceArea)
 	if err != nil {
@@ -50,7 +50,7 @@ func (p domesticLinehaulPricer) Price(contractCode string, requestedPickupDate t
 }
 
 // PriceUsingParams determines the price for a domestic linehaul given PaymentServiceItemParams
-func (p domesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_origin_additional_days_sit_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_additional_days_sit_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticOriginAdditionalDaysSITPricer(db *pop.Connection) services.Domes
 }
 
 // Price determines the price for domestic origin additional days SIT
-func (p domesticOriginAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticAdditionalDaysSIT(p.db, models.ReServiceCodeDOASIT, contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 }
 
 // PriceUsingParams determines the price for domestic origin first day SIT given PaymentServiceItemParams
-func (p domesticOriginAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_origin_first_day_sit_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_first_day_sit_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticOriginFirstDaySITPricer(db *pop.Connection) services.DomesticOri
 }
 
 // Price determines the price for domestic origin first day SIT
-func (p domesticOriginFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticFirstDaySIT(p.db, models.ReServiceCodeDOFSIT, contractCode, requestedPickupDate, weight, serviceArea)
 }
 
 // PriceUsingParams determines the price for domestic origin first day SIT given PaymentServiceItemParams
-func (p domesticOriginFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_origin_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer.go
@@ -26,7 +26,7 @@ func NewDomesticOriginPricer(db *pop.Connection) services.DomesticOriginPricer {
 }
 
 // Price determines the price for a domestic origin
-func (p domesticOriginPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -62,7 +62,7 @@ func (p domesticOriginPricer) Price(contractCode string, requestedPickupDate tim
 }
 
 // PriceUsingParams determines the price for a domestic origin given PaymentServiceItemParams
-func (p domesticOriginPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer.go
@@ -22,12 +22,12 @@ func NewDomesticOriginSITPickupPricer(db *pop.Connection) services.DomesticOrigi
 }
 
 // Price determines the price for domestic origin SIT pickup
-func (p domesticOriginSITPickupPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginSITPickupPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, services.PricingDisplayParams, error) {
 	return priceDomesticPickupDeliverySIT(p.db, models.ReServiceCodeDOPSIT, contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipSITOriginOriginal, zipSITOriginActual, distance)
 }
 
 // PriceUsingParams determines the price for domestic origin SIT pickup given PaymentServiceItemParams
-func (p domesticOriginSITPickupPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticOriginSITPickupPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_pack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer.go
@@ -26,7 +26,7 @@ func NewDomesticPackPricer(db *pop.Connection) services.DomesticPackPricer {
 }
 
 // Price determines the price for a domestic pack/unpack service
-func (p domesticPackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, services.PricingParams, error) {
+func (p domesticPackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, services.PricingDisplayParams, error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -64,7 +64,7 @@ func (p domesticPackPricer) Price(contractCode string, requestedPickupDate time.
 }
 
 // PriceUsingParams determines the price for a domestic pack given PaymentServiceItemParams
-func (p domesticPackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticPackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
@@ -29,7 +29,7 @@ func NewDomesticShorthaulPricer(db *pop.Connection) services.DomesticShorthaulPr
 }
 
 // Price determines the price for a counseling service
-func (p domesticShorthaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (totalCost unit.Cents, params services.PricingParams, err error) {
+func (p domesticShorthaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (totalCost unit.Cents, params services.PricingDisplayParams, err error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -84,7 +84,7 @@ func (p domesticShorthaulPricer) Price(contractCode string, requestedPickupDate 
 	return totalCost, nil, nil
 }
 
-func (p domesticShorthaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticShorthaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/domestic_unpack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_unpack_pricer.go
@@ -26,7 +26,7 @@ func NewDomesticUnpackPricer(db *pop.Connection) services.DomesticUnpackPricer {
 }
 
 // Price determines the price for a domestic pack/unpack service
-func (p domesticUnpackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, services.PricingParams, error) {
+func (p domesticUnpackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, services.PricingDisplayParams, error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -64,7 +64,7 @@ func (p domesticUnpackPricer) Price(contractCode string, requestedPickupDate tim
 }
 
 // PriceUsingParams determines the price for a domestic pack given PaymentServiceItemParams
-func (p domesticUnpackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p domesticUnpackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/fuel_surcharge_pricer.go
+++ b/pkg/services/ghcrateengine/fuel_surcharge_pricer.go
@@ -29,7 +29,7 @@ func NewFuelSurchargePricer(db *pop.Connection) services.FuelSurchargePricer {
 }
 
 // Price determines the price for a counseling service
-func (p fuelSurchargePricer) Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, services.PricingParams, error) {
+func (p fuelSurchargePricer) Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, services.PricingDisplayParams, error) {
 	// Validate parameters
 	if len(contractCode) == 0 {
 		return 0, nil, errors.New("ContractCode is required")
@@ -55,7 +55,7 @@ func (p fuelSurchargePricer) Price(contractCode string, actualPickupDate time.Ti
 	return totalCost, nil, nil
 }
 
-func (p fuelSurchargePricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p fuelSurchargePricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/management_services_pricer.go
+++ b/pkg/services/ghcrateengine/management_services_pricer.go
@@ -23,17 +23,16 @@ func NewManagementServicesPricer(db *pop.Connection) services.ManagementServices
 }
 
 // Price determines the price for a management service
-func (p managementServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingParams, error) {
+func (p managementServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingDisplayParams, error) {
 	taskOrderFee, err := fetchTaskOrderFee(p.db, contractCode, models.ReServiceCodeMS, mtoAvailableToPrimeAt)
 	if err != nil {
 		return unit.Cents(0), nil, fmt.Errorf("could not fetch task order fee: %w", err)
 	}
-
 	return taskOrderFee.PriceCents, nil, nil
 }
 
 // PriceUsingParams determines the price for a management service given PaymentServiceItemParams
-func (p managementServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (p managementServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	contractCode, err := getParamString(params, models.ServiceItemParamNameContractCode)
 	if err != nil {
 		return unit.Cents(0), nil, err

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-func priceDomesticFirstDaySIT(db *pop.Connection, firstDaySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func priceDomesticFirstDaySIT(db *pop.Connection, firstDaySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	var sitType string
 	if firstDaySITCode == models.ReServiceCodeDDFSIT {
 		sitType = "destination"
@@ -46,7 +46,7 @@ func priceDomesticFirstDaySIT(db *pop.Connection, firstDaySITCode models.ReServi
 	return totalPriceCents, nil, nil
 }
 
-func priceDomesticAdditionalDaysSIT(db *pop.Connection, additionalDaySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingParams, error) {
+func priceDomesticAdditionalDaysSIT(db *pop.Connection, additionalDaySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingDisplayParams, error) {
 	var sitType string
 	if additionalDaySITCode == models.ReServiceCodeDDASIT {
 		sitType = "destination"
@@ -80,7 +80,7 @@ func priceDomesticAdditionalDaysSIT(db *pop.Connection, additionalDaySITCode mod
 	return totalPriceCents, nil, nil
 }
 
-func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipOriginal string, zipActual string, distance unit.Miles) (unit.Cents, services.PricingParams, error) {
+func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode models.ReServiceCode, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipOriginal string, zipActual string, distance unit.Miles) (unit.Cents, services.PricingDisplayParams, error) {
 	var sitType, sitModifier, zipOriginalName, zipActualName string
 	if pickupDeliverySITCode == models.ReServiceCodeDDDSIT {
 		sitType = "destination"
@@ -160,11 +160,11 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	return totalPriceCents, nil, nil
 }
 
-func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.UUID, params services.PricingParams) (models.PaymentServiceItemParams, error) {
+func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.UUID, params services.PricingDisplayParams) (models.PaymentServiceItemParams, error) {
 	var paymentServiceItemParams models.PaymentServiceItemParams
 
 	if len(params) == 0 {
-		return paymentServiceItemParams, fmt.Errorf("PricingParams must not be empty")
+		return paymentServiceItemParams, fmt.Errorf("PricingDisplayParams must not be empty")
 	}
 
 	for _, param := range params {

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -179,7 +179,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Mil
 }
 
 func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
-	params := services.PricingParams{
+	params := services.PricingDisplayParams{
 		{
 			Key:   models.ServiceItemParamNamePriceRateOrFactor,
 			Value: 40000.9,
@@ -260,7 +260,7 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 	})
 
 	suite.T().Run("errors if PricingParm points to a serviceItem that doesnt originate from the Pricer", func(t *testing.T) {
-		invalidParam := services.PricingParams{
+		invalidParam := services.PricingDisplayParams{
 			{
 				Key:   models.ServiceItemParamNameServiceAreaOrigin,
 				Value: 40000.9,
@@ -282,10 +282,10 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 	})
 
 	suite.T().Run("errors if no PricingParms passed from the Pricer", func(t *testing.T) {
-		emptyParams := services.PricingParams{}
+		emptyParams := services.PricingDisplayParams{}
 
 		_, err := createPricerGeneratedParams(suite.DB(), paymentServiceItem.ID, emptyParams)
 		suite.Error(err)
-		suite.Contains(err.Error(), "PricingParams must not be empty")
+		suite.Contains(err.Error(), "PricingDisplayParams must not be empty")
 	})
 }

--- a/pkg/services/mocks/CounselingServicesPricer.go
+++ b/pkg/services/mocks/CounselingServicesPricer.go
@@ -19,7 +19,7 @@ type CounselingServicesPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, mtoAvailableToPrimeAt
-func (_m *CounselingServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingParams, error) {
+func (_m *CounselingServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, mtoAvailableToPrimeAt)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *CounselingServicesPricer) Price(contractCode string, mtoAvailableToPri
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, mtoAvailableToPrimeAt)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *CounselingServicesPricer) Price(contractCode string, mtoAvailableToPri
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *CounselingServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *CounselingServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *CounselingServicesPricer) PriceUsingParams(params models.PaymentServic
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticDestinationAdditionalDaysSITPricer.go
+++ b/pkg/services/mocks/DomesticDestinationAdditionalDaysSITPricer.go
@@ -19,7 +19,7 @@ type DomesticDestinationAdditionalDaysSITPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT
-func (_m *DomesticDestinationAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticDestinationAdditionalDaysSITPricer) Price(contractCode string,
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticDestinationAdditionalDaysSITPricer) Price(contractCode string,
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticDestinationAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticDestinationAdditionalDaysSITPricer) PriceUsingParams(params mo
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticDestinationFirstDaySITPricer.go
+++ b/pkg/services/mocks/DomesticDestinationFirstDaySITPricer.go
@@ -19,7 +19,7 @@ type DomesticDestinationFirstDaySITPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea
-func (_m *DomesticDestinationFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticDestinationFirstDaySITPricer) Price(contractCode string, reque
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticDestinationFirstDaySITPricer) Price(contractCode string, reque
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticDestinationFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticDestinationFirstDaySITPricer) PriceUsingParams(params models.P
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticDestinationPricer.go
+++ b/pkg/services/mocks/DomesticDestinationPricer.go
@@ -19,7 +19,7 @@ type DomesticDestinationPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea
-func (_m *DomesticDestinationPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticDestinationPricer) Price(contractCode string, requestedPickupD
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticDestinationPricer) Price(contractCode string, requestedPickupD
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticDestinationPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticDestinationPricer) PriceUsingParams(params models.PaymentServi
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticDestinationSITDeliveryPricer.go
+++ b/pkg/services/mocks/DomesticDestinationSITDeliveryPricer.go
@@ -19,7 +19,7 @@ type DomesticDestinationSITDeliveryPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipDest, zipSITDest, distance
-func (_m *DomesticDestinationSITDeliveryPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationSITDeliveryPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipDest, zipSITDest, distance)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticDestinationSITDeliveryPricer) Price(contractCode string, reque
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int, string, string, unit.Miles) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int, string, string, unit.Miles) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipDest, zipSITDest, distance)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticDestinationSITDeliveryPricer) Price(contractCode string, reque
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticDestinationSITDeliveryPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticDestinationSITDeliveryPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticDestinationSITDeliveryPricer) PriceUsingParams(params models.P
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticLinehaulPricer.go
+++ b/pkg/services/mocks/DomesticLinehaulPricer.go
@@ -19,7 +19,7 @@ type DomesticLinehaulPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, distance, weight, serviceArea
-func (_m *DomesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticLinehaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, distance, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticLinehaulPricer) Price(contractCode string, requestedPickupDate
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, distance, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticLinehaulPricer) Price(contractCode string, requestedPickupDate
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticLinehaulPricer) PriceUsingParams(params models.PaymentServiceI
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticOriginAdditionalDaysSITPricer.go
+++ b/pkg/services/mocks/DomesticOriginAdditionalDaysSITPricer.go
@@ -19,7 +19,7 @@ type DomesticOriginAdditionalDaysSITPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT
-func (_m *DomesticOriginAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginAdditionalDaysSITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticOriginAdditionalDaysSITPricer) Price(contractCode string, requ
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea, numberOfDaysInSIT)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticOriginAdditionalDaysSITPricer) Price(contractCode string, requ
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticOriginAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginAdditionalDaysSITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticOriginAdditionalDaysSITPricer) PriceUsingParams(params models.
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticOriginFirstDaySITPricer.go
+++ b/pkg/services/mocks/DomesticOriginFirstDaySITPricer.go
@@ -19,7 +19,7 @@ type DomesticOriginFirstDaySITPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea
-func (_m *DomesticOriginFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginFirstDaySITPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticOriginFirstDaySITPricer) Price(contractCode string, requestedP
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticOriginFirstDaySITPricer) Price(contractCode string, requestedP
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticOriginFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginFirstDaySITPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticOriginFirstDaySITPricer) PriceUsingParams(params models.Paymen
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticOriginPricer.go
+++ b/pkg/services/mocks/DomesticOriginPricer.go
@@ -19,7 +19,7 @@ type DomesticOriginPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea
-func (_m *DomesticOriginPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticOriginPricer) Price(contractCode string, requestedPickupDate t
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticOriginPricer) Price(contractCode string, requestedPickupDate t
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticOriginPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticOriginPricer) PriceUsingParams(params models.PaymentServiceIte
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticOriginSITPickupPricer.go
+++ b/pkg/services/mocks/DomesticOriginSITPickupPricer.go
@@ -19,7 +19,7 @@ type DomesticOriginSITPickupPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipSITOriginOriginal, zipSITOriginActual, distance
-func (_m *DomesticOriginSITPickupPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginSITPickupPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipSITOriginOriginal, zipSITOriginActual, distance)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticOriginSITPickupPricer) Price(contractCode string, requestedPic
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int, string, string, unit.Miles) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, string, int, string, string, unit.Miles) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, serviceArea, sitSchedule, zipSITOriginOriginal, zipSITOriginActual, distance)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticOriginSITPickupPricer) Price(contractCode string, requestedPic
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticOriginSITPickupPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticOriginSITPickupPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticOriginSITPickupPricer) PriceUsingParams(params models.PaymentS
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticPackPricer.go
+++ b/pkg/services/mocks/DomesticPackPricer.go
@@ -19,7 +19,7 @@ type DomesticPackPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, servicesScheduleOrigin
-func (_m *DomesticPackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticPackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, servicesScheduleOrigin)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticPackPricer) Price(contractCode string, requestedPickupDate tim
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, int) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, int) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, servicesScheduleOrigin)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticPackPricer) Price(contractCode string, requestedPickupDate tim
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticPackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticPackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticPackPricer) PriceUsingParams(params models.PaymentServiceItemP
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticShorthaulPricer.go
+++ b/pkg/services/mocks/DomesticShorthaulPricer.go
@@ -19,7 +19,7 @@ type DomesticShorthaulPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, distance, weight, serviceArea
-func (_m *DomesticShorthaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticShorthaulPricer) Price(contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, distance, weight, serviceArea)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticShorthaulPricer) Price(contractCode string, requestedPickupDat
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, string) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, string) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, distance, weight, serviceArea)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticShorthaulPricer) Price(contractCode string, requestedPickupDat
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticShorthaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticShorthaulPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticShorthaulPricer) PriceUsingParams(params models.PaymentService
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/DomesticUnpackPricer.go
+++ b/pkg/services/mocks/DomesticUnpackPricer.go
@@ -19,7 +19,7 @@ type DomesticUnpackPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, requestedPickupDate, weight, servicesScheduleDest
-func (_m *DomesticUnpackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticUnpackPricer) Price(contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, requestedPickupDate, weight, servicesScheduleDest)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *DomesticUnpackPricer) Price(contractCode string, requestedPickupDate t
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, int) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Pound, int) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, requestedPickupDate, weight, servicesScheduleDest)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *DomesticUnpackPricer) Price(contractCode string, requestedPickupDate t
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *DomesticUnpackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *DomesticUnpackPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *DomesticUnpackPricer) PriceUsingParams(params models.PaymentServiceIte
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/FuelSurchargePricer.go
+++ b/pkg/services/mocks/FuelSurchargePricer.go
@@ -19,7 +19,7 @@ type FuelSurchargePricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, actualPickupDate, distance, weight, weightBasedDistanceMultiplier, fuelPrice
-func (_m *FuelSurchargePricer) Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, services.PricingParams, error) {
+func (_m *FuelSurchargePricer) Price(contractCode string, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, weightBasedDistanceMultiplier float64, fuelPrice unit.Millicents) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, actualPickupDate, distance, weight, weightBasedDistanceMultiplier, fuelPrice)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *FuelSurchargePricer) Price(contractCode string, actualPickupDate time.
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, float64, unit.Millicents) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time, unit.Miles, unit.Pound, float64, unit.Millicents) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, actualPickupDate, distance, weight, weightBasedDistanceMultiplier, fuelPrice)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *FuelSurchargePricer) Price(contractCode string, actualPickupDate time.
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *FuelSurchargePricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *FuelSurchargePricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *FuelSurchargePricer) PriceUsingParams(params models.PaymentServiceItem
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 

--- a/pkg/services/mocks/ManagementServicesPricer.go
+++ b/pkg/services/mocks/ManagementServicesPricer.go
@@ -19,7 +19,7 @@ type ManagementServicesPricer struct {
 }
 
 // Price provides a mock function with given fields: contractCode, mtoAvailableToPrimeAt
-func (_m *ManagementServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingParams, error) {
+func (_m *ManagementServicesPricer) Price(contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(contractCode, mtoAvailableToPrimeAt)
 
 	var r0 unit.Cents
@@ -29,12 +29,12 @@ func (_m *ManagementServicesPricer) Price(contractCode string, mtoAvailableToPri
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(string, time.Time) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(string, time.Time) services.PricingDisplayParams); ok {
 		r1 = rf(contractCode, mtoAvailableToPrimeAt)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (_m *ManagementServicesPricer) Price(contractCode string, mtoAvailableToPri
 }
 
 // PriceUsingParams provides a mock function with given fields: params
-func (_m *ManagementServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingParams, error) {
+func (_m *ManagementServicesPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {
 	ret := _m.Called(params)
 
 	var r0 unit.Cents
@@ -59,12 +59,12 @@ func (_m *ManagementServicesPricer) PriceUsingParams(params models.PaymentServic
 		r0 = ret.Get(0).(unit.Cents)
 	}
 
-	var r1 services.PricingParams
-	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingParams); ok {
+	var r1 services.PricingDisplayParams
+	if rf, ok := ret.Get(1).(func(models.PaymentServiceItemParams) services.PricingDisplayParams); ok {
 		r1 = rf(params)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(services.PricingParams)
+			r1 = ret.Get(1).(services.PricingDisplayParams)
 		}
 	}
 


### PR DESCRIPTION
## Description

I asked @reggieriser  if we could rename `PricingParam` to `PricingDisplayParam` since that helps differentiate it and make it clear that why the type will soon be changed to a string. The type is not changed is this PR as there is a refactor + tests to be fixed when that is done. 

Just pushing the name change first because it touches a LOT of files and it will make reviews of all the other prs easier if I just do it early. 

I believe if the tests run in CI that's probably good enough testing but would appreciate hearing from Pearl or Reggie if we should do more. 

## References

* [Jira story](https://dp3.atlassian.net/browse/mb-6836) for this change

