### PR TITLE
[MB-7667] Add GBLOC to creation of new devlocal office users

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -414,7 +414,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		}
 
 		role := roles.Role{}
-		err = h.db.Where("role_type = $1", "ppm_office_users").First(&role)
+		err = h.db.Where("role_type = $1", roles.RoleTypePPMOfficeUsers).First(&role)
 		if err != nil {
 			h.logger.Error("could not fetch role ppm_office_users", zap.Error(err))
 		}
@@ -438,6 +438,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 			Latitude:  37.7678355,
 			Longitude: -122.4199298,
 			Hours:     models.StringPointer("0900-1800 Mon-Sat"),
+			Gbloc:     "LKNQ",
 		}
 
 		verrs, err = h.db.ValidateAndSave(&office)
@@ -485,7 +486,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		}
 
 		role := roles.Role{}
-		err = h.db.Where("role_type = $1", "transportation_ordering_officer").First(&role)
+		err = h.db.Where("role_type = $1", roles.RoleTypeTOO).First(&role)
 		if err != nil {
 			h.logger.Error("could not fetch role transportation_ordering_officer", zap.Error(err))
 		}
@@ -509,6 +510,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 			Latitude:  37.7678355,
 			Longitude: -122.4199298,
 			Hours:     models.StringPointer("0900-1800 Mon-Sat"),
+			Gbloc:     "LKNQ",
 		}
 
 		verrs, err = h.db.ValidateAndSave(&office)
@@ -556,7 +558,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 		}
 
 		role := roles.Role{}
-		err = h.db.Where("role_type = $1", "transportation_invoicing_officer").First(&role)
+		err = h.db.Where("role_type = $1", roles.RoleTypeTIO).First(&role)
 		if err != nil {
 			h.logger.Error("could not fetch role transporation_invoicing_officer", zap.Error(err))
 		}
@@ -579,6 +581,7 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 			Latitude:  37.7678355,
 			Longitude: -122.4199298,
 			Hours:     models.StringPointer("0900-1800 Mon-Sat"),
+			Gbloc:     "LKNQ",
 		}
 
 		verrs, err = h.db.ValidateAndSave(&office)
@@ -693,14 +696,13 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 			h.logger.Error("validation errors creating dps user", zap.Stringer("errors", verrs))
 		}
 	case AdminUserType:
