### PR TITLE
Update url-parse to 1.5.1 to avoid vulnerability in previous versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "reselect": "^4.0.0",
     "swagger-client": "^3.13.2",
     "swagger-ui-dist": "^3.47.1",
-    "url-parse": "^1.5.1",
     "uswds": "2.10.3",
     "uuid": "^8.3.2",
     "yup": "^0.32.9"
@@ -78,6 +77,7 @@
     "kind-of": "^6.0.2",
     "selfsigned": "^1.10.8",
     "immer": "^8.0.1",
+    "url-parse": "^1.5.1",
     "y18n": "^5.0.5"
   },
   "name": "client",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,10 @@
     "redux-thunk": "^2.2.0",
     "regenerator-runtime": "^0.13.7",
     "reselect": "^4.0.0",
-    "swagger-ui-dist": "^3.47.1",
-    "uswds": "2.10.3",
     "swagger-client": "^3.13.2",
+    "swagger-ui-dist": "^3.47.1",
+    "url-parse": "^1.5.1",
+    "uswds": "2.10.3",
     "uuid": "^8.3.2",
     "yup": "^0.32.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20213,15 +20213,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
-url-parse@^1.4.7, url-parse@^1.5.1:
+url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -20221,7 +20221,7 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url-parse@^1.4.7:
+url-parse@^1.4.7, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==


### PR DESCRIPTION
## Description

Update the url-parse package to version 1.5.1. This version clears a vulnerability in previous versions of interpreting URIs as relative paths.

https://www.npmjs.com/advisories/1678

