### PR TITLE
Fix date format

### DIFF
--- a/src/components/Office/ReviewServiceItems/ReviewServiceItems.stories.jsx
+++ b/src/components/Office/ReviewServiceItems/ReviewServiceItems.stories.jsx
@@ -74,7 +74,7 @@ export const HHG = () => (
       {
         id: '1',
         mtoShipmentID: '10',
-        mtoShipmentDepartureDate: '04 May 2021',
+        mtoShipmentDepartureDate: '2020-04-29',
         mtoShipmentPickupAddress: 'Fairfield, CA 94535',
         mtoShipmentDestinationAddress: 'Beverly Hills, CA 90210',
         mtoShipmentType: SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC,

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './ServiceItemCard.module.scss';
 
 import ShipmentContainer from 'components/Office/ShipmentContainer';
-import { toDollarString } from 'shared/formatters';
+import { toDollarString, formatDateFromIso } from 'shared/formatters';
 import { ShipmentOptionsOneOf } from 'types/shipment';
 import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 import { shipmentTypes } from 'constants/shipments';
@@ -77,7 +77,7 @@ const ServiceItemCard = ({
               <small className={styles.addressBlock}>
                 {mtoShipmentDepartureDate && (
                   <div>
-                    <span>Departed</span> {mtoShipmentDepartureDate}
+                    <span>Departed</span> {formatDateFromIso(mtoShipmentDepartureDate, 'DD MMM YYYY')}
                   </div>
                 )}
                 {mtoShipmentPickupAddress && (
@@ -178,7 +178,7 @@ const ServiceItemCard = ({
                     <small className={styles.addressBlock}>
                       {mtoShipmentDepartureDate && (
                         <div>
-                          <span>Departed</span> {mtoShipmentDepartureDate}
+                          <span>Departed</span> {formatDateFromIso(mtoShipmentDepartureDate, 'DD MMM YYYY')}
                         </div>
                       )}
                       {mtoShipmentPickupAddress && (

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.stories.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.stories.jsx
@@ -28,7 +28,7 @@ export const Basic = (args) => (
 export const HHG = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -43,7 +43,7 @@ export const HHG = (args) => (
 export const NTS = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.NTS}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -58,7 +58,7 @@ export const NTS = (args) => (
 export const NTSR = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.NTSR}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -73,7 +73,7 @@ export const NTSR = (args) => (
 export const HHGLonghaulDomestic = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -88,7 +88,7 @@ export const HHGLonghaulDomestic = (args) => (
 export const HHGShorthaulDomestic = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -103,7 +103,7 @@ export const HHGShorthaulDomestic = (args) => (
 export const NeedsReviewRequestCalculations = (args) => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -118,7 +118,7 @@ export const NeedsReviewRequestCalculations = (args) => (
 export const AcceptedRequestComplete = () => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"
@@ -133,7 +133,7 @@ export const AcceptedRequestComplete = () => (
 export const RejectedRequestComplete = () => (
   <ServiceItemCard
     mtoShipmentType={SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC}
-    mtoShipmentDepartureDate="04 May 2021"
+    mtoShipmentDepartureDate="2020-03-16"
     mtoShipmentPickupAddress="Fairfield, CA 94535"
     mtoShipmentDestinationAddress="Beverly Hills, CA 90210"
     mtoServiceItemCode="FSC"


### PR DESCRIPTION
## Description

This PR fixes the format for the Departure Date on the service item card. 

<img width="367" alt="Screen Shot 2021-05-12 at 9 40 09 AM" src="https://user-images.githubusercontent.com/56279459/118020088-337df300-b306-11eb-9ce5-301d200c871d.png">


## Setup

Start the milmove office app locally and navigate to the TIO screen. Selected a payment request from the queue, then review the service items. The correctly formatted date will show on the service item card.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7687) for this change