### PR TITLE
MB-8073 Update Zap.Object names to make parsing logs easier

### DIFF
--- a/pkg/services/invoice/syncada_sftp_reader.go
+++ b/pkg/services/invoice/syncada_sftp_reader.go
@@ -44,7 +44,7 @@ func (s *syncadaReaderSFTPSession) FetchAndProcessSyncadaFiles(pickupPath string
 			ProcessEndedAt:   time.Now(),
 			NumEDIsProcessed: numProcessed,
 		}
-		s.logger.Info("EDIs processed", zap.Object("EDIs processed", &ediProcessing))
+		s.logger.Info("EDIs processed", zap.Object("edisProcessed", &ediProcessing))
 
 		verrs, err := s.db.ValidateAndCreate(&ediProcessing)
 		if err != nil {

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -201,7 +201,7 @@ func (p *paymentRequestReviewedProcessor) ProcessReviewedPaymentRequest() {
 			ProcessEndedAt:   time.Now(),
 			NumEDIsProcessed: numProcessed,
 		}
-		p.logger.Info("EDIs processed", zap.Object("EDIs processed", &ediProcessing))
+		p.logger.Info("EDIs processed", zap.Object("edisProcessed", &ediProcessing))
 
 		verrs, err := p.db.ValidateAndCreate(&ediProcessing)
 		if err != nil {


### PR DESCRIPTION
## Description

AWS parses json so you can filter on specific elements of the message,
but 'EDIs Processed' has a space which was proving too hard to filter on
this removes the space

## Reviewer Notes

Any better name for the Zap Object? Also I added [this section](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#tip-use-json-friendly-names-for-zapobjects) to the docs for others to hopefully not have the same issue

## Setup

Run the job runner

```sh
go run ./cmd/milmove-tasks process-edis
```

look for the updated name `edisProcessed` in the logs
```json
{"level":"info","ts":"2021-05-10T22:56:50.720Z","caller":"payment_request/payment_request_reviewed_processor.go:204","msg":"EDIs processed","edisProcessed":{"EDIType":"858","NumEDIsProcessed":0,"ProcessStartedAt":"2021-05-10T22:56:50.361Z","ProcessEndedAt":"2021-05-10T22:56:50.720Z"}}
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8073) for this change
