### PR TITLE
MB-3538 Switch from `Count` to `Exists` for ref ID uniqueness check

### DIFF
--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -654,10 +654,11 @@ func generateReferenceIDHelper(db *pop.Connection) (string, error) {
 
 	newReferenceID := fmt.Sprintf("%04d-%04d", firstNum, secondNum)
 
-	count, err := db.Where(`reference_id= $1`, newReferenceID).Count(&Move{})
+	exists, err := db.Where(`reference_id= $1`, newReferenceID).Exists(&Move{})
+
 	if err != nil {
 		return "", err
-	} else if count > 0 {
+	} else if exists {
 		return "", errors.New("move: reference_id already exists")
 	}
 


### PR DESCRIPTION
## Description

We need to check if we have generated a unique reference ID for a move. Our current implementation uses `Count` to see if any exist with that ID. This changes to using `Exists` since we don't care about the actual count beyond whether it's >0, which `Exists` handles for us.

## Reviewer Notes

Not sure if there's a way to test for efficiency. I've used things before in django to kind of keep an eye on queries and timing, but not quite at this level, usually at an integration test level (like making sure a single handler doesn't perform more than x queries).

## Setup

```sh
make server_test
```

or

```sh
go test ./pkg/models -v -testify.m TestGenerateReferenceID
```

## Code Review Verification Steps

* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3538) for this change