### PR TITLE
temp test to test dtod

### DIFF
--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -129,6 +129,31 @@ func (suite *PlannerFullSuite) TestZip3Distance() {
 	}
 }
 
+func (suite *PlannerFullSuite) TestZip5Distance() {
+	tests := []struct {
+		zip1        string
+		zip2        string
+		distanceMin int
+		distanceMax int
+	}{
+		{zip1: txZip, zip2: caZip, distanceMin: 1000, distanceMax: 2000},
+		{zip1: ca2Zip, zip2: caZip, distanceMin: 30, distanceMax: 49},
+		{zip1: "902101234", zip2: caZip, distanceMin: 30, distanceMax: 49},
+	}
+	for _, ts := range tests {
+		distance, err := suite.planner.Zip5TransitDistance(ts.zip1, ts.zip2)
+		if len(ts.zip1) > 5 {
+			suite.Error(err)
+			suite.Equal(distance, 0)
+		} else {
+			suite.NoError(err)
+			if distance < ts.distanceMin || distance > ts.distanceMax {
+				suite.Fail("Implausible distance", "Implausible distance from %s to %s: %d", ts.zip1, ts.zip2, distance)
+			}
+		}
+	}
+}
+
 func TestHandlerSuite(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	if err != nil {


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate && rm bin/prime-api-client ; make bin/prime-api-client 
make server_run
```


```sh
prime-api-demo RDY4PY
```


```sh
prime-api-client --insecure fetch-mto-updates | jq 'sort_by(.updatedAt) | .[-1]' > demo_mto.json
```


```sh
cat demo_mto.json | jq " .mtoServiceItems | map(select(.reServiceCode == \"DDDSIT\"))[0] | {mtoServiceItemId: .id, ifMatch: .eTag, body: {id: .id, modelType: \"UpdateMTOServiceItemSIT\", sitDestinationFinalAddress: {streetAddress1: \"20245 4th St\", city: \"Harlem\", state: \"GA\", postalCode: \"30814\", country: \"United States\"}}}" > update_dddsit_service_item.json
```

```sh
prime-api-client --insecure update-mto-service-item --filename update_dddsit_service_item.json  | jq
```


saved output from above and put it into output_create_dddsit.json 


```sh
cat output_create_dddsit.json | jq ' {  body:  {  isFinal: false,  moveTaskOrderID: .moveTaskOrderID,      serviceItems: {id: .id}}  }' > create_dddsit_request_pr.json
```


edit the file create_dddsit_request_pr.json  to add the correct `[]` around the service items ids.


```sh
vim create_dddsit_request_pr.json
```



```json
e.g.,
		serviceItems: [       
			{         
				id: test       
			}
		]
```




```sh
prime-api-client create-payment-request --insecure --filename  create_dddsit_request_pr.json | jq
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
