### PR TITLE
MB-6827 Update domestic pack pricer to return display params

### DIFF
--- a/pkg/services/ghcrateengine/domestic_pack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer.go
@@ -60,7 +60,26 @@ func (p domesticPackPricer) Price(contractCode string, requestedPickupDate time.
 	escalatedPrice := basePrice * contractYear.EscalationCompounded
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 
-	return totalCost, nil, nil
+	displayParams := services.PricingDisplayParams{
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: contractYear.Name,
+		},
+		{
+			Key:   models.ServiceItemParamNamePriceRateOrFactor,
+			Value: FormatCents(domOtherPrice.PriceCents),
+		},
+		{
+			Key:   models.ServiceItemParamNameIsPeak,
+			Value: FormatBool(isPeakPeriod),
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: FormatFloat(contractYear.EscalationCompounded, 5),
+		},
+	}
+
+	return totalCost, displayParams, nil
 }
 
 // PriceUsingParams determines the price for a domestic pack given PaymentServiceItemParams

--- a/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
@@ -61,10 +61,17 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPackWithServiceItemPara
 	pricer := NewDomesticPackPricer(suite.DB())
 
 	suite.T().Run("success all params for domestic pack available", func(t *testing.T) {
-		cost, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
+		cost, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+
+		if suite.Len(displayParams, 4) {
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Base Period Year 1")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "true")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.46")
+		}
 	})
 
 	suite.T().Run("validation errors", func(t *testing.T) {

--- a/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
+++ b/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
@@ -56,6 +56,7 @@ func (suite *GHCRateEngineServiceSuite) setUpDomesticPackAndUnpackData(code mode
 			ReContractYear: models.ReContractYear{
 				Escalation:           1.0197,
 				EscalationCompounded: 1.0407,
+				Name:                 "Base Period Year 1",
 			},
 		})
 


### PR DESCRIPTION
## Description

This PR adds display params for the DPK service item. It also adds two formatting functions to display bool and float values.

## Setup

`make server_test`

To view the pricer params, follow the steps below:

- Build and start your local client/server (and make sure your DB is up-to-date)
- Create a new move in the customer UI
- As a TOO in the office UI, edit the orders to add the missing fields, then approve the move and the service items. That should automatically add other service items like DPK.
- Run prime-api-demo <move code> local to populate actual weight and other params needed to create a payment request
- Create a payment request using postman with the following body
```
{
    "moveTaskOrderID": "<the move id you created in the UI>",
    "serviceItems": [
        {
            "id": "<ID of the DPK service item you want to create a payment request for. >"
        }
    ],
    "isFinal": false,
    "pointOfContact": "Duis est id dolore elit"
}
```
- Running a fetch-mto-updates via the prime-api-client or postman. You will see the params in the response:
```
                            {
                                "eTag": "MjAyMS0wNC0wN1QyMjo0NDozNC42NDA0NjZa",
                                "id": "2dcb4560-67b6-4d62-9f68-06fa09625efb",
                                "key": "ContractYearName",
                                "origin": "PRICER",
                                "paymentServiceItemID": "7ecc125b-8c1f-4b6f-bf68-6c94f9d5865e",
                                "type": "STRING",
                                "value": "Base Period Year 2"
                            },
                            {
                                "eTag": "MjAyMS0wNC0wN1QyMjo0NDozNC42NDUyNjJa",
                                "id": "2482aa60-7722-472d-9afd-a07888d17c76",
                                "key": "PriceRateOrFactor",
                                "origin": "PRICER",
                                "paymentServiceItemID": "7ecc125b-8c1f-4b6f-bf68-6c94f9d5865e",
                                "type": "DECIMAL",
                                "value": "73.95"
                            },
                            {
                                "eTag": "MjAyMS0wNC0wN1QyMjo0NDozNC42NDla",
                                "id": "f92f1f29-ad39-45a8-aecb-59871a584a9b",
                                "key": "IsPeak",
                                "origin": "PRICER",
                                "paymentServiceItemID": "7ecc125b-8c1f-4b6f-bf68-6c94f9d5865e",
                                "type": "BOOLEAN",
                                "value": "false"
                            },
                            {
                                "eTag": "MjAyMS0wNC0wN1QyMjo0NDozNC42NTMxNVo=",
                                "id": "e87caab6-d3eb-4d13-a7f3-165ecdb4029d",
                                "key": "EscalationCompounded",
                                "origin": "PRICER",
                                "paymentServiceItemID": "7ecc125b-8c1f-4b6f-bf68-6c94f9d5865e",
                                "type": "DECIMAL",
                                "value": "1.02060"
                            }
```
<img width="1124" alt="Screen Shot 2021-04-07 at 2 59 31 PM" src="https://user-images.githubusercontent.com/56279459/113945035-ffb52800-97b1-11eb-8abe-0585addd3986.png">

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.
