### PR TITLE
MB-7427 Service Counseling fields for Prime API payload

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1179,7 +1179,7 @@ func init() {
           "x-nullable": true,
           "example": false
         },
-        "organizationalClothingandIndividualEquipment": {
+        "organizationalClothingAndIndividualEquipment": {
           "type": "boolean",
           "example": false
         },
@@ -3824,7 +3824,7 @@ func init() {
           "x-nullable": true,
           "example": false
         },
-        "organizationalClothingandIndividualEquipment": {
+        "organizationalClothingAndIndividualEquipment": {
           "type": "boolean",
           "example": false
         },

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1179,6 +1179,10 @@ func init() {
           "x-nullable": true,
           "example": false
         },
+        "organizationalClothingandIndividualEquipment": {
+          "type": "boolean",
+          "example": false
+        },
         "privatelyOwnedVehicle": {
           "type": "boolean",
           "x-nullable": true,
@@ -1190,6 +1194,11 @@ func init() {
           "example": 2000
         },
         "proGearWeightSpouse": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
+        },
+        "requiredMedicalEquipmentWeight": {
           "type": "integer",
           "x-formatting": "weight",
           "example": 500
@@ -3815,6 +3824,10 @@ func init() {
           "x-nullable": true,
           "example": false
         },
+        "organizationalClothingandIndividualEquipment": {
+          "type": "boolean",
+          "example": false
+        },
         "privatelyOwnedVehicle": {
           "type": "boolean",
           "x-nullable": true,
@@ -3826,6 +3839,11 @@ func init() {
           "example": 2000
         },
         "proGearWeightSpouse": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
+        },
+        "requiredMedicalEquipmentWeight": {
           "type": "integer",
           "x-formatting": "weight",
           "example": 500

--- a/pkg/gen/primemessages/entitlements.go
+++ b/pkg/gen/primemessages/entitlements.go
@@ -34,6 +34,9 @@ type Entitlements struct {
 	// non temporary storage
 	NonTemporaryStorage *bool `json:"nonTemporaryStorage,omitempty"`
 
+	// organizational clothingand individual equipment
+	OrganizationalClothingandIndividualEquipment bool `json:"organizationalClothingandIndividualEquipment,omitempty"`
+
 	// privately owned vehicle
 	PrivatelyOwnedVehicle *bool `json:"privatelyOwnedVehicle,omitempty"`
 
@@ -42,6 +45,9 @@ type Entitlements struct {
 
 	// pro gear weight spouse
 	ProGearWeightSpouse int64 `json:"proGearWeightSpouse,omitempty"`
+
+	// required medical equipment weight
+	RequiredMedicalEquipmentWeight int64 `json:"requiredMedicalEquipmentWeight,omitempty"`
 
 	// storage in transit
 	StorageInTransit int64 `json:"storageInTransit,omitempty"`

--- a/pkg/gen/primemessages/entitlements.go
+++ b/pkg/gen/primemessages/entitlements.go
@@ -34,8 +34,8 @@ type Entitlements struct {
 	// non temporary storage
 	NonTemporaryStorage *bool `json:"nonTemporaryStorage,omitempty"`
 
-	// organizational clothingand individual equipment
-	OrganizationalClothingandIndividualEquipment bool `json:"organizationalClothingandIndividualEquipment,omitempty"`
+	// organizational clothing and individual equipment
+	OrganizationalClothingAndIndividualEquipment bool `json:"organizationalClothingAndIndividualEquipment,omitempty"`
 
 	// privately owned vehicle
 	PrivatelyOwnedVehicle *bool `json:"privatelyOwnedVehicle,omitempty"`

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1086,6 +1086,10 @@ func init() {
           "x-nullable": true,
           "example": false
         },
+        "organizationalClothingAndIndividualEquipment": {
+          "type": "boolean",
+          "example": false
+        },
         "privatelyOwnedVehicle": {
           "type": "boolean",
           "x-nullable": true,
@@ -1101,6 +1105,11 @@ func init() {
           "type": "integer",
           "x-formatting": "weight",
           "readOnly": true,
+          "example": 500
+        },
+        "requiredMedicalEquipmentWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
           "example": 500
         },
         "storageInTransit": {
@@ -3777,6 +3786,10 @@ func init() {
           "x-nullable": true,
           "example": false
         },
+        "organizationalClothingAndIndividualEquipment": {
+          "type": "boolean",
+          "example": false
+        },
         "privatelyOwnedVehicle": {
           "type": "boolean",
           "x-nullable": true,
@@ -3792,6 +3805,11 @@ func init() {
           "type": "integer",
           "x-formatting": "weight",
           "readOnly": true,
+          "example": 500
+        },
+        "requiredMedicalEquipmentWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
           "example": 500
         },
         "storageInTransit": {

--- a/pkg/gen/supportmessages/entitlement.go
+++ b/pkg/gen/supportmessages/entitlement.go
@@ -34,6 +34,9 @@ type Entitlement struct {
 	// non temporary storage
 	NonTemporaryStorage *bool `json:"nonTemporaryStorage,omitempty"`
 
+	// organizational clothing and individual equipment
+	OrganizationalClothingAndIndividualEquipment bool `json:"organizationalClothingAndIndividualEquipment,omitempty"`
+
 	// privately owned vehicle
 	PrivatelyOwnedVehicle *bool `json:"privatelyOwnedVehicle,omitempty"`
 
@@ -44,6 +47,9 @@ type Entitlement struct {
 	// pro gear weight spouse
 	// Read Only: true
 	ProGearWeightSpouse int64 `json:"proGearWeightSpouse,omitempty"`
+
+	// required medical equipment weight
+	RequiredMedicalEquipmentWeight int64 `json:"requiredMedicalEquipmentWeight,omitempty"`
 
 	// storage in transit
 	StorageInTransit int64 `json:"storageInTransit,omitempty"`

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -147,7 +147,7 @@ func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 		ProGearWeight:                  int64(entitlement.ProGearWeight),
 		ProGearWeightSpouse:            int64(entitlement.ProGearWeightSpouse),
 		RequiredMedicalEquipmentWeight: int64(entitlement.RequiredMedicalEquipmentWeight),
-		OrganizationalClothingandIndividualEquipment: entitlement.OrganizationalClothingAndIndividualEquipment,
+		OrganizationalClothingAndIndividualEquipment: entitlement.OrganizationalClothingAndIndividualEquipment,
 		StorageInTransit: sit,
 		TotalDependents:  totalDependents,
 		TotalWeight:      totalWeight,

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -121,10 +121,8 @@ func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 	if entitlement == nil {
 		return nil
 	}
-	var proGearWeight, proGearWeightSpouse, totalWeight int64
+	var totalWeight int64
 	if entitlement.WeightAllotment() != nil {
-		proGearWeight = int64(entitlement.WeightAllotment().ProGearWeight)
-		proGearWeightSpouse = int64(entitlement.WeightAllotment().ProGearWeightSpouse)
 		totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
 	}
 	var authorizedWeight *int64
@@ -141,17 +139,19 @@ func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 		totalDependents = int64(*entitlement.TotalDependents)
 	}
 	return &primemessages.Entitlements{
-		ID:                    strfmt.UUID(entitlement.ID.String()),
-		AuthorizedWeight:      authorizedWeight,
-		DependentsAuthorized:  entitlement.DependentsAuthorized,
-		NonTemporaryStorage:   entitlement.NonTemporaryStorage,
-		PrivatelyOwnedVehicle: entitlement.PrivatelyOwnedVehicle,
-		ProGearWeight:         proGearWeight,
-		ProGearWeightSpouse:   proGearWeightSpouse,
-		StorageInTransit:      sit,
-		TotalDependents:       totalDependents,
-		TotalWeight:           totalWeight,
-		ETag:                  etag.GenerateEtag(entitlement.UpdatedAt),
+		ID:                             strfmt.UUID(entitlement.ID.String()),
+		AuthorizedWeight:               authorizedWeight,
+		DependentsAuthorized:           entitlement.DependentsAuthorized,
+		NonTemporaryStorage:            entitlement.NonTemporaryStorage,
+		PrivatelyOwnedVehicle:          entitlement.PrivatelyOwnedVehicle,
+		ProGearWeight:                  int64(entitlement.ProGearWeight),
+		ProGearWeightSpouse:            int64(entitlement.ProGearWeightSpouse),
+		RequiredMedicalEquipmentWeight: int64(entitlement.RequiredMedicalEquipmentWeight),
+		OrganizationalClothingandIndividualEquipment: entitlement.OrganizationalClothingAndIndividualEquipment,
+		StorageInTransit: sit,
+		TotalDependents:  totalDependents,
+		TotalWeight:      totalWeight,
+		ETag:             etag.GenerateEtag(entitlement.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -144,10 +144,8 @@ func Entitlement(entitlement *models.Entitlement) *supportmessages.Entitlement {
 	if entitlement == nil {
 		return nil
 	}
-	var proGearWeight, proGearWeightSpouse, totalWeight int64
+	var totalWeight int64
 	if entitlement.WeightAllotment() != nil {
-		proGearWeight = int64(entitlement.WeightAllotment().ProGearWeight)
-		proGearWeightSpouse = int64(entitlement.WeightAllotment().ProGearWeightSpouse)
 		totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
 	}
 	var authorizedWeight *int64
@@ -164,17 +162,18 @@ func Entitlement(entitlement *models.Entitlement) *supportmessages.Entitlement {
 		totalDependents = int64(*entitlement.TotalDependents)
 	}
 	return &supportmessages.Entitlement{
-		ID:                    strfmt.UUID(entitlement.ID.String()),
-		AuthorizedWeight:      authorizedWeight,
-		DependentsAuthorized:  entitlement.DependentsAuthorized,
-		NonTemporaryStorage:   entitlement.NonTemporaryStorage,
-		PrivatelyOwnedVehicle: entitlement.PrivatelyOwnedVehicle,
-		ProGearWeight:         proGearWeight,
-		ProGearWeightSpouse:   proGearWeightSpouse,
-		StorageInTransit:      sit,
-		TotalDependents:       totalDependents,
-		TotalWeight:           totalWeight,
-		ETag:                  etag.GenerateEtag(entitlement.UpdatedAt),
+		ID:                             strfmt.UUID(entitlement.ID.String()),
+		AuthorizedWeight:               authorizedWeight,
+		DependentsAuthorized:           entitlement.DependentsAuthorized,
+		NonTemporaryStorage:            entitlement.NonTemporaryStorage,
+		PrivatelyOwnedVehicle:          entitlement.PrivatelyOwnedVehicle,
+		ProGearWeight:                  int64(entitlement.ProGearWeight),
+		ProGearWeightSpouse:            int64(entitlement.ProGearWeightSpouse),
+		RequiredMedicalEquipmentWeight: int64(entitlement.RequiredMedicalEquipmentWeight),
+		StorageInTransit:               sit,
+		TotalDependents:                totalDependents,
+		TotalWeight:                    totalWeight,
+		ETag:                           etag.GenerateEtag(entitlement.UpdatedAt),
 	}
 }
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1015,6 +1015,13 @@ definitions:
         example: 500
         type: integer
         x-formatting: weight
+      requiredMedicalEquipmentWeight:
+        example: 500
+        type: integer
+        x-formatting: weight
+      organizationalClothingandIndividualEquipment:
+        type: boolean
+        example: false
       storageInTransit:
         example: 90
         type: integer

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1019,7 +1019,7 @@ definitions:
         example: 500
         type: integer
         x-formatting: weight
-      organizationalClothingandIndividualEquipment:
+      organizationalClothingAndIndividualEquipment:
         type: boolean
         example: false
       storageInTransit:

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -864,6 +864,13 @@ definitions:
         type: integer
         x-formatting: weight
         readOnly: true
+      requiredMedicalEquipmentWeight:
+        example: 500
+        type: integer
+        x-formatting: weight
+      organizationalClothingAndIndividualEquipment:
+        type: boolean
+        example: false
       storageInTransit:
         example: 90
         type: integer


### PR DESCRIPTION


## Description

Adds the requiredMedicalEquipmentWeight and organizationalClothingAndIndividualEquipment to the Entitlement payload for the Prime. This also ensures the progear and spouse-progear fields are taken from the entitlement object (database).


## Setup

Run the prime API

```sh
make db_dev_e2e_populate && make server_run
```

Then hit the prime API for some data like so: 
`go run ./cmd/prime-api-client --insecure get-move-task-order --id "cff839ab-ac1e-4db0-9d6e-c4b368bf854a"`

You should get the new fields on the entitlements output like this:
```json
"entitlement":{"authorizedWeight":8000,"dependentsAuthorized":true,"eTag":"MjAyMS0wNS0wNlQxOTozNzo0OC4zMjQ1NTVa","id":"cf8dc44e-d06c-42fb-8912-ea82e7b4a620","nonTemporaryStorage":true,"privatelyOwnedVehicle":true,"proGearWeight":1000,"proGearWeightSpouse":200,"requiredMedicalEquipmentWeight":1000,"storageInTransit":2,"totalDependents":1,"totalWeight":5000}
```



## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7427) for this change

