### PR TITLE
MB-8077 Speed up models tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,6 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
-	gotest.tools/gotestsum v1.6.4
 	pault.ag/go/pksigner v1.0.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -75,10 +75,11 @@ require (
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/text v0.3.6
-	golang.org/x/tools v0.0.0-20200929161345-d7fc70abf50f
+	golang.org/x/tools v0.1.0
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
+	gotest.tools/gotestsum v1.6.4
 	pault.ag/go/pksigner v1.0.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
-github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
-github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -160,18 +158,16 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a h1:yU/FENpkHYISWsQrbr3pcZOBj0EuRjPzNc1+dTCLu44=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a/go.mod h1:AEugkNu3BjBxyz958nJ5holD9PRjta6iprcoUauDbU4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -419,9 +415,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -438,8 +433,6 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200905233945-acf8798be1f7/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -576,8 +569,6 @@ github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXL
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
-github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -657,9 +648,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -1094,7 +1084,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1158,7 +1147,6 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1332,10 +1320,6 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools/gotestsum v1.6.4 h1:HFkapG0hK/HWiOxWS78SbR/JK5EpbH8hFzUuCvvfbfQ=
-gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
-gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -158,16 +160,18 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a h1:yU/FENpkHYISWsQrbr3pcZOBj0EuRjPzNc1+dTCLu44=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a/go.mod h1:AEugkNu3BjBxyz958nJ5holD9PRjta6iprcoUauDbU4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -415,8 +419,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -433,6 +438,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200905233945-acf8798be1f7/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -569,6 +576,8 @@ github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXL
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -648,8 +657,9 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -1030,6 +1040,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200930145003-4acb6c075d10/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -1051,8 +1062,9 @@ golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1082,6 +1094,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1145,6 +1158,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190823170909-c4a336ef6a2f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1185,8 +1199,9 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20200929161345-d7fc70abf50f h1:18s2P7JILnVhIF2+ZtGJQ9czV5bvTsb13/UGtNPDbjA=
 golang.org/x/tools v0.0.0-20200929161345-d7fc70abf50f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1317,6 +1332,10 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/gotestsum v1.6.4 h1:HFkapG0hK/HWiOxWS78SbR/JK5EpbH8hFzUuCvvfbfQ=
+gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/handlers/ordersapi/post_revision.go
+++ b/pkg/handlers/ordersapi/post_revision.go
@@ -110,7 +110,7 @@ func (h PostRevisionHandler) Handle(params ordersoperations.PostRevisionParams) 
 		}
 
 		newRevision = toElectronicOrdersRevision(orders, params.Revision)
-		verrs, err = models.CreateElectronicOrdersRevision(h.DB(), newRevision)
+		verrs, err = h.DB().ValidateAndCreate(newRevision)
 	}
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(logger, verrs, err)

--- a/pkg/handlers/ordersapi/post_revision_to_orders.go
+++ b/pkg/handlers/ordersapi/post_revision_to_orders.go
@@ -59,7 +59,7 @@ func (h PostRevisionToOrdersHandler) Handle(params ordersoperations.PostRevision
 	}
 
 	newRevision := toElectronicOrdersRevision(orders, params.Revision)
