### PR TITLE
MB-7669 Allow SC Completed Moves to be approved

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -1,3 +1,5 @@
+import { fileUploadTimeout } from '../../support/constants';
+
 describe('the PPM flow', function () {
   before(() => {
     cy.prepareCustomerApp();
@@ -302,12 +304,12 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
 
   cy.upload_file('[data-testid=empty-weight-upload] .filepond--root', 'top-secret.png');
   // cy.wait('@postUploadDocument').its('response.statusCode').should('eq', 201);
-  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
+  cy.get('[data-filepond-item-state="processing-complete"]', { timeout: fileUploadTimeout }).should('have.length', 1);
 
   cy.get('input[name="full_weight"]').type('5000');
   cy.upload_file('[data-testid=full-weight-upload] .filepond--root', 'top-secret.png');
   // cy.wait('@postUploadDocument').its('response.statusCode').should('eq', 201);
-  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
+  cy.get('[data-filepond-item-state="processing-complete"]', { timeout: fileUploadTimeout }).should('have.length', 2);
   cy.get('input[name="weight_ticket_date"]').type('6/2/2018{enter}').blur();
   cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -191,6 +191,8 @@ func (suite *HandlerSuite) TestShowMoveWrongUser() {
 }
 
 func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
+	os.Setenv("FEATURE_FLAG_SERVICE_COUNSELING", "false")
+
 	suite.Run("Submits ppm success", func() {
 		// Given: a set of orders, a move, user and servicemember
 		ppm := testdatagen.MakeDefaultPPM(suite.DB())

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -153,13 +153,17 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 	})
 }
 
-func (suite *HandlerSuite) TestMakeMoveTaskOrderAvailableHandlerIntegrationSuccess() {
-	moveTaskOrder := testdatagen.MakeDefaultMove(suite.DB())
+func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusSUBMITTED,
+		},
+	})
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/available-to-prime", nil)
 	params := move_task_order.MakeMoveTaskOrderAvailableParams{
 		HTTPRequest:     request,
-		MoveTaskOrderID: moveTaskOrder.ID.String(),
-		IfMatch:         etag.GenerateEtag(moveTaskOrder.UpdatedAt),
+		MoveTaskOrderID: move.ID.String(),
+		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 	queryBuilder := query.NewQueryBuilder(suite.DB())
@@ -172,12 +176,12 @@ func (suite *HandlerSuite) TestMakeMoveTaskOrderAvailableHandlerIntegrationSucce
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)
-	moveTaskOrdersResponse := response.(*movetaskorderops.MakeMoveTaskOrderAvailableOK)
-	moveTaskOrdersPayload := moveTaskOrdersResponse.Payload
+	moveResponse := response.(*movetaskorderops.MakeMoveTaskOrderAvailableOK)
+	movePayload := moveResponse.Payload
 
 	suite.Assertions.IsType(&move_task_order.MakeMoveTaskOrderAvailableOK{}, response)
-	suite.Equal(moveTaskOrdersPayload.ID, strfmt.UUID(moveTaskOrder.ID.String()))
-	suite.NotNil(moveTaskOrdersPayload.AvailableToPrimeAt)
+	suite.Equal(movePayload.ID, strfmt.UUID(move.ID.String()))
+	suite.NotNil(movePayload.AvailableToPrimeAt)
 }
 
 func (suite *HandlerSuite) TestGetMoveTaskOrder() {

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -111,11 +111,9 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 		now := time.Now()
 		move.AvailableToPrimeAt = &now
 
-		if move.Status == models.MoveStatusSUBMITTED {
-			err = move.Approve()
-			if err != nil {
-				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
-			}
+		err = move.Approve()
+		if err != nil {
+			return &models.Move{}, services.NewConflictError(move.ID, err.Error())
 		}
 
 		verrs, err = o.builder.UpdateOne(move, &eTag)


### PR DESCRIPTION
## Description

The conditional in `MakeAvailableToPrime` was only allowing Moves in
`Submitted` status to be approved. This meant that Moves in the new
`ServiceCounselingCompleted` status didn't get a chance to get approved,
but the code still tried to create service items, which failed because
the Move wasn't approved yet.

Instead of wrapping the call to `move.Approve` in a conditional, we
should call it directly since it has its own logic for determining
when a move can be approved, and it will return an error if the move
can't be approved, which will prevent service items from being created.

## Reviewer Notes

1. Create a new move from scratch as a service member
2. View the move as a Service Counselor at officelocal:3000/counseling/queue
3. Submit the move
4. View the move as a TOO
5. Update the orders to fill in all required fields
6. Approve the shipments and submit the move

Expected: You should be able to approve the move and shipments.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7669) for this change

