### PR TITLE
Disable rule in all files in src and in cypress

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -7,7 +7,8 @@
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",
-    "react/jsx-curly-brace-presence": "error"
+    "react/jsx-curly-brace-presence": "error",
+    "security/detect-object-injection": "off",
   },
   "globals": {
     "cy": "readonly",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    // okay to disable because the threat actor (web application user) already controls the execution environment (web browser)
+    'security/detect-object-injection': 'off',
+  },
+};

--- a/src/components/Customer/Home/ShipmentList/index.jsx
+++ b/src/components/Customer/Home/ShipmentList/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 import React from 'react';
 import { string, arrayOf, shape, func, number, bool } from 'prop-types';
 import classnames from 'classnames';

--- a/src/components/ShipmentTag/ShipmentTag.jsx
+++ b/src/components/ShipmentTag/ShipmentTag.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable security/detect-object-injection */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tag } from '@trussworks/react-uswds';

--- a/src/components/form/StackedTableRowForm.jsx
+++ b/src/components/form/StackedTableRowForm.jsx
@@ -19,10 +19,8 @@ export const StackedTableRowForm = ({ label, name, validationSchema, initialValu
   const errorCallback = (formErrors) => {
     setErrors(formErrors);
   };
-  /* eslint-disable security/detect-object-injection */
   const errorMsg = errors[name];
   const value = initialValues[name];
-  /* eslint-enable security/detect-object-injection */
 
   /* eslint-disable react/jsx-props-no-spreading */
   const content = show ? (

--- a/src/scenes/.eslintrc
+++ b/src/scenes/.eslintrc
@@ -8,6 +8,7 @@
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",
     "react/jsx-curly-brace-presence": "error",
-    "react/no-danger": "error"
+    "react/no-danger": "error",
+    "security/detect-object-injection": "off"
   }
 }

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -30,7 +30,6 @@ async function asyncValidate(values, dispatch, props, currentFieldName) {
   // If either postal code is blurred, check both of them for errors. We want to
   // catch these before checking on dates via `GetPpmWeightEstimate`.
   if (['destination_postal_code', 'pickup_postal_code'].includes(currentFieldName)) {
-    // eslint-disable-next-line security/detect-object-injection
     const zipValue = values[currentFieldName];
     if (zipValue && zipValue.length < 5) {
       return;

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -84,7 +84,6 @@ class ExpensesUpload extends Component {
       requested_amount_cents: requestedAmountCents,
     } = formValues;
 
-    // eslint-disable-next-line security/detect-object-injection
     let files = this.uploader.getFiles();
     const uploadIds = map(files, 'id');
     const personallyProcuredMoveId = currentPpm ? currentPpm.id : null;
@@ -117,7 +116,6 @@ class ExpensesUpload extends Component {
 
   cleanup = () => {
     const { reset } = this.props;
-    // eslint-disable-next-line security/detect-object-injection
     this.uploader.clearFiles();
     reset();
     this.setState({ ...this.initialState });

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -72,7 +72,6 @@ class WeightTicketListItem extends Component {
         {/* size of largest of the images */}
         <div style={{ minWidth: 95 }}>
           {showWeightTicketIcon && (
-            /* eslint-disable security/detect-object-injection */
             <img
               className="weight-ticket-image"
               src={WEIGHT_TICKET_IMAGES[weight_ticket_set_type]}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -151,10 +151,7 @@ class WeightTicket extends Component {
 
   nonEmptyUploaderKeys() {
     const uploadersKeys = Object.keys(this.uploaders);
-    return uploadersKeys.filter(
-      // eslint-disable-next-line security/detect-object-injection
-      (key) => this.uploaders[key].uploaderRef && !this.uploaders[key].uploaderRef.isEmpty(),
-    );
+    return uploadersKeys.filter((key) => this.uploaders[key].uploaderRef && !this.uploaders[key].uploaderRef.isEmpty());
   }
 
   saveAndAddHandler = (formValues) => {
@@ -165,7 +162,6 @@ class WeightTicket extends Component {
     const uploadIds = [];
     // eslint-disable-next-line no-unused-vars
     for (const key of uploaderKeys) {
-      // eslint-disable-next-line security/detect-object-injection
       let files = this.uploaders[key].uploaderRef.getFiles();
       const documentUploadIds = map(files, 'id');
       uploadIds.push(...documentUploadIds);
@@ -206,7 +202,6 @@ class WeightTicket extends Component {
     const uploaderKeys = this.nonEmptyUploaderKeys();
     // eslint-disable-next-line no-unused-vars
     for (const key of uploaderKeys) {
-      // eslint-disable-next-line security/detect-object-injection
       uploaders[key].uploaderRef.clearFiles();
     }
     reset();

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -198,7 +198,6 @@ const pages = {
 
 export const getPagesInFlow = ({ selectedMoveType, conusStatus, lastMoveIsCanceled, context }) =>
   Object.keys(pages).filter((pageKey) => {
-    // eslint-disable-next-line security/detect-object-injection
     const page = pages[pageKey];
     return page.isInFlow({ selectedMoveType, conusStatus, lastMoveIsCanceled, context });
   });
@@ -235,7 +234,6 @@ export const getWorkflowRoutes = (props) => {
   const flowProps = pick(props, ['selectedMoveType', 'conusStatus', 'lastMoveIsCanceled', 'context']);
   const pageList = getPagesInFlow(flowProps);
   return Object.keys(pages).map((key) => {
-    // eslint-disable-next-line security/detect-object-injection
     const currPage = pages[key];
     if (currPage.isInFlow(flowProps)) {
       const render = currPage.render(key, pageList, currPage.description, props);

--- a/src/scenes/PpmLanding/PpmSummary.jsx
+++ b/src/scenes/PpmLanding/PpmSummary.jsx
@@ -110,7 +110,6 @@ export class PpmSummaryComponent extends React.Component {
     } = this.props;
     const moveStatus = get(move, 'status', 'DRAFT');
     const ppmStatus = getPPMStatus(moveStatus, ppm);
-    // eslint-disable-next-line security/detect-object-injection
     const PPMComponent = genPpmSummaryStatusComponents[ppmStatus];
     return (
       <div>

--- a/src/scenes/SystemAdmin/shared/TitleizedField.jsx
+++ b/src/scenes/SystemAdmin/shared/TitleizedField.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { startCase } from 'lodash';
 
-/* eslint-disable security/detect-object-injection */
 const TitleizedField = ({ source, record = {} }) => {
   return <span>{startCase(record[source])}</span>;
 };
-/* eslint-enable security/detect-object-injection */
 
 export default TitleizedField;

--- a/src/services/swaggerRequest.js
+++ b/src/services/swaggerRequest.js
@@ -63,7 +63,6 @@ const toCamelCase = (str) => str[0].toLowerCase() + str.slice(1);
 // This key can be used to determine what key to find the object's
 // definition in within our normalizr schema.
 function successfulReturnType(routeDefinition, status) {
-  // eslint-disable-next-line security/detect-object-injection
   const response = routeDefinition.responses[status];
   const schemaKey = response.schema.$$ref.split('/').pop();
   if (!response) {

--- a/src/shared/.eslintrc
+++ b/src/shared/.eslintrc
@@ -7,6 +7,7 @@
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",
-    "react/jsx-curly-brace-presence": "error"
+    "react/jsx-curly-brace-presence": "error",
+    "security/detect-object-injection": "off"
   }
 }

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -46,7 +46,6 @@ export const PanelField = (props) => {
     </div>
   );
 
-  /* eslint-disable security/detect-object-injection */
   if (required && !(value || props.children)) {
     component = (
       <div className={'missing ' + classes}>
@@ -55,7 +54,6 @@ export const PanelField = (props) => {
       </div>
     );
   }
-  /* eslint-enable security/detect-object-injection */
 
   return component;
 };
@@ -71,7 +69,6 @@ export const SwaggerValue = (props) => {
   const { fieldName, schema, values } = props;
   let swaggerProps = {};
   if (schema.properties) {
-    /* eslint-disable security/detect-object-injection */
     swaggerProps = schema.properties[fieldName];
   }
   let value = values[fieldName] || '';
@@ -87,7 +84,6 @@ export const SwaggerValue = (props) => {
   if (value && swaggerProps['x-formatting'] === 'weight') {
     value = value.toLocaleString() + ' lbs';
   }
-  /* eslint-enable security/detect-object-injection */
   return <React.Fragment>{value || null}</React.Fragment>;
 };
 SwaggerValue.propTypes = {
@@ -107,7 +103,6 @@ export const PanelSwaggerField = (props) => {
     </PanelField>
   );
 
-  /* eslint-disable security/detect-object-injection */
   if (required && !values[fieldName]) {
     component = (
       <PanelField title={title} className={classes} required>
@@ -115,7 +110,6 @@ export const PanelSwaggerField = (props) => {
       </PanelField>
     );
   }
-  /* eslint-enable security/detect-object-injection */
 
   return component;
 };

--- a/src/shared/JsonSchemaForm/index.jsx
+++ b/src/shared/JsonSchemaForm/index.jsx
@@ -5,7 +5,6 @@ import SchemaField, { ALWAYS_REQUIRED_KEY } from './JsonSchemaField';
 import { isEmpty, uniq } from 'lodash';
 import { reduxForm, Field } from 'redux-form';
 import 'shared/JsonSchemaForm/index.css';
-/* eslint-disable security/detect-object-injection */
 
 const renderGroupOrField = (fieldName, fields, uiSchema, nameSpace) => {
   /*TODO:

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -31,7 +31,6 @@ const toCamelCase = (str) => str[0].toLowerCase() + str.slice(1);
 // This key can be used to determine what key to find the object's
 // definition in within our normalizr schema.
 function successfulReturnType(routeDefinition, status) {
-  // eslint-disable-next-line security/detect-object-injection
   const response = routeDefinition.responses[status];
   const schemaKey = response.schema['$$ref'].split('/').pop();
   if (!response) {
@@ -126,13 +125,11 @@ export function swaggerRequest(getClient, operationPath, params, options = {}) {
           schemaKey = newSchemaKey;
         }
 
-        // eslint-disable-next-line security/detect-object-injection
         const payloadSchema = schema[schemaKey];
         if (!payloadSchema) {
           throw new Error(`Could not find a schema for ${schemaKey}`);
         }
         if (options.deleteId) {
-          // eslint-disable-next-line security/detect-object-injection
           var oldEntity = state.entities[schemaKey][options.deleteId];
           action.entities = normalize([oldEntity], payloadSchema).entities;
         } else {

--- a/src/shared/Swagger/selectors.js
+++ b/src/shared/Swagger/selectors.js
@@ -43,7 +43,6 @@ export function getLastRequestIsSuccess(state, label) {
 
 // Return the last error for a given label
 export function getLastError(state, label) {
-  // eslint-disable-next-line security/detect-object-injection
   return state.requests.lastErrors[label];
 }
 

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -7,9 +7,7 @@ export function selectEntitlements(rankEntitlement, hasDependents = false, spous
     return {};
   }
   const totalKey = hasDependents ? 'total_weight_self_plus_dependents' : 'total_weight_self';
-  // eslint-disable-next-line security/detect-object-injection
   const entitlement = {
-    // eslint-disable-next-line security/detect-object-injection
     weight: rankEntitlement[totalKey],
     pro_gear: rankEntitlement.pro_gear_weight,
     pro_gear_spouse: spouseHasProGear ? rankEntitlement.pro_gear_weight_spouse : 0,

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -54,7 +54,6 @@ export function flagsFromURL(search) {
     if (prefix === 'flag' && name.length > 0) {
       if (validateFlag(name)) {
         // name is validated by the previous line
-        // eslint-disable-next-line security/detect-object-injection
         flags[name] = value === 'true';
       }
     }
@@ -102,7 +101,6 @@ function validateFlag(name) {
 export function detectFlags(nodeEnv, host, search) {
   let env = detectEnvironment(nodeEnv, host);
   // env can only be one of the values hard-coded into detectEnvironment()
-  // eslint-disable-next-line security/detect-object-injection
   return Object.assign({}, environmentFlags[env], flagsFromURL(search));
 }
 

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -278,7 +278,6 @@ export const addCommasToNumberString = (numOrString, decimalPlaces = 0) => {
 export const formatToOrdinal = (n) => {
   const s = ['th', 'st', 'nd', 'rd'];
   const v = n % 100;
-  // eslint-disable-next-line security/detect-object-injection
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 };
 

--- a/src/stories/colors.stories.jsx
+++ b/src/stories/colors.stories.jsx
@@ -70,7 +70,6 @@ const colorsHelper = (color) => {
     // The use of colors[color] triggers a security warning from our eslint security plugin.
     // However, since we verify inputs against imported colors and this function is not used where
     // users input color we are diabling the warning.
-    // eslint-disable-next-line security/detect-object-injection
     return colors[color];
   }
   return colors.base;

--- a/src/stories/samples.stories.jsx
+++ b/src/stories/samples.stories.jsx
@@ -17,10 +17,8 @@ const InlineForm = ({ name, label, initialValues, validationSchema, onSubmit, on
   const errorCallback = (formErrors) => {
     setErrors(formErrors);
   };
-  /* eslint-disable security/detect-object-injection */
   const errorMsg = errors[name];
   const value = initialValues[name];
-  /* eslint-enable security/detect-object-injection */
   /* eslint-disable react/jsx-props-no-spreading */
   const content = show ? (
     <Formik

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -7,7 +7,6 @@ function formatAgentForDisplay(agent) {
   const agentCopy = { ...agent };
   // handle the diff between expected FE and BE phone format
   Object.keys(agentCopy).forEach((key) => {
-    /* eslint-disable security/detect-object-injection */
     if (key === 'phone') {
       const phoneNum = agentCopy[key];
       // will be in format xxxxxxxxxx
@@ -21,7 +20,6 @@ function formatAgentForAPI(agent) {
   const agentCopy = { ...agent };
   Object.keys(agentCopy).forEach((key) => {
     const sanitizedKey = `${key}`;
-    /* eslint-disable security/detect-object-injection */
     if (agentCopy[sanitizedKey] === '') {
       delete agentCopy[sanitizedKey];
     } else if (sanitizedKey === 'phone') {
@@ -29,7 +27,6 @@ function formatAgentForAPI(agent) {
       // will be in format xxx-xxx-xxxx
       agentCopy[sanitizedKey] = `${phoneNum.slice(0, 3)}-${phoneNum.slice(3, 6)}-${phoneNum.slice(6, 10)}`;
     }
-    /* eslint-enable security/detect-object-injection */
   });
   return agentCopy;
 }


### PR DESCRIPTION
## Description

Disables the eslint rule `security/detect-object-injection` for files inside of `src` and `cypress` through directory level `.eslintrc.js` files and removes the no-longer-necessary disable comments.

## Reviewer Notes

This disabling was approved by Jarod, ISSO.  Discussion is here https://ustcdp3.slack.com/archives/CP4UNF7H6/p1619201976056800

```
the threat actor (web application user) already controls the execution environment (web browser)
```

## Setup

`yarn lint`
and you should not see any errors.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [This thread](https://ustcdp3.slack.com/archives/CTNTFJSBA/p1619209810324700?thread_ts=1619205442.317600&cid=CTNTFJSBA) for this change
