### PR TITLE
[MB-7607] Add deleteFromSyncada param to support-reviewed-payment-requests

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -2060,9 +2060,15 @@ func init() {
       "type": "object",
       "required": [
         "sendToSyncada",
-        "readFromSyncada"
+        "readFromSyncada",
+        "deleteFromSyncada"
       ],
       "properties": {
+        "deleteFromSyncada": {
+          "type": "boolean",
+          "x-nullable": true,
+          "example": true
+        },
         "paymentRequestID": {
           "type": "string",
           "format": "uuid",
@@ -4743,9 +4749,15 @@ func init() {
       "type": "object",
       "required": [
         "sendToSyncada",
-        "readFromSyncada"
+        "readFromSyncada",
+        "deleteFromSyncada"
       ],
       "properties": {
+        "deleteFromSyncada": {
+          "type": "boolean",
+          "x-nullable": true,
+          "example": true
+        },
         "paymentRequestID": {
           "type": "string",
           "format": "uuid",

--- a/pkg/gen/supportmessages/process_reviewed_payment_requests.go
+++ b/pkg/gen/supportmessages/process_reviewed_payment_requests.go
@@ -17,6 +17,10 @@ import (
 // swagger:model ProcessReviewedPaymentRequests
 type ProcessReviewedPaymentRequests struct {
 
+	// delete from syncada
+	// Required: true
+	DeleteFromSyncada *bool `json:"deleteFromSyncada"`
+
 	// payment request ID
 	// Read Only: true
 	// Format: uuid
@@ -38,6 +42,10 @@ type ProcessReviewedPaymentRequests struct {
 func (m *ProcessReviewedPaymentRequests) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDeleteFromSyncada(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePaymentRequestID(formats); err != nil {
 		res = append(res, err)
 	}
@@ -57,6 +65,15 @@ func (m *ProcessReviewedPaymentRequests) Validate(formats strfmt.Registry) error
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ProcessReviewedPaymentRequests) validateDeleteFromSyncada(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteFromSyncada", "body", m.DeleteFromSyncada); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -263,6 +263,7 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 	paymentRequestID := uuid.FromStringOrNil(params.Body.PaymentRequestID.String())
 	sendToSyncada := params.Body.SendToSyncada
 	readFromSyncada := params.Body.ReadFromSyncada
+	deleteFromSyncada := params.Body.DeleteFromSyncada
 	paymentRequestStatus := params.Body.Status
 	var paymentRequests models.PaymentRequests
 	var updatedPaymentRequests models.PaymentRequests
@@ -272,6 +273,9 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 	}
 	if readFromSyncada == nil {
 		return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, readFromSyncada flag required", h.GetTraceID()))
+	}
+	if deleteFromSyncada == nil {
+		return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, deleteFromSyncada flag required", h.GetTraceID()))
 	}
 
 	if *sendToSyncada {
@@ -383,7 +387,7 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 		}()
 
 		wrappedSFTPClient := invoice.NewSFTPClientWrapper(sftpClient)
-		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, h.DB(), logger, false)
+		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, h.DB(), logger, *deleteFromSyncada)
 
 		// TODO GEX will put different response types in different directories, but
 		// Syncada puts everything in the same directory. When we have access to GEX in staging

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -573,13 +573,15 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
 			Body: &supportmessages.ProcessReviewedPaymentRequests{
-				SendToSyncada:   &sendToSyncada,
-				ReadFromSyncada: &readFromSyncada,
-				Status:          "SENT_TO_GEX",
+				SendToSyncada:     &sendToSyncada,
+				ReadFromSyncada:   &readFromSyncada,
+				DeleteFromSyncada: &deleteFromSyncada,
+				Status:            "SENT_TO_GEX",
 			},
 		}
 
@@ -598,12 +600,14 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
 			Body: &supportmessages.ProcessReviewedPaymentRequests{
-				SendToSyncada:   &sendToSyncada,
-				ReadFromSyncada: &readFromSyncada,
-				Status:          "SENT_TO_GEX",
+				SendToSyncada:     &sendToSyncada,
+				ReadFromSyncada:   &readFromSyncada,
+				DeleteFromSyncada: &deleteFromSyncada,
+				Status:            "SENT_TO_GEX",
 			},
 		}
 
@@ -628,9 +632,10 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
-			Body:        &supportmessages.ProcessReviewedPaymentRequests{ReadFromSyncada: &readFromSyncada, SendToSyncada: &sendToSyncada},
+			Body:        &supportmessages.ProcessReviewedPaymentRequests{ReadFromSyncada: &readFromSyncada, SendToSyncada: &sendToSyncada, DeleteFromSyncada: &deleteFromSyncada},
 		}
 
 		response := handler.Handle(params)
@@ -653,12 +658,14 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
 			Body: &supportmessages.ProcessReviewedPaymentRequests{
-				SendToSyncada:    &sendToSyncada,
-				ReadFromSyncada:  &readFromSyncada,
-				PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
+				SendToSyncada:     &sendToSyncada,
+				ReadFromSyncada:   &readFromSyncada,
+				DeleteFromSyncada: &deleteFromSyncada,
+				PaymentRequestID:  strfmt.UUID(paymentRequestID.String()),
 			},
 		}
 
@@ -712,13 +719,15 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		prID := reviewedPRs[0].ID
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
 			Body: &supportmessages.ProcessReviewedPaymentRequests{
-				SendToSyncada:    &sendToSyncada,
-				ReadFromSyncada:  &readFromSyncada,
-				PaymentRequestID: strfmt.UUID(prID.String()),
+				SendToSyncada:     &sendToSyncada,
+				ReadFromSyncada:   &readFromSyncada,
+				DeleteFromSyncada: &deleteFromSyncada,
+				PaymentRequestID:  strfmt.UUID(prID.String()),
 			},
 		}
 
@@ -748,12 +757,14 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		req := httptest.NewRequest("PATCH", fmt.Sprint(urlFormat), nil)
 		sendToSyncada := false
 		readFromSyncada := false
+		deleteFromSyncada := false
 
 		params := paymentrequestop.ProcessReviewedPaymentRequestsParams{
 			HTTPRequest: req,
 			Body: &supportmessages.ProcessReviewedPaymentRequests{
-				SendToSyncada:   &sendToSyncada,
-				ReadFromSyncada: &readFromSyncada,
+				SendToSyncada:     &sendToSyncada,
+				ReadFromSyncada:   &readFromSyncada,
+				DeleteFromSyncada: &deleteFromSyncada,
 			},
 		}
 

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -383,7 +383,7 @@ cat > ./tmp/pad_update_payment_request_status.json <<-EOM
   "body": {
     "paymentRequestID": "${prID}",
     "sendToSyncada": false,
-    "readFromSyncada": false
+    "readFromSyncada": false,
     "deleteFromSyncada": false
   }
 }

--- a/scripts/prime-api-demo
+++ b/scripts/prime-api-demo
@@ -384,6 +384,7 @@ cat > ./tmp/pad_update_payment_request_status.json <<-EOM
     "paymentRequestID": "${prID}",
     "sendToSyncada": false,
     "readFromSyncada": false
+    "deleteFromSyncada": false
   }
 }
 EOM

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1639,9 +1639,14 @@ definitions:
         example: true
         type: boolean
         x-nullable: true
+      deleteFromSyncada:
+        example: true
+        type: boolean
+        x-nullable: true
     required:
       - sendToSyncada
       - readFromSyncada
+      - deleteFromSyncada
   ProofOfServicePackage:
     properties:
       id:


### PR DESCRIPTION
## Description
I was originally hardcoding this value when passing to `NewSyncadaSFTPReaderSession`, but we decided to add a parameter for it so it doesn't require a code change to modify.

## Reviewer Notes

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
rm bin/prime-api-client && make bin/prime-api-client

```
deletefromsyncada.json
```json
{
  "body": {
    "sendToSyncada": false,
    "readFromSyncada": true,
    "deleteFromSyncada": true
  }
}
```

```sh
prime-api-client --insecure support-reviewed-payment-requests --filename deletefromsyncada.json
```
If you have any payment requests locally that match a response file in syncada, then they should be deleted from Syncada. However, since we can't get response files from syncada right now, we can't test that the deletion is really happening.
We've tested deleting from syncada in previous work though, so I think the most important thing to test is that I didn't break anything and the command still runs.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7607) for this change