### PR TITLE
MB-7735 update date filter to use time stamp

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1767,7 +1767,7 @@ func init() {
           {
             "type": "string",
             "format": "date-time",
-            "description": "filters the date of when the service member submitted their move",
+            "description": "Start of the submitted at date in the user's local time zone converted to UTC",
             "name": "submittedAt",
             "in": "query"
           },
@@ -1983,7 +1983,7 @@ func init() {
           {
             "type": "string",
             "format": "date-time",
-            "description": "limit results to those matching submitted at date",
+            "description": "Start of the submitted at date in the user's local time zone converted to UTC",
             "name": "submittedAt",
             "in": "query"
           },
@@ -6198,7 +6198,7 @@ func init() {
           {
             "type": "string",
             "format": "date-time",
-            "description": "filters the date of when the service member submitted their move",
+            "description": "Start of the submitted at date in the user's local time zone converted to UTC",
             "name": "submittedAt",
             "in": "query"
           },
@@ -6426,7 +6426,7 @@ func init() {
           {
             "type": "string",
             "format": "date-time",
-            "description": "limit results to those matching submitted at date",
+            "description": "Start of the submitted at date in the user's local time zone converted to UTC",
             "name": "submittedAt",
             "in": "query"
           },

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1766,6 +1766,7 @@ func init() {
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "filters the date of when the service member submitted their move",
             "name": "submittedAt",
             "in": "query"
@@ -1981,7 +1982,7 @@ func init() {
           },
           {
             "type": "string",
-            "format": "date",
+            "format": "date-time",
             "description": "limit results to those matching submitted at date",
             "name": "submittedAt",
             "in": "query"
@@ -6196,6 +6197,7 @@ func init() {
           },
           {
             "type": "string",
+            "format": "date-time",
             "description": "filters the date of when the service member submitted their move",
             "name": "submittedAt",
             "in": "query"
@@ -6423,7 +6425,7 @@ func init() {
           },
           {
             "type": "string",
-            "format": "date",
+            "format": "date-time",
             "description": "limit results to those matching submitted at date",
             "name": "submittedAt",
             "in": "query"

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_parameters.go
@@ -74,7 +74,7 @@ type GetPaymentRequestsQueueParams struct {
 	  In: query
 	*/
 	Status []string
-	/*limit results to those matching submitted at date
+	/*Start of the submitted at date in the user's local time zone converted to UTC
 	  In: query
 	*/
 	SubmittedAt *strfmt.DateTime

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_parameters.go
@@ -77,7 +77,7 @@ type GetPaymentRequestsQueueParams struct {
 	/*limit results to those matching submitted at date
 	  In: query
 	*/
-	SubmittedAt *strfmt.Date
+	SubmittedAt *strfmt.DateTime
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -409,12 +409,12 @@ func (o *GetPaymentRequestsQueueParams) bindSubmittedAt(rawData []string, hasKey
 		return nil
 	}
 
-	// Format: date
-	value, err := formats.Parse("date", raw)
+	// Format: date-time
+	value, err := formats.Parse("date-time", raw)
 	if err != nil {
-		return errors.InvalidType("submittedAt", "query", "strfmt.Date", raw)
+		return errors.InvalidType("submittedAt", "query", "strfmt.DateTime", raw)
 	}
-	o.SubmittedAt = (value.(*strfmt.Date))
+	o.SubmittedAt = (value.(*strfmt.DateTime))
 
 	if err := o.validateSubmittedAt(formats); err != nil {
 		return err
@@ -426,7 +426,7 @@ func (o *GetPaymentRequestsQueueParams) bindSubmittedAt(rawData []string, hasKey
 // validateSubmittedAt carries on validations for parameter SubmittedAt
 func (o *GetPaymentRequestsQueueParams) validateSubmittedAt(formats strfmt.Registry) error {
 
-	if err := validate.FormatOf("submittedAt", "query", "date", o.SubmittedAt.String(), formats); err != nil {
+	if err := validate.FormatOf("submittedAt", "query", "date-time", o.SubmittedAt.String(), formats); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_payment_requests_queue_urlbuilder.go
@@ -26,7 +26,7 @@ type GetPaymentRequestsQueueURL struct {
 	PerPage                *int64
 	Sort                   *string
 	Status                 []string
-	SubmittedAt            *strfmt.Date
+	SubmittedAt            *strfmt.DateTime
 
 	_basePath string
 	// avoid unkeyed usage

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_parameters.go
@@ -82,7 +82,7 @@ type GetServicesCounselingQueueParams struct {
 	  In: query
 	*/
 	Status []string
-	/*filters the date of when the service member submitted their move
+	/*Start of the submitted at date in the user's local time zone converted to UTC
 	  In: query
 	*/
 	SubmittedAt *strfmt.DateTime

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_parameters.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_parameters.go
@@ -85,7 +85,7 @@ type GetServicesCounselingQueueParams struct {
 	/*filters the date of when the service member submitted their move
 	  In: query
 	*/
-	SubmittedAt *string
+	SubmittedAt *strfmt.DateTime
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -463,7 +463,25 @@ func (o *GetServicesCounselingQueueParams) bindSubmittedAt(rawData []string, has
 		return nil
 	}
 
-	o.SubmittedAt = &raw
+	// Format: date-time
+	value, err := formats.Parse("date-time", raw)
+	if err != nil {
+		return errors.InvalidType("submittedAt", "query", "strfmt.DateTime", raw)
+	}
+	o.SubmittedAt = (value.(*strfmt.DateTime))
 
+	if err := o.validateSubmittedAt(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSubmittedAt carries on validations for parameter SubmittedAt
+func (o *GetServicesCounselingQueueParams) validateSubmittedAt(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("submittedAt", "query", "date-time", o.SubmittedAt.String(), formats); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_urlbuilder.go
+++ b/pkg/gen/ghcapi/ghcoperations/queues/get_services_counseling_queue_urlbuilder.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
 
@@ -27,7 +28,7 @@ type GetServicesCounselingQueueURL struct {
 	RequestedMoveDate      *string
 	Sort                   *string
 	Status                 []string
-	SubmittedAt            *string
+	SubmittedAt            *strfmt.DateTime
 
 	_basePath string
 	// avoid unkeyed usage
@@ -170,7 +171,7 @@ func (o *GetServicesCounselingQueueURL) Build() (*url.URL, error) {
 
 	var submittedAtQ string
 	if o.SubmittedAt != nil {
-		submittedAtQ = *o.SubmittedAt
+		submittedAtQ = o.SubmittedAt.String()
 	}
 	if submittedAtQ != "" {
 		qs.Set("submittedAt", submittedAtQ)

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -96,12 +96,6 @@ func (h GetPaymentRequestsQueueHandler) Handle(params queues.GetPaymentRequestsQ
 		return queues.NewGetPaymentRequestsQueueForbidden()
 	}
 
-	var submittedAt *string
-	if params.SubmittedAt != nil {
-		str := params.SubmittedAt.String()
-		submittedAt = &str
-	}
-
 	listPaymentRequestParams := services.FetchPaymentRequestListParams{
 		Branch:                 params.Branch,
 		Locator:                params.Locator,
@@ -111,7 +105,7 @@ func (h GetPaymentRequestsQueueHandler) Handle(params queues.GetPaymentRequestsQ
 		Status:                 params.Status,
 		Page:                   params.Page,
 		PerPage:                params.PerPage,
-		SubmittedAt:            submittedAt,
+		SubmittedAt:            handlers.FmtDateTimePtrToPopPtr(params.SubmittedAt),
 		Sort:                   params.Sort,
 		Order:                  params.Order,
 	}
@@ -162,12 +156,6 @@ func (h GetServicesCounselingQueueHandler) Handle(params queues.GetServicesCouns
 		return queues.NewGetServicesCounselingQueueForbidden()
 	}
 
-	var submittedAt *string
-	if params.SubmittedAt != nil {
-		str := params.SubmittedAt.String()
-		submittedAt = &str
-	}
-
 	ListOrderParams := services.ListOrderParams{
 		Branch:                 params.Branch,
 		Locator:                params.Locator,
@@ -175,7 +163,7 @@ func (h GetServicesCounselingQueueHandler) Handle(params queues.GetServicesCouns
 		LastName:               params.LastName,
 		DestinationDutyStation: params.DestinationDutyStation,
 		OriginGBLOC:            params.OriginGBLOC,
-		SubmittedAt:            submittedAt,
+		SubmittedAt:            handlers.FmtDateTimePtrToPopPtr(params.SubmittedAt),
 		RequestedMoveDate:      params.RequestedMoveDate,
 		Page:                   params.Page,
 		PerPage:                params.PerPage,

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -162,6 +162,12 @@ func (h GetServicesCounselingQueueHandler) Handle(params queues.GetServicesCouns
 		return queues.NewGetServicesCounselingQueueForbidden()
 	}
 
+	var submittedAt *string
+	if params.SubmittedAt != nil {
+		str := params.SubmittedAt.String()
+		submittedAt = &str
+	}
+
 	ListOrderParams := services.ListOrderParams{
 		Branch:                 params.Branch,
 		Locator:                params.Locator,
@@ -169,7 +175,7 @@ func (h GetServicesCounselingQueueHandler) Handle(params queues.GetServicesCouns
 		LastName:               params.LastName,
 		DestinationDutyStation: params.DestinationDutyStation,
 		OriginGBLOC:            params.OriginGBLOC,
-		SubmittedAt:            params.SubmittedAt,
+		SubmittedAt:            submittedAt,
 		RequestedMoveDate:      params.RequestedMoveDate,
 		Page:                   params.Page,
 		PerPage:                params.PerPage,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -841,7 +841,8 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 		},
 	})
 
-	createdAtTime, _ := time.Parse("2006-01-02", "2020-10-29")
+	createdAtTime := time.Date(2020, 10, 29, 0, 0, 0, 0, time.UTC)
+	//createdAtTime, _ := time.Parse("2006-01-02", "2020-10-29")
 	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
 			CreatedAt: createdAtTime,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -842,7 +842,6 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	})
 
 	createdAtTime := time.Date(2020, 10, 29, 0, 0, 0, 0, time.UTC)
-	//createdAtTime, _ := time.Parse("2006-01-02", "2020-10-29")
 	testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
 			CreatedAt: createdAtTime,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -890,7 +890,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	})
 
 	suite.Run("returns results matching SubmittedAt date", func() {
-		submittedAtDate := strfmt.Date(time.Date(2020, 10, 29, 0, 0, 0, 0, time.UTC))
+		submittedAtDate := strfmt.DateTime(time.Date(2020, 10, 29, 0, 0, 0, 0, time.UTC))
 
 		params := queues.GetPaymentRequestsQueueParams{
 			HTTPRequest: request,

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -889,9 +889,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	})
 
 	suite.Run("returns results matching SubmittedAt date", func() {
-		submittedAtDate := strfmt.Date{}
-		err := submittedAtDate.UnmarshalText([]byte("2020-10-29"))
-		suite.NoError(err)
+		submittedAtDate := strfmt.Date(time.Date(2020, 10, 29, 0, 0, 0, 0, time.UTC))
 
 		params := queues.GetPaymentRequestsQueueParams{
 			HTTPRequest: request,

--- a/pkg/services/order.go
+++ b/pkg/services/order.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"time"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -27,7 +29,7 @@ type ListOrderParams struct {
 	LastName               *string
 	DestinationDutyStation *string
 	OriginGBLOC            *string
-	SubmittedAt            *string
+	SubmittedAt            *time.Time
 	RequestedMoveDate      *string
 	Status                 []string
 	Page                   *int64

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -244,14 +244,12 @@ func moveStatusFilter(statuses []string) QueryOption {
 	}
 }
 
-func submittedAtFilter(submittedAt *string) QueryOption {
+func submittedAtFilter(submittedAt *time.Time) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
-			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
-
 			// Between is inclusive, so the end date is set to 1 milsecond prior to the next day
-			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
-			query.Where("moves.submitted_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
+			submittedAtEnd := submittedAt.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
+			query.Where("moves.submitted_at between ? and ?", submittedAt.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -250,7 +250,8 @@ func submittedAtFilter(submittedAt *string) QueryOption {
 			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
 			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1)
 			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
-
+			// Use a timezone that is +UTC and at midnight
+			// Test endpoints of the ranges to make sure it excludes right before and right after
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
@@ -246,7 +247,10 @@ func moveStatusFilter(statuses []string) QueryOption {
 func submittedAtFilter(submittedAt *string) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
-			query.Where("CAST(moves.submitted_at AS DATE) = ?", *submittedAt)
+			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
+			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1)
+			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
+
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -248,10 +248,10 @@ func submittedAtFilter(submittedAt *string) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
 			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
-			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1)
-			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
-			// Use a timezone that is +UTC and at midnight
-			// Test endpoints of the ranges to make sure it excludes right before and right after
+
+			// Between is inclusive, so the end date is set to 1 milsecond prior to the next day
+			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
+			query.Where("moves.submitted_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -164,13 +164,6 @@ func (suite *OrderServiceSuite) TestListMoves() {
 				SubmittedAt: &submittedAt,
 			},
 		})
-		createdSubmittedDate := submittedAt.Format(time.RFC3339Nano)
-		params := services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
-
-		moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
-
-		suite.FatalNoError(err)
-		suite.Equal(1, len(moves))
 
 		// Test edge cases
 		submittedAt2 := time.Date(2022, 04, 02, 0, 0, 0, 0, time.UTC)
@@ -180,14 +173,6 @@ func (suite *OrderServiceSuite) TestListMoves() {
 			},
 		})
 
-		// Use previous date to search again
-		params = services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
-
-		moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
-
-		suite.FatalNoError(err)
-		suite.Equal(1, len(moves))
-
 		// Test edge cases
 		submittedAt3 := time.Date(2022, 03, 31, 23, 59, 59, 59, time.UTC)
 		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
@@ -196,10 +181,9 @@ func (suite *OrderServiceSuite) TestListMoves() {
 			},
 		})
 
-		// Use previous date to search again
-		params = services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
+		params := services.ListOrderParams{SubmittedAt: &submittedAt}
 
-		moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
+		moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
 
 		suite.FatalNoError(err)
 		suite.Equal(1, len(moves))

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -169,6 +168,38 @@ func (suite *OrderServiceSuite) TestListMoves() {
 		params := services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
 
 		moves, _, err := orderFetcher.ListOrders(officeUser.ID, &params)
+
+		suite.FatalNoError(err)
+		suite.Equal(1, len(moves))
+
+		// Test edge cases
+		submittedAt2 := time.Date(2022, 04, 02, 0, 0, 0, 0, time.UTC)
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				SubmittedAt: &submittedAt2,
+			},
+		})
+
+		// Use previous date to search again
+		params = services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
+
+		moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
+
+		suite.FatalNoError(err)
+		suite.Equal(1, len(moves))
+
+		// Test edge cases
+		submittedAt3 := time.Date(2022, 03, 31, 23, 59, 59, 59, time.UTC)
+		testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				SubmittedAt: &submittedAt3,
+			},
+		})
+
+		// Use previous date to search again
+		params = services.ListOrderParams{SubmittedAt: &createdSubmittedDate}
+
+		moves, _, err = orderFetcher.ListOrders(officeUser.ID, &params)
 
 		suite.FatalNoError(err)
 		suite.Equal(1, len(moves))

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"io"
+	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -62,7 +63,7 @@ type FetchPaymentRequestListParams struct {
 	Status                 []string
 	Page                   *int64
 	PerPage                *int64
-	SubmittedAt            *string
+	SubmittedAt            *time.Time
 	Sort                   *string
 	Order                  *string
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/swag"
 
@@ -259,7 +260,9 @@ func destinationDutyStationFilter(destinationDutyStation *string) QueryOption {
 func submittedAtFilter(submittedAt *string) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
-			query.Where("CAST(payment_requests.created_at AS DATE) = ?", *submittedAt)
+			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
+			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1)
+			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -264,7 +264,7 @@ func submittedAtFilter(submittedAt *string) QueryOption {
 
 			// Between is inclusive, so the end date is set to 1 milsecond prior to the next day
 			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
-			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
+			query.Where("payment_requests.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -261,7 +261,9 @@ func submittedAtFilter(submittedAt *string) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
 			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
-			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1)
+
+			// Between is inclusive, so the end date is set to 1 milsecond prior to the next day
+			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
 			query.Where("moves.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -257,14 +257,12 @@ func destinationDutyStationFilter(destinationDutyStation *string) QueryOption {
 	}
 }
 
-func submittedAtFilter(submittedAt *string) QueryOption {
+func submittedAtFilter(submittedAt *time.Time) QueryOption {
 	return func(query *pop.Query) {
 		if submittedAt != nil {
-			submittedAtStart, _ := time.Parse(time.RFC3339, *submittedAt)
-
 			// Between is inclusive, so the end date is set to 1 milsecond prior to the next day
-			submittedAtEnd := submittedAtStart.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
-			query.Where("payment_requests.created_at between ? and ?", submittedAtStart.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
+			submittedAtEnd := submittedAt.AddDate(0, 0, 1).Add(-1 * time.Millisecond)
+			query.Where("payment_requests.created_at between ? and ?", submittedAt.Format(time.RFC3339), submittedAtEnd.Format(time.RFC3339))
 		}
 	}
 }

--- a/src/components/Table/Filters/DateSelectFilter.jsx
+++ b/src/components/Table/Filters/DateSelectFilter.jsx
@@ -6,7 +6,7 @@ import SingleDatePicker from '../../../shared/JsonSchemaForm/SingleDatePicker';
 import { formatDateForSwagger, formatDateTime } from 'shared/dates';
 
 // Return function with proper type
-const DateSelectFilter = ({ type, column: { filterValue, setFilter } }) => {
+const DateSelectFilter = ({ dateTime, column: { filterValue, setFilter } }) => {
   return (
     <SingleDatePicker
       value={filterValue || ''}
@@ -14,10 +14,15 @@ const DateSelectFilter = ({ type, column: { filterValue, setFilter } }) => {
       data-testid="DateSelectFilter"
       placeholder=""
       onChange={(e) => {
-        setFilter(type === 'DateTime' ? formatDateTime(e) || undefined : formatDateForSwagger(e) || undefined); // Set undefined to remove the filter entirely
+        setFilter(dateTime ? formatDateTime(e) || undefined : formatDateForSwagger(e) || undefined); // Set undefined to remove the filter entirely
       }}
     />
   );
+};
+
+//
+DateSelectFilter.defaultProps = {
+  dateTime: false,
 };
 
 // Values come from react-table
@@ -26,7 +31,7 @@ DateSelectFilter.propTypes = {
     filterValue: PropTypes.string,
     setFilter: PropTypes.func,
   }).isRequired,
-  type: PropTypes.string.isRequired,
+  dateTime: PropTypes.bool,
 };
 
 export default DateSelectFilter;

--- a/src/components/Table/Filters/DateSelectFilter.jsx
+++ b/src/components/Table/Filters/DateSelectFilter.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 
 import SingleDatePicker from '../../../shared/JsonSchemaForm/SingleDatePicker';
 
-import { formatDateForSwagger } from 'shared/dates';
+import { formatDateForSwagger, formatDateTime } from 'shared/dates';
 
-const DateSelectFilter = ({ column: { filterValue, setFilter } }) => {
+// Return function with proper type
+const DateSelectFilter = ({ type, column: { filterValue, setFilter } }) => {
   return (
     <SingleDatePicker
       value={filterValue || ''}
@@ -13,7 +14,7 @@ const DateSelectFilter = ({ column: { filterValue, setFilter } }) => {
       data-testid="DateSelectFilter"
       placeholder=""
       onChange={(e) => {
-        setFilter(formatDateForSwagger(e) || undefined); // Set undefined to remove the filter entirely
+        setFilter(type === 'DateTime' ? formatDateTime(e) || undefined : formatDateForSwagger(e) || undefined); // Set undefined to remove the filter entirely
       }}
     />
   );
@@ -25,6 +26,7 @@ DateSelectFilter.propTypes = {
     filterValue: PropTypes.string,
     setFilter: PropTypes.func,
   }).isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 export default DateSelectFilter;

--- a/src/components/Table/Filters/DateSelectFilter.test.jsx
+++ b/src/components/Table/Filters/DateSelectFilter.test.jsx
@@ -4,9 +4,21 @@ import { mount } from 'enzyme';
 import DateSelectFilter from './DateSelectFilter';
 
 describe('React table', () => {
-  it('renders without crashing', () => {
+  it('renders without crashing as a Date', () => {
     const wrapper = mount(
       <DateSelectFilter
+        column={{
+          filterValue: '',
+          setFilter: jest.fn(),
+        }}
+      />,
+    );
+    expect(wrapper.find('[data-testid="DateSelectFilter"]').length).toBe(1);
+  });
+  it('renders without crashing as a DateTime', () => {
+    const wrapper = mount(
+      <DateSelectFilter
+        dateTime
         column={{
           filterValue: '',
           setFilter: jest.fn(),

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -68,7 +68,7 @@ const columns = (showBranchFilter = true) => [
       id: 'submittedAt',
       isFilterable: true,
       // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter {...props} />,
+      Filter: (props) => <DateSelectFilter dateTime {...props} />,
     },
   ),
   createHeader('Move Code', 'locator', {

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -68,7 +68,7 @@ const columns = (showBranchFilter = true) => [
       id: 'submittedAt',
       isFilterable: true,
       // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter type="DateTime" {...props} />,
+      Filter: (props) => <DateSelectFilter {...props} />,
     },
   ),
   createHeader('Move Code', 'locator', {

--- a/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
+++ b/src/pages/Office/PaymentRequestQueue/PaymentRequestQueue.jsx
@@ -67,7 +67,8 @@ const columns = (showBranchFilter = true) => [
     {
       id: 'submittedAt',
       isFilterable: true,
-      Filter: DateSelectFilter,
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      Filter: (props) => <DateSelectFilter type="DateTime" {...props} />,
     },
   ),
   createHeader('Move Code', 'locator', {

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -59,7 +59,8 @@ const columns = (isMarineCorpsUser = false) => [
     {
       id: 'requestedMoveDate',
       isFilterable: true,
-      Filter: DateSelectFilter,
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      Filter: (props) => <DateSelectFilter type="Date" {...props} />,
     },
   ),
   createHeader(
@@ -70,7 +71,8 @@ const columns = (isMarineCorpsUser = false) => [
     {
       id: 'submittedAt',
       isFilterable: true,
-      Filter: DateSelectFilter,
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      Filter: (props) => <DateSelectFilter type="DateTime" {...props} />,
     },
   ),
   createHeader(

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -60,7 +60,7 @@ const columns = (isMarineCorpsUser = false) => [
       id: 'requestedMoveDate',
       isFilterable: true,
       // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter type="Date" {...props} />,
+      Filter: (props) => <DateSelectFilter {...props} />,
     },
   ),
   createHeader(
@@ -72,7 +72,7 @@ const columns = (isMarineCorpsUser = false) => [
       id: 'submittedAt',
       isFilterable: true,
       // eslint-disable-next-line react/jsx-props-no-spreading
-      Filter: (props) => <DateSelectFilter type="DateTime" {...props} />,
+      Filter: (props) => <DateSelectFilter dateTime {...props} />,
     },
   ),
   createHeader(

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -12,6 +12,7 @@ const allowedDateFormats = [
   'MMM-D-YYYY',
   'DD-MMM-YY',
   'DD MMM YYYY',
+  'YYYY-MM-DDTHH:MM:SSZ',
 ];
 
 export function parseDate(str, _format, locale = 'en') {
@@ -37,6 +38,6 @@ export function formatDateForSwagger(dateString) {
 export function formatDateTime(dateString) {
   if (dateString) {
     const startOfDay = moment(dateString).hour(0);
-    return moment.utc(startOfDay).format();
+    return moment.utc(startOfDay).format('YYYY-MM-DDTHH:MM:SSZ');
   }
 }

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -33,3 +33,10 @@ export function formatDateForSwagger(dateString) {
     return formatDate(dateString, swaggerDateFormat);
   }
 }
+
+export function formatDateTime(dateString) {
+  if (dateString) {
+    const startOfDay = moment(dateString).hour(0);
+    return moment.utc(startOfDay).format();
+  }
+}

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 export const swaggerDateFormat = 'YYYY-MM-DD';
 export const defaultDateFormat = 'M/D/YYYY';
+export const utcDateFormat = 'YYYY-MM-DDThh:mm:ssZ';
 
 // First date format is take to be the default
 const allowedDateFormats = [
@@ -12,7 +13,7 @@ const allowedDateFormats = [
   'MMM-D-YYYY',
   'DD-MMM-YY',
   'DD MMM YYYY',
-  'YYYY-MM-DDTHH:MM:SSZ',
+  'YYYY-MM-DDThh:mm:ssZ',
 ];
 
 export function parseDate(str, _format, locale = 'en') {
@@ -38,6 +39,6 @@ export function formatDateForSwagger(dateString) {
 export function formatDateTime(dateString) {
   if (dateString) {
     const startOfDay = moment(dateString).hour(0);
-    return moment.utc(startOfDay).format('YYYY-MM-DDTHH:MM:SSZ');
+    return moment.utc(startOfDay).format(utcDateFormat);
   }
 }

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -1,4 +1,4 @@
-import { parseDate, formatDate, formatDateForSwagger } from './dates';
+import { parseDate, formatDate, formatDateForSwagger, formatDateTime } from './dates';
 import moment from 'moment';
 describe('dates', () => {
   describe('parseDate', () => {
@@ -48,6 +48,14 @@ describe('dates', () => {
       const result = formatDateForSwagger('8-23-2019');
       it('should return a date in the format swagger accepts', () => {
         expect(result).toEqual('2019-08-23');
+      });
+    });
+  });
+  describe('formatDateTime', () => {
+    describe('when parsing a date that does the match allowed date formats', () => {
+      const result = formatDateTime('8-23-2019');
+      it('should return a date in the format swagger accepts', () => {
+        expect(result).toEqual('2019-08-23T12:00:00+00:00');
       });
     });
   });

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1205,6 +1205,7 @@ paths:
         - in: query
           name: submittedAt
           type: string
+          format: date-time
           description: filters the date of when the service member submitted their move
         - in: query
           name: originGBLOC
@@ -1337,7 +1338,7 @@ paths:
         - in: query
           name: submittedAt
           type: string
-          format: date
+          format: date-time
           description: limit results to those matching submitted at date
         - in: query
           name: branch

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1206,7 +1206,7 @@ paths:
           name: submittedAt
           type: string
           format: date-time
-          description: filters the date of when the service member submitted their move
+          description: Start of the submitted at date in the user's local time zone converted to UTC
         - in: query
           name: originGBLOC
           type: string
@@ -1339,7 +1339,7 @@ paths:
           name: submittedAt
           type: string
           format: date-time
-          description: limit results to those matching submitted at date
+          description: Start of the submitted at date in the user's local time zone converted to UTC
         - in: query
           name: branch
           type: string


### PR DESCRIPTION
## Description

This PR updates the DateFilterSelectFilter.jsx component to allow it to return either just a date or a UTC time stamp. The services counselor and payment request queues' submittedAt columns have been updated to use the time stamp option. Using the the time stamp will account for different time zones and will ensure the correct rows are returned. Additionally, the service objects have been updated so the submittedAt filter will account for the 24hr period for the individuals timezone. 

## Reviewer Notes

One server test is currently failing for the payment request queue, and I'm not sure whats going on. I'm planning on looking at it more tomorrow morning. 

## Setup

To test that the correct dates are filtered complete the following steps:
* Start the office app locally
* Navigate to the Services counselor queue
* Test the SubmittedAt filter and the requested move date filter

* Navigate to the TIO payment requests queue
* Test the SubmittedAt filter

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7735) for this change