### PR TITLE
Mb 7962 mp new shipment card storybook

### DIFF
--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
-import { Checkbox, Button } from '@trussworks/react-uswds';
+import { Checkbox } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 
@@ -8,21 +8,13 @@ import ShipmentContainer from '../ShipmentContainer';
 
 import styles from './ShipmentDisplay.module.scss';
 
+import { EditButton } from 'components/form/IconButtons';
 import { AddressShape } from 'types/address';
 import { formatAddress } from 'utils/shipmentDisplay';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { formatDate } from 'shared/dates';
 
 const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSubmitted, showIcon, editURL }) => {
-  const editButtonClasses = classnames(
-    'usa-button',
-    'usa-button--secondary',
-    'usa-button--small',
-    'usa-button--icon',
-    'margin-left-1',
-    styles.editButton,
-  );
-
   const containerClasses = classnames(styles.container, { [styles.noIcon]: !showIcon });
 
   return (
@@ -62,12 +54,13 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
           </div>
         </dl>
         {editURL && (
-          <Button to={editURL} className={editButtonClasses} data-testid="editButton">
-            <span className="icon">
-              <FontAwesomeIcon icon="pen" alt=" " inverse />
-            </span>
-            <span>Edit shipment</span>
-          </Button>
+          <EditButton
+            to={editURL}
+            className={styles.editButton}
+            data-testid="editButton"
+            label="Edit shipment"
+            secondary
+          />
         )}
       </ShipmentContainer>
     </div>

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -1,23 +1,35 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
-import { Checkbox } from '@trussworks/react-uswds';
+import { Checkbox, Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 
 import ShipmentContainer from '../ShipmentContainer';
-import { AddressShape } from '../../../types/address';
 
 import styles from './ShipmentDisplay.module.scss';
 
+import { AddressShape } from 'types/address';
 import { formatAddress } from 'utils/shipmentDisplay';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { formatDate } from 'shared/dates';
 
-const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSubmitted }) => {
+const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSubmitted, showIcon, editURL }) => {
+  const editButtonClasses = classnames(
+    'usa-button',
+    'usa-button--secondary',
+    'usa-button--small',
+    'usa-button--icon',
+    'margin-left-1',
+    styles.editButton,
+  );
+
+  const containerClasses = classnames(styles.container, { [styles.noIcon]: !showIcon });
+
   return (
     <div className={styles.ShipmentCard} data-testid="shipment-display">
-      <ShipmentContainer className={styles.container} shipmentType={shipmentType}>
+      <ShipmentContainer className={containerClasses} shipmentType={shipmentType}>
         <div className={styles.heading}>
-          {isSubmitted && (
+          {showIcon && isSubmitted && (
             <Checkbox
               id={`shipment-display-checkbox-${shipmentId}`}
               data-testid="shipment-display-checkbox"
@@ -27,7 +39,7 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
               value={shipmentId}
             />
           )}
-          {!isSubmitted && <FontAwesomeIcon icon={['far', 'check-circle']} className={styles.approved} />}
+          {showIcon && !isSubmitted && <FontAwesomeIcon icon={['far', 'check-circle']} className={styles.approved} />}
           <h3>{displayInfo.heading}</h3>
           <FontAwesomeIcon icon="chevron-down" />
         </div>
@@ -44,7 +56,19 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             <dt className={styles.label}>Destination address</dt>
             <dd data-testid="shipmentDestinationAddress">{formatAddress(displayInfo.destinationAddress)}</dd>
           </div>
+          <div className={styles.row}>
+            <dt className={styles.label}>Counselor remarks</dt>
+            <dd data-testid="counselorRemarks">{displayInfo.counselorRemarks || '—'}</dd>
+          </div>
         </dl>
+        {editURL && (
+          <Button to={editURL} className={editButtonClasses} data-testid="editButton">
+            <span className="icon">
+              <FontAwesomeIcon icon="pen" alt=" " inverse />
+            </span>
+            <span>Edit shipment</span>
+          </Button>
+        )}
       </ShipmentContainer>
     </div>
   );
@@ -66,12 +90,17 @@ ShipmentDisplay.propTypes = {
     requestedMoveDate: PropTypes.string.isRequired,
     currentAddress: AddressShape.isRequired,
     destinationAddress: AddressShape,
+    counselorRemarks: PropTypes.string,
   }).isRequired,
+  showIcon: PropTypes.bool,
+  editURL: PropTypes.string,
 };
 
 ShipmentDisplay.defaultProps = {
   onChange: () => {},
   shipmentType: SHIPMENT_OPTIONS.HHG,
+  showIcon: true,
+  editURL: '',
 };
 
 export default ShipmentDisplay;

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
@@ -16,6 +16,7 @@
     h3 {
       font-weight: normal;
       @include u-margin(0);
+      @include u-margin-left(1);
       flex-grow: 1;
     }
 
@@ -77,5 +78,17 @@
         @include u-border-bottom('base-lighter');
       }
     }
