### PR TITLE
MB-7946 Fix Crash Editing Service Info Before Orders are Uploaded

### DIFF
--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
@@ -14,7 +14,7 @@ const ServiceInfoDisplay = ({
   edipi,
   firstName,
   isEditable,
-  shouldNotifyTransportationOffice,
+  showMessage,
   lastName,
   editURL,
   rank,
@@ -25,7 +25,7 @@ const ServiceInfoDisplay = ({
         <h2>Service info</h2>
         {isEditable && <Link to={editURL}>Edit</Link>}
       </div>
-      {!isEditable && shouldNotifyTransportationOffice && (
+      {!isEditable && showMessage && (
         <div className={serviceInfoDisplayStyles.whoToContactContainer}>
           To change information in this section, contact the {originTransportationOfficeName} transportation office
           {originTransportationOfficePhone ? ` at ${originTransportationOfficePhone}.` : '.'}
@@ -73,7 +73,7 @@ ServiceInfoDisplay.propTypes = {
   edipi: string.isRequired,
   firstName: string.isRequired,
   isEditable: bool,
-  shouldNotifyTransportationOffice: bool,
+  showMessage: bool,
   lastName: string.isRequired,
   editURL: string,
   rank: string.isRequired,
@@ -83,7 +83,7 @@ ServiceInfoDisplay.defaultProps = {
   originTransportationOfficePhone: '',
   editURL: '',
   isEditable: true,
-  shouldNotifyTransportationOffice: false,
+  showMessage: false,
 };
 
 export default ServiceInfoDisplay;

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.jsx
@@ -14,6 +14,7 @@ const ServiceInfoDisplay = ({
   edipi,
   firstName,
   isEditable,
+  shouldNotifyTransportationOffice,
   lastName,
   editURL,
   rank,
@@ -24,7 +25,7 @@ const ServiceInfoDisplay = ({
         <h2>Service info</h2>
         {isEditable && <Link to={editURL}>Edit</Link>}
       </div>
-      {!isEditable && (
+      {!isEditable && shouldNotifyTransportationOffice && (
         <div className={serviceInfoDisplayStyles.whoToContactContainer}>
           To change information in this section, contact the {originTransportationOfficeName} transportation office
           {originTransportationOfficePhone ? ` at ${originTransportationOfficePhone}.` : '.'}
@@ -72,6 +73,7 @@ ServiceInfoDisplay.propTypes = {
   edipi: string.isRequired,
   firstName: string.isRequired,
   isEditable: bool,
+  shouldNotifyTransportationOffice: bool,
   lastName: string.isRequired,
   editURL: string,
   rank: string.isRequired,
@@ -81,6 +83,7 @@ ServiceInfoDisplay.defaultProps = {
   originTransportationOfficePhone: '',
   editURL: '',
   isEditable: true,
+  shouldNotifyTransportationOffice: false,
 };
 
 export default ServiceInfoDisplay;

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.stories.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.stories.jsx
@@ -37,7 +37,7 @@ export const Editable = () => (
 
 export const NonEditableWithMessage = () => (
   <div style={{ padding: 40 }}>
-    <ServiceInfoDisplay {...defaultProps} isEditable={false} shouldNotifyTransportationOffice />
+    <ServiceInfoDisplay {...defaultProps} isEditable={false} showMessage />
   </div>
 );
 

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.stories.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.stories.jsx
@@ -35,7 +35,13 @@ export const Editable = () => (
   </div>
 );
 
-export const NonEditable = () => (
+export const NonEditableWithMessage = () => (
+  <div style={{ padding: 40 }}>
+    <ServiceInfoDisplay {...defaultProps} isEditable={false} shouldNotifyTransportationOffice />
+  </div>
+);
+
+export const NonEditableWithoutMessage = () => (
   <div style={{ padding: 40 }}>
     <ServiceInfoDisplay {...defaultProps} isEditable={false} />
   </div>

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.test.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.test.jsx
@@ -60,7 +60,7 @@ describe('ServiceInfoDisplay component', () => {
   });
 
   it('renders who to contact when the service info is no longer editable and it should notify the transportation office', async () => {
-    renderWithRouter(<ServiceInfoDisplay {...testProps} isEditable={false} shouldNotifyTransportationOffice />);
+    renderWithRouter(<ServiceInfoDisplay {...testProps} isEditable={false} showMessage />);
 
     expect(screen.queryByText('Edit')).toBeNull();
 

--- a/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.test.jsx
+++ b/src/components/Customer/Review/ServiceInfoDisplay/ServiceInfoDisplay.test.jsx
@@ -59,8 +59,8 @@ describe('ServiceInfoDisplay component', () => {
     expect(editLink).toBeInTheDocument();
   });
 
-  it('renders who to contact when the service info is no longer editable', async () => {
-    renderWithRouter(<ServiceInfoDisplay {...testProps} isEditable={false} />);
+  it('renders who to contact when the service info is no longer editable and it should notify the transportation office', async () => {
+    renderWithRouter(<ServiceInfoDisplay {...testProps} isEditable={false} shouldNotifyTransportationOffice />);
 
     expect(screen.queryByText('Edit')).toBeNull();
 
@@ -69,5 +69,17 @@ describe('ServiceInfoDisplay component', () => {
     );
 
     expect(whoToContact).toBeInTheDocument();
+  });
+
+  it('renders a non editable service info display wuth no message', () => {
+    renderWithRouter(<ServiceInfoDisplay {...testProps} isEditable={false} />);
+
+    expect(screen.queryByText('Edit')).toBeNull();
+
+    expect(
+      screen.queryByText(
+        `To change information in this section, contact the ${testProps.originTransportationOfficeName} transportation office at ${testProps.originTransportationOfficePhone}.`,
+      ),
+    ).toBeNull();
   });
 });

--- a/src/pages/MyMove/Profile/EditServiceInfo.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.jsx
@@ -131,8 +131,8 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state) => ({
   serviceMember: selectServiceMemberFromLoggedInUser(state),
-  currentOrders: selectCurrentOrders(state),
-  entitlement: selectEntitlementsForLoggedInUser(state),
+  currentOrders: selectCurrentOrders(state) || {},
+  entitlement: selectEntitlementsForLoggedInUser(state) || {},
   moveIsInDraft: selectMoveIsInDraft(state),
 });
 

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -18,6 +18,7 @@ import { customerRoutes } from 'constants/routes';
 import formStyles from 'styles/form.module.scss';
 
 const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsInDraft }) => {
+  const showMessages = currentOrders.id && !moveIsInDraft;
   const rank = currentOrders.grade ?? serviceMember.rank;
   const originStation = currentOrders.origin_duty_station ?? serviceMember.current_station;
   const transportationOfficePhoneLines = originStation?.transportation_office?.phone_lines;
@@ -34,7 +35,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
       <div className="grid-row">
         <div className="grid-col-12">
           <h1>Profile</h1>
-          {!moveIsInDraft && <Alert type="info">Contact your movers if you need to make changes to your move.</Alert>}
+          {showMessages && <Alert type="info">Contact your movers if you need to make changes to your move.</Alert>}
           <SectionWrapper className={formStyles.formSection}>
             <ContactInfoDisplay
               telephone={serviceMember?.telephone || ''}
@@ -59,6 +60,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               edipi={serviceMember?.edipi || ''}
               editURL={customerRoutes.SERVICE_INFO_EDIT_PATH}
               isEditable={moveIsInDraft}
+              shouldNotifyTransportationOffice={showMessages}
             />
           </SectionWrapper>
         </div>
@@ -77,8 +79,7 @@ Profile.propTypes = {
 function mapStateToProps(state) {
   return {
     serviceMember: selectServiceMemberFromLoggedInUser(state),
-    // The move still counts as in draft if there are no orders.
-    moveIsInDraft: selectMoveIsInDraft(state) || !selectCurrentOrders(state),
+    moveIsInDraft: selectMoveIsInDraft(state),
     currentOrders: selectCurrentOrders(state) || {},
     currentBackupContacts: selectBackupContacts(state),
   };

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -60,7 +60,7 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
               edipi={serviceMember?.edipi || ''}
               editURL={customerRoutes.SERVICE_INFO_EDIT_PATH}
               isEditable={moveIsInDraft}
-              shouldNotifyTransportationOffice={showMessages}
+              showMessage={showMessages}
             />
           </SectionWrapper>
         </div>

--- a/src/pages/MyMove/Profile/Profile.test.jsx
+++ b/src/pages/MyMove/Profile/Profile.test.jsx
@@ -177,7 +177,11 @@ describe('Profile component', () => {
 
     const editLinks = screen.getAllByText('Edit');
 
-    expect(editLinks.length).toBe(2);
+    expect(editLinks.length).toBe(1);
+
+    expect(screen.queryByText('Contact your movers if you need to make changes to your move.')).not.toBeInTheDocument();
+
+    expect(screen.queryByText(/To change information in this section, contact the/)).not.toBeInTheDocument();
   });
 
   it('does not allow the user to edit the service info information after a move has been submitted', async () => {
@@ -197,6 +201,7 @@ describe('Profile component', () => {
             },
             status: 'DRAFT',
             moves: ['testMove'],
+            id: 'testOrder',
           },
         },
         moves: {
@@ -258,6 +263,10 @@ describe('Profile component', () => {
         <ConnectedProfile {...testProps} />
       </MockProviders>,
     );
+
+    const alert = screen.getByText('Contact your movers if you need to make changes to your move.');
+
+    expect(alert).toBeInTheDocument();
 
     const whoToContact = screen.getByText(/To change information in this section, contact the/);
 

--- a/src/store/entities/selectors.js
+++ b/src/store/entities/selectors.js
@@ -191,10 +191,10 @@ export const selectEntitlementsForLoggedInUser = createSelector(
   (serviceMember, orders) => {
     const entitlement = {
       pro_gear: serviceMember.weight_allotment?.pro_gear_weight,
-      pro_gear_spouse: orders.spouse_has_pro_gear ? serviceMember.weight_allotment?.pro_gear_weight_spouse : 0,
+      pro_gear_spouse: orders?.spouse_has_pro_gear ? serviceMember.weight_allotment?.pro_gear_weight_spouse : 0,
     };
 
-    if (orders.has_dependents) {
+    if (orders?.has_dependents) {
       entitlement.weight = serviceMember.weight_allotment?.total_weight_self_plus_dependents;
     } else {
       entitlement.weight = serviceMember.weight_allotment?.total_weight_self;


### PR DESCRIPTION
Add in Nullity Checks when Retrieving Order and Disallow Editing of Service Info Before Orders Are Uploaded

- put in null checks in EditServiceInfo and selectors when retrieving orders information
-- this covers cases where orders are not yet uploaded
- edit the service info table to include a separate option to hide the who to contact message
-- add in an extra storybook story to show this new state
-- add extra test cases to check that the message does not appear if that option is turned off
- change the profile page to not allow editing of service info if orders have not been
uploaded yet
-- add tests to check that the correct messages show up for each state that the move is in

## Description

Trying to edit the service information on the profile page before the orders were uploaded would cause a crash.
To mitigate this, the edit button on the profile page in the service information section has been removed if there are no orders.

## Reviewer Notes

Is there a better way for me to do this?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make client_run
make server_run
make storybook
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7946) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._

![image](https://user-images.githubusercontent.com/6477059/115792260-d2a27100-a37e-11eb-9e4b-7d26a55dfa7d.png)
