### PR TITLE
[MB-6828] Adding Pricer Params to Domestic Destination Pricer

### DIFF
--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -61,6 +61,7 @@ func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDat
 		{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: fmt.Sprintf("%v", domServiceAreaPrice.PriceCents.ToDollarString())},
 		{Key: models.ServiceItemParamNameContractYearName, Value: fmt.Sprintf("%v", contractYear.Name)},
 		{Key: models.ServiceItemParamNameIsPeak, Value: fmt.Sprintf("%v", isPeakPeriod)},
+		{Key: models.ServiceItemParamNameEscalationCompounded, Value: fmt.Sprintf("%v", contractYear.EscalationCompounded)},
 	}
 
 	return totalCost, pricingParams, nil

--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -58,8 +58,8 @@ func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDat
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 
 	pricingParams := services.PricingDisplayParams{
-		{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: fmt.Sprintf("%v", domServiceAreaPrice.PriceCents.ToDollarString())},
-		{Key: models.ServiceItemParamNameContractYearName, Value: fmt.Sprintf("%v", contractYear.Name)},
+		{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatCents(domServiceAreaPrice.PriceCents)},
+		{Key: models.ServiceItemParamNameContractYearName, Value: contractYear.Name},
 		{Key: models.ServiceItemParamNameIsPeak, Value: fmt.Sprintf("%v", isPeakPeriod)},
 		{Key: models.ServiceItemParamNameEscalationCompounded, Value: fmt.Sprintf("%v", contractYear.EscalationCompounded)},
 	}

--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -60,8 +60,8 @@ func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDat
 	pricingParams := services.PricingDisplayParams{
 		{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatCents(domServiceAreaPrice.PriceCents)},
 		{Key: models.ServiceItemParamNameContractYearName, Value: contractYear.Name},
-		{Key: models.ServiceItemParamNameIsPeak, Value: fmt.Sprintf("%v", isPeakPeriod)},
-		{Key: models.ServiceItemParamNameEscalationCompounded, Value: fmt.Sprintf("%v", contractYear.EscalationCompounded)},
+		{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(isPeakPeriod)},
+		{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatFloat(contractYear.EscalationCompounded, 5)},
 	}
 
 	return totalCost, pricingParams, nil

