### PR TITLE
[MB-7937] update health check request message log

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -742,7 +742,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		// Log the number of headers, which can be used for finding abnormal requests
 		fields = append(fields, zap.Int("headers", len(r.Header)))
 
-		logger.Info("Request", fields...)
+		logger.Info("Request health", fields...)
 
 	})
 


### PR DESCRIPTION
## Description

Updating health check message. In the AWS log it is hard to filter out because the word is simply `Request` and other messages use the word `Request` as well. Expanding this message to be `Request health`

![Screen Shot 2021-04-21 at 4 45 37 PM](https://user-images.githubusercontent.com/1359520/115624974-01f2a880-a2c1-11eb-8ec4-2f30372d82e8.png)

## Reviewer Notes

n/a

## Setup

I do not see this message when running `make server_run`. Once deployed login into AWS console and look for the new status message.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7937) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
