### PR TITLE
[MB-7652] Service item calculations should show first three digits of ZIP3 fields

### DIFF
--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
@@ -97,7 +97,7 @@ describe('ServiceItemCalculations', () => {
     {
       value: '210',
       label: 'Mileage',
-      details: ['ZIP 210 to ZIP 910'],
+      details: ['ZIP 322 to ZIP 919'],
     },
     {
       value: '1.71',

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -62,17 +62,17 @@ const billableWeight = (params) => {
   return calculation(value, label, weightBilledActualDetail, weightEstimatedDetail);
 };
 
-// mileage calculation
-const mileageZIP3 = (params) => {
+// display the first 3 digits of the ZIP code
+const mileageFirstThreeZip = (params) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.DistanceZip3, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.Mileage;
   const detail = `${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress]} ${getParamValue(
-    SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress, // take the zip 3
+    SERVICE_ITEM_PARAM_KEYS.ZipPickupAddress,
     params,
-  )?.slice(2)} to ${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipDestAddress]} ${getParamValue(
+  )?.slice(0, 3)} to ${SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.ZipDestAddress]} ${getParamValue(
     SERVICE_ITEM_PARAM_KEYS.ZipDestAddress,
     params,
-  )?.slice(2)}`;
+  )?.slice(0, 3)}`;
 
   return calculation(value, label, detail);
 };
@@ -279,7 +279,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
     case SERVICE_ITEM_CODES.DLH:
       result = [
         billableWeight(params),
-        mileageZIP3(params),
+        mileageFirstThreeZip(params),
         baselineLinehaulPrice(params),
         priceEscalationFactor(params),
         totalAmountRequested(totalAmount),
@@ -289,7 +289,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
     case SERVICE_ITEM_CODES.FSC:
       result = [
         billableWeight(params),
-        mileageZIP3(params),
+        mileageFirstThreeZip(params),
         fuelSurchargePrice(params),
         totalAmountRequested(totalAmount),
       ];

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -13,7 +13,7 @@ describe('makeCalculations', () => {
       {
         value: '210',
         label: 'Mileage',
-        details: ['ZIP 210 to ZIP 910'],
+        details: ['ZIP 322 to ZIP 919'],
       },
       {
         value: '1.71',
@@ -390,7 +390,7 @@ describe('makeCalculations', () => {
       {
         value: '210',
         label: 'Mileage',
-        details: ['ZIP 210 to ZIP 910'],
+        details: ['ZIP 322 to ZIP 919'],
       },
       {
         value: '0.09',


### PR DESCRIPTION
## Description

Change zip3 display helper to show first 3 digits of ZIP code rather than last 3.

## Reviewer Notes

Nothing that I can think of.

## Setup

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7652) for this change

## Screenshots

Before:
![Screen Shot 2021-04-27 at 10 21 34 AM](https://user-images.githubusercontent.com/3903208/116262628-b586ed00-a746-11eb-91b8-83114d597026.png)

After:
![Screen Shot 2021-04-27 at 10 33 45 AM](https://user-images.githubusercontent.com/3903208/116262675-bb7cce00-a746-11eb-9ed0-daa4fcd69637.png)
