### PR TITLE
MB-7626 Skip processing response files if SEND_TO_SYNCADA is false

### DIFF
--- a/cmd/milmove-tasks/process_edis.go
+++ b/cmd/milmove-tasks/process_edis.go
@@ -222,6 +222,11 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 	}
 	logger.Info("Finished processing reviewed payment requests")
 
+	if sendToSyncada == false {
+		logger.Info("Skipping processing of response files EDI997 acknowledgement and EDI824 application advice responses")
+		return nil
+	}
+
 	// SSH and SFTP Connection Setup
 	sshClient, err := cli.InitGEXSSH(v, logger)
 	if err != nil {


### PR DESCRIPTION
## Description

When sending to Syncada is false we were still attempting to connect and read responses from Syncada. This PR changes it so that if `SEND_TO_SYNCADA` is false we skip processing response files as well as skipping sending.

## Reviewer Notes

No

## Setup

Look for new message `Skipping processing of response files EDI997 acknowledgement and EDI824 application advice responses` when send to syncada is false, and ensure it is not there when send is set to true.

```sh
# when send is false
❯ go run ./cmd/milmove-tasks process-edis
{"level":"info","ts":"2021-04-21T18:25:04.762Z","caller":"cli/dbconn.go:258","msg":"Connecting to the database","url":"postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable","db-ssl-root-cert":""}
{"level":"info","ts":"2021-04-21T18:25:04.762Z","caller":"cli/dbconn.go:364","msg":"Starting database ping...."}
{"level":"info","ts":"2021-04-21T18:25:04.777Z","caller":"cli/dbconn.go:371","msg":"...DB ping successful!"}
{"level":"info","ts":"2021-04-21T18:25:04.777Z","caller":"milmove-tasks/process_edis.go:174","msg":"Starting in development mode, which enables additional features"}
{"level":"info","ts":"2021-04-21T18:25:04.777Z","caller":"milmove-tasks/process_edis.go:178","msg":"SendToSyncada is false"}
2021-04-21T18:25:04.778Z        INFO    certs/certs_entrust.go:28       certificate chain from move-mil-dod-tls-cert parsed     {"count": 1}
2021-04-21T18:25:04.778Z        INFO    certs/certs_entrust.go:36       certificate chain from move-mil-dod-ca-cert parsed      {"count": 1}
2021-04-21T18:25:04.779Z        INFO    certs/certs_entrust.go:47       DOD keypair     {"certificates": 2}
{"level":"info","ts":"2021-04-21T18:25:04.796Z","caller":"payment_request/payment_request_reviewed_processor.go:190","msg":"EDIs processed","EDIs processed":{"EDIType":"858","NumEDIsProcessed":0,"ProcessStartedAt":"2021-04-21T18:25:04.779Z","ProcessEndedAt":"2021-04-21T18:25:04.796Z"}}
{"level":"info","ts":"2021-04-21T18:25:04.804Z","caller":"milmove-tasks/process_edis.go:223","msg":"Finished processing reviewed payment requests"}
{"level":"info","ts":"2021-04-21T18:25:04.804Z","caller":"milmove-tasks/process_edis.go:226","msg":"Skipping processing of response files EDI997 acknowledgement and EDI824 application advice responses"}
{"level":"info","ts":"2021-04-21T18:25:04.804Z","caller":"milmove-tasks/process_edis.go:114","msg":"Duration of processEDIs task: 42.436218ms"}

# when send is true
❯ go run ./cmd/milmove-tasks process-edis --send-to-syncada
{"level":"info","ts":"2021-04-21T18:48:00.704Z","caller":"cli/dbconn.go:258","msg":"Connecting to the database","url":"postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable","db-ssl-root-cert":""}
{"level":"info","ts":"2021-04-21T18:48:00.704Z","caller":"cli/dbconn.go:364","msg":"Starting database ping...."}
{"level":"info","ts":"2021-04-21T18:48:00.718Z","caller":"cli/dbconn.go:371","msg":"...DB ping successful!"}
{"level":"info","ts":"2021-04-21T18:48:00.718Z","caller":"milmove-tasks/process_edis.go:174","msg":"Starting in development mode, which enables additional features"}
{"level":"info","ts":"2021-04-21T18:48:00.718Z","caller":"milmove-tasks/process_edis.go:178","msg":"SendToSyncada is true"}
2021-04-21T18:48:00.718Z        INFO    certs/certs_entrust.go:28       certificate chain from move-mil-dod-tls-cert parsed     {"count": 1}
2021-04-21T18:48:00.718Z        INFO    certs/certs_entrust.go:36       certificate chain from move-mil-dod-ca-cert parsed      {"count": 1}
2021-04-21T18:48:00.719Z        INFO    certs/certs_entrust.go:47       DOD keypair     {"certificates": 2}
{"level":"info","ts":"2021-04-21T18:48:00.732Z","caller":"payment_request/payment_request_reviewed_processor.go:190","msg":"EDIs processed","EDIs processed":{"EDIType":"858","NumEDIsProcessed":0,"ProcessStartedAt":"2021-04-21T18:48:00.719Z","ProcessEndedAt":"2021-04-21T18:48:00.732Z"}}
{"level":"info","ts":"2021-04-21T18:48:00.743Z","caller":"milmove-tasks/process_edis.go:223","msg":"Finished processing reviewed payment requests"}
{"level":"info","ts":"2021-04-21T18:48:00.743Z","caller":"cli/gex_sftp.go:73","msg":"Parsing GEX SFTP host key..."}
{"level":"info","ts":"2021-04-21T18:48:00.743Z","caller":"cli/gex_sftp.go:79","msg":"...Parsing GEX SFTP host key successful"}
{"level":"info","ts":"2021-04-21T18:48:00.744Z","caller":"cli/gex_sftp.go:91","msg":"Connecting to GEX SSH...","address":"199.10.68.85:22"}
{"level":"error","ts":"2021-04-21T18:49:16.282Z","caller":"cli/gex_sftp.go:94","msg":"Failed to connect to GEX SSH","error":"dial tcp 199.10.68.85:22: connect: operation timed out","stacktrace":"github.com/transcom/mymove/pkg/cli.InitGEXSSH"}
{"level":"fatal","ts":"2021-04-21T18:49:16.282Z","caller":"milmove-tasks/process_edis.go:233","msg":"couldn't initialize SSH client","error":"dial tcp 199.10.68.85:22: connect: operation timed out","stacktrace":"\t/Users/john/projects/dod/mymove/cmd/milmove-tasks/process_edis.go:233"}
exit status 1

```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7626) for this change