### PR TITLE
Update cypress image to the commit that has the cypress update to 7.2

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-6c43a15e79cbbd76a4f6204a98b9a5b08a53bc1d
+FROM milmove/circleci-docker:milmove-cypress-c5ab4711080339a97b749254d3926ebee498bab4
 
 COPY . ./cypress
 COPY cypress.json ./cypress.json


### PR DESCRIPTION
## Description

This updates the git commit hash on the milmove cypress image tag so that it's using this commit: https://github.com/transcom/circleci-docker/commit/c5ab4711080339a97b749254d3926ebee498bab4 which updates cypress to 7.2

