### PR TITLE
[MB-8034] Fix remaining lint errors in pkg directory

### DIFF
--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -105,7 +105,8 @@ func setupScsSession(ctx context.Context, session *auth.Session, sessionManager 
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	sessionManager.Store.Commit("session_token", b, expiry) // nolint:errcheck
+	// nolint:errcheck
+	sessionManager.Store.Commit("session_token", b, expiry)
 	scsContext, _ := sessionManager.Load(ctx, "session_token")
 	//RA Summary: gosec - errcheck - Unchecked return value
 	//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
@@ -115,7 +116,8 @@ func setupScsSession(ctx context.Context, session *auth.Session, sessionManager 
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	sessionManager.Commit(scsContext) // nolint:errcheck
+	// nolint:errcheck
+	sessionManager.Commit(scsContext)
 	return scsContext
 }
 

--- a/pkg/auth/authentication/login_gov.go
+++ b/pkg/auth/authentication/login_gov.go
@@ -150,7 +150,6 @@ func (p LoginGovProvider) AuthorizationURL(r *http.Request) (*LoginGovData, erro
 
 // LogoutURL returns a full URL to log out of login.gov with required params
 func (p LoginGovProvider) LogoutURL(redirectURL string, idToken string) string {
-	/* #nosec URL is known to be good */
 	logoutPath, _ := url.Parse(fmt.Sprintf("https://%s/openid_connect/logout", p.hostname))
 	// Parameters taken from https://developers.login.gov/oidc/#logout
 	params := url.Values{

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -35,7 +35,8 @@ func (suite *certTestSuite) Setup(fn initFlags, flagSet []string) {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	flag.Parse(flagSet) // nolint:errcheck
+	// nolint:errcheck
+	flag.Parse(flagSet)
 
 	v := viper.New()
 	err := v.BindPFlags(flag)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -34,7 +34,8 @@ func (suite *cliTestSuite) Setup(fn initFlags, flagSet []string) {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	flag.Parse(flagSet) // nolint:errcheck
+	// nolint:errcheck
+	flag.Parse(flagSet)
 
 	v := viper.New()
 	err := v.BindPFlags(flag)

--- a/pkg/handlers/adminapi/api_test.go
+++ b/pkg/handlers/adminapi/api_test.go
@@ -36,7 +36,8 @@ func (suite *HandlerSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Data.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Data.Close()
 	}
 }
 

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -34,7 +34,8 @@ func (suite *HandlerSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Data.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Data.Close()
 	}
 }
 

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -34,7 +34,8 @@ func (suite *HandlerSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Data.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Data.Close()
 	}
 }
 

--- a/pkg/handlers/internalapi/backup_contacts.go
+++ b/pkg/handlers/internalapi/backup_contacts.go
@@ -36,7 +36,6 @@ func (h CreateBackupContactHandler) Handle(params backupop.CreateServiceMemberBa
 
 	// User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromContext(ctx)
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
 	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
@@ -65,7 +64,6 @@ type IndexBackupContactsHandler struct {
 func (h IndexBackupContactsHandler) Handle(params backupop.IndexServiceMemberBackupContactsParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
 	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
 	if err != nil {
@@ -92,7 +90,6 @@ type ShowBackupContactHandler struct {
 func (h ShowBackupContactHandler) Handle(params backupop.ShowServiceMemberBackupContactParams) middleware.Responder {
 	// User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	contactID, _ := uuid.FromString(params.BackupContactID.String())
 	contact, err := models.FetchBackupContact(h.DB(), session, contactID)
 	if err != nil {
@@ -112,7 +109,6 @@ type UpdateBackupContactHandler struct {
 func (h UpdateBackupContactHandler) Handle(params backupop.UpdateServiceMemberBackupContactParams) middleware.Responder {
 	// User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	contactID, _ := uuid.FromString(params.BackupContactID.String())
 	contact, err := models.FetchBackupContact(h.DB(), session, contactID)
 	if err != nil {

--- a/pkg/handlers/internalapi/backup_contacts_test.go
+++ b/pkg/handlers/internalapi/backup_contacts_test.go
@@ -51,7 +51,8 @@ func (suite *HandlerSuite) TestCreateBackupContactHandler() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	suite.DB().Q().Eager().All(&contacts) // nolint:errcheck
+	// nolint:errcheck
+	suite.DB().Q().Eager().All(&contacts)
 	if len(contacts) != 1 {
 		t.Errorf("Expected to find 1 result but found %v", len(contacts))
 	}

--- a/pkg/handlers/internalapi/generic_move_documents.go
+++ b/pkg/handlers/internalapi/generic_move_documents.go
@@ -39,8 +39,10 @@ type CreateGenericMoveDocumentHandler struct {
 // Handle is the handler
 func (h CreateGenericMoveDocumentHandler) Handle(params movedocop.CreateGenericMoveDocumentParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)

--- a/pkg/handlers/internalapi/generic_move_documents_test.go
+++ b/pkg/handlers/internalapi/generic_move_documents_test.go
@@ -65,7 +65,8 @@ func (suite *HandlerSuite) TestCreateGenericMoveDocumentHandler() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	suite.DB().Find(&fetchedUpload, userUpload.ID) // nolint:errcheck
+	// nolint:errcheck
+	suite.DB().Find(&fetchedUpload, userUpload.ID)
 	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
 
 	// Next try the wrong user

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -181,11 +181,12 @@ type IndexMoveDocumentsHandler struct {
 
 // Handle handles the request
 func (h IndexMoveDocumentsHandler) Handle(params movedocop.IndexMoveDocumentsParams) middleware.Responder {
-	// #nosec User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
 
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)
 	if err != nil {

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -75,7 +75,8 @@ func (suite *HandlerSuite) TestCreateMoveDocumentHandler() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	suite.DB().Find(&fetchedUpload, userUpload.ID) // nolint:errcheck
+	// nolint:errcheck
+	suite.DB().Find(&fetchedUpload, userUpload.ID)
 	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
 
 	// Next try the wrong user

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -87,7 +87,6 @@ type ShowMoveHandler struct {
 func (h ShowMoveHandler) Handle(params moveop.ShowMoveParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
@@ -117,7 +116,6 @@ type PatchMoveHandler struct {
 // Handle ... patches a Move from a request payload
 func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
@@ -162,7 +160,6 @@ type SubmitMoveHandler struct {
 func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	/* #nosec UUID is pattern matched by swagger which checks the format */
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	move, err := models.FetchMove(h.DB(), session, moveID)

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -44,8 +44,10 @@ type CreateMovingExpenseDocumentHandler struct {
 // Handle is the handler
 func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMovingExpenseDocumentParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)

--- a/pkg/handlers/internalapi/moving_expense_documents_test.go
+++ b/pkg/handlers/internalapi/moving_expense_documents_test.go
@@ -70,7 +70,8 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandler() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	suite.DB().Find(&fetchedUpload, userUpload.ID) // nolint:errcheck
+	// nolint:errcheck
+	suite.DB().Find(&fetchedUpload, userUpload.ID)
 	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
 
 	// Check that the status is correct

--- a/pkg/handlers/internalapi/office.go
+++ b/pkg/handlers/internalapi/office.go
@@ -25,8 +25,12 @@ func (h ApproveMoveHandler) Handle(params officeop.ApproveMoveParams) middleware
 	if !session.IsOfficeUser() {
 		return officeop.NewApproveMoveForbidden()
 	}
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
 	move, err := models.FetchMove(h.DB(), session, moveID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
@@ -72,8 +76,10 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 		return officeop.NewCancelMoveForbidden()
 	}
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	move, err := models.FetchMove(h.DB(), session, moveID)
 	if err != nil {
@@ -121,8 +127,10 @@ func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.R
 		return officeop.NewApprovePPMForbidden()
 	}
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
 	if err != nil {
@@ -172,8 +180,10 @@ func (h ApproveReimbursementHandler) Handle(params officeop.ApproveReimbursement
 		return officeop.NewApproveReimbursementForbidden()
 	}
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	reimbursementID, _ := uuid.FromString(params.ReimbursementID.String())
+	reimbursementID, err := uuid.FromString(params.ReimbursementID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	reimbursement, err := models.FetchReimbursement(h.DB(), session, reimbursementID)
 	if err != nil {

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -162,8 +162,11 @@ type ShowOrdersHandler struct {
 // Handle retrieves orders in the system belonging to the logged in user given order ID
 func (h ShowOrdersHandler) Handle(params ordersop.ShowOrdersParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec swagger verifies uuid format
-	orderID, _ := uuid.FromString(params.OrdersID.String())
+	orderID, err := uuid.FromString(params.OrdersID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
 	order, err := models.FetchOrderForUser(h.DB(), session, orderID)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -97,8 +97,10 @@ type CreatePersonallyProcuredMoveHandler struct {
 // Handle is the handler
 func (h CreatePersonallyProcuredMoveHandler) Handle(params ppmop.CreatePersonallyProcuredMoveParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)
@@ -149,10 +151,11 @@ type IndexPersonallyProcuredMovesHandler struct {
 
 // Handle handles the request
 func (h IndexPersonallyProcuredMovesHandler) Handle(params ppmop.IndexPersonallyProcuredMovesParams) middleware.Responder {
-	// #nosec User should always be populated by middleware
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)
@@ -267,10 +270,15 @@ type UpdatePersonallyProcuredMoveEstimateHandler struct {
 func (h UpdatePersonallyProcuredMoveEstimateHandler) Handle(params ppmop.UpdatePersonallyProcuredMoveEstimateParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
 	if err != nil {
@@ -334,10 +342,15 @@ type PatchPersonallyProcuredMoveHandler struct {
 func (h PatchPersonallyProcuredMoveHandler) Handle(params ppmop.PatchPersonallyProcuredMoveParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
 	if err != nil {
@@ -372,11 +385,12 @@ type SubmitPersonallyProcuredMoveHandler struct {
 func (h SubmitPersonallyProcuredMoveHandler) Handle(params ppmop.SubmitPersonallyProcuredMoveParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
-
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -413,8 +427,10 @@ type RequestPPMPaymentHandler struct {
 func (h RequestPPMPaymentHandler) Handle(params ppmop.RequestPPMPaymentParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
 	if err != nil {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -21,8 +21,10 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.CreatePPMAttachmentsParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	ppmID, err := uuid.FromString(params.PersonallyProcuredMoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 	logger.Info("got ppm id: ", zap.Any("id", ppmID))
 
 	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -92,7 +92,8 @@ func (suite *HandlerSuite) TestCreatePPMAttachmentsHandlerTests() {
 			//RA Developer Status: Mitigated
 			//RA Validator Status: Mitigated
 			//RA Modified Severity: N/A
-			userUploader.CreateUserUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, uploader.File{File: f}, uploader.AllowedTypesServiceMember) // nolint:errcheck
+			// nolint:errcheck
+			userUploader.CreateUserUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, uploader.File{File: f}, uploader.AllowedTypesServiceMember)
 
 			request := httptest.NewRequest("POST", "/fake/path", nil)
 			request = suite.AuthenticateOfficeRequest(request, officeUser)

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -87,8 +87,10 @@ type CreateWeightTicketSetDocumentHandler struct {
 func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeightTicketDocumentParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	// #nosec UUID is pattern matched by swagger and will be ok
-	moveID, _ := uuid.FromString(params.MoveID.String())
+	moveID, err := uuid.FromString(params.MoveID.String())
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
 	// Validate that this move belongs to the current user
 	move, err := models.FetchMove(h.DB(), session, moveID)

--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -34,7 +34,8 @@ func (suite *HandlerSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Data.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Data.Close()
 	}
 }
 

--- a/pkg/handlers/supportapi/api_test.go
+++ b/pkg/handlers/supportapi/api_test.go
@@ -34,7 +34,8 @@ func (suite *HandlerSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Data.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Data.Close()
 	}
 }
 

--- a/pkg/migrate/SplitStatements_test.go
+++ b/pkg/migrate/SplitStatements_test.go
@@ -123,8 +123,7 @@ func TestSplitStatementsLoop(t *testing.T) {
 	f, err := os.Open(fixture)
 
 	defer func() {
-		// TODO
-		if fixtureCloseErr := f.Close(); fixtureCloseErr != nil { // #nosec G307
+		if fixtureCloseErr := f.Close(); fixtureCloseErr != nil {
 			t.Error("Failed to close fixture", zap.Error(fixtureCloseErr))
 		}
 	}()

--- a/pkg/models/reimbursement_test.go
+++ b/pkg/models/reimbursement_test.go
@@ -50,7 +50,8 @@ func (suite *ModelSuite) TestBasicReimbursement() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	reimbursement.Request() // nolint:errcheck
+	// nolint:errcheck
+	reimbursement.Request()
 
 	verrs, err := suite.DB().ValidateAndCreate(&reimbursement)
 	suite.NoError(err)

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -159,7 +159,8 @@ func (suite *ModelSuite) TestFetchDeletedUpload() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	models.DeleteUpload(suite.DB(), &upload) // nolint:errcheck
+	// nolint:errcheck
+	models.DeleteUpload(suite.DB(), &upload)
 	up, _ := models.FetchUserUpload(suite.DB(), &session, upload.ID)
 
 	// fetches a nil upload

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -72,7 +72,8 @@ func (suite *ModelSuite) TestUserCreationDuplicateUUID() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	suite.DB().Create(&newUser) // nolint:errcheck
+	// nolint:errcheck
+	suite.DB().Create(&newUser)
 	err := suite.DB().Create(&sameUser)
 
 	suite.True(dberr.IsDBErrorForConstraint(err, pgerrcode.UniqueViolation, "constraint_name"), "Db should have errored on unique constraint for UUID")

--- a/pkg/paperwork/forms_test.go
+++ b/pkg/paperwork/forms_test.go
@@ -24,7 +24,8 @@ func (suite *PaperworkSuite) TestFormFillerSmokeTest() {
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
 	// #nosec G307
-	defer f.Close() // nolint:errcheck
+	// nolint:errcheck
+	defer f.Close()
 
 	var fields = map[string]FieldPos{
 		"FieldName": FormField(28, 11, 79, nil, nil, nil),

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -36,7 +36,8 @@ func (suite *PaperworkSuite) sha256ForPath(path string, fs *afero.Afero) (string
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	defer file.Close() // nolint:errcheck
+	// nolint:errcheck
+	defer file.Close()
 
 	hash := sha256.New()
 	if _, err := io.Copy(hash, file); err != nil {
@@ -229,7 +230,8 @@ func (suite *PaperworkSuite) TestCleanup() {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	generator.Cleanup() // nolint:errcheck
+	// nolint:errcheck
+	generator.Cleanup()
 
 	fs := suite.userUploader.FileSystem()
 	exists, existsErr := fs.DirExists(generator.workDir)

--- a/pkg/paperwork/paperwork_test.go
+++ b/pkg/paperwork/paperwork_test.go
@@ -33,7 +33,8 @@ func (suite *PaperworkSuite) AfterTest() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		file.Close() // nolint:errcheck
+		// nolint:errcheck
+		file.Close()
 	}
 }
 

--- a/pkg/parser/pricing/parse_test.go
+++ b/pkg/parser/pricing/parse_test.go
@@ -412,5 +412,6 @@ func (suite *PricingParserSuite) helperTestExpectedFileOutput(goldenFilename str
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Modified Severity: N/A
-	os.Remove(currentOutputFilename) // nolint:errcheck
+	// nolint:errcheck
+	os.Remove(currentOutputFilename)
 }

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
@@ -37,7 +37,8 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID) // nolint:errcheck
+		// nolint:errcheck
+		suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
 
 		suite.Equal(unit.Miles(defaultZip5Distance), *mtoShipment.Distance)
 	})

--- a/pkg/services/dbtools/table_from_slice_creator_test.go
+++ b/pkg/services/dbtools/table_from_slice_creator_test.go
@@ -108,7 +108,8 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSliceWithinTransaction() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		suite.DB().Transaction(func(tx *pop.Connection) error { // nolint:errcheck
+		// nolint:errcheck
+		suite.DB().Transaction(func(tx *pop.Connection) error {
 			tableFromSliceCreator := NewTableFromSliceCreator(tx, suite.logger, true, true)
 			err := tableFromSliceCreator.CreateTableFromSlice(validSlice)
 			suite.NoError(err)

--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -233,7 +233,8 @@ func (suite *EventServiceSuite) Test_MTOEventTrigger() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		json.Unmarshal([]byte(notification.Payload), &mtoInPayload) // nolint:errcheck
+		// nolint:errcheck
+		json.Unmarshal([]byte(notification.Payload), &mtoInPayload)
 		// Check some params
 		suite.Equal(mto.PPMType, &mtoInPayload.PpmType)
 		suite.Equal(handlers.FmtDateTimePtr(mto.AvailableToPrimeAt).String(), mtoInPayload.AvailableToPrimeAt.String())
@@ -293,7 +294,8 @@ func (suite *EventServiceSuite) Test_MTOShipmentEventTrigger() {
 		//RA Developer Status: Mitigated
 		//RA Validator Status: Mitigated
 		//RA Modified Severity: N/A
-		json.Unmarshal([]byte(notification.Payload), &mtoShipmentInPayload) // nolint:errcheck
+		// nolint:errcheck
+		json.Unmarshal([]byte(notification.Payload), &mtoShipmentInPayload)
 		// Check some params
 		suite.EqualValues(mtoShipment.ShipmentType, mtoShipmentInPayload.ShipmentType)
 		suite.EqualValues(handlers.FmtDatePtr(mtoShipment.RequestedPickupDate).String(), mtoShipmentInPayload.RequestedPickupDate.String())

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -698,16 +698,17 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 	// This won't work because we don't have PaymentServiceItems on the PaymentRequest right now.
 	// nilPaymentRequest.PaymentServiceItems[0].PriceCents = nil
 
-	//RA Summary: gosec - errcheck - Unchecked return value
-	//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-	//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-	//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-	//RA: in a unit test, then there is no risk
-	//RA Developer Status: Mitigated
-	//RA Validator Status: Mitigated
-	//RA Modified Severity: N/A
 	panicFunc := func() {
-		generator.Generate(nilPaymentRequest, false) // nolint:errcheck
+		//RA Summary: gosec - errcheck - Unchecked return value
+		//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+		//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+		//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+		//RA: in a unit test, then there is no risk
+		//RA Developer Status: Mitigated
+		//RA Validator Status: Mitigated
+		//RA Modified Severity: N/A
+		// nolint:errcheck
+		generator.Generate(nilPaymentRequest, false)
 	}
 
 	suite.T().Run("nil TAC does not cause panic", func(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -55,7 +55,8 @@ func ComputeChecksum(data io.ReadSeeker) (string, error) {
 	//RA Validator Status: Mitigated
 	//RA Validator: jneuner@mitre.org
 	//RA Modified Severity: CAT III
-	hash := md5.New() // #nosec G401
+	// #nosec G401
+	hash := md5.New()
 	if _, err := io.Copy(hash, data); err != nil {
 		return "", errors.Wrap(err, "could not read file")
 	}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -185,7 +185,6 @@ func Fixture(name string) afero.File {
 	}
 
 	fixturePath := path.Join(cwd, "pkg/testdatagen", fixtureDir, name)
-	// #nosec This will only be using test data
 	file, err := os.Open(filepath.Clean(fixturePath))
 	if err != nil {
 		log.Panic(fmt.Errorf("Error opening local file: %v", err))


### PR DESCRIPTION
## Description

#6521 Unearthed a few lint errors that were not getting caught by ato-linter. This PR fixes them. Issues are predominantly inline disabling if errcheck and unnecessary nosec disablings

## Setup
go run ./cmd/ato-linter/main.go -- ./pkg/...
There should be no lint errors

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8034) for this change
