### PR TITLE
MB-7625 Swap channels to correct variables

### DIFF
--- a/pkg/cli/gex.go
+++ b/pkg/cli/gex.go
@@ -29,10 +29,10 @@ const (
 	GEXURLFlag string = "gex-url"
 	// SendToSyncada is the flag to control if we try sending files to syncada or not
 	SendToSyncada string = "send-to-syncada"
-	// GEXChannelDataWarehouse is the URL query parameter that we use when sending to USBank's data warehouse
-	GEXChannelDataWarehouse string = "TRANSCOM-DPS-MILMOVE-CPS-IN-USBANK-RCOM"
-	// GEXChannelInvoice is the URL query parameter that we use when sending EDI invoices to GEX
-	GEXChannelInvoice string = "TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM"
+	// GEXChannelInvoice is the URL query parameter that we use when sending EDI invoices to US Bank via GEX
+	GEXChannelInvoice string = "TRANSCOM-DPS-MILMOVE-CPS-IN-USBANK-RCOM"
+	// GEXChannelDataWarehouse is the URL query parameter that we use when sending data to the IGC data warehouse
+	GEXChannelDataWarehouse string = "TRANSCOM-DPS-MILMOVE-GHG-IN-IGC-RCOM"
 )
 
 var gexHostnames = []string{


### PR DESCRIPTION
## Description

We discovered in testing that the variable GEXChannelInvoice was using data warehouse channel name and GEXChannelDataWarehouse was using the us bank invoice channel. This PR swaps them to use the correct channels.

## Reviewer Notes

Nothing of note, as long as there are no typos.

## Setup

If you want to trigger the job runner, though sending won't work locally

```sh
# setup database
make db_dev_e2e_populate
make server_run
make office_client_run
# mark all e2e payment requests as sent
go run ./cmd/milmove-tasks process-edis
go run ./cmd/milmove-tasks process-edis
# create a payment request
prime-api-demo RDY4PY
# approve the above payment request in the office UI
# once approved run the below
go run ./cmd/milmove-tasks process-edis --send-to-syncada
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7625) for this change