### PR TITLE
MB-8135 updateMTOShipment won't blank out addresses 

### DIFF
--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -17,7 +17,11 @@ import (
 
 // AddressModel model
 func AddressModel(address *primemessages.Address) *models.Address {
-	if address == nil {
+	// To check if the model is intended to be blank, we'll look at both ID and StreetAddress1
+	// We should always have ID if the user intends to update an Address,
+	// and StreetAddress1 is a required field on creation. If both are blank, it should be treated as nil.
+	var blankSwaggerID strfmt.UUID
+	if address == nil || (address.ID == blankSwaggerID && address.StreetAddress1 == nil) {
 		return nil
 	}
 	modelAddress := &models.Address{

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -280,7 +280,7 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(dbShipment *models.MTOShipment
 
 		if newShipment.SecondaryPickupAddress != nil {
 			if dbShipment.SecondaryPickupAddressID != nil {
-				newShipment.PickupAddress.ID = *dbShipment.SecondaryPickupAddressID
+				newShipment.SecondaryPickupAddress.ID = *dbShipment.SecondaryPickupAddressID
 			}
 
 			err := tx.Save(newShipment.SecondaryPickupAddress)


### PR DESCRIPTION
## Description

Recently, I had updated the Prime API YAML file to have a new structure for address fields in shipments so that they could each have an individual description. However, this introduced a bug to the `updateMTOShipment` endpoint wherein an address would have its values blanked out if it was not included in the request body. Fixing this involved updating the `AddressModel` function in `payload_to_model` to accurately identify blank addresses. I also added a test and caught another little bug in the meantime.

## Reviewer Notes

One other effect of the update to the Prime API's address structure is the return values. Instead of omitting the field if a null value was sent back from the server, now the response will look like:

```json
"secondaryDeliveryAddress": {
  "city": null,
  "postalCode": null,
  "state": null,
  "streetAddress1": null
},
```

There is no way to get around this if we want to have visible documentation for each of these fields. The question - is this acceptable? Is the documentation not worth the potential confusion with the response? I'd appreciate feedback on that!

## Setup

Populate your db and run your server:

```sh
make db_dev_e2e_populate server_run
```

Using the Prime API testing tool of your choice ([Prime API Client](https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client) or [Postman](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman)):

* Run `fetchMTOUpdates` to grab a shipment's ID and eTag 
* Save a record of one of its addresses (`pickupAddress`, `destinationAddress`, `secondaryPickupAddress`, or `secondaryDeliveryAddress`) so that you can refer to it later
* Go to `updateMTOShipment`. Fill in the ID and eTag in the path params and `IfMatch` header, respectively.
* Set up a _small_ request body. Something like:
  ```json
  {
    "scheduledPickupDate": "2021-06-23"
  }
  ```
* Send the request.
* Check out your chosen address field in the response. Are all the values the same as they were before you sent the update? Then yay, that's a success!

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8135) for this change.
