### PR TITLE
MB-6833 Add domestic origin sit pickup pricer params

### DIFF
--- a/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
@@ -115,7 +115,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 }
 
 func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer50MilesOrLessDiffZip3s() {
-	suite.setupDomesticOtherPrice(models.ReServiceCodeDDDSIT, dddsitTestSchedule, dddsitTestIsPeakPeriod, dddsitTestDomesticOtherBasePriceCents, dddsitTestEscalationCompounded)
+	suite.setupDomesticOtherPrice(models.ReServiceCodeDDDSIT, dddsitTestSchedule, dddsitTestIsPeakPeriod, dddsitTestDomesticOtherBasePriceCents, "Test Year 1", dddsitTestEscalationCompounded)
 
 	zipDest := "30907"
 	zipSITDest := "29801"      // different zip3

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
@@ -140,7 +140,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50PlusM
 }
 
 func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50MilesOrLessDiffZip3s() {
-	suite.setupDomesticOtherPrice(models.ReServiceCodeDOPSIT, dopsitTestSchedule, dopsitTestIsPeakPeriod, dopsitTestDomesticOtherBasePriceCents, "Test Year 1", dopsitTestEscalationCompounded)
+	suite.setupDomesticOtherPrice(models.ReServiceCodeDOPSIT, dopsitTestSchedule, dopsitTestIsPeakPeriod, dopsitTestDomesticOtherBasePriceCents, dopsitTestContractYearName, dopsitTestEscalationCompounded)
 
 	zipOriginal := "29201"
 	zipActual := "29123"       // different zip3

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
@@ -115,7 +115,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50PlusM
 }
 
 func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50MilesOrLessDiffZip3s() {
-	suite.setupDomesticOtherPrice(models.ReServiceCodeDOPSIT, dopsitTestSchedule, dopsitTestIsPeakPeriod, dopsitTestDomesticOtherBasePriceCents, dopsitTestEscalationCompounded)
+	suite.setupDomesticOtherPrice(models.ReServiceCodeDOPSIT, dopsitTestSchedule, dopsitTestIsPeakPeriod, dopsitTestDomesticOtherBasePriceCents, "Test Year 1", dopsitTestEscalationCompounded)
 
 	zipOriginal := "29201"
 	zipActual := "29123"       // different zip3

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -40,15 +41,31 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricerSameZip
 	expectedPrice := unit.Cents(127316) // dopsitTestDomesticServiceAreaBasePriceCents * (dopsitTestWeight / 100) * distance * dopsitTestEscalationCompounded
 
 	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
-		priceCents, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
+		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
+
+		expectedParams := services.PricingDisplayParams{
+			{Key: models.ServiceItemParamNameContractYearName, Value: dopsitTestContractYearName},
+			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dopsitTestEscalationCompounded)},
+			{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(dopsitTestIsPeakPeriod)},
+			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatCents(dopsitTestDomesticServiceAreaBasePriceCents)},
+		}
+		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
 	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
-		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
+		priceCents, displayParams, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
+
+		expectedParams := services.PricingDisplayParams{
+			{Key: models.ServiceItemParamNameContractYearName, Value: dopsitTestContractYearName},
+			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dopsitTestEscalationCompounded)},
+			{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(dopsitTestIsPeakPeriod)},
+			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatCents(dopsitTestDomesticServiceAreaBasePriceCents)},
+		}
+		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
 	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
@@ -96,9 +113,17 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50PlusM
 	expectedPrice := expectedPriceMillicents.ToCents()
 
 	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
-		priceCents, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
+		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
+
+		expectedParams := services.PricingDisplayParams{
+			{Key: models.ServiceItemParamNameContractYearName, Value: dopsitTestContractYearName},
+			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dopsitTestEscalationCompounded)},
+			{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(dopsitTestIsPeakPeriod)},
+			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatFloat(dopsitTestDomesticLinehaulBasePriceMillicents.ToDollarFloatNoRound(), 3)},
+		}
+		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
 	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {

--- a/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
+++ b/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
@@ -84,10 +84,11 @@ func (suite *GHCRateEngineServiceSuite) setUpDomesticPackAndUnpackData(code mode
 	suite.MustSave(&domesticPackUnpackNonpeakPrice)
 }
 
-func (suite *GHCRateEngineServiceSuite) setupDomesticOtherPrice(code models.ReServiceCode, schedule int, isPeakPeriod bool, priceCents unit.Cents, escalationCompounded float64) {
+func (suite *GHCRateEngineServiceSuite) setupDomesticOtherPrice(code models.ReServiceCode, schedule int, isPeakPeriod bool, priceCents unit.Cents, contractYearName string, escalationCompounded float64) {
 	contractYear := testdatagen.MakeReContractYear(suite.DB(),
 		testdatagen.Assertions{
 			ReContractYear: models.ReContractYear{
+				Name:                 contractYearName,
 				EscalationCompounded: escalationCompounded,
 			},
 		})

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -123,12 +123,12 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	if zip3Original == zip3Actual {
 		// Do a normal shorthaul calculation
 		shorthaulPricer := NewDomesticShorthaulPricer(db)
-		totalPriceCents, _, err := shorthaulPricer.Price(contractCode, requestedPickupDate, distance, weight, serviceArea)
+		totalPriceCents, displayParams, err := shorthaulPricer.Price(contractCode, requestedPickupDate, distance, weight, serviceArea)
 		if err != nil {
 			return unit.Cents(0), nil, fmt.Errorf("could not price shorthaul: %w", err)
 		}
 
-		return totalPriceCents, nil, nil
+		return totalPriceCents, displayParams, nil
 	}
 
 	// Zip3s must be different at this point.  Now examine distance.
@@ -137,12 +137,12 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	if distance > 50 {
 		// Do a normal linehaul calculation
 		linehaulPricer := NewDomesticLinehaulPricer(db)
-		totalPriceCents, _, err := linehaulPricer.Price(contractCode, requestedPickupDate, distance, weight, serviceArea)
+		totalPriceCents, displayParams, err := linehaulPricer.Price(contractCode, requestedPickupDate, distance, weight, serviceArea)
 		if err != nil {
 			return unit.Cents(0), nil, fmt.Errorf("could not price linehaul: %w", err)
 		}
 
-		return totalPriceCents, nil, nil
+		return totalPriceCents, displayParams, nil
 	}
 
 	// Zip3s must be different at this point and distance is <= 50.
@@ -164,7 +164,26 @@ func priceDomesticPickupDeliverySIT(db *pop.Connection, pickupDeliverySITCode mo
 	escalatedTotalPrice := baseTotalPrice * contractYear.EscalationCompounded
 	totalPriceCents := unit.Cents(math.Round(escalatedTotalPrice))
 
-	return totalPriceCents, nil, nil
+	displayParams := services.PricingDisplayParams{
+		{
+			Key:   models.ServiceItemParamNamePriceRateOrFactor,
+			Value: FormatCents(totalPriceCents),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: contractYear.Name,
+		},
+		{
+			Key:   models.ServiceItemParamNameIsPeak,
+			Value: FormatBool(isPeakPeriod),
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: FormatEscalation(contractYear.EscalationCompounded),
+		},
+	}
+
+	return totalPriceCents, displayParams, nil
 }
 
 // createPricerGeneratedParams stores PaymentServiceItemParams, whose origin is the PRICER, into the database

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -92,7 +92,6 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticAdditionalDaysSIT() {
 	})
 }
 
-// #TODO Update test
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZip3s() {
 	dshZipDest := "30907"
 	dshZipSITDest := "30901" // same zip3
@@ -148,7 +147,6 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZ
 	})
 }
 
