### PR TITLE
Update nix docs, add postgresql

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -294,7 +294,9 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   # set NIX_PROFILE so nix-env operations don't need to manually
   # specify the profile path
   export NIX_PROFILE=/nix/var/nix/profiles/mymove
-  # Having this set means go won't use macOS keychain based certs
+
+  # Having NIX_SSL_CERT_FILE set means go won't use macOS keychain based certs
+  export NIX_SSL_CERT_FILE_ORIG=$NIX_SSL_CERT_FILE
   unset NIX_SSL_CERT_FILE
 
   nix_dir="nix"
@@ -304,7 +306,7 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   store_hash=$(nix-store -q --hash "${NIX_PROFILE}")
 
   # The .nix-hash file is created by nix/update.sh
-  if ! grep -q "${config_hash}-${store_hash}" .nix-hash; then
+  if [ ! -r .nix-hash ] || ! grep -q "${config_hash}-${store_hash}" .nix-hash; then
     log_status "WARNING: nix packages out of date. Run ${nix_dir}/update.sh"
   fi
 

--- a/README.md
+++ b/README.md
@@ -353,8 +353,10 @@ do not need to follow the instructions above about [Setup: Golang](#setup-golang
 NOTE: Nix as an experiment means you ask for help in the `#code-nix`
 slack channel. It's not an officially supported development environment.
 
-1. First read the overview in the [Truss Engineering Playbook](https://github.com/trussworks/Engineering-Playbook/tree/adh-nix-devenv/developing/nix).
+1. First read the overview in the [Truss Engineering Playbook](https://github.com/trussworks/Engineering-Playbook/tree/main/developing/nix).
 1. Follow the [macOS installation instructions](https://nixos.org/manual/nix/stable/#sect-macos-installation).
+1. Ensure you have `direnv` and a modern `bash` installed. To install
+   globally with nix, run `nix-env -i direnv bash`
 1. Ensure you have run `direnv allow` to set up the appropriate nix
    environment variables.
 1. Make sure you have disabled any `nodeenv`, `asdf` or any other

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -47,6 +47,14 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
+      name = "postgresql-12.4";
+      url = "https://github.com/NixOS/nixpkgs/";
+      ref = "refs/heads/nixpkgs-unstable";
+      rev = "db2de55cbe4258f223ca7af0ace34fce9046d731";
+    }) {}).postgresql_12
+
+    (import (builtins.fetchGit {
+      # Descriptive name to make the store path easier to identify
       name = "pre-commit-2.7.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";


### PR DESCRIPTION
## Description

Add postgresql as needed nix dependency, add more doc instructions

## Reviewer Notes

I tested this out on a new machine and found some gaps

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
