### PR TITLE
[MB-7593] Add reservice name when creating a service item

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -63,8 +63,9 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	if err != nil {
 		return nil, nil, services.NewNotFoundError(uuid.Nil, fmt.Sprintf("for service item with code: %s", reServiceCode))
 	}
-	// set re service for service item
+	// set re service fields for service item
 	serviceItem.ReServiceID = reService.ID
+	serviceItem.ReService.Name = reService.Name
 
 	// We can have two service items that come in from a MTO approval that do not have an MTOShipmentID
 	// they are MTO level service items. This should capture that and create them accordingly, they are thankfully


### PR DESCRIPTION
## Description

When prepping for the slice demo, I noticed that a DDFSIT's reServiceName is not returned properly when creating a service item. This pr sets that value.

* Need to create a bug in jira to track the work

## Setup

Use the prime api to create a DDFSIT. Confirm that the reServiceName is returned.

## Code Review Verification Steps)

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7593) for this change

