### PR TITLE
MB-7726 add staticcheck and errcheck to ATO linter

### DIFF
--- a/pkg/ato-linter/ato.go
+++ b/pkg/ato-linter/ato.go
@@ -1,7 +1,9 @@
 package atolinter
 
 import (
+	"fmt"
 	"go/ast"
+	"regexp"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -32,13 +34,16 @@ var validatorStatuses = map[string]bool{
 // check if comment group has disabling of gosec in it but it doesn't have a specific rule it is disabling
 func containsGosecDisableNoRule(comments []*ast.Comment) bool {
 	for _, comment := range comments {
-		if strings.Contains(comment.Text, disableNoSec) {
-			individualCommentArr := strings.Split(comment.Text, " ")
-			for index, str := range individualCommentArr {
-				if str == disableNoSec && index == len(individualCommentArr)-1 {
-					return true
-				}
-			}
+		noSecRegex := regexp.MustCompile(fmt.Sprintf("(?P<linter>%v) ?(?P<rule>G\\d{3})?", disableNoSec))
+
+		match := noSecRegex.FindStringSubmatch(comment.Text)
+
+		if match == nil {
+			return false
+		}
+
+		if match[2] == "" {
+			return true
 		}
 	}
 	return false

--- a/pkg/ato-linter/ato.go
+++ b/pkg/ato-linter/ato.go
@@ -47,7 +47,7 @@ func containsGosecDisableNoRule(comments []*ast.Comment) bool {
 		match := noSecRegex.FindStringSubmatch(comment.Text)
 
 		if match == nil {
-			return false
+			continue
 		}
 
 		if match[2] == "" {
@@ -65,7 +65,7 @@ func containsStaticcheckDisableNoRule(comments []*ast.Comment) bool {
 		match := noSecRegex.FindStringSubmatch(comment.Text)
 
 		if match == nil {
-			return false
+			continue
 		}
 
 		if match[2] == "" {

--- a/testdata/src/linter_tests/ato.go
+++ b/testdata/src/linter_tests/ato.go
@@ -59,15 +59,14 @@ func errcheckShouldHaveAnnotation() {}
 // nolint:errcheck
 func errcheckAnnotationNotApprovedTemplate() {}
 
-//RA Summary: gosec - G401 - Weak cryptographic hash  // want "Annotation needs approval from an ISSO"
-//RA: This line was flagged because of the use of MD5 hashing
-//RA: This line of code hashes the AWS object to be able to verify data integrity
-//RA: Purpose of this hash is to protect against environmental risks, it does not
-//RA: hash any sensitive user provided information such as passwords.
-//RA: AWS S3 API requires use of MD5 to validate data integrity.
+//RA Summary: gosec - errcheck - Unchecked return value // want "Annotation needs approval from an ISSO"
+//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+//RA: in which this would be considered a risk
 //RA Developer Status:
 //RA Validator Status:
-//RA Modified Severity: CAT III
+//RA Modified Severity: N/A
 // nolint:errcheck
 func errcheckAnnotationNotApprovedEmpty() {}
 
@@ -81,3 +80,44 @@ func errcheckAnnotationNotApprovedEmpty() {}
 //RA Modified Severity: N/A
 // nolint:errcheck
 func errcheckAnnotationApproved() {}
+
+// staticcheck section
+
+// lint:ignore // want "Please provide the rule that is being disabled"
+func staticcheckShouldProvideRule() {}
+
+// lint:ignore S1001 // want "Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit#heading=h.b2vss780hqfi"
+func staticcheckShouldHaveAnnotation() {}
+
+//RA Summary: [linter] - [linter type code] - [Linter summary] // want "Annotation needs approval from an ISSO"
+//RA: <Why did the linter flag this line of code?>
+//RA: <Why is this line of code valuable?>
+//RA: <What mitigates the risk of negative impact?>
+//RA Developer Status:  {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+//RA Validator Status:  {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Modified Severity: CAT III
+// lint:ignore SA1017
+func staticcheckAnnotationNotApprovedTemplate() {}
+
+//RA Summary: staticcheck - SA2002 - Weak cryptographic hash  // want "Annotation needs approval from an ISSO"
+//RA: This line was flagged because of the use of MD5 hashing
+//RA: This line of code hashes the AWS object to be able to verify data integrity
+//RA: Purpose of this hash is to protect against environmental risks, it does not
+//RA: hash any sensitive user provided information such as passwords.
+//RA: AWS S3 API requires use of MD5 to validate data integrity.
+//RA Developer Status:
+//RA Validator Status:
+//RA Modified Severity: CAT III
+// lint:ignore SA2002
+func staticcheckAnnotationNotApprovedEmpty() {}
+
+//RA Summary: staticcheck - ST1021 - Unchecked return value
+//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+//RA: Functions with unchecked return values in the file are used to close a local server connection to ensure a unit test server is not left running indefinitely
+//RA: Given the functions causing the lint errors are used to close a local server connection for testing purposes, it is not deemed a risk
+//RA Developer Status: Mitigated
+//RA Validator Status: Mitigated
+//RA Validator: jneuner@mitre.org
+//RA Modified Severity: N/A
+// lint:ignore ST1021
+func staticcheckAnnotationApproved() {}

--- a/testdata/src/linter_tests/ato.go
+++ b/testdata/src/linter_tests/ato.go
@@ -1,15 +1,43 @@
 package linter_tests
 
-// #nosec // want "Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit#heading=h.b2vss780hqfi"
+// Just a regular comment
+func noDisabledLinter() {}
+
+// #nosec // want "Please provide the rule that is being disabled"
+func nosecShouldProvideRule() {}
+
+// #nosec G101 // want "Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit#heading=h.b2vss780hqfi"
 func nosecShouldHaveAnnotation() {}
 
 //RA Summary: [linter] - [linter type code] - [Linter summary] // want "Annotation needs approval from an ISSO"
 //RA: <Why did the linter flag this line of code?>
 //RA: <Why is this line of code valuable?>
 //RA: <What mitigates the risk of negative impact?>
-//RA Developer Status: {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
-//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Developer Status:  {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+//RA Validator Status:  {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Modified Severity: CAT III
+// #nosec G402
+func nosecAnnotationNotApprovedTemplate() {}
+
+//RA Summary: gosec - G401 - Weak cryptographic hash  // want "Annotation needs approval from an ISSO"
+//RA: This line was flagged because of the use of MD5 hashing
+//RA: This line of code hashes the AWS object to be able to verify data integrity
+//RA: Purpose of this hash is to protect against environmental risks, it does not
+//RA: hash any sensitive user provided information such as passwords.
+//RA: AWS S3 API requires use of MD5 to validate data integrity.
+//RA Developer Status:
+//RA Validator Status:
+//RA Modified Severity: CAT III
+// #nosec G501
+func nosecAnnotationNotApprovedEmpty() {}
+
+//RA Summary: gosec - errcheck - Unchecked return value
+//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+//RA: Functions with unchecked return values in the file are used to close a local server connection to ensure a unit test server is not left running indefinitely
+//RA: Given the functions causing the lint errors are used to close a local server connection for testing purposes, it is not deemed a risk
+//RA Developer Status: Mitigated
+//RA Validator Status: Mitigated
 //RA Validator: jneuner@mitre.org
-//RA Modified Severity:
-// #nosec G100
-func nosecAnnotationNotApproved() {}
+//RA Modified Severity: N/A
+// #nosec G307
+func nosecAnnotationApproved() {}

--- a/testdata/src/linter_tests/ato.go
+++ b/testdata/src/linter_tests/ato.go
@@ -3,6 +3,8 @@ package linter_tests
 // Just a regular comment
 func noDisabledLinter() {}
 
+// #nosec section
+
 // #nosec // want "Please provide the rule that is being disabled"
 func nosecShouldProvideRule() {}
 
@@ -41,3 +43,41 @@ func nosecAnnotationNotApprovedEmpty() {}
 //RA Modified Severity: N/A
 // #nosec G307
 func nosecAnnotationApproved() {}
+
+// errcheck section
+
+// nolint:errcheck // want "Please visit https://docs.google.com/document/d/1qiBNHlctSby0RZeaPzb-afVxAdA9vlrrQgce00zjDww/edit#heading=h.b2vss780hqfi"
+func errcheckShouldHaveAnnotation() {}
+
+//RA Summary: [linter] - [linter type code] - [Linter summary] // want "Annotation needs approval from an ISSO"
+//RA: <Why did the linter flag this line of code?>
+//RA: <Why is this line of code valuable?>
+//RA: <What mitigates the risk of negative impact?>
+//RA Developer Status:  {RA Request, RA Accepted, POA&M Request, POA&M Accepted, Mitigated, Need Developer Fix, False Positive, Bad Practice}
+//RA Validator Status:  {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+//RA Modified Severity: CAT III
+// nolint:errcheck
+func errcheckAnnotationNotApprovedTemplate() {}
+
+//RA Summary: gosec - G401 - Weak cryptographic hash  // want "Annotation needs approval from an ISSO"
+//RA: This line was flagged because of the use of MD5 hashing
+//RA: This line of code hashes the AWS object to be able to verify data integrity
+//RA: Purpose of this hash is to protect against environmental risks, it does not
+//RA: hash any sensitive user provided information such as passwords.
+//RA: AWS S3 API requires use of MD5 to validate data integrity.
+//RA Developer Status:
+//RA Validator Status:
+//RA Modified Severity: CAT III
+// nolint:errcheck
+func errcheckAnnotationNotApprovedEmpty() {}
+
+//RA Summary: gosec - errcheck - Unchecked return value
+//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+//RA: Functions with unchecked return values in the file are used to close a local server connection to ensure a unit test server is not left running indefinitely
+//RA: Given the functions causing the lint errors are used to close a local server connection for testing purposes, it is not deemed a risk
+//RA Developer Status: Mitigated
+//RA Validator Status: Mitigated
+//RA Validator: jneuner@mitre.org
+//RA Modified Severity: N/A
+// nolint:errcheck
+func errcheckAnnotationApproved() {}


### PR DESCRIPTION
## Description

Expand our custom ato-linter to also check for disabling of staticcheck or errcheck. 

I have one more case for `staticcheck` (`lint:file-ignore`). I'll update with that tomorrow.

## Reviewer Notes

How do the regex patterns look? I tested them a lot manually (plus the tests), but more review is always good with regex.

## Setup

### Running linter

```sh
go install ./cmd/...
ato-linter ./pkg/...
```

### Tests

```sh
go test -v ./pkg/ato-linter/...
```

or 

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7726) for this change
* [this article](https://disaev.me/p/writing-useful-go-analysis-linter/) explains go-analysis setup
* [this repo](https://github.com/dbraley/example-linter) is an example linter
* [official linter docs](https://golangci-lint.run/contributing/new-linters/)
* [another helpful tutorial](https://arslan.io/2019/06/13/using-go-analysis-to-write-a-custom-linter/)