### PR TITLE
Remove @suzubara as codeowner from UI changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,13 +16,11 @@
 /migrations/ @transcom/truss-db
 
 # Require design / frontend reviews on Storybook & CSS changes
-/src/stories/ @transcom/truss-design @suzubara
-*.stories.jsx @transcom/truss-design @suzubara
-*.css @transcom/truss-design @suzubara
-*.scss @transcom/truss-design @suzubara
+/src/stories/ @transcom/truss-design
+*.stories.jsx @transcom/truss-design
+*.css @transcom/truss-design
+*.scss @transcom/truss-design
 
 # Require team Pamplemoose to review changes to configs that may affect cATO static analysis compliancy
 .golangci.yaml @transcom/Truss-Pamplemoose
 .pre-commit-config.yaml @transcom/Truss-Pamplemoose
-
-


### PR DESCRIPTION
## Description

Originally I was added as a codeowner to CSS & Storybook changes to help steer F/E work and also the lift of design review. At this point I believe F/E knowledge & practices have been spread around enough and there's no reason to tag me automatically on these PRs, so I'm removing myself.
