### PR TITLE
[MB-3908] Implementation for Logoff POAM

### DIFF
--- a/src/containers/Headers/CustomerLoggedInHeader.jsx
+++ b/src/containers/Headers/CustomerLoggedInHeader.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import MilMoveHeader from 'components/MilMoveHeader/index';
 import CustomerUserInfo from 'components/MilMoveHeader/CustomerUserInfo';
@@ -9,9 +10,15 @@ import { logOut as logOutAction } from 'store/auth/actions';
 import { selectIsProfileComplete } from 'store/entities/selectors';
 
 const CustomerLoggedInHeader = ({ isProfileComplete, logOut }) => {
+  const history = useHistory();
   const handleLogout = () => {
     logOut();
-    LogoutUser();
+    LogoutUser().then(() => {
+      history.push({
+        pathname: '/sign-in',
+        state: { hasLoggedOut: true },
+      });
+    });
   };
 
   return (

--- a/src/containers/Headers/OfficeLoggedInHeader.jsx
+++ b/src/containers/Headers/OfficeLoggedInHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 import MilMoveHeader from 'components/MilMoveHeader/index';
 import OfficeUserInfo from 'components/MilMoveHeader/OfficeUserInfo';
@@ -12,9 +12,15 @@ import { selectLoggedInUser } from 'store/entities/selectors';
 import { roleTypes } from 'constants/userRoles';
 
 const OfficeLoggedInHeader = ({ officeUser, activeRole, logOut }) => {
+  const history = useHistory();
   const handleLogout = () => {
     logOut();
-    LogoutUser();
+    LogoutUser().then(() => {
+      history.push({
+        pathname: '/sign-in',
+        state: { hasLoggedOut: true },
+      });
+    });
   };
 
   let queueText = '';

--- a/src/layout/LogoutOnInactivity.jsx
+++ b/src/layout/LogoutOnInactivity.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import IdleTimer from 'react-idle-timer';
+import { withRouter } from 'react-router-dom';
 
 import { selectIsLoggedIn } from 'store/auth/selectors';
 import Alert from 'shared/Alert';
 import { LogoutUser } from 'utils/api';
+import { HistoryShape } from 'types/customerShapes';
 
 const maxIdleTimeInSeconds = 15 * 60;
 const maxWarningTimeBeforeTimeoutInSeconds = 60;
@@ -43,10 +45,15 @@ export class LogoutOnInactivity extends React.Component {
 
   countdown = () => {
     const { timeLeftInSeconds } = this.state;
-    const timedout = true;
+    const { history } = this.props;
 
     if (timeLeftInSeconds === 0) {
-      LogoutUser(timedout);
+      LogoutUser().then(() => {
+        history.push({
+          pathname: '/sign-in',
+          state: { timedout: true },
+        });
+      });
     } else {
       this.setState({ timeLeftInSeconds: timeLeftInSeconds - 1 });
     }
@@ -85,6 +92,7 @@ export class LogoutOnInactivity extends React.Component {
 
 LogoutOnInactivity.propTypes = {
   isLoggedIn: PropTypes.bool,
+  history: HistoryShape.isRequired,
 };
 
 LogoutOnInactivity.defaultProps = {
@@ -97,4 +105,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(mapStateToProps)(LogoutOnInactivity);
+export default withRouter(connect(mapStateToProps)(LogoutOnInactivity));

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import { Button } from '@trussworks/react-uswds';
 import { generatePath } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 import styles from './Home.module.scss';
 import {
@@ -430,9 +431,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 });
 
 export default withContext(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps,
-  )(requireCustomerState(Home, profileStates.BACKUP_CONTACTS_COMPLETE)),
+  withRouter(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps,
+      mergeProps,
+    )(requireCustomerState(Home, profileStates.BACKUP_CONTACTS_COMPLETE)),
+  ),
 );

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import qs from 'query-string';
 import { bool, shape, string } from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
+import { useHistory } from 'react-router-dom';
 
 import styles from './SignIn.module.scss';
 import '@trussworks/react-uswds/lib/index.css';
@@ -15,8 +16,14 @@ import { isDevelopment } from 'shared/constants';
 const SignIn = ({ context, location, showLocalDevLogin }) => {
   const [showEula, setShowEula] = useState(false);
 
+  const history = useHistory();
+  useEffect(() => {
+    return () => {
+      history.replace('', null);
+    };
+  });
+
   const { error } = qs.parse(location.search);
-  const hash = qs.parse(location.hash);
   const { siteName, showLoginWarning } = context;
 
   return (
@@ -38,10 +45,17 @@ const SignIn = ({ context, location, showLocalDevLogin }) => {
               <br />
             </div>
           )}
-          {'timedout' in hash && (
+          {location.state && location.state.timedout && (
             <div>
               <Alert type="error" heading="Logged out">
                 You have been logged out due to inactivity.
+              </Alert>
+            </div>
+          )}
+          {location.state && location.state.hasLoggedOut && (
+            <div>
+              <Alert type="success" heading="You have signed out of MilMove">
+                You have successfully signed out
               </Alert>
             </div>
           )}

--- a/src/scenes/SystemAdmin/shared/Menu.jsx
+++ b/src/scenes/SystemAdmin/shared/Menu.jsx
@@ -4,9 +4,11 @@ import { MenuItemLink, getResources } from 'react-admin';
 import { withRouter } from 'react-router-dom';
 import ExitIcon from '@material-ui/icons/PowerSettingsNew';
 import { LogoutUser } from 'utils/api';
+import { createBrowserHistory } from 'history';
 
 const Menu = (props) => {
   const resources = props.resources;
+  const history = createBrowserHistory({ basename: '' });
   return (
     <div>
       {resources
@@ -24,7 +26,13 @@ const Menu = (props) => {
         leftIcon={<ExitIcon />}
         onClick={(e) => {
           e.preventDefault();
-          LogoutUser();
+          LogoutUser().then(() => {
+            console.log('logoutuser then -- Menu.jsx');
+            history.push({
+              pathname: '/sign-in',
+              state: { hasLoggedOut: true },
+            });
+          });
         }}
       />
     </div>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,7 +2,6 @@
 // utility functions related to API interactions
 
 import Swagger from 'swagger-client';
-import qs from 'query-string';
 
 import { getClient, checkResponse, requestInterceptor } from 'shared/Swagger/api';
 
@@ -30,7 +29,7 @@ export async function GetIsLoggedIn() {
   return response.body;
 }
 
-export async function LogoutUser(timedout) {
+export function LogoutUser() {
   const logoutEndpoint = '/auth/logout';
   const req = {
     url: logoutEndpoint,
@@ -38,13 +37,5 @@ export async function LogoutUser(timedout) {
     credentials: 'same-origin', // Passes through CSRF cookies
     requestInterceptor,
   };
-  try {
-    // Successful logout should return a redirect url
-    const resp = await Swagger.http(req);
-    const redirectUrl = timedout ? qs.stringifyUrl({ url: resp.text, fragmentIdentifier: 'timedout' }) : resp.text;
-    window.location.href = redirectUrl;
-  } catch (err) {
-    // Failure to logout should return user to homepage
-    window.location.href = '/';
-  }
+  return Swagger.http(req);
 }


### PR DESCRIPTION
## Description

A follow-on to the draft design doc/PR https://github.com/transcom/mymove/pull/6555 that was done before implementing the changes. 

**POAM: V-69249**: The application must display an explicit logoff message to users indicating the reliable termination of authenticated communications sessions.

Update all 3 apps to display a success logoff message after logging out. 
Clear the message on refresh of the page.
Make sure the timeout logoff functionality is still working.

The main work of this PR was to change how LogoutUser() was working to allow the promise to used to update the state to know that the logoff has happened and to return to the signin page.


### Logoff for Customer, Office and Admin apps. 

Logoff for Office is working. 

Logoff for Customer partially works. You can logoff and get an alert, but the alert does not clear on refresh of the screen.

Admin app, does not go to the new link when logoff is selected. You can see in the URL that the new URL is present to go to `/sign-in` but the page does not change.


https://user-images.githubusercontent.com/1359520/117070765-d07fd100-acf3-11eb-8f40-cb5adf5b333c.mp4


### Timeout for apps

Timeout is working like before. It was refactored to also use `history` and use the promise being returned from LogoutUser() function. 


https://user-images.githubusercontent.com/1359520/117070896-fdcc7f00-acf3-11eb-811b-8b564b28df6a.mp4


## Reviewer Notes


## Setup
```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Visit all 3 apps and test the logoff function
* http://officelocal:3000/
* http://milmovelocal:3000/
* http://adminlocal:3000/

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3908) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
