### PR TITLE
[MB-7664] Add Sort by GBLOC to the ListOrders for Service Counseling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ db_dev_fresh: db_dev_reset db_dev_migrate
 	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development"
 
 .PHONY: db_dev_e2e_populate
-db_dev_e2e_populate: db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
+db_dev_e2e_populate: db_dev_run db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
 	@echo "Ensure that you're running the correct APPLICATION..."
 	./scripts/ensure-application app
 	@echo "Truncate the ${DB_NAME_DEV} database..."

--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ db_dev_fresh: db_dev_reset db_dev_migrate
 	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development"
 
 .PHONY: db_dev_e2e_populate
-db_dev_e2e_populate: db_dev_run db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
+db_dev_e2e_populate: db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
 	@echo "Ensure that you're running the correct APPLICATION..."
 	./scripts/ensure-application app
 	@echo "Truncate the ${DB_NAME_DEV} database..."

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -45,6 +45,7 @@ func (f orderFetcher) ListOrders(officeUserID uuid.UUID, params *services.ListOr
 	// We also only want to do the gbloc filtering thing if we aren't a USMC user, which we cover with the else.
 	var gblocQuery QueryOption
 	if gbloc == "USMC" {
+		fmt.Println("gbloc is usmc")
 		branchQuery = branchFilter(swag.String(string(models.AffiliationMARINES)))
 	} else {
 		gblocQuery = gblocFilter(gbloc)
@@ -256,7 +257,6 @@ func sortOrder(sort *string, order *string) QueryOption {
 		"submittedAt":            "moves.submitted_at",
 		"destinationDutyStation": "dest_ds.name",
 		"originGBLOC":            "origin_to.gbloc",
-		"requestedMoveDate":      "min(mto_shipments.requested_pickup_date)",
 	}
 
 	return func(query *pop.Query) {

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -95,6 +95,9 @@ func (f orderFetcher) ListOrders(officeUserID uuid.UUID, params *services.ListOr
 	if params.Sort != nil && *params.Sort == "destinationDutyStation" {
 		groupByColumms = append(groupByColumms, "dest_ds.name")
 	}
+	if params.Sort != nil && *params.Sort == "originGBLOC" {
+		groupByColumms = append(groupByColumms, "origin_to.id")
+	}
 
 	err = query.GroupBy("moves.id", groupByColumms...).Paginate(int(*params.Page), int(*params.PerPage)).All(&moves)
 	if err != nil {
@@ -252,6 +255,7 @@ func sortOrder(sort *string, order *string) QueryOption {
 		"status":                 "moves.status",
 		"submittedAt":            "moves.submitted_at",
 		"destinationDutyStation": "dest_ds.name",
+		"originGBLOC":            "origin_to.gbloc",
 		"requestedMoveDate":      "min(mto_shipments.requested_pickup_date)",
 	}
 

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -45,7 +45,6 @@ func (f orderFetcher) ListOrders(officeUserID uuid.UUID, params *services.ListOr
 	// We also only want to do the gbloc filtering thing if we aren't a USMC user, which we cover with the else.
 	var gblocQuery QueryOption
 	if gbloc == "USMC" {
-		fmt.Println("gbloc is usmc")
 		branchQuery = branchFilter(swag.String(string(models.AffiliationMARINES)))
 	} else {
 		gblocQuery = gblocFilter(gbloc)
@@ -256,6 +255,7 @@ func sortOrder(sort *string, order *string) QueryOption {
 		"status":                 "moves.status",
 		"submittedAt":            "moves.submitted_at",
 		"destinationDutyStation": "dest_ds.name",
+		"requestedMoveDate":      "min(mto_shipments.requested_pickup_date)",
 		"originGBLOC":            "origin_to.gbloc",
 	}
 

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3328,6 +3328,8 @@ func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uplo
 	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			Affiliation: &marineCorps,
+			FirstName:   models.StringPointer("USMC"),
+			LastName:    models.StringPointer("ServiceCounseling"),
 		},
 	})
 
@@ -3342,7 +3344,6 @@ func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uplo
 	submittedAt := time.Now()
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
-			Locator:     "USMCSC",
 			Status:      models.MoveStatusNeedsServiceCounseling,
 			SubmittedAt: &submittedAt,
 		},
@@ -3414,6 +3415,9 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	// Services Counseling
 	createHHGNeedsServicesCounseling(db)
 	createHHGNeedsServicesCounselingUSMC(db, userUploader)
+	createHHGNeedsServicesCounselingUSMC(db, userUploader)
+	createHHGNeedsServicesCounselingUSMC(db, userUploader)
+
 	createHHGServicesCounselingCompleted(db)
 
 	// TXO Queues

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3328,8 +3328,6 @@ func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uplo
 	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			Affiliation: &marineCorps,
-			FirstName:   models.StringPointer("USMC"),
-			LastName:    models.StringPointer("ServiceCounseling"),
 		},
 	})
 