+  }
+
+
+  .noIcon {
+    dl {
+      @include u-margin-x(3);
+      @include u-padding-y(1.5);
+    }
+  }
+
+  .noIcon .editButton {
+    @include u-margin-x(3);
   }
 }

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -3,10 +3,18 @@ import { object } from '@storybook/addon-knobs';
 
 import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { MockProviders } from 'testUtils';
 
 export default {
   title: 'Office Components/Shipment Display',
   component: ShipmentDisplay,
+  decorators: [
+    (Story) => (
+      <MockProviders>
+        <Story />
+      </MockProviders>
+    ),
+  ],
 };
 
 const hhgInfo = {
@@ -60,6 +68,33 @@ const postalOnlyInfo = {
 export const HHGShipment = () => (
   <div style={{ padding: '20px' }}>
     <ShipmentDisplay displayInfo={object('displayInfo', hhgInfo)} isSubmitted />
+  </div>
+);
+
+export const HHGShipmentNoIcon = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay displayInfo={object('displayInfo', hhgInfo)} isSubmitted showIcon={false} />
+  </div>
+);
+
+export const HHGShipmentWithCounselorRemarks = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay
+      displayInfo={{ ...hhgInfo, counselorRemarks: 'counselor approved' }}
+      isSubmitted
+      showIcon={false}
+    />
+  </div>
+);
+
+export const HHGShipmentEditable = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay
+      displayInfo={{ ...hhgInfo, counselorRemarks: 'counselor approved' }}
+      isSubmitted
+      showIcon={false}
+      editURL="/"
+    />
   </div>
 );
 

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -18,6 +18,7 @@ const info = {
     state: 'WA',
     postal_code: '98421',
   },
+  counselorRemarks: 'counselor approved',
 };
 
 const postalOnly = {
@@ -46,5 +47,23 @@ describe('Shipment Container', () => {
       <ShipmentDisplay shipmentId="1" displayInfo={postalOnly} onChange={jest.fn()} isSubmitted={false} />,
     );
     expect(wrapper.find('div[data-testid="shipment-display"]').exists()).toBe(true);
+  });
+  it('renders with comments', () => {
+    const wrapper = mount(
+      <ShipmentDisplay shipmentId="1" displayInfo={info} onChange={jest.fn()} isSubmitted={false} />,
+    );
+    expect(wrapper.find('dd[data-testid="counselorRemarks"]').exists()).toBe(true);
+  });
+  it('renders with edit button', () => {
+    const wrapper = mount(
+      <ShipmentDisplay shipmentId="1" displayInfo={info} editURL="url" onChange={jest.fn()} isSubmitted={false} />,
+    );
+    expect(wrapper.find('button[data-testid="editButton"]').exists()).toBe(true);
+  });
+  it('renders without edit button', () => {
+    const wrapper = mount(
+      <ShipmentDisplay shipmentId="1" displayInfo={postalOnly} onChange={jest.fn()} isSubmitted={false} />,
+    );
+    expect(wrapper.find('button[data-testid="editButton"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Description
Updated shipment display card in storybook to include counselor remarks and an edit button

## Reviewer Notes

Used the already existing edit button component -- has a filled in pen icon rather than a pen outline. is this ok?
Should this be optimized for mobile viewing?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7962) for this change


## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
<img width="527" alt="Screen Shot 2021-05-05 at 2 56 26 PM" src="https://user-images.githubusercontent.com/14057912/117201318-23b85900-adb2-11eb-8ebe-bc6fe5bdbb7b.png">
