### PR TITLE
[MB-7383] Services Counselor can edit move contact info (storybook)

### DIFF
--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -14,23 +14,22 @@ import { Form } from 'components/form/Form';
 import formStyles from 'styles/form.module.scss';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import { requiredAddressSchema } from 'utils/validation';
+import { ResidentialAddressShape } from 'types/address';
 
 const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
   const validationSchema = Yup.object().shape({
-    first_name: Yup.string().required('Required'),
-    last_name: Yup.string().required('Required'),
-    middle_name: Yup.string(),
+    firstName: Yup.string().required('Required'),
+    lastName: Yup.string().required('Required'),
+    middleName: Yup.string(),
     suffix: Yup.string(),
-    customer_email: Yup.string()
+    customerEmail: Yup.string()
       .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
       .required('Required'),
-    customer_telephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code').required('Required'), // min 12 includes hyphens
-    customer_address: requiredAddressSchema.required(),
-    name: Yup.string().required('Required'),
-    email: Yup.string()
-      .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
-      .required('Required'),
-    telephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code').required('Required'), // min 12 includes hyphens
+    customerTelephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code').required('Required'), // min 12 includes hyphens
+    customerAddress: requiredAddressSchema.required(),
+    name: Yup.string(),
+    email: Yup.string().matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address'),
+    telephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code'), // min 12 includes hyphens
   });
 
   return (
@@ -54,9 +53,9 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
                 )}
               />
               <h3 className={styles.sectionHeader}>Current Address</h3>
-              <AddressFields name="customer_address" />
+              <AddressFields name="customerAddress" />
             </SectionWrapper>
-            <SectionWrapper className={formStyles.formSection}>
+            <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
               <h2 className={styles.sectionHeader}>
                 Backup contact <span className={styles.optional}>Optional</span>
               </h2>
