### PR TITLE
[MB-7624] update SFTP reader to user GEX env vars

### DIFF
--- a/pkg/cli/gex_sftp.go
+++ b/pkg/cli/gex_sftp.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/pkg/sftp"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+)
+
+// TODO: Figure out what to do in terms of static analysis on the false positive for G101
+const (
+	// GEXSFTPPortFlag is the ENV var for the GEX SFTP port
+	GEXSFTPPortFlag string = "gex-sftp-port"
+	// GEXSFTPUserIDFlag is the ENV var for the GEX SFTP user ID
+	GEXSFTPUserIDFlag string = "gex-sftp-user-id"
+	// GEXSFTPIPAddressFlag is the ENV var for the GEX SFTP IP address
+	GEXSFTPIPAddressFlag string = "gex-sftp-ip-address"
+	// GEXSFTPPasswordFlag is the ENV var for the GEX SFTP password
+	GEXSFTPPasswordFlag string = "gex-sftp-password" // #nosec G101
+	// GEXSFTPHostKeyFlag is the ENV var for the GEX SFTP host key
+	GEXSFTPHostKeyFlag string = "gex-sftp-host-key"
+	// GEXSFTP997PickupDirectory is the ENV var for the directory where GEX delivers responses
+	GEXSFTP997PickupDirectory string = "gex_sftp_997_pickup_directory"
+	// GEXSFTP824PickupDirectory is the ENV var for the directory where GEX delivers responses
+	GEXSFTP824PickupDirectory string = "gex_sftp_824_pickup_directory"
+)
+
+// InitGEXSFTPFlags initializes GEX SFTP command line flags
+func InitGEXSFTPFlags(flag *pflag.FlagSet) {
+	flag.Int(GEXSFTPPortFlag, 22, "GEX SFTP Port")
+	flag.String(GEXSFTPUserIDFlag, "", "GEX SFTP User ID")
+	flag.String(GEXSFTPIPAddressFlag, "localhost", "GEX SFTP IP Address")
+	flag.String(GEXSFTPPasswordFlag, "", "GEX SFTP Password")
+	flag.String(GEXSFTPHostKeyFlag, "", "GEX SFTP Host Key")
+	flag.String(GEXSFTP997PickupDirectory, "", "GEX 997 SFTP Pickup Directory")
+	flag.String(GEXSFTP824PickupDirectory, "", "GEX 834 SFTP Pickup Directory")
+}
+
+// CheckGEXSFTP validates GEX SFTP command line flags
+func CheckGEXSFTP(v *viper.Viper) error {
+	if err := ValidatePort(v, GEXSFTPPortFlag); err != nil {
+		return err
+	}
+
+	if err := ValidateHost(v, GEXSFTPIPAddressFlag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InitGEXSSH initializes a GEX SSH client from command line flags.
+func InitGEXSSH(v *viper.Viper, logger Logger) (*ssh.Client, error) {
+	userID := v.GetString(GEXSFTPUserIDFlag)
+	password := v.GetString(GEXSFTPPasswordFlag)
+	hostKeyString := v.GetString(GEXSFTPHostKeyFlag)
+	remote := v.GetString(GEXSFTPIPAddressFlag)
+	port := v.GetString(GEXSFTPPortFlag)
+
+	logger.Info("Parsing GEX SFTP host key...")
+	hostKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostKeyString))
+	if err != nil {
+		logger.Error("Failed to parse GEX SFTP host key", zap.Error(err))
+		return nil, fmt.Errorf("failed to parse host key %w", err)
+	}
+	logger.Info("...Parsing GEX SFTP host key successful")
+
+	config := &ssh.ClientConfig{
+		User: userID,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: ssh.FixedHostKey(hostKey),
+	}
+
+	// Connect to SSH client
+	address := remote + ":" + port
+	logger.Info("Connecting to GEX SSH...", zap.String("address", address))
+	sshClient, err := ssh.Dial("tcp", address, config)
+	if err != nil {
+		logger.Error("Failed to connect to GEX SSH", zap.Error(err))
+		return nil, err
+	}
+	logger.Info("...GEX SSH connection successful")
+
+	return sshClient, nil
+}
+
+// InitGEXSFTP initializes a GEX SFTP client from command line flags.
+func InitGEXSFTP(sshClient *ssh.Client, logger Logger) (*sftp.Client, error) {
+	// Create new SFTP client
+	logger.Info("Connecting to GEX SFTP...")
+	client, err := sftp.NewClient(sshClient)
+	if err != nil {
+		logger.Error("Failed to connect to GEX SFTP", zap.Error(err))
+		return nil, err
+	}
+	logger.Info("...GEX SFTP connection successful")
+
+	return client, nil
+}

