### PR TITLE
Fix G307 occurrence

### DIFF
--- a/pkg/services/payment_request/upload_creator_test.go
+++ b/pkg/services/payment_request/upload_creator_test.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage/test"
 
@@ -79,7 +81,12 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 		testFile, err := os.Open("../../testdatagen/testdata/test.pdf")
 		suite.NoError(err)
 
-		defer testFile.Close() // #nosec G307
+		defer func() {
+			if closeErr := testFile.Close(); closeErr != nil {
+				t.Error("Failed to close file", zap.Error(closeErr))
+			}
+		}()
+
 		uploadCreator := NewPaymentRequestUploadCreator(suite.DB(), suite.logger, fakeS3)
 		_, err = uploadCreator.CreateUpload(testFile, uuid.FromStringOrNil("96b77644-4028-48c2-9ab8-754f33309db9"), contractor.ID, "unit-test-file.pdf")
 		suite.Error(err)
@@ -89,7 +96,11 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 		testFile, err := os.Open("../../testdatagen/testdata/test.pdf")
 		suite.NoError(err)
 
-		defer testFile.Close() // #nosec G307
+		defer func() {
+			if closeErr := testFile.Close(); closeErr != nil {
+				t.Error("Failed to close file", zap.Error(closeErr))
+			}
+		}()
 
 		paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 		uploadCreator := NewPaymentRequestUploadCreator(suite.DB(), suite.logger, fakeS3)
@@ -103,7 +114,11 @@ func (suite *PaymentRequestServiceSuite) TestCreateUploadFailure() {
 		wrongTypeFile, err := os.Open("../../testdatagen/testdata/test.txt")
 		suite.NoError(err)
 
-		defer wrongTypeFile.Close() // #nosec G307
+		defer func() {
+			if closeErr := wrongTypeFile.Close(); closeErr != nil {
+				t.Error("Failed to close file", zap.Error(closeErr))
+			}
+		}()
 
 		_, err = uploadCreator.CreateUpload(wrongTypeFile, paymentRequest.ID, contractor.ID, "unit-test-file.pdf")
 		suite.Error(err)


### PR DESCRIPTION
## Description

Running the linter shows violations of G307: "Deferring a method which returns an error" in the `upload_creator_test.go`.  This remediates those occurrences and removes the disables.

## Setup

Run `pre-commit run -v --all-files golangci-lint`
There should be no linter violations.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7548) for this change
