### PR TITLE
[MB-7926] Services Counselor can't update Authorized weight (backend)

### DIFF
--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -85,8 +85,8 @@ type UpdateOrderHandler struct {
 func (h UpdateOrderHandler) Handle(params orderop.UpdateOrderParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	if session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
-		return orderop.NewUpdateOrderBadRequest()
+	if session.IsOfficeUser() || session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
+		return orderop.NewUpdateOrderUnauthorized()
 	}
 
 	orderID, err := uuid.FromString(params.OrderID.String())

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -10,6 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/event"
 
@@ -82,7 +83,11 @@ type UpdateOrderHandler struct {
 
 // Handle ... updates an order from a request payload
 func (h UpdateOrderHandler) Handle(params orderop.UpdateOrderParams) middleware.Responder {
-	_, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
+	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
+
+	if session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
+		return orderop.NewUpdateOrderBadRequest()
+	}
 
 	orderID, err := uuid.FromString(params.OrderID.String())
 	if err != nil {

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -85,7 +85,7 @@ type UpdateOrderHandler struct {
 func (h UpdateOrderHandler) Handle(params orderop.UpdateOrderParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
-	if session.IsOfficeUser() || session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
+	if session.IsOfficeUser() && session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
 		return orderop.NewUpdateOrderUnauthorized()
 	}
 

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -84,7 +84,6 @@ type UpdateOrderHandler struct {
 // Handle ... updates an order from a request payload
 func (h UpdateOrderHandler) Handle(params orderop.UpdateOrderParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
-
 	if session.IsOfficeUser() && session.Roles.HasRole(roles.RoleTypeServicesCounselor) && params.Body.AuthorizedWeight != nil {
 		return orderop.NewUpdateOrderUnauthorized()
 	}

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -22,9 +22,16 @@ import (
 )
 
 func (suite *HandlerSuite) TestGetOrderHandlerIntegration() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	request := httptest.NewRequest("GET", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
+
 	params := orderop.GetOrderParams{
 		HTTPRequest: request,
 		OrderID:     strfmt.UUID(order.ID.String()),
@@ -143,11 +150,18 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerIntegration() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	originDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
 	destinationDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
+
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
@@ -211,13 +225,10 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerIntegration() {
 }
 
 func (suite *HandlerSuite) TestUpdateServicesCounselorOrderHandlerIntegration() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeServicesCounselor,
-	})
+	servicesCounselorUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
-	request = suite.AuthenticateOfficeRequest(request, officeUser)
+	request = suite.AuthenticateOfficeRequest(request, servicesCounselorUser)
 
 	newAuthorizedWeight := int64(10000)
 
@@ -306,7 +317,13 @@ func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerNotFound() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
@@ -343,12 +360,18 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerNotFound() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerPreconditionsFailed() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	originDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
 	destinationDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
@@ -387,6 +410,11 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerPreconditionsFailed() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerValidationError() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	originDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
@@ -397,6 +425,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerValidationError() {
 	suite.MustSave(&move)
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")
@@ -441,6 +470,11 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerValidationError() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerWithoutTac() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	order.TAC = nil
@@ -466,6 +500,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithoutTac() {
 	}
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	suite.Run("When Move is still in draft status, TAC can be nil", func() {
 		params := orderop.UpdateOrderParams{

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/models/roles"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
@@ -22,10 +21,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestGetOrderHandlerIntegration() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
@@ -150,10 +146,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerIntegration() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
@@ -257,10 +250,7 @@ func (suite *HandlerSuite) TestUpdateServicesCounselorOrderHandlerIntegration() 
 
 // Test that an order notification got stored Successfully
 func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeAvailableMove(suite.DB())
 	order := move.Orders
@@ -317,10 +307,7 @@ func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerNotFound() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
@@ -360,10 +347,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerNotFound() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerPreconditionsFailed() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
@@ -410,10 +394,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerPreconditionsFailed() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerValidationError() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
@@ -470,10 +451,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerValidationError() {
 }
 
 func (suite *HandlerSuite) TestUpdateOrderHandlerWithoutTac() {
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTOO,
-	})
+	officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -246,12 +246,18 @@ func (suite *HandlerSuite) TestUpdateServicesCounselorOrderHandlerIntegration() 
 
 // Test that an order notification got stored Successfully
 func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
+	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+		RoleType: roles.RoleTypeTOO,
+	})
+
 	move := testdatagen.MakeAvailableMove(suite.DB())
 	order := move.Orders
 	originDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
 	destinationDutyStation := testdatagen.MakeDefaultDutyStation(suite.DB())
 
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
+	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
 	issueDate, _ := time.Parse("2006-01-02", "2020-08-01")
 	reportByDate, _ := time.Parse("2006-01-02", "2020-10-31")


### PR DESCRIPTION
## Description

PATCH requests sent from the services counselor cannot change the authorized weight

## Reviewer Notes
I'm unsure of the solution here and the test is definitely not working. Before I work to figure that out, I wanted to get feedback on the solution and ensure the test is going in the right direction.

- Is the code solution acceptable?
- Is the test for this solution set up similarly to what would be expected?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7926) for this change
* [this article](tbd) explains more about the approach used.