--- a/pkg/cli/gex_sftp.go
+++ b/pkg/cli/gex_sftp.go
@@ -23,9 +23,9 @@ const (
 	// GEXSFTPHostKeyFlag is the ENV var for the GEX SFTP host key
 	GEXSFTPHostKeyFlag string = "gex-sftp-host-key"
 	// GEXSFTP997PickupDirectory is the ENV var for the directory where GEX delivers responses
-	GEXSFTP997PickupDirectory string = "gex_sftp_997_pickup_directory"
+	GEXSFTP997PickupDirectory string = "gex-sftp-997-pickup-directory"
 	// GEXSFTP824PickupDirectory is the ENV var for the directory where GEX delivers responses
-	GEXSFTP824PickupDirectory string = "gex_sftp_824_pickup_directory"
+	GEXSFTP824PickupDirectory string = "gex-sftp-824-pickup-directory"
 )
 
 // InitGEXSFTPFlags initializes GEX SFTP command line flags

--- a/pkg/cli/gex_sftp.go
+++ b/pkg/cli/gex_sftp.go
@@ -19,7 +19,7 @@ const (
 	// GEXSFTPIPAddressFlag is the ENV var for the GEX SFTP IP address
 	GEXSFTPIPAddressFlag string = "gex-sftp-ip-address"
 	// GEXSFTPPasswordFlag is the ENV var for the GEX SFTP password
-	GEXSFTPPasswordFlag string = "gex-sftp-password" // #nosec G101
+	GEXSFTPPasswordFlag string = "gex-sftp-password" // #nosec G101 https://dp3.atlassian.net/browse/MB-7728
 	// GEXSFTPHostKeyFlag is the ENV var for the GEX SFTP host key
 	GEXSFTPHostKeyFlag string = "gex-sftp-host-key"
 	// GEXSFTP997PickupDirectory is the ENV var for the directory where GEX delivers responses

--- a/pkg/cli/gex_sftp_test.go
+++ b/pkg/cli/gex_sftp_test.go
@@ -1,0 +1,6 @@
+package cli
+
+func (suite *cliTestSuite) TestConfigGEXSFTP() {
+	suite.Setup(InitGEXSFTPFlags, []string{})
+	suite.NoError(CheckGEXSFTP(suite.viper))
+}

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -367,7 +367,7 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 		v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 		v.AutomaticEnv()
 
-		sshClient, err := cli.InitSyncadaSSH(v, logger)
+		sshClient, err := cli.InitGEXSSH(v, logger)
 		if err != nil {
 			logger.Fatal("couldn't initialize SSH client", zap.Error(err))
 		}
@@ -377,7 +377,7 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 			}
 		}()
 
-		sftpClient, err := cli.InitSyncadaSFTP(sshClient, logger)
+		sftpClient, err := cli.InitGEXSFTP(sshClient, logger)
 		if err != nil {
 			logger.Fatal("couldn't initialize SFTP client", zap.Error(err))
 		}
@@ -390,18 +390,15 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 		wrappedSFTPClient := invoice.NewSFTPClientWrapper(sftpClient)
 		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, h.DB(), logger, *deleteFromSyncada)
 
-		// TODO GEX will put different response types in different directories, but
-		// Syncada puts everything in the same directory. When we have access to GEX in staging
-		// we will have to change this to use separate paths for different response types.
-		path := "/" + v.GetString(cli.SyncadaSFTPUserIDFlag) + v.GetString(cli.SyncadaSFTPOutboundDirectory)
-
-		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path, time.Time{}, invoice.NewEDI997Processor(h.DB(), logger))
+		path997 := v.GetString(cli.GEXSFTP997PickupDirectory)
+		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path997, time.Time{}, invoice.NewEDI997Processor(h.DB(), logger))
 		if err != nil {
 			logger.Error("Error reading 997 responses", zap.Error(err))
 		} else {
 			logger.Info("Successfully processed 997 responses")
 		}