-// #TODO Update Test
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50PlusMilesDiffZip3s() {
 	dlhZipDest := "30907"
 	dlhZipSITDest := "36106"       // different zip3
@@ -162,16 +160,13 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Plu
 		expectedPriceMillicents := unit.Millicents(45944438) // dddsitTestDomesticLinehaulBasePriceMillicents * (dddsitTestWeight / 100) * distance * dddsitTestEscalationCompounded
 		expectedPrice := expectedPriceMillicents.ToCents()
 
-		expectedPriceRateOrFactor := dddsitTestDomesticLinehaulBasePriceMillicents.ToDollarFloatNoRound()
-
-		fmt.Println("🍐what is expected price rate or factor", expectedPriceRateOrFactor)
 		suite.Equal(expectedPrice, priceCents)
 
 		expectedParams := services.PricingDisplayParams{
 			{Key: models.ServiceItemParamNameContractYearName, Value: dlhContractName},
 			{Key: models.ServiceItemParamNameEscalationCompounded, Value: FormatEscalation(dddsitTestEscalationCompounded)},
 			{Key: models.ServiceItemParamNameIsPeak, Value: FormatBool(dddsitTestIsPeakPeriod)},
-			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: fmt.Sprintf("%g", expectedPriceRateOrFactor)}, //#TODO Should this be a new helper
+			{Key: models.ServiceItemParamNamePriceRateOrFactor, Value: FormatFloat(dddsitTestDomesticLinehaulBasePriceMillicents.ToDollarFloatNoRound(), 3)},
 		}
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
@@ -183,7 +178,6 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Plu
 	})
 }
 
-// #TODO Update Test
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50MilesOrLessDiffZip3s() {
 	domOtherZipDest := "30907"
 	domOtherZipSITDest := "29801"      // different zip3

--- a/pkg/unit/millicents.go
+++ b/pkg/unit/millicents.go
@@ -33,6 +33,11 @@ func (m Millicents) ToCents() Cents {
 	return Cents(math.Round(float64(m) / 1000))
 }
 
+// ToCentsNoRound returns a Cents representation of this value (no rounding)
+func (m Millicents) ToCentsNoRound() Cents {
+	return Cents(float64(m) / 1000.0)
+}
+
 // ToDollarString returns a dollar string representation of this value
 func (m Millicents) ToDollarString() string {
 	d := float64(m) / 100000.0

--- a/pkg/unit/millicents.go
+++ b/pkg/unit/millicents.go
@@ -33,11 +33,6 @@ func (m Millicents) ToCents() Cents {
 	return Cents(math.Round(float64(m) / 1000))
 }
 
-// ToCentsNoRound returns a Cents representation of this value (no rounding)
-func (m Millicents) ToCentsNoRound() Cents {
-	return Cents(float64(m) / 1000.0)
-}
-
 // ToDollarString returns a dollar string representation of this value
 func (m Millicents) ToDollarString() string {
 	d := float64(m) / 100000.0


### PR DESCRIPTION
## Description

* Adds pricer params to domestic origin sit pickup pricer

## Reviewer Notes

* Added `ContractYearName` to the shared test function `setupDomesticOtherPrice`. 
* This means I needed to update `TestDomesticDestinationSITDeliveryPricer50MilesOrLessDiffZip3s` even though it's destination, not origin.

## Setup

Create a DOFSIT on an approved shipment in order to auto-create the DOPSIT.


There should be 4 new params for Domestic origin SIT pickup (DOPSIT):

`ContractYearName`
`PriceRateOrFactor`
`IsPeak`
`EscalationCompounded`

## Code Review Verification Steps

(https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6833) for this change

## Screenshots

