### PR TITLE
[MB-7725] Colocate all #nosec instances to be with annotation

### DIFF
--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -36,6 +36,7 @@ func (e *errInvalidHostname) Error() string {
 	return fmt.Sprintf("invalid hostname %s, must be one of %s, %s, or %s", e.Hostname, e.MilApp, e.OfficeApp, e.AdminApp)
 }
 
+// GorillaCSRFToken is the name of the base CSRF token
 //RA Summary: gosec - G101 - Password Management: Hardcoded Password
 //RA: This line was flagged because it detected use of the word "token"
 //RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
@@ -44,9 +45,8 @@ func (e *errInvalidHostname) Error() string {
 //RA Validator Status: Mitigated
 //RA Validator: jneuner@mitre.org
 //RA Modified Severity: CAT III
-
-// GorillaCSRFToken is the name of the base CSRF token
-const GorillaCSRFToken = "_gorilla_csrf" // #nosec G101
+// #nosec G101
+const GorillaCSRFToken = "_gorilla_csrf"
 
 // MaskedGorillaCSRFToken is the masked CSRF token used to send back in the 'X-CSRF-Token' request header
 const MaskedGorillaCSRFToken = "masked_gorilla_csrf"

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Set of flags used for authentication
 const (
 	//RA Summary: gosec - G101 - Password Management: Hardcoded Password
 	//RA: This line was flagged because of use of the word "secret"
@@ -19,8 +20,8 @@ const (
 	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-
-	// ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag // #nosec G101
+	// #nosec G101
+	// ClientAuthSecretKeyFlag is the Client Auth Secret Key Flag
 	ClientAuthSecretKeyFlag string = "client-auth-secret-key"
 	// LoginGovCallbackProtocolFlag is the Login.gov Callback Protocol Flag
 	LoginGovCallbackProtocolFlag string = "login-gov-callback-protocol"

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Set of flags used for DPS system
 const (
 	// HTTPSDDCServerNameFlag is the HTTP SDDC Server Name Flag
 	HTTPSDDCServerNameFlag string = "http-sddc-server-name"
@@ -24,8 +25,8 @@ const (
 	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-
-	// DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag // #nosec G101
+	// #nosec G101
+	// DPSAuthSecretKeyFlag is the DPS Auth Secret Key Flag
 	DPSAuthSecretKeyFlag string = "dps-auth-secret-key"
 	// DPSRedirectURLFlag is the DPS Redirect URL Flag
 	DPSRedirectURLFlag string = "dps-redirect-url"
@@ -42,8 +43,8 @@ const (
 	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-
-	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag // #nosec G101
+	// #nosec G101
+	// DPSAuthCookieSecretKeyFlag is the DPS Auth Cookie Secret Key Flag
 	DPSAuthCookieSecretKeyFlag string = "dps-auth-cookie-secret-key"
 	// DPSCookieExpiresInMinutesFlag is the DPS Cookie Expires In Minutes Flag
 	DPSCookieExpiresInMinutesFlag string = "dps-cookie-expires-in-minutes"

--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Set of flags used for GEX
 const (
 	// GEXBasicAuthUsernameFlag is the GEX Basic Auth Username Flag
 	GEXBasicAuthUsernameFlag string = "gex-basic-auth-username"
@@ -19,8 +20,8 @@ const (
 	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-
-	// GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag #nosec G101
+	// #nosec G101
+	// GEXBasicAuthPasswordFlag is the GEX Basic Auth Password Flag
 	GEXBasicAuthPasswordFlag string = "gex-basic-auth-password"
 	// GEXSendProdInvoiceFlag is the GEX Send Prod Invoice Flag
 	GEXSendProdInvoiceFlag string = "gex-send-prod-invoice"

--- a/pkg/cli/syncada_sftp.go
+++ b/pkg/cli/syncada_sftp.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// Set of flags used for SyncadaSFTP
 const (
 	// SyncadaSFTPPortFlag is the ENV var for the Syncada SFTP port
 	SyncadaSFTPPortFlag string = "syncada-sftp-port"
@@ -27,9 +28,9 @@ const (
 	//RA Validator Status: Known Issue
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-
+	// #nosec G101
 	// SyncadaSFTPPasswordFlag is the ENV var for the Syncada SFTP password
-	SyncadaSFTPPasswordFlag string = "syncada-sftp-password" // #nosec G101
+	SyncadaSFTPPasswordFlag string = "syncada-sftp-password"
 	// SyncadaSFTPHostKeyFlag is the ENV var for the Syncada SFTP host key
 	SyncadaSFTPHostKeyFlag string = "syncada-sftp-host-key"
 	// SyncadaSFTPOutboundDirectory is the ENV var for the directory where Syncada uploads responses

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -10,7 +10,8 @@ import (
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: CAT III
-	"crypto/md5" // #nosec G501
+	// #nosec G501
+	"crypto/md5"
 	"encoding/base64"
 	"io"
 	"net/http"


### PR DESCRIPTION
## Description

Colocated all #nosec instances to be with annotation to ensure that ato-linter does not flag it as a false positive

## Reviewer Notes
- there is one instance at `mymove/pkg/cli/gex_sftp.go:22:51` which will need annotation. Annotation will be done in separate pr
- having a comment above a group of constant declarations was needed for #nosec to have expected behavior. Without it, it was expecting the required comment for a constant to be above the annotation block

## Setup
`go install ./cmd/...`
`ato-linter ./pkg/...`
Expected results: It should have 1 lint error located at `mymove/pkg/cli/gex_sftp.go:22:51`
Annotation for this will be in a separate PR

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7725) for this change

