### PR TITLE
MB-7358 Add orders details for Services Counselor

### DIFF
--- a/src/components/Office/DefinitionLists/ServicesCounselingOrdersList.jsx
+++ b/src/components/Office/DefinitionLists/ServicesCounselingOrdersList.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import styles from './OfficeDefinitionLists.module.scss';
+
+import { OrdersInfoShape } from 'types/order';
+import { formatDate } from 'shared/dates';
+import { ordersTypeReadable } from 'shared/formatters';
+import descriptionListStyles from 'styles/descriptionList.module.scss';
+
+const ServicesCounselingOrdersList = ({ ordersInfo }) => {
+  return (
+    <div className={styles.OfficeDefinitionLists}>
+      <dl className={descriptionListStyles.descriptionList}>
+        <div className={descriptionListStyles.row}>
+          <dt>Current duty station</dt>
+          <dd data-testid="currentDutyStation">{ordersInfo.currentDutyStation?.name}</dd>
+        </div>
+        <div className={descriptionListStyles.row}>
+          <dt>New duty station</dt>
+          <dd data-testid="newDutyStation">{ordersInfo.newDutyStation?.name}</dd>
+        </div>
+        <div className={descriptionListStyles.row}>
+          <dt>Date issued</dt>
+          <dd data-testid="issuedDate">{formatDate(ordersInfo.issuedDate, 'DD MMM YYYY')}</dd>
+        </div>
+        <div className={descriptionListStyles.row}>
+          <dt>Report by date</dt>
+          <dd data-testid="reportByDate">{formatDate(ordersInfo.reportByDate, 'DD MMM YYYY')}</dd>
+        </div>
+        <div className={classnames(descriptionListStyles.row, { [styles.missingInfoError]: !ordersInfo.ordersType })}>
+          <dt>Orders type</dt>
+          <dd data-testid="ordersType">{ordersTypeReadable(ordersInfo.ordersType)}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+};
+
+ServicesCounselingOrdersList.propTypes = {
+  ordersInfo: OrdersInfoShape.isRequired,
+};
+
+export default ServicesCounselingOrdersList;

--- a/src/components/Office/DefinitionLists/ServicesCounselingOrdersList.test.jsx
+++ b/src/components/Office/DefinitionLists/ServicesCounselingOrdersList.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ServicesCounselingOrdersList from './ServicesCounselingOrdersList';
+
+const ordersInfo = {
+  currentDutyStation: { name: 'JBSA Lackland' },
+  newDutyStation: { name: 'JB Lewis-McChord' },
+  issuedDate: '2020-03-08',
+  reportByDate: '2020-04-01',
+  ordersType: 'PERMANENT_CHANGE_OF_STATION',
+};
+
+// what ordersInfo from above should be rendered as
+const expectedRenderedOrdersInfo = {
+  currentDutyStation: 'JBSA Lackland',
+  newDutyStation: 'JB Lewis-McChord',
+  issuedDate: '08 Mar 2020',
+  reportByDate: '01 Apr 2020',
+  ordersType: 'Permanent Change Of Station (PCS)',
+};
+
+const ordersInfoOnlyForTOO = {
+  departmentIndicator: '17 Navy and Marine Corps',
+  ordersNumber: '999999999',
+  ordersTypeDetail: 'Shipment of HHG Permitted',
+  tacMDC: '9999',
+  sacSDN: '999 999999 999',
+};
+
+describe('ServicesCounselingOrdersList', () => {
+  it('renders formatted orders info', () => {
+    render(<ServicesCounselingOrdersList ordersInfo={ordersInfo} />);
+
+    Object.keys(expectedRenderedOrdersInfo).forEach((key) => {
+      expect(screen.getByText(expectedRenderedOrdersInfo[key])).toBeInTheDocument();
+    });
+  });
+
+  it('does not render orders info that are only relevant to a TOO', () => {
+    render(<ServicesCounselingOrdersList ordersInfo={ordersInfo} />);
+
+    Object.keys(ordersInfoOnlyForTOO).forEach((key) => {
+      expect(screen.queryByText(ordersInfoOnlyForTOO[key])).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -5,6 +5,7 @@ import { queryCache, useMutation } from 'react-query';
 import classnames from 'classnames';
 
 import DetailsPanel from '../../../components/Office/DetailsPanel/DetailsPanel';
+import ServicesCounselingOrdersList from '../../../components/Office/DefinitionLists/ServicesCounselingOrdersList';
 import AllowancesList from '../../../components/Office/DefinitionLists/AllowancesList';
 import CustomerInfoList from '../../../components/Office/DefinitionLists/CustomerInfoList';
 import { SubmitMoveConfirmationModal } from '../../../components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
@@ -48,6 +49,14 @@ const ServicesCounselingMoveDetails = () => {
     dependents: allowances.dependentsAuthorized,
     requiredMedicalEquipmentWeight: allowances.requiredMedicalEquipmentWeight,
     organizationalClothingAndIndividualEquipment: allowances.organizationalClothingAndIndividualEquipment,
+  };
+
+  const ordersInfo = {
+    currentDutyStation: order.originDutyStation,
+    newDutyStation: order.destinationDutyStation,
+    issuedDate: order.date_issued,
+    reportByDate: order.report_by_date,
+    ordersType: order.order_type,
   };
 
   // use mutation calls
@@ -107,6 +116,18 @@ const ServicesCounselingMoveDetails = () => {
               )}
             </Grid>
           </Grid>
+          <div className={styles.section} id="orders">
+            <DetailsPanel
+              title="Orders"
+              editButton={
+                <Link className="usa-button usa-button--secondary" data-testid="edit-orders" to="orders">
+                  View and edit orders
+                </Link>
+              }
+            >
+              <ServicesCounselingOrdersList ordersInfo={ordersInfo} />
+            </DetailsPanel>
+          </div>
           <div className={styles.section} id="allowances">
             <DetailsPanel
               title="Allowances"

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -166,8 +166,14 @@ describe('MoveDetails page', () => {
       expect(wrapper.find('button[data-testid="submitMoveDetailsBtn"]').length).toBe(1);
     });
 
+    it('renders the Orders Definition List', () => {
+      expect(wrapper.find('#orders h2').text()).toEqual('Orders');
+      expect(wrapper.find('[data-testid="currentDutyStation"]').exists()).toBe(true);
+    });
+
     it('renders the Allowances Table', () => {
       expect(wrapper.find('#allowances h2').text()).toEqual('Allowances');
+      expect(wrapper.find('[data-testid="branchRank"]').exists()).toBe(true);
     });
 
     it('allows the service counseler to use the modal as expected', () => {


### PR DESCRIPTION
## Description

This adds the Orders details definition list to the Services Counseling
view. A Services Counselor needs less info than a TOO, so I duplicated
the `OrdersList` that we use on the TOO's view, and removed the info
that a Services Counselor does not need to see.

I also added the `View and edit orders` button, but it doesn't do
anything currently, as that will be implemented in a separate story.


## Reviewer Notes

1. Using Local Sign In, sign in with a user that has the services counselor role
2. You should only see one move that needs service counseling in your queue
3. Click on it
4. You should see the Orders table as shown in the screenshot below

## Setup

```sh
make server_run
make db_dev_e2e_populate (or `make db_dev_fresh` if that fails)
make office_client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7358) for this change

## Screenshots

![Screen Shot 2021-05-05 at 12 43 52 PM](https://user-images.githubusercontent.com/811150/117183841-07aeba80-ada6-11eb-8b6b-b96119db946d.png)
