### PR TITLE
[MB-5824]Truss-IS3 as code owners of cATO related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,9 @@
 *.css @transcom/truss-design
 *.scss @transcom/truss-design
 
-# Require team Pamplemoose to review changes to configs that may affect cATO static analysis compliancy
-.golangci.yaml @transcom/Truss-Pamplemoose
-.pre-commit-config.yaml @transcom/Truss-Pamplemoose
+# Require security group to review changes to configs that may affect cATO static analysis compliancy
+.golangci.yaml @transcom/Truss-IS3
+.pre-commit-config.yaml @transcom/Truss-IS3
+.eslintrc.js @transcom/Truss-IS3
+/eslint-plugin-ato/ @transcom/Truss-IS3
+/pkg/ato-linter/ @transcom/Truss-IS3

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -178,7 +178,7 @@ const bypassingLinterChecks = async () => {
   if (dangerMsgSegment) {
     warn(
       `It looks like you are attempting to bypass a linter rule, which is not within
-      security compliance rules.\n** ${dangerMsgSegment} **\n Please remove the bypass code and address the underlying issue. cc: @transcom/Truss-Pamplemoose`,
+      security compliance rules.\n** ${dangerMsgSegment} **\n Please remove the bypass code and address the underlying issue. cc: @transcom/Truss-IS3`,
     );
   }
 };


### PR DESCRIPTION
## Description

Changed codeowners of cATO related files (lint, config) to Truss-IS3 

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5824) for this change

