### PR TITLE
Reset access code feature flag to false and remove unused err type

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -48,14 +48,6 @@ var environments = []string{
 	EnvironmentReview,
 }
 
-type errInvalidEnvironment struct {
-	Environment string
-}
-
-func (e *errInvalidEnvironment) Error() string {
-	return fmt.Sprintf("invalid environment %q, expecting one of %q", e.Environment, environments)
-}
-
 // InitEnvironmentFlags initializes the Environment command line flags
 func InitEnvironmentFlags(flag *pflag.FlagSet) {
 	flag.StringP(EnvironmentFlag, "e", EnvironmentDevelopment, fmt.Sprintf("The environment name, one of %v", environments))

--- a/pkg/cli/featureflag.go
+++ b/pkg/cli/featureflag.go
@@ -14,7 +14,7 @@ const (
 
 // InitFeatureFlags initializes FeatureFlags command line flags
 func InitFeatureFlags(flag *pflag.FlagSet) {
-	flag.Bool(FeatureFlagAccessCode, true, "Flag (bool) to enable requires-access-code")
+	flag.Bool(FeatureFlagAccessCode, false, "Flag (bool) to enable requires-access-code")
 	flag.Bool(FeatureFlagServiceCounseling, false, "Flag (bool) to enable service counseling")
 }
 


### PR DESCRIPTION
Reset access code feature flag to false and remove unused err type for linter

## Description

Master broke because some unused code was caught by the linter.  In the process I also noticed that I accidentally merged a feature flag change that I had used for testing.  This fixes both.

## Reviewer Notes

This is the PR that accidentally changed the feature flag. https://github.com/transcom/mymove/pull/6511/files

## Setup

Master was broken due to some unused code. The fix should allow pass pre-tests to pass.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change


_Please frame screenshots to show enough useful context but also highlight the affected regions._
