### PR TITLE
Change the gbloc for Truss transportation office in experimental

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -627,3 +627,4 @@
 20210414170143_add_FSC_service_item_param_keys.up.sql
 20210414214012_add_index_to_requested_pickup_date_on_mto_shipments_table.up.sql
 20210415231923_add_index_on_submitted_at_in_moves_table.up.sql
+20210421175513_exp_truss_office_gbloc_change.up.sql

--- a/migrations/app/secure/20210421175513_exp_truss_office_gbloc_change.up.sql
+++ b/migrations/app/secure/20210421175513_exp_truss_office_gbloc_change.up.sql
@@ -1,0 +1,5 @@
+-- This is a migration that will ultimately impact experimental. It seeks to change the gbloc of a commonly used
+-- test transportation office.
+UPDATE transportation_offices
+SET gbloc = 'AGFM'
+WHERE id = 'ffee171d-f085-4451-95b7-918dc4d5fff7'


### PR DESCRIPTION
## Description

Changes the GBLOC so that when we do testing in experimental coming up we're able to see moves in the move queue on the office app.

