### PR TITLE
[DRAFT] Discovery design doc for Logoff POAM, not working draft of needed changes for logoff

### DIFF
--- a/src/containers/LoginButton/LoginButton.jsx
+++ b/src/containers/LoginButton/LoginButton.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { bool, func } from 'prop-types';
@@ -20,11 +20,6 @@ import { HistoryShape } from 'types/customerShapes';
 
 const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete, history }) => {
   const [showEula, setShowEula] = useState(false);
-  useEffect(() => {
-    return () => {
-      history.replace('', null);
-    };
-  });
 
   if (!isLoggedIn) {
     return (
@@ -66,7 +61,7 @@ const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete
     logOut();
     LogoutUser().then(() => {
       console.log('logoutuser then -- LoginButton.jsx');
-      history.replace({
+      history.push({
         pathname: '/sign-in',
         state: { hasLoggedOut: true },
       });
@@ -92,7 +87,7 @@ const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete
           aria-label="Sign Out"
           className={styles.signOut}
           data-testid="signout"
-          onClick={() => handleLogOut}
+          onClick={handleLogOut}
           type="button"
         >
           Sign Out
@@ -107,7 +102,11 @@ LoginButton.propTypes = {
   logOut: func.isRequired,
   showDevlocalButton: bool.isRequired,
   isProfileComplete: bool.isRequired,
-  history: HistoryShape.isRequired,
+  history: HistoryShape,
+};
+
+LoginButton.defaultProps = {
+  history: { goBack: () => {}, push: () => {}, replace: () => {} },
 };
 
 function mapStateToProps(state) {

--- a/src/containers/LoginButton/LoginButton.jsx
+++ b/src/containers/LoginButton/LoginButton.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { bool, func } from 'prop-types';
@@ -16,9 +16,15 @@ import { logOut as logOutFunction } from 'store/auth/actions';
 import ConnectedEulaModal from 'components/EulaModal';
 import { customerRoutes } from 'constants/routes';
 import { selectIsProfileComplete } from 'store/entities/selectors';
+import { HistoryShape } from 'types/customerShapes';
 
-const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete }) => {
+const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete, history }) => {
   const [showEula, setShowEula] = useState(false);
+  useEffect(() => {
+    return () => {
+      history.replace('', null);
+    };
+  });
 
   if (!isLoggedIn) {
     return (
@@ -58,7 +64,13 @@ const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete
   }
   const handleLogOut = () => {
     logOut();
-    LogoutUser();
+    LogoutUser().then(() => {
+      console.log('logoutuser then -- LoginButton.jsx');
+      history.replace({
+        pathname: '/sign-in',
+        state: { hasLoggedOut: true },
+      });
+    });
   };
 
   return (
@@ -80,7 +92,7 @@ const LoginButton = ({ isLoggedIn, logOut, showDevlocalButton, isProfileComplete
           aria-label="Sign Out"
           className={styles.signOut}
           data-testid="signout"
-          onClick={handleLogOut}
+          onClick={() => handleLogOut}
           type="button"
         >
           Sign Out
@@ -95,6 +107,7 @@ LoginButton.propTypes = {
   logOut: func.isRequired,
   showDevlocalButton: bool.isRequired,
   isProfileComplete: bool.isRequired,
+  history: HistoryShape.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import { Button } from '@trussworks/react-uswds';
 import { generatePath } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 import styles from './Home.module.scss';
 import {
@@ -430,9 +431,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 });
 
 export default withContext(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps,
-  )(requireCustomerState(Home, profileStates.BACKUP_CONTACTS_COMPLETE)),
+  withRouter(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps,
+      mergeProps,
+    )(requireCustomerState(Home, profileStates.BACKUP_CONTACTS_COMPLETE)),
+  ),
 );

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -32,6 +32,7 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { withContext } from 'shared/AppContext';
 import { LocationShape, UserRolesShape, OfficeUserInfoShape } from 'types/index';
 import { LogoutUser } from 'utils/api';
+import { HistoryShape } from 'types/customerShapes';
 
 // Lazy load these dependencies (they correspond to unique routes & only need to be loaded when that URL is accessed)
 const SignIn = lazy(() => import('pages/SignIn/SignIn'));
@@ -90,6 +91,7 @@ export class OfficeApp extends Component {
       officeUser,
       location: { pathname },
       logOut,
+      history,
     } = this.props;
     const selectedRole = userIsLoggedIn && activeRole;
 
@@ -176,7 +178,13 @@ export class OfficeApp extends Component {
                     firstName={officeUser.first_name}
                     handleLogout={() => {
                       logOut();
-                      LogoutUser();
+                      LogoutUser().then(() => {
+                        console.log('logoutuser then -- Office/index.jsx');
+                        history.push({
+                          pathname: '/sign-in',
+                          state: { hasLoggedOut: true },
+                        });
+                      });
                     }}
                   >
                     {officeUser.transportation_office && (
@@ -275,6 +283,7 @@ OfficeApp.propTypes = {
   activeRole: PropTypes.string,
   officeUser: OfficeUserInfoShape,
   logOut: PropTypes.func.isRequired,
+  history: HistoryShape.isRequired,
 };
 
 OfficeApp.defaultProps = {

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import qs from 'query-string';
 import { bool, shape, string } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
@@ -10,13 +10,19 @@ import { withContext } from 'shared/AppContext';
 import Alert from 'shared/Alert';
 import ConnectedEulaModal from 'components/EulaModal';
 import { LocationShape } from 'types/index';
+import { HistoryShape } from 'types/customerShapes';
 
-const SignIn = ({ context, location }) => {
+const SignIn = ({ context, location, history }) => {
   const [showEula, setShowEula] = useState(false);
 
   const { error } = qs.parse(location.search);
   const hash = qs.parse(location.hash);
   const { siteName, showLoginWarning } = context;
+  useEffect(() => {
+    return () => {
+      history.replace('', null);
+    };
+  });
 
   return (
     <div className="grid-container usa-prose">
@@ -41,6 +47,13 @@ const SignIn = ({ context, location }) => {
             <div>
               <Alert type="error" heading="Logged out">
                 You have been logged out due to inactivity.
+              </Alert>
+            </div>
+          )}
+          {location.state && location.state.hasLoggedOut && (
+            <div>
+              <Alert type="success" heading="You have signed out of MilMove">
+                You have successfully signed out
               </Alert>
             </div>
           )}
@@ -85,6 +98,7 @@ SignIn.propTypes = {
     showLoginWarning: bool,
   }).isRequired,
   location: LocationShape.isRequired,
+  history: HistoryShape.isRequired,
 };
 
 export default withContext(SignIn);

--- a/src/types/customerShapes.js
+++ b/src/types/customerShapes.js
@@ -121,6 +121,7 @@ export const MatchShape = shape({
 export const HistoryShape = shape({
   goBack: func.isRequired,
   push: func.isRequired,
+  replace: func.isRequired,
 });
 
 export const PageListShape = arrayOf(string);

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,7 +2,7 @@
 // utility functions related to API interactions
 
 import Swagger from 'swagger-client';
-import qs from 'query-string';
+// import qs from 'query-string';
 
 import { getClient, checkResponse, requestInterceptor } from 'shared/Swagger/api';
 
@@ -30,7 +30,7 @@ export async function GetIsLoggedIn() {
   return response.body;
 }
 
-export async function LogoutUser(timedout) {
+export function LogoutUser() {
   const logoutEndpoint = '/auth/logout';
   const req = {
     url: logoutEndpoint,
@@ -38,7 +38,11 @@ export async function LogoutUser(timedout) {
     credentials: 'same-origin', // Passes through CSRF cookies
     requestInterceptor,
   };
-  try {
+  console.log('return swagger.http from LogoutUser');
+  return Swagger.http(req);
+  /*
+ TODO: timeout modification will be needed
+ try {
     // Successful logout should return a redirect url
     const resp = await Swagger.http(req);
     const redirectUrl = timedout ? qs.stringifyUrl({ url: resp.text, fragmentIdentifier: 'timedout' }) : resp.text;
@@ -47,4 +51,5 @@ export async function LogoutUser(timedout) {
     // Failure to logout should return user to homepage
     window.location.href = '/';
   }
+  */
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -30,6 +30,34 @@ export async function GetIsLoggedIn() {
   return response.body;
 }
 
+/*
+export async function LogoutUser(timedout) {
+  const logoutEndpoint = '/auth/logout';
+  const req = {
+    url: logoutEndpoint,
+    method: 'POST',
+    credentials: 'same-origin', // Passes through CSRF cookies
+    requestInterceptor,
+  };
+  console.log('return swagger.http from LogoutUser');
+
+  try {
+    // Successful logout should return a redirect url
+    const resp = await Swagger.http(req);
+    console.log('LogoutUser after Swagger.http call');
+    history.replace({
+      pathname: '/sign-in',
+      state: { hasLoggedOut: true },
+    });
+    const redirectUrl = timedout ? qs.stringifyUrl({ url: resp.text, fragmentIdentifier: 'timedout' }) : resp.text;
+    window.location.href = redirectUrl;
+  } catch (err) {
+    // Failure to logout should return user to homepage
+    window.location.href = '/';
+  }
+}
+ */
+
 export function LogoutUser() {
   const logoutEndpoint = '/auth/logout';
   const req = {
@@ -40,16 +68,4 @@ export function LogoutUser() {
   };
   console.log('return swagger.http from LogoutUser');
   return Swagger.http(req);
-  /*
- TODO: timeout modification will be needed
- try {
-    // Successful logout should return a redirect url
-    const resp = await Swagger.http(req);
-    const redirectUrl = timedout ? qs.stringifyUrl({ url: resp.text, fragmentIdentifier: 'timedout' }) : resp.text;
-    window.location.href = redirectUrl;
-  } catch (err) {
-    // Failure to logout should return user to homepage
-    window.location.href = '/';
-  }
-  */
 }


### PR DESCRIPTION
## Description

This PR is a companion to the [Discovery for Logoff POAM document](https://docs.google.com/document/d/1lHsA-ugUR_7vanXM38lXuLhuFTXbDKUvIHvUdiP_P_Y/edit#heading=h.i1spgnekh1dw).

The office application changes are working. Right now, the customer application is not working and I've include the changes that are failing in hopes to get feedback on how to fix it. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7952) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
