### PR TITLE
MB-7736 failed gex connection should not mark payment reqeust status as edi error

### DIFF
--- a/pkg/payment_request/send_to_syncada.go
+++ b/pkg/payment_request/send_to_syncada.go
@@ -31,6 +31,7 @@ func SendToSyncada(edi string, icn int64, gexSender services.GexSender, sftpSend
 			return fmt.Errorf("GEX sender encountered an error: %w", err)
 		}
 		if resp == nil {
+			logger.Error("GEX Sender receieved no response from GEX")
 			return fmt.Errorf("no response when sending EDI to GEX")
 		}
 		if resp.StatusCode != http.StatusOK {
@@ -38,7 +39,7 @@ func SendToSyncada(edi string, icn int64, gexSender services.GexSender, sftpSend
 			return fmt.Errorf("received error response when sending EDI to GEX %v", resp)
 		}
 		logger.Info(
-			"SUCCESS: 858 Processor sent new file to syncada for Payment Request, using GEX",
+			"SUCCESS: EDI858 Processor sent a new file to syncada for Payment Request, using GEX",
 			zap.String("filename", syncadaFileName))
 	} else if sftpSender != nil {
 		// Send to Syncada via SFTP
@@ -49,7 +50,7 @@ func SendToSyncada(edi string, icn int64, gexSender services.GexSender, sftpSend
 		if err != nil {
 			return err
 		}
-		logger.Info("SUCCESS: 858 Processor sent new file to syncada for Payment Request", zap.String("syncadaFileName", syncadaFileName))
+		logger.Info("SUCCESS: EDI858 Processor sent new file to syncada for Payment Request", zap.String("syncadaFileName", syncadaFileName))
 	}
 	return nil
 }

--- a/pkg/payment_request/send_to_syncada_test.go
+++ b/pkg/payment_request/send_to_syncada_test.go
@@ -1,0 +1,105 @@
+package paymentrequest
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/mocks"
+)
+
+func (suite *PaymentRequestHelperSuite) TestSendToSyncada() {
+	suite.T().Run("returns no error if send is false", func(t *testing.T) {
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := services.GexSender(nil)
+		err := SendToSyncada("edi string", 12345, gexSender, sftpSender, false, suite.logger)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("returns error if no sender", func(t *testing.T) {
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := services.GexSender(nil)
+		err := SendToSyncada("edi string", 12345, gexSender, sftpSender, true, suite.logger)
+		suite.Error(err)
+		suite.Equal("cannot send to Syncada, SendToSyncada() senders are nil", err.Error())
+	})
+
+	suite.T().Run("successful on gex sender", func(t *testing.T) {
+		fakeEdi := "pretend this is an edi"
+		response := &http.Response{StatusCode: http.StatusOK}
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := &mocks.GexSender{}
+		expectedFilename := fmt.Sprintf("%s_%d_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"), 12345)
+		gexSender.
+			On("SendToGex", fakeEdi, expectedFilename).Return(response, nil)
+		err := SendToSyncada(fakeEdi, 12345, gexSender, sftpSender, true, suite.logger)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("unsuccessful on gex sender", func(t *testing.T) {
+		fakeEdi := "pretend this is an edi"
+		response := &http.Response{StatusCode: http.StatusForbidden}
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := &mocks.GexSender{}
+		expectedFilename := fmt.Sprintf("%s_%d_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"), 12345)
+		gexSender.
+			On("SendToGex", fakeEdi, expectedFilename).Return(response, nil)
+		err := SendToSyncada(fakeEdi, 12345, gexSender, sftpSender, true, suite.logger)
+		suite.Error(err)
+		suite.Contains("received error response when sending EDI to GEX &{ 403  0 0 map[] <nil> 0 [] false false map[] <nil> <nil>}", err.Error())
+	})
+
+	suite.T().Run("no response on gex sender", func(t *testing.T) {
+		fakeEdi := "pretend this is an edi"
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := &mocks.GexSender{}
+		expectedFilename := fmt.Sprintf("%s_%d_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"), 12345)
+		gexSender.
+			On("SendToGex", fakeEdi, expectedFilename).Return(nil, nil)
+		err := SendToSyncada(fakeEdi, 12345, gexSender, sftpSender, true, suite.logger)
+		suite.Error(err)
+		suite.Contains("no response when sending EDI to GEX", err.Error())
+	})
+
+	suite.T().Run("error response on gex sender", func(t *testing.T) {
+		fakeEdi := "pretend this is an edi"
+		sftpSender := services.SyncadaSFTPSender(nil)
+		gexSender := &mocks.GexSender{}
+		expectedFilename := fmt.Sprintf("%s_%d_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"), 12345)
+		gexSender.
+			On("SendToGex", fakeEdi, expectedFilename).Return(nil, fmt.Errorf("gex send threw error"))
+		err := SendToSyncada(fakeEdi, 12345, gexSender, sftpSender, true, suite.logger)
+		suite.Error(err)
+		suite.Contains("GEX sender encountered an error: gex send threw error", err.Error())
+	})
+
+	suite.T().Run("error on sftp sender", func(t *testing.T) {
+		bytesSent := int64(0)
+		// int64, error
+		sftpSender := &mocks.SyncadaSFTPSender{}
+		sftpSender.
+			On("SendToSyncadaViaSFTP", mock.Anything, mock.Anything).Return(bytesSent, fmt.Errorf("test error"))
+		gexSender := services.GexSender(nil)
+		err := SendToSyncada("edi string", 12345, gexSender, sftpSender, true, suite.logger)
+		suite.Error(err)
+		suite.Equal("test error", err.Error())
+	})
+
+	suite.T().Run("successful on sftp sender", func(t *testing.T) {
+		fakeEdi := "pretend this is an edi"
+		bytesSent := int64(10)
+		// int64, error
+		sftpSender := &mocks.SyncadaSFTPSender{}
+		expectedFilename := fmt.Sprintf("%s_%d_edi858.txt", time.Now().Format("2006_01_02T15_04_05Z07_00"), 12345)
+		sftpSender.
+			On("SendToSyncadaViaSFTP", strings.NewReader(fakeEdi), expectedFilename).Return(bytesSent, nil)
+		gexSender := services.GexSender(nil)
+		err := SendToSyncada(fakeEdi, 12345, gexSender, sftpSender, true, suite.logger)
+		suite.NoError(err)
+	})
+}

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/gobuffalo/pop/v5"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services/invoice"
@@ -17,6 +18,16 @@ import (
 	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
 	"github.com/transcom/mymove/pkg/services"
 )