-	verrs, err := models.CreateElectronicOrdersRevision(h.DB(), newRevision)
+	verrs, err := h.DB().ValidateAndCreate(newRevision)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(logger, verrs, err)
 	}

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -32,21 +32,6 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *HandlerSuite) TestTruncateAll() {
-
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	fmt.Println("created move", move.ID, move.ContractorID)
-
-	err := suite.DB().TruncateAll()
-	fmt.Println(err)
-	fmt.Println("truncated db")
-
-	foundMove := models.Move{}
-	err = suite.DB().Find(&foundMove, move.ID.String())
-	fmt.Println(err)
-	fmt.Println("found move", foundMove.ID, foundMove.ContractorID)
-}
-
 func (suite *HandlerSuite) TestFetchMTOUpdatesHandler() {
 	// unavailable MTO
 	testdatagen.MakeDefaultMove(suite.DB())

--- a/pkg/models/address_test.go
+++ b/pkg/models/address_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (suite *ModelSuite) TestBasicAddressInstantiation() {
-	newAddress := Address{
+	newAddress := &Address{
 		StreetAddress1: "street 1",
 		StreetAddress2: swag.String("street 2"),
 		StreetAddress3: swag.String("street 3"),
@@ -16,9 +16,9 @@ func (suite *ModelSuite) TestBasicAddressInstantiation() {
 		PostalCode:     "90210",
 	}
 
-	verrs, err := suite.DB().ValidateAndCreate(&newAddress)
+	verrs, err := newAddress.Validate(nil)
 
-	suite.Nil(err, "Error writing to the db.")
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "Error validating model")
 }
 

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -1,16 +1,12 @@
 package models_test
 
 import (
-	"github.com/gofrs/uuid"
-
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestAdminUserCreation() {
-	t := suite.T()
-
-	user := testdatagen.MakeDefaultUser(suite.DB())
+	user := testdatagen.MakeStubbedUser(suite.DB())
 
 	newAdminUser := AdminUser{
 		FirstName: "Leo",
@@ -20,13 +16,10 @@ func (suite *ModelSuite) TestAdminUserCreation() {
 		Email:     "leo@gmail.com",
 	}
 
-	if verrs, err := suite.DB().ValidateAndCreate(&newAdminUser); err != nil || verrs.HasAny() {
-		t.Fatal("Didn't create admin user in db.")
-	}
+	verrs, err := newAdminUser.Validate(nil)
 
-	if newAdminUser.ID == uuid.Nil {
-		t.Error("Didn't get an id back for admin user.")
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) TestAdminUserCreationWithoutValues() {

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -1,17 +1,13 @@
 package models_test
 
 import (
-	"fmt"
-
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_BackupContactCreate() {
-	t := suite.T()
-
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := testdatagen.MakeStubbedServiceMember(suite.DB())
 
 	newContact := models.BackupContact{
 		ServiceMemberID: serviceMember.ID,
@@ -21,16 +17,10 @@ func (suite *ModelSuite) Test_BackupContactCreate() {
 		Permission:      models.BackupContactPermissionEDIT,
 	}
 
-	verrs, err := suite.DB().ValidateAndCreate(&newContact)
+	verrs, err := newContact.Validate(nil)
 
-	if err != nil {
-		fmt.Println(err)
-		t.Fatal("could not save BackupContact", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect validation errors: %v", verrs)
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) Test_BackupContactValidations() {

--- a/pkg/models/distance_calculation_test.go
+++ b/pkg/models/distance_calculation_test.go
@@ -9,10 +9,8 @@ import (
 )
 
 func (suite *ModelSuite) Test_DistanceCalculationCreate() {
-	t := suite.T()
-
-	address1 := testdatagen.MakeDefaultAddress(suite.DB())
-	address2 := testdatagen.MakeDefaultAddress(suite.DB())
+	address1 := testdatagen.MakeStubbedAddress(suite.DB())
+	address2 := testdatagen.MakeStubbedAddress(suite.DB())
 
 	distanceCalculation := models.DistanceCalculation{
 		OriginAddress:        address1,
@@ -22,15 +20,10 @@ func (suite *ModelSuite) Test_DistanceCalculationCreate() {
 		DistanceMiles:        1044,
 	}
 
-	verrs, err := suite.DB().ValidateAndSave(&distanceCalculation)
+	verrs, err := distanceCalculation.Validate(nil)
 
-	if err != nil {
-		t.Fatalf("could not save DistanceCalculation: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect validation errors: %v", verrs)
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) Test_DistanceCalculationValidations() {
@@ -46,8 +39,8 @@ func (suite *ModelSuite) Test_DistanceCalculationValidations() {
 }
 
 func (suite *ModelSuite) Test_NewDistanceCalculationCallsPlanner() {
-	address1 := testdatagen.MakeDefaultAddress(suite.DB())
-	address2 := testdatagen.MakeDefaultAddress(suite.DB())
+	address1 := testdatagen.MakeStubbedAddress(suite.DB())
+	address2 := testdatagen.MakeStubbedAddress(suite.DB())
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		address1.PostalCode,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -11,23 +11,16 @@ import (
 )
 
 func (suite *ModelSuite) Test_DocumentCreate() {
-	t := suite.T()
-
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+	serviceMember := testdatagen.MakeStubbedServiceMember(suite.DB())
 
 	document := models.Document{
 		ServiceMemberID: serviceMember.ID,
 	}
 
-	verrs, err := suite.DB().ValidateAndSave(&document)
+	verrs, err := document.Validate(nil)
 
-	if err != nil {
-		t.Fatalf("could not save Document: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect validation errors: %v", verrs)
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) Test_DocumentValidations() {

--- a/pkg/models/dps_users_test.go
+++ b/pkg/models/dps_users_test.go
@@ -7,21 +7,14 @@ import (
 )
 
 func (suite *ModelSuite) Test_DpsUserCreate() {
-	t := suite.T()
-
 	dpsUser := models.DpsUser{
 		LoginGovEmail: "test@example.com",
 	}
 
-	verrs, err := suite.DB().ValidateAndSave(&dpsUser)
+	verrs, err := dpsUser.Validate(nil)
 
-	if err != nil {
-		t.Fatalf("could not save DPS user: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect validation errors: %v", verrs)
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) Test_DpsUserValidations() {

--- a/pkg/models/duty_station_test.go
+++ b/pkg/models/duty_station_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func (suite *ModelSuite) TestFindDutyStations() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
+
 	address := models.Address{
 		StreetAddress1: "some address",
 		City:           "city",
@@ -103,6 +106,8 @@ func (suite *ModelSuite) Test_DutyStationValidations() {
 	suite.verifyValidationErrors(station, expErrors)
 }
 func (suite *ModelSuite) Test_FetchDutyStationTransportationOffice() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 

--- a/pkg/models/electronic_order.go
+++ b/pkg/models/electronic_order.go
@@ -110,7 +110,7 @@ func CreateElectronicOrderWithRevision(dbConnection *pop.Connection, order *Elec
 		}
 		firstRevision.ElectronicOrderID = order.ID
 		firstRevision.ElectronicOrder = *order
-		if verrs, err := CreateElectronicOrdersRevision(dbConnection, firstRevision); verrs.HasAny() || err != nil {
+		if verrs, err := dbConnection.ValidateAndCreate(firstRevision); verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = err
 			return transactionError

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func (suite *ModelSuite) TestElectronicOrderValidateAndCreate() {
-	newOrder := models.ElectronicOrder{
+func (suite *ModelSuite) TestElectronicOrderValidate() {
+	newOrder := &models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
 		OrdersNumber: "8675309",
 	}
 
-	verrs, err := suite.DB().ValidateAndCreate(&newOrder)
+	verrs, err := newOrder.Validate(nil)
 	suite.NoError(err)
 	suite.NoVerrs(verrs)
 }
@@ -37,6 +37,8 @@ func (suite *ModelSuite) TestElectronicOrderValidations() {
 }
 
 func (suite *ModelSuite) TestCreateElectronicOrder() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -49,6 +51,8 @@ func (suite *ModelSuite) TestCreateElectronicOrder() {
 }
 
 func (suite *ModelSuite) TestCreateElectronicOrderWithRevision() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -74,6 +78,8 @@ func (suite *ModelSuite) TestCreateElectronicOrderWithRevision() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrderByID() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -93,7 +99,8 @@ func (suite *ModelSuite) TestFetchElectronicOrderByID() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrderByIssuerAndOrdersNum() {
-
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -113,6 +120,8 @@ func (suite *ModelSuite) TestFetchElectronicOrderByIssuerAndOrdersNum() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrdersByEdipiAndIssuers() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	edipi := "1234567890"
 	newOrder1 := models.ElectronicOrder{
 		Edipi:        edipi,

--- a/pkg/models/electronic_orders_revision.go
+++ b/pkg/models/electronic_orders_revision.go
@@ -334,15 +334,3 @@ func (e *ElectronicOrdersRevision) ValidateCreate(tx *pop.Connection) (*validate
 func (e *ElectronicOrdersRevision) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
-
-// CreateElectronicOrdersRevision inserts a revision into the database
-func CreateElectronicOrdersRevision(dbConnection *pop.Connection, revision *ElectronicOrdersRevision) (*validate.Errors, error) {
-
-	responseVErrors := validate.NewErrors()
-	verrs, responseError := dbConnection.ValidateAndCreate(revision)
-	if verrs.HasAny() {
-		responseVErrors.Append(verrs)
-	}
-
-	return responseVErrors, responseError
-}

--- a/pkg/models/fuel_eia_diesel_price_test.go
+++ b/pkg/models/fuel_eia_diesel_price_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/transcom/mymove/pkg/db/dberr"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) TestBasicFuelEIADieselPriceInstantiation() {
@@ -128,30 +127,6 @@ func (suite *ModelSuite) TestFuelEIADieselPriceOverlappingDatesConstraint() {
 	})
 }
 
-// Create multiple records covering a range of dates
-// Can change the dates for start and end ranges and
-// can create a default baseline and price to use via assertions
-func (suite *ModelSuite) TestMakeFuelEIADieselPrices() {
-	testdatagen.MakeDefaultFuelEIADieselPrices(suite.DB())
-	// or call testdatagen.MakeDefaultFuelEIADieselPrices(suite.DB())
-	// to change the date range:
-	//     assertions testdatagen.Assertions{}
-	//     assertions.assertions.FuelEIADieselPrice.RateStartDate = time.Date(testdatagen.TestYear-1, time.July, 15, 0, 0, 0, 0, time.UTC)
-	//     assertions.assertions.FuelEIADieselPrice.RateEndDate = time.Date(testdatagen.TestYear+1, time.July, 14, 0, 0, 0, 0, time.UTC)
-	//     testdatagen.MakeFuelEIADieselPrices(suite.DB(), assertions)
-}
-
-// Create 1 record for the shipment date provided and use assertions
-func (suite *ModelSuite) TestMakeFuelEIADieselPriceForDate() {
-	rateStartDate := time.Date(2017, time.July, 15, 0, 0, 0, 0, time.UTC)
-	assertions := testdatagen.Assertions{}
-	assertions.FuelEIADieselPrice.RateStartDate = rateStartDate
-	assertions.FuelEIADieselPrice.EIAPricePerGallonMillicents = unit.Millicents(695700)
-	shipmentDate := assertions.FuelEIADieselPrice.RateStartDate.AddDate(0, 0, 10)
-
-	testdatagen.MakeFuelEIADieselPriceForDate(suite.DB(), shipmentDate, assertions)
-}
-
 func (suite *ModelSuite) TestFetchMostRecentFuelPrices() {
 	// Make fuel price records for the last twelve months
 	clock := clock.NewMock()
@@ -172,10 +147,4 @@ func (suite *ModelSuite) TestFetchMostRecentFuelPrices() {
 	expectedNumFuelPrices = 12
 	suite.NoError(err)
 	suite.Equal(expectedNumFuelPrices, len(fuelPrices))
-}
-
-// Create 1 record for the shipment date provided
-func (suite *ModelSuite) TestMakeDefaultFuelEIADieselPriceForDate() {
-	shipmentDate := time.Now()
-	testdatagen.MakeDefaultFuelEIADieselPriceForDate(suite.DB(), shipmentDate)
 }

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"log"
 	"reflect"
 	"sort"
 	"testing"
@@ -17,17 +16,14 @@ type ModelSuite struct {
 }
 
 func (suite *ModelSuite) SetupTest() {
-	errTruncateAll := suite.TruncateAll()
-	if errTruncateAll != nil {
-		log.Panicf("failed to truncate database: %#v", errTruncateAll)
-	}
+
 }
 
 func (suite *ModelSuite) verifyValidationErrors(model models.ValidateableModel, exp map[string][]string) {
 	t := suite.T()
 	t.Helper()
 
-	verrs, err := model.Validate(suite.DB())
+	verrs, err := model.Validate(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -231,9 +231,8 @@ func (m *Move) SetApprovalsRequested() error {
 
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
-	// We can cancel any move that isn't already complete.
 	if m.Status == MoveStatusCANCELED {
-		return errors.Wrap(ErrInvalidTransition, "Cancel")
+		return errors.Wrap(ErrInvalidTransition, "Cannot cancel a move that is already canceled.")
 	}
 
 	m.Status = MoveStatusCANCELED

--- a/pkg/models/move_document_test.go
+++ b/pkg/models/move_document_test.go
@@ -99,7 +99,7 @@ func (suite *ModelSuite) TestFetchApprovedMovingExpenseDocuments() {
 	}
 
 	// When: the logged in user is an office user
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	officeUser := testdatagen.MakeStubbedOfficeUser(suite.DB())
 	session.UserID = *officeUser.UserID
 	session.OfficeUserID = officeUser.ID
 	session.ApplicationName = auth.OfficeApp
@@ -217,7 +217,7 @@ func (suite *ModelSuite) TestFetchMovingExpenseDocuments() {
 func (suite *ModelSuite) TestFetchMovingExpenseDocumentsAuth() {
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	sm := ppm.Move.Orders.ServiceMember
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	officeUser := testdatagen.MakeStubbedOfficeUser(suite.DB())
 	authorizedSession := &auth.Session{
 		ApplicationName: auth.MilApp,
 		UserID:          sm.UserID,
@@ -278,7 +278,7 @@ func (suite *ModelSuite) TestFetchMoveDocument() {
 	}
 
 	// When: the logged in user is an office user
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	officeUser := testdatagen.MakeStubbedOfficeUser(suite.DB())
 	session.UserID = *officeUser.UserID
 	session.OfficeUserID = officeUser.ID
 	session.ApplicationName = auth.OfficeApp

--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -3,8 +3,6 @@ package models_test
 import (
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
@@ -28,22 +26,4 @@ func (suite *ModelSuite) TestMTOAgentValidation() {
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validMTOAgent, expErrors)
 	})
-}
-
-func (suite *ModelSuite) Test_MTOAgentTestdataGen() {
-	//test with no assertions
-	MTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{})
-	suite.Equal(MTOAgent.FirstName, swag.String("Jason"))
-	suite.Equal(MTOAgent.LastName, swag.String("Ash"))
-	suite.Equal(MTOAgent.Email, swag.String("jason.ash@example.com"))
-	suite.Equal(MTOAgent.Phone, swag.String("202-555-9301"))
-	suite.Equal(MTOAgent.MTOAgentType, models.MTOAgentReleasing)
-	// test with assertions
-	someFirstName := "Some other agent name"
-	otherMTOAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
-		MTOAgent: models.MTOAgent{
-			FirstName: &someFirstName,
-		},
-	})
-	suite.Equal(otherMTOAgent.FirstName, swag.String("Some other agent name"))
 }

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -28,10 +28,12 @@ func (suite *ModelSuite) TestBasicOrderInstantiation() {
 }
 
 func (suite *ModelSuite) TestTacNotNilAfterSubmission() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	order.TAC = nil
-	err := move.Submit()
+	err = move.Submit()
 	if err != nil {
 		suite.T().Fatal("Should transition.")
 	}
@@ -47,6 +49,8 @@ func (suite *ModelSuite) TestTacNotNilAfterSubmission() {
 }
 
 func (suite *ModelSuite) TestOrdersNumberPresenceAfterSubmission() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	invalidCases := []struct {
 		desc  string
 		value *string
@@ -75,6 +79,8 @@ func (suite *ModelSuite) TestOrdersNumberPresenceAfterSubmission() {
 }
 
 func (suite *ModelSuite) TestOrdersTypeDetailPresenceAfterSubmission() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	emptyString := internalmessages.OrdersTypeDetail("")
 
 	invalidCases := []struct {
@@ -106,10 +112,12 @@ func (suite *ModelSuite) TestOrdersTypeDetailPresenceAfterSubmission() {
 }
 
 func (suite *ModelSuite) TestDepartmentIndicatorNotNilAfterSubmission() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	order := move.Orders
 	order.DepartmentIndicator = nil
-	err := move.Submit()
+	err = move.Submit()
 	if err != nil {
 		suite.T().Fatal("Should transition.")
 	}
@@ -125,6 +133,8 @@ func (suite *ModelSuite) TestDepartmentIndicatorNotNilAfterSubmission() {
 }
 
 func (suite *ModelSuite) TestFetchOrderForUser() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 	serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
@@ -206,6 +216,8 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 }
 
 func (suite *ModelSuite) TestFetchOrderNotForUser() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
@@ -253,6 +265,8 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 }
 
 func (suite *ModelSuite) TestOrderStateMachine() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
 	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
@@ -287,7 +301,7 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 	suite.MustSave(&order)
 
 	// Submit Orders
-	err := order.Submit()
+	err = order.Submit()
 	suite.NoError(err)
 	suite.Equal(OrderStatusSUBMITTED, order.Status, "expected Submitted")
 
@@ -297,64 +311,9 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 	suite.Equal(OrderStatusCANCELED, order.Status, "expected Canceled")
 }
 
-func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
-	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
-	testdatagen.MakeDefaultContractor(suite.DB())
-
-	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
-	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
-	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
-	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
-	hasDependents := true
-	spouseHasProGear := true
-	uploadedOrder := Document{
-		ServiceMember:   serviceMember1,
-		ServiceMemberID: serviceMember1.ID,
-	}
-	deptIndicator := testdatagen.DefaultDepartmentIndicator
-	TAC := testdatagen.DefaultTransportationAccountingCode
-	suite.MustSave(&uploadedOrder)
-	orders := Order{
-		ServiceMemberID:     serviceMember1.ID,
-		ServiceMember:       serviceMember1,
-		IssueDate:           issueDate,
-		ReportByDate:        reportByDate,
-		OrdersType:          ordersType,
-		HasDependents:       hasDependents,
-		SpouseHasProGear:    spouseHasProGear,
-		NewDutyStationID:    dutyStation.ID,
-		NewDutyStation:      dutyStation,
-		UploadedOrdersID:    uploadedOrder.ID,
-		UploadedOrders:      uploadedOrder,
-		Status:              OrderStatusSUBMITTED,
-		TAC:                 &TAC,
-		DepartmentIndicator: &deptIndicator,
-	}
-	suite.MustSave(&orders)
-
-	selectedMoveType := SelectedMoveTypeHHGPPM
-	moveOptions := MoveOptions{
-		SelectedType: &selectedMoveType,
-		Show:         swag.Bool(true),
-	}
-	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.NoError(err)
-	suite.False(verrs.HasAny(), "failed to validate move")
-	move.Orders = orders
-	suite.MustSave(move)
-
-	err = move.Submit()
-	suite.NoError(err)
-
-	reason := "Mistaken identity"
-	err = move.Cancel(reason)
-	suite.NoError(err)
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
-	suite.Equal(OrderStatusCANCELED, move.Orders.Status, "expected Canceled")
-
-}
-
 func (suite *ModelSuite) TestSaveOrder() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	orderID := uuid.Must(uuid.NewV4())
 	moveID, _ := uuid.FromString("7112b18b-7e03-4b28-adde-532b541bba8d")
 

--- a/pkg/models/organization_test.go
+++ b/pkg/models/organization_test.go
@@ -1,14 +1,10 @@
 package models_test
 
 import (
-	"github.com/gofrs/uuid"
-
 	. "github.com/transcom/mymove/pkg/models"
 )
 
-func (suite *ModelSuite) TestOrganizationCreation() {
-	t := suite.T()
-
+func (suite *ModelSuite) TestOrganizationValidation() {
 	email := "test@truss.works"
 	phone := "9144825484"
 
@@ -18,13 +14,10 @@ func (suite *ModelSuite) TestOrganizationCreation() {
 		PocPhone: &phone,
 	}
 
-	if verrs, err := suite.DB().ValidateAndCreate(&newOrganization); err != nil || verrs.HasAny() {
-		t.Fatal("Didn't create admin user in db.")
-	}
+	verrs, err := newOrganization.Validate(nil)
 
-	if newOrganization.ID == uuid.Nil {
-		t.Error("Didn't get an id back for admin user.")
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) TestOrganizationCreationWithoutValues() {

--- a/pkg/models/payment_request_to_interchange_control_number_test.go
+++ b/pkg/models/payment_request_to_interchange_control_number_test.go
@@ -6,22 +6,9 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestPaymentRequestToInterchangeControlNumber() {
-	suite.T().Run("test PaymentRequest association", func(t *testing.T) {
-		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{})
-		validPR2ICN := testdatagen.MakePaymentRequestToInterchangeControlNumber(suite.DB(), testdatagen.Assertions{
-			PaymentRequestToInterchangeControlNumber: models.PaymentRequestToInterchangeControlNumber{
-				PaymentRequestID: paymentRequest.ID,
-			}})
-		suite.Equal(paymentRequest.ID, validPR2ICN.PaymentRequestID)
-		err := suite.DB().Load(&validPR2ICN, "PaymentRequest")
-		suite.NoError(err)
-		suite.Equal(paymentRequest.ID, validPR2ICN.PaymentRequest.ID)
-	})
-
 	suite.T().Run("test valid PaymentRequestToInterchangeControlNumber", func(t *testing.T) {
 		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
 			PaymentRequestID:         uuid.Must(uuid.NewV4()),

--- a/pkg/models/prime_upload_test.go
+++ b/pkg/models/prime_upload_test.go
@@ -11,11 +11,6 @@ import (
 )
 
 func (suite *ModelSuite) Test_PrimeUploadCreate() {
-	t := suite.T()
-
-	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
-
 	upload := models.Upload{
 		Filename:    "test.pdf",
 		Bytes:       1048576,
@@ -24,76 +19,22 @@ func (suite *ModelSuite) Test_PrimeUploadCreate() {
 		UploadType:  models.UploadTypePRIME,
 	}
 
-	verrs, err := suite.DB().ValidateAndSave(&upload)
-	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
-	}
+	verrs, err := upload.Validate(nil)
 
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect PrimeUpload validation errors: %v", verrs)
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 
 	primeUpload := models.PrimeUpload{
-		ProofOfServiceDocID: posDoc.ID,
-		ContractorID:        contractor.ID,
+		ID:                  uuid.Must(uuid.NewV4()),
+		ProofOfServiceDocID: uuid.Must(uuid.NewV4()),
+		ContractorID:        uuid.Must(uuid.NewV4()),
 		Upload:              upload,
 	}
 
-	verrs, err = suite.DB().ValidateAndSave(&primeUpload)
+	verrs, err = primeUpload.Validate(nil)
 
-	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect PrimeUpload validation errors: %v", verrs)
-	}
-}
-
-func (suite *ModelSuite) Test_PrimeUploadCreateWithID() {
-	t := suite.T()
-
-	upload := models.Upload{
-		Filename:    "test.pdf",
-		Bytes:       1048576,
-		ContentType: "application/pdf",
-		Checksum:    "ImGQ2Ush0bDHsaQthV5BnQ==",
-		UploadType:  models.UploadTypePRIME,
-	}
-
-	verrs, err := suite.DB().ValidateAndSave(&upload)
-	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect PrimeUpload validation errors: %v", verrs)
-	}
-
-	posDoc := testdatagen.MakeDefaultProofOfServiceDoc(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
-
-	id := uuid.Must(uuid.NewV4())
-	primeUpload := models.PrimeUpload{
-		ID:                  id,
-		ProofOfServiceDocID: posDoc.ID,
-		ContractorID:        contractor.ID,
-		Upload:              upload,
-	}
-
-	verrs, err = suite.DB().ValidateAndSave(&primeUpload)
-
-	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
-	}
-
-	if verrs.Count() != 0 {
-		t.Errorf("did not expect PrimeUpload validation errors: %v", verrs)
-	}
-
-	if primeUpload.ID.String() != id.String() {
-		t.Errorf("wrong uuid for PrimeUpload: expected %s, got %s", id.String(), primeUpload.ID.String())
-	}
+	suite.NoError(err)
+	suite.False(verrs.HasAny(), "Error validating model")
 }
 
 func (suite *ModelSuite) Test_PrimeUploadValidations() {

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -37,6 +39,8 @@ func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 }
 
 func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -63,6 +67,8 @@ func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 }
 
 func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -79,6 +85,8 @@ func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
 }
 
 func (suite *ModelSuite) TestShowPPMQueue() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	all := map[string]bool{
 		string(models.PPMStatusAPPROVED):         true,
 		string(models.PPMStatusPAYMENTREQUESTED): true,

--- a/pkg/models/reimbursement_test.go
+++ b/pkg/models/reimbursement_test.go
@@ -53,10 +53,10 @@ func (suite *ModelSuite) TestBasicReimbursement() {
 	// nolint:errcheck
 	reimbursement.Request()
 
-	verrs, err := suite.DB().ValidateAndCreate(&reimbursement)
+	verrs, err := reimbursement.Validate(nil)
+
 	suite.NoError(err)
 	suite.False(verrs.HasAny())
-
 	suite.NotNil(reimbursement.ID)
 
 	since := time.Since(*reimbursement.RequestedDate)

--- a/pkg/models/tariff400ng_item_rate_test.go
+++ b/pkg/models/tariff400ng_item_rate_test.go
@@ -11,6 +11,8 @@ func intPointer(i int) *int {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateBySchedule() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			Schedule:  intPointer(1),
@@ -39,6 +41,8 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateBySchedule() {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateNullSchedule() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	rate1 := testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			Schedule:  nil,
@@ -55,6 +59,8 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateNullSchedule() {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateByWeight() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			WeightLbsLower: unit.Pound(1000),

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -18,6 +18,8 @@ func (suite *ModelSuite) Test_TrafficDistributionList() {
 }
 
 func (suite *ModelSuite) Test_FetchTDL() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -38,6 +40,8 @@ func (suite *ModelSuite) Test_FetchTDL() {
 }
 
 func (suite *ModelSuite) Test_FetchOrCreateTDL() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	foundTDL := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -96,6 +100,8 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 }
 
 func (suite *ModelSuite) Test_TDLUniqueChannelCOS() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -99,6 +99,8 @@ func (suite *ModelSuite) Test_GetRateCycle() {
 }
 
 func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -139,6 +141,8 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 }
 
 func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -156,7 +160,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 	})
 	band := 1
 
-	err := AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
+	err = AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
 	if err != nil {
 		t.Fatalf("Did not update quality band: %v", err)
 	}
@@ -174,6 +178,8 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 }
 
 func (suite *ModelSuite) Test_BVSWithLowMPS() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 	tspsToMake := 5
 
@@ -231,6 +237,8 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 
 // Test_FetchNextQualityBandTSPPerformance ensures that the TSP with the highest BVS is returned in the expected band
 func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -439,6 +447,8 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 // Test_GatherNextEligibleTSPPerformanceByBand ensures that TSPs are returned in the expected
 // order for the Award Queue operation.
 func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
 	tsp1 := testdatagen.MakeDefaultTSP(suite.DB())
@@ -513,6 +523,8 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 // Test_FetchTSPPerformancesForQualityBandAssignment ensures that TSPs are returned in the expected
 // order for the division into quality bands.
 func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -574,6 +586,8 @@ func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
 // Test_MinimumPerformanceScore ensures that TSPs whose BVS is below the MPS
 // do not enter the Award Queue process.
 func (suite *ModelSuite) Test_MinimumPerformanceScore() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -619,6 +633,8 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 }
 
 func (suite *ModelSuite) Test_FetchUnbandedTSPPerformanceGroups() {
+	err := suite.TruncateAll()
+	suite.FatalNoError(err)
 	t := suite.T()
 
 	foundTDL := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/webhook_notification_test.go
+++ b/pkg/models/webhook_notification_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -32,22 +31,10 @@ func (suite *ModelSuite) TestWebhookNotification() {
 			Payload:         "{\"msg\": \"This is the payload\"}",
 			Status:          "PENDING",
 		}
+
 		expErrors := map[string][]string{}
+
 		suite.verifyValidationErrors(&newNotification, expErrors)
-		if verrs, err := suite.DB().ValidateAndCreate(&newNotification); err != nil || verrs.HasAny() {
-			if verrs.HasAny() {
-				fmt.Println(verrs)
-			}
-			fmt.Println(err)
-			suite.T().Fatal("Didn't create notification in db.")
-		}
-
-		if newNotification.ID == uuid.Nil {
-			t.Error("Didn't get an id back for Notification.")
-		} else {
-			fmt.Println("got id ", newNotification.ID.String())
-		}
-
 	})
 
 	suite.T().Run("test simple notification", func(t *testing.T) {
@@ -57,7 +44,9 @@ func (suite *ModelSuite) TestWebhookNotification() {
 			Payload:  "{\"msg\": \"This is the payload\"}",
 			Status:   "SKIPPED",
 		}
+
 		expErrors := map[string][]string{}
+
 		suite.verifyValidationErrors(&newNotification, expErrors)
 	})
 
@@ -69,11 +58,12 @@ func (suite *ModelSuite) TestWebhookNotification() {
 			Payload:  "",
 			Status:   "NEW",
 		}
+
 		expErrors := map[string][]string{}
 		expErrors["status"] = []string{"Status is not in the list [PENDING, SENT, SKIPPED, FAILING, FAILED]."}
 		expErrors["event_key"] = []string{"Eventkey should be in Subject.Action format."}
 		expErrors["payload"] = []string{"Payload can not be blank."}
-		suite.verifyValidationErrors(&newNotification, expErrors)
 
+		suite.verifyValidationErrors(&newNotification, expErrors)
 	})
 }

--- a/pkg/notifications/move_approved_test.go
+++ b/pkg/notifications/move_approved_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -32,12 +34,7 @@ func (suite *NotificationSuite) TestMoveApproved() {
 }
 
 func (suite *NotificationSuite) TestMoveApprovedHTMLTemplateRender() {
-	approver := testdatagen.MakeStubbedUser(suite.DB())
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
-		UserID:          approver.ID,
-		ApplicationName: auth.OfficeApp,
-	}, "milmovelocal", move.ID)
+	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{}, "milmovelocal", uuid.Must(uuid.NewV4()))
 
 	s := moveApprovedEmailData{
 		Link:                       "https://milmovelocal/downloads/ppm_info_sheet.pdf",
@@ -78,13 +75,7 @@ func (suite *NotificationSuite) TestMoveApprovedHTMLTemplateRender() {
 }
 
 func (suite *NotificationSuite) TestMoveApprovedTextTemplateRender() {
-
-	approver := testdatagen.MakeStubbedUser(suite.DB())
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
-		UserID:          approver.ID,
-		ApplicationName: auth.OfficeApp,
-	}, "milmovelocal", move.ID)
+	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{}, "milmovelocal", uuid.Must(uuid.NewV4()))
 
 	s := moveApprovedEmailData{
 		Link:                       "https://milmovelocal/downloads/ppm_info_sheet.pdf",

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -489,14 +489,14 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		currentTime := time.Now()
 		diff := currentTime.Sub(*actualApprovedAt)
 		diffInSeconds := diff.Seconds()
-		oneSecond := 1.000000
+		twoSeconds := 2.000000
 		// If we've gotten the shipment updated and fetched it without error then we can inspect the
 		// service items created as a side effect to see if they are approved.
 		for i := range serviceItems {
 			suite.Equal(models.MTOServiceItemStatusApproved, serviceItems[i].Status)
 			suite.Equal(expectedReServiceCodes[i], serviceItems[i].ReService.Code)
 			// Test that service item was approved within a few seconds of the current
-			suite.Assertions.LessOrEqual(diffInSeconds, oneSecond)
+			suite.Assertions.LessOrEqual(diffInSeconds, twoSeconds)
 		}
 
 		err = suite.DB().Find(&fetchedMove, mto.ID)

--- a/pkg/testdatagen/make_address.go
+++ b/pkg/testdatagen/make_address.go
@@ -3,6 +3,7 @@ package testdatagen
 import (
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -89,4 +90,14 @@ func MakeDefaultAddress(db *pop.Connection) models.Address {
 	FetchOrMakeDefaultTariff400ngZip3(db)
 
 	return MakeAddress(db, Assertions{})
+}
+
+// MakeStubbedAddress returns a stubbed address without saving it to the DB
+func MakeStubbedAddress(db *pop.Connection) models.Address {
+	return MakeAddress(db, Assertions{
+		Address: models.Address{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		Stub: true,
+	})
 }

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -255,3 +255,16 @@ func MakeServicesCounselorOfficeUserWithUSMCGBLOC(db *pop.Connection) models.Off
 		},
 	})
 }
+
+// MakeStubbedOfficeUser returns a user without hitting the DB
+func MakeStubbedOfficeUser(db *pop.Connection) models.OfficeUser {
+	return MakeOfficeUser(db, Assertions{
+		OfficeUser: models.OfficeUser{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		User: models.User{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		Stub: true,
+	})
+}

--- a/pkg/testdatagen/make_payment_request.go
+++ b/pkg/testdatagen/make_payment_request.go
@@ -169,3 +169,13 @@ func MakeFullDLHMTOServiceItem(db *pop.Connection, assertions Assertions) (model
 
 	return moveTaskOrder, mtoServiceItems
 }
+
+// MakeStubbedPaymentRequest returns a payment request without hitting the DB
+func MakeStubbedPaymentRequest(db *pop.Connection) models.PaymentRequest {
+	return MakePaymentRequest(db, Assertions{
+		PaymentRequest: models.PaymentRequest{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		Stub: true,
+	})
+}

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v5"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -140,4 +141,16 @@ func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models
 	}
 
 	return serviceMember
+}
+
+// MakeStubbedServiceMember returns a stubbed service member that is not stored in the DB
+func MakeStubbedServiceMember(db *pop.Connection) models.ServiceMember {
+	return MakeServiceMember(db, Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:     uuid.Must(uuid.NewV4()),
+			User:   MakeStubbedUser(db),
+			UserID: uuid.Must(uuid.NewV4()),
+		},
+		Stub: true,
+	})
 }

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -145,11 +145,13 @@ func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models
 
 // MakeStubbedServiceMember returns a stubbed service member that is not stored in the DB
 func MakeStubbedServiceMember(db *pop.Connection) models.ServiceMember {
+	user := MakeStubbedUser(db)
+
 	return MakeServiceMember(db, Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:     uuid.Must(uuid.NewV4()),
-			User:   MakeStubbedUser(db),
-			UserID: uuid.Must(uuid.NewV4()),
+			User:   user,
+			UserID: user.ID,
 		},
 		Stub: true,
 	})

--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -35,5 +35,10 @@ func MakeDefaultUser(db *pop.Connection) models.User {
 
 // MakeStubbedUser returns a user without hitting the DB
 func MakeStubbedUser(db *pop.Connection) models.User {
-	return MakeUser(db, Assertions{Stub: true})
+	return MakeUser(db, Assertions{
+		User: models.User{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		Stub: true,
+	})
 }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/namsral/flag"
 	_ "github.com/stretchr/objx"
 	_ "github.com/tealeg/xlsx"
+	_ "gotest.tools/gotestsum"
 
 	// Install go-junit-report for CirclCI test result report generation
 	_ "github.com/jstemmer/go-junit-report"

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -24,7 +24,6 @@ import (
 	_ "github.com/namsral/flag"
 	_ "github.com/stretchr/objx"
 	_ "github.com/tealeg/xlsx"
-	_ "gotest.tools/gotestsum"
 
 	// Install go-junit-report for CirclCI test result report generation
 	_ "github.com/jstemmer/go-junit-report"

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -111,4 +111,4 @@ if [[ "${SERVER_REPORT:-}" == "1" ]]; then
 fi
 
 # shellcheck disable=SC2086
-DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" gotestsum --format pkgname --jsonfile json.log --packages=${package_list} -- ${failfast_flag} -vet=off -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} | tee "${test_output_file}"
+DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test ${failfast_flag} -vet=off -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -111,4 +111,4 @@ if [[ "${SERVER_REPORT:-}" == "1" ]]; then
 fi
 
 # shellcheck disable=SC2086
-DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test ${failfast_flag} -vet=off -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
+DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" gotestsum --format pkgname --jsonfile json.log --packages=${package_list} -- ${failfast_flag} -vet=off -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} | tee "${test_output_file}"


### PR DESCRIPTION
**Description**

The main purpose of this PR is to speed up the models tests by 4x to 5x:
from about 100s down to about 20-30s. The main reason our server tests are 
slow is because we truncate the DB in between each test. In this PR, we 
remove the call to suite.TruncateAll from the SetupTest function, and 
only call it in tests that require it.

This PR also refactors models tests to remove unnecessary DB calls by 
calling `Validate` instead of `ValidateAndCreate` or `ValidateAndSave`, 
and by using the stubbed versions of testdatagen objects.

## Reviewer Notes

1. On the `master` branch, run `make db_test_reset db_test_migrate`
1. On the `master` branch, run `go test ./pkg/models -count=1`. Note how long it takes.
2. Run `go test ./pkg/models -count=1` on this branch. Verify that it runs much faster.


## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8077) for this change
