### PR TITLE
[MB-6358] Add SAC to end of EDI858 invoices

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -32,6 +32,7 @@ type Invoice858C struct {
 	SE           edisegment.SE
 	GE           edisegment.GE
 	IEA          edisegment.IEA
+	FA2          edisegment.FA2
 }
 
 // InvoiceHeader holds all of the segments that are part of an Invoice858C's Header
@@ -156,6 +157,7 @@ func (invoice Invoice858C) Segments() [][]string {
 	records = append(records, invoice.SE.StringArray())
 	records = append(records, invoice.GE.StringArray())
 	records = append(records, invoice.IEA.StringArray())
+	records = append(records, invoice.FA2.StringArray())
 	return records
 }
 

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -86,6 +86,7 @@ L3*300.000*B***100
 SE*12345*ABCDE
 GE*1*9999
 IEA*1*000009999
+FA2*ZZ*1234
 `, ediString)
 	})
 }
@@ -255,6 +256,10 @@ func MakeValidEdi() Invoice858C {
 		IEA: edisegment.IEA{
 			NumberOfIncludedFunctionalGroups: 1,
 			InterchangeControlNumber:         9999,
+		},
+		FA2: edisegment.FA2{
+			BreakdownStructureDetailCode: "ZZ",
+			FinancialInformationCode:     "1234",
 		},
 	}
 }

--- a/pkg/edi/segment/fa2.go
+++ b/pkg/edi/segment/fa2.go
@@ -6,7 +6,7 @@ import (
 
 // FA2 represents the FA2 EDI segment
 type FA2 struct {
-	BreakdownStructureDetailCode string `validate:"eq=TA"`
+	BreakdownStructureDetailCode string `validate:"oneof=TA ZZ"`
 	FinancialInformationCode     string `validate:"min=1,max=80"`
 }
 

--- a/pkg/edi/segment/fa2_test.go
+++ b/pkg/edi/segment/fa2_test.go
@@ -22,7 +22,7 @@ func (suite *SegmentSuite) TestValidateFA2() {
 		}
 
 		err := suite.validator.Struct(fa2)
-		suite.ValidateError(err, "BreakdownStructureDetailCode", "eq")
+		suite.ValidateError(err, "BreakdownStructureDetailCode", "oneof")
 		suite.ValidateError(err, "FinancialInformationCode", "min")
 		suite.ValidateErrorLen(err, 2)
 	})

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -308,6 +308,9 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 			PaymentServiceItem: models.PaymentServiceItem{
 				Status: models.PaymentServiceItemStatusApproved,
 			},
+			Order: models.Order{
+				SAC: models.StringPointer("1234"),
+			},
 		},
 	)
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -268,9 +268,10 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		InterchangeControlNumber:         interchangeControlNumber,
 	}
 
-	if moveTaskOrder.Orders.SAC == nil {
-		return ediinvoice.Invoice858C{}, fmt.Errorf("Missing SAC")
+	if moveTaskOrder.Orders.SAC == nil || *moveTaskOrder.Orders.SAC == "" {
+		return ediinvoice.Invoice858C{}, services.NewConflictError(moveTaskOrder.Orders.ID, "Invalid order. Must have a SAC value")
 	}
+
 	edi858.FA2 = edisegment.FA2{
 		BreakdownStructureDetailCode: "ZZ",
 		FinancialInformationCode:     *moveTaskOrder.Orders.SAC,

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -268,6 +268,14 @@ func (g ghcPaymentRequestInvoiceGenerator) Generate(paymentRequest models.Paymen
 		InterchangeControlNumber:         interchangeControlNumber,
 	}
 
+	if moveTaskOrder.Orders.SAC == nil {
+		return ediinvoice.Invoice858C{}, fmt.Errorf("Missing SAC")
+	}
+	edi858.FA2 = edisegment.FA2{
+		BreakdownStructureDetailCode: "ZZ",
+		FinancialInformationCode:     *moveTaskOrder.Orders.SAC,
+	}
+
 	return edi858, nil
 }
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -91,7 +91,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		},
 	}
 
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			SAC: models.StringPointer("1234"),
+		},
+	})
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 		Move: mto,
@@ -607,7 +611,11 @@ func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {
 			Value:   testdatagen.DefaultContractCode,
 		},
 	}
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			SAC: models.StringPointer("1234"),
+		},
+	})
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		PaymentRequest: models.PaymentRequest{

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -747,6 +747,34 @@ func (suite *GHCInvoiceSuite) TestNilValues() {
 		nilPaymentRequest.MoveTaskOrder.Orders.TAC = oldTAC
 	})
 
+	suite.T().Run("nil SAC does not cause panic", func(t *testing.T) {
+		oldSAC := nilPaymentRequest.MoveTaskOrder.Orders.SAC
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = nil
+		suite.NotPanics(panicFunc)
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = oldSAC
+	})
+
+	suite.T().Run("nil SAC returns error", func(t *testing.T) {
+		oldSAC := nilPaymentRequest.MoveTaskOrder.Orders.SAC
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = nil
+		_, err := generator.Generate(nilPaymentRequest, false)
+		suite.Error(err)
+		suite.IsType(services.ConflictError{}, err)
+		suite.Equal(fmt.Sprintf("id: %s is in a conflicting state Invalid order. Must have a SAC value", nilPaymentRequest.MoveTaskOrder.OrdersID), err.Error())
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = oldSAC
+	})
+
+	suite.T().Run("empty SAC returns error", func(t *testing.T) {
+		oldSAC := nilPaymentRequest.MoveTaskOrder.Orders.SAC
+		blank := ""
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = &blank
+		_, err := generator.Generate(nilPaymentRequest, false)
+		suite.Error(err)
+		suite.IsType(services.ConflictError{}, err)
+		suite.Equal(fmt.Sprintf("id: %s is in a conflicting state Invalid order. Must have a SAC value", nilPaymentRequest.MoveTaskOrder.OrdersID), err.Error())
+		nilPaymentRequest.MoveTaskOrder.Orders.SAC = oldSAC
+	})
+
 	suite.T().Run("nil country for NewDutyStation does not cause panic", func(t *testing.T) {
 		oldCountry := nilPaymentRequest.MoveTaskOrder.Orders.NewDutyStation.Address.Country
 		nilPaymentRequest.MoveTaskOrder.Orders.NewDutyStation.Address.Country = nil

--- a/pkg/services/payment_request/payment_request_reviewed_processor_test.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor_test.go
@@ -59,7 +59,11 @@ func (suite *PaymentRequestServiceSuite) createPaymentRequest(num int) models.Pa
 			},
 		}
 
-		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
+		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+			Order: models.Order{
+				SAC: models.StringPointer("1234"),
+			},
+		})
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 			Move: mto,
 			PaymentRequest: models.PaymentRequest{


### PR DESCRIPTION
We are sending SAC as a new FA2 service item at the end
of the invoice.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
