### PR TITLE
MB-8003-migration-cancel-and-diverted-shipment

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -633,3 +633,4 @@
 20210421175513_exp_truss_office_gbloc_change.up.sql
 20210423140812_update-gbloc-truss-offices-experimental.up.sql
 20210428225942_marty_cac.up.sql
+20210503211133_cancelled_and_diverted_statuses.up.sql

--- a/migrations/app/schema/20210503211133_cancelled_and_diverted_statuses.up.sql
+++ b/migrations/app/schema/20210503211133_cancelled_and_diverted_statuses.up.sql
@@ -1,0 +1,6 @@
+ALTER TYPE mto_shipment_status ADD VALUE 'CANCELED';
+ALTER TYPE mto_shipment_status ADD VALUE 'DIVERSION_REQUESTED';
+COMMENT ON COLUMN mto_shipments.status IS 'The status of a shipment.';
+ALTER TABLE mto_shipments
+    ADD COLUMN diversion BOOLEAN NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN mto_shipments.diversion IS 'Indicate if the shipment is part of a diversion';

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -59,6 +59,10 @@ const (
 	MTOShipmentStatusRejected MTOShipmentStatus = "REJECTED"
 	// MTOShipmentStatusCancellationRequested is the status that indicates the TOO has requested that the Prime cancel the shipment
 	MTOShipmentStatusCancellationRequested MTOShipmentStatus = "CANCELLATION_REQUESTED"
+	// MTOShipmentStatusCanceled is the status that indicates that a shipment has been canceled by the Prime
+	MTOShipmentStatusCanceled MTOShipmentStatus = "CANCELED"
+	// MTOShipmentStatusDiversionRequested is the status that indicates that teh TOO has requested that the prime divert a shipment
+	MTOShipmentStatusDiversionRequested MTOShipmentStatus = "DIVERSION_REQUESTED"
 )
 
 // MTOShipment is an object representing data for a move task order shipment
@@ -89,6 +93,7 @@ type MTOShipment struct {
 	PrimeActualWeight                *unit.Pound       `db:"prime_actual_weight"`
 	ShipmentType                     MTOShipmentType   `db:"shipment_type"`
 	Status                           MTOShipmentStatus `db:"status"`
+	Diversion                        bool              `db:"diversion"`
 	RejectionReason                  *string           `db:"rejection_reason"`
 	Distance                         *unit.Miles       `db:"distance"`
 	CreatedAt                        time.Time         `db:"created_at"`
@@ -107,6 +112,8 @@ func (m *MTOShipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		string(MTOShipmentStatusSubmitted),
 		string(MTOShipmentStatusDraft),
 		string(MTOShipmentStatusCancellationRequested),
+		string(MTOShipmentStatusCanceled),
+		string(MTOShipmentStatusDiversionRequested),
 	}})
 	vs = append(vs, &validators.UUIDIsPresent{Field: m.MoveTaskOrderID, Name: "MoveTaskOrderID"})
 	if m.PrimeEstimatedWeight != nil {

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -28,7 +28,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		emptyMTOShipment := models.MTOShipment{}
 		expErrors := map[string][]string{
 			"move_task_order_id": {"MoveTaskOrderID can not be blank."},
-			"status":             {"Status is not in the list [APPROVED, REJECTED, SUBMITTED, DRAFT, CANCELLATION_REQUESTED]."},
+			"status":             {"Status is not in the list [APPROVED, REJECTED, SUBMITTED, DRAFT, CANCELLATION_REQUESTED, CANCELED, DIVERSION_REQUESTED]."},
 		}
 		suite.verifyValidationErrors(&emptyMTOShipment, expErrors)
 	})


### PR DESCRIPTION
## Description

Create a migration for the new added statuses "Cancelation" and "Diversion Requested" and the new column "Diversion" in the mto_shipments table.

Update the model with the new statuses and the new column name.

Update the model test to reflect the new statuses
## Setup

Make sure that the migration was added to the list of migrations: `20210503211133_cancelled_and_diverted_statuses.up.sql`

Run the model tests to make sure tests pass: 
`go test ./pkg/models/   -v`
## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8003) for this change
* [this article](https://github.com/transcom/mymove/wiki/Database-Migrations#Creating-Migrations) explains more about the approach used.