-		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path, time.Time{}, invoice.NewEDI824Processor(h.DB(), logger))
+		path824 := v.GetString(cli.GEXSFTP824PickupDirectory)
+		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path824, time.Time{}, invoice.NewEDI824Processor(h.DB(), logger))
 		if err != nil {
 			logger.Error("Error reading 824 responses", zap.Error(err))
 		} else {

--- a/pkg/services/invoice.go
+++ b/pkg/services/invoice.go
@@ -37,7 +37,7 @@ type SFTPFiler interface {
 	WriteTo(w io.Writer) (int64, error)
 }
 
-// SFTPClient is the exported interface for an SFTP client created for reading from Syncada
+// SFTPClient is the exported interface for an SFTP client created for reading from and SFTP connection
 //go:generate mockery --name SFTPClient
 type SFTPClient interface {
 	ReadDir(p string) ([]os.FileInfo, error)
@@ -45,10 +45,10 @@ type SFTPClient interface {
 	Remove(path string) error
 }
 
-// SyncadaSFTPReader is the exported interface for reading files from Syncada
+// SyncadaSFTPReader is the exported interface for reading files from an SFTP connection
 //go:generate mockery -name SyncadaSFTPReader
 type SyncadaSFTPReader interface {
-	FetchAndProcessSyncadaFiles(syncadaPath string, lastRead time.Time, processor SyncadaFileProcessor) (time.Time, error)
+	FetchAndProcessSyncadaFiles(pickupPath string, lastRead time.Time, processor SyncadaFileProcessor) (time.Time, error)
 }
 
 // SyncadaFileProcessor is the exported interface for processing EDI files from Syncada

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -853,43 +853,7 @@ func (suite *GHCInvoiceSuite) TestTruncateStrFunc() {
 
 func (suite *GHCInvoiceSuite) TestGeneratorFailedToInitDB() {
 	generator := NewGHCPaymentRequestInvoiceGenerator(suite.icnSequencer, clock.NewMock())
-	basicPaymentServiceItemParams := []testdatagen.CreatePaymentServiceItemParams{
-		{
-			Key:     models.ServiceItemParamNameContractCode,
-			KeyType: models.ServiceItemParamTypeString,
-			Value:   testdatagen.DefaultContractCode,
-		},
-	}
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         false,
-			Status:          models.PaymentRequestStatusPending,
-			RejectionReason: nil,
-		},
-	})
-
-	assertions := testdatagen.Assertions{
-		Move:           mto,
-		PaymentRequest: paymentRequest,
-		PaymentServiceItem: models.PaymentServiceItem{
-			Status: models.PaymentServiceItemStatusApproved,
-		},
-	}
-
-	testdatagen.MakePaymentServiceItemWithParams(
-		suite.DB(),
-		models.ReServiceCodeMS,
-		basicPaymentServiceItemParams,
-		assertions,
-	)
-	testdatagen.MakePaymentServiceItemWithParams(
-		suite.DB(),
-		models.ReServiceCodeCS,
-		basicPaymentServiceItemParams,
-		assertions,
-	)
+	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{})
 
 	_, err := generator.Generate(paymentRequest, false)
 	suite.Error(err, "DB pointer is nil")