-		var role models.AdminRole = "SYSTEM_ADMIN"
 
 		adminUser := models.AdminUser{
 			UserID:    &user.ID,
 			Email:     user.LoginGovEmail,
 			FirstName: "Leo",
 			LastName:  "Spaceman",
-			Role:      role,
+			Role:      models.SystemAdminRole,
 		}
 		verrs, err := h.db.ValidateAndSave(&adminUser)
 

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func getCookie(name string, cookies []*http.Cookie) (*http.Cookie, error) {
@@ -75,53 +77,72 @@ func (suite *AuthSuite) TestCreateUserHandlerMilMove() {
 func (suite *AuthSuite) TestCreateUserHandlerOffice() {
 	t := suite.T()
 
+	// These roles are created during migrations but our test suite truncates all tables
+	testdatagen.MakePPMOfficeRole(suite.DB())
+	testdatagen.MakeTOORole(suite.DB())
+	testdatagen.MakeTIORole(suite.DB())
+	testdatagen.MakeServicesCounselorRole(suite.DB())
+
 	appnames := ApplicationTestServername()
 	callbackPort := 1234
-
-	// Exercise all variables in the office user
-	form := url.Values{}
-	form.Add("userType", "PPM office")
-	form.Add("firstName", "Carol")
-	form.Add("lastName", "X")
-	form.Add("telephone", "222-222-2222")
-	form.Add("email", "office_user@example.com")
-
-	req := httptest.NewRequest("POST", fmt.Sprintf("http://%s/devlocal-auth/create", appnames.OfficeServername), strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
-	req.ParseForm()
 
 	sessionManagers := setupSessionManagers()
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort, sessionManagers)
 	handler := NewCreateUserHandler(authContext, suite.DB(), appnames)
 
-	rr := httptest.NewRecorder()
-	officeSession.LoadAndSave(handler).ServeHTTP(rr, req)
+	for _, newOfficeUser := range []struct {
+		userType string
+		roleType roles.RoleType
+		email    string
+	}{{userType: PPMOfficeUserType, roleType: roles.RoleTypePPMOfficeUsers, email: "ppm_office_user@example.com"}, {userType: TOOOfficeUserType, roleType: roles.RoleTypeTOO, email: "too_office_user@example.com"}, {userType: TIOOfficeUserType, roleType: roles.RoleTypeTIO, email: "tio_office_user@example.com"}} {
+		// Exercise all variables in the office user
+		form := url.Values{}
+		form.Add("userType", newOfficeUser.userType)
+		form.Add("firstName", "Carol")
+		form.Add("lastName", "X")
+		form.Add("telephone", "222-222-2222")
+		form.Add("email", newOfficeUser.email)
 
-	suite.Equal(http.StatusOK, rr.Code, "handler returned wrong status code")
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusOK)
+		req := httptest.NewRequest("POST", fmt.Sprintf("http://%s/devlocal-auth/create", appnames.OfficeServername), strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
+		req.ParseForm()
+
+		rr := httptest.NewRecorder()
+		officeSession.LoadAndSave(handler).ServeHTTP(rr, req)
+
+		suite.Equal(http.StatusOK, rr.Code, "handler returned wrong status code")
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusOK)
+		}
+
+		cookies := rr.Result().Cookies()
+		if _, err := getCookie("office_session_token", cookies); err != nil {
+			t.Error("could not find session token in response")
+		}
+
+		user := models.User{}
+		err := json.Unmarshal(rr.Body.Bytes(), &user)
+		if err != nil {
+			t.Error("Could not unmarshal json data into User model.", err)
+		}
+
+		officeUser, err := models.FetchOfficeUserByEmail(suite.DB(), user.LoginGovEmail)
+		if err != nil {
+			t.Error("Could not find office user for this user.", err)
+		}
+
+		err = suite.DB().Load(officeUser, "TransportationOffice", "User.Roles")
+		if err != nil {
+			t.Error("Could not load transportation office for this user")
+		}
+
+		suite.Equal("Carol", officeUser.FirstName)
+		suite.Equal("X", officeUser.LastName)
+		suite.Equal("222-222-2222", officeUser.Telephone)
+		suite.Equal(newOfficeUser.roleType, officeUser.User.Roles[0].RoleType)
+		suite.Equal("LKNQ", officeUser.TransportationOffice.Gbloc)
 	}
-
-	cookies := rr.Result().Cookies()
-	if _, err := getCookie("office_session_token", cookies); err != nil {
-		t.Error("could not find session token in response")
-	}
-
-	user := models.User{}
-	err := json.Unmarshal(rr.Body.Bytes(), &user)
-	if err != nil {
-		t.Error("Could not unmarshal json data into User model.", err)
-	}
-
-	officeUser, err := models.FetchOfficeUserByEmail(suite.DB(), user.LoginGovEmail)
-	if err != nil {
-		t.Error("Could not find office user for this user.", err)
-	}
-
-	suite.Equal(officeUser.FirstName, "Carol")
-	suite.Equal(officeUser.LastName, "X")
-	suite.Equal(officeUser.Telephone, "222-222-2222")
 }
 
 func (suite *AuthSuite) TestCreateUserHandlerDPS() {
@@ -213,6 +234,10 @@ func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 	if err := queryBuilder.FetchOne(&adminUser, filters); err != nil {
 		t.Error("Couldn't find admin user record")
 	}
+
+	suite.Equal("Leo", adminUser.FirstName)
+	suite.Equal("Spaceman", adminUser.LastName)
+	suite.Equal(models.SystemAdminRole, adminUser.Role)
 }
 
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -95,7 +95,7 @@ func (suite *AuthSuite) TestCreateUserHandlerOffice() {
 		userType string
 		roleType roles.RoleType
 		email    string
-	}{{userType: PPMOfficeUserType, roleType: roles.RoleTypePPMOfficeUsers, email: "ppm_office_user@example.com"}, {userType: TOOOfficeUserType, roleType: roles.RoleTypeTOO, email: "too_office_user@example.com"}, {userType: TIOOfficeUserType, roleType: roles.RoleTypeTIO, email: "tio_office_user@example.com"}} {
+	}{{userType: PPMOfficeUserType, roleType: roles.RoleTypePPMOfficeUsers, email: "ppm_office_user@example.com"}, {userType: TOOOfficeUserType, roleType: roles.RoleTypeTOO, email: "too_office_user@example.com"}, {userType: TIOOfficeUserType, roleType: roles.RoleTypeTIO, email: "tio_office_user@example.com"}, {userType: ServicesCounselorOfficeUserType, roleType: roles.RoleTypeServicesCounselor, email: "services_counselor_office_user@example.com"}} {
 		// Exercise all variables in the office user
 		form := url.Values{}
 		form.Add("userType", newOfficeUser.userType)

--- a/pkg/testdatagen/make_role.go
+++ b/pkg/testdatagen/make_role.go
@@ -1,0 +1,74 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models/roles"
+)
+
+// MakeRole creates a single Role defaulting to the customer.
+func MakeRole(db *pop.Connection, assertions Assertions) roles.Role {
+	role := roles.Role{
+		ID:       uuid.Must(uuid.NewV4()),
+		RoleType: roles.RoleTypeCustomer,
+		RoleName: "Customer",
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&role, assertions.Role)
+
+	mustCreate(db, &role, assertions.Stub)
+
+	return role
+}
+
+// MakeServicesCounselorRole creates a single services counselor role.
+func MakeServicesCounselorRole(db *pop.Connection) roles.Role {
+	return MakeRole(db, Assertions{
+		Role: roles.Role{
+			RoleType: roles.RoleTypeServicesCounselor,
+			RoleName: "Services Counselor",
+		},
+	})
+}
+
+// MakePPMOfficeRole creates a single ppm office user role.
+func MakePPMOfficeRole(db *pop.Connection) roles.Role {
+	return MakeRole(db, Assertions{
+		Role: roles.Role{
+			RoleType: roles.RoleTypePPMOfficeUsers,
+			RoleName: "PPP Office User",
+		},
+	})
+}
+
+// MakeTOORole creates a single transportation ordering officer role.
+func MakeTOORole(db *pop.Connection) roles.Role {
+	return MakeRole(db, Assertions{
+		Role: roles.Role{
+			RoleType: roles.RoleTypeTOO,
+			RoleName: "Transportation Ordering Officer",
+		},
+	})
+}
+
+// MakeTIORole creates a single transportation inovicing officer role.
+func MakeTIORole(db *pop.Connection) roles.Role {
+	return MakeRole(db, Assertions{
+		Role: roles.Role{
+			RoleType: roles.RoleTypeTIO,
+			RoleName: "Transportation Invoicing Officer",
+		},
+	})
+}
+
+// MakeContractingOfficerRole creates a single contracting officer role.
+func MakeContractingOfficerRole(db *pop.Connection) roles.Role {
+	return MakeRole(db, Assertions{
+		Role: roles.Role{
+			RoleType: roles.RoleTypeContractingOfficer,
+			RoleName: "Contracting Officer",
+		},
+	})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/transcom/mymove/pkg/models/roles"
+
 	"github.com/transcom/mymove/pkg/random"
 
 	"github.com/gobuffalo/pop/v5"
@@ -72,6 +74,7 @@ type Assertions struct {
 	ReRateArea                               models.ReRateArea
 	ReService                                models.ReService
 	ReZip3                                   models.ReZip3
+	Role                                     roles.Role
 	SecondaryPickupAddress                   models.Address
 	SecondaryDeliveryAddress                 models.Address
 	ServiceItemParamKey                      models.ServiceItemParamKey


### PR DESCRIPTION
## Description

In devlocal creating new PPM/TOO/TOO users were creating transportation offices with no GBLOC value supplied.  This meant even though you could create a new office user that they would never see any moves or payment requests without a matching GBLOC.

This PR adds the "LKNQ" GBLOC to all new office users, which is the same default used in the devseed.

The devlocal tests weren't very thorough I've added new tests to make sure the role and gbloc data are present for all users.

Emily is adding some things for the new Services Counselor role in a related PR https://github.com/transcom/mymove/pull/6461

I also added some test factories for role creation because they didn't exist.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_test
make client_test
```

1. From the homepage officelocal:3000 click on the local sign-in button in the top right nav menu
2. Create a new office user using one of the buttons in the right column.
3. The user should be created and you will be logged in.
4. The transportation office GBLOC should be indicated in the top menu and moves/payment requests from the seed data should show in the non-empty queue matching "LKNQ".

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7667) for this change

## Screenshots

https://user-images.githubusercontent.com/52669884/115607181-a8837d00-a2b2-11eb-9d1a-35d196bcff1f.mov