### PR TITLE
[MB-8026] Optimizing FetchMany in query builder

### DIFF
--- a/pkg/handlers/adminapi/access_code.go
+++ b/pkg/handlers/adminapi/access_code.go
@@ -51,7 +51,7 @@ func (h IndexAccessCodesHandler) Handle(params accesscodeop.IndexAccessCodesPara
 	}
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	associations := query.NewQueryAssociations(queryAssociations)
+	associations := query.NewQueryAssociationsPreload(queryAssociations)
 	accessCodes, err := h.AccessCodeListFetcher.FetchAccessCodeList(queryFilters, associations, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -46,11 +46,10 @@ func (h IndexAdminUsersHandler) Handle(params adminuserop.IndexAdminUsersParams)
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	pagination := h.NewPagination(params.Page, params.PerPage)
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	adminUsers, err := h.AdminUserListFetcher.FetchAdminUserList(queryFilters, associations, pagination, ordering)
+	adminUsers, err := h.AdminUserListFetcher.FetchAdminUserList(queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -39,10 +39,9 @@ func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElect
 	queryFilters := []services.QueryFilter{}
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	electronicOrders, err := h.ElectronicOrderListFetcher.FetchElectronicOrderList(queryFilters, associations, pagination, ordering)
+	electronicOrders, err := h.ElectronicOrderListFetcher.FetchElectronicOrderList(queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/moves.go
+++ b/pkg/handlers/adminapi/moves.go
@@ -65,7 +65,7 @@ func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Res
 	}
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	associations := query.NewQueryAssociations(queryAssociations)
+	associations := query.NewQueryAssociationsPreload(queryAssociations)
 	moves, err := h.MoveListFetcher.FetchMoveList(queryFilters, associations, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/adminapi/notifications.go
+++ b/pkg/handlers/adminapi/notifications.go
@@ -42,7 +42,7 @@ func (h IndexNotificationsHandler) Handle(params notificationsop.IndexNotificati
 	queryAssociations := []services.QueryAssociation{
 		query.NewQueryAssociation("ServiceMember.User"),
 	}
-	associations := query.NewQueryAssociations(queryAssociations)
+	associations := query.NewQueryAssociationsPreload(queryAssociations)
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
 	var notifications []models.Notification

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -74,11 +74,10 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 	queryFilters := h.generateQueryFilters(params.Filter, logger)
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
 	var officeUsers models.OfficeUsers
-	err := h.ListFetcher.FetchRecordList(&officeUsers, queryFilters, associations, pagination, ordering)
+	err := h.ListFetcher.FetchRecordList(&officeUsers, queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -44,15 +44,9 @@ func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middlewa
 	queryFilters := h.generateQueryFilters(params.Filter, logger)
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
-	// FetchMany does an eager query of all associated data. By listing only ShippingOffice as an association we reduce
-	// the association fetching down to one. Ideally this should be zero, but the query builder does not support this
-	// at this time.
-	associations := query.NewQueryAssociations([]services.QueryAssociation{
-		query.NewQueryAssociation("ShippingOffice"),
-	})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters, associations, pagination, ordering)
+	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/organizations.go
+++ b/pkg/handlers/adminapi/organizations.go
@@ -39,10 +39,9 @@ func (h IndexOrganizationsHandler) Handle(params organization.IndexOrganizations
 	queryFilters := []services.QueryFilter{}
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	organizations, err := h.OrganizationListFetcher.FetchOrganizationList(queryFilters, associations, pagination, ordering)
+	organizations, err := h.OrganizationListFetcher.FetchOrganizationList(queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/transportation_service_provider_performances.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances.go
@@ -52,10 +52,9 @@ func (h IndexTSPPsHandler) Handle(params tsppop.IndexTSPPsParams) middleware.Res
 	queryFilters := h.generateQueryFilters(params.Filter, logger)
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 
-	tspps, err := h.TransportationServiceProviderPerformanceListFetcher.FetchTransportationServiceProviderPerformanceList(queryFilters, associations, pagination, ordering)
+	tspps, err := h.TransportationServiceProviderPerformanceListFetcher.FetchTransportationServiceProviderPerformanceList(queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/users.go
+++ b/pkg/handlers/adminapi/users.go
@@ -66,12 +66,11 @@ func (h IndexUsersHandler) Handle(params userop.IndexUsersParams) middleware.Res
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := h.generateQueryFilters(params.Filter, logger)
 
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 	pagination := h.NewPagination(params.Page, params.PerPage)
 
 	var users models.Users
-	err := h.ListFetcher.FetchRecordList(&users, queryFilters, associations, pagination, ordering)
+	err := h.ListFetcher.FetchRecordList(&users, queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/webhook_subscriptions.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions.go
@@ -30,12 +30,11 @@ func (h IndexWebhookSubscriptionsHandler) Handle(params webhooksubscriptionop.In
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	associations := query.NewQueryAssociations([]services.QueryAssociation{})
 	ordering := query.NewQueryOrder(params.Sort, params.Order)
 	pagination := h.NewPagination(params.Page, params.PerPage)
 
 	var webhookSubscriptions models.WebhookSubscriptions
-	err := h.ListFetcher.FetchRecordList(&webhookSubscriptions, queryFilters, associations, pagination, ordering)
+	err := h.ListFetcher.FetchRecordList(&webhookSubscriptions, queryFilters, nil, pagination, ordering)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/ghcapi/mto_agent.go
+++ b/pkg/handlers/ghcapi/mto_agent.go
@@ -42,7 +42,7 @@ func (h ListMTOAgentsHandler) Handle(params mtoagentop.FetchMTOAgentListParams) 
 		query.NewQueryFilter("mto_shipment_id", "=", mtoShipmentID.String()),
 	}
 	var mtoAgents models.MTOAgents
-	err = h.FetchRecordList(&mtoAgents, queryFilters, query.NewQueryAssociations([]services.QueryAssociation{}), nil, nil)
+	err = h.FetchRecordList(&mtoAgents, queryFilters, nil, nil, nil)
 	// return errors
 	if err != nil {
 		if err.Error() == "FETCH_NOT_FOUND" {

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -146,7 +146,7 @@ func (h ListMTOServiceItemsHandler) Handle(params mtoserviceitemop.ListMTOServic
 	queryFilters = []services.QueryFilter{
 		query.NewQueryFilter("move_id", "=", moveTaskOrderID.String()),
 	}
-	queryAssociations := query.NewQueryAssociations([]services.QueryAssociation{
+	queryAssociations := query.NewQueryAssociationsPreload([]services.QueryAssociation{
 		query.NewQueryAssociation("ReService"),
 		query.NewQueryAssociation("CustomerContacts"),
 		query.NewQueryAssociation("Dimensions"),

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -57,6 +57,11 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 	queryFilters = []services.QueryFilter{
 		query.NewQueryFilter("move_id", "=", moveTaskOrderID.String()),
 	}
+
+	// TODO: These associations could be preloaded, but it will require Pop 5.3.4 to land first as it
+	//   has a fix for using a "has_many" association that has a pointer-based foreign key (like the
+	//   case with "MTOServiceItems.ReService"). There appear to be other changes that will need to be
+	//   made for Pop 5.3.4 though (see https://ustcdp3.slack.com/archives/CP497TGAU/p1620421441217700).
 	queryAssociations := query.NewQueryAssociations([]services.QueryAssociation{
 		query.NewQueryAssociation("MTOServiceItems.ReService"),
 		query.NewQueryAssociation("MTOAgents"),

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -183,11 +183,11 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 		query.NewQueryFilter("move_id", "=", moveTaskOrderID.String()),
 	}
 
-	// In some places, we used this unbound eager call accidentally and loaded all associations when the
-	// intention was to load no associations. In this instance, we get E2E failures if we change this to load
-	// no associations, so we'll keep it as is and can revisit later if we want to optimize further.  This is
-	// just loading shipments for a specific move (likely only 1 or 2 in most cases), so the impact of the
-	// additional loading shouldn't be too dramatic.
+	// TODO: In some places, we used this unbound eager call accidentally and loaded all associations when the
+	//   intention was to load no associations. In this instance, we get E2E failures if we change this to load
+	//   no associations, so we'll keep it as is and can revisit later if we want to optimize further.  This is
+	//   just loading shipments for a specific move (likely only 1 or 2 in most cases), so the impact of the
+	//   additional loading shouldn't be too dramatic.
 	queryAssociations := query.NewQueryAssociations([]services.QueryAssociation{})
 
 	queryOrder := query.NewQueryOrder(swag.String("created_at"), swag.Bool(true))

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -183,10 +183,17 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 		query.NewQueryFilter("move_id", "=", moveTaskOrderID.String()),
 	}
 
+	// In some places, we used this unbound eager call accidentally and loaded all associations when the
+	// intention was to load no associations. In this instance, we get E2E failures if we change this to load
+	// no associations, so we'll keep it as is and can revisit later if we want to optimize further.  This is
+	// just loading shipments for a specific move (likely only 1 or 2 in most cases), so the impact of the
+	// additional loading shouldn't be too dramatic.
+	queryAssociations := query.NewQueryAssociations([]services.QueryAssociation{})
+
 	queryOrder := query.NewQueryOrder(swag.String("created_at"), swag.Bool(true))
 
 	var shipments models.MTOShipments
-	err = h.ListFetcher.FetchRecordList(&shipments, queryFilters, nil, nil, queryOrder)
+	err = h.ListFetcher.FetchRecordList(&shipments, queryFilters, queryAssociations, nil, queryOrder)
 	// return any errors
 	if err != nil {
 		logger.Error("Error fetching mto shipments : ", zap.Error(err))

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -182,12 +182,11 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 	queryFilters = []services.QueryFilter{
 		query.NewQueryFilter("move_id", "=", moveTaskOrderID.String()),
 	}
-	queryAssociations := query.NewQueryAssociations([]services.QueryAssociation{})
 
 	queryOrder := query.NewQueryOrder(swag.String("created_at"), swag.Bool(true))
 
 	var shipments models.MTOShipments
-	err = h.ListFetcher.FetchRecordList(&shipments, queryFilters, queryAssociations, nil, queryOrder)
+	err = h.ListFetcher.FetchRecordList(&shipments, queryFilters, nil, nil, queryOrder)
 	// return any errors
 	if err != nil {
 		logger.Error("Error fetching mto shipments : ", zap.Error(err))

--- a/pkg/models/access_code.go
+++ b/pkg/models/access_code.go
@@ -14,7 +14,7 @@ import (
 type AccessCode struct {
 	ID              uuid.UUID        `json:"id" db:"id"`
 	ServiceMemberID *uuid.UUID       `json:"service_member_id" db:"service_member_id"`
-	ServiceMember   ServiceMember    `belongs_to:"service_members"`
+	ServiceMember   ServiceMember    `belongs_to:"service_members" fk_id:"service_member_id"`
 	Code            string           `json:"code" db:"code"`
 	MoveType        SelectedMoveType `json:"move_type" db:"move_type"`
 	CreatedAt       time.Time        `json:"created_at" db:"created_at"`

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -40,13 +40,13 @@ type AdminUser struct {
 	CreatedAt      time.Time    `json:"created_at" db:"created_at"`
 	UpdatedAt      time.Time    `json:"updated_at" db:"updated_at"`
 	UserID         *uuid.UUID   `json:"user_id" db:"user_id"`
-	User           User         `belongs_to:"user"`
+	User           User         `belongs_to:"user" fk_id:"user_id"`
 	Role           AdminRole    `json:"role" db:"role"`
 	Email          string       `json:"email" db:"email"`
 	FirstName      string       `json:"first_name" db:"first_name"`
 	LastName       string       `json:"last_name" db:"last_name"`
 	OrganizationID *uuid.UUID   `json:"organization_id" db:"organization_id"`
-	Organization   Organization `belongs_to:"organization"`
+	Organization   Organization `belongs_to:"organization" fk_id:"organization_id"`
 	Active         bool         `json:"active" db:"active"`
 }
 

--- a/pkg/models/backup_contact.go
+++ b/pkg/models/backup_contact.go
@@ -30,7 +30,7 @@ type BackupContact struct {
 	CreatedAt       time.Time               `json:"created_at" db:"created_at"`
 	UpdatedAt       time.Time               `json:"updated_at" db:"updated_at"`
 	ServiceMemberID uuid.UUID               `json:"service_member_id" db:"service_member_id"`
-	ServiceMember   ServiceMember           `belongs_to:"service_member"`
+	ServiceMember   ServiceMember           `belongs_to:"service_member" fk_id:"service_member_id"`
 	Permission      BackupContactPermission `json:"permission" db:"permission"`
 	Name            string                  `json:"name" db:"name"`
 	Email           string                  `json:"email" db:"email"`

--- a/pkg/models/distance_calculation.go
+++ b/pkg/models/distance_calculation.go
@@ -19,9 +19,9 @@ type distanceCalculator interface {
 type DistanceCalculation struct {
 	ID                   uuid.UUID `json:"id" db:"id"`
 	OriginAddressID      uuid.UUID `json:"origin_address_id" db:"origin_address_id"`
-	OriginAddress        Address   `belongs_to:"address"`
+	OriginAddress        Address   `belongs_to:"address" fk_id:"origin_address_id"`
 	DestinationAddressID uuid.UUID `json:"destination_address_id" db:"destination_address_id"`
-	DestinationAddress   Address   `belongs_to:"address"`
+	DestinationAddress   Address   `belongs_to:"address" fk_id:"destination_address_id"`
 	DistanceMiles        int       `json:"distance_miles" db:"distance_miles"`
 	CreatedAt            time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt            time.Time `json:"updated_at" db:"updated_at"`

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -18,7 +18,7 @@ import (
 type Document struct {
 	ID              uuid.UUID     `db:"id"`
 	ServiceMemberID uuid.UUID     `db:"service_member_id"`
-	ServiceMember   ServiceMember `belongs_to:"service_members"`
+	ServiceMember   ServiceMember `belongs_to:"service_members" fk_id:"service_member_id"`
 	CreatedAt       time.Time     `db:"created_at"`
 	UpdatedAt       time.Time     `db:"updated_at"`
 	DeletedAt       *time.Time    `db:"deleted_at"`

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -22,7 +22,7 @@ type Document struct {
 	CreatedAt       time.Time     `db:"created_at"`
 	UpdatedAt       time.Time     `db:"updated_at"`
 	DeletedAt       *time.Time    `db:"deleted_at"`
-	UserUploads     UserUploads   `has_many:"user_uploads" order_by:"created_at asc"`
+	UserUploads     UserUploads   `has_many:"user_uploads" fk_id:"document_id" order_by:"created_at asc"`
 }
 
 // Documents is not required by pop and may be deleted

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -20,9 +20,9 @@ type DutyStation struct {
 	Name                   string                       `json:"name" db:"name"`
 	Affiliation            internalmessages.Affiliation `json:"affiliation" db:"affiliation"`
 	AddressID              uuid.UUID                    `json:"address_id" db:"address_id"`
-	Address                Address                      `belongs_to:"address"`
+	Address                Address                      `belongs_to:"address" fk_id:"address_id"`
 	TransportationOfficeID *uuid.UUID                   `json:"transportation_office_id" db:"transportation_office_id"`
-	TransportationOffice   TransportationOffice         `belongs_to:"transportation_offices"`
+	TransportationOffice   TransportationOffice         `belongs_to:"transportation_offices" fk_id:"transportation_office_id"`
 }
 
 // DutyStations is not required by pop and may be deleted

--- a/pkg/models/duty_station_names.go
+++ b/pkg/models/duty_station_names.go
@@ -13,7 +13,7 @@ type DutyStationName struct {
 	UpdatedAt     time.Time   `json:"updated_at" db:"updated_at"`
 	Name          string      `json:"name" db:"name"`
 	DutyStationID uuid.UUID   `json:"duty_station_id" db:"duty_station_id"`
-	DutyStation   DutyStation `belongs_to:"duty_stations"`
+	DutyStation   DutyStation `belongs_to:"duty_stations" fk_id:"duty_station_id"`
 }
 
 // DutyStationNames is not required by pop and may be deleted

--- a/pkg/models/edi_errors.go
+++ b/pkg/models/edi_errors.go
@@ -15,9 +15,9 @@ type EdiError struct {
 	CreatedAt                  time.Time                                `json:"created_at" db:"created_at"`
 	UpdatedAt                  time.Time                                `json:"updated_at" db:"updated_at"`
 	PaymentRequestID           uuid.UUID                                `json:"payment_request_id" db:"payment_request_id"`
-	PaymentRequest             PaymentRequest                           `belongs_to:"payment_requests"`
+	PaymentRequest             PaymentRequest                           `belongs_to:"payment_requests" fk_id:"payment_request_id"`
 	InterchangeControlNumberID *uuid.UUID                               `json:"interchange_control_number_id" db:"interchange_control_number_id"`
-	InterchangeControlNumber   PaymentRequestToInterchangeControlNumber `belongs_to:"payment_request_to_interchange_control_numbers"`
+	InterchangeControlNumber   PaymentRequestToInterchangeControlNumber `belongs_to:"payment_request_to_interchange_control_numbers" fk_id:"interchange_control_number_id"`
 	Code                       *string                                  `json:"code" db:"code"`
 	Description                *string                                  `json:"description" db:"description"`
 	EDIType                    EDIType                                  `json:"edi_type" db:"edi_type"`

--- a/pkg/models/electronic_order.go
+++ b/pkg/models/electronic_order.go
@@ -35,7 +35,7 @@ type ElectronicOrder struct {
 	OrdersNumber string                    `json:"orders_number" db:"orders_number"`
 	Edipi        string                    `json:"edipi" db:"edipi"`
 	Issuer       Issuer                    `json:"issuer" db:"issuer"`
-	Revisions    ElectronicOrdersRevisions `has_many:"electronic_orders_revisions" order_by:"seq_num asc"`
+	Revisions    ElectronicOrdersRevisions `has_many:"electronic_orders_revisions" fk_id:"electronic_order_id" order_by:"seq_num asc"`
 }
 
 // String is not required by pop and may be deleted

--- a/pkg/models/electronic_orders_revision.go
+++ b/pkg/models/electronic_orders_revision.go
@@ -154,7 +154,7 @@ type ElectronicOrdersRevision struct {
 	CreatedAt             time.Time                   `json:"created_at" db:"created_at"`
 	UpdatedAt             time.Time                   `json:"updated_at" db:"updated_at"`
 	ElectronicOrderID     uuid.UUID                   `json:"electronic_order_id" db:"electronic_order_id"`
-	ElectronicOrder       ElectronicOrder             `belongs_to:"electronic_order"`
+	ElectronicOrder       ElectronicOrder             `belongs_to:"electronic_order" fk_id:"electronic_order_id"`
 	SeqNum                int                         `json:"seq_num" db:"seq_num"`
 	GivenName             string                      `json:"given_name" db:"given_name"`
 	MiddleName            *string                     `json:"middle_name" db:"middle_name"`

--- a/pkg/models/invoice.go
+++ b/pkg/models/invoice.go
@@ -34,14 +34,14 @@ const (
 type Invoice struct {
 	ID            uuid.UUID     `json:"id" db:"id"`
 	ApproverID    uuid.UUID     `json:"approver_id" db:"approver_id"`
-	Approver      OfficeUser    `belongs_to:"office_user"`
+	Approver      OfficeUser    `belongs_to:"office_user" fk_id:"approver_id"`
 	Status        InvoiceStatus `json:"status" db:"status"`
 	InvoiceNumber string        `json:"invoice_number" db:"invoice_number"`
 	InvoicedDate  time.Time     `json:"invoiced_date" db:"invoiced_date"`
 	CreatedAt     time.Time     `json:"created_at" db:"created_at"`
 	UpdatedAt     time.Time     `json:"updated_at" db:"updated_at"`
 	UserUploadID  *uuid.UUID    `json:"user_upload_id" db:"user_upload_id"`
-	UserUpload    *UserUpload   `belongs_to:"user_uploads"`
+	UserUpload    *UserUpload   `belongs_to:"user_uploads" fk_id:"user_upload_id"`
 }
 
 // Invoices is an array of invoices

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -81,7 +81,7 @@ type Move struct {
 	UpdatedAt                    time.Time               `json:"updated_at" db:"updated_at"`
 	SubmittedAt                  *time.Time              `json:"submitted_at" db:"submitted_at"`
 	OrdersID                     uuid.UUID               `json:"orders_id" db:"orders_id"`
-	Orders                       Order                   `belongs_to:"orders"`
+	Orders                       Order                   `belongs_to:"orders" fk_id:"orders_id"`
 	SelectedMoveType             *SelectedMoveType       `json:"selected_move_type" db:"selected_move_type"`
 	PersonallyProcuredMoves      PersonallyProcuredMoves `has_many:"personally_procured_moves" fk_id:"move_id" order_by:"created_at desc"`
 	MoveDocuments                MoveDocuments           `has_many:"move_documents" fk_id:"move_id" order_by:"created_at desc"`
@@ -91,7 +91,7 @@ type Move struct {
 	Show                         *bool                   `json:"show" db:"show"`
 	AvailableToPrimeAt           *time.Time              `db:"available_to_prime_at"`
 	ContractorID                 *uuid.UUID              `db:"contractor_id"`
-	Contractor                   *Contractor             `belongs_to:"contractors"`
+	Contractor                   *Contractor             `belongs_to:"contractors" fk_id:"contractor_id"`
 	PPMEstimatedWeight           *unit.Pound             `db:"ppm_estimated_weight"`
 	PPMType                      *string                 `db:"ppm_type"`
 	MTOServiceItems              MTOServiceItems         `has_many:"mto_service_items" fk_id:"move_id"`

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -83,10 +83,10 @@ type Move struct {
 	OrdersID                     uuid.UUID               `json:"orders_id" db:"orders_id"`
 	Orders                       Order                   `belongs_to:"orders"`
 	SelectedMoveType             *SelectedMoveType       `json:"selected_move_type" db:"selected_move_type"`
-	PersonallyProcuredMoves      PersonallyProcuredMoves `has_many:"personally_procured_moves" order_by:"created_at desc"`
-	MoveDocuments                MoveDocuments           `has_many:"move_documents" order_by:"created_at desc"`
+	PersonallyProcuredMoves      PersonallyProcuredMoves `has_many:"personally_procured_moves" fk_id:"move_id" order_by:"created_at desc"`
+	MoveDocuments                MoveDocuments           `has_many:"move_documents" fk_id:"move_id" order_by:"created_at desc"`
 	Status                       MoveStatus              `json:"status" db:"status"`
-	SignedCertifications         SignedCertifications    `has_many:"signed_certifications" order_by:"created_at desc"`
+	SignedCertifications         SignedCertifications    `has_many:"signed_certifications" fk_id:"move_id" order_by:"created_at desc"`
 	CancelReason                 *string                 `json:"cancel_reason" db:"cancel_reason"`
 	Show                         *bool                   `json:"show" db:"show"`
 	AvailableToPrimeAt           *time.Time              `db:"available_to_prime_at"`
@@ -94,9 +94,9 @@ type Move struct {
 	Contractor                   *Contractor             `belongs_to:"contractors"`
 	PPMEstimatedWeight           *unit.Pound             `db:"ppm_estimated_weight"`
 	PPMType                      *string                 `db:"ppm_type"`
-	MTOServiceItems              MTOServiceItems         `has_many:"mto_service_items"`
-	PaymentRequests              PaymentRequests         `has_many:"payment_requests"`
-	MTOShipments                 MTOShipments            `has_many:"mto_shipments"`
+	MTOServiceItems              MTOServiceItems         `has_many:"mto_service_items" fk_id:"move_id"`
+	PaymentRequests              PaymentRequests         `has_many:"payment_requests" fk_id:"move_id"`
+	MTOShipments                 MTOShipments            `has_many:"mto_shipments" fk_id:"move_id"`
 	ReferenceID                  *string                 `db:"reference_id"`
 	ServiceCounselingCompletedAt *time.Time              `db:"service_counseling_completed_at"`
 }

--- a/pkg/models/move_document.go
+++ b/pkg/models/move_document.go
@@ -108,11 +108,11 @@ const (
 type MoveDocument struct {
 	ID                       uuid.UUID                `json:"id" db:"id"`
 	DocumentID               uuid.UUID                `json:"document_id" db:"document_id"`
-	Document                 Document                 `belongs_to:"documents"`
+	Document                 Document                 `belongs_to:"documents" fk_id:"document_id"`
 	MoveID                   uuid.UUID                `json:"move_id" db:"move_id"`
-	Move                     Move                     `belongs_to:"moves"`
+	Move                     Move                     `belongs_to:"moves" fk_id:"move_id"`
 	PersonallyProcuredMoveID *uuid.UUID               `json:"personally_procured_move_id" db:"personally_procured_move_id"`
-	PersonallyProcuredMove   PersonallyProcuredMove   `belongs_to:"personally_procured_moves"`
+	PersonallyProcuredMove   PersonallyProcuredMove   `belongs_to:"personally_procured_moves" fk_id:"personally_procured_move_id"`
 	Title                    string                   `json:"title" db:"title"`
 	Status                   MoveDocumentStatus       `json:"status" db:"status"`
 	MoveDocumentType         MoveDocumentType         `json:"move_document_type" db:"move_document_type"`

--- a/pkg/models/move_documents_extractor.go
+++ b/pkg/models/move_documents_extractor.go
@@ -13,9 +13,9 @@ import (
 type MoveDocumentExtractor struct {
 	ID                       uuid.UUID            `json:"id" db:"id"`
 	DocumentID               uuid.UUID            `json:"document_id" db:"document_id"`
-	Document                 Document             `belongs_to:"documents"`
+	Document                 Document             `belongs_to:"documents" fk_id:"document_id"`
 	MoveID                   uuid.UUID            `json:"move_id" db:"move_id"`
-	Move                     Move                 `belongs_to:"moves"`
+	Move                     Move                 `belongs_to:"moves" fk_id:"move_id"`
 	Title                    string               `json:"title" db:"title"`
 	Status                   MoveDocumentStatus   `json:"status" db:"status"`
 	PersonallyProcuredMoveID *uuid.UUID           `json:"personally_procured_move_id" db:"personally_procured_move_id"`

--- a/pkg/models/moving_expense_document.go
+++ b/pkg/models/moving_expense_document.go
@@ -55,7 +55,7 @@ func IsExpenseModelDocumentType(docType MoveDocumentType) bool {
 type MovingExpenseDocument struct {
 	ID                   uuid.UUID         `json:"id" db:"id"`
 	MoveDocumentID       uuid.UUID         `json:"move_document_id" db:"move_document_id"`
-	MoveDocument         MoveDocument      `belongs_to:"move_documents"`
+	MoveDocument         MoveDocument      `belongs_to:"move_documents" fk_id:"move_document_id"`
 	MovingExpenseType    MovingExpenseType `json:"moving_expense_type" db:"moving_expense_type"`
 	RequestedAmountCents unit.Cents        `json:"requested_amount_cents" db:"requested_amount_cents"`
 	PaymentMethod        string            `json:"payment_method" db:"payment_method"`

--- a/pkg/models/mto_agents.go
+++ b/pkg/models/mto_agents.go
@@ -21,7 +21,7 @@ const (
 // MTOAgent is a struct that represents the mto_agents table.
 type MTOAgent struct {
 	ID            uuid.UUID    `db:"id"`
-	MTOShipment   MTOShipment  `belongs_to:"mto_shipments"`
+	MTOShipment   MTOShipment  `belongs_to:"mto_shipments" fk_id:"mto_shipment_id"`
 	MTOShipmentID uuid.UUID    `db:"mto_shipment_id"`
 	FirstName     *string      `db:"first_name"`
 	LastName      *string      `db:"last_name"`

--- a/pkg/models/mto_service_item_customer_contacts.go
+++ b/pkg/models/mto_service_item_customer_contacts.go
@@ -23,7 +23,7 @@ const (
 // MTOServiceItemCustomerContact is an object representing customer contact for a service item.
 type MTOServiceItemCustomerContact struct {
 	ID                         uuid.UUID           `db:"id"`
-	MTOServiceItem             MTOServiceItem      `belongs_to:"mto_service_items"`
+	MTOServiceItem             MTOServiceItem      `belongs_to:"mto_service_items" fk_id:"mto_service_item_id"`
 	MTOServiceItemID           uuid.UUID           `db:"mto_service_item_id"`
 	Type                       CustomerContactType `db:"type"`
 	TimeMilitary               string              `db:"time_military"`

--- a/pkg/models/mto_service_item_dimensions.go
+++ b/pkg/models/mto_service_item_dimensions.go
@@ -24,7 +24,7 @@ const (
 // MTOServiceItemDimension is an object representing dimensions for a service item.
 type MTOServiceItemDimension struct {
 	ID               uuid.UUID             `db:"id"`
-	MTOServiceItem   MTOServiceItem        `belongs_to:"mto_service_items"`
+	MTOServiceItem   MTOServiceItem        `belongs_to:"mto_service_items" fk_id:"mto_service_item_id"`
 	MTOServiceItemID uuid.UUID             `db:"mto_service_item_id"`
 	Type             DimensionType         `db:"type"`
 	Length           unit.ThousandthInches `db:"length_thousandth_inches"`

--- a/pkg/models/mto_service_items.go
+++ b/pkg/models/mto_service_items.go
@@ -24,11 +24,11 @@ const (
 // MTOServiceItem is an object representing service items for a move task order.
 type MTOServiceItem struct {
 	ID                            uuid.UUID                      `db:"id"`
-	MoveTaskOrder                 Move                           `belongs_to:"moves"`
+	MoveTaskOrder                 Move                           `belongs_to:"moves" fk_id:"move_id"`
 	MoveTaskOrderID               uuid.UUID                      `db:"move_id"`
-	MTOShipment                   MTOShipment                    `belongs_to:"mto_shipments"`
+	MTOShipment                   MTOShipment                    `belongs_to:"mto_shipments" fk_id:"mto_shipment_id"`
 	MTOShipmentID                 *uuid.UUID                     `db:"mto_shipment_id"`
-	ReService                     ReService                      `belongs_to:"re_services"`
+	ReService                     ReService                      `belongs_to:"re_services" fk_id:"re_service_id"`
 	ReServiceID                   uuid.UUID                      `db:"re_service_id"`
 	Reason                        *string                        `db:"reason"`
 	RejectionReason               *string                        `db:"rejection_reason"`
@@ -37,11 +37,11 @@ type MTOServiceItem struct {
 	SITPostalCode                 *string                        `db:"sit_postal_code"`
 	SITEntryDate                  *time.Time                     `db:"sit_entry_date"`
 	SITDepartureDate              *time.Time                     `db:"sit_departure_date"`
-	SITOriginHHGOriginalAddress   *Address                       `belongs_to:"addresses"`
+	SITOriginHHGOriginalAddress   *Address                       `belongs_to:"addresses" fk_id:"sit_origin_hhg_original_address_id"`
 	SITOriginHHGOriginalAddressID *uuid.UUID                     `db:"sit_origin_hhg_original_address_id"`
-	SITOriginHHGActualAddress     *Address                       `belongs_to:"addresses"`
+	SITOriginHHGActualAddress     *Address                       `belongs_to:"addresses" fk_id:"sit_origin_hhg_actual_address_id"`
 	SITOriginHHGActualAddressID   *uuid.UUID                     `db:"sit_origin_hhg_actual_address_id"`
-	SITDestinationFinalAddress    *Address                       `belongs_to:"addresses"`
+	SITDestinationFinalAddress    *Address                       `belongs_to:"addresses" fk_id:"sit_destination_final_address_id"`
 	SITDestinationFinalAddressID  *uuid.UUID                     `db:"sit_destination_final_address_id"`
 	Description                   *string                        `db:"description"`
 	Dimensions                    MTOServiceItemDimensions       `has_many:"mto_service_item_dimensions" fk_id:"mto_service_item_id"`

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -68,7 +68,7 @@ const (
 // MTOShipment is an object representing data for a move task order shipment
 type MTOShipment struct {
 	ID                               uuid.UUID         `db:"id"`
-	MoveTaskOrder                    Move              `belongs_to:"moves"`
+	MoveTaskOrder                    Move              `belongs_to:"moves" fk_id:"move_id"`
 	MoveTaskOrderID                  uuid.UUID         `db:"move_id"`
 	ScheduledPickupDate              *time.Time        `db:"scheduled_pickup_date"`
 	RequestedPickupDate              *time.Time        `db:"requested_pickup_date"`
@@ -78,15 +78,15 @@ type MTOShipment struct {
 	ActualPickupDate                 *time.Time        `db:"actual_pickup_date"`
 	RequiredDeliveryDate             *time.Time        `db:"required_delivery_date"`
 	CustomerRemarks                  *string           `db:"customer_remarks"`
-	PickupAddress                    *Address          `belongs_to:"addresses"`
+	PickupAddress                    *Address          `belongs_to:"addresses" fk_id:"pickup_address_id"`
 	PickupAddressID                  *uuid.UUID        `db:"pickup_address_id"`
-	DestinationAddress               *Address          `belongs_to:"addresses"`
+	DestinationAddress               *Address          `belongs_to:"addresses" fk_id:"destination_address_id"`
 	DestinationAddressID             *uuid.UUID        `db:"destination_address_id"`
 	MTOAgents                        MTOAgents         `has_many:"mto_agents" fk_id:"mto_shipment_id"`
 	MTOServiceItems                  MTOServiceItems   `has_many:"mto_service_items" fk_id:"mto_shipment_id"`
-	SecondaryPickupAddress           *Address          `belongs_to:"addresses"`
+	SecondaryPickupAddress           *Address          `belongs_to:"addresses" fk_id:"secondary_pickup_address_id"`
 	SecondaryPickupAddressID         *uuid.UUID        `db:"secondary_pickup_address_id"`
-	SecondaryDeliveryAddress         *Address          `belongs_to:"addresses"`
+	SecondaryDeliveryAddress         *Address          `belongs_to:"addresses" fk_id:"secondary_delivery_address_id"`
 	SecondaryDeliveryAddressID       *uuid.UUID        `db:"secondary_delivery_address_id"`
 	PrimeEstimatedWeight             *unit.Pound       `db:"prime_estimated_weight"`
 	PrimeEstimatedWeightRecordedDate *time.Time        `db:"prime_estimated_weight_recorded_date"`

--- a/pkg/models/notifications.go
+++ b/pkg/models/notifications.go
@@ -24,7 +24,7 @@ const (
 type Notification struct {
 	ID               uuid.UUID         `db:"id"`
 	ServiceMemberID  uuid.UUID         `db:"service_member_id"`
-	ServiceMember    ServiceMember     `belongs_to:"service_member"`
+	ServiceMember    ServiceMember     `belongs_to:"service_member" fk_id:"service_member_id"`
 	SESMessageID     string            `db:"ses_message_id"`
 	NotificationType NotificationTypes `db:"notification_type"`
 	CreatedAt        time.Time         `db:"created_at"`

--- a/pkg/models/office_email.go
+++ b/pkg/models/office_email.go
@@ -13,7 +13,7 @@ import (
 type OfficeEmail struct {
 	ID                     uuid.UUID            `json:"id" db:"id"`
 	TransportationOfficeID uuid.UUID            `json:"transportation_office_id" db:"transportation_office_id"`
-	TransportationOffice   TransportationOffice `belongs_to:"transportation_office"`
+	TransportationOffice   TransportationOffice `belongs_to:"transportation_office" fk_id:"transportation_office_id"`
 	Email                  string               `json:"email" db:"email"`
 	Label                  *string              `json:"label" db:"label"`
 	CreatedAt              time.Time            `json:"created_at" db:"created_at"`

--- a/pkg/models/office_phone_line.go
+++ b/pkg/models/office_phone_line.go
@@ -13,7 +13,7 @@ import (
 type OfficePhoneLine struct {
 	ID                     uuid.UUID            `json:"id" db:"id"`
 	TransportationOfficeID uuid.UUID            `json:"transportation_office_id" db:"transportation_office_id"`
-	TransportationOffice   TransportationOffice `belongs_to:"transportation_office"`
+	TransportationOffice   TransportationOffice `belongs_to:"transportation_office" fk_id:"transportation_office_id"`
 	Number                 string               `json:"number" db:"number"`
 	Label                  *string              `json:"label" db:"label"`
 	IsDsnNumber            bool                 `json:"is_dsn_number" db:"is_dsn_number"`

--- a/pkg/models/office_user.go
+++ b/pkg/models/office_user.go
@@ -14,14 +14,14 @@ import (
 type OfficeUser struct {
 	ID                     uuid.UUID            `json:"id" db:"id"`
 	UserID                 *uuid.UUID           `json:"user_id" db:"user_id"`
-	User                   User                 `belongs_to:"user"`
+	User                   User                 `belongs_to:"user" fk_id:"user_id"`
 	LastName               string               `json:"last_name" db:"last_name"`
 	FirstName              string               `json:"first_name" db:"first_name"`
 	MiddleInitials         *string              `json:"middle_initials" db:"middle_initials"`
 	Email                  string               `json:"email" db:"email"`
 	Telephone              string               `json:"telephone" db:"telephone"`
 	TransportationOfficeID uuid.UUID            `json:"transportation_office_id" db:"transportation_office_id"`
-	TransportationOffice   TransportationOffice `belongs_to:"transportation_office"`
+	TransportationOffice   TransportationOffice `belongs_to:"transportation_office" fk_id:"transportation_office_id"`
 	CreatedAt              time.Time            `json:"created_at" db:"created_at"`
 	UpdatedAt              time.Time            `json:"updated_at" db:"updated_at"`
 	Active                 bool                 `json:"active" db:"active"`

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -37,7 +37,7 @@ type Order struct {
 	CreatedAt           time.Time                          `json:"created_at" db:"created_at"`
 	UpdatedAt           time.Time                          `json:"updated_at" db:"updated_at"`
 	ServiceMemberID     uuid.UUID                          `json:"service_member_id" db:"service_member_id"`
-	ServiceMember       ServiceMember                      `belongs_to:"service_members"`
+	ServiceMember       ServiceMember                      `belongs_to:"service_members" fk_id:"service_member_id"`
 	IssueDate           time.Time                          `json:"issue_date" db:"issue_date"`
 	ReportByDate        time.Time                          `json:"report_by_date" db:"report_by_date"`
 	OrdersType          internalmessages.OrdersType        `json:"orders_type" db:"orders_type"`
@@ -48,7 +48,7 @@ type Order struct {
 	OriginDutyStationID *uuid.UUID                         `json:"origin_duty_station_id" db:"origin_duty_station_id"`
 	NewDutyStationID    uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
 	NewDutyStation      DutyStation                        `belongs_to:"duty_stations" fk_id:"new_duty_station_id"`
-	UploadedOrders      Document                           `belongs_to:"documents"`
+	UploadedOrders      Document                           `belongs_to:"documents" fk_id:"uploaded_orders_id"`
 	UploadedOrdersID    uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
 	OrdersNumber        *string                            `json:"orders_number" db:"orders_number"`
 	Moves               Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
@@ -57,7 +57,7 @@ type Order struct {
 	SAC                 *string                            `json:"sac" db:"sac"`
 	DepartmentIndicator *string                            `json:"department_indicator" db:"department_indicator"`
 	Grade               *string                            `json:"grade" db:"grade"`
-	Entitlement         *Entitlement                       `belongs_to:"entitlements"`
+	Entitlement         *Entitlement                       `belongs_to:"entitlements" fk_id:"entitlement_id"`
 	EntitlementID       *uuid.UUID                         `json:"entitlement_id" db:"entitlement_id"`
 }
 

--- a/pkg/models/payment_request.go
+++ b/pkg/models/payment_request.go
@@ -63,9 +63,9 @@ type PaymentRequest struct {
 
 	// Associations
 	MoveTaskOrder       Move                `belongs_to:"moves"`
-	PaymentServiceItems PaymentServiceItems `has_many:"payment_service_items"`
-	ProofOfServiceDocs  ProofOfServiceDocs  `has_many:"proof_of_service_docs"`
-	EdiErrors           EdiErrors           `has_many:"edi_errors"`
+	PaymentServiceItems PaymentServiceItems `has_many:"payment_service_items" fk_id:"payment_request_id"`
+	ProofOfServiceDocs  ProofOfServiceDocs  `has_many:"proof_of_service_docs" fk_id:"payment_request_id"`
+	EdiErrors           EdiErrors           `has_many:"edi_errors" fk_id:"payment_request_id"`
 }
 
 // PaymentRequests is a slice of PaymentRequest

--- a/pkg/models/payment_request.go
+++ b/pkg/models/payment_request.go
@@ -62,7 +62,7 @@ type PaymentRequest struct {
 	UpdatedAt            time.Time            `db:"updated_at"`
 
 	// Associations
-	MoveTaskOrder       Move                `belongs_to:"moves"`
+	MoveTaskOrder       Move                `belongs_to:"moves" fk_id:"move_id"`
 	PaymentServiceItems PaymentServiceItems `has_many:"payment_service_items" fk_id:"payment_request_id"`
 	ProofOfServiceDocs  ProofOfServiceDocs  `has_many:"proof_of_service_docs" fk_id:"payment_request_id"`
 	EdiErrors           EdiErrors           `has_many:"edi_errors" fk_id:"payment_request_id"`

--- a/pkg/models/payment_request_to_interchange_control_number.go
+++ b/pkg/models/payment_request_to_interchange_control_number.go
@@ -15,7 +15,7 @@ type PaymentRequestToInterchangeControlNumber struct {
 	EDIType                  EDIType   `db:"edi_type"`
 
 	// Associations
-	PaymentRequest PaymentRequest `belongs_to:"payment_requests"`
+	PaymentRequest PaymentRequest `belongs_to:"payment_requests" fk_id:"payment_request_id"`
 }
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/payment_service_item.go
+++ b/pkg/models/payment_service_item.go
@@ -68,8 +68,8 @@ type PaymentServiceItem struct {
 	UpdatedAt        time.Time                `db:"updated_at"`
 
 	//Associations
-	PaymentRequest           PaymentRequest           `belongs_to:"payment_request"`
-	MTOServiceItem           MTOServiceItem           `belongs_to:"mto_service_item"`
+	PaymentRequest           PaymentRequest           `belongs_to:"payment_request" fk_id:"payment_request_id"`
+	MTOServiceItem           MTOServiceItem           `belongs_to:"mto_service_item" fk_id:"mto_service_item_id"`
 	PaymentServiceItemParams PaymentServiceItemParams `has_many:"payment_service_item_params" fk_id:"payment_service_item_id"`
 }
 

--- a/pkg/models/payment_service_item.go
+++ b/pkg/models/payment_service_item.go
@@ -70,7 +70,7 @@ type PaymentServiceItem struct {
 	//Associations
 	PaymentRequest           PaymentRequest           `belongs_to:"payment_request"`
 	MTOServiceItem           MTOServiceItem           `belongs_to:"mto_service_item"`
-	PaymentServiceItemParams PaymentServiceItemParams `has_many:"payment_service_item_params"`
+	PaymentServiceItemParams PaymentServiceItemParams `has_many:"payment_service_item_params" fk_id:"payment_service_item_id"`
 }
 
 // PaymentServiceItems is not required by pop and may be deleted

--- a/pkg/models/payment_service_item_param.go
+++ b/pkg/models/payment_service_item_param.go
@@ -19,8 +19,8 @@ type PaymentServiceItemParam struct {
 	UpdatedAt             time.Time `db:"updated_at"`
 
 	// Associations
-	PaymentServiceItem  PaymentServiceItem  `belongs_to:"payment_service_item"`
-	ServiceItemParamKey ServiceItemParamKey `belongs_to:"service_item_param_key"`
+	PaymentServiceItem  PaymentServiceItem  `belongs_to:"payment_service_item" fk_id:"payment_service_item_id"`
+	ServiceItemParamKey ServiceItemParamKey `belongs_to:"service_item_param_key" fk_id:"service_item_param_key_id"`
 
 	// Used to lookup the appropriate ServiceItemParamKeyID when creating a PaymentServiceItemParam
 	IncomingKey string `db:"-"`

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -48,7 +48,7 @@ const (
 type PersonallyProcuredMove struct {
 	ID                            uuid.UUID      `json:"id" db:"id"`
 	MoveID                        uuid.UUID      `json:"move_id" db:"move_id"`
-	Move                          Move           `belongs_to:"move"`
+	Move                          Move           `belongs_to:"move" fk_id:"move_id"`
 	CreatedAt                     time.Time      `json:"created_at" db:"created_at"`
 	UpdatedAt                     time.Time      `json:"updated_at" db:"updated_at"`
 	WeightEstimate                *unit.Pound    `json:"weight_estimate" db:"weight_estimate"`
@@ -73,8 +73,8 @@ type PersonallyProcuredMove struct {
 	Status                        PPMStatus      `json:"status" db:"status"`
 	HasRequestedAdvance           bool           `json:"has_requested_advance" db:"has_requested_advance"`
 	AdvanceID                     *uuid.UUID     `json:"advance_id" db:"advance_id"`
-	Advance                       *Reimbursement `belongs_to:"reimbursements"`
-	AdvanceWorksheet              Document       `belongs_to:"documents"`
+	Advance                       *Reimbursement `belongs_to:"reimbursements" fk_id:"advance_id"`
+	AdvanceWorksheet              Document       `belongs_to:"documents" fk_id:"advance_worksheet_id"`
 	AdvanceWorksheetID            *uuid.UUID     `json:"advance_worksheet_id" db:"advance_worksheet_id"`
 	TotalSITCost                  *unit.Cents    `json:"total_sit_cost" db:"total_sit_cost"`
 	HasProGear                    *ProGearStatus `json:"has_pro_gear" db:"has_pro_gear"`

--- a/pkg/models/prime_upload.go
+++ b/pkg/models/prime_upload.go
@@ -16,11 +16,11 @@ import (
 type PrimeUpload struct {
 	ID                  uuid.UUID         `db:"id"`
 	ProofOfServiceDocID uuid.UUID         `db:"proof_of_service_docs_id"`
-	ProofOfServiceDoc   ProofOfServiceDoc `belongs_to:"proof_of_service_docs"`
+	ProofOfServiceDoc   ProofOfServiceDoc `belongs_to:"proof_of_service_docs" fk_id:"proof_of_service_docs_id"`
 	ContractorID        uuid.UUID         `db:"contractor_id"`
-	Contractor          Contractor        `belongs_to:"contractors"`
+	Contractor          Contractor        `belongs_to:"contractors" fk_id:"contractor_id"`
 	UploadID            uuid.UUID         `db:"upload_id"`
-	Upload              Upload            `belongs_to:"uploads"`
+	Upload              Upload            `belongs_to:"uploads" fk_id:"upload_id"`
 	CreatedAt           time.Time         `db:"created_at"`
 	UpdatedAt           time.Time         `db:"updated_at"`
 	DeletedAt           *time.Time        `db:"deleted_at"`

--- a/pkg/models/proof_of_service_doc.go
+++ b/pkg/models/proof_of_service_doc.go
@@ -17,7 +17,7 @@ type ProofOfServiceDoc struct {
 	UpdatedAt        time.Time `db:"updated_at"`
 
 	//Associations
-	PaymentRequest PaymentRequest `belongs_to:"payment_request"`
+	PaymentRequest PaymentRequest `belongs_to:"payment_request" fk_id:"payment_request_id"`
 	PrimeUploads   PrimeUploads   `has_many:"prime_uploads" fk_id:"proof_of_service_docs_id" order_by:"created_at asc"`
 }
 

--- a/pkg/models/re_contract_year.go
+++ b/pkg/models/re_contract_year.go
@@ -22,7 +22,7 @@ type ReContractYear struct {
 	UpdatedAt            time.Time `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
 }
 
 // ReContractYears is not required by pop and may be deleted

--- a/pkg/models/re_domestic_accessorial_price.go
+++ b/pkg/models/re_domestic_accessorial_price.go
@@ -22,8 +22,8 @@ type ReDomesticAccessorialPrice struct {
 	UpdatedAt        time.Time  `json:"updated_at" db:"updated_at"`
 
 	//associations
-	Contract ReContract `belongs_to:"re_contract"`
-	Service  ReService  `belongs_to:"re_service"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service  ReService  `belongs_to:"re_service" fk_id:"service_id"`
 }
 
 // ReDomesticAccessorialPrices is not required by pop and may be deleted

--- a/pkg/models/re_domestic_linehaul_price.go
+++ b/pkg/models/re_domestic_linehaul_price.go
@@ -26,8 +26,8 @@ type ReDomesticLinehaulPrice struct {
 	UpdatedAt             time.Time       `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract            ReContract            `belongs_to:"re_contract"`
-	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_area"`
+	Contract            ReContract            `belongs_to:"re_contract" fk_id:"contract_id"`
+	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_area" fk_id:"domestic_service_area_id"`
 }
 
 // ReDomesticLinehaulPrices is not required by pop and may be deleted

--- a/pkg/models/re_domestic_other_price.go
+++ b/pkg/models/re_domestic_other_price.go
@@ -23,8 +23,8 @@ type ReDomesticOtherPrice struct {
 	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
-	Service  ReService  `belongs_to:"re_service"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service  ReService  `belongs_to:"re_service" fk_id:"service_id"`
 }
 
 // ReDomesticOtherPrices is not required by pop and may be deleted

--- a/pkg/models/re_domestic_service_area.go
+++ b/pkg/models/re_domestic_service_area.go
@@ -20,7 +20,7 @@ type ReDomesticServiceArea struct {
 	UpdatedAt        time.Time `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
 }
 
 // ReDomesticServiceAreas is not required by pop and may be deleted

--- a/pkg/models/re_domestic_service_area_price.go
+++ b/pkg/models/re_domestic_service_area_price.go
@@ -23,9 +23,9 @@ type ReDomesticServiceAreaPrice struct {
 	UpdatedAt             time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract            ReContract            `belongs_to:"re_contract"`
-	Service             ReService             `belongs_to:"re_service"`
-	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_area"`
+	Contract            ReContract            `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service             ReService             `belongs_to:"re_service" fk_id:"service_id"`
+	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_area" fk_id:"domestic_service_area_id"`
 }
 
 // ReDomesticServiceAreaPrices is not required by pop and may be deleted

--- a/pkg/models/re_intl_accessorial_price.go
+++ b/pkg/models/re_intl_accessorial_price.go
@@ -40,8 +40,8 @@ type ReIntlAccessorialPrice struct {
 	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
 
 	//associations
-	Contract ReContract `belongs_to:"re_contract"`
-	Service  ReService  `belongs_to:"re_service"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service  ReService  `belongs_to:"re_service" fk_id:"service_id"`
 }
 
 // ReIntlAccessorialPrices is not required by pop and may be deleted

--- a/pkg/models/re_intl_other_price.go
+++ b/pkg/models/re_intl_other_price.go
@@ -23,9 +23,9 @@ type ReIntlOtherPrice struct {
 	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
-	Service  ReService  `belongs_to:"re_service"`
-	RateArea ReRateArea `belongs_to:"re_rate_area"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service  ReService  `belongs_to:"re_service" fk_id:"service_id"`
+	RateArea ReRateArea `belongs_to:"re_rate_area" fk_id:"rate_area_id"`
 }
 
 // ReIntlOtherPrices is a slice of ReIntlOtherPrice

--- a/pkg/models/re_intl_price.go
+++ b/pkg/models/re_intl_price.go
@@ -24,10 +24,10 @@ type ReIntlPrice struct {
 	UpdatedAt             time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract            ReContract `belongs_to:"re_contract"`
-	Service             ReService  `belongs_to:"re_service"`
-	OriginRateArea      ReRateArea `belongs_to:"re_rate_area"`
-	DestinationRateArea ReRateArea `belongs_to:"re_rate_area"`
+	Contract            ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service             ReService  `belongs_to:"re_service" fk_id:"service_id"`
+	OriginRateArea      ReRateArea `belongs_to:"re_rate_area" fk_id:"origin_rate_area_id"`
+	DestinationRateArea ReRateArea `belongs_to:"re_rate_area" fk_id:"destination_rate_area_id"`
 }
 
 // ReIntlPrices is a slice of ReIntlPrice objects

--- a/pkg/models/re_rate_area.go
+++ b/pkg/models/re_rate_area.go
@@ -20,7 +20,7 @@ type ReRateArea struct {
 	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
 }
 
 // ReRateAreas is not required by pop and may be deleted

--- a/pkg/models/re_shipment_type_price.go
+++ b/pkg/models/re_shipment_type_price.go
@@ -20,8 +20,8 @@ type ReShipmentTypePrice struct {
 	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
 
 	//Associations
-	Contract ReContract `belongs_to:"re_contract"`
-	Service  ReService  `belongs_to:"re_service"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	Service  ReService  `belongs_to:"re_service" fk_id:"service_id"`
 }
 
 // ReShipmentTypePrices is not required by pop and may be deleted

--- a/pkg/models/re_task_order_fee.go
+++ b/pkg/models/re_task_order_fee.go
@@ -21,8 +21,8 @@ type ReTaskOrderFee struct {
 	UpdatedAt      time.Time  `json:"updated_at" db:"updated_at"`
 
 	//Associations
-	ContractYear ReContractYear `belongs_to:"re_contract_year"`
-	Service      ReService      `belongs_to:"re_service"`
+	ContractYear ReContractYear `belongs_to:"re_contract_year" fk_id:"contract_year_id"`
+	Service      ReService      `belongs_to:"re_service" fk_id:"service_id"`
 }
 
 // ReTaskOrderFees is not required by pop and may be deleted

--- a/pkg/models/re_zip3s.go
+++ b/pkg/models/re_zip3s.go
@@ -23,9 +23,9 @@ type ReZip3 struct {
 	UpdatedAt             time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract            ReContract            `belongs_to:"re_contract"`
-	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_areas"`
-	RateArea            *ReRateArea           `belongs_to:"re_rate_areas"`
+	Contract            ReContract            `belongs_to:"re_contract" fk_id:"contract_id"`
+	DomesticServiceArea ReDomesticServiceArea `belongs_to:"re_domestic_service_areas" fk_id:"domestic_service_area_id"`
+	RateArea            *ReRateArea           `belongs_to:"re_rate_areas" fk_id:"rate_area_id"`
 }
 
 // ReZip3s is not required by pop and may be deleted

--- a/pkg/models/re_zip5_rate_areas.go
+++ b/pkg/models/re_zip5_rate_areas.go
@@ -19,8 +19,8 @@ type ReZip5RateArea struct {
 	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
 
 	// Associations
-	Contract ReContract `belongs_to:"re_contract"`
-	RateArea ReRateArea `belongs_to:"re_rate_areas"`
+	Contract ReContract `belongs_to:"re_contract" fk_id:"contract_id"`
+	RateArea ReRateArea `belongs_to:"re_rate_areas" fk_id:"rate_area_id"`
 }
 
 // ReZip5RateAreas is not required by pop and may be deleted

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -58,8 +58,8 @@ type ServiceMember struct {
 	ResidentialAddress     *Address                  `belongs_to:"address"`
 	BackupMailingAddressID *uuid.UUID                `json:"backup_mailing_address_id" db:"backup_mailing_address_id"`
 	BackupMailingAddress   *Address                  `belongs_to:"address"`
-	Orders                 Orders                    `has_many:"orders" order_by:"created_at desc"`
-	BackupContacts         BackupContacts            `has_many:"backup_contacts"`
+	Orders                 Orders                    `has_many:"orders" fk_id:"service_member_id" order_by:"created_at desc" `
+	BackupContacts         BackupContacts            `has_many:"backup_contacts" fk_id:"service_member_id"`
 	DutyStationID          *uuid.UUID                `json:"duty_station_id" db:"duty_station_id"`
 	DutyStation            DutyStation               `belongs_to:"duty_stations"`
 	RequiresAccessCode     bool                      `json:"requires_access_code" db:"requires_access_code"`

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -41,7 +41,7 @@ type ServiceMember struct {
 	CreatedAt              time.Time                 `json:"created_at" db:"created_at"`
 	UpdatedAt              time.Time                 `json:"updated_at" db:"updated_at"`
 	UserID                 uuid.UUID                 `json:"user_id" db:"user_id"`
-	User                   User                      `belongs_to:"user"`
+	User                   User                      `belongs_to:"user" fk_id:"user_id"`
 	Edipi                  *string                   `json:"edipi" db:"edipi"`
 	Affiliation            *ServiceMemberAffiliation `json:"affiliation" db:"affiliation"`
 	Rank                   *ServiceMemberRank        `json:"rank" db:"rank"`
@@ -55,13 +55,13 @@ type ServiceMember struct {
 	PhoneIsPreferred       *bool                     `json:"phone_is_preferred" db:"phone_is_preferred"`
 	EmailIsPreferred       *bool                     `json:"email_is_preferred" db:"email_is_preferred"`
 	ResidentialAddressID   *uuid.UUID                `json:"residential_address_id" db:"residential_address_id"`
-	ResidentialAddress     *Address                  `belongs_to:"address"`
+	ResidentialAddress     *Address                  `belongs_to:"address" fk_id:"residential_address_id"`
 	BackupMailingAddressID *uuid.UUID                `json:"backup_mailing_address_id" db:"backup_mailing_address_id"`
-	BackupMailingAddress   *Address                  `belongs_to:"address"`
+	BackupMailingAddress   *Address                  `belongs_to:"address" fk_id:"backup_mailing_address_id"`
 	Orders                 Orders                    `has_many:"orders" fk_id:"service_member_id" order_by:"created_at desc" `
 	BackupContacts         BackupContacts            `has_many:"backup_contacts" fk_id:"service_member_id"`
 	DutyStationID          *uuid.UUID                `json:"duty_station_id" db:"duty_station_id"`
-	DutyStation            DutyStation               `belongs_to:"duty_stations"`
+	DutyStation            DutyStation               `belongs_to:"duty_stations" fk_id:"duty_station_id"`
 	RequiresAccessCode     bool                      `json:"requires_access_code" db:"requires_access_code"`
 }
 

--- a/pkg/models/service_param.go
+++ b/pkg/models/service_param.go
@@ -18,8 +18,8 @@ type ServiceParam struct {
 	UpdatedAt             time.Time `db:"updated_at"`
 
 	//Associations
-	Service             ReServices          `belongs_to:"re_service"`
-	ServiceItemParamKey ServiceItemParamKey `belongs_to:"service_item_param_key"`
+	Service             ReServices          `belongs_to:"re_service" fk_id:"service_id"`
+	ServiceItemParamKey ServiceItemParamKey `belongs_to:"service_item_param_key" fk_id:"service_item_param_key_id"`
 }
 
 // ServiceParams is not required by pop and may be deleted

--- a/pkg/models/transportation_office.go
+++ b/pkg/models/transportation_office.go
@@ -21,8 +21,8 @@ type TransportationOffice struct {
 	AddressID        uuid.UUID             `json:"address_id" db:"address_id"`
 	Latitude         float32               `json:"latitude" db:"latitude"`
 	Longitude        float32               `json:"longitude" db:"longitude"`
-	PhoneLines       OfficePhoneLines      `has_many:"office_phone_lines"`
-	Emails           OfficeEmails          `has_many:"office_emails"`
+	PhoneLines       OfficePhoneLines      `has_many:"office_phone_lines" fk_id:"transportation_office_id"`
+	Emails           OfficeEmails          `has_many:"office_emails" fk_id:"transportation_office_id"`
 	Hours            *string               `json:"hours" db:"hours"`
 	Services         *string               `json:"services" db:"services"`
 	Note             *string               `json:"note" db:"note"`

--- a/pkg/models/transportation_office.go
+++ b/pkg/models/transportation_office.go
@@ -15,9 +15,9 @@ import (
 type TransportationOffice struct {
 	ID               uuid.UUID             `json:"id" db:"id"`
 	ShippingOfficeID *uuid.UUID            `json:"shipping_office_id" db:"shipping_office_id"`
-	ShippingOffice   *TransportationOffice `belongs_to:"transportation_offices"`
+	ShippingOffice   *TransportationOffice `belongs_to:"transportation_offices" fk_id:"shipping_office_id"`
 	Name             string                `json:"name" db:"name"`
-	Address          Address               `belongs_to:"address"`
+	Address          Address               `belongs_to:"address" fk_id:"address_id"`
 	AddressID        uuid.UUID             `json:"address_id" db:"address_id"`
 	Latitude         float32               `json:"latitude" db:"latitude"`
 	Longitude        float32               `json:"longitude" db:"longitude"`

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -38,9 +38,9 @@ type TransportationServiceProviderPerformance struct {
 	RateCycleStart                  time.Time                     `json:"rate_cycle_start" db:"rate_cycle_start"`
 	RateCycleEnd                    time.Time                     `json:"rate_cycle_end" db:"rate_cycle_end"`
 	TrafficDistributionListID       uuid.UUID                     `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
-	TrafficDistributionList         TrafficDistributionList       `belongs_to:"traffic_distribution_list"`
+	TrafficDistributionList         TrafficDistributionList       `belongs_to:"traffic_distribution_list" fk_id:"traffic_distribution_list_id"`
 	TransportationServiceProviderID uuid.UUID                     `json:"transportation_service_provider_id" db:"transportation_service_provider_id"`
-	TransportationServiceProvider   TransportationServiceProvider `belongs_to:"transportation_service_provider"`
+	TransportationServiceProvider   TransportationServiceProvider `belongs_to:"transportation_service_provider" fk_id:"transportation_service_provider_id"`
 	QualityBand                     *int                          `json:"quality_band" db:"quality_band"`
 	BestValueScore                  float64                       `json:"best_value_score" db:"best_value_score"`
 	LinehaulRate                    unit.DiscountRate             `json:"linehaul_rate" db:"linehaul_rate"`

--- a/pkg/models/user_upload.go
+++ b/pkg/models/user_upload.go
@@ -17,10 +17,10 @@ import (
 type UserUpload struct {
 	ID         uuid.UUID  `db:"id"`
 	DocumentID *uuid.UUID `db:"document_id"`
-	Document   Document   `belongs_to:"documents"`
+	Document   Document   `belongs_to:"documents" fk_id:"document_id"`
 	UploaderID uuid.UUID  `db:"uploader_id"`
 	UploadID   uuid.UUID  `db:"upload_id"`
-	Upload     Upload     `belongs_to:"uploads"`
+	Upload     Upload     `belongs_to:"uploads" fk_id:"upload_id"`
 	CreatedAt  time.Time  `db:"created_at"`
 	UpdatedAt  time.Time  `db:"updated_at"`
 	DeletedAt  *time.Time `db:"deleted_at"`

--- a/pkg/models/webhook_notification.go
+++ b/pkg/models/webhook_notification.go
@@ -36,7 +36,7 @@ type WebhookNotification struct {
 	EventKey         string                    `db:"event_key"`
 	TraceID          *uuid.UUID                `db:"trace_id"`
 	MoveTaskOrderID  *uuid.UUID                `db:"move_id"`
-	MoveTaskOrder    Move                      `belongs_to:"moves"`
+	MoveTaskOrder    Move                      `belongs_to:"moves" fk_id:"move_id"`
 	ObjectID         *uuid.UUID                `db:"object_id"`
 	Payload          string                    `db:"payload"`
 	Status           WebhookNotificationStatus `db:"status"`

--- a/pkg/models/webhook_subscription.go
+++ b/pkg/models/webhook_subscription.go
@@ -26,7 +26,7 @@ type WebhookSubscriptionStatus string
 // A WebhookSubscription represents a webhook subscription
 type WebhookSubscription struct {
 	ID           uuid.UUID                 `db:"id"`
-	Subscriber   Contractor                `belongs_to:"contractors:"`
+	Subscriber   Contractor                `belongs_to:"contractors" fk_id:"subscriber_id"`
 	SubscriberID uuid.UUID                 `db:"subscriber_id"`
 	Status       WebhookSubscriptionStatus `db:"status"`
 	Severity     int                       `db:"severity"` // Zero indicates no severity value, 1 is highest

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -35,7 +35,7 @@ const (
 type WeightTicketSetDocument struct {
 	ID                       uuid.UUID           `json:"id" db:"id"`
 	MoveDocumentID           uuid.UUID           `json:"move_document_id" db:"move_document_id"`
-	MoveDocument             MoveDocument        `belongs_to:"move_documents"`
+	MoveDocument             MoveDocument        `belongs_to:"move_documents" fk_id:"move_document_id"`
 	EmptyWeight              *unit.Pound         `json:"empty_weight,omitempty" db:"empty_weight"`
 	EmptyWeightTicketMissing bool                `json:"empty_weight_ticket_missing,omitempty" db:"empty_weight_ticket_missing"`
 	FullWeight               *unit.Pound         `json:"full_weight,omitempty" db:"full_weight"`

--- a/pkg/services/mocks/QueryAssociations.go
+++ b/pkg/services/mocks/QueryAssociations.go
@@ -9,6 +9,20 @@ type QueryAssociations struct {
 	mock.Mock
 }
 
+// Preload provides a mock function with given fields:
+func (_m *QueryAssociations) Preload() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // StringGetAssociations provides a mock function with given fields:
 func (_m *QueryAssociations) StringGetAssociations() []string {
 	ret := _m.Called()

--- a/pkg/services/payment_request/payment_request_status_updater.go
+++ b/pkg/services/payment_request/payment_request_status_updater.go
@@ -34,8 +34,7 @@ func (p *paymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest 
 			query.NewQueryFilter("payment_request_id", "=", id),
 			query.NewQueryFilter("status", "=", models.PaymentServiceItemStatusRequested),
 		}
-		associations := query.NewQueryAssociations([]services.QueryAssociation{})
-		error := p.builder.FetchMany(&paymentServiceItems, serviceItemFilter, associations, nil, nil)
+		error := p.builder.FetchMany(&paymentServiceItems, serviceItemFilter, nil, nil, nil)
 
 		if error != nil {
 			return nil, error

--- a/pkg/services/query.go
+++ b/pkg/services/query.go
@@ -27,6 +27,7 @@ type NewQueryAssociation func(field string) QueryAssociation
 //go:generate mockery -name QueryAssociations
 type QueryAssociations interface {
 	StringGetAssociations() []string
+	Preload() bool
 }
 
 // NewQueryAssociations is a function type definition for building a QueryAssociations

--- a/pkg/services/query/query_association.go
+++ b/pkg/services/query/query_association.go
@@ -22,6 +22,7 @@ func NewQueryAssociation(field string) services.QueryAssociation {
 
 type queryAssociations struct {
 	associations []services.QueryAssociation
+	preload      bool
 }
 
 // StringGetAssociations returns a slice of string associations
@@ -35,9 +36,23 @@ func (qa queryAssociations) StringGetAssociations() []string {
 	return associations
 }
 
+// Preload returns whether the association should be preloaded or not
+func (qa queryAssociations) Preload() bool {
+	return qa.preload
+}
+
 // NewQueryAssociations returns new query associations
 func NewQueryAssociations(associations []services.QueryAssociation) services.QueryAssociations {
 	return queryAssociations{
 		associations,
+		false,
+	}
+}
+
+// NewQueryAssociationsPreload returns new query associations using preload
+func NewQueryAssociationsPreload(associations []services.QueryAssociation) services.QueryAssociations {
+	return queryAssociations{
+		associations,
+		true,
 	}
 }

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -459,6 +459,9 @@ func (p *Builder) QueryForAssociations(model interface{}, associations services.
 }
 
 func associatedQuery(query *pop.Query, associations services.QueryAssociations, model interface{}) *pop.Query {
+	if associations == nil {
+		return query
+	}
 	return query.Eager(associations.StringGetAssociations()...)
 }
 

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -462,6 +462,10 @@ func associatedQuery(query *pop.Query, associations services.QueryAssociations, 
 	if associations == nil {
 		return query
 	}
+
+	if associations.Preload() {
+		return query.EagerPreload(associations.StringGetAssociations()...)
+	}
 	return query.Eager(associations.StringGetAssociations()...)
 }
 


### PR DESCRIPTION
## Description

This PR begins to address two performance problems with our current implementation of `FetchMany` in the query builder:
- `FetchMany` uses Pop's `Eager` not `EagerPreload` so it is making way more requests than it should.
- `FetchMany` does not have a way to tell it you want to load zero associations. So it loads ALL associations. 

## Reviewer Notes

- There are a lot of files changed in this PR, but the changes break down as follows:
  - `NewQueryAssociation` was remapped to the new `NewQueryAssociationPreload` in some places where preloading made sense and seemed to work fine.
  - Changed some (accidental) default `Eager` calls (which loaded all associations) to `nil` to load no associations.  This required changes to the query builder to support the `nil`.
  - A good bit of the file changes are due to adding an explicit `fk_id` to `has_many` and `belongs_to` relationships so we don't have to rely on Pop's guesses for the field names (it was sometimes guessing wrong when preloading).
  - Added ability to specify preloading as part of setting up query associations in the query build (see pkg/services/query/)
- I tried to change`FetchOne` as well to preload associations, but I got a lot of failures when doing so; we'll have to work through those if we want to make that change.  `FetchOne` probably needs a refactoring anyway as it is loading all associations every time and there's no way to change that behavior on a case-by-case basis.  The good news is that since `FetchOne` is fetching a single base record, default eager loading of associations doesn't cause an explosion of additional queries like it can be with a big list of base records (like `FetchMany` might have).
- The most obvious performance improvements are found in the admin interface list views.  In particular, the TSPP listing should be a lot faster.  You can see the difference in SQL queries generated on dev by comparing the admin interface on master with this branch.
- I ran into a bug in Pop when trying to preload a `has_many` association with a pointer-based foreign key (like we have when preloading `MTOServiceItems.ReService` for a shipment).  I made a [PR for Pop](https://github.com/gobuffalo/pop/pull/647) and it's been merged and is in Pop 5.3.4, but [we have other issues](https://github.com/transcom/mymove/pull/6589#issuecomment-834774756) it looks like we have to solve first before moving to that version.

## Setup

- The tests should hopefully catch any major issue here; I had to avoid a preload or deleting the default eager in a few places when tests started failing.
- Most of the changes were around the admin interface, so try it and make sure you don't see anything new that's broken or data that's missing.

## Code Review Verification Steps

* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8026) for this change
* [Relevant Slack thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1619811517304100)
