### PR TITLE
[MB-7220] Turn flag on for deleting files from Syncada

### DIFF
--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -383,7 +383,7 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 		}()
 
 		wrappedSFTPClient := invoice.NewSFTPClientWrapper(sftpClient)
-		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, h.DB(), logger, false)
+		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, h.DB(), logger, true)
 
 		// TODO GEX will put different response types in different directories, but
 		// Syncada puts everything in the same directory. When we have access to GEX in staging


### PR DESCRIPTION
## Description

I had this flag set to false so it wouldn't clear out the files I was using for testing, and forgot to flip it back.

## Reviewer Notes


## Setup

- Create a move
- approve with TOO
- use prime demo script and TIO interface to create a payment request and send it
- Run the following command a couple of times to send the request to syncada and process it when it comes back.`prime-api-client --insecure support-reviewed-payment-requests --filename readfromsyncada.json`
It should eventually change your payment request status to RECEIVED_BY_GEX, and delete the file from syncada