### PR TITLE
[MB-7055] Split origin and destination price function back into two

### DIFF
--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -82,22 +82,35 @@ const baselineLinehaulPrice = (params) => {
   return calculation(value, label, detail1, detail2, detail3);
 };
 
-// There is no param representing the orgin price or destination price as available in the re_domestic_service_area_prices table
+// There is no param representing the orgin price as available in the re_domestic_service_area_prices table
 // A param to return the service schedule is also not being created
-const originOrDestinationPrice = (params, isOrigin = true) => {
+const originPrice = (params) => {
   const value = getPriceRateOrFactor(params);
-  const serviceAreaKey = isOrigin ? SERVICE_ITEM_PARAM_KEYS.ServiceAreaOrigin : SERVICE_ITEM_PARAM_KEYS.ServiceAreaDest;
-  const serviceAreaVal = getParamValue(serviceAreaKey, params) ? getParamValue(serviceAreaKey, params) : '';
+  const serviceAreaVal = getParamValue(SERVICE_ITEM_PARAM_KEYS.ServiceAreaOrigin, params) || '';
   const requestedPickupDateVal = getParamValue(SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate, params) || '';
-  const label = isOrigin
-    ? SERVICE_ITEM_CALCULATION_LABELS.OriginPrice
-    : SERVICE_ITEM_CALCULATION_LABELS.DestinationPrice;
-
+  const label = SERVICE_ITEM_CALCULATION_LABELS.OriginPrice;
   const serviceArea = `${SERVICE_ITEM_CALCULATION_LABELS.ServiceArea}: ${serviceAreaVal}`;
   const requestedPickupDate = `${
     SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate]
   }: ${formatDate(requestedPickupDateVal, 'DD MMM YYYY')}`;
+  const isPeak = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.IsPeak]} ${
+    getParamValue(SERVICE_ITEM_PARAM_KEYS.IsPeak, params)?.toLowerCase() === 'true' ? 'peak' : 'non-peak'
+  }`;
 
+  return calculation(value, label, serviceArea, requestedPickupDate, isPeak);
+};
+
+// There is no param representing the destination price as available in the re_domestic_service_area_prices table
+// A param to return the service schedule is also not being created
+const destinationPrice = (params) => {
+  const value = getPriceRateOrFactor(params);
+  const serviceAreaVal = getParamValue(SERVICE_ITEM_PARAM_KEYS.ServiceAreaDest, params) || '';
+  const requestedPickupDateVal = getParamValue(SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate, params) || '';
+  const label = SERVICE_ITEM_CALCULATION_LABELS.DestinationPrice;
+  const serviceArea = `${SERVICE_ITEM_CALCULATION_LABELS.ServiceArea}: ${serviceAreaVal}`;
+  const requestedPickupDate = `${
+    SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.RequestedPickupDate]
+  }: ${formatDate(requestedPickupDateVal, 'DD MMM YYYY')}`;
   const isPeak = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.IsPeak]} ${
     getParamValue(SERVICE_ITEM_PARAM_KEYS.IsPeak, params)?.toLowerCase() === 'true' ? 'peak' : 'non-peak'
   }`;
@@ -233,7 +246,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
     case SERVICE_ITEM_CODES.DOP:
       result = [
         billableWeight(params),
-        originOrDestinationPrice(params),
+        originPrice(params),
         priceEscalationFactor(params),
         totalAmountRequested(totalAmount),
       ];
@@ -242,7 +255,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
     case SERVICE_ITEM_CODES.DOFSIT:
       result = [
         billableWeight(params),
-        originOrDestinationPrice(params),
+        originPrice(params),
         priceEscalationFactor(params),
         totalAmountRequested(totalAmount),
       ];
@@ -271,7 +284,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
     case SERVICE_ITEM_CODES.DDP:
       result = [
         billableWeight(params),
-        originOrDestinationPrice(params, false),
+        destinationPrice(params),
         priceEscalationFactor(params),
         totalAmountRequested(totalAmount),
       ];


### PR DESCRIPTION
## Description

Follow up to https://github.com/transcom/mymove/pull/6263, split the `originOrDestinationPrice` function back into two separate functions. See: https://github.com/transcom/mymove/pull/6263#discussion_r605742817

## Reviewer Notes

Should display all the information in the calculators like before.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```