### PR TITLE
MB-7927 Services Counselor must confirm before submitting move

### DIFF
--- a/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.test.jsx
+++ b/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.test.jsx
@@ -3,6 +3,13 @@ import { mount } from 'enzyme';
 
 import { RequestShipmentCancellationModal } from 'components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal';
 
+let onClose;
+let onSubmit;
+beforeEach(() => {
+  onClose = jest.fn();
+  onSubmit = jest.fn();
+});
+
 describe('RequestShipmentCancellationModal', () => {
   const shipmentInfo = {
     shipmentID: '123456',
@@ -12,7 +19,7 @@ describe('RequestShipmentCancellationModal', () => {
 
   it('renders the component', () => {
     const wrapper = mount(
-      <RequestShipmentCancellationModal onSubmit={jest.fn()} onClose={jest.fn()} shipmentInfo={shipmentInfo} />,
+      <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={onClose} shipmentInfo={shipmentInfo} />,
     );
     expect(wrapper.find('RequestShipmentCancellationModal').exists()).toBe(true);
     expect(wrapper.find('ModalTitle').exists()).toBe(true);
@@ -23,9 +30,8 @@ describe('RequestShipmentCancellationModal', () => {
   });
 
   it('closes the modal when close icon is clicked', () => {
-    const onClose = jest.fn();
     const wrapper = mount(
-      <RequestShipmentCancellationModal onSubmit={jest.fn()} onClose={onClose} shipmentInfo={shipmentInfo} />,
+      <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={onClose} shipmentInfo={shipmentInfo} />,
     );
 
     wrapper.find('button[data-testid="modalCloseButton"]').simulate('click');
@@ -34,9 +40,8 @@ describe('RequestShipmentCancellationModal', () => {
   });
 
   it('closes the modal when the cancel button is clicked', () => {
-    const onClose = jest.fn();
     const wrapper = mount(
-      <RequestShipmentCancellationModal onSubmit={jest.fn()} onClose={onClose} shipmentInfo={shipmentInfo} />,
+      <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={onClose} shipmentInfo={shipmentInfo} />,
     );
 
     wrapper.find('button[data-testid="modalBackButton"]').simulate('click');
@@ -45,9 +50,8 @@ describe('RequestShipmentCancellationModal', () => {
   });
 
   it('calls the submit function when submit putton is clicked', async () => {
-    const onSubmit = jest.fn();
     const wrapper = mount(
-      <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={jest.fn()} shipmentInfo={shipmentInfo} />,
+      <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={onClose} shipmentInfo={shipmentInfo} />,
     );
 
     wrapper.find('button[type="submit"]').simulate('click');

--- a/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.test.jsx
+++ b/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.test.jsx
@@ -49,7 +49,7 @@ describe('RequestShipmentCancellationModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('calls the submit function when submit putton is clicked', async () => {
+  it('calls the submit function when submit button is clicked', async () => {
     const wrapper = mount(
       <RequestShipmentCancellationModal onSubmit={onSubmit} onClose={onClose} shipmentInfo={shipmentInfo} />,
     );

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Overlay, ModalContainer } from '@trussworks/react-uswds';
+
+import Modal, { ModalTitle, ModalClose, ModalActions, connectModal } from 'components/Modal/Modal';
+
+export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
+  <div>
+    <Overlay />
+    <ModalContainer>
+      <Modal>
+        <ModalClose handleClick={() => onClose()} />
+        <ModalTitle>
+          <h3>Are you sure?</h3>
+        </ModalTitle>
+        <p>You can’t make changes after you submit the move.</p>
+        <ModalActions>
+          <Button className="usa-button--submit" type="submit" onClick={() => onSubmit()}>
+            Yes, submit
+          </Button>
+          <Button
+            className="usa-button--tertiary"
+            type="button"
+            onClick={() => onClose()}
+            data-testid="modalBackButton"
+          >
+            Cancel
+          </Button>
+        </ModalActions>
+      </Modal>
+    </ModalContainer>
+  </div>
+);
+
+SubmitMoveConfirmationModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+SubmitMoveConfirmationModal.displayName = 'SubmitMoveConfirmationModal';
+
+export default connectModal(SubmitMoveConfirmationModal);

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
@@ -11,7 +11,7 @@ export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
       <Modal>
         <ModalClose handleClick={() => onClose()} />
         <ModalTitle>
-          <h3>Are you sure?</h3>
+          <h2>Are you sure?</h2>
         </ModalTitle>
         <p>You can’t make changes after you submit the move.</p>
         <ModalActions>

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
@@ -5,7 +5,7 @@ import { Button, Overlay, ModalContainer } from '@trussworks/react-uswds';
 import Modal, { ModalTitle, ModalClose, ModalActions, connectModal } from 'components/Modal/Modal';
 
 export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
-  <div>
+  <div data-testid="SubmitMoveConfirmationModal">
     <Overlay />
     <ModalContainer>
       <Modal>
@@ -22,7 +22,7 @@ export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
             className="usa-button--tertiary"
             type="button"
             onClick={() => onClose()}
-            data-testid="modalBackButton"
+            data-testid="modalCancelButton"
           >
             Cancel
           </Button>

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.stories.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.stories.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { SubmitMoveConfirmationModal } from './SubmitMoveConfirmationModal';
+
+export default {
+  title: 'Office Components/SubmitMoveConfirmationModal',
+  component: SubmitMoveConfirmationModal,
+};
+
+export const Basic = () => <SubmitMoveConfirmationModal onClose={() => {}} onSubmit={() => {}} />;

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
+
+describe('SubmitMoveConfirmationModal', () => {
+  it('renders the component', () => {
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={jest.fn()} />);
+    expect(wrapper.find('SubmitMoveConfirmationModal').exists()).toBe(true);
+    expect(wrapper.find('ModalTitle').exists()).toBe(true);
+    expect(wrapper.find('ModalActions').exists()).toBe(true);
+    expect(wrapper.find('ModalClose').exists()).toBe(true);
+    expect(wrapper.find('button[data-testid="modalBackButton"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+  });
+
+  it('closes the modal when close icon is clicked', () => {
+    const onClose = jest.fn();
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={onClose} />);
+
+    wrapper.find('button[data-testid="modalCloseButton"]').simulate('click');
+
+    expect(onClose.mock.calls.length).toBe(1);
+  });
+
+  it('closes the modal when the cancel button is clicked', () => {
+    const onClose = jest.fn();
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={onClose} />);
+
+    wrapper.find('button[data-testid="modalBackButton"]').simulate('click');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls the submit function when submit putton is clicked', async () => {
+    const onSubmit = jest.fn();
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={jest.fn()} />);
+
+    wrapper.find('button[type="submit"]').simulate('click');
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
@@ -37,7 +37,7 @@ describe('SubmitMoveConfirmationModal', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('calls the submit function when submit putton is clicked', async () => {
+  it('calls the submit function when submit button is clicked', async () => {
     const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
 
     wrapper.find('button[type="submit"]').simulate('click');

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
@@ -3,20 +3,26 @@ import { mount } from 'enzyme';
 
 import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 
+let onClose;
+let onSubmit;
+beforeEach(() => {
+  onClose = jest.fn();
+  onSubmit = jest.fn();
+});
+
 describe('SubmitMoveConfirmationModal', () => {
   it('renders the component', () => {
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={jest.fn()} />);
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
     expect(wrapper.find('SubmitMoveConfirmationModal').exists()).toBe(true);
     expect(wrapper.find('ModalTitle').exists()).toBe(true);
     expect(wrapper.find('ModalActions').exists()).toBe(true);
     expect(wrapper.find('ModalClose').exists()).toBe(true);
-    expect(wrapper.find('button[data-testid="modalBackButton"]').exists()).toBe(true);
+    expect(wrapper.find('button[data-testid="modalCancelButton"]').exists()).toBe(true);
     expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
   });
 
   it('closes the modal when close icon is clicked', () => {
-    const onClose = jest.fn();
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={onClose} />);
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
 
     wrapper.find('button[data-testid="modalCloseButton"]').simulate('click');
 
@@ -24,17 +30,15 @@ describe('SubmitMoveConfirmationModal', () => {
   });
 
   it('closes the modal when the cancel button is clicked', () => {
-    const onClose = jest.fn();
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={jest.fn()} onClose={onClose} />);
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
 
-    wrapper.find('button[data-testid="modalBackButton"]').simulate('click');
+    wrapper.find('button[data-testid="modalCancelButton"]').simulate('click');
 
     expect(onClose).toHaveBeenCalled();
   });
 
   it('calls the submit function when submit putton is clicked', async () => {
-    const onSubmit = jest.fn();
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={jest.fn()} />);
+    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
 
     wrapper.find('button[type="submit"]').simulate('click');
 

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -24,7 +24,7 @@ const ServicesCounselingMoveDetails = () => {
   const { moveCode } = useParams();
   const [alertMessage, setAlertMessage] = useState(null);
   const [alertType, setAlertType] = useState('success');
-  const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
+  const [isSubmitModalVisible, setIsSubmitModalVisible] = useState(false);
 
   const { order, move, isLoading, isError } = useMoveDetailsQueries(moveCode);
   const { customer, entitlement: allowances } = order;
@@ -69,18 +69,19 @@ const ServicesCounselingMoveDetails = () => {
   if (isError) return <SomethingWentWrong />;
 
   const handleShowCancellationModal = () => {
-    setIsCancelModalVisible(true);
+    setIsSubmitModalVisible(true);
   };
 
   const handleConfirmSubmitMoveDetails = () => {
     mutateMoveStatus({ moveTaskOrderID: move.id, ifMatchETag: move.eTag });
+    setIsSubmitModalVisible(false);
   };
 
   return (
     <div className={styles.tabContent}>
       <div className={styles.container}>
-        {isCancelModalVisible && (
-          <SubmitMoveConfirmationModal onClose={setIsCancelModalVisible} onSubmit={handleConfirmSubmitMoveDetails} />
+        {isSubmitModalVisible && (
+          <SubmitMoveConfirmationModal onClose={setIsSubmitModalVisible} onSubmit={handleConfirmSubmitMoveDetails} />
         )}
 
         <GridContainer

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -111,9 +111,11 @@ const ServicesCounselingMoveDetails = () => {
             <DetailsPanel
               title="Allowances"
               editButton={
-                <Link className="usa-button usa-button--secondary" data-testid="edit-allowances" to="allowances">
-                  Edit allowances
-                </Link>
+                move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING && (
+                  <Link className="usa-button usa-button--secondary" data-testid="edit-allowances" to="allowances">
+                    Edit allowances
+                  </Link>
+                )
               }
             >
               <AllowancesList info={allowancesInfo} />
@@ -123,9 +125,11 @@ const ServicesCounselingMoveDetails = () => {
             <DetailsPanel
               title="Customer info"
               editButton={
-                <Link className="usa-button usa-button--secondary" data-testid="edit=customer-info" to="#">
-                  Edit customer info
-                </Link>
+                move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING && (
+                  <Link className="usa-button usa-button--secondary" data-testid="edit=customer-info" to="#">
+                    Edit customer info
+                  </Link>
+                )
               }
             >
               <CustomerInfoList customerInfo={customerInfo} />

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import DetailsPanel from '../../../components/Office/DetailsPanel/DetailsPanel';
 import AllowancesList from '../../../components/Office/DefinitionLists/AllowancesList';
 import CustomerInfoList from '../../../components/Office/DefinitionLists/CustomerInfoList';
+import { SubmitMoveConfirmationModal } from '../../../components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 import styles from '../ServicesCounselingMoveInfo/ServicesCounselingTab.module.scss';
 
 import scMoveDetailsStyles from './ServicesCounselingMoveDetails.module.scss';
@@ -23,6 +24,7 @@ const ServicesCounselingMoveDetails = () => {
   const { moveCode } = useParams();
   const [alertMessage, setAlertMessage] = useState(null);
   const [alertType, setAlertType] = useState('success');
+  const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
 
   const { order, move, isLoading, isError } = useMoveDetailsQueries(moveCode);
   const { customer, entitlement: allowances } = order;
@@ -66,10 +68,20 @@ const ServicesCounselingMoveDetails = () => {
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
+  const handleShowCancellationModal = () => {
+    setIsCancelModalVisible(true);
+  };
+
+  const handleConfirmSubmitMoveDetails = () => {
+    mutateMoveStatus({ moveTaskOrderID: move.id, ifMatchETag: move.eTag });
+  };
+
   return (
     <div className={styles.tabContent}>
       <div className={styles.container}>
-        {/* LeftNav here */}
+        {isCancelModalVisible && (
+          <SubmitMoveConfirmationModal onClose={setIsCancelModalVisible} onSubmit={handleConfirmSubmitMoveDetails} />
+        )}
 
         <GridContainer
           className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}
@@ -88,13 +100,7 @@ const ServicesCounselingMoveDetails = () => {
             </Grid>
             <Grid col={6} className={scMoveDetailsStyles.submitMoveDetailsContainer}>
               {move.status === MOVE_STATUSES.NEEDS_SERVICE_COUNSELING && (
-                <Button
-                  data-testid="submitMoveDetailsBtn"
-                  type="button"
-                  onClick={() => {
-                    mutateMoveStatus({ moveTaskOrderID: move.id, ifMatchETag: move.eTag });
-                  }}
-                >
+                <Button data-testid="submitMoveDetailsBtn" type="button" onClick={handleShowCancellationModal}>
                   Submit move details
                 </Button>
               )}

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -169,6 +169,14 @@ describe('MoveDetails page', () => {
     it('renders the Allowances Table', () => {
       expect(wrapper.find('#allowances h2').text()).toEqual('Allowances');
     });
+
+    it('allows the service counseler to use the modal as expected', () => {
+      wrapper.find('[data-testid="submitMoveDetailsBtn"]').first().simulate('click');
+      expect(wrapper.find('[data-testid="SubmitMoveConfirmationModal"]').length).toBe(1);
+
+      wrapper.find('button[type="submit"]').simulate('click');
+      expect(wrapper.find('[data-testid="SubmitMoveConfirmationModal"]').length).toBe(0);
+    });
   });
 
   describe('service counseling completed', () => {


### PR DESCRIPTION
## Description
When the services counselor clicks `Submit move details`, they see a modal dialog requiring them to confirm.

When they click `Yes, submit` on the modal, they see move details again, now in the non-editable/counseling complete state, and with a feedback message.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
make storybook
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7927) for this change

## Screenshots

![Screen Shot 2021-05-06 at 11 21 49 AM](https://user-images.githubusercontent.com/1587316/117323851-42275e80-ae5d-11eb-91b4-765863e3d2d5.png)
