### PR TITLE
MB-5883 Update Profile to pass secondaryTelephone to ContactInfoDisplay

### DIFF
--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -38,6 +38,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
           <SectionWrapper className={formStyles.formSection}>
             <ContactInfoDisplay
               telephone={serviceMember?.telephone || ''}
+              secondaryTelephone={serviceMember?.secondary_telephone || ''}
               personalEmail={serviceMember?.personal_email || ''}
               emailIsPreferred={serviceMember?.email_is_preferred}
               phoneIsPreferred={serviceMember?.phone_is_preferred}


### PR DESCRIPTION
## Description

Fixes a bug where secondary telephone (aka alt. phone) wasn't showing up on the profile page. Most of the work for this ticket was in #6407, this is just catching a bug we hadn't noticed.

## Reviewer Notes

Not sure if I should expand the tests to cover more details on the page. Currently we're checking headers and edit links, but maybe it should check all the data? It would be more tedious and verbose tests, but that way we could be sure we aren't missing info we expect? What do y'all think?

## Setup

1. Run server

    ```sh
    make server_run
    ```

1. Run client 

    ```sh
    make client_run
    ```

1. Log in as a service member.
1. Go to their profile page.
1. If they don't already have an alt phone, edit their profile to add one.
1. You should see the alt phone displayed

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5883) for this change

## Screenshots

Shows secondary number on profile page:
![Screen Shot 2021-04-21 at 18 43 43](https://user-images.githubusercontent.com/35938642/115635544-9238e980-a2d1-11eb-9c7e-a2acce6508c1.png)
