### PR TITLE
[MB-5918] Checks major version only, doesn't care about minor release.

### DIFF
--- a/scripts/check-bash-version
+++ b/scripts/check-bash-version
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-VERSION="5.1"
+VERSION="5"
 
 # Script helps ensure that /etc/shells has all the correct entries in it
 


### PR DESCRIPTION
## Description

Checks major version only. No longer cares about minor version.

## Reviewer Notes

Changed `VERSION` variable in the script a few times to confirm the desired behavior

```
bash-3.2$ ./scripts/check-bash-version 
Bash 5.1.4(1)-release installed
bash-3.2$ ./scripts/check-bash-version 
Bash 5.1.4(1)-release installed
bash-3.2$ ./scripts/check-bash-version 
Bash 5.2.x is required to run this project! Found 5.1.4(1)-release
Run 'brew install bash', add '/usr/local/bin/bash' to your /etc/shells file, and restart your terminal
bash-3.2$ ./scripts/check-bash-version 
Bash 5.1.4(1)-release installed
bash-3.2$ ./scripts/check-bash-version 
Bash 3.x is required to run this project! Found 5.1.4(1)-release
Run 'brew install bash', add '/usr/local/bin/bash' to your /etc/shells file, and restart your terminal
```
#

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5918) for this change
