### PR TITLE
[MB-7741] Special case for DDDSIT TIO calculations less than 50 miles different ZIP3

### DIFF
--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
@@ -27,6 +27,15 @@ export default {
 
 export const DDDSIT = (data) => (
   <ServiceItemCalculations
+    serviceItemParams={testParams.DomesticDestinationSITDeliveryLonghaul}
+    totalAmountRequested={642}
+    itemCode="DDDSIT"
+    tableSize={data.tableSize}
+  />
+);
+
+export const DDDSITShorthaulDifferentZIP3 = (data) => (
+  <ServiceItemCalculations
     serviceItemParams={testParams.DomesticDestinationSITDelivery}
     totalAmountRequested={642}
     itemCode="DDDSIT"

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -226,7 +226,7 @@ const additionalDayDestinationSITPrice = (params) => {
   return calculation(value, label, serviceAreaDest(params), requestedPickupDate(params), peak(params));
 };
 
-const sitDeliveryPrice = (params, belowLonghaulDistance = false) => {
+const sitDeliveryPrice = (params) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.PriceRateOrFactor, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.SITDeliveryPrice;
 
@@ -234,16 +234,18 @@ const sitDeliveryPrice = (params, belowLonghaulDistance = false) => {
     SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.SITScheduleDest]
   }: ${getParamValue(SERVICE_ITEM_PARAM_KEYS.SITScheduleDest, params)}`;
 
-  const details = [sitScheduleDestination, requestedPickupDate(params), peak(params)];
-  if (belowLonghaulDistance) {
-    details.push('<=50 miles');
-  }
-
-  return calculation(value, label, ...details);
+  return calculation(value, label, sitScheduleDestination, requestedPickupDate(params), peak(params));
 };
 
 const sitDeliveryPriceShorthaulDifferentZIP3 = (params) => {
-  return sitDeliveryPrice(params, true);
+  const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.PriceRateOrFactor, params);
+  const label = SERVICE_ITEM_CALCULATION_LABELS.SITDeliveryPrice;
+
+  const sitScheduleDestination = `${
+    SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.SITScheduleDest]
+  }: ${getParamValue(SERVICE_ITEM_PARAM_KEYS.SITScheduleDest, params)}`;
+
+  return calculation(value, label, sitScheduleDestination, requestedPickupDate(params), peak(params), '<=50 miles');
 };
 
 const daysInSIT = (params) => {

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -1,4 +1,5 @@
 import { SERVICE_ITEM_CALCULATION_LABELS, SERVICE_ITEM_CODES, SERVICE_ITEM_PARAM_KEYS } from 'constants/serviceItems';
+import { LONGHAUL_MIN_DISTANCE } from 'constants/shipments';
 import { formatWeight, formatCents, toDollarString } from 'shared/formatters';
 import { formatDate } from 'shared/dates';
 import { formatWeightCWTFromLbs, formatDollarFromMillicents } from 'utils/formatters';
@@ -225,14 +226,20 @@ const additionalDayDestinationSITPrice = (params) => {
   return calculation(value, label, serviceAreaDest(params), requestedPickupDate(params), peak(params));
 };
 
-const sitDeliveryPrice = (params) => {
+const sitDeliveryPrice = (params, belowLonghaulDistance = false) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.PriceRateOrFactor, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.SITDeliveryPrice;
+
   const sitScheduleDestination = `${
     SERVICE_ITEM_CALCULATION_LABELS[SERVICE_ITEM_PARAM_KEYS.SITScheduleDest]
   }: ${getParamValue(SERVICE_ITEM_PARAM_KEYS.SITScheduleDest, params)}`;
 
-  return calculation(value, label, sitScheduleDestination, requestedPickupDate(params), peak(params));
+  const details = [sitScheduleDestination, requestedPickupDate(params), peak(params)];
+  if (belowLonghaulDistance) {
+    details.push('<=50 miles');
+  }
+
+  return calculation(value, label, ...details);
 };
 
 const daysInSIT = (params) => {
@@ -266,15 +273,30 @@ const makeCalculations = (itemCode, totalAmount, params) => {
   let result = [];
 
   switch (itemCode) {
-    case SERVICE_ITEM_CODES.DDDSIT:
-      result = [
-        billableWeight(params),
-        dddSITmileageZip5(params),
-        sitDeliveryPrice(params),
-        priceEscalationFactor(params),
-        totalAmountRequested(totalAmount),
-      ];
+    case SERVICE_ITEM_CODES.DDDSIT: {
+      const mileage = getParamValue(SERVICE_ITEM_PARAM_KEYS.DistanceZipSITDest, params);
+      const startZip = getParamValue(SERVICE_ITEM_PARAM_KEYS.ZipDestAddress, params)?.slice(0, 3);
+      const endZip = getParamValue(SERVICE_ITEM_PARAM_KEYS.ZipSITDestHHGFinalAddress, params)?.slice(0, 3);
+      // Mileage does not factor into the pricing for distances less than 50 miles and non-matching
+      // zip3, so we won't display mileage
+      if (mileage <= LONGHAUL_MIN_DISTANCE && startZip !== endZip) {
+        result = [
+          billableWeight(params),
+          sitDeliveryPrice(params, true), // Display under mileage threshold
+          priceEscalationFactor(params),
+          totalAmountRequested(totalAmount),
+        ];
+      } else {
+        result = [
+          billableWeight(params),
+          dddSITmileageZip5(params),
+          sitDeliveryPrice(params),
+          priceEscalationFactor(params),
+          totalAmountRequested(totalAmount),
+        ];
+      }
       break;
+    }
     // Domestic longhaul
     case SERVICE_ITEM_CODES.DLH:
       result = [

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -242,6 +242,10 @@ const sitDeliveryPrice = (params, belowLonghaulDistance = false) => {
   return calculation(value, label, ...details);
 };
 
+const sitDeliveryPriceShorthaulDifferentZIP3 = (params) => {
+  return sitDeliveryPrice(params, true);
+};
+
 const daysInSIT = (params) => {
   const value = getParamValue(SERVICE_ITEM_PARAM_KEYS.NumberDaysSIT, params);
   const label = SERVICE_ITEM_CALCULATION_LABELS.DaysInSIT;
@@ -282,7 +286,7 @@ const makeCalculations = (itemCode, totalAmount, params) => {
       if (mileage <= LONGHAUL_MIN_DISTANCE && startZip !== endZip) {
         result = [
           billableWeight(params),
-          sitDeliveryPrice(params, true), // Display under mileage threshold
+          sitDeliveryPriceShorthaulDifferentZIP3(params), // Display under mileage threshold
           priceEscalationFactor(params),
           totalAmountRequested(totalAmount),
         ];

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -199,7 +199,7 @@ describe('makeCalculations', () => {
     ]);
   });
 
-  it('returns correct data for DomesticDestinationAdditionalSIT', () => {
+  describe('returns correct data for DomesticDestinationAdditionalSIT', () => {
     const result = makeCalculations('DDASIT', 99999, testParams.DomesticDestinationAdditionalSIT);
     expect(result).toEqual([
       {
@@ -261,35 +261,94 @@ describe('makeCalculations', () => {
     ]);
   });
 
-  it('returns correct data for DomesticDestinationSITDelivery', () => {
-    const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDelivery);
-    expect(result).toEqual([
-      {
-        details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
-        label: 'Billable weight (cwt)',
-        value: '85 cwt',
-      },
-      {
-        value: '29',
-        label: 'Mileage',
-        details: ['ZIP 91910 to ZIP 94535'],
-      },
-      {
-        details: ['Destination SIT schedule: 3', 'Requested pickup: 09 Mar 2020', 'Domestic non-peak'],
-        label: 'SIT delivery price',
-        value: '1.71',
-      },
-      {
-        value: '1.033',
-        label: 'Price escalation factor',
-        details: ['Base year: 2'],
-      },
-      {
-        value: '$999.99',
-        label: 'Total amount requested',
-        details: [''],
-      },
-    ]);
+  describe('DomesticDestinationSITDelivery', () => {
+    it('returns the correct data for mileage above 50', () => {
+      const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDeliveryLonghaul);
+      expect(result).toEqual([
+        {
+          details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
+          label: 'Billable weight (cwt)',
+          value: '85 cwt',
+        },
+        {
+          value: '51',
+          label: 'Mileage',
+          details: ['ZIP 91910 to ZIP 94535'],
+        },
+        {
+          details: ['Destination SIT schedule: 3', 'Requested pickup: 09 Mar 2020', 'Domestic non-peak'],
+          label: 'SIT delivery price',
+          value: '1.71',
+        },
+        {
+          value: '1.033',
+          label: 'Price escalation factor',
+          details: ['Base year: 2'],
+        },
+        {
+          value: '$999.99',
+          label: 'Total amount requested',
+          details: [''],
+        },
+      ]);
+    });
+
+    it('returns the correct data for mileage below 50 with matching ZIP3s', () => {
+      const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDeliveryMachingZip3);
+      expect(result).toEqual([
+        {
+          details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
+          label: 'Billable weight (cwt)',
+          value: '85 cwt',
+        },
+        {
+          value: '3',
+          label: 'Mileage',
+          details: ['ZIP 91910 to ZIP 91920'],
+        },
+        {
+          details: ['Destination SIT schedule: 3', 'Requested pickup: 09 Mar 2020', 'Domestic non-peak'],
+          label: 'SIT delivery price',
+          value: '1.71',
+        },
+        {
+          value: '1.033',
+          label: 'Price escalation factor',
+          details: ['Base year: 2'],
+        },
+        {
+          value: '$999.99',
+          label: 'Total amount requested',
+          details: [''],
+        },
+      ]);
+    });
+
+    it('returns the correct data for mileage below 50 with non-matching ZIP3s', () => {
+      const result = makeCalculations('DDDSIT', 99999, testParams.DomesticDestinationSITDelivery);
+      expect(result).toEqual([
+        {
+          details: ['Shipment weight: 8,500 lbs', 'Estimated: 8,000 lbs'],
+          label: 'Billable weight (cwt)',
+          value: '85 cwt',
+        },
+        {
+          details: ['Destination SIT schedule: 3', 'Requested pickup: 09 Mar 2020', 'Domestic non-peak', '<=50 miles'],
+          label: 'SIT delivery price',
+          value: '1.71',
+        },
+        {
+          value: '1.033',
+          label: 'Price escalation factor',
+          details: ['Base year: 2'],
+        },
+        {
+          value: '$999.99',
+          label: 'Total amount requested',
+          details: [''],
+        },
+      ]);
+    });
   });
 
   it('returns correct data for DomesticPacking', () => {

--- a/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
+++ b/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
@@ -190,6 +190,26 @@ const DistanceZipSITDest = {
   value: '29',
 };
 
+const DistanceZipSITDestMatchingZip3 = {
+  eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
+  id: '45ede48b-364d-473a-8c61-0f520a6a4e04',
+  key: 'DistanceZipSITDest',
+  origin: 'SYSTEM',
+  paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
+  type: 'INTEGER',
+  value: '3',
+};
+
+const DistanceZipSITDestLonghaul = {
+  eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
+  id: '45ede48b-364d-473a-8c61-0f520a6a4e04',
+  key: 'DistanceZipSITDest',
+  origin: 'SYSTEM',
+  paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
+  type: 'INTEGER',
+  value: '51',
+};
+
 const ZipSITOriginHHGOriginalAddress = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
   id: '70eecf7f-beae-4906-95ba-cbfe6797cf3a',
@@ -218,6 +238,16 @@ const ZipSITDestHHGFinalAddress = {
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'STRING',
   value: '94535',
+};
+
+const ZipSITDestHHGFinalAddressMatchingZip3 = {
+  eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
+  id: '70eecf7f-beae-4906-95ba-cbfe6797cf3a',
+  key: 'ZipSITDestHHGFinalAddress',
+  origin: 'PRIME',
+  paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
+  type: 'STRING',
+  value: '91920',
 };
 
 const EIAFuelPrice = {
@@ -524,6 +554,39 @@ const testParams = {
     ZipDestAddress,
     ZipSITDestHHGFinalAddress,
   ],
+
+  DomesticDestinationSITDeliveryLonghaul: [
+    ContractCode,
+    ContractYearName,
+    DistanceZipSITDestLonghaul,
+    EscalationCompounded,
+    PriceRateOrFactor,
+    RequestedPickupDate,
+    ServiceAreaDest,
+    SITScheduleDest,
+    WeightActual,
+    WeightBilledActual,
+    WeightEstimated,
+    ZipDestAddress,
+    ZipSITDestHHGFinalAddress,
+  ],
+
+  DomesticDestinationSITDeliveryMachingZip3: [
+    ContractCode,
+    ContractYearName,
+    DistanceZipSITDestMatchingZip3,
+    EscalationCompounded,
+    PriceRateOrFactor,
+    RequestedPickupDate,
+    ServiceAreaDest,
+    SITScheduleDest,
+    WeightActual,
+    WeightBilledActual,
+    WeightEstimated,
+    ZipDestAddress,
+    ZipSITDestHHGFinalAddressMatchingZip3,
+  ],
+
   DomesticPacking: [
     ContractYearName,
     EscalationCompounded,

--- a/src/constants/shipments.js
+++ b/src/constants/shipments.js
@@ -26,3 +26,5 @@ export const shipmentStatuses = {
   REJECTED: 'REJECTED',
   CANCELLATION_REQUESTED: 'CANCELLATION_REQUESTED',
 };
+
+export const LONGHAUL_MIN_DISTANCE = 50;


### PR DESCRIPTION
## Description

For the DDDSIT payment service item, there is a special case when the distance is within the shorthaul range (less than or equal to 50 miles) and the ZIP3 values are different that doesn't use mileage in the price calculation.

In that scenario we will not display the mileage distance section for DDDSIT and add a <=50 miles row label to the SIT Delivery Price column.

The payment service item params sent back from the pricer is not changing because this seemed easy enough to handle for now on the frontend.

Here is the [slack thread discussion](https://ustcdp3.slack.com/archives/CP6F568DC/p1618588878050700) for reference

[Server tests](https://github.com/transcom/mymove/blob/master/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go) that describe the different calculations for DDDSIT

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

Visit http://localhost:6006/?path=/story/office-components-serviceitemcalculations--dddsit-shorthaul-different-zip-3 to see the example of when the distance is <= 50 miles and the ZIP3s are different.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7741) for this change

## Screenshots

<img width="1355" alt="Screen Shot 2021-04-28 at 3 13 14 PM" src="https://user-images.githubusercontent.com/52669884/116459848-4f789380-a834-11eb-924b-c00258139c24.png">

