### PR TITLE
MB-6829 Domestic Origin Pricer Params

### DIFF
--- a/pkg/services/ghcrateengine/domestic_origin_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer.go
@@ -58,7 +58,25 @@ func (p domesticOriginPricer) Price(contractCode string, requestedPickupDate tim
 	escalatedPrice := basePrice * contractYear.EscalationCompounded
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 
-	return totalCost, nil, nil
+	params := services.PricingDisplayParams{
+		{
+			Key:   models.ServiceItemParamNamePriceRateOrFactor,
+			Value: FormatCents(domServiceAreaPrice.PriceCents),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: contractYear.Name,
+		},
+		{
+			Key:   models.ServiceItemParamNameIsPeak,
+			Value: FormatBool(isPeakPeriod),
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: FormatFloat(contractYear.EscalationCompounded, 2),
+		},
+	}
+	return totalCost, params, nil
 }
 
 // PriceUsingParams determines the price for a domestic origin given PaymentServiceItemParams

--- a/pkg/services/ghcrateengine/domestic_origin_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer.go
@@ -73,7 +73,7 @@ func (p domesticOriginPricer) Price(contractCode string, requestedPickupDate tim
 		},
 		{
 			Key:   models.ServiceItemParamNameEscalationCompounded,
-			Value: FormatFloat(contractYear.EscalationCompounded, 2),
+			Value: FormatFloat(contractYear.EscalationCompounded, 5),
 		},
 	}
 	return totalCost, params, nil

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -105,7 +105,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 	pricer := NewDomesticOriginPricer(suite.DB())
 
 	suite.T().Run("success domestic origin cost within peak period", func(t *testing.T) {
-		cost, _, err := pricer.Price(
+		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
 			dopTestWeight,
@@ -114,19 +114,30 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Test Contract Year")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "true")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.46")
 	})
 
 	suite.T().Run("success domestic origin cost within non-peak period", func(t *testing.T) {
 		nonPeakDate := peakStart.addDate(0, -1)
-		cost, _, err := pricer.Price(
+		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, nonPeakDate.month, nonPeakDate.day, 0, 0, 0, 0, time.UTC),
 			dopTestWeight,
 			dopTestServiceArea,
 		)
+
 		expectedCost := unit.Cents(4758)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Test Contract Year")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "false")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.27")
 	})
 
 	suite.T().Run("failure if contract code bogus", func(t *testing.T) {

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -61,10 +61,16 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemPa
 	pricer := NewDomesticOriginPricer(suite.DB())
 
 	suite.T().Run("success all params for domestic origin available", func(t *testing.T) {
-		cost, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
+		cost, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
+
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Test Contract Year")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "true")
+		suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.46")
 	})
 
 	suite.T().Run("validation errors", func(t *testing.T) {


### PR DESCRIPTION
## Description

* Updates the Domestic Origin Pricer to return its 4 display params.


## Setup

Please follow [A-Team's testing instructions](https://github.com/transcom/mymove/wiki/Acceptance-Testing-Payment-Requests#move-task-order-actions) for creating a new MTO. When you use the TOO interface (or the Support API endpoint) to approve a shipment associated with this move, the default service items should be created. One is DOP or the domestic origin price.

Note that this change is NOT yet visible in the payment request.
This change is visible in the TIO payment request but only after you approve the payment request.
This change is also visible in fetch-mto-updates

There should be 4 new params for

* `ContractYearName`
* `PriceRateOrFactor`
* `IsPeak`
* `EscalationCompounded`

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6829) for this change

