### PR TITLE
[MB-7724] Eslint-plugin-ato checks for eslint-disable-line usage

### DIFF
--- a/eslint-plugin-ato/no-unapproved-annotation.js
+++ b/eslint-plugin-ato/no-unapproved-annotation.js
@@ -1,9 +1,11 @@
 const REQUIRES_APPROVAL_MESSAGE_ID = 'no-unapproved-annotation';
 const NO_ANNOTATION_MESSAGE_ID = 'no-annotation';
+const NO_INLINE_DISABLE = 'no-inline-disable';
 const messages = {
   [REQUIRES_APPROVAL_MESSAGE_ID]: 'Requires annotation approval from an ISSO',
   [NO_ANNOTATION_MESSAGE_ID]:
     'Disabling of this rule requires an annotation. Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit?usp=sharing',
+  [NO_INLINE_DISABLE]: 'Please use eslint-disable-next-line instead of eslint-disable-line',
 };
 
 // eslint-disable-next-line security/detect-unsafe-regex
@@ -106,7 +108,21 @@ const create = (context) => ({
         result && // It's a eslint-disable comment
         result.groups.ruleId // disabling a specific rule
       ) {
-        const [, rule] = result.input.split(' ');
+        const [disableComment, rule] = result.input.split(' ');
+        if (disableComment === 'eslint-disable-line') {
+          context.report({
+            // Can't set it at the given location as the warning
+            // will be ignored due to the disable comment
+            loc: {
+              start: {
+                ...comment.loc.start,
+                column: -1,
+              },
+              end: comment.loc.end,
+            },
+            messageId: NO_INLINE_DISABLE,
+          });
+        }
         const commentsBefore = context.getCommentsBefore(comment).map(({ value }) => value.trim());
         const validatorStatus = getValidatorStatus(commentsBefore);
         if (!approvedBypassableRules.has(rule) && !hasAnnotation(commentsBefore)) {

--- a/eslint-plugin-ato/tests/no-unapproved-annotation.test.js
+++ b/eslint-plugin-ato/tests/no-unapproved-annotation.test.js
@@ -4,6 +4,12 @@ const rule = require('../no-unapproved-annotation');
 
 const ruleTester = new RuleTester();
 
+const ERRORS = {
+  REQUIRES_APPROVAL_MSG: 'Requires annotation approval from an ISSO',
+  REQUIRES_ANNOTATION_MSG:
+    'Disabling of this rule requires an annotation. Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit?usp=sharing',
+  NO_INLINE_DISABLE_MSG: 'Please use eslint-disable-next-line instead of eslint-disable-line',
+};
 ruleTester.run('no-unapproved-annotation', rule, {
   valid: [
     '// RA Validator Status: Mitigated\n// eslint-disable no-console',
@@ -62,18 +68,28 @@ ruleTester.run('no-unapproved-annotation', rule, {
     {
       code:
         '// RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}\n// eslint-disable no-console',
-      errors: [{ message: 'Requires annotation approval from an ISSO' }],
+      errors: [{ message: ERRORS.REQUIRES_APPROVAL_MSG }],
     },
     {
       code: '// RA Validator Status: \n// eslint-disable-next-line no-console',
-      errors: [{ message: 'Requires annotation approval from an ISSO' }],
+      errors: [{ message: ERRORS.REQUIRES_APPROVAL_MSG }],
     },
     {
       code: '// eslint-disable security/detect-unsafe-regex',
       errors: [
         {
-          message:
-            'Disabling of this rule requires an annotation. Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit?usp=sharing',
+          message: ERRORS.REQUIRES_ANNOTATION_MSG,
+        },
+      ],
+    },
+    {
+      code: '// eslint-disable-line no-unused-vars',
+      errors: [
+        {
+          message: ERRORS.NO_INLINE_DISABLE_MSG,
+        },
+        {
+          message: ERRORS.REQUIRES_ANNOTATION_MSG,
         },
       ],
     },


### PR DESCRIPTION
## Description

Eslint-plugin-ato checks for eslint-disable-line usage and asks the developer to use `eslint-disable-next-line` instead

## Setup
yarn install (if nothing happens, `rm -rf node_modulesn then yarn install`
In .eslintrc.js
Change 'ato/no-unapproved-annotation': 'off', to 'ato/no-unapproved-annotation': 'error',
Add `const test = 'test'; // eslint-disable-line no-unused-vars` to any file not in the scenes or shared directory`
yarn run lint
Expected result: There should be a lint error

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7724) for this change
