### PR TITLE
[MB-7386] Add counselor remarks to MTO Shipment

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -634,3 +634,4 @@
 20210423140812_update-gbloc-truss-offices-experimental.up.sql
 20210428225942_marty_cac.up.sql
 20210503211133_cancelled_and_diverted_statuses.up.sql
+20210504104241_add_counselor_remarks_to_mto_shipments.up.sql

--- a/migrations/app/schema/20210504104241_add_counselor_remarks_to_mto_shipments.up.sql
+++ b/migrations/app/schema/20210504104241_add_counselor_remarks_to_mto_shipments.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE mto_shipments
+    ADD COLUMN counselor_remarks text;
+COMMENT ON COLUMN mto_shipments.counselor_remarks IS 'Remarks service counselor has on the MTO Shipment';

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -78,6 +78,7 @@ type MTOShipment struct {
 	ActualPickupDate                 *time.Time        `db:"actual_pickup_date"`
 	RequiredDeliveryDate             *time.Time        `db:"required_delivery_date"`
 	CustomerRemarks                  *string           `db:"customer_remarks"`
+	CounselorRemarks                 *string           `db:"counselor_remarks"`
 	PickupAddress                    *Address          `belongs_to:"addresses"`
 	PickupAddressID                  *uuid.UUID        `db:"pickup_address_id"`
 	DestinationAddress               *Address          `belongs_to:"addresses"`

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -15,6 +15,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	shipmentType := models.MTOShipmentTypeHHG
 	shipmentStatus := models.MTOShipmentStatusDraft
 	mtoShipment := assertions.MTOShipment
+	counselorRemarks := mtoShipment.CounselorRemarks
 	// Make move if it was not provided
 	moveTaskOrder := assertions.Move
 	if isZeroUUID(moveTaskOrder.ID) {
@@ -27,6 +28,10 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 
 	if mtoShipment.Status != "" {
 		shipmentStatus = mtoShipment.Status
+	}
+
+	if counselorRemarks != nil {
+		counselorRemarks = mtoShipment.CounselorRemarks
 	}
 
 	shipmentHasPickupDetails := mtoShipment.ShipmentType != models.MTOShipmentTypeHHGOutOfNTSDom
@@ -107,6 +112,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 		ActualPickupDate:      &actualPickupDate,
 		RequestedDeliveryDate: &requestedDeliveryDate,
 		CustomerRemarks:       swag.String("Please treat gently"),
+		CounselorRemarks:      counselorRemarks,
 		PrimeEstimatedWeight:  estimatedWeight,
 		PrimeActualWeight:     &actualWeight,
 		ShipmentType:          shipmentType,

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -418,6 +418,7 @@ func createMoveWithPPMAndHHG(db *pop.Connection, userUploader *uploader.UserUplo
 			ShipmentType:         models.MTOShipmentTypeHHG,
 			ApprovedDate:         swag.Time(time.Now()),
 			Status:               models.MTOShipmentStatusSubmitted,
+			CounselorRemarks:     swag.String("Please handle with care"),
 			MoveTaskOrder:        move,
 			MoveTaskOrderID:      move.ID,
 		},


### PR DESCRIPTION
## Description

Add counselor remarks field to an MTO Shipment

## Reviewer Notes
- there are no tests that need changing until we get to changing the handler functionality to support changing counselor remarks

## Setup
`make db_dev_e2e_populate`
View DB `mto_shipment` table, there should be 1 mto_shipment with counselor remarks

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7386) for this change

