### PR TITLE
MB-6362 TIO can see save feedback on review payment service item page

### DIFF
--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -178,26 +178,55 @@ const ServiceItemCard = ({
                     {values.status === DENIED && (
                       <FormGroup>
                         <Label htmlFor={`rejectReason-${id}`}>Reason for rejection</Label>
-                        <Textarea
-                          id={`rejectReason-${id}`}
-                          name="rejectionReason"
-                          onChange={handleChange}
-                          value={values.rejectionReason}
-                        />
-                        {!requestComplete && (
-                          <div className={styles.rejectionButtonGroup}>
-                            <Button type="button" data-testid="rejectionSaveButton" onClick={submitForm}>
-                              Save
-                            </Button>
+                        {!canEditRejection && (
+                          <>
+                            <p data-testid="rejectionReasonReadOnly">{values.rejectionReason}</p>
                             <Button
-                              data-testid="cancelRejectionButton"
-                              secondary
-                              onClick={handleFormReset}
                               type="button"
+                              unstyled
+                              data-testid="editReasonButton"
+                              className={styles.clearStatus}
+                              onClick={() => setCanEditRejection(true)}
+                              aria-label="Edit reason button"
                             >
-                              Cancel
+                              <span className="icon">
+                                <FontAwesomeIcon icon="pen" title="Edit reason" alt="" />
+                              </span>
+                              <span aria-hidden="true">Edit reason</span>
                             </Button>
-                          </div>
+                          </>
+                        )}
+
+                        {!requestComplete && canEditRejection && (
+                          <>
+                            <Textarea
+                              id={`rejectReason-${id}`}
+                              name="rejectionReason"
+                              onChange={handleChange}
+                              value={values.rejectionReason}
+                            />
+                            <div className={styles.rejectionButtonGroup}>
+                              <Button
+                                id="rejectionSaveButton"
+                                type="button"
+                                data-testid="rejectionSaveButton"
+                                onClick={handleRejectChange}
+                                disabled={!values.rejectionReason}
+                                aria-label="Rejection save button"
+                              >
+                                Save
+                              </Button>
+                              <Button
+                                data-testid="cancelRejectionButton"
+                                secondary
+                                onClick={handleRejectCancel}
+                                type="button"
+                                aria-label="Cancel rejection button"
+                              >
+                                Cancel
+                              </Button>
+                            </div>
+                          </>
                         )}
                       </FormGroup>
                     )}

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -111,7 +111,7 @@ const ServiceItemCard = ({
         }}
         enableReinitialize
       >
-        {({ handleChange, submitForm, values, setValues }) => {
+        {({ initialValues, handleReset, handleChange, submitForm, values, setValues }) => {
           const handleApprovalChange = (event) => {
             handleChange(event);
             submitForm();

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -30,6 +30,7 @@ const ServiceItemCard = ({
   paymentServiceItemParams,
 }) => {
   const [calculationsVisible, setCalulationsVisible] = useState(false);
+  const [canEditRejection, setCanEditRejection] = useState(!rejectionReason);
 
   const { APPROVED, DENIED } = PAYMENT_SERVICE_ITEM_STATUS;
 

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -108,6 +108,7 @@ const ServiceItemCard = ({
         onSubmit={(values) => {
           patchPaymentServiceItem(id, values);
         }}
+        enableReinitialize
       >
         {({ handleChange, submitForm, values, setValues }) => {
           const handleApprovalChange = (event) => {

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -113,8 +113,23 @@ const ServiceItemCard = ({
       >
         {({ initialValues, handleReset, handleChange, submitForm, values, setValues }) => {
           const handleApprovalChange = (event) => {
+            setCanEditRejection(true);
             handleChange(event);
             submitForm();
+          };
+
+          const handleRejectChange = (event) => {
+            setCanEditRejection(false);
+            handleChange(event);
+            submitForm();
+          };
+
+          const handleRejectCancel = (event) => {
+            if (initialValues.rejectionReason) {
+              setCanEditRejection(false);
+            }
+
+            handleReset(event);
           };
 
           const handleFormReset = () => {

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -133,9 +133,10 @@ const ServiceItemCard = ({
           };
 
           const handleFormReset = () => {
+            setCanEditRejection(true);
             setValues({
               status: 'REQUESTED',
-              rejectionReason: undefined,
+              rejectionReason: '',
             });
             submitForm();
           };

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.module.scss
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.module.scss
@@ -80,6 +80,11 @@
           margin-top: 0;
         }
       }
+
+      p {
+        @include u-margin-top(1);
+        @include u-margin-bottom(0);
+      }
     }
 
     &.selected {

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.test.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import { mount } from 'enzyme';
 
 import testParams from '../ServiceItemCalculations/serviceItemTestParams';
@@ -70,6 +70,76 @@ describe('ServiceItemCard component', () => {
     it('does not render calculations toggle when the service item calculations are not implemented', () => {
       const component = mount(<ServiceItemCard {...basicServiceItemCard} />);
       expect(component.find('button[data-testid="toggleCalculations"]').exists()).toBe(false);
+    });
+
+    // using react testing library to test dom interactions
+    it('save button is disabled when rejection reason is empty', () => {
+      const { getByTestId } = render(<ServiceItemCard {...basicServiceItemCard} />);
+      const rejectRadio = getByTestId('rejectRadio');
+
+      waitFor(() => {
+        fireEvent.click(rejectRadio);
+      });
+
+      expect(getByTestId('rejectionSaveButton')).toHaveAttribute('disabled');
+    });
+
+    // using react testing library to test dom interactions
+    it('edit reason button link show after saving', async () => {
+      const { getByTestId } = render(<ServiceItemCard {...basicServiceItemCard} />);
+      const rejectRadio = getByTestId('rejectRadio');
+
+      // Click on reject radio and fill in text area
+      await waitFor(() => {
+        fireEvent.click(rejectRadio);
+      });
+
+      await waitFor(() => {
+        fireEvent.change(getByTestId('textarea'), {
+          target: { value: 'Rejected just because.' },
+        });
+      });
+
+      expect(getByTestId('rejectionSaveButton').hasAttribute('disabled')).toBeFalsy();
+
+      // Save
+      await waitFor(() => {
+        fireEvent.click(getByTestId('rejectionSaveButton'));
+      });
+
+      expect(getByTestId('editReasonButton')).toBeTruthy();
+      expect(getByTestId('rejectionReasonReadOnly').textContent).toBe('Rejected just because.');
+    });
+
+    // using react testing library to test dom interactions
+    it('edit existing rejection reason', async () => {
+      const data = {
+        ...basicServiceItemCard,
+        status: PAYMENT_SERVICE_ITEM_STATUS.DENIED,
+        rejectionReason: 'Rejected just because.',
+      };
+      const { getByTestId } = render(<ServiceItemCard {...data} />);
+
+      expect(getByTestId('editReasonButton')).toBeTruthy();
+      expect(getByTestId('rejectionReasonReadOnly').textContent).toBe('Rejected just because.');
+
+      // Click on Edit reason button, edit text area and save
+      await waitFor(() => {
+        fireEvent.click(getByTestId('editReasonButton'));
+      });
+
+      await waitFor(() => {
+        fireEvent.change(getByTestId('textarea'), {
+          target: { value: 'Edited rejection reason.' },
+        });
+      });
+
+      await waitFor(() => {
+        fireEvent.click(getByTestId('rejectionSaveButton'));
+      });
+
+      expect(getByTestId('editReasonButton')).toBeTruthy();
+      expect(getByTestId('rejectionReasonReadOnly').textContent).toBe('Edited rejection reason.');
     });
   });
 


### PR DESCRIPTION
## Description

This PR refactors the form for the rejection portion when reviewing the payment service items. After saving the rejection reason, the form disappears and now shows a link button and a read only value of the rejection reason saved.

> As a TIO
> I want to see feedback that my service item rejection text was accepted
> So that I know my actions are taking effect

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- I refactored the behavior of the `Cancel` button a bit. It no longer submits the form and resets the form back to its initial state. Thought that would make more sense.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Test
1. Log in as TIO
2. Click on any payment request
3. Click on `Review service items` button
4. Click on `Reject` radio button
5. Fill in rejection reason in textarea input
6. Click on `Save`

Edit rejection reason
1. After saving rejection reason, click on `Edit reason` link button
2. Edit rejection reason
3. Click `Save`
4. Notice the updated value as readonly text

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-6362) for this change

## Screenshots


https://user-images.githubusercontent.com/1522549/117222341-0c806800-adc0-11eb-9801-0c682e48de8b.mov

