### PR TITLE
Updated pricerDisplayParam to string

### DIFF
--- a/pkg/services/ghc_rate_engine.go
+++ b/pkg/services/ghc_rate_engine.go
@@ -19,7 +19,7 @@ type ServiceItemPricer interface {
 // PricingDisplayParam represents a parameter (key/value pair) returned from a pricer
 type PricingDisplayParam struct {
 	Key   models.ServiceItemParamName
-	Value interface{}
+	Value string
 }
 
 // PricingDisplayParams represents a slice of pricing parameters

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -160,8 +160,8 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	return totalPriceCents, nil, nil
 }
 
-// createPricerGeneratedParams stores params, whose origin is the PRICER, into the database
-// It also returns the
+// createPricerGeneratedParams stores PaymentServiceItemParams, whose origin is the PRICER, into the database
+// It also returns the newly created PaymentServiceItemParams.
 func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.UUID, params services.PricingDisplayParams) (models.PaymentServiceItemParams, error) {
 	var paymentServiceItemParams models.PaymentServiceItemParams
 

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -160,6 +160,8 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	return totalPriceCents, nil, nil
 }
 
+// createPricerGeneratedParams stores params, whose origin is the PRICER, into the database
+// It also returns the
 func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.UUID, params services.PricingDisplayParams) (models.PaymentServiceItemParams, error) {
 	var paymentServiceItemParams models.PaymentServiceItemParams
 
@@ -168,37 +170,24 @@ func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.U
 	}
 
 	for _, param := range params {
+
+		// Find the paymentServiceItemParam associated with this PricingDisplayParam
 		var serviceItemParamKey models.ServiceItemParamKey
 		err := db.Q().
 			Where("key = ?", param.Key).
 			First(&serviceItemParamKey)
 		if err != nil {
-			return paymentServiceItemParams, fmt.Errorf("Unable to find service item param key for %v", serviceItemParamKey.Key)
+			return paymentServiceItemParams, fmt.Errorf("Unable to find service item param key for %v", param.Key)
 		}
 		if serviceItemParamKey.Origin != models.ServiceItemParamOriginPricer {
 			return paymentServiceItemParams, fmt.Errorf("Service item param key is not a pricer param. Param key: %v", serviceItemParamKey.Key)
 		}
 
-		value := param.Value
-		switch serviceItemParamKey.Type {
-		case models.ServiceItemParamTypeTimestamp:
-			if timestampValue, ok := param.Value.(time.Time); ok {
-				value = timestampValue.Format(TimestampParamFormat)
-			} else {
-				return paymentServiceItemParams, fmt.Errorf("Pricing param value is invalid timestamp time.Time type for key: %v", serviceItemParamKey.Key)
-			}
-		case models.ServiceItemParamTypeDate:
-			if dateValue, ok := param.Value.(time.Time); ok {
-				value = dateValue.Format(DateParamFormat)
-			} else {
-				return paymentServiceItemParams, fmt.Errorf("Pricing param value is invalid date time.Time type for key: %v", serviceItemParamKey.Key)
-			}
-		}
-
+		// Create the PaymentServiceItemParam from the PricingDisplayParam and store it in the DB
 		newParam := models.PaymentServiceItemParam{
 			PaymentServiceItemID:  paymentServiceItemID,
 			ServiceItemParamKeyID: serviceItemParamKey.ID,
-			Value:                 fmt.Sprintf("%v", value),
+			Value:                 param.Value,
 		}
 
 		verrs, err := db.ValidateAndCreate(&newParam)
@@ -207,6 +196,7 @@ func createPricerGeneratedParams(db *pop.Connection, paymentServiceItemID uuid.U
 		} else if verrs.HasAny() {
 			return paymentServiceItemParams, services.NewInvalidCreateInputError(verrs, "validation error with creating payment service item param")
 		} else {
+			// Append it to a slice of PaymentServiceItemParams to return
 			paymentServiceItemParams = append(paymentServiceItemParams, newParam)
 		}
 	}

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -182,13 +182,13 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 	params := services.PricingDisplayParams{
 		{
 			Key:   models.ServiceItemParamNamePriceRateOrFactor,
-			Value: 40000.9,
+			Value: "4000.90",
 		}, {
 			Key:   models.ServiceItemParamNameEscalationCompounded,
-			Value: 1.06,
+			Value: "1.06",
 		}, {
 			Key:   models.ServiceItemParamNameIsPeak,
-			Value: true,
+			Value: "True",
 		}, {
 			Key:   models.ServiceItemParamNameContractYearName,
 			Value: "TRUSS_TEST",
@@ -263,7 +263,7 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 		invalidParam := services.PricingDisplayParams{
 			{
 				Key:   models.ServiceItemParamNameServiceAreaOrigin,
-				Value: 40000.9,
+				Value: "40000.9",
 			},
 		}
 


### PR DESCRIPTION
## Description

`PricingDisplayParam.Value` will be stored in the db table `PaymentServiceItemParams` as a string and returned to UI, audit records or Prime. Therefore it needs to be formatted as a string that is human readable/comprehensible, so we will be changing the format of the field to a string in the `PricingDisplayParam` type as well. 

Type updated, tests fixed. 


## Setup

Run the tests for the `ghcrateengine`
```
go test ./pkg/services/ghcrateengine/ -v
```

## References

* [Jira story](https://dp3.atlassian.net/browse/mb-7541) for this change
* [this slack conversation](https://ustcdp3.slack.com/archives/CP497TGAU/p1617233952146100) explains more about the approach used.

