### PR TITLE
MB-7366 Review Service Items aria labelling refactor

### DIFF
--- a/src/components/Office/ReviewServiceItems/ReviewServiceItems.jsx
+++ b/src/components/Office/ReviewServiceItems/ReviewServiceItems.jsx
@@ -120,8 +120,14 @@ const ReviewServiceItems = ({
     return (
       <div data-testid="ReviewServiceItems" className={styles.ReviewServiceItems}>
         <div className={styles.top}>
-          <Button data-testid="closeSidebar" type="button" onClick={handleClose} unstyled>
-            <FontAwesomeIcon icon="times" title="Close Service Item review" aria-label="Close Service Item review" />
+          <Button
+            data-testid="closeSidebar"
+            type="button"
+            onClick={handleClose}
+            unstyled
+            aria-label="Close Service Item review"
+          >
+            <FontAwesomeIcon icon="times" title="Close Service Item review" alt=" " />
           </Button>
           <h2 className={styles.header}>Complete request</h2>
         </div>
@@ -157,8 +163,14 @@ const ReviewServiceItems = ({
   return (
     <div data-testid="ReviewServiceItems" className={styles.ReviewServiceItems}>
       <div className={styles.top}>
-        <Button data-testid="closeSidebar" type="button" onClick={handleClose} unstyled>
-          <FontAwesomeIcon icon="times" aria-label="Close Service Item review" />
+        <Button
+          data-testid="closeSidebar"
+          type="button"
+          onClick={handleClose}
+          unstyled
+          aria-label="Close Service Item review"
+        >
+          <FontAwesomeIcon icon="times" alt=" " />
         </Button>
         <div data-testid="itemCount" className={styles.eyebrowTitle}>
           {curCardIndex + 1} OF {totalCards} ITEMS

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -196,7 +196,7 @@ const ServiceItemCard = ({
                       aria-label="Clear status"
                     >
                       <span className="icon">
-                        <FontAwesomeIcon icon="times" title="Clear status" />
+                        <FontAwesomeIcon icon="times" title="Clear status" alt=" " />
                       </span>
                       <span aria-hidden="true">Clear selection</span>
                     </Button>

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -160,7 +160,7 @@ const ServiceItemCard = ({
 
                     {values.status === DENIED && (
                       <FormGroup>
-                        <Label htmlFor="rejectReason">Reason for rejection</Label>
+                        <Label htmlFor={`rejectReason-${id}`}>Reason for rejection</Label>
                         <Textarea
                           id={`rejectReason-${id}`}
                           name="rejectionReason"
@@ -193,11 +193,12 @@ const ServiceItemCard = ({
                       data-testid="clearStatusButton"
                       className={styles.clearStatus}
                       onClick={handleFormReset}
+                      aria-label="Clear status"
                     >
                       <span className="icon">
-                        <FontAwesomeIcon icon="times" title="Clear status" aria-label="Clear status" />
+                        <FontAwesomeIcon icon="times" title="Clear status" />
                       </span>
-                      Clear selection
+                      <span aria-hidden="true">Clear selection</span>
                     </Button>
                   )}
                 </Fieldset>


### PR DESCRIPTION
## Description

this branch resolves some critical a11y testing errors in the Review Service Items component(s). It moves aria labels to the Button component and adds empty alt text to icons in unstyled buttons to ensure their purpose is not read out twice by a screen reader. It also adjusts the form labeling on the rejection fields.

## Reviewer Notes

cypress seems to dislike the htmlFor attribute, and reads it as a duplicated id, so I'll have to change the approach here if i see an integration test failure.

## Setup

```sh
yarn storybook
```

[http://localhost:6006/?path=/story/office-components-reviewserviceitems--basic ](http://localhost:6006/?path=/story/office-components-reviewserviceitems--basic )

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7366?atlOrigin=eyJpIjoiYWM5ZjY0Yzc4N2M5NGFhNGEyMmNhMDU3MzVjMmVkYmIiLCJwIjoiaiJ9) for this change
* [Buttons must have discernible text article](https://dequeuniversity.com/rules/axe/4.1/button-name?application=axeAPI) explains more about the approach used.

## Screenshots
no visual changes ~
