### PR TITLE
[MB-7392] Add soft deletion indicator to MTO Shipments

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -637,3 +637,4 @@
 20210504104241_add_counselor_remarks_to_mto_shipments.up.sql
 20210504162959_add_provides_services_counseling.up.sql
 20210505203801_populate_duty_station_services_counseling.up.sql
+20210512164642_add_deleted_at_to_mto_shipments_table.up.sql

--- a/migrations/app/schema/20210512164642_add_deleted_at_to_mto_shipments_table.up.sql
+++ b/migrations/app/schema/20210512164642_add_deleted_at_to_mto_shipments_table.up.sql
@@ -1,1 +1,3 @@
 ALTER TABLE mto_shipments ADD COLUMN deleted_at timestamp with time zone;
+-- Column comment
+COMMENT ON COLUMN mto_shipments.deleted_at IS 'Indicates whether the shipment has been soft deleted or not, and when it was soft deleted.';

--- a/migrations/app/schema/20210512164642_add_deleted_at_to_mto_shipments_table.up.sql
+++ b/migrations/app/schema/20210512164642_add_deleted_at_to_mto_shipments_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mto_shipments ADD COLUMN deleted_at timestamp with time zone;

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -99,6 +99,7 @@ type MTOShipment struct {
 	Distance                         *unit.Miles       `db:"distance"`
 	CreatedAt                        time.Time         `db:"created_at"`
 	UpdatedAt                        time.Time         `db:"updated_at"`
+	DeletedAt                        *time.Time        `db:"deleted_at"`
 }
 
 // MTOShipments is a list of mto shipments


### PR DESCRIPTION
## Description

Add a deleted_at column to the mto_shipments table. This follows the pattern that other tables use for soft deletion (like, documents, for example.)

## Reviewer Notes

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
make db_dev_e2e_populate
make schemaspy (to see new column/comment, can use your tool of choice, though)
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7392) for this change
