### PR TITLE
[MB-7547] add EDI_ERROR to support API

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -585,7 +585,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/status": {
       "patch": {
-        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, or PAID.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
+        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, or EDI_ERROR.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
         "consumes": [
           "application/json"
         ],
@@ -2047,7 +2047,8 @@ func init() {
         "REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED",
         "SENT_TO_GEX",
         "RECEIVED_BY_GEX",
-        "PAID"
+        "PAID",
+        "EDI_ERROR"
       ]
     },
     "PaymentRequests": {
@@ -3232,7 +3233,7 @@ func init() {
     },
     "/payment-requests/{paymentRequestID}/status": {
       "patch": {
-        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, or PAID.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
+        "description": "Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, or EDI_ERROR.\n\nA status of REVIEWED can optionally have a ` + "`" + `rejectionReason` + "`" + `.\n\nThis is a support endpoint and is not available in production.\n",
         "consumes": [
           "application/json"
         ],
@@ -4736,7 +4737,8 @@ func init() {
         "REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED",
         "SENT_TO_GEX",
         "RECEIVED_BY_GEX",
-        "PAID"
+        "PAID",
+        "EDI_ERROR"
       ]
     },
     "PaymentRequests": {

--- a/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status.go
+++ b/pkg/gen/supportapi/supportoperations/payment_request/update_payment_request_status.go
@@ -33,7 +33,7 @@ func NewUpdatePaymentRequestStatus(ctx *middleware.Context, handler UpdatePaymen
 
 updatePaymentRequestStatus
 
-Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, or PAID.
+Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, or EDI_ERROR.
 
 A status of REVIEWED can optionally have a `rejectionReason`.
 

--- a/pkg/gen/supportclient/payment_request/payment_request_client.go
+++ b/pkg/gen/supportclient/payment_request/payment_request_client.go
@@ -163,7 +163,7 @@ func (a *Client) ProcessReviewedPaymentRequests(params *ProcessReviewedPaymentRe
 /*
   UpdatePaymentRequestStatus updates payment request status
 
-  Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, or PAID.
+  Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, or EDI_ERROR.
 
 A status of REVIEWED can optionally have a `rejectionReason`.
 

--- a/pkg/gen/supportmessages/payment_request_status.go
+++ b/pkg/gen/supportmessages/payment_request_status.go
@@ -37,6 +37,9 @@ const (
 
 	// PaymentRequestStatusPAID captures enum value "PAID"
 	PaymentRequestStatusPAID PaymentRequestStatus = "PAID"
+
+	// PaymentRequestStatusEDIERROR captures enum value "EDI_ERROR"
+	PaymentRequestStatusEDIERROR PaymentRequestStatus = "EDI_ERROR"
 )
 
 // for schema
@@ -44,7 +47,7 @@ var paymentRequestStatusEnum []interface{}
 
 func init() {
 	var res []PaymentRequestStatus
-	if err := json.Unmarshal([]byte(`["PENDING","REVIEWED","REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED","SENT_TO_GEX","RECEIVED_BY_GEX","PAID"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["PENDING","REVIEWED","REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED","SENT_TO_GEX","RECEIVED_BY_GEX","PAID","EDI_ERROR"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -87,6 +87,8 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 	case "PAID":
 		status = models.PaymentRequestStatusPaid
 		paidAtDate = time.Now()
+	case "EDI_ERROR":
+		status = models.PaymentRequestStatusEDIError
 	}
 
 	// If we got a rejection reason let's use it
@@ -334,6 +336,8 @@ func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.Pr
 				paidAt := time.Now()
 				pr.Status = models.PaymentRequestStatusPaid
 				pr.PaidAt = &paidAt
+			case "EDI_ERROR":
+				pr.Status = models.PaymentRequestStatusEDIError
 			case "":
 				sentToGex := time.Now()
 				pr.Status = models.PaymentRequestStatusSentToGex

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -270,7 +270,7 @@ paths:
     patch:
       summary: updatePaymentRequestStatus
       description: |
-        Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, or PAID.
+        Updates status of a payment request to REVIEWED, SENT_TO_GEX, RECEIVED_BY_GEX, REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED, PAID, or EDI_ERROR.
 
         A status of REVIEWED can optionally have a `rejectionReason`.
 
@@ -1619,6 +1619,7 @@ definitions:
       - SENT_TO_GEX
       - RECEIVED_BY_GEX
       - PAID
+      - EDI_ERROR
     title: Payment Request Status
     type: string
   ProcessReviewedPaymentRequests:


### PR DESCRIPTION
## Description

Adding `EDI_ERROR` status to the support API. It was introduced in PR https://github.com/transcom/mymove/pull/6089 but adding to the support API was missed.

## Reviewer Notes

n/a

## Setup

This is the effect support API. Run locally or in staging. There is nothing really see happening right now. The connections to GEX are not working.

filename: sendtosyncada.json
```json
{
  "body": {
    "sendToSyncada": true,
    "readFromSyncada": false,
    "deleteFromSyncada": false
  }
}
```

```sh
prime-api-client --insecure support-reviewed-payment-requests --filename sendtosyncada.json
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7547) for this change


## Screenshots

n/a
