### PR TITLE
…

### DIFF
--- a/pkg/cli/featureflag.go
+++ b/pkg/cli/featureflag.go
@@ -14,7 +14,7 @@ const (
 
 // InitFeatureFlags initializes FeatureFlags command line flags
 func InitFeatureFlags(flag *pflag.FlagSet) {
-	flag.Bool(FeatureFlagAccessCode, false, "Flag (bool) to enable requires-access-code")
+	flag.Bool(FeatureFlagAccessCode, true, "Flag (bool) to enable requires-access-code")
 	flag.Bool(FeatureFlagServiceCounseling, false, "Flag (bool) to enable service counseling")
 }
 

--- a/pkg/handlers/internalapi/access_code.go
+++ b/pkg/handlers/internalapi/access_code.go
@@ -59,8 +59,7 @@ func (h FetchAccessCodeHandler) Handle(params accesscodeop.FetchAccessCodeParams
 
 	if err != nil {
 		logger.Error("Error retrieving access_code for service member", zap.Error(err))
-		fetchAccessCodePayload = &internalmessages.AccessCode{}
-		return accesscodeop.NewFetchAccessCodeOK().WithPayload(fetchAccessCodePayload)
+		return accesscodeop.NewFetchAccessCodeNotFound()
 	}
 
 	fetchAccessCodePayload = payloadForAccessCodeModel(*accessCode)

--- a/pkg/services/accesscode/access_code_fetcher_test.go
+++ b/pkg/services/accesscode/access_code_fetcher_test.go
@@ -30,5 +30,5 @@ func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchNotFound() {
 	fetchAccessCode := NewAccessCodeFetcher(suite.DB())
 	_, err := fetchAccessCode.FetchAccessCode(*serviceMemberID)
 	suite.Error(err)
-	suite.Equal(sql.ErrNoRows, err.Error())
+	suite.Equal(sql.ErrNoRows, err)
 }

--- a/pkg/services/accesscode/access_code_fetcher_test.go
+++ b/pkg/services/accesscode/access_code_fetcher_test.go
@@ -1,6 +1,8 @@
 package accesscode
 
 import (
+	"database/sql"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -28,5 +30,5 @@ func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchNotFound() {
 	fetchAccessCode := NewAccessCodeFetcher(suite.DB())
 	_, err := fetchAccessCode.FetchAccessCode(*serviceMemberID)
 	suite.Error(err)
-	suite.Equal("sql: no rows in result set", err.Error())
+	suite.Equal(sql.ErrNoRows, err.Error())
 }

--- a/pkg/services/accesscode/access_code_fetcher_test.go
+++ b/pkg/services/accesscode/access_code_fetcher_test.go
@@ -22,10 +22,11 @@ func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchAccessCode() {
 	suite.Equal(ac.Code, accessCode.Code, "expected CODE12")
 }
 
-func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchEmptyAccessCode() {
+func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchNotFound() {
 	user := testdatagen.MakeDefaultServiceMember(suite.DB())
 	serviceMemberID := &user.ID
 	fetchAccessCode := NewAccessCodeFetcher(suite.DB())
-	ac, _ := fetchAccessCode.FetchAccessCode(*serviceMemberID)
-	suite.Equal(ac.Code, "")
+	_, err := fetchAccessCode.FetchAccessCode(*serviceMemberID)
+	suite.Error(err)
+	suite.Equal("sql: no rows in result set", err.Error())
 }


### PR DESCRIPTION
Fixes service test to check for not found error and returns a NotFound response from the handler

## Description

A bug was reported that the api response for fetching an access code for a service member should return an error.  This ensures that the `FetchAccessCodeHandler` returns a `NotFound` error if there is no record found and creates a test for that.  It also adjusts the service test to check for that error.

## Reviewer Notes

The second reported case says that the `ValidateAccessCodeHandler` should return an error.  As a GET, and based on how it is handled on the frontend, this is meant to return an empty `AccessCode.code` if it is not valid and an `AccessCode` with values if valid.  It should only return an error if there's an authorization or authentication issue hitting that endpoint, or an internal server error.
Some discussion [here](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1619470549187900)

If there should be a redesign of how we check for a valid access code, that should be its own story.

## Setup

`make client_test`
or
`go test ./pkg/services/accesscode -v -testify.m TestFetchAccessCode_FetchNotFound`
`go test ./pkg/handlers/internalapi -v -testify.m TestFetchAccessCodeHandler_Failure`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6918) for this change
