### PR TITLE
MB-8054 trace id as response header

### DIFF
--- a/pkg/middleware/context_logger.go
+++ b/pkg/middleware/context_logger.go
@@ -14,11 +14,12 @@ func ContextLogger(field string, original Logger) func(next http.Handler) http.H
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			logs := original
 			if id := trace.FromContext(ctx); len(id) > 0 {
-				next.ServeHTTP(w, r.WithContext(logging.NewContext(ctx, original.With(zap.String(field, id)))))
-			} else {
-				next.ServeHTTP(w, r.WithContext(logging.NewContext(ctx, original)))
+				logs = logs.With(zap.String(field, id))
 			}
+			ctx = logging.NewContext(ctx, logs)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }


### PR DESCRIPTION
## Description

Provide the `trace-id` in the response headers, to enable easier debugging.

## Setup

Hit the running with any request, and see the header `X-MILMOVE-TRACE-ID` returned with a unique value.

```sh
$ curl -v http://milmovelocal:8080/internal/swagger.yml
*   Trying 127.0.0.1...
...
< HTTP/1.1 401 Unauthorized
< Cache-Control: no-cache="Set-Cookie"
< Content-Security-Policy: frame-ancestors 'none'
...
< X-Milmove-Trace-Id: f917d324-ae59-4b04-b37e-5ad78ba7ea91
< Content-Length: 13
<
Unauthorized
```

The value of the header (`f917d324-ae59-4b04-b37e-5ad78ba7ea91`) is then useful for correlating to the logs:

```sh
2021-05-11T00:29:58.864Z	INFO	middleware/request_logger.go:85	Request	{"git_branch": "nelz-traceid-viz", "git_commit": "5df105428ec8e2adf63e86ec805e60c5623aa902", "milmove_trace_id": "f917d324-ae59-4b04-b37e-5ad78ba7ea91", "accepted-language": "", "content-length": 0, "host": "milmovelocal:8080", "method": "GET", "protocol-version": "HTTP/1.1", "referer": "", "source": "127.0.0.1:51040", "url": "/internal/swagger.yml", "user-agent": "curl/7.64.1", "protocol": "http", "headers": 2, "duration": "139.292µs", "resp-size-bytes": 13, "resp-status": 401}
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
