### PR TITLE
MB-7942 Update SM patch api to only update orders if move is in draft

### DIFF
--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -211,7 +211,7 @@ func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMem
 		return handlers.ResponseForVErrors(logger, verrs, err)
 	}
 
-	if len(serviceMember.Orders) != 0 {
+	if len(serviceMember.Orders) != 0 && h.isDraftMove(&serviceMember) {
 		// Will have to be refactored once we support multiple moves/orders
 		order, err := models.FetchOrderForUser(h.DB(), session, serviceMember.Orders[0].ID)
 

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -372,6 +372,18 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerSubmittedMove() {
 			ServiceMemberID: newServiceMember.ID,
 		},
 	})
+
+	// The testdatagen sets these values, fails if you try to blank them out via Assertions,
+	// and gives defaults if you pass nil, so we have to set this after the creation.
+	// This more closely resembles what orders would look like pre and post submission, before
+	// a TOO gets to them.
+	move.Orders.TAC = nil
+	move.Orders.DepartmentIndicator = nil
+	move.Orders.OrdersNumber = nil
+	move.Orders.OrdersTypeDetail = nil
+
+	suite.MustSave(&move.Orders)
+
 	move.Submit()
 	suite.MustSave(&move)
 


### PR DESCRIPTION
Also update test so that the Orders/Move look more like they would when submitted, before a TOO gets to them.

## Description

This was stopping a user from editing contact info after submitting their move.

## Reviewer Notes

Anything weird?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7942) for this change