### PR TITLE
[MB-7656] Filter by gbloc for the Services Counseling Queue

### DIFF
--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -169,6 +169,7 @@ func (h GetServicesCounselingQueueHandler) Handle(params queues.GetServicesCouns
 		DodID:                  params.DodID,
 		LastName:               params.LastName,
 		DestinationDutyStation: params.DestinationDutyStation,
+		OriginGBLOC:            params.OriginGBLOC,
 		SubmittedAt:            params.SubmittedAt,
 		RequestedMoveDate:      params.RequestedMoveDate,
 		Page:                   params.Page,

--- a/pkg/services/order.go
+++ b/pkg/services/order.go
@@ -26,6 +26,7 @@ type ListOrderParams struct {
 	DodID                  *string
 	LastName               *string
 	DestinationDutyStation *string
+	OriginGBLOC            *string
 	SubmittedAt            *string
 	RequestedMoveDate      *string
 	Status                 []string

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -466,18 +466,13 @@ func (suite *OrderServiceSuite) TestListMovesWithSortOrder() {
 	})
 }
 
-func (suite *OrderServiceSuite) TestListUSMCMovesWithGBLOCSortOrder() {
+func (suite *OrderServiceSuite) TestListUSMCMovesWithGBLOCSortFilter() {
 
 	// TESTCASE SCENARIO
 	// Under test: OrderFetcher.ListOrders function
 	// Mocked:     None
 	// Set up:     We create 2 USMC moves with different GBLOCs, ACME and ZANY
 	//             We create an office user with the USMC GBLOC
-	//             Then we request a list of moves sorted by GBLOC, first ascending then descending
-	// Expected outcome:
-	//             We expect both moves to be returned
-	//             In asc mode, we should get the ACME move, then the ZANY move
-	//             In desc mode, we should get the ZANY move, then the ACME move
 
 	// Create an office user at the USMC GBLOC transportation office
 	officeUser := testdatagen.MakeOfficeUserWithUSMCGBLOC(suite.DB())
@@ -538,26 +533,64 @@ func (suite *OrderServiceSuite) TestListUSMCMovesWithGBLOCSortOrder() {
 	gblocACME := acmeMove.Orders.OriginDutyStation.TransportationOffice.Gbloc
 	gblocZANY := zanyMove.Orders.OriginDutyStation.TransportationOffice.Gbloc
 
-	// Setup and run the function under test sorting GBLOC with ascending mode
-	orderFetcher := NewOrderFetcher(suite.DB())
-	statuses := []string{"NEEDS SERVICE COUNSELING"}
-	// Sort by service member name
-	params := services.ListOrderParams{Sort: swag.String("originGBLOC"), Order: swag.String("asc"), Status: statuses}
-	moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
+	suite.T().Run("Sort by origin GBLOC", func(t *testing.T) {
+		// TESTCASE SCENARIO
+		// Under test: OrderFetcher.ListOrders function
+		// Mocked:     None
+		// Set up:     We create 2 USMC moves with different GBLOCs, ACME and ZANY
+		//             We create an office user with the USMC GBLOC
+		//             Then we request a list of moves sorted by GBLOC, first ascending then descending
+		// Expected outcome:
+		//             We expect both moves to be returned
+		//             In asc mode, we should get the ACME move, then the ZANY move
+		//             In desc mode, we should get the ZANY move, then the ACME move
 
-	// Check the results
-	suite.NoError(err)
-	suite.Equal(2, len(moves))
-	suite.Equal(gblocACME, moves[0].Orders.OriginDutyStation.TransportationOffice.Gbloc)
-	suite.Equal(gblocZANY, moves[1].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+		// Setup and run the function under test sorting GBLOC with ascending mode
+		orderFetcher := NewOrderFetcher(suite.DB())
+		statuses := []string{"NEEDS SERVICE COUNSELING"}
+		// Sort by service member name
+		params := services.ListOrderParams{Sort: swag.String("originGBLOC"), Order: swag.String("asc"), Status: statuses}
+		moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
 
-	// Setup and run the function under test sorting GBLOC with descending mode
-	params = services.ListOrderParams{Sort: swag.String("originGBLOC"), Order: swag.String("desc"), Status: statuses}
-	moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
+		// Check the results
+		suite.NoError(err)
+		suite.Equal(2, len(moves))
+		suite.Equal(gblocACME, moves[0].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+		suite.Equal(gblocZANY, moves[1].Orders.OriginDutyStation.TransportationOffice.Gbloc)
 
-	// Check the results
-	suite.NoError(err)
-	suite.Equal(2, len(moves))
-	suite.Equal(gblocZANY, moves[0].Orders.OriginDutyStation.TransportationOffice.Gbloc)
-	suite.Equal(gblocACME, moves[1].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+		// Setup and run the function under test sorting GBLOC with descending mode
+		params = services.ListOrderParams{Sort: swag.String("originGBLOC"), Order: swag.String("desc"), Status: statuses}
+		moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
+
+		// Check the results
+		suite.NoError(err)
+		suite.Equal(2, len(moves))
+		suite.Equal(gblocZANY, moves[0].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+		suite.Equal(gblocACME, moves[1].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+	})
+
+	suite.T().Run("Filter by origin GBLOC", func(t *testing.T) {
+		// TESTCASE SCENARIO
+		// Under test: OrderFetcher.ListOrders function
+		// Mocked:     None
+		// Set up:     We create 2 USMC moves with different GBLOCs, ACME and ZANY
+		//             We create an office user with the USMC GBLOC
+		//             Then we request a list of moves filtered by GBLOC ZANY
+		// Expected outcome:
+		//             We expect 1 moves to be returned, the ZANY move
+
+		// Setup and run the function under test filtering GBLOC for ZANY
+		orderFetcher := NewOrderFetcher(suite.DB())
+		statuses := []string{"NEEDS SERVICE COUNSELING"}
+		// Sort by service member name
+		params := services.ListOrderParams{OriginGBLOC: swag.String("ZANY"), Status: statuses}
+		moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
+
+		// Check the results
+		suite.NoError(err)
+		suite.Equal(1, len(moves))
+		suite.Equal(gblocZANY, moves[0].Orders.OriginDutyStation.TransportationOffice.Gbloc)
+
+	})
+
 }


### PR DESCRIPTION
## Description

This ticket is to ensure that filtering by GBLOC works. 

If you've accessed the Office UI as a TOO, you'll notice we only see one GBLOC, the one that matches the office user's transportation office. So you can't really sort GBLOCs if you're only getting one GBLOC. 

The GBLOC sorting comes into play for USMC office users. We have a separate transportation office for USMC office users. If you sign in as office user from that GBLOC, you should see all moves associated with US Marine service users. In that case, there could be multiple GBLOCs so you can test the filter. 

To test
- Run `make server_run` and `make client_run`
- Go to `officelocal:3000`
- Sign in as a USMC office user. In devlocal local sign-in, you'll one available called `too_tio_role_usmc@office.mil`
- Go to the services counseling page `officelocal:3000/counseling/queue` and filter the 2 users you should see using the gbloc.

Also there's a new test in pkg/services/order.

## References

* [Jira story](https://dp3.atlassian.net/browse/mb-7656) for this change