+
+//GexSendError is returned when there is an error sending an EDI to GEX
+type GexSendError struct {
+	paymentRequestID uuid.UUID
+	err              error
+}
+
+func (e GexSendError) Error() string {
+	return fmt.Sprintf("error sending the following EDI (PaymentRequest.ID: %s) to Syncada: %s", e.paymentRequestID, e.err.Error())
+}
 
 type paymentRequestReviewedProcessor struct {
 	db                            *pop.Connection
@@ -113,7 +124,7 @@ func (p *paymentRequestReviewedProcessor) ProcessAndLockReviewedPR(pr models.Pay
 		// If sent successfully to GEX, update payment request status to SENT_TO_GEX.
 		err = paymentrequesthelper.SendToSyncada(edi858cString, icn, p.gexSender, p.sftpSender, p.runSendToSyncada, p.logger)
 		if err != nil {
-			return fmt.Errorf("error sending the following EDI (PaymentRequest.ID: %s, error string) to Syncada: %s", lockedPR.ID, err)
+			return GexSendError{paymentRequestID: lockedPR.ID, err: err}
 		}
 		sentToGexAt := time.Now()
 		lockedPR.SentToGexAt = &sentToGexAt
@@ -153,7 +164,12 @@ func (p *paymentRequestReviewedProcessor) ProcessAndLockReviewedPR(pr models.Pay
 			)
 		}
 
-		pr.Status = models.PaymentRequestStatusEDIError
+		switch transactionError.(type) {
+		case GexSendError:
+			// if we failed in sending there is nothing to do here but retry later so keep the status the same
+		default:
+			pr.Status = models.PaymentRequestStatusEDIError
+		}
 		verrs, err = p.db.ValidateAndUpdate(&pr)
 		if err != nil {
 			p.logger.Error(
@@ -211,7 +227,13 @@ func (p *paymentRequestReviewedProcessor) ProcessReviewedPaymentRequest() error 
 	for _, pr := range reviewedPaymentRequests {
 		err := p.ProcessAndLockReviewedPR(pr)
 		if err != nil {
-			return err
+			switch err.(type) {
+			case GexSendError:
+				// if we failed in sending there is nothing to do here but retry later
+				return nil
+			default:
+				return err
+			}
 		}
 		numProcessed++
 	}

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -26,7 +26,7 @@ type GexSendError struct {
 }
 
 func (e GexSendError) Error() string {
-	return fmt.Sprintf("error sending the following EDI (PaymentRequest.ID: %s) to Syncada: %s", e.paymentRequestID, e.err.Error())
+	return fmt.Sprintf("error sending the following EDI (PaymentRequest.ID: %s) to GEX: %s", e.paymentRequestID, e.err.Error())
 }
 
 type paymentRequestReviewedProcessor struct {


### PR DESCRIPTION
## Description

Currently when the job runner processes a Payment Request and fails to send it to GEX due to connection issue the status of the request is changed. This should not be the case as the only option for us is to retry later. This PR fixes that so the status stays `REVIEWED` so that it will be retried later.

## Reviewer Notes

I moved some tests from the payment request reviewed processor into a file for send to syncada helper, since that's what was  really being tested.

## Setup

Make sure `GEX_URL` is not set in your environment
change line 601 of `cmd/milmove/serve.go` to return a non 200 status

```golang
			w.WriteHeader(http.StatusForbidden)
```

setup the server

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Mark existing payment requests as sent
```sql
update payment_requests SET status = 'SENT_TO_GEX';
```

Create a payment request
```sh
rm -f bin/prime-api-client
make bin/prime-api-client
prime-api-demo RDY4PY
```

Approve the payment request

Run the job runner and see that the status does not change

```sh
go run ./cmd/milmove-tasks process-edis --send-to-syncada
```

```sql
select * from payment_requests where id = '<id of pr>';
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7736) for this change