### PR TITLE
[MB-7529] Add ApprovedAt field to service item updater

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/getlantern/deepcopy"
+	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
@@ -746,6 +747,7 @@ func constructMTOServiceItemModels(shipmentID uuid.UUID, mtoID uuid.UUID, reServ
 			MTOShipmentID:   &shipmentID,
 			ReService:       models.ReService{Code: reServiceCode},
 			Status:          "APPROVED",
+			ApprovedAt:      swag.Time(time.Now()),
 		}
 		serviceItems[i] = serviceItem
 	}

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -740,14 +740,14 @@ func CalculateRequiredDeliveryDate(planner route.Planner, db *pop.Connection, pi
 // This private function is used to generically construct service items when shipments are approved.
 func constructMTOServiceItemModels(shipmentID uuid.UUID, mtoID uuid.UUID, reServiceCodes []models.ReServiceCode) models.MTOServiceItems {
 	serviceItems := make(models.MTOServiceItems, len(reServiceCodes))
-
+	currentTime := swag.Time(time.Now())
 	for i, reServiceCode := range reServiceCodes {
 		serviceItem := models.MTOServiceItem{
 			MoveTaskOrderID: mtoID,
 			MTOShipmentID:   &shipmentID,
 			ReService:       models.ReService{Code: reServiceCode},
 			Status:          "APPROVED",
-			ApprovedAt:      swag.Time(time.Now()),
+			ApprovedAt:      currentTime,
 		}
 		serviceItems[i] = serviceItem
 	}

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -486,6 +486,8 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		for i := range serviceItems {
 			suite.Equal(models.MTOServiceItemStatusApproved, serviceItems[i].Status)
 			suite.Equal(expectedReServiceCodes[i], serviceItems[i].ReService.Code)
+			// TODO: actually assert this in a better way?
+			suite.NotNil(serviceItems[i].ApprovedAt)
 		}
 
 		err = suite.DB().Find(&fetchedMove, mto.ID)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -481,13 +481,21 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.NoError(err)
 
 		suite.Equal(6, len(serviceItems))
+
+		// All ApprovedAt times for service items should be the same, so just get the first one
+		actualApprovedAt := serviceItems[0].ApprovedAt
+		currentTime := time.Now()
+		diff := currentTime.Sub(*actualApprovedAt)
+		diffInSeconds := diff.Seconds()
+		var oneSecond float64
+		oneSecond = 1.000000
 		// If we've gotten the shipment updated and fetched it without error then we can inspect the
 		// service items created as a side effect to see if they are approved.
 		for i := range serviceItems {
 			suite.Equal(models.MTOServiceItemStatusApproved, serviceItems[i].Status)
 			suite.Equal(expectedReServiceCodes[i], serviceItems[i].ReService.Code)
-			// TODO: actually assert this in a better way?
-			suite.NotNil(serviceItems[i].ApprovedAt)
+			// Test that service item was approved within a few seconds of the current
+			suite.Assertions.LessOrEqual(diffInSeconds, oneSecond)
 		}
 
 		err = suite.DB().Find(&fetchedMove, mto.ID)


### PR DESCRIPTION
## Description

When a service item is set to approved in the MTO shipment updater, also add the ApprovedAt field with the current time.

## Reviewer Notes

Am I missing any other spot this needs to be added? This is a very small change that took me a good amount of digging to find, and I'm still not fully sure how all of this works, so definitely looking for anything else to improve/that I may have missed. Also, if there is another team or person I should tag on this review, let me know!

I also would like feedback on the TODO item I added to the test - is there a way to actually assert that the value is a certain time?

## Setup

```sh
make server_run
make client_run
```

## Code Review Verification Steps

1. Login to office app as TOO user
2. Go to a new move
3. Add service items to the move, and click on "Approve selected shipments" and then "Approve and send"
4. The Approved service items table should now display the approved date (today's date in this example) below the service item name.

On master, doing the above steps, you will not see the date below the approved service item names.

## References

* [Jira story](https://dp3.atlassian.net/secure/RapidBoard.jspa?rapidView=27&modal=detail&selectedIssue=MB-7529) for this change

## Screenshots

Here are the dates properly showing up:
![Screen Shot 2021-04-21 at 12 03 57 PM](https://user-images.githubusercontent.com/3903208/115585785-ed4eea00-a299-11eb-997c-52bc8fa32351.png)


Compare to Duncan's screenshot on the ticket where the dates are not shown.
