### PR TITLE
MB-6943 controlling the send to syncada

### DIFF
--- a/cmd/milmove-tasks/process_edis.go
+++ b/cmd/milmove-tasks/process_edis.go
@@ -147,6 +147,9 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 		logger.Info(fmt.Sprintf("Starting in %s mode, which enables additional features", dbEnv))
 	}
 
+	sendToSyncada := v.GetBool(cli.SendToSyncada)
+	logger.Info(fmt.Sprintf("SendToSyncada is %v", sendToSyncada))
+
 	// Set the ICNSequencer in the handler: if we are in dev/test mode and sending to a real
 	// GEX URL, then we should use a random ICN number within a defined range to avoid duplicate
 	// test ICNs in Syncada.
@@ -161,7 +164,7 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 		icnSequencer = sequence.NewDatabaseSequencer(dbConnection, ediinvoice.ICNSequenceName)
 	}
 
-	reviewedPaymentRequestProcessor, err := paymentrequest.InitNewPaymentRequestReviewedProcessor(dbConnection, logger, false, icnSequencer)
+	reviewedPaymentRequestProcessor, err := paymentrequest.InitNewPaymentRequestReviewedProcessor(dbConnection, logger, sendToSyncada, icnSequencer)
 	if err != nil {
 		logger.Fatal("InitNewPaymentRequestReviewedProcessor failed", zap.Error(err))
 	}

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -26,6 +26,8 @@ const (
 	GEXSendProdInvoiceFlag string = "gex-send-prod-invoice"
 	// GEXURLFlag is the GEX URL FLag
 	GEXURLFlag string = "gex-url"
+	// SendToSyncada is the flag to control if we try sending files to syncada or not
+	SendToSyncada string = "send-to-syncada"
 )
 
 var gexHostnames = []string{
@@ -49,6 +51,8 @@ func InitGEXFlags(flag *pflag.FlagSet) {
 	flag.String(GEXBasicAuthUsernameFlag, "", "GEX api auth username")
 	flag.String(GEXBasicAuthPasswordFlag, "", "GEX api auth password")
 	flag.Bool(GEXSendProdInvoiceFlag, false, "Flag (bool) for EDI Invoices to signify if they should be sent with Production or Test indicator")
+	flag.Bool(SendToSyncada, false, "Flag (bool) for turning on or off sending EDI 858s to syncada, default false")
+
 	flag.String(GEXURLFlag, "", "URL for sending an HTTP POST request to GEX")
 }
 

--- a/pkg/payment_request/send_to_syncada.go
+++ b/pkg/payment_request/send_to_syncada.go
@@ -24,6 +24,7 @@ func SendToSyncada(edi string, gexSender services.GexSender, sftpSender services
 		syncadaFileName := fmt.Sprintf("%s_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"))
 
 		if sendEDIFile == true {
+			logger.Info("SendToSyncada() is in send mode, sending syncadaFileName: " + syncadaFileName + "")
 			_, err = sftpSender.SendToSyncadaViaSFTP(edi858String, syncadaFileName)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description

We need a way to control when the scheduled task `process-edi` would send EDI 858s to syncada. By default it shouldn't send them unless we set a flag to true. We are storing the flag in chamber as that will allow us to change the setting without having to redeploy the task.

## Reviewer Notes

There are no tests for this, we'll really only be able to verify this works by running the task locally or in exp/stg and checking the exp/stg logs.

## Setup

Run the task locally and it should look like this important bit is `SendToSyncada is false`

```sh
❯ go run ./cmd/milmove-tasks process-edis
{"level":"info","ts":"2021-04-02T22:14:03.314Z","caller":"cli/dbconn.go:258","msg":"Connecting to the database","url":"postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable","db-ssl-root-cert":""}
{"level":"info","ts":"2021-04-02T22:14:03.315Z","caller":"cli/dbconn.go:364","msg":"Starting database ping...."}
{"level":"info","ts":"2021-04-02T22:14:03.329Z","caller":"cli/dbconn.go:371","msg":"...DB ping successful!"}
{"level":"info","ts":"2021-04-02T22:14:03.329Z","caller":"milmove-tasks/process_edis.go:147","msg":"Starting in development mode, which enables additional features"}
{"level":"info","ts":"2021-04-02T22:14:03.329Z","caller":"milmove-tasks/process_edis.go:151","msg":"SendToSyncada is false"}
{"level":"info","ts":"2021-04-02T22:14:03.344Z","caller":"payment_request/payment_request_reviewed_processor.go:138","msg":"EDIs processed","EDIs processed":{"EDIType":"858","NumEDIsProcessed":0,"ProcessStartedAt":"2021-04-02T22:14:03.329Z","ProcessEndedAt":"2021-04-02T22:14:03.344Z"}}
{"level":"info","ts":"2021-04-02T22:14:03.349Z","caller":"milmove-tasks/process_edis.go:87","msg":"Duration of processEDIs task: 34.604706ms"}
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6943) for this change