--- a/pkg/services/ghcrateengine/domestic_destination_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer.go
@@ -57,7 +57,13 @@ func (p domesticDestinationPricer) Price(contractCode string, requestedPickupDat
 	escalatedPrice := basePrice * contractYear.EscalationCompounded
 	totalCost := unit.Cents(math.Round(escalatedPrice))
 
-	return totalCost, nil, nil
+	pricingParams := services.PricingDisplayParams{
+		{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: fmt.Sprintf("%v", domServiceAreaPrice.PriceCents.ToDollarString())},
+		{Key: models.ServiceItemParamNameContractYearName, Value: fmt.Sprintf("%v", contractYear.Name)},
+		{Key: models.ServiceItemParamNameIsPeak, Value: fmt.Sprintf("%v", isPeakPeriod)},
+	}
+
+	return totalCost, pricingParams, nil
 }
 
 func (p domesticDestinationPricer) PriceUsingParams(params models.PaymentServiceItemParams) (unit.Cents, services.PricingDisplayParams, error) {

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -99,7 +99,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 	pricer := NewDomesticDestinationPricer(suite.DB())
 
 	suite.T().Run("success destination cost within peak period", func(t *testing.T) {
-		cost, _, err := pricer.Price(
+		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
 			ddpTestWeight,
@@ -108,6 +108,19 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+		suite.Equal(4, len(displayParams))
+		for _, param := range displayParams {
+			switch param.Key {
+			case models.ServiceItemParamNamePriceRateOrFactor:
+				suite.Equal("1.46", param.Value)
+			case models.ServiceItemParamNameContractYearName:
+				suite.Equal("Base Year 5", param.Value)
+			case models.ServiceItemParamNameIsPeak:
+				suite.Equal("true", param.Value)
+			case models.ServiceItemParamNameEscalationCompounded:
+				suite.Equal("1.0407", param.Value)
+			}
+		}
 	})
 
 	suite.T().Run("success destination cost within non-peak period", func(t *testing.T) {
@@ -219,6 +232,7 @@ func (suite *GHCRateEngineServiceSuite) setUpDomesticDestinationData() {
 			ReContractYear: models.ReContractYear{
 				Escalation:           1.0197,
 				EscalationCompounded: 1.0407,
+				Name:                 "Base Year 5",
 			},
 		})
 

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -107,6 +107,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		)
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
+
 		suite.Equal(expectedCost, cost)
 		suite.Equal(4, len(displayParams))
 		for _, param := range displayParams {
@@ -125,7 +126,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 
 	suite.T().Run("success destination cost within non-peak period", func(t *testing.T) {
 		nonPeakDate := peakStart.addDate(0, -1)
-		cost, _, err := pricer.Price(
+		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, nonPeakDate.month, nonPeakDate.day, 0, 0, 0, 0, time.UTC),
 			ddpTestWeight,
@@ -134,6 +135,20 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		expectedCost := unit.Cents(4758)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
+
+		suite.Equal(4, len(displayParams))
+		for _, param := range displayParams {
+			switch param.Key {
+			case models.ServiceItemParamNamePriceRateOrFactor:
+				suite.Equal("1.27", param.Value)
+			case models.ServiceItemParamNameContractYearName:
+				suite.Equal("Base Year 5", param.Value)
+			case models.ServiceItemParamNameIsPeak:
+				suite.Equal("false", param.Value)
+			case models.ServiceItemParamNameEscalationCompounded:
+				suite.Equal("1.0407", param.Value)
+			}
+		}
 	})
 
 	suite.T().Run("failure if contract code bogus", func(t *testing.T) {

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -109,19 +109,13 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.NoError(err)
 
 		suite.Equal(expectedCost, cost)
-		suite.Equal(4, len(displayParams))
-		for _, param := range displayParams {
-			switch param.Key {
-			case models.ServiceItemParamNamePriceRateOrFactor:
-				suite.Equal("1.46", param.Value)
-			case models.ServiceItemParamNameContractYearName:
-				suite.Equal("Base Year 5", param.Value)
-			case models.ServiceItemParamNameIsPeak:
-				suite.Equal("true", param.Value)
-			case models.ServiceItemParamNameEscalationCompounded:
-				suite.Equal("1.0407", param.Value)
-			}
+		if suite.Len(displayParams, 4) {
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Base Year 5")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "true")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.46")
 		}
+
 	})
 
 	suite.T().Run("success destination cost within non-peak period", func(t *testing.T) {
@@ -136,18 +130,11 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
 
-		suite.Equal(4, len(displayParams))
-		for _, param := range displayParams {
-			switch param.Key {
-			case models.ServiceItemParamNamePriceRateOrFactor:
-				suite.Equal("1.27", param.Value)
-			case models.ServiceItemParamNameContractYearName:
-				suite.Equal("Base Year 5", param.Value)
-			case models.ServiceItemParamNameIsPeak:
-				suite.Equal("false", param.Value)
-			case models.ServiceItemParamNameEscalationCompounded:
-				suite.Equal("1.0407", param.Value)
-			}
+		if suite.Len(displayParams, 4) {
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameContractYearName, "Base Year 5")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameEscalationCompounded, "1.04070")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNameIsPeak, "false")
+			suite.HasDisplayParam(displayParams, models.ServiceItemParamNamePriceRateOrFactor, "1.27")
 		}
 	})
 

--- a/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
+++ b/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
@@ -177,7 +177,7 @@ func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulPrice(serviceAreaCo
 func (suite *GHCRateEngineServiceSuite) HasDisplayParam(displayParams services.PricingDisplayParams, key models.ServiceItemParamName, value string) bool {
 	for _, displayParam := range displayParams {
 		if displayParam.Key == key {
-			return suite.Equal(value, displayParam.Value)
+			return suite.Equal(value, displayParam.Value, "%s param actual value did not match expected", key.String())
 		}
 	}
 

--- a/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
+++ b/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
@@ -177,9 +177,7 @@ func (suite *GHCRateEngineServiceSuite) setupDomesticLinehaulPrice(serviceAreaCo
 func (suite *GHCRateEngineServiceSuite) HasDisplayParam(displayParams services.PricingDisplayParams, key models.ServiceItemParamName, value string) bool {
 	for _, displayParam := range displayParams {
 		if displayParam.Key == key {
-			if displayParam.Value == value {
-				return true
-			}
+			return suite.Equal(value, displayParam.Value)
 		}
 	}
 


### PR DESCRIPTION
## Description

Updates the Domestic Destination pricer to return a display parameter for 4 param keys.


## Setup

Please follow [A-Team's testing instructions](https://github.com/transcom/mymove/wiki/Acceptance-Testing-Payment-Requests#move-task-order-actions) for creating a new MTO. When you use the TOO interface (or the Support API endpoint) to approve a shipment associated with this move, the default service items should be created. One is DDP or the domestic destination price. 

Note that this change is NOT yet visible in the payment request.
This change is visible in the TIO payment request but only after you approve the payment request. 
This change is also visible in fetch-mto-updates

There should be 4 new params for 
*    ContractYearName
*    PriceRateOrFactor
*    IsPeak
*    EscalationCompounded

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6828) for this change.