### PR TITLE
Refactor PaymentRequestReviewedProcessor and tests

### DIFF
--- a/pkg/payment_request/send_to_syncada.go
+++ b/pkg/payment_request/send_to_syncada.go
@@ -14,9 +14,6 @@ import (
 func SendToSyncada(edi string, gexSender services.GexSender, sftpSender services.SyncadaSFTPSender, sendEDIFile bool, logger Logger) error {
 	var err error
 
-	if (gexSender == nil) && (sftpSender == nil) {
-		return fmt.Errorf("cannot send to Syncada, SendToSyncada() senders are nil")
-	}
 	if gexSender != nil {
 		//TODO: Send to Syncada via GEX needs to be implemented
 		logger.Warn("func SendToSyncada() -- GEX Sender NOT IMPLEMENTED")

--- a/pkg/services/payment_request/payment_request_reviewed_fetcher.go
+++ b/pkg/services/payment_request/payment_request_reviewed_fetcher.go
@@ -18,7 +18,7 @@ func NewPaymentRequestReviewedFetcher(db *pop.Connection) services.PaymentReques
 	return &paymentRequestReviewedFetcher{db}
 }
 
-//FetchReviewedPaymentRequest finds all payment request with status 'reviewed'
+// FetchReviewedPaymentRequest finds all payment requests with status 'reviewed'
 func (p *paymentRequestReviewedFetcher) FetchReviewedPaymentRequest() (models.PaymentRequests, error) {
 	var reviewedPaymentRequests models.PaymentRequests
 	err := p.db.Q().


### PR DESCRIPTION
## Description

This speeds up the tests by more than half: from over 30 seconds down to
about 12 seconds.

Here are the principles I used in this refactor:

- Functions should be as short as possible
- Extract each logical component of a function into a separate function
- Where it makes sense, create an interface for that logical component
so it can be mocked easily in tests
- Tests should be as fast as possible
- Tests should use the DB as little as possible
- Don't test the same things in every test. Each variation should focus
on what's unique and mock everything else that was already tested.
- If there are more than 2 subtests that write to the same DB table,
use `suite.TruncateAll()` before each subtest to avoid confusion around
what data is expected to be present in each subtest. By not truncating,
it prevents running a single subtest and forces the developer to run
the entire set of subtests, which slows them down. This can be avoided
by using the DB as little as possible. See the previous principles.

I added more comments inline.

There is further improvement that can speed up the tests even more, by
being able to mock more of this flow.

There's also a missing test that I wasn't sure how to write off the top
of my head. Since this workflow runs while iterating through payment
requests, we want to test that if there is more than one payment
request, if the first one succeeds, but the second one does not, the
first one should pass, but the second one should not. I think that's
what we want, but I'm not 100% sure. I don't know if testify supports
this kind of mocking, where you tell it to return an error only on the
second time.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