@@ -80,9 +79,16 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
 
 CustomerContactInfoForm.propTypes = {
   initialValues: PropTypes.shape({
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    middleName: PropTypes.string,
+    suffix: PropTypes.string,
+    customerTelephone: PropTypes.string,
+    customerEmail: PropTypes.string,
     name: PropTypes.string,
     telephone: PropTypes.string,
     email: PropTypes.string,
+    customerAddress: ResidentialAddressShape,
   }).isRequired,
   onSubmit: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -37,7 +37,7 @@ const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
       {({ isValid, isSubmitting, handleSubmit }) => {
         return (
           <Form className={formStyles.form}>
-            <SectionWrapper className={formStyles.formSection}>
+            <SectionWrapper className={`${formStyles.formSection} ${styles.formSectionHeader}`}>
               <CustomerAltContactInfoFields
                 render={(fields) => (
                   <>

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Formik } from 'formik';
+import * as Yup from 'yup';
+import PropTypes from 'prop-types';
+import { Checkbox } from '@trussworks/react-uswds';
+
+import styles from './CustomerContactInfoForm.module.scss';
+
+import { BackupContactInfoFields } from 'components/form/BackupContactInfoFields';
+import { CustomerAltContactInfoFields } from 'components/form/CustomerAltContactInfoFields';
+import { AddressFields } from 'components/form/AddressFields/AddressFields';
+import SectionWrapper from 'components/Customer/SectionWrapper';
+import { Form } from 'components/form/Form';
+import formStyles from 'styles/form.module.scss';
+import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
+import { requiredAddressSchema } from 'utils/validation';
+
+const CustomerContactInfoForm = ({ initialValues, onSubmit, onBack }) => {
+  const validationSchema = Yup.object().shape({
+    first_name: Yup.string().required('Required'),
+    last_name: Yup.string().required('Required'),
+    middle_name: Yup.string(),
+    suffix: Yup.string(),
+    customer_email: Yup.string()
+      .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
+      .required('Required'),
+    customer_telephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code').required('Required'), // min 12 includes hyphens
+    customer_address: requiredAddressSchema.required(),
+    name: Yup.string().required('Required'),
+    email: Yup.string()
+      .matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$/, 'Must be a valid email address')
+      .required('Required'),
+    telephone: Yup.string().min(12, 'Number must have 10 digits and a valid area code').required('Required'), // min 12 includes hyphens
+  });
+
+  return (
+    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema} validateOnMount>
+      {({ isValid, isSubmitting, handleSubmit }) => {
+        return (
+          <Form className={formStyles.form}>
+            <SectionWrapper className={formStyles.formSection}>
+              <CustomerAltContactInfoFields
+                render={(fields) => (
+                  <>
+                    <h2>Contact info</h2>
+                    <Checkbox
+                      data-testid="useCurrentResidence"
+                      label="This is not the person named on the orders."
+                      name="useCurrentResidence"
+                      id="useCurrentResidenceCheckbox"
+                    />
+                    {fields}
+                  </>
+                )}
+              />
+              <h3 className={styles.sectionHeader}>Current Address</h3>
+              <AddressFields name="customer_address" />
+            </SectionWrapper>
+            <SectionWrapper className={formStyles.formSection}>
+              <h2 className={styles.sectionHeader}>
+                Backup contact <span className={styles.optional}>Optional</span>
+              </h2>
+
+              <BackupContactInfoFields />
+            </SectionWrapper>
+            <div className={formStyles.formActions}>
+              <WizardNavigation
+                editMode
+                disableNext={!isValid || isSubmitting}
+                onCancelClick={onBack}
+                onNextClick={handleSubmit}
+              />
+            </div>
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+};
+
+CustomerContactInfoForm.propTypes = {
+  initialValues: PropTypes.shape({
+    name: PropTypes.string,
+    telephone: PropTypes.string,
+    email: PropTypes.string,
+  }).isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
+};
+
+export default CustomerContactInfoForm;

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
@@ -1,0 +1,18 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+@import 'shared/styles/_custom';
+
+.sectionHeader {
+  margin-bottom: 0 !important;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  .optional {
+    font-size: 13px;
+    line-height: 1.3;
+    color: $base;
+    font-weight: normal;
+    float: right;
+  }
+}

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
@@ -10,9 +10,7 @@
   justify-content: space-between;
   .optional {
     font-size: 13px;
-    line-height: 1.3;
     color: $base;
     font-weight: normal;
-    float: right;
   }
 }

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.module.scss
@@ -3,14 +3,16 @@
 @import 'shared/styles/colors';
 @import 'shared/styles/_custom';
 
-.sectionHeader {
-  margin-bottom: 0 !important;
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  .optional {
-    font-size: 13px;
-    color: $base;
-    font-weight: normal;
+.formSectionHeader {
+  .sectionHeader {
+    margin-bottom: 0;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    .optional {
+      font-size: 13px;
+      color: $base;
+      font-weight: normal;
+    }
   }
 }

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.stories.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.stories.jsx
@@ -18,13 +18,13 @@ export const DefaultState = (argTypes) => (
 export const WithInitialValues = (argTypes) => (
   <CustomerContactInfoForm
     initialValues={{
-      first_name: 'Leo',
-      middle_name: 'Star',
-      last_name: 'Spaceman',
+      firstName: 'Leo',
+      middleName: 'Star',
+      lastName: 'Spaceman',
       suffix: 'Mr.',
-      customer_telephone: '555-555-5555',
-      customer_email: 'test@sample.com',
-      customer_address: {
+      customerTelephone: '555-555-5555',
+      customerEmail: 'test@sample.com',
+      customerAddress: {
         street_address_1: '235 Prospect Valley Road SE',
         street_address_2: 'Apt. 3B',
         city: 'El Paso',

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.stories.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.stories.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import CustomerContactInfoForm from './CustomerContactInfoForm';
+
+export default {
+  title: 'Office Components / Forms/ Customer Contact Info Form',
+  component: CustomerContactInfoForm,
+  argTypes: {
+    onSubmit: { action: 'submitted on Next' },
+    onBack: { action: 'to previous page on Back' },
+  },
+};
+
+export const DefaultState = (argTypes) => (
+  <CustomerContactInfoForm initialValues={{}} onSubmit={argTypes.onSubmit} onBack={argTypes.onBack} />
+);
+
+export const WithInitialValues = (argTypes) => (
+  <CustomerContactInfoForm
+    initialValues={{
+      first_name: 'Leo',
+      middle_name: 'Star',
+      last_name: 'Spaceman',
+      suffix: 'Mr.',
+      customer_telephone: '555-555-5555',
+      customer_email: 'test@sample.com',
+      customer_address: {
+        street_address_1: '235 Prospect Valley Road SE',
+        street_address_2: 'Apt. 3B',
+        city: 'El Paso',
+        state: 'TX',
+        postal_code: '79912',
+      },
+      name: 'Leo Spaceman',
+      telephone: '555-555-5555',
+      email: 'test@sample.com',
+    }}
+    onNextClick={argTypes.onSubmit}
+    onCancelClick={argTypes.onBack}
+  />
+);

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -58,11 +58,8 @@ describe('CustomerContactInfoForm Component', () => {
       expect(screen.getByLabelText('ZIP')).toBeInstanceOf(HTMLInputElement);
 
       expect(screen.getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getByLabelText('Name')).toBeRequired();
       expect(screen.getAllByLabelText('Phone')[1]).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getAllByLabelText('Phone')[1]).toBeRequired();
       expect(screen.getAllByLabelText('Email')[1]).toBeInstanceOf(HTMLInputElement);
-      expect(screen.getAllByLabelText('Email')[1]).toBeRequired();
     });
   });
 });

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+// import userEvent from '@testing-library/user-event';
+
+import CustomerContactInfoForm from './CustomerContactInfoForm';
+
+describe('CustomerContactInfoForm Component', () => {
+  const initialValues = {
+    first_name: '',
+    middle_name: '',
+    last_name: '',
+    suffix: '',
+    customer_telephone: '',
+    customer_email: '',
+    customer_address: {
+      street_address_1: '',
+      street_address_2: '',
+      city: '',
+      state: '',
+      postal_code: '',
+    },
+    name: '',
+    telephone: '',
+    email: '',
+  };
+  const testProps = {
+    initialValues,
+    onSubmit: jest.fn(),
+    onBack: jest.fn(),
+  };
+
+  it('renders the form inputs', async () => {
+    render(<CustomerContactInfoForm {...testProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Contact info')).toBeInstanceOf(HTMLHeadingElement);
+      expect(screen.getByLabelText('First name')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('First name')).toBeRequired();
+
+      expect(screen.getByLabelText(/Middle name/)).toBeInstanceOf(HTMLInputElement);
+
+      expect(screen.getByLabelText('Last name')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Last name')).toBeRequired();
+
+      expect(screen.getByLabelText(/Suffix/)).toBeInstanceOf(HTMLInputElement);
+
+      expect(screen.getAllByLabelText('Phone')[0]).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getAllByLabelText('Phone')[0]).toBeRequired();
+      expect(screen.getAllByLabelText('Email')[0]).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getAllByLabelText('Email')[0]).toBeRequired();
+
+      expect(screen.getByText('Current Address')).toBeInstanceOf(HTMLHeadingElement);
+      expect(screen.getByLabelText('Address 1')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText(/Address 2/)).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('City')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('State')).toBeInstanceOf(HTMLSelectElement);
+      expect(screen.getByLabelText('ZIP')).toBeInstanceOf(HTMLInputElement);
+
+      expect(screen.getByLabelText('Name')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Name')).toBeRequired();
+      expect(screen.getAllByLabelText('Phone')[1]).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getAllByLabelText('Phone')[1]).toBeRequired();
+      expect(screen.getAllByLabelText('Email')[1]).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getAllByLabelText('Email')[1]).toBeRequired();
+    });
+  });
+
+  // it('validates the customer phone field', async () => {
+  //   render(<CustomerContactInfoForm {...testProps} />);
+  //   userEvent.type(screen.getByLabelText('Best contact phone'), '12345');
+  //   userEvent.tab();
+
+  //   await waitFor(() => {
+  //     expect(screen.getByText('Number must have 10 digits and a valid area code')).toBeInTheDocument();
+  //   });
+  // });
+
+  // it('validates the customer email field', async () => {
+  //   render(<CustomerContactInfoForm {...testProps} />);
+  //   userEvent.type(screen.getByLabelText('Email'), 'sample@');
+  //   userEvent.tab();
+
+  //   await waitFor(() => {
+  //     expect(screen.getByText('Must be a valid email address')).toBeInTheDocument();
+  //   });
+  // });
+
+  // it('shows an error message when trying to submit an invalid form', async () => {
+  //   render(<CustomerContactInfoForm {...testProps} />);
+  //   const submitBtn = screen.getByRole('button', { name: 'Save' });
+
+  //   userEvent.click(submitBtn);
+
+  //   await waitFor(() => {
+  //     expect(screen.getAllByText('Required').length).toBe(2);
+  //   });
+
+  //   expect(testProps.onSubmit).not.toHaveBeenCalled();
+  // });
+
+  // it('submits a form when it is valid', async () => {
+  //   render(<CustomerContactInfoForm {...testProps} />);
+  //   const submitBtn = screen.getByRole('button', { name: 'Next' });
+
+  //   userEvent.type(screen.getByLabelText('Phone'), '555-555-5555');
+  //   userEvent.type(screen.getByLabelText('Email'), 'test@sample.com');
+  //   userEvent.click(screen.getByLabelText('Email'));
+  //   userEvent.click(submitBtn);
+
+  //   await waitFor(() => {
+  //     expect(testProps.onSubmit).toHaveBeenCalled();
+  //   });
+  // });
+
+  // it('calls the cancel handler when cancel button is clicked', async () => {
+  //   render(<CustomerContactInfoForm {...testProps} />);
+  //   const backBtn = screen.getByRole('button', { name: 'Cancel' });
+
+  //   userEvent.type(screen.getByLabelText('Phone'), '555-555-1111');
+  //   userEvent.type(screen.getByLabelText('Email'), 'test@sample.com');
+  //   userEvent.click(screen.getByLabelText('Email'));
+  //   userEvent.click(backBtn);
+
+  //   await waitFor(() => {
+  //     expect(testProps.onBack).toHaveBeenCalled();
+  //   });
+  // });
+});

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -34,6 +34,7 @@ describe('CustomerContactInfoForm Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Contact info')).toBeInstanceOf(HTMLHeadingElement);
+      expect(screen.getByLabelText('This is not the person named on the orders.')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('First name')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('First name')).toBeRequired();
 
@@ -64,65 +65,4 @@ describe('CustomerContactInfoForm Component', () => {
       expect(screen.getAllByLabelText('Email')[1]).toBeRequired();
     });
   });
-
-  // it('validates the customer phone field', async () => {
-  //   render(<CustomerContactInfoForm {...testProps} />);
-  //   userEvent.type(screen.getByLabelText('Best contact phone'), '12345');
-  //   userEvent.tab();
-
-  //   await waitFor(() => {
-  //     expect(screen.getByText('Number must have 10 digits and a valid area code')).toBeInTheDocument();
-  //   });
-  // });
-
-  // it('validates the customer email field', async () => {
-  //   render(<CustomerContactInfoForm {...testProps} />);
-  //   userEvent.type(screen.getByLabelText('Email'), 'sample@');
-  //   userEvent.tab();
-
-  //   await waitFor(() => {
-  //     expect(screen.getByText('Must be a valid email address')).toBeInTheDocument();
-  //   });
-  // });
-
-  // it('shows an error message when trying to submit an invalid form', async () => {
-  //   render(<CustomerContactInfoForm {...testProps} />);
-  //   const submitBtn = screen.getByRole('button', { name: 'Save' });
-
-  //   userEvent.click(submitBtn);
-
-  //   await waitFor(() => {
-  //     expect(screen.getAllByText('Required').length).toBe(2);
-  //   });
-
-  //   expect(testProps.onSubmit).not.toHaveBeenCalled();
-  // });
-
-  // it('submits a form when it is valid', async () => {
-  //   render(<CustomerContactInfoForm {...testProps} />);
-  //   const submitBtn = screen.getByRole('button', { name: 'Next' });
-
-  //   userEvent.type(screen.getByLabelText('Phone'), '555-555-5555');
-  //   userEvent.type(screen.getByLabelText('Email'), 'test@sample.com');
-  //   userEvent.click(screen.getByLabelText('Email'));
-  //   userEvent.click(submitBtn);
-
-  //   await waitFor(() => {
-  //     expect(testProps.onSubmit).toHaveBeenCalled();
-  //   });
-  // });
-
-  // it('calls the cancel handler when cancel button is clicked', async () => {
-  //   render(<CustomerContactInfoForm {...testProps} />);
-  //   const backBtn = screen.getByRole('button', { name: 'Cancel' });
-
-  //   userEvent.type(screen.getByLabelText('Phone'), '555-555-1111');
-  //   userEvent.type(screen.getByLabelText('Email'), 'test@sample.com');
-  //   userEvent.click(screen.getByLabelText('Email'));
-  //   userEvent.click(backBtn);
-
-  //   await waitFor(() => {
-  //     expect(testProps.onBack).toHaveBeenCalled();
-  //   });
-  // });
 });

--- a/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
+++ b/src/components/Office/CustomerContactInfoForm/CustomerContactInfoForm.test.jsx
@@ -6,13 +6,13 @@ import CustomerContactInfoForm from './CustomerContactInfoForm';
 
 describe('CustomerContactInfoForm Component', () => {
   const initialValues = {
-    first_name: '',
-    middle_name: '',
-    last_name: '',
+    firstName: '',
+    middleName: '',
+    lastName: '',
     suffix: '',
-    customer_telephone: '',
-    customer_email: '',
-    customer_address: {
+    customerTelephone: '',
+    customerEmail: '',
+    customerAddress: {
       street_address_1: '',
       street_address_2: '',
       city: '',

--- a/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.stories.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.stories.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import { CustomerAltContactInfoFields } from './index';
+
+import { Form } from 'components/form/Form';
+import formStyles from 'styles/form.module.scss';
+
+export default {
+  title: 'Components/Fieldsets/AltContactInfoFields',
+};
+
+export const DefaultState = () => (
+  <Formik initialValues={{}}>
+    {() => (
+      <Form className={formStyles.form}>
+        <CustomerAltContactInfoFields legend="Contact info" />
+      </Form>
+    )}
+  </Formik>
+);
+export const WithInitialValues = () => (
+  <Formik
+    initialValues={{
+      first_name: 'Leo',
+      middle_name: 'Star',
+      last_name: 'Spaceman',
+      suffix: 'Mr.',
+      customer_telephone: '555-555-5555',
+      customer_email: 'test@sample.com',
+    }}
+  >
+    {() => (
+      <Form className={formStyles.form}>
+        <CustomerAltContactInfoFields legend="Contact info" />
+      </Form>
+    )}
+  </Formik>
+);

--- a/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
@@ -1,29 +1,29 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
 
 import { CustomerAltContactInfoFields } from './index';
 
 describe('ContactInfoFields component', () => {
   it('renders a legend and all service member contact info inputs', () => {
-    const { getByText, getByLabelText } = render(
+    render(
       <Formik>
         <CustomerAltContactInfoFields legend="Contact info" />
       </Formik>,
     );
-    expect(getByText('Contact info')).toBeInstanceOf(HTMLLegendElement);
-    expect(getByLabelText('First name')).toBeInstanceOf(HTMLInputElement);
-    expect(getByLabelText('First name')).toBeRequired();
+    expect(screen.getByText('Contact info')).toBeInstanceOf(HTMLLegendElement);
+    expect(screen.getByLabelText('First name')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('First name')).toBeRequired();
 
-    expect(getByLabelText(/Middle name/)).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText(/Middle name/)).toBeInstanceOf(HTMLInputElement);
 
-    expect(getByLabelText('Last name')).toBeInstanceOf(HTMLInputElement);
-    expect(getByLabelText('Last name')).toBeRequired();
+    expect(screen.getByLabelText('Last name')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('Last name')).toBeRequired();
 
-    expect(getByLabelText(/Suffix/)).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText(/Suffix/)).toBeInstanceOf(HTMLInputElement);
 
-    expect(getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
-    expect(getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
   });
 
   describe('with pre-filled values', () => {
@@ -43,9 +43,9 @@ describe('ContactInfoFields component', () => {
         </Formik>,
       );
       expect(getByLabelText('First name')).toHaveValue(initialValues.first_name);
-      expect(getByLabelText('Middle name', { exact: false })).toHaveValue(initialValues.middle_name);
+      expect(getByLabelText(/Middle name/)).toHaveValue(initialValues.middle_name);
       expect(getByLabelText('Last name')).toHaveValue(initialValues.last_name);
-      expect(getByLabelText('Suffix', { exact: false })).toHaveValue(initialValues.suffix);
+      expect(getByLabelText(/Suffix/)).toHaveValue(initialValues.suffix);
       expect(getByLabelText('Phone')).toHaveValue(initialValues.customer_telephone);
       expect(getByLabelText('Email')).toHaveValue(initialValues.customer_email);
     });

--- a/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Formik } from 'formik';
+
+import { CustomerAltContactInfoFields } from './index';
+
+describe('ContactInfoFields component', () => {
+  it('renders a legend and all service member contact info inputs', () => {
+    const { getByText, getByLabelText } = render(
+      <Formik>
+        <CustomerAltContactInfoFields legend="Contact info" />
+      </Formik>,
+    );
+    expect(getByText('Contact info')).toBeInstanceOf(HTMLLegendElement);
+    expect(getByLabelText('First name')).toBeInstanceOf(HTMLInputElement);
+    expect(getByLabelText('First name')).toBeRequired();
+
+    expect(getByLabelText(/Middle name/)).toBeInstanceOf(HTMLInputElement);
+
+    expect(getByLabelText('Last name')).toBeInstanceOf(HTMLInputElement);
+    expect(getByLabelText('Last name')).toBeRequired();
+
+    expect(getByLabelText(/Suffix/)).toBeInstanceOf(HTMLInputElement);
+
+    expect(getByLabelText('Phone')).toBeInstanceOf(HTMLInputElement);
+    expect(getByLabelText('Email')).toBeInstanceOf(HTMLInputElement);
+  });
+
+  describe('with pre-filled values', () => {
+    it('renders a legend and all service member contact info inputs', () => {
+      const initialValues = {
+        first_name: 'Leo',
+        middle_name: 'Star',
+        last_name: 'Spaceman',
+        suffix: 'Mr.',
+        customer_telephone: '555-555-5555',
+        customer_email: 'test@sample.com',
+      };
+
+      const { getByLabelText } = render(
+        <Formik initialValues={initialValues}>
+          <CustomerAltContactInfoFields legend="Contact info" name="contact" />
+        </Formik>,
+      );
+      expect(getByLabelText('First name')).toHaveValue(initialValues.first_name);
+      expect(getByLabelText('Middle name', { exact: false })).toHaveValue(initialValues.middle_name);
+      expect(getByLabelText('Last name')).toHaveValue(initialValues.last_name);
+      expect(getByLabelText('Suffix', { exact: false })).toHaveValue(initialValues.suffix);
+      expect(getByLabelText('Phone')).toHaveValue(initialValues.customer_telephone);
+      expect(getByLabelText('Email')).toHaveValue(initialValues.customer_email);
+    });
+  });
+});

--- a/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/CustomerAltContactInfoFields.test.jsx
@@ -4,7 +4,7 @@ import { Formik } from 'formik';
 
 import { CustomerAltContactInfoFields } from './index';
 
-describe('ContactInfoFields component', () => {
+describe('CustomerAltContactInfoFields component', () => {
   it('renders a legend and all service member contact info inputs', () => {
     render(
       <Formik>
@@ -29,12 +29,12 @@ describe('ContactInfoFields component', () => {
   describe('with pre-filled values', () => {
     it('renders a legend and all service member contact info inputs', () => {
       const initialValues = {
-        first_name: 'Leo',
-        middle_name: 'Star',
-        last_name: 'Spaceman',
+        firstName: 'Leo',
+        middleName: 'Star',
+        lastName: 'Spaceman',
         suffix: 'Mr.',
-        customer_telephone: '555-555-5555',
-        customer_email: 'test@sample.com',
+        customerTelephone: '555-555-5555',
+        customerEmail: 'test@sample.com',
       };
 
       const { getByLabelText } = render(
@@ -42,12 +42,12 @@ describe('ContactInfoFields component', () => {
           <CustomerAltContactInfoFields legend="Contact info" name="contact" />
         </Formik>,
       );
-      expect(getByLabelText('First name')).toHaveValue(initialValues.first_name);
-      expect(getByLabelText(/Middle name/)).toHaveValue(initialValues.middle_name);
-      expect(getByLabelText('Last name')).toHaveValue(initialValues.last_name);
+      expect(getByLabelText('First name')).toHaveValue(initialValues.firstName);
+      expect(getByLabelText(/Middle name/)).toHaveValue(initialValues.middleName);
+      expect(getByLabelText('Last name')).toHaveValue(initialValues.lastName);
       expect(getByLabelText(/Suffix/)).toHaveValue(initialValues.suffix);
-      expect(getByLabelText('Phone')).toHaveValue(initialValues.customer_telephone);
-      expect(getByLabelText('Email')).toHaveValue(initialValues.customer_email);
+      expect(getByLabelText('Phone')).toHaveValue(initialValues.customerTelephone);
+      expect(getByLabelText('Email')).toHaveValue(initialValues.customerEmail);
     });
   });
 });

--- a/src/components/form/CustomerAltContactInfoFields/index.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/index.jsx
@@ -1,0 +1,68 @@
+import React, { useRef } from 'react';
+import { func, node, string } from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import { Fieldset } from '@trussworks/react-uswds';
+
+import TextField from 'components/form/fields/TextField';
+import MaskedTextField from 'components/form/fields/MaskedTextField';
+
+export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
+  const CustomerAltContactInfoFieldsUUID = useRef(uuidv4());
+
+  return (
+    <Fieldset legend={legend} className={className}>
+      {render(
+        <>
+          <div className="grid-row grid-gap">
+            <div className="grid-col-6">
+              <TextField label="First name" name="first_name" id="firstName" required />
+            </div>
+            <div className="grid-col-6">
+              <TextField label="Middle name" name="middle_name" id="middleName" labelHint="Optional" />
+            </div>
+            <div className="grid-col-6">
+              <TextField label="Last name" name="last_name" id="lastName" required />
+            </div>
+            <div className="grid-col-6">
+              <TextField label="Suffix" name="suffix" id="suffix" labelHint="Optional" />
+            </div>
+          </div>
+          <div className="grid-row grid-gap">
+            <div className="mobile-lg:grid-col-7">
+              <MaskedTextField
+                label="Phone"
+                id={`customer_telephone_${CustomerAltContactInfoFieldsUUID.current}`}
+                name="customer_telephone"
+                type="tel"
+                minimum="12"
+                mask="000{-}000{-}0000"
+                required
+              />
+            </div>
+          </div>
+
+          <TextField
+            label="Email"
+            id={`customer_email_${CustomerAltContactInfoFieldsUUID.current}`}
+            name="customer_email"
+            required
+          />
+        </>,
+      )}
+    </Fieldset>
+  );
+};
+
+CustomerAltContactInfoFields.propTypes = {
+  legend: node,
+  className: string,
+  render: func,
+};
+
+CustomerAltContactInfoFields.defaultProps = {
+  legend: '',
+  className: '',
+  render: (fields) => fields,
+};
+
+export default CustomerAltContactInfoFields;

--- a/src/components/form/CustomerAltContactInfoFields/index.jsx
+++ b/src/components/form/CustomerAltContactInfoFields/index.jsx
@@ -15,13 +15,13 @@ export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
         <>
           <div className="grid-row grid-gap">
             <div className="grid-col-6">
-              <TextField label="First name" name="first_name" id="firstName" required />
+              <TextField label="First name" name="firstName" id="firstName" required />
             </div>
             <div className="grid-col-6">
-              <TextField label="Middle name" name="middle_name" id="middleName" labelHint="Optional" />
+              <TextField label="Middle name" name="middleName" id="middleName" labelHint="Optional" />
             </div>
             <div className="grid-col-6">
-              <TextField label="Last name" name="last_name" id="lastName" required />
+              <TextField label="Last name" name="lastName" id="lastName" required />
             </div>
             <div className="grid-col-6">
               <TextField label="Suffix" name="suffix" id="suffix" labelHint="Optional" />
@@ -31,8 +31,8 @@ export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
             <div className="mobile-lg:grid-col-7">
               <MaskedTextField
                 label="Phone"
-                id={`customer_telephone_${CustomerAltContactInfoFieldsUUID.current}`}
-                name="customer_telephone"
+                id={`customerTelephone_${CustomerAltContactInfoFieldsUUID.current}`}
+                name="customerTelephone"
                 type="tel"
                 minimum="12"
                 mask="000{-}000{-}0000"
@@ -43,8 +43,8 @@ export const CustomerAltContactInfoFields = ({ legend, className, render }) => {
 
           <TextField
             label="Email"
-            id={`customer_email_${CustomerAltContactInfoFieldsUUID.current}`}
-            name="customer_email"
+            id={`customerEmail_${CustomerAltContactInfoFieldsUUID.current}`}
+            name="customerEmail"
             required
           />
         </>,

--- a/src/components/form/CustomerContactInfoFields/index.jsx
+++ b/src/components/form/CustomerContactInfoFields/index.jsx
@@ -24,7 +24,6 @@ export const CustomerContactInfoFields = ({ legend, className, render }) => {
                 type="tel"
                 minimum="12"
                 mask="000{-}000{-}0000"
-                useMaskedValue
                 required
               />
             </div>

--- a/src/styles/form.module.scss
+++ b/src/styles/form.module.scss
@@ -99,15 +99,6 @@
     @include u-margin-bottom(6);
   }
 
-  :global(.usa-form-group:first-of-type .usa-label) {
-    @include u-margin-top('105');
-  }
-
-  > :global(.usa-form-group:first-child .usa-label),
-  > :global(.usa-form-group--error:first-child) {
-    @include u-margin-top(0);
-  }
-
   @include at-media('tablet') {
     @include u-margin-y(3);
 

--- a/src/styles/form.module.scss
+++ b/src/styles/form.module.scss
@@ -99,6 +99,15 @@
     @include u-margin-bottom(6);
   }
 
+  :global(.usa-form-group:first-of-type .usa-label) {
+    @include u-margin-top('105');
+  }
+
+  > :global(.usa-form-group:first-child .usa-label),
+  > :global(.usa-form-group--error:first-child) {
+    @include u-margin-top(0);
+  }
+
   @include at-media('tablet') {
     @include u-margin-y(3);
 


### PR DESCRIPTION
## Description

As a services counselor, 
I want to be edit to view the service members contact info for a move, 
so I can make and necessary adjustments in case of error.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7383) for this change
