### PR TITLE
Add annotation regarding use of child-process

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -6,9 +6,9 @@ import { danger, warn, fail } from 'danger';
 //RA: This usage checks for any critical or high vulnerabilities and upgrades in our dependencies to alert the Github user.
 //RA: This usage does not utilize any user input and there is no opening for command injection.
 //RA Developer Status: Mitigated
-//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-//RA Validator:
-//RA Modified Severity:
+//RA Validator Status: Mitigated
+//RA Validator: leodis.f.scott.civ@mail.mil
+//RA Modified Severity: CAT III
 // eslint-disable-next-line security/detect-child-process
 const child = require('child_process');
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,5 +1,14 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { danger, warn, fail } from 'danger';
+//RA Summary: eslint-plugin-security - detect-child-process -
+//RA Executing commands from an untrusted source or in an untrusted environment can cause an application to execute malicious commands on behalf of an attacker.
+//RA: Locates usages of child process.
+//RA: This usage checks for any critical or high vulnerabilities and upgrades in our dependencies to alert the Github user.
+//RA: This usage does not utilize any user input and there is no opening for command injection.
+//RA Developer Status: Mitigated
+//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Validator:
+//RA Modified Severity:
 // eslint-disable-next-line security/detect-child-process
 const child = require('child_process');
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -161,7 +170,9 @@ function checkPRHasProhibitedLinterOverride(dangerJSDiffCollection) {
 }
 
 const bypassingLinterChecks = async () => {
-  const allFiles = danger.git.modified_files.concat(danger.git.created_files).filter(file => file.includes('src/') || file.includes('pkg/'));
+  const allFiles = danger.git.modified_files
+    .concat(danger.git.created_files)
+    .filter((file) => file.includes('src/') || file.includes('pkg/'));
   const diffsByFile = await Promise.all(allFiles.map((f) => danger.git.diffForFile(f)));
   const dangerMsgSegment = checkPRHasProhibitedLinterOverride(diffsByFile);
   if (dangerMsgSegment) {


### PR DESCRIPTION
## Description

We are disabling `eslint-plugin-security` linter rule `detect-child-process` in the `dangerfile.ts`.  This PR adds annotation explaining why we are using the child-process and how this usage does not involve user input, which is the concern.

## Reviewer Notes

This article explains the concern and how to avoid it https://github.com/nodesecurity/eslint-plugin-security/blob/master/docs/avoid-command-injection-node.md.

```
Avoid using child_process.exec, and never use it if the command contains any input that changes based on user input.
Try to avoid letting users pass in options to commands if possible. Typically values are okay when using spawn or execfile, but selecting options via a user controlled string is a bad idea.
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7722) for this change
* [this article](https://github.com/nodesecurity/eslint-plugin-security/blob/master/docs/avoid-command-injection-node.md.) explains more about the approach used.