@@ -3344,6 +3342,7 @@ func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uplo
 	submittedAt := time.Now()
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
+			Locator:     "USMCSC",
 			Status:      models.MoveStatusNeedsServiceCounseling,
 			SubmittedAt: &submittedAt,
 		},
@@ -3415,9 +3414,6 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	// Services Counseling
 	createHHGNeedsServicesCounseling(db)
 	createHHGNeedsServicesCounselingUSMC(db, userUploader)
-	createHHGNeedsServicesCounselingUSMC(db, userUploader)
-	createHHGNeedsServicesCounselingUSMC(db, userUploader)
-
 	createHHGServicesCounselingCompleted(db)
 
 	// TXO Queues

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3324,29 +3324,22 @@ func createHHGNeedsServicesCounseling(db *pop.Connection) {
 }
 
 func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uploader.UserUploader) {
+
 	marineCorps := models.AffiliationMARINES
-	customer := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			Affiliation: &marineCorps,
-		},
-	})
-
-	orders := testdatagen.MakeOrder(db, testdatagen.Assertions{
-		Order: models.Order{
-			ServiceMemberID: customer.ID,
-			ServiceMember:   customer,
-		},
-		UserUploader: userUploader,
-	})
-
 	submittedAt := time.Now()
+
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
-			Locator:     "USMCSC",
+			Locator:     "USMCSS",
 			Status:      models.MoveStatusNeedsServiceCounseling,
 			SubmittedAt: &submittedAt,
 		},
-		Order: orders,
+		ServiceMember: models.ServiceMember{
+			Affiliation: &marineCorps,
+			LastName:    swag.String("Marine"),
+			FirstName:   swag.String("Ted"),
+		},
+		UserUploader: userUploader,
 	})
 
 	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
@@ -3372,6 +3365,43 @@ func createHHGNeedsServicesCounselingUSMC(db *pop.Connection, userUploader *uplo
 			RequestedDeliveryDate: &requestedDeliveryDate,
 		},
 	})
+}
+
+func createHHGNeedsServicesCounselingUSMC2(db *pop.Connection, userUploader *uploader.UserUploader) {
+
+	marineCorps := models.AffiliationMARINES
+	submittedAt := time.Now()
+
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			Locator:     "USMCSC",
+			Status:      models.MoveStatusNeedsServiceCounseling,
+			SubmittedAt: &submittedAt,
+		},
+		Order: models.Order{},
+		ServiceMember: models.ServiceMember{
+			Affiliation: &marineCorps,
+			LastName:    swag.String("Marine"),
+			FirstName:   swag.String("Barbara"),
+		},
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "ZANY",
+		},
+		UserUploader: userUploader,
+	})
+
+	requestedPickupDate := submittedAt.Add(20 * 24 * time.Hour)
+	requestedDeliveryDate := requestedPickupDate.Add(14 * 24 * time.Hour)
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:          models.MTOShipmentTypeHHG,
+			Status:                models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:   &requestedPickupDate,
+			RequestedDeliveryDate: &requestedDeliveryDate,
+		},
+	})
+
 }
 
 func createHHGServicesCounselingCompleted(db *pop.Connection) {
@@ -3414,6 +3444,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	// Services Counseling
 	createHHGNeedsServicesCounseling(db)
 	createHHGNeedsServicesCounselingUSMC(db, userUploader)
+	createHHGNeedsServicesCounselingUSMC2(db, userUploader)
 	createHHGServicesCounselingCompleted(db)
 
 	// TXO Queues


### PR DESCRIPTION
## Description

This ticket is to ensure that sorting by GBLOC works. 

If you've accessed the Office UI as a TOO, you'll notice we only see one GBLOC, the one that matches the office user's transportation office. So you can't really sort GBLOCs if you're only getting one GBLOC. 

The GBLOC sorting comes into play for USMC office users. We have a separate transportation office for USMC office users. If you sign in as office user from that GBLOC, you should see all moves associated with US Marine service users. In that case, there could be multiple GBLOCs so you can test the sort. 

To test
- Run `make server_run` and `make client_run`
- Go to `officelocal:3000`
- Sign in as a USMC office user. In devlocal local sign-in, you'll one available called `too_tio_role_usmc@office.mil`
- Go to the services counseling page `officelocal:3000/counseling/queue` and sort the 2 users you should see using the gbloc.

Also there's a new test in pkg/services/order

## References

* [Jira story](https://dp3.atlassian.net/browse/mb-7664) for this change