--- a/pkg/services/invoice/syncada_sftp_reader.go
+++ b/pkg/services/invoice/syncada_sftp_reader.go
@@ -15,7 +15,7 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-// syncadaReaderSFTPSession contains information to create a new Syncada SFTP session
+// syncadaReaderSFTPSession contains information to create a new SFTP session
 type syncadaReaderSFTPSession struct {
 	client                     services.SFTPClient
 	db                         *pop.Connection
@@ -34,7 +34,7 @@ func NewSyncadaSFTPReaderSession(client services.SFTPClient, db *pop.Connection,
 }
 
 // FetchAndProcessSyncadaFiles downloads Syncada files with SFTP, processes them using the provided processor, and deletes them from the SFTP server if they were successfully processed
-func (s *syncadaReaderSFTPSession) FetchAndProcessSyncadaFiles(syncadaPath string, lastRead time.Time, processor services.SyncadaFileProcessor) (time.Time, error) {
+func (s *syncadaReaderSFTPSession) FetchAndProcessSyncadaFiles(pickupPath string, lastRead time.Time, processor services.SyncadaFileProcessor) (time.Time, error) {
 	// Store/log metrics about EDI processing upon exiting this method.
 	numProcessed := 0
 	start := time.Now()
@@ -56,9 +56,9 @@ func (s *syncadaReaderSFTPSession) FetchAndProcessSyncadaFiles(syncadaPath strin
 		}
 	}()
 
-	fileList, err := s.client.ReadDir(syncadaPath)
+	fileList, err := s.client.ReadDir(pickupPath)
 	if err != nil {
-		s.logger.Error("Error reading SFTP directory", zap.String("directory", syncadaPath))
+		s.logger.Error("Error reading SFTP directory", zap.String("directory", pickupPath))
 		return time.Time{}, err
 	}
 
@@ -82,7 +82,7 @@ func (s *syncadaReaderSFTPSession) FetchAndProcessSyncadaFiles(syncadaPath strin
 			if fileInfo.ModTime().After(mostRecentFileModTime) {
 				mostRecentFileModTime = fileInfo.ModTime()
 			}
-			filePath := sftp.Join(syncadaPath, fileInfo.Name())
+			filePath := sftp.Join(pickupPath, fileInfo.Name())
 
 			fileText, err := s.downloadFile(filePath)
 			if err != nil {

--- a/pkg/services/mocks/SyncadaSFTPReader.go
+++ b/pkg/services/mocks/SyncadaSFTPReader.go
@@ -14,20 +14,20 @@ type SyncadaSFTPReader struct {
 	mock.Mock
 }
 
-// FetchAndProcessSyncadaFiles provides a mock function with given fields: syncadaPath, lastRead, processor
-func (_m *SyncadaSFTPReader) FetchAndProcessSyncadaFiles(syncadaPath string, lastRead time.Time, processor services.SyncadaFileProcessor) (time.Time, error) {
-	ret := _m.Called(syncadaPath, lastRead, processor)
+// FetchAndProcessSyncadaFiles provides a mock function with given fields: pickupPath, lastRead, processor
+func (_m *SyncadaSFTPReader) FetchAndProcessSyncadaFiles(pickupPath string, lastRead time.Time, processor services.SyncadaFileProcessor) (time.Time, error) {
+	ret := _m.Called(pickupPath, lastRead, processor)
 
 	var r0 time.Time
 	if rf, ok := ret.Get(0).(func(string, time.Time, services.SyncadaFileProcessor) time.Time); ok {
-		r0 = rf(syncadaPath, lastRead, processor)
+		r0 = rf(pickupPath, lastRead, processor)
 	} else {
 		r0 = ret.Get(0).(time.Time)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, time.Time, services.SyncadaFileProcessor) error); ok {
-		r1 = rf(syncadaPath, lastRead, processor)
+		r1 = rf(pickupPath, lastRead, processor)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
## Description

Update the process EDIs functions to use GEX SFTP instead of using Syncada SFTP. I kept the Syncada SFTP file intact since we still have all of the chamber envs to go with it. I will create a new PR to remove the Syncada ENVs and the code files that go with it.

## Reviewer Notes

**This code cannot be tested locally. I guess running to see that you fail locally is the only thing that you can do. This will have to be tested in staging.**

All of the GEX envs should be present in chamber. 
```sh
aws-vault exec transcom-gov-milmove-stg -- chamber env app-stg  | grep -i gex_sftp
```

Just check that there are values for all of the following:
gex_sftp_host
gex_sftp_host_key
gex_sftp_ip_address
gex_sftp_password
gex_sftp_port
gex_sftp_user_id
gex_sftp_997_pickup_directory
gex_sftp_824_pickup_directory


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
