### PR TITLE
MB-7626 Clarify log messages for those less familiar with EDI formats

### DIFF
--- a/cmd/milmove-tasks/process_edis.go
+++ b/cmd/milmove-tasks/process_edis.go
@@ -220,7 +220,7 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		logger.Fatal("Could not process reviewed payment request(s)", zap.Error(err))
 	}
-	logger.Info("Successfully sent 858 files")
+	logger.Info("Finished processing reviewed payment requests")
 
 	// SSH and SFTP Connection Setup
 	sshClient, err := cli.InitGEXSSH(v, logger)
@@ -261,18 +261,18 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 	path997 := v.GetString(cli.GEXSFTP997PickupDirectory)
 	_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path997, lastReadTime, invoice.NewEDI997Processor(dbConnection, logger))
 	if err != nil {
-		logger.Error("Error reading 997 responses", zap.Error(err))
+		logger.Error("Error reading EDI997 acknowledgement responses", zap.Error(err))
 	} else {
-		logger.Info("Successfully processed 997 responses")
+		logger.Info("Successfully processed EDI997 acknowledgement responses")
 	}
 
 	// Process 824s
 	path824 := v.GetString(cli.GEXSFTP824PickupDirectory)
 	_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(path824, lastReadTime, invoice.NewEDI824Processor(dbConnection, logger))
 	if err != nil {
-		logger.Error("Error reading 824 responses", zap.Error(err))
+		logger.Error("Error reading EDI824 application advice responses", zap.Error(err))
 	} else {
-		logger.Info("Successfully processed 824 responses")
+		logger.Info("Successfully processed EDI824 application advice responses")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

In looking at the logs for the job runner process-edi task it became apparent that EDI file types (858, 997, and 824) could easily be confused for counts of files processed. This pr updates the output to clarify that.

## Reviewer Notes

Is this clear?

## Setup

```sh
go run ./cmd/milmove-tasks process-edis

{"level":"info","ts":"2021-04-21T00:38:46.334Z","caller":"cli/dbconn.go:258","msg":"Connecting to the database","url":"postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable","db-ssl-root-cert":""}
{"level":"info","ts":"2021-04-21T00:38:46.334Z","caller":"cli/dbconn.go:364","msg":"Starting database ping...."}
{"level":"info","ts":"2021-04-21T00:38:46.350Z","caller":"cli/dbconn.go:371","msg":"...DB ping successful!"}
{"level":"info","ts":"2021-04-21T00:38:46.350Z","caller":"milmove-tasks/process_edis.go:174","msg":"Starting in development mode, which enables additional features"}
{"level":"info","ts":"2021-04-21T00:38:46.350Z","caller":"milmove-tasks/process_edis.go:178","msg":"SendToSyncada is false"}
2021-04-21T00:38:46.350Z        INFO    certs/certs_entrust.go:28       certificate chain from move-mil-dod-tls-cert parsed     {"count": 1}
2021-04-21T00:38:46.350Z        INFO    certs/certs_entrust.go:36       certificate chain from move-mil-dod-ca-cert parsed      {"count": 1}
2021-04-21T00:38:46.351Z        INFO    certs/certs_entrust.go:47       DOD keypair     {"certificates": 2}
{"level":"info","ts":"2021-04-21T00:38:46.366Z","caller":"payment_request/payment_request_reviewed_processor.go:190","msg":"EDIs processed","EDIs processed":{"EDIType":"858","NumEDIsProcessed":0,"ProcessStartedAt":"2021-04-21T00:38:46.351Z","ProcessEndedAt":"2021-04-21T00:38:46.366Z"}}
{"level":"info","ts":"2021-04-21T00:38:46.371Z","caller":"milmove-tasks/process_edis.go:223","msg":"Finished processing reviewed payment requests"}
{"level":"info","ts":"2021-04-21T00:38:46.371Z","caller":"cli/gex_sftp.go:63","msg":"Parsing GEX SFTP host key..."}
{"level":"info","ts":"2021-04-21T00:38:46.371Z","caller":"cli/gex_sftp.go:69","msg":"...Parsing GEX SFTP host key successful"}
{"level":"info","ts":"2021-04-21T00:38:46.371Z","caller":"cli/gex_sftp.go:81","msg":"Connecting to GEX SSH...","address":"199.10.68.85:22"}
{"level":"error","ts":"2021-04-21T00:40:01.988Z","caller":"cli/gex_sftp.go:84","msg":"Failed to connect to GEX SSH","error":"dial tcp 199.10.68.85:22: connect: operation timed out","stacktrace":"github.com/transcom/mymove/pkg/cli.InitGEXSSH"}
{"level":"fatal","ts":"2021-04-21T00:40:01.988Z","caller":"milmove-tasks/process_edis.go:228","msg":"couldn't initialize SSH client","error":"dial tcp 199.10.68.85:22: connect: operation timed out","stacktrace":"\t/Users/john/projects/dod/mymove/cmd/milmove-tasks/process_edis.go:228"}
exit status 1
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7626) for this change