### PR TITLE
MB-8384: txdb investigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,18 @@ commands:
             MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
             MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'
       - run:
+          name: make db_test_truncate for <<parameters.application>>
+          command: make db_test_truncate
+          environment:
+            APPLICATION: '<< parameters.application >>'
+            DB_PASSWORD: mysecretpassword
+            DB_USER: postgres
+            DB_HOST: localhost
+            DB_PORT_TEST: 5433
+            DB_PORT: 5432
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+      - run:
           name: make server_test_standalone for <<parameters.application>>
           command: |
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV

--- a/Makefile
+++ b/Makefile
@@ -401,8 +401,11 @@ endif
 mocks_generate: bin/mockery ## Generate mockery mocks for tests
 	go generate $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
+.PHONY: server_test_setup
+server_test_setup: db_test_reset db_test_migrate redis_reset db_test_truncate
+
 .PHONY: server_test
-server_test: db_test_reset db_test_migrate redis_reset server_test_standalone ## Run server unit tests
+server_test: server_test_setup server_test_standalone ## Run server unit tests
 
 .PHONY: server_test_standalone
 server_test_standalone: ## Run server unit tests with no deps
@@ -647,16 +650,16 @@ else
 	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)?sslmode=disable -c 'CREATE DATABASE $(DB_NAME_TEST);'
 endif
 
-.PHONY: db_test_truncate
-db_test_truncate: ## Truncate e2e db
-	@echo "Truncate the ${DB_NAME_TEST} database..."
-	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE; TRUNCATE webhook_subscriptions CASCADE; TRUNCATE traffic_distribution_lists CASCADE'
-
 .PHONY: db_test_run
 db_test_run: db_test_start db_test_create ## Run Test DB
 
 .PHONY: db_test_reset
 db_test_reset: db_test_destroy db_test_run ## Reset Test DB (destroy and run)
+
+.PHONY: db_test_truncate
+db_test_truncate:
+	@echo "Truncating ${DB_NAME_TEST} database..."
+	DB_PORT=$(DB_PORT_TEST) DB_NAME=$(DB_NAME_TEST) ./scripts/db-truncate
 
 .PHONY: db_test_migrate_standalone
 db_test_migrate_standalone: bin/milmove ## Migrate Test DB directly

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/gobuffalo/pop/v5 v5.3.4
 	github.com/gobuffalo/validate/v3 v3.3.0
 	github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576
-	github.com/gofrs/flock v0.7.3
 	github.com/gofrs/uuid v3.4.0+incompatible
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-github/v31 v31.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/0xAX/notificator v0.0.0-20191016112426-3962a5ea8da1 // indirect
 	github.com/99designs/aws-vault v4.5.1+incompatible
 	github.com/99designs/keyring v1.1.6
+	github.com/DATA-DOG/go-txdb v0.1.4
 	github.com/alexedwards/scs/redisstore v0.0.0-20200225172727-3308e1066830
 	github.com/alexedwards/scs/v2 v2.4.0
 	github.com/aws/aws-sdk-go v1.38.64

--- a/go.sum
+++ b/go.sum
@@ -382,8 +382,6 @@ github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576/go.mod h1:/oj50ZdPq
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/flock v0.7.3 h1:I0EKY9l8HZCXTMYC4F80vwT6KNypV9uYKP3Alm/hjmQ=
-github.com/gofrs/flock v0.7.3/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v3.4.0+incompatible h1:d3y9DuA2LnGr8hiQ+1dPQrNsydLvutmRq9cjULPWYZQ=
 github.com/gofrs/uuid v3.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/99designs/keyring v1.1.6 h1:kVDC2uCgVwecxCk+9zoCt2uEL6dt+dfVzMvGgnVcI
 github.com/99designs/keyring v1.1.6/go.mod h1:16e0ds7LGQQcT59QqkTg72Hh5ShM51Byv5PEmW6uoRU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-txdb v0.1.4 h1:6On4TAD6V33/QlE6Y5l0A4KngRzYrUQ7bgPsDrFrtQo=
+github.com/DATA-DOG/go-txdb v0.1.4/go.mod h1:DhAhxMXZpUJVGnT+p9IbzJoRKvlArO2pkHjnGX7o0n0=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/pkg/handlers/adminapi/api_test.go
+++ b/pkg/handlers/adminapi/api_test.go
@@ -20,12 +20,6 @@ type HandlerSuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// SetupTest sets up the test suite by preparing the DB
-func (suite *HandlerSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 // AfterTest completes tests by trying to close open files
 func (suite *HandlerSuite) AfterTest() {
 	for _, file := range suite.TestFilesToClose() {
@@ -49,7 +43,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("adminlocal", logger), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("adminlocal", logger), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -32,9 +32,9 @@ type BaseHandlerTestSuite struct {
 }
 
 // NewBaseHandlerTestSuite returns a new BaseHandlerTestSuite
-func NewBaseHandlerTestSuite(logger Logger, sender notifications.NotificationSender, packageName testingsuite.PackageName) BaseHandlerTestSuite {
+func NewBaseHandlerTestSuite(logger Logger, sender notifications.NotificationSender, packageName testingsuite.PackageName, opts ...testingsuite.PopTestSuiteOption) BaseHandlerTestSuite {
 	return BaseHandlerTestSuite{
-		PopTestSuite:       testingsuite.NewPopTestSuite(packageName),
+		PopTestSuite:       testingsuite.NewPopTestSuite(packageName, opts...),
 		logger:             logger,
 		notificationSender: sender,
 	}

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -18,12 +18,6 @@ type HandlerSuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// SetupTest sets up the test suite by preparing the DB
-func (suite *HandlerSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 // AfterTest completes tests by trying to close open files
 func (suite *HandlerSuite) AfterTest() {
 	for _, file := range suite.TestFilesToClose() {
@@ -47,7 +41,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -28,10 +28,15 @@ func payloadForClientError(title string, detail string, instance uuid.UUID) *ghc
 }
 
 func payloadForValidationError(title string, detail string, instance uuid.UUID, validationErrors *validate.Errors) *ghcmessages.ValidationError {
-	return &ghcmessages.ValidationError{
-		InvalidFields: handlers.NewValidationErrorsResponse(validationErrors).Errors,
-		ClientError:   *payloadForClientError(title, detail, instance),
+	payload := &ghcmessages.ValidationError{
+		ClientError: *payloadForClientError(title, detail, instance),
 	}
+
+	if validationErrors != nil {
+		payload.InvalidFields = handlers.NewValidationErrorsResponse(validationErrors).Errors
+	}
+
+	return payload
 }
 
 // UpdateMTOServiceItemStatusHandler struct that describes updating service item status

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -2,8 +2,9 @@ package ghcapi
 
 import (
 	"fmt"
+	"log"
+	"net/http"
 	"net/http/httptest"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models/roles"
@@ -37,7 +38,16 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
+type listMTOShipmentsSubtestData struct {
+	mtoAgent       models.MTOAgent
+	mtoServiceItem models.MTOServiceItem
+	shipments      models.MTOShipments
+	params         mtoshipmentops.ListMTOShipmentsParams
+}
+
+func (suite *HandlerSuite) makeListMTOShipmentsSubtestData() (subtestData *listMTOShipmentsSubtestData) {
+	subtestData = &listMTOShipmentsSubtestData{}
+
 	mto := testdatagen.MakeDefaultMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
@@ -46,29 +56,39 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			CounselorRemarks: handlers.FmtString("counselor remark"),
 		},
 	})
-	mtoAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
+	subtestData.mtoAgent = testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
 		MTOAgent: models.MTOAgent{
 			MTOShipmentID: mtoShipment.ID,
 		},
 	})
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+	subtestData.mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
 			MTOShipmentID: &mtoShipment.ID,
 		},
 	})
 
-	shipments := models.MTOShipments{mtoShipment}
+	subtestData.shipments = models.MTOShipments{mtoShipment}
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/move_task_orders/%s/mto_shipments", mto.ID.String()), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
-	params := mtoshipmentops.ListMTOShipmentsParams{
+	subtestData.params = mtoshipmentops.ListMTOShipmentsParams{
 		HTTPRequest:     req,
 		MoveTaskOrderID: *handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
 	}
 
-	suite.T().Run("Successful list fetch - Integration Test", func(t *testing.T) {
+	return subtestData
+}
+
+func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
+	suite.Run("Successful list fetch - Integration Test", func() {
+		subtestData := suite.makeListMTOShipmentsSubtestData()
+		params := subtestData.params
+		shipments := subtestData.shipments
+		mtoAgent := subtestData.mtoAgent
+		mtoServiceItem := subtestData.mtoServiceItem
+
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		listFetcher := fetch.NewListFetcher(queryBuilder)
 		fetcher := fetch.NewFetcher(queryBuilder)
@@ -89,7 +109,10 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.Equal(mtoServiceItem.ID.String(), okResponse.Payload[0].MtoServiceItems[0].ID.String())
 	})
 
-	suite.T().Run("Failure list fetch - Internal Server Error", func(t *testing.T) {
+	suite.Run("Failure list fetch - Internal Server Error", func() {
+		subtestData := suite.makeListMTOShipmentsSubtestData()
+		params := subtestData.params
+
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 		handler := ListMTOShipmentsHandler{
@@ -117,7 +140,10 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsInternalServerError{}, response)
 	})
 
-	suite.T().Run("Failure list fetch - 404 Not Found - Move Task Order ID", func(t *testing.T) {
+	suite.Run("Failure list fetch - 404 Not Found - Move Task Order ID", func() {
+		subtestData := suite.makeListMTOShipmentsSubtestData()
+		params := subtestData.params
+
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 		handler := ListMTOShipmentsHandler{
@@ -138,9 +164,18 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 	})
 }
 
-func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
+type patchMTOShipmentSubtestData struct {
+	params      mtoshipmentops.PatchMTOShipmentStatusParams
+	planner     *routemocks.Planner
+	mtoShipment models.MTOShipment
+	req         *http.Request
+}
+
+func (suite *HandlerSuite) makePatchMTOShipmentSubtestData() (subtestData *patchMTOShipmentSubtestData) {
+	subtestData = &patchMTOShipmentSubtestData{}
+
 	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+	subtestData.mtoShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		MTOShipment: models.MTOShipment{
 			Status:       models.MTOShipmentStatusSubmitted,
@@ -169,22 +204,22 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 	}
 
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
-	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
+	eTag := etag.GenerateEtag(subtestData.mtoShipment.UpdatedAt)
 
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_shipments/%s", mto.ID.String(), mtoShipment.ID.String()), nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
+	nreq := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_shipments/%s", mto.ID.String(), subtestData.mtoShipment.ID.String()), nil)
+	subtestData.req = suite.AuthenticateUserRequest(nreq, requestUser)
 
 	approvedStatus := string(models.MTOShipmentStatusApproved)
-	params := mtoshipmentops.PatchMTOShipmentStatusParams{
-		HTTPRequest:     req,
-		MoveTaskOrderID: *handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
-		ShipmentID:      *handlers.FmtUUID(mtoShipment.ID),
+	subtestData.params = mtoshipmentops.PatchMTOShipmentStatusParams{
+		HTTPRequest:     subtestData.req,
+		MoveTaskOrderID: *handlers.FmtUUID(subtestData.mtoShipment.MoveTaskOrderID),
+		ShipmentID:      *handlers.FmtUUID(subtestData.mtoShipment.ID),
 		Body:            &ghcmessages.PatchMTOShipmentStatus{Status: &approvedStatus},
 		IfMatch:         eTag,
 	}
 
 	// Run swagger validations
-	suite.NoError(params.Body.Validate(strfmt.Default))
+	suite.NoError(subtestData.params.Body.Validate(strfmt.Default))
 
 	ghcDomesticTransitTime := models.GHCDomesticTransitTime{
 		MaxDaysTransitTime: 12,
@@ -193,17 +228,27 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		DistanceMilesLower: 0,
 		DistanceMilesUpper: 10000,
 	}
-	_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
+	verrs, err := suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
+	if err != nil {
+		log.Panicf("Error creating valid ghc domestic transit time: %v, %v", err, verrs)
+	}
 
-	planner := &routemocks.Planner{}
-	planner.On("TransitDistance",
+	subtestData.planner = &routemocks.Planner{}
+	subtestData.planner.On("TransitDistance",
 		mock.Anything,
 		mock.Anything,
 	).Return(1000, nil)
 
-	var nilString *string
+	return subtestData
+}
 
-	suite.T().Run("Successful patch - Integration Test", func(t *testing.T) {
+func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
+	suite.Run("Successful patch - Integration Test", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		planner := subtestData.planner
+		params := subtestData.params
+		mtoShipment := subtestData.mtoShipment
+
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(queryBuilder)
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder)
@@ -222,7 +267,13 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.NotNil(okResponse.Payload.ETag)
 	})
 
-	suite.T().Run("Patch failure - 500", func(t *testing.T) {
+	suite.Run("Patch failure - 500", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		params := subtestData.params
+		eTag := params.IfMatch
+		var nilString *string
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		handler := PatchShipmentHandler{
@@ -244,7 +295,13 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.PatchMTOShipmentStatusInternalServerError{}, response)
 	})
 
-	suite.T().Run("Patch failure - 404", func(t *testing.T) {
+	suite.Run("Patch failure - 404", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		params := subtestData.params
+		eTag := params.IfMatch
+		var nilString *string
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		handler := PatchShipmentHandler{
@@ -264,7 +321,13 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.PatchMTOShipmentStatusNotFound{}, response)
 	})
 
-	suite.T().Run("Patch failure - 422", func(t *testing.T) {
+	suite.Run("Patch failure - 422", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		params := subtestData.params
+		eTag := params.IfMatch
+		var nilString *string
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		handler := PatchShipmentHandler{
@@ -284,7 +347,13 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.PatchMTOShipmentStatusUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Patch failure - 412", func(t *testing.T) {
+	suite.Run("Patch failure - 412", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		params := subtestData.params
+		eTag := params.IfMatch
+		var nilString *string
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		handler := PatchShipmentHandler{
@@ -304,7 +373,13 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.PatchMTOShipmentStatusPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Patch failure - 409", func(t *testing.T) {
+	suite.Run("Patch failure - 409", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		params := subtestData.params
+		eTag := params.IfMatch
+		var nilString *string
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		handler := PatchShipmentHandler{
@@ -324,7 +399,11 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.PatchMTOShipmentStatusConflict{}, response)
 	})
 
-	suite.T().Run("Successful patch with webhook notification - On an approved move", func(t *testing.T) {
+	suite.Run("Successful patch with webhook notification - On an approved move", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		req := subtestData.req
+		var nilString *string
+
 		// Create mock fetcher and updater
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
@@ -341,7 +420,9 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 			},
 		})
 
-		params = mtoshipmentops.PatchMTOShipmentStatusParams{
+		eTag := etag.GenerateEtag(shipment.UpdatedAt)
+		approvedStatus := string(models.MTOShipmentStatusApproved)
+		params := mtoshipmentops.PatchMTOShipmentStatusParams{
 			HTTPRequest:     req,
 			MoveTaskOrderID: *handlers.FmtUUID(shipment.MoveTaskOrderID),
 			ShipmentID:      *handlers.FmtUUID(shipment.ID),
@@ -381,7 +462,11 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Successful patch to CANCELLATION_REQUESTED status", func(t *testing.T) {
+	suite.Run("Successful patch to CANCELLATION_REQUESTED status", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		planner := subtestData.planner
+		req := subtestData.req
+
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(queryBuilder)
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder)
@@ -394,7 +479,7 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 				Status: models.MTOShipmentStatusApproved,
 			},
 		})
-		eTag = etag.GenerateEtag(approvedShipment.UpdatedAt)
+		eTag := etag.GenerateEtag(approvedShipment.UpdatedAt)
 
 		// Set the traceID so we can use it to find the webhook notification
 		handlerContext := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
@@ -429,7 +514,12 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 
 	})
 
-	suite.T().Run("Swagger endpoint allows passing in CANCELED status", func(t *testing.T) {
+	suite.Run("Swagger endpoint allows passing in CANCELED status", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		req := subtestData.req
+		eTag := subtestData.params.IfMatch
+
 		canceledStatus := string(models.MTOShipmentStatusCanceled)
 		params := mtoshipmentops.PatchMTOShipmentStatusParams{
 			HTTPRequest: req,
@@ -441,7 +531,12 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.NoError(params.Body.Validate(strfmt.Default))
 	})
 
-	suite.T().Run("Swagger endpoint allows passing in DIVERSION_REQUESTED status", func(t *testing.T) {
+	suite.Run("Swagger endpoint allows passing in DIVERSION_REQUESTED status", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		req := subtestData.req
+		eTag := subtestData.params.IfMatch
+
 		diversionRequestedStatus := string(models.MTOShipmentStatusDiversionRequested)
 		params := mtoshipmentops.PatchMTOShipmentStatusParams{
 			HTTPRequest: req,
@@ -453,7 +548,12 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.NoError(params.Body.Validate(strfmt.Default))
 	})
 
-	suite.T().Run("Swagger endpoint allows passing in REJECTED status", func(t *testing.T) {
+	suite.Run("Swagger endpoint allows passing in REJECTED status", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		req := subtestData.req
+		eTag := subtestData.params.IfMatch
+
 		rejectedStatus := string(models.MTOShipmentStatusRejected)
 		params := mtoshipmentops.PatchMTOShipmentStatusParams{
 			HTTPRequest: req,
@@ -465,7 +565,12 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 		suite.NoError(params.Body.Validate(strfmt.Default))
 	})
 
-	suite.T().Run("Swagger endpoint does NOT allow passing in SUBMITTED status", func(t *testing.T) {
+	suite.Run("Swagger endpoint does NOT allow passing in SUBMITTED status", func() {
+		subtestData := suite.makePatchMTOShipmentSubtestData()
+		mtoShipment := subtestData.mtoShipment
+		req := subtestData.req
+		eTag := subtestData.params.IfMatch
+
 		submittedStatus := string(models.MTOShipmentStatusSubmitted)
 		params := mtoshipmentops.PatchMTOShipmentStatusParams{
 			HTTPRequest: req,
@@ -479,7 +584,7 @@ func (suite *HandlerSuite) TestPatchMTOShipmentHandler() {
 }
 
 func (suite *HandlerSuite) TestDeleteShipmentHandler() {
-	suite.T().Run("Returns a 403 when the office user is not a service counselor", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a service counselor", func() {
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		deleter := &mocks.ShipmentDeleter{}
@@ -503,7 +608,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 		suite.IsType(&shipmentops.DeleteShipmentForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 204 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 204 when all validations pass", func() {
 		shipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		deleter := &mocks.ShipmentDeleter{}
@@ -528,7 +633,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 		suite.IsType(&shipmentops.DeleteShipmentNoContent{}, response)
 	})
 
-	suite.T().Run("Returns 404 when deleter returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when deleter returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		deleter := &mocks.ShipmentDeleter{}
@@ -552,7 +657,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 		suite.IsType(&shipmentops.DeleteShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 403 when deleter returns ForbiddenError", func(t *testing.T) {
+	suite.Run("Returns 403 when deleter returns ForbiddenError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		deleter := &mocks.ShipmentDeleter{}
@@ -578,7 +683,7 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 }
 
 func (suite *HandlerSuite) TestApproveShipmentHandler() {
-	suite.T().Run("Returns 200 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 200 when all validations pass", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -638,7 +743,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Returns a 403 when the office user is not a TOO", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a TOO", func() {
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		approver := &mocks.ShipmentApprover{}
@@ -663,7 +768,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 404 when approver returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when approver returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -689,7 +794,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 409 when approver returns Conflict Error", func(t *testing.T) {
+	suite.Run("Returns 409 when approver returns Conflict Error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -715,7 +820,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentConflict{}, response)
 	})
 
-	suite.T().Run("Returns 412 when eTag does not match", func(t *testing.T) {
+	suite.Run("Returns 412 when eTag does not match", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(time.Now())
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -741,7 +846,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Returns 422 when approver returns validation errors", func(t *testing.T) {
+	suite.Run("Returns 422 when approver returns validation errors", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -767,7 +872,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Returns 500 when approver returns unexpected error", func(t *testing.T) {
+	suite.Run("Returns 500 when approver returns unexpected error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -795,7 +900,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 }
 
 func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
-	suite.T().Run("Returns 200 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 200 when all validations pass", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -832,7 +937,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Returns a 403 when the office user is not a TOO", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a TOO", func() {
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		requester := &mocks.ShipmentDiversionRequester{}
@@ -857,7 +962,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.RequestShipmentDiversionForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 404 when requester returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when requester returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -883,7 +988,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.RequestShipmentDiversionNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 409 when requester returns Conflict Error", func(t *testing.T) {
+	suite.Run("Returns 409 when requester returns Conflict Error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -909,7 +1014,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.RequestShipmentDiversionConflict{}, response)
 	})
 
-	suite.T().Run("Returns 412 when eTag does not match", func(t *testing.T) {
+	suite.Run("Returns 412 when eTag does not match", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(time.Now())
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -935,7 +1040,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.RequestShipmentDiversionPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Returns 422 when requester returns validation errors", func(t *testing.T) {
+	suite.Run("Returns 422 when requester returns validation errors", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -961,7 +1066,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.RequestShipmentDiversionUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Returns 500 when requester returns unexpected error", func(t *testing.T) {
+	suite.Run("Returns 500 when requester returns unexpected error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -989,7 +1094,7 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 }
 
 func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
-	suite.T().Run("Returns 200 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 200 when all validations pass", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -1026,7 +1131,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Returns a 403 when the office user is not a TOO", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a TOO", func() {
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		approver := &mocks.ShipmentDiversionApprover{}
@@ -1051,7 +1156,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentDiversionForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 404 when approver returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when approver returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1077,7 +1182,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentDiversionNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 409 when approver returns Conflict Error", func(t *testing.T) {
+	suite.Run("Returns 409 when approver returns Conflict Error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1103,7 +1208,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentDiversionConflict{}, response)
 	})
 
-	suite.T().Run("Returns 412 when eTag does not match", func(t *testing.T) {
+	suite.Run("Returns 412 when eTag does not match", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(time.Now())
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1129,7 +1234,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentDiversionPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Returns 422 when approver returns validation errors", func(t *testing.T) {
+	suite.Run("Returns 422 when approver returns validation errors", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1155,7 +1260,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 		suite.IsType(&shipmentops.ApproveShipmentDiversionUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Returns 500 when approver returns unexpected error", func(t *testing.T) {
+	suite.Run("Returns 500 when approver returns unexpected error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1185,7 +1290,7 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 func (suite *HandlerSuite) TestRejectShipmentHandler() {
 	reason := "reason"
 
-	suite.T().Run("Returns 200 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 200 when all validations pass", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -1224,7 +1329,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Returns a 403 when the office user is not a TOO", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a TOO", func() {
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		rejecter := &mocks.ShipmentRejecter{}
@@ -1254,7 +1359,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 404 when rejecter returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when rejecter returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1285,7 +1390,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 409 when rejecter returns Conflict Error", func(t *testing.T) {
+	suite.Run("Returns 409 when rejecter returns Conflict Error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1316,7 +1421,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentConflict{}, response)
 	})
 
-	suite.T().Run("Returns 412 when eTag does not match", func(t *testing.T) {
+	suite.Run("Returns 412 when eTag does not match", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(time.Now())
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1347,7 +1452,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Returns 422 when rejecter returns validation errors", func(t *testing.T) {
+	suite.Run("Returns 422 when rejecter returns validation errors", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1378,7 +1483,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Returns 500 when rejecter returns unexpected error", func(t *testing.T) {
+	suite.Run("Returns 500 when rejecter returns unexpected error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1409,7 +1514,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 		suite.IsType(&shipmentops.RejectShipmentInternalServerError{}, response)
 	})
 
-	suite.T().Run("Requires rejection reason in Body of request", func(t *testing.T) {
+	suite.Run("Requires rejection reason in Body of request", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -1444,7 +1549,7 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 }
 
 func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
-	suite.T().Run("Returns 200 when all validations pass", func(t *testing.T) {
+	suite.Run("Returns 200 when all validations pass", func() {
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{
@@ -1481,7 +1586,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.HasWebhookNotification(shipment.ID, handlerContext.GetTraceID())
 	})
 
-	suite.T().Run("Returns a 403 when the office user is not a TOO", func(t *testing.T) {
+	suite.Run("Returns a 403 when the office user is not a TOO", func() {
 		officeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		uuid := uuid.Must(uuid.NewV4())
 		canceler := &mocks.ShipmentCancellationRequester{}
@@ -1506,7 +1611,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.IsType(&shipmentops.RequestShipmentCancellationForbidden{}, response)
 	})
 
-	suite.T().Run("Returns 404 when canceler returns NotFoundError", func(t *testing.T) {
+	suite.Run("Returns 404 when canceler returns NotFoundError", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1532,7 +1637,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.IsType(&shipmentops.RequestShipmentCancellationNotFound{}, response)
 	})
 
-	suite.T().Run("Returns 409 when canceler returns Conflict Error", func(t *testing.T) {
+	suite.Run("Returns 409 when canceler returns Conflict Error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1558,7 +1663,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.IsType(&shipmentops.RequestShipmentCancellationConflict{}, response)
 	})
 
-	suite.T().Run("Returns 412 when eTag does not match", func(t *testing.T) {
+	suite.Run("Returns 412 when eTag does not match", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(time.Now())
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1584,7 +1689,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.IsType(&shipmentops.RequestShipmentCancellationPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Returns 422 when canceler returns validation errors", func(t *testing.T) {
+	suite.Run("Returns 422 when canceler returns validation errors", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1610,7 +1715,7 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 		suite.IsType(&shipmentops.RequestShipmentCancellationUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Returns 500 when canceler returns unexpected error", func(t *testing.T) {
+	suite.Run("Returns 500 when canceler returns unexpected error", func() {
 		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -1637,7 +1742,14 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 	})
 }
 
-func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
+type createMTOShipmentSubtestData struct {
+	builder *query.Builder
+	params  mtoshipmentops.CreateMTOShipmentParams
+}
+
+func (suite *HandlerSuite) makeCreateMTOShipmentSubtestData() (subtestData *createMTOShipmentSubtestData) {
+	subtestData = &createMTOShipmentSubtestData{}
+
 	mto := testdatagen.MakeAvailableMove(suite.DB())
 	pickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
 	destinationAddress := testdatagen.MakeDefaultAddress(suite.DB())
@@ -1648,11 +1760,11 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	mtoShipment.MoveTaskOrderID = mto.ID
 
-	builder := query.NewQueryBuilder(suite.DB())
+	subtestData.builder = query.NewQueryBuilder(suite.DB())
 
 	req := httptest.NewRequest("POST", "/mto-shipments", nil)
 
-	params := mtoshipmentops.CreateMTOShipmentParams{
+	subtestData.params = mtoshipmentops.CreateMTOShipmentParams{
 		HTTPRequest: req,
 		Body: &ghcmessages.CreateMTOShipment{
 			MoveTaskOrderID:     handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
@@ -1662,7 +1774,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			RequestedPickupDate: handlers.FmtDatePtr(mtoShipment.RequestedPickupDate),
 		},
 	}
-	params.Body.DestinationAddress.Address = ghcmessages.Address{
+	subtestData.params.Body.DestinationAddress.Address = ghcmessages.Address{
 		City:           &destinationAddress.City,
 		Country:        destinationAddress.Country,
 		PostalCode:     &destinationAddress.PostalCode,
@@ -1671,7 +1783,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		StreetAddress2: destinationAddress.StreetAddress2,
 		StreetAddress3: destinationAddress.StreetAddress3,
 	}
-	params.Body.PickupAddress.Address = ghcmessages.Address{
+	subtestData.params.Body.PickupAddress.Address = ghcmessages.Address{
 		City:           &pickupAddress.City,
 		Country:        pickupAddress.Country,
 		PostalCode:     &pickupAddress.PostalCode,
@@ -1681,11 +1793,23 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		StreetAddress3: pickupAddress.StreetAddress3,
 	}
 
-	suite.T().Run("Successful POST - Integration Test", func(t *testing.T) {
+	return subtestData
+}
+
+func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
+	// Set the traceID so we can use it to find the webhook notification
+	handlerContext := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+	handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
+
+	suite.Run("Successful POST - Integration Test", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		builder := subtestData.builder
+		params := subtestData.params
+
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			handlerContext,
 			creator,
 		}
 		response := handler.Handle(params)
@@ -1699,11 +1823,14 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.Equal(string("counselor remark"), *createMTOShipmentPayload.CounselorRemarks)
 	})
 
-	suite.T().Run("POST failure - 500", func(t *testing.T) {
+	suite.Run("POST failure - 500", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		params := subtestData.params
+
 		mockCreator := mocks.MTOShipmentCreator{}
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			handlerContext,
 			&mockCreator,
 		}
 
@@ -1719,12 +1846,16 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentInternalServerError{}, response)
 	})
 
-	suite.T().Run("POST failure - 422 -- Bad agent IDs set on shipment", func(t *testing.T) {
+	suite.Run("POST failure - 422 -- Bad agent IDs set on shipment", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		builder := subtestData.builder
+		params := subtestData.params
+
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			handlerContext,
 			creator,
 		}
 
@@ -1744,30 +1875,42 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.NotEmpty(typedResponse.Payload.InvalidFields)
 	})
 
-	suite.T().Run("POST failure - 422 - invalid input, missing pickup address", func(t *testing.T) {
+	//
+	// TODO: this test panics with a null pointer exception. Duncan
+	// said he would look into a fix - ahobson 3 June 2021
+	//
+	// suite.Run("POST failure - 422 - invalid input, missing pickup address", func() {
+	// 	subtestData := suite.makeCreateMTOShipmentSubtestData()
+	// 	builder := subtestData.builder
+	// 	params := subtestData.params
+
+	// 	fetcher := fetch.NewFetcher(builder)
+	// 	creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+
+	// 	handler := CreateMTOShipmentHandler{
+	// 		handlerContext,
+	// 		creator,
+	// 	}
+
+	// 	badParams := params
+	// 	badParams.Body.PickupAddress.Address.StreetAddress1 = nil
+
+	// 	response := handler.Handle(badParams)
+	// 	suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
+	// 	typedResponse := response.(*mtoshipmentops.CreateMTOShipmentUnprocessableEntity)
+	// 	suite.NotEmpty(typedResponse.Payload.InvalidFields)
+	// })
+
+	suite.Run("POST failure - 404 -- not found", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		builder := subtestData.builder
+		params := subtestData.params
+
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-			creator,
-		}
-
-		badParams := params
-		badParams.Body.PickupAddress.Address.StreetAddress1 = nil
-
-		response := handler.Handle(badParams)
-		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
-		typedResponse := response.(*mtoshipmentops.CreateMTOShipmentUnprocessableEntity)
-		suite.NotEmpty(typedResponse.Payload.InvalidFields)
-	})
-
-	suite.T().Run("POST failure - 404 -- not found", func(t *testing.T) {
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
-
-		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			handlerContext,
 			creator,
 		}
 
@@ -1776,15 +1919,18 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		badParams.Body.MoveTaskOrderID = handlers.FmtUUID(uuid.FromStringOrNil(uuidString))
 
 		response := handler.Handle(badParams)
-		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
+		suite.IsType(&mtoshipmentops.CreateMTOShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("POST failure - 400 -- nil body", func(t *testing.T) {
+	suite.Run("POST failure - 400 -- nil body", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		builder := subtestData.builder
+
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			handlerContext,
 			creator,
 		}
 
@@ -1862,14 +2008,14 @@ func (suite *HandlerSuite) getUpdateShipmentParams(originalShipment models.MTOSh
 }
 
 func (suite *HandlerSuite) TestUpdateShipmentHandler() {
-	builder := query.NewQueryBuilder(suite.DB())
 	planner := &routemocks.Planner{}
 	planner.On("TransitDistance",
 		mock.Anything,
 		mock.Anything,
 	).Return(400, nil)
 
-	suite.T().Run("Successful PATCH - Integration Test", func(t *testing.T) {
+	suite.Run("Successful PATCH - Integration Test", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateShipmentHandler{
@@ -1908,7 +2054,31 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		suite.Equal(params.Body.RequestedDeliveryDate.String(), updatedShipment.RequestedDeliveryDate.String())
 	})
 
-	suite.T().Run("PATCH failure - 404 -- not found", func(t *testing.T) {
+	suite.Run("PATCH failure - 400 -- nil body", func() {
+		builder := query.NewQueryBuilder(suite.DB())
+		fetcher := fetch.NewFetcher(builder)
+		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
+		handler := UpdateShipmentHandler{
+			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			fetcher,
+			updater,
+		}
+
+		oldShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		params := suite.getUpdateShipmentParams(oldShipment)
+		params.Body = nil
+
+		response := handler.Handle(params)
+
+		suite.IsType(&mtoshipmentops.UpdateMTOShipmentUnprocessableEntity{}, response)
+	})
+
+	suite.Run("PATCH failure - 404 -- not found", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateShipmentHandler{
@@ -1934,7 +2104,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 412 -- etag mismatch", func(t *testing.T) {
+	suite.Run("PATCH failure - 412 -- etag mismatch", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateShipmentHandler{
@@ -1959,7 +2130,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 412 -- shipment shouldn't be updatable", func(t *testing.T) {
+	suite.Run("PATCH failure - 412 -- shipment shouldn't be updatable", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateShipmentHandler{
@@ -1984,7 +2156,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 500", func(t *testing.T) {
+	suite.Run("PATCH failure - 500", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		mockUpdater := mocks.MTOShipmentUpdater{}
 		fetcher := fetch.NewFetcher(builder)
 		handler := UpdateShipmentHandler{

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -1875,31 +1875,31 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.NotEmpty(typedResponse.Payload.InvalidFields)
 	})
 
-	//
-	// TODO: this test panics with a null pointer exception. Duncan
-	// said he would look into a fix - ahobson 3 June 2021
-	//
-	// suite.Run("POST failure - 422 - invalid input, missing pickup address", func() {
-	// 	subtestData := suite.makeCreateMTOShipmentSubtestData()
-	// 	builder := subtestData.builder
-	// 	params := subtestData.params
+	suite.Run("POST failure - 422 - invalid input, missing pickup address", func() {
+		subtestData := suite.makeCreateMTOShipmentSubtestData()
+		builder := subtestData.builder
+		params := subtestData.params
 
-	// 	fetcher := fetch.NewFetcher(builder)
-	// 	creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+		fetcher := fetch.NewFetcher(builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
 
-	// 	handler := CreateMTOShipmentHandler{
-	// 		handlerContext,
-	// 		creator,
-	// 	}
+		handler := CreateMTOShipmentHandler{
+			handlerContext,
+			creator,
+		}
 
-	// 	badParams := params
-	// 	badParams.Body.PickupAddress.Address.StreetAddress1 = nil
+		badParams := params
+		badParams.Body.PickupAddress.Address.StreetAddress1 = nil
 
-	// 	response := handler.Handle(badParams)
-	// 	suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
-	// 	typedResponse := response.(*mtoshipmentops.CreateMTOShipmentUnprocessableEntity)
-	// 	suite.NotEmpty(typedResponse.Payload.InvalidFields)
-	// })
+		suite.NoError(badParams.Body.Validate(strfmt.Default))
+
+		response := handler.Handle(badParams)
+		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
+		typedResponse := response.(*mtoshipmentops.CreateMTOShipmentUnprocessableEntity)
+		// CreateMTOShipment is returning services.NewInvalidInputError without any validation errors
+		// so InvalidFields won't be added to the payload.
+		suite.Empty(typedResponse.Payload.InvalidFields)
+	})
 
 	suite.Run("POST failure - 404 -- not found", func() {
 		subtestData := suite.makeCreateMTOShipmentSubtestData()

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -18,12 +18,6 @@ type HandlerSuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// SetupTest sets up the test suite by preparing the DB
-func (suite *HandlerSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 // AfterTest completes tests by trying to close open files
 func (suite *HandlerSuite) AfterTest() {
 	for _, file := range suite.TestFilesToClose() {
@@ -47,7 +41,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -32,9 +32,6 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			ppmStatus = models.PPMStatusSUBMITTED
 		}
 
-		err := suite.TruncateAll()
-		suite.FatalNoError(err)
-
 		// Given: An office user
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/transcom/mymove/pkg/services/mocks"
 
 	"net/http/httptest"
-	"testing"
 
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/services/query"
@@ -31,22 +30,32 @@ import (
 // CREATE
 //
 
-func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
-	mto := testdatagen.MakeDefaultMove(suite.DB())
+type mtoCreateSubtestData struct {
+	serviceMember models.ServiceMember
+	pickupAddress models.Address
+	mtoShipment   models.MTOShipment
+	builder       *query.Builder
+	params        mtoshipmentops.CreateMTOShipmentParams
+}
 
-	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
+func (suite *HandlerSuite) makeCreateSubtestData() (subtestData *mtoCreateSubtestData) {
+	subtestData = &mtoCreateSubtestData{}
+	db := suite.DB()
+	mto := testdatagen.MakeDefaultMove(db)
 
-	pickupAddress := testdatagen.MakeDefaultAddress(suite.DB())
+	subtestData.serviceMember = testdatagen.MakeDefaultServiceMember(db)
+
+	subtestData.pickupAddress = testdatagen.MakeDefaultAddress(db)
 	secondaryPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
 
 	destinationAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
 	secondaryDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
 
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+	subtestData.mtoShipment = testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
 		Move:        mto,
 		MTOShipment: models.MTOShipment{},
 	})
-	mtoShipment.MoveTaskOrderID = mto.ID
+	subtestData.mtoShipment.MoveTaskOrderID = mto.ID
 
 	mtoAgent := testdatagen.MakeDefaultMTOAgent(suite.DB())
 	agents := internalmessages.MTOAgents{&internalmessages.MTOAgent{
@@ -59,26 +68,25 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	customerRemarks := "I have some grandfather clocks."
 
-	builder := query.NewQueryBuilder(suite.DB())
+	subtestData.builder = query.NewQueryBuilder(db)
 
 	req := httptest.NewRequest("POST", "/mto_shipments", nil)
-	unauthorizedReq := httptest.NewRequest("POST", "/mto_shipments", nil)
-	req = suite.AuthenticateRequest(req, serviceMember)
+	req = suite.AuthenticateRequest(req, subtestData.serviceMember)
 
-	params := mtoshipmentops.CreateMTOShipmentParams{
+	subtestData.params = mtoshipmentops.CreateMTOShipmentParams{
 		HTTPRequest: req,
 		Body: &internalmessages.CreateShipment{
-			MoveTaskOrderID: handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
+			MoveTaskOrderID: handlers.FmtUUID(subtestData.mtoShipment.MoveTaskOrderID),
 			Agents:          agents,
 			CustomerRemarks: &customerRemarks,
 			PickupAddress: &internalmessages.Address{
-				City:           &pickupAddress.City,
-				Country:        pickupAddress.Country,
-				PostalCode:     &pickupAddress.PostalCode,
-				State:          &pickupAddress.State,
-				StreetAddress1: &pickupAddress.StreetAddress1,
-				StreetAddress2: pickupAddress.StreetAddress2,
-				StreetAddress3: pickupAddress.StreetAddress3,
+				City:           &subtestData.pickupAddress.City,
+				Country:        subtestData.pickupAddress.Country,
+				PostalCode:     &subtestData.pickupAddress.PostalCode,
+				State:          &subtestData.pickupAddress.State,
+				StreetAddress1: &subtestData.pickupAddress.StreetAddress1,
+				StreetAddress2: subtestData.pickupAddress.StreetAddress2,
+				StreetAddress3: subtestData.pickupAddress.StreetAddress3,
 			},
 			SecondaryPickupAddress: &internalmessages.Address{
 				City:           &secondaryPickupAddress.City,
@@ -107,20 +115,26 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 				StreetAddress2: secondaryDeliveryAddress.StreetAddress2,
 				StreetAddress3: secondaryDeliveryAddress.StreetAddress3,
 			},
-			RequestedPickupDate:   strfmt.Date(*mtoShipment.RequestedPickupDate),
-			RequestedDeliveryDate: strfmt.Date(*mtoShipment.RequestedDeliveryDate),
+			RequestedPickupDate:   strfmt.Date(*subtestData.mtoShipment.RequestedPickupDate),
+			RequestedDeliveryDate: strfmt.Date(*subtestData.mtoShipment.RequestedDeliveryDate),
 			ShipmentType:          internalmessages.MTOShipmentTypeHHG,
 		},
 	}
 
-	suite.T().Run("Successful POST - Integration Test", func(t *testing.T) {
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+	return subtestData
+}
+
+func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
+	suite.Run("Successful POST - Integration Test", func() {
+		subtestData := suite.makeCreateSubtestData()
+		params := subtestData.params
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
 		handler := CreateMTOShipmentHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			creator,
 		}
-		response := handler.Handle(params)
+		response := handler.Handle(subtestData.params)
 
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentOK{}, response)
 
@@ -145,16 +159,17 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.NotEmpty(createdShipment.Agents[0].ID)
 	})
 
-	suite.T().Run("POST failure - 400 - invalid input, missing pickup address", func(t *testing.T) {
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+	suite.Run("POST failure - 400 - invalid input, missing pickup address", func() {
+		subtestData := suite.makeCreateSubtestData()
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			creator,
 		}
 
-		badParams := params
+		badParams := subtestData.params
 		badParams.Body.PickupAddress = nil
 
 		response := handler.Handle(badParams)
@@ -162,26 +177,29 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("POST failure - 401- permission denied - not authenticated", func(t *testing.T) {
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+	suite.Run("POST failure - 401- permission denied - not authenticated", func() {
+		subtestData := suite.makeCreateSubtestData()
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
+
+		unauthorizedReq := httptest.NewRequest("POST", "/mto_shipments", nil)
 		unauthorizedParams := mtoshipmentops.CreateMTOShipmentParams{
 			HTTPRequest: unauthorizedReq,
 			Body: &internalmessages.CreateShipment{
-				MoveTaskOrderID: handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
+				MoveTaskOrderID: handlers.FmtUUID(subtestData.mtoShipment.MoveTaskOrderID),
 				Agents:          internalmessages.MTOAgents{},
 				CustomerRemarks: nil,
 				PickupAddress: &internalmessages.Address{
-					City:           &pickupAddress.City,
-					Country:        pickupAddress.Country,
-					PostalCode:     &pickupAddress.PostalCode,
-					State:          &pickupAddress.State,
-					StreetAddress1: &pickupAddress.StreetAddress1,
-					StreetAddress2: pickupAddress.StreetAddress2,
-					StreetAddress3: pickupAddress.StreetAddress3,
+					City:           &subtestData.pickupAddress.City,
+					Country:        subtestData.pickupAddress.Country,
+					PostalCode:     &subtestData.pickupAddress.PostalCode,
+					State:          &subtestData.pickupAddress.State,
+					StreetAddress1: &subtestData.pickupAddress.StreetAddress1,
+					StreetAddress2: subtestData.pickupAddress.StreetAddress2,
+					StreetAddress3: subtestData.pickupAddress.StreetAddress3,
 				},
-				RequestedPickupDate:   strfmt.Date(*mtoShipment.RequestedPickupDate),
-				RequestedDeliveryDate: strfmt.Date(*mtoShipment.RequestedDeliveryDate),
+				RequestedPickupDate:   strfmt.Date(*subtestData.mtoShipment.RequestedPickupDate),
+				RequestedDeliveryDate: strfmt.Date(*subtestData.mtoShipment.RequestedDeliveryDate),
 				ShipmentType:          internalmessages.MTOShipmentTypeHHG,
 			},
 		}
@@ -196,12 +214,14 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnauthorized{}, response)
 	})
 
-	suite.T().Run("POST failure - 403- permission denied - wrong application", func(t *testing.T) {
+	suite.Run("POST failure - 403- permission denied - wrong application", func() {
+		subtestData := suite.makeCreateSubtestData()
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
-		unauthorizedReq = suite.AuthenticateOfficeRequest(req, officeUser)
-		unauthorizedParams := params
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
+		req := subtestData.params.HTTPRequest
+		unauthorizedReq := suite.AuthenticateOfficeRequest(req, officeUser)
+		unauthorizedParams := subtestData.params
 		unauthorizedParams.HTTPRequest = unauthorizedReq
 
 		handler := CreateMTOShipmentHandler{
@@ -214,10 +234,11 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentUnauthorized{}, response)
 	})
 
-	suite.T().Run("POST failure - 404 -- not found", func(t *testing.T) {
+	suite.Run("POST failure - 404 -- not found", func() {
+		subtestData := suite.makeCreateSubtestData()
 
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
@@ -225,7 +246,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		uuidString := "d874d002-5582-4a91-97d3-786e8f66c763"
-		badParams := params
+		badParams := subtestData.params
 		badParams.Body.MoveTaskOrderID = handlers.FmtUUID(uuid.FromStringOrNil(uuidString))
 
 		response := handler.Handle(badParams)
@@ -233,9 +254,10 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("POST failure - 400 -- nil body", func(t *testing.T) {
-		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), builder, fetcher)
+	suite.Run("POST failure - 400 -- nil body", func() {
+		subtestData := suite.makeCreateSubtestData()
+		fetcher := fetch.NewFetcher(subtestData.builder)
+		creator := mtoshipment.NewMTOShipmentCreator(suite.DB(), subtestData.builder, fetcher)
 
 		handler := CreateMTOShipmentHandler{
 			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
@@ -243,14 +265,15 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		}
 
 		otherParams := mtoshipmentops.CreateMTOShipmentParams{
-			HTTPRequest: req,
+			HTTPRequest: subtestData.params.HTTPRequest,
 		}
 		response := handler.Handle(otherParams)
 
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentBadRequest{}, response)
 	})
 
-	suite.T().Run("POST failure - 500", func(t *testing.T) {
+	suite.Run("POST failure - 500", func() {
+		subtestData := suite.makeCreateSubtestData()
 		mockCreator := mocks.MTOShipmentCreator{}
 
 		handler := CreateMTOShipmentHandler{
@@ -265,7 +288,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			mock.Anything,
 		).Return(nil, err)
 
-		response := handler.Handle(params)
+		response := handler.Handle(subtestData.params)
 
 		suite.IsType(&mtoshipmentops.CreateMTOShipmentInternalServerError{}, response)
 
@@ -365,14 +388,14 @@ func (suite *HandlerSuite) getUpdateMTOShipmentParams(originalShipment models.MT
 }
 
 func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
-	builder := query.NewQueryBuilder(suite.DB())
 	planner := &routemocks.Planner{}
 	planner.On("TransitDistance",
 		mock.Anything,
 		mock.Anything,
 	).Return(400, nil)
 
-	suite.T().Run("Successful PATCH - Integration Test", func(t *testing.T) {
+	suite.Run("Successful PATCH - Integration Test", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -407,7 +430,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.NotEmpty(updatedShipment.Agents[0].ID)
 	})
 
-	suite.T().Run("Successful PATCH - Can update shipment status", func(t *testing.T) {
+	suite.Run("Successful PATCH - Can update shipment status", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -430,7 +454,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(expectedStatus, updatedResponse.Payload.Status)
 	})
 
-	suite.T().Run("PATCH failure - 400 -- nil body", func(t *testing.T) {
+	suite.Run("PATCH failure - 400 -- nil body", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -447,7 +472,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentBadRequest{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 400 -- invalid requested status update", func(t *testing.T) {
+	suite.Run("PATCH failure - 400 -- invalid requested status update", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -464,7 +490,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentBadRequest{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 401- permission denied - not authenticated", func(t *testing.T) {
+	suite.Run("PATCH failure - 401- permission denied - not authenticated", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -484,7 +511,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentUnauthorized{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 403- permission denied - wrong application / user", func(t *testing.T) {
+	suite.Run("PATCH failure - 403- permission denied - wrong application / user", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
@@ -506,7 +534,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentForbidden{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 404 -- not found", func(t *testing.T) {
+	suite.Run("PATCH failure - 404 -- not found", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -524,7 +553,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentNotFound{}, response)
 	})
 
-	suite.T().Run("PATCH failure - 412 -- etag mismatch", func(t *testing.T) {
+	suite.Run("PATCH failure - 412 -- etag mismatch", func() {
+		builder := query.NewQueryBuilder(suite.DB())
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
 		handler := UpdateMTOShipmentHandler{
@@ -545,7 +575,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	// Update: This test is not passing due swagger validation failing and no server-side validation
 	// happening. These changes weren't covered in MB-3691, so we'll need to do addt'l
 	// work to fix. Since we have refactoring slated for addresses, we can do then.
-	// suite.T().Run("PATCH failure - 422 -- invalid input", func(t *testing.T) {
+	// suite.Run("PATCH failure - 422 -- invalid input", func() {
 	// 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 	// 	fetcher := fetch.NewFetcher(builder)
 	// 	updater := mtoshipment.NewMTOShipmentUpdater(suite.DB(), builder, fetcher, planner)
@@ -585,7 +615,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 	// })
 
-	suite.T().Run("PATCH failure - 500", func(t *testing.T) {
+	suite.Run("PATCH failure - 500", func() {
 		mockUpdater := mocks.MTOShipmentUpdater{}
 
 		handler := UpdateMTOShipmentHandler{
@@ -617,7 +647,13 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 // GET ALL
 //
 
-func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
+type mtoListSubtestData struct {
+	shipments models.MTOShipments
+	params    mtoshipmentops.ListMTOShipmentsParams
+}
+
+func (suite *HandlerSuite) makeListSubtestData() (subtestData *mtoListSubtestData) {
+	subtestData = &mtoListSubtestData{}
 	mto := testdatagen.MakeDefaultMove(suite.DB())
 	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
@@ -663,18 +699,24 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		SecondaryDeliveryAddress: secondaryDeliveryAddress,
 	})
 
-	shipments := models.MTOShipments{mtoShipment, mtoShipment2}
+	subtestData.shipments = models.MTOShipments{mtoShipment, mtoShipment2}
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("/moves/%s/mto_shipments", mto.ID.String()), nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
-	params := mtoshipmentops.ListMTOShipmentsParams{
+	subtestData.params = mtoshipmentops.ListMTOShipmentsParams{
 		HTTPRequest:     req,
 		MoveTaskOrderID: *handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
 	}
 
-	suite.T().Run("Successful list fetch - 200 - Integration Test", func(t *testing.T) {
+	return subtestData
+
+}
+
+func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
+	suite.Run("Successful list fetch - 200 - Integration Test", func() {
+		subtestData := suite.makeListSubtestData()
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 		listFetcher := fetch.NewListFetcher(queryBuilder)
 		fetcher := fetch.NewFetcher(queryBuilder)
@@ -684,22 +726,33 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			fetcher,
 		}
 
-		response := handler.Handle(params)
+		response := handler.Handle(subtestData.params)
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsOK{}, response)
 
 		okResponse := response.(*mtoshipmentops.ListMTOShipmentsOK)
-
 		suite.Len(okResponse.Payload, 2)
+		suite.Equal(subtestData.shipments[0].ID.String(), okResponse.Payload[0].ID.String())
+
+		firstCreatedShipment := subtestData.shipments[0]
+		nextCreatedShipment := subtestData.shipments[1]
+		if nextCreatedShipment.CreatedAt.Before(firstCreatedShipment.CreatedAt) {
+			firstCreatedShipment = subtestData.shipments[1]
+			nextCreatedShipment = subtestData.shipments[0]
+		}
+		_, err := time.Parse(time.RFC3339, okResponse.Payload[0].CreatedAt.String())
+		if err != nil {
+			suite.TestLogger().Fatal("unable to parse string time")
+		}
 
 		firstShipmentReturned := okResponse.Payload[0]
 		secondShipmentReturned := okResponse.Payload[1]
 
 		// we expect the shipment that was created first to come first in the response
-		suite.Equal(mtoShipment.ID.String(), firstShipmentReturned.ID.String())
-		suite.Equal(mtoShipment2.ID.String(), secondShipmentReturned.ID.String())
+		suite.Equal(subtestData.shipments[0].ID.String(), firstShipmentReturned.ID.String())
+		suite.Equal(subtestData.shipments[1].ID.String(), secondShipmentReturned.ID.String())
 
 		for i, returnedShipment := range okResponse.Payload {
-			expectedShipment := shipments[i]
+			expectedShipment := subtestData.shipments[i]
 
 			suite.Equal(expectedShipment.Status, models.MTOShipmentStatus(returnedShipment.Status))
 
@@ -739,9 +792,10 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 	})
 
-	suite.T().Run("POST failure - 400 - Bad Request", func(t *testing.T) {
+	suite.Run("POST failure - 400 - Bad Request", func() {
+		subtestData := suite.makeListSubtestData()
 		emtpyMTOID := mtoshipmentops.ListMTOShipmentsParams{
-			HTTPRequest:     req,
+			HTTPRequest:     subtestData.params.HTTPRequest,
 			MoveTaskOrderID: "",
 		}
 		mockListFetcher := mocks.ListFetcher{}
@@ -757,12 +811,13 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsBadRequest{}, response)
 	})
 
-	suite.T().Run("POST failure - 401 - permission denied - not authenticated", func(t *testing.T) {
+	suite.Run("POST failure - 401 - permission denied - not authenticated", func() {
+		subtestData := suite.makeListSubtestData()
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-		unauthorizedReq := suite.AuthenticateOfficeRequest(req, officeUser)
+		unauthorizedReq := suite.AuthenticateOfficeRequest(subtestData.params.HTTPRequest, officeUser)
 		unauthorizedParams := mtoshipmentops.ListMTOShipmentsParams{
 			HTTPRequest:     unauthorizedReq,
-			MoveTaskOrderID: *handlers.FmtUUID(mtoShipment.MoveTaskOrderID),
+			MoveTaskOrderID: *handlers.FmtUUID(subtestData.shipments[0].MoveTaskOrderID),
 		}
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
@@ -777,7 +832,8 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsUnauthorized{}, response)
 	})
 
-	suite.T().Run("Failure list fetch - 404 Not Found - Move Task Order ID", func(t *testing.T) {
+	suite.Run("Failure list fetch - 404 Not Found - Move Task Order ID", func() {
+		subtestData := suite.makeListSubtestData()
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 		handler := ListMTOShipmentsHandler{
@@ -793,11 +849,12 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			mock.Anything,
 		).Return(notfound)
 
-		response := handler.Handle(params)
+		response := handler.Handle(subtestData.params)
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsNotFound{}, response)
 	})
 
-	suite.T().Run("Failure list fetch - 500 Internal Server Error", func(t *testing.T) {
+	suite.Run("Failure list fetch - 500 Internal Server Error", func() {
+		subtestData := suite.makeListSubtestData()
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 		handler := ListMTOShipmentsHandler{
@@ -821,7 +878,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			mock.Anything,
 		).Return(internalServerErr)
 
-		response := handler.Handle(params)
+		response := handler.Handle(subtestData.params)
 		suite.IsType(&mtoshipmentops.ListMTOShipmentsInternalServerError{}, response)
 	})
 }

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -731,18 +731,6 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 
 		okResponse := response.(*mtoshipmentops.ListMTOShipmentsOK)
 		suite.Len(okResponse.Payload, 2)
-		suite.Equal(subtestData.shipments[0].ID.String(), okResponse.Payload[0].ID.String())
-
-		firstCreatedShipment := subtestData.shipments[0]
-		nextCreatedShipment := subtestData.shipments[1]
-		if nextCreatedShipment.CreatedAt.Before(firstCreatedShipment.CreatedAt) {
-			firstCreatedShipment = subtestData.shipments[1]
-			nextCreatedShipment = subtestData.shipments[0]
-		}
-		_, err := time.Parse(time.RFC3339, okResponse.Payload[0].CreatedAt.String())
-		if err != nil {
-			suite.TestLogger().Fatal("unable to parse string time")
-		}
 
 		firstShipmentReturned := okResponse.Payload[0]
 		secondShipmentReturned := okResponse.Payload[1]

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -53,12 +53,12 @@ func (suite *HandlerSuite) TestCreatePPMAttachmentsHandlerTests() {
 		{name: "problem pdf", pdfName: "../../testdatagen/testdata/orders.pdf", expectedPages: 4},
 	}
 	uploadKeyRe := regexp.MustCompile(`(user/.+/uploads/.+)\?`)
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-	// Context gives us our file storer and filesystem
-	context := suite.createHandlerContext()
-
 	for _, test := range tests {
 		suite.Run(test.name, func() {
+			officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+			// Context gives us our file storer and filesystem
+			context := suite.createHandlerContext()
+
 			ppm := testdatagen.MakeDefaultPPM(suite.DB())
 			expDoc := testdatagen.MakeMovingExpenseDocument(suite.DB(), testdatagen.Assertions{
 				MoveDocument: models.MoveDocument{

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -112,18 +112,20 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreate() {
 	}
 
 	for _, t := range tests {
-		newWeightTicketSetDocParams := createWeightTicketSetDocument(suite, t.weightTicketSetType)
+		suite.Run(t.weightTicketSetType, func() {
+			newWeightTicketSetDocParams := createWeightTicketSetDocument(suite, t.weightTicketSetType)
 
-		context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
-		fakeS3 := storageTest.NewFakeS3Storage(true)
-		context.SetFileStorer(fakeS3)
-		handler := CreateWeightTicketSetDocumentHandler{context}
-		response := handler.Handle(newWeightTicketSetDocParams)
-		suite.IsNotErrResponse(response)
-		createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
-		createdPayload := createdResponse.Payload
-		suite.NotNil(createdPayload.ID)
-		suite.Equal(*createdPayload.Title, t.resultTitle)
+			context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+			fakeS3 := storageTest.NewFakeS3Storage(true)
+			context.SetFileStorer(fakeS3)
+			handler := CreateWeightTicketSetDocumentHandler{context}
+			response := handler.Handle(newWeightTicketSetDocParams)
+			suite.IsNotErrResponse(response)
+			createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
+			createdPayload := createdResponse.Payload
+			suite.NotNil(createdPayload.ID)
+			suite.Equal(*createdPayload.Title, t.resultTitle)
+		})
 	}
 }
 

--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -20,12 +20,6 @@ type HandlerSuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// SetupTest sets up the test suite by preparing the DB
-func (suite *HandlerSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 // AfterTest completes tests by trying to close open files
 func (suite *HandlerSuite) AfterTest() {
 	for _, file := range suite.TestFilesToClose() {
@@ -49,7 +43,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/supportapi/api_test.go
+++ b/pkg/handlers/supportapi/api_test.go
@@ -18,12 +18,6 @@ type HandlerSuite struct {
 	handlers.BaseHandlerTestSuite
 }
 
-// SetupTest sets up the test suite by preparing the DB
-func (suite *HandlerSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 // AfterTest completes tests by trying to close open files
 func (suite *HandlerSuite) AfterTest() {
 	for _, file := range suite.TestFilesToClose() {
@@ -47,7 +41,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/models/duty_station_test.go
+++ b/pkg/models/duty_station_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func (suite *ModelSuite) TestFindDutyStations() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-
 	address := models.Address{
 		StreetAddress1: "some address",
 		City:           "city",
@@ -106,8 +103,6 @@ func (suite *ModelSuite) Test_DutyStationValidations() {
 	suite.verifyValidationErrors(station, expErrors)
 }
 func (suite *ModelSuite) Test_FetchDutyStationTransportationOffice() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 

--- a/pkg/models/electronic_order_test.go
+++ b/pkg/models/electronic_order_test.go
@@ -37,8 +37,6 @@ func (suite *ModelSuite) TestElectronicOrderValidations() {
 }
 
 func (suite *ModelSuite) TestCreateElectronicOrder() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -51,8 +49,6 @@ func (suite *ModelSuite) TestCreateElectronicOrder() {
 }
 
 func (suite *ModelSuite) TestCreateElectronicOrderWithRevision() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -78,8 +74,6 @@ func (suite *ModelSuite) TestCreateElectronicOrderWithRevision() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrderByID() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -99,8 +93,6 @@ func (suite *ModelSuite) TestFetchElectronicOrderByID() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrderByIssuerAndOrdersNum() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	newOrder := models.ElectronicOrder{
 		Edipi:        "1234567890",
 		Issuer:       models.IssuerArmy,
@@ -120,8 +112,6 @@ func (suite *ModelSuite) TestFetchElectronicOrderByIssuerAndOrdersNum() {
 }
 
 func (suite *ModelSuite) TestFetchElectronicOrdersByEdipiAndIssuers() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	edipi := "1234567890"
 	newOrder1 := models.ElectronicOrder{
 		Edipi:        edipi,

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -50,7 +50,7 @@ func (suite *ModelSuite) verifyValidationErrors(model models.ValidateableModel, 
 }
 
 func TestModelSuite(t *testing.T) {
-	hs := &ModelSuite{PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage())}
+	hs := &ModelSuite{PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction())}
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()
 }

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -150,9 +150,6 @@ func (suite *ModelSuite) TestOrdersTypeDetailPresenceAfterSubmission() {
 }
 
 func (suite *ModelSuite) TestFetchOrderForUser() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 	serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
@@ -233,9 +230,6 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 }
 
 func (suite *ModelSuite) TestFetchOrderNotForUser() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
 	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
@@ -282,8 +276,6 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 }
 
 func (suite *ModelSuite) TestOrderStateMachine() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
 	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
@@ -318,7 +310,7 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 	suite.MustSave(&order)
 
 	// Submit Orders
-	err = order.Submit()
+	err := order.Submit()
 	suite.NoError(err)
 	suite.Equal(OrderStatusSUBMITTED, order.Status, "expected Submitted")
 
@@ -329,8 +321,6 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 }
 
 func (suite *ModelSuite) TestSaveOrder() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	orderID := uuid.Must(uuid.NewV4())
 	moveID, _ := uuid.FromString("7112b18b-7e03-4b28-adde-532b541bba8d")
 

--- a/pkg/models/payment_service_item_test.go
+++ b/pkg/models/payment_service_item_test.go
@@ -143,7 +143,7 @@ func (suite *ModelSuite) TestGeneratePSIReferenceID() {
 		suite.Equal(*mtoReferenceID+"-"+psiIDDigits[:models.PaymentServiceItemMinReferenceIDSuffixLength], referenceID)
 
 		paymentServiceItem.ReferenceID = referenceID
-		suite.MustCreate(suite.DB(), &paymentServiceItem)
+		suite.MustCreate(&paymentServiceItem)
 	})
 
 	suite.T().Run("test another payment request with ID that differs by a digit", func(t *testing.T) {
@@ -174,7 +174,7 @@ func (suite *ModelSuite) TestGeneratePSIReferenceID() {
 				Status:           "REQUESTED",
 				RequestedAt:      time.Now(),
 			}
-			suite.MustCreate(suite.DB(), &psiLongReferenceID)
+			suite.MustCreate(&psiLongReferenceID)
 		}
 
 		_, err := paymentServiceItem2.GeneratePSIReferenceID(suite.DB())

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -39,8 +37,6 @@ func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 }
 
 func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -67,8 +63,6 @@ func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 }
 
 func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	testdatagen.MakeDefaultContractor(suite.DB())
 
@@ -85,8 +79,6 @@ func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
 }
 
 func (suite *ModelSuite) TestShowPPMQueue() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	all := map[string]bool{
 		string(models.PPMStatusAPPROVED):         true,
 		string(models.PPMStatusPAYMENTREQUESTED): true,

--- a/pkg/models/tariff400ng_item_rate_test.go
+++ b/pkg/models/tariff400ng_item_rate_test.go
@@ -11,8 +11,6 @@ func intPointer(i int) *int {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateBySchedule() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			Schedule:  intPointer(1),
@@ -41,8 +39,6 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateBySchedule() {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateNullSchedule() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	rate1 := testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			Schedule:  nil,
@@ -59,8 +55,6 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateNullSchedule() {
 }
 
 func (suite *ModelSuite) TestFetchTariff400ngItemRateByWeight() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItemRate: models.Tariff400ngItemRate{
 			WeightLbsLower: unit.Pound(1000),

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -18,8 +18,6 @@ func (suite *ModelSuite) Test_TrafficDistributionList() {
 }
 
 func (suite *ModelSuite) Test_FetchTDL() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -40,8 +38,6 @@ func (suite *ModelSuite) Test_FetchTDL() {
 }
 
 func (suite *ModelSuite) Test_FetchOrCreateTDL() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	foundTDL := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -100,8 +96,6 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 }
 
 func (suite *ModelSuite) Test_TDLUniqueChannelCOS() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -826,7 +826,7 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 		LinehaulRate:                    unit.NewDiscountRateFromPercent(50.5),
 		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
 	}
-	suite.MustCreate(suite.DB(), &tspPerformance1)
+	suite.MustCreate(&tspPerformance1)
 
 	tspPerformance2 := TransportationServiceProviderPerformance{
 		ID:                              uuid.FromStringOrNil("5f5b3950-5962-4d54-a963-e508ef3f3252"),
@@ -841,7 +841,7 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 		LinehaulRate:                    unit.NewDiscountRateFromPercent(55.5),
 		SITRate:                         unit.NewDiscountRateFromPercent(52.0),
 	}
-	suite.MustCreate(suite.DB(), &tspPerformance2)
+	suite.MustCreate(&tspPerformance2)
 
 	// Given matching BVS scores, the TSPP with the alphabetically first ID should be returned.  Make that our target.
 	targetTspPerformance := tspPerformance1

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -99,8 +99,6 @@ func (suite *ModelSuite) Test_GetRateCycle() {
 }
 
 func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -141,8 +139,6 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 }
 
 func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
@@ -160,7 +156,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 	})
 	band := 1
 
-	err = AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
+	err := AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
 	if err != nil {
 		t.Fatalf("Did not update quality band: %v", err)
 	}
@@ -178,8 +174,6 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 }
 
 func (suite *ModelSuite) Test_BVSWithLowMPS() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 	tspsToMake := 5
 
@@ -237,8 +231,6 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 
 // Test_FetchNextQualityBandTSPPerformance ensures that the TSP with the highest BVS is returned in the expected band
 func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -447,8 +439,6 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 // Test_GatherNextEligibleTSPPerformanceByBand ensures that TSPs are returned in the expected
 // order for the Award Queue operation.
 func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
 	tsp1 := testdatagen.MakeDefaultTSP(suite.DB())
@@ -523,8 +513,6 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 // Test_FetchTSPPerformancesForQualityBandAssignment ensures that TSPs are returned in the expected
 // order for the division into quality bands.
 func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -586,8 +574,6 @@ func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
 // Test_MinimumPerformanceScore ensures that TSPs whose BVS is below the MPS
 // do not enter the Award Queue process.
 func (suite *ModelSuite) Test_MinimumPerformanceScore() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.DB())
@@ -633,8 +619,6 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 }
 
 func (suite *ModelSuite) Test_FetchUnbandedTSPPerformanceGroups() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	t := suite.T()
 
 	foundTDL := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/db/dberr"
@@ -89,8 +87,6 @@ func (suite *ModelSuite) TestCreateUser() {
 }
 
 func (suite *ModelSuite) TestFetchUserIdentity() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
 	const goodUUID = "39b28c92-0506-4bef-8b57-e39519f42dc2"
 	// First check that it all works with no record
 	identity, err := FetchUserIdentity(suite.DB(), goodUUID)
@@ -188,9 +184,6 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 }
 
 func (suite *ModelSuite) TestFetchUserIdentityDeletedRoles() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-
 	// creates a custom comparison function for testing the role type
 	compareRoleTypeLists := func(expectedList roles.Roles, actualList roles.Roles) func() (success bool) {
 		return func() (success bool) {
@@ -255,16 +248,14 @@ func (suite *ModelSuite) TestFetchUserIdentityDeletedRoles() {
 }
 
 func (suite *ModelSuite) TestFetchAppUserIdentities() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-	suite.T().Run("default user no profile", func(t *testing.T) {
+	suite.Run("default user no profile", func() {
 		testdatagen.MakeStubbedUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
 		suite.NoError(err)
 		suite.Empty(identities)
 	})
 
-	suite.T().Run("service member", func(t *testing.T) {
+	suite.Run("service member", func() {
 
 		// Regular service member
 		testdatagen.MakeDefaultServiceMember(suite.DB())
@@ -294,7 +285,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 	// In the following tests you won't see extra users returned. Eeach query is
 	// limited by the app it expects to be run in.
 
-	suite.T().Run("office user", func(t *testing.T) {
+	suite.Run("office user", func() {
 		testdatagen.MakeDefaultOfficeUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.OfficeApp, 5)
 		suite.NoError(err)
@@ -307,7 +298,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 		}
 	})
 
-	suite.T().Run("admin user", func(t *testing.T) {
+	suite.Run("admin user", func() {
 		testdatagen.MakeDefaultAdminUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.AdminApp, 5)
 		suite.Nil(err)
@@ -323,9 +314,6 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 }
 
 func (suite *ModelSuite) TestGetUser() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-
 	alice := testdatagen.MakeDefaultUser(suite.DB())
 
 	user1, err := GetUserFromEmail(suite.DB(), alice.LoginGovEmail)

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -37,11 +37,6 @@ type ServiceParamValueLookupsSuite struct {
 	planner route.Planner
 }
 
-func (suite *ServiceParamValueLookupsSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 func TestServiceParamValueLookupsSuite(t *testing.T) {
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
@@ -58,7 +53,7 @@ func TestServiceParamValueLookupsSuite(t *testing.T) {
 	).Return(defaultZip5Distance, nil)
 
 	ts := &ServiceParamValueLookupsSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 		logger:       zap.NewNop(), // Use a no-op logger during testing
 		planner:      planner,
 	}

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -271,7 +271,6 @@ func (suite *RateEngineSuite) TestComputePPMMoveCosts() {
 	move := models.Move{
 		Locator: "ABC123",
 	}
-	suite.setupRateEngineTest()
 	logger, _ := zap.NewDevelopment()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
@@ -284,9 +283,11 @@ func (suite *RateEngineSuite) TestComputePPMMoveCosts() {
 	distanceMilesFromOriginPickupZip := 1044
 	distanceMilesFromDutyStationZip := 3300
 	weight := unit.Pound(2000)
-	engine := NewRateEngine(suite.DB(), logger, move)
 
 	suite.Run("TestComputePPMMoveCosts with origin zip results in lower GCC", func() {
+		suite.setupRateEngineTest()
+		engine := NewRateEngine(suite.DB(), logger, move)
+
 		ppmCostWithPickupZip, err := suite.computePPMIncludingLHRates(
 			originZip,
 			destinationZip,
@@ -337,6 +338,9 @@ func (suite *RateEngineSuite) TestComputePPMMoveCosts() {
 	})
 
 	suite.Run("TestComputePPMMoveCosts when origin duty station results in lower GCC", func() {
+		suite.setupRateEngineTest()
+		engine := NewRateEngine(suite.DB(), logger, move)
+
 		originZip := "50309"
 		originDutyStationZip := "39574"
 		distanceMilesFromOriginPickupZip := 3300
@@ -396,17 +400,12 @@ type RateEngineSuite struct {
 	logger Logger
 }
 
-func (suite *RateEngineSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 func TestRateEngineSuite(t *testing.T) {
 	// Use a no-op logger during testing
 	logger, _ := zap.NewDevelopment()
 
 	hs := &RateEngineSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 		logger:       logger,
 	}
 	suite.Run(t, hs)

--- a/pkg/services/ghcimport/ghc_rateengine_importer_test.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer_test.go
@@ -93,7 +93,6 @@ func TestGHCRateEngineImportSuite(t *testing.T) {
 	}
 
 	suite.Run(t, hs)
-	hs.PopTestSuite.TearDown()
 }
 
 func (suite *GHCRateEngineImportSuite) TestGHCRateEngineImporter_Import() {

--- a/pkg/services/ghcrateengine/counseling_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/counseling_services_pricer_test.go
@@ -1,7 +1,6 @@
 package ghcrateengine
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -21,7 +20,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceCounselingServices() {
 	paymentServiceItem := suite.setupCounselingServicesItem()
 	counselingServicesPricer := NewCounselingServicesPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := counselingServicesPricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(csPriceCents, priceCents)
@@ -33,18 +32,18 @@ func (suite *GHCRateEngineServiceSuite) TestPriceCounselingServices() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := counselingServicesPricer.Price(testdatagen.DefaultContractCode, csAvailableToPrimeAt)
 		suite.NoError(err)
 		suite.Equal(csPriceCents, priceCents)
 	})
 
-	suite.T().Run("sending PaymentServiceItemParams without expected param", func(t *testing.T) {
+	suite.Run("sending PaymentServiceItemParams without expected param", func() {
 		_, _, err := counselingServicesPricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := counselingServicesPricer.Price("BOGUS", csAvailableToPrimeAt)
 		suite.Error(err)
 	})

--- a/pkg/services/ghcrateengine/domestic_destination_additional_days_sit_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_additional_days_sit_pricer_test.go
@@ -3,7 +3,6 @@ package ghcrateengine
 import (
 	"fmt"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -30,7 +29,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationAdditionalDaysSIT
 	paymentServiceItem := suite.setupDomesticDestinationAdditionalDaysSITServiceItem()
 	pricer := NewDomesticDestinationAdditionalDaysSITPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(ddasitTestPriceCents, priceCents)
@@ -44,33 +43,33 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationAdditionalDaysSIT
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, ddasitTestRequestedPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.NoError(err)
 		suite.Equal(ddasitTestPriceCents, priceCents)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 		// this is the first param checked for, otherwise error doesn't matter
 		suite.Equal("could not find param with key ContractCode", err.Error())
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, ddasitTestRequestedPickupDate, badWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 250 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", ddasitTestRequestedPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination additional days SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := ddasitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
@@ -194,7 +193,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationAdditionalDaysSIT
 			data.psiParams,
 		)
 
-		suite.T().Run(data.testDescription, func(t *testing.T) {
+		suite.Run(data.testDescription, func() {
 			_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 			suite.Error(err)
 			suite.Contains(err.Error(), data.expectedError)

--- a/pkg/services/ghcrateengine/domestic_destination_first_day_sit_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_first_day_sit_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -28,7 +27,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationFirstDaySITPricer
 	paymentServiceItem := suite.setupDomesticDestinationFirstDaySITServiceItem()
 	pricer := NewDomesticDestinationFirstDaySITPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(ddfsitTestPriceCents, priceCents)
@@ -42,31 +41,31 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationFirstDaySITPricer
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, ddfsitTestRequestedPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.NoError(err)
 		suite.Equal(ddfsitTestPriceCents, priceCents)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, ddfsitTestRequestedPickupDate, badWeight, ddfsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 250 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", ddfsitTestRequestedPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination first day SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := ddfsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -48,7 +47,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestinationWithServiceI
 
 	pricer := NewDomesticDestinationPricer(suite.DB())
 
-	suite.T().Run("failure during pricing bubbles up", func(t *testing.T) {
+	suite.Run("failure during pricing bubbles up", func() {
 		_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.Error(err)
 		suite.Equal("Weight must be a minimum of 500", err.Error())
@@ -61,14 +60,14 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestinationWithServiceI
 
 	pricer := NewDomesticDestinationPricer(suite.DB())
 
-	suite.T().Run("success all params for destination available", func(t *testing.T) {
+	suite.Run("success all params for destination available", func() {
 		cost, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
 		suite.Equal(expectedCost, cost)
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		// No contract code
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
@@ -99,7 +98,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 
 	pricer := NewDomesticDestinationPricer(suite.DB())
 
-	suite.T().Run("success destination cost within peak period", func(t *testing.T) {
+	suite.Run("success destination cost within peak period", func() {
 		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -119,7 +118,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success destination cost within non-peak period", func(t *testing.T) {
+	suite.Run("success destination cost within non-peak period", func() {
 		nonPeakDate := peakStart.addDate(0, -1)
 		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
@@ -140,7 +139,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("failure if contract code bogus", func(t *testing.T) {
+	suite.Run("failure if contract code bogus", func() {
 		_, _, err := pricer.Price(
 			"bogus_code",
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -152,7 +151,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.Equal("Could not lookup Domestic Service Area Price: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("failure if move date is outside of contract year", func(t *testing.T) {
+	suite.Run("failure if move date is outside of contract year", func() {
 		_, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear+1, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -164,7 +163,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.Equal("Could not lookup contract year: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("weight below minimum", func(t *testing.T) {
+	suite.Run("weight below minimum", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -176,7 +175,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticDestination() {
 		suite.Equal("Weight must be a minimum of 500", err.Error())
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		requestedPickupDate := time.Date(testdatagen.TestYear, time.July, 4, 0, 0, 0, 0, time.UTC)
 
 		// No contract code

--- a/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_sit_delivery_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -40,7 +39,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 	pricer := NewDomesticDestinationSITDeliveryPricer(suite.DB())
 	expectedPrice := unit.Cents(53187) // dddsitTestDomesticServiceAreaBasePriceCents * (dddsitTestWeight / 100) * distance * dddsitTestEscalationCompounded
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -54,18 +53,18 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, badWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
@@ -73,19 +72,19 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		suite.Contains(err.Error(), expectedError)
 	})
 
-	suite.T().Run("bad destination zip", func(t *testing.T) {
+	suite.Run("bad destination zip", func() {
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, "123", zipSITDest, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid destination postal code")
 	})
 
-	suite.T().Run("bad SIT final destination zip", func(t *testing.T) {
+	suite.Run("bad SIT final destination zip", func() {
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, "456", distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid SIT final destination postal code")
 	})
 
-	suite.T().Run("error from shorthaul pricer", func(t *testing.T) {
+	suite.Run("error from shorthaul pricer", func() {
 		_, _, err := pricer.Price("BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price shorthaul")
@@ -104,7 +103,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 	expectedPriceMillicents := unit.Millicents(45944438) // dddsitTestDomesticLinehaulBasePriceMillicents * (dddsitTestWeight / 100) * distance * dddsitTestEscalationCompounded
 	expectedPrice := expectedPriceMillicents.ToCents()
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -118,13 +117,13 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
 	})
 
-	suite.T().Run("error from linehaul pricer", func(t *testing.T) {
+	suite.Run("error from linehaul pricer", func() {
 		_, _, err := pricer.Price("BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price linehaul")
@@ -142,7 +141,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 	pricer := NewDomesticDestinationSITDeliveryPricer(suite.DB())
 	expectedPrice := unit.Cents(58355) // dddsitTestDomesticOtherBasePriceCents * (dddsitTestWeight / 100) * dddsitTestEscalationCompounded
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -156,19 +155,19 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticDestinationSITDeliveryPricer
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination SIT delivery rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, zipDest, zipSITDest, distance)
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -33,7 +32,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 	paymentServiceItem := suite.setupDomesticLinehaulServiceItem()
 	linehaulServicePricer := NewDomesticLinehaulPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := linehaulServicePricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(dlhPriceCents, priceCents)
@@ -47,13 +46,13 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := linehaulServicePricer.Price(testdatagen.DefaultContractCode, dlhRequestedPickupDate, dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
 		suite.NoError(err)
 		suite.Equal(dlhPriceCents, priceCents)
 	})
 
-	suite.T().Run("sending PaymentServiceItemParams without expected param", func(t *testing.T) {
+	suite.Run("sending PaymentServiceItemParams without expected param", func() {
 		_, _, err := linehaulServicePricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
@@ -61,22 +60,22 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticLinehaul() {
 	paramsWithBelowMinimumWeight := paymentServiceItem.PaymentServiceItemParams
 	weightBilledActualIndex := 5
 	if paramsWithBelowMinimumWeight[weightBilledActualIndex].ServiceItemParamKey.Key != models.ServiceItemParamNameWeightBilledActual {
-		suite.T().Fatalf("Test needs to adjust the weight of %s but the index is pointing to %s ", models.ServiceItemParamNameWeightBilledActual, paramsWithBelowMinimumWeight[5].ServiceItemParamKey.Key)
+		suite.Fail("Test needs to adjust the weight of %s but the index is pointing to %s ", models.ServiceItemParamNameWeightBilledActual, paramsWithBelowMinimumWeight[5].ServiceItemParamKey.Key)
 	}
 	paramsWithBelowMinimumWeight[weightBilledActualIndex].Value = "200"
-	suite.T().Run("fails using PaymentServiceItemParams with below minimum weight for WeightBilledActual", func(t *testing.T) {
+	suite.Run("fails using PaymentServiceItemParams with below minimum weight for WeightBilledActual", func() {
 		priceCents, _, err := linehaulServicePricer.PriceUsingParams(paramsWithBelowMinimumWeight)
 		suite.Error(err)
 		suite.Equal("Weight must be at least 500", err.Error())
 		suite.Equal(unit.Cents(0), priceCents)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := linehaulServicePricer.Price("BOGUS", dlhRequestedPickupDate, dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
 		suite.Error(err)
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		// No contract code
 		_, _, err := linehaulServicePricer.Price("", dlhRequestedPickupDate, dlhTestDistance, dlhTestWeight, dlhTestServiceArea)
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/domestic_origin_additional_days_sit_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_additional_days_sit_pricer_test.go
@@ -3,7 +3,6 @@ package ghcrateengine
 import (
 	"fmt"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -30,7 +29,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginAdditionalDaysSITPrice
 	paymentServiceItem := suite.setupDomesticOriginAdditionalDaysSITServiceItem()
 	pricer := NewDomesticOriginAdditionalDaysSITPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(doasitTestPriceCents, priceCents)
@@ -44,33 +43,33 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginAdditionalDaysSITPrice
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, doasitTestRequestedPickupDate, doasitTestWeight, doasitTestServiceArea, doasitTestNumberOfDaysInSIT)
 		suite.NoError(err)
 		suite.Equal(doasitTestPriceCents, priceCents)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 		// this is the first param checked for, otherwise error doesn't matter
 		suite.Equal("could not find param with key ContractCode", err.Error())
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, doasitTestRequestedPickupDate, badWeight, doasitTestServiceArea, doasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 250 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", doasitTestRequestedPickupDate, doasitTestWeight, doasitTestServiceArea, doasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic origin additional days SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := doasitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, doasitTestWeight, doasitTestServiceArea, doasitTestNumberOfDaysInSIT)
 		suite.Error(err)
@@ -194,7 +193,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginAdditionalDaysSITPrice
 			data.psiParams,
 		)
 
-		suite.T().Run(data.testDescription, func(t *testing.T) {
+		suite.Run(data.testDescription, func() {
 			_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 			suite.Error(err)
 			suite.Contains(err.Error(), data.expectedError)

--- a/pkg/services/ghcrateengine/domestic_origin_first_day_sit_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_first_day_sit_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -28,7 +27,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginFirstDaySITPricer() {
 	paymentServiceItem := suite.setupDomesticOriginFirstDaySITServiceItem()
 	pricer := NewDomesticOriginFirstDaySITPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(dofsitTestPriceCents, priceCents)
@@ -42,31 +41,31 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginFirstDaySITPricer() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dofsitTestRequestedPickupDate, dofsitTestWeight, dofsitTestServiceArea)
 		suite.NoError(err)
 		suite.Equal(dofsitTestPriceCents, priceCents)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dofsitTestRequestedPickupDate, badWeight, dofsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 250 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", dofsitTestRequestedPickupDate, dofsitTestWeight, dofsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic origin first day SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := dofsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dofsitTestWeight, dofsitTestServiceArea)
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -48,7 +47,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemPa
 
 	pricer := NewDomesticOriginPricer(suite.DB())
 
-	suite.T().Run("failure during pricing bubbles up", func(t *testing.T) {
+	suite.Run("failure during pricing bubbles up", func() {
 		_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.Error(err)
 		suite.Equal("Weight must be a minimum of 500", err.Error())
@@ -61,7 +60,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemPa
 
 	pricer := NewDomesticOriginPricer(suite.DB())
 
-	suite.T().Run("success all params for domestic origin available", func(t *testing.T) {
+	suite.Run("success all params for domestic origin available", func() {
 		cost, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
 
@@ -77,7 +76,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOriginWithServiceItemPa
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		// No contract code
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
@@ -108,7 +107,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 
 	pricer := NewDomesticOriginPricer(suite.DB())
 
-	suite.T().Run("success domestic origin cost within peak period", func(t *testing.T) {
+	suite.Run("success domestic origin cost within peak period", func() {
 		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -128,7 +127,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success domestic origin cost within non-peak period", func(t *testing.T) {
+	suite.Run("success domestic origin cost within non-peak period", func() {
 		nonPeakDate := peakStart.addDate(0, -1)
 		cost, displayParams, err := pricer.Price(
 			testdatagen.DefaultContractCode,
@@ -150,7 +149,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("failure if contract code bogus", func(t *testing.T) {
+	suite.Run("failure if contract code bogus", func() {
 		_, _, err := pricer.Price(
 			"bogus_code",
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -162,7 +161,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal("Could not lookup Domestic Service Area Price: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("failure if move date is outside of contract year", func(t *testing.T) {
+	suite.Run("failure if move date is outside of contract year", func() {
 		_, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear+1, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -174,7 +173,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal("Could not lookup contract year: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("weight below minimum", func(t *testing.T) {
+	suite.Run("weight below minimum", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -186,7 +185,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticOrigin() {
 		suite.Equal("Weight must be a minimum of 500", err.Error())
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		requestedPickupDate := time.Date(testdatagen.TestYear, time.July, 4, 0, 0, 0, 0, time.UTC)
 
 		// No contract code

--- a/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_sit_pickup_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -40,7 +39,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricerSameZip
 	pricer := NewDomesticOriginSITPickupPricer(suite.DB())
 	expectedPrice := unit.Cents(127316) // dopsitTestDomesticServiceAreaBasePriceCents * (dopsitTestWeight / 100) * distance * dopsitTestEscalationCompounded
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -54,7 +53,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricerSameZip
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -68,12 +67,12 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricerSameZip
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("PriceUsingParams but sending empty params", func(t *testing.T) {
+	suite.Run("PriceUsingParams but sending empty params", func() {
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(333)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, badWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)
@@ -81,19 +80,19 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricerSameZip
 		suite.Contains(err.Error(), expectedError)
 	})
 
-	suite.T().Run("bad original zip", func(t *testing.T) {
+	suite.Run("bad original zip", func() {
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, "7891", zipActual, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid SIT origin original postal code")
 	})
 
-	suite.T().Run("bad actual zip", func(t *testing.T) {
+	suite.Run("bad actual zip", func() {
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, "12", distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid SIT origin actual postal code")
 	})
 
-	suite.T().Run("error from shorthaul pricer", func(t *testing.T) {
+	suite.Run("error from shorthaul pricer", func() {
 		_, _, err := pricer.Price("BOGUS", dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price shorthaul")
@@ -112,7 +111,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50PlusM
 	expectedPriceMillicents := unit.Millicents(16320568) // dopsitTestDomesticLinehaulBasePriceMillicents * (dopsitTestWeight / 100) * distance * dopsitTestEscalationCompounded
 	expectedPrice := expectedPriceMillicents.ToCents()
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -126,13 +125,13 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50PlusM
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
 	})
 
-	suite.T().Run("error from linehaul pricer", func(t *testing.T) {
+	suite.Run("error from linehaul pricer", func() {
 		_, _, err := pricer.Price("BOGUS", dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price linehaul")
@@ -150,7 +149,7 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50Miles
 	pricer := NewDomesticOriginSITPickupPricer(suite.DB())
 	expectedPrice := unit.Cents(133691) // dopsitTestDomesticOtherBasePriceCents * (dopsitTestWeight / 100) * dopsitTestEscalationCompounded
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
@@ -164,19 +163,19 @@ func (suite *GHCRateEngineServiceSuite) TestDomesticOriginSITPickupPricer50Miles
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := pricer.Price(testdatagen.DefaultContractCode, dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.NoError(err)
 		suite.Equal(expectedPrice, priceCents)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := pricer.Price("BOGUS", dopsitTestRequestedPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic origin SIT pickup rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
 		twoYearsLaterPickupDate := dopsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := pricer.Price(testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dopsitTestWeight, dopsitTestServiceArea, dopsitTestSchedule, zipOriginal, zipActual, distance)
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -48,7 +47,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPackWithServiceItemPara
 
 	pricer := NewDomesticPackPricer(suite.DB())
 
-	suite.T().Run("failure during pricing bubbles up", func(t *testing.T) {
+	suite.Run("failure during pricing bubbles up", func() {
 		_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.Error(err)
 		suite.Equal("Weight must be a minimum of 500", err.Error())
@@ -61,7 +60,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPackWithServiceItemPara
 
 	pricer := NewDomesticPackPricer(suite.DB())
 
-	suite.T().Run("success all params for domestic pack available", func(t *testing.T) {
+	suite.Run("success all params for domestic pack available", func() {
 		cost, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
@@ -76,7 +75,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPackWithServiceItemPara
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		// No contract code
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
@@ -107,7 +106,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 
 	pricer := NewDomesticPackPricer(suite.DB())
 
-	suite.T().Run("success domestic pack cost within peak period", func(t *testing.T) {
+	suite.Run("success domestic pack cost within peak period", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -119,7 +118,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 		suite.Equal(expectedCost, cost)
 	})
 
-	suite.T().Run("success domestic pack cost within non-peak period", func(t *testing.T) {
+	suite.Run("success domestic pack cost within non-peak period", func() {
 		nonPeakDate := peakStart.addDate(0, -1)
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
@@ -132,7 +131,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 		suite.Equal(expectedCost, cost)
 	})
 
-	suite.T().Run("failure if contract code bogus", func(t *testing.T) {
+	suite.Run("failure if contract code bogus", func() {
 		_, _, err := pricer.Price(
 			"bogus_code",
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -144,7 +143,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 		suite.Equal("Could not lookup Domestic Other Price: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("failure if move date is outside of contract year", func(t *testing.T) {
+	suite.Run("failure if move date is outside of contract year", func() {
 		_, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear+1, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -156,7 +155,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 		suite.Equal("Could not lookup contract year: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("weight below minimum", func(t *testing.T) {
+	suite.Run("weight below minimum", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -168,7 +167,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticPack() {
 		suite.Equal("Weight must be a minimum of 500", err.Error())
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		requestedPickupDate := time.Date(testdatagen.TestYear, time.July, 4, 0, 0, 0, 0, time.UTC)
 
 		// No contract code

--- a/pkg/services/ghcrateengine/domestic_unpack_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_unpack_pricer_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -48,7 +47,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpackWithServiceItemPa
 
 	pricer := NewDomesticUnpackPricer(suite.DB())
 
-	suite.T().Run("failure during pricing bubbles up", func(t *testing.T) {
+	suite.Run("failure during pricing bubbles up", func() {
 		_, _, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.Error(err)
 		suite.Equal("Weight must be a minimum of 500", err.Error())
@@ -61,7 +60,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpackWithServiceItemPa
 
 	pricer := NewDomesticUnpackPricer(suite.DB())
 
-	suite.T().Run("success all params for domestic unpack available", func(t *testing.T) {
+	suite.Run("success all params for domestic unpack available", func() {
 		cost, displayParams, err := pricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		expectedCost := unit.Cents(5470)
 		suite.NoError(err)
@@ -76,7 +75,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpackWithServiceItemPa
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		// No contract code
 		_, _, err := pricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
@@ -107,7 +106,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 
 	pricer := NewDomesticUnpackPricer(suite.DB())
 
-	suite.T().Run("success domestic unpack cost within peak period", func(t *testing.T) {
+	suite.Run("success domestic unpack cost within peak period", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -119,7 +118,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 		suite.Equal(expectedCost, cost)
 	})
 
-	suite.T().Run("success domestic unpack cost within non-peak period", func(t *testing.T) {
+	suite.Run("success domestic unpack cost within non-peak period", func() {
 		nonPeakDate := peakStart.addDate(0, -1)
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
@@ -132,7 +131,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 		suite.Equal(expectedCost, cost)
 	})
 
-	suite.T().Run("failure if contract code bogus", func(t *testing.T) {
+	suite.Run("failure if contract code bogus", func() {
 		_, _, err := pricer.Price(
 			"bogus_code",
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -144,7 +143,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 		suite.Equal("Could not lookup Domestic Other Price: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("failure if move date is outside of contract year", func(t *testing.T) {
+	suite.Run("failure if move date is outside of contract year", func() {
 		_, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear+1, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -156,7 +155,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 		suite.Equal("Could not lookup contract year: "+models.RecordNotFoundErrorString, err.Error())
 	})
 
-	suite.T().Run("weight below minimum", func(t *testing.T) {
+	suite.Run("weight below minimum", func() {
 		cost, _, err := pricer.Price(
 			testdatagen.DefaultContractCode,
 			time.Date(testdatagen.TestYear, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC),
@@ -168,7 +167,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceDomesticUnpack() {
 		suite.Equal("Weight must be a minimum of 500", err.Error())
 	})
 
-	suite.T().Run("validation errors", func(t *testing.T) {
+	suite.Run("validation errors", func() {
 		requestedPickupDate := time.Date(testdatagen.TestYear, time.July, 4, 0, 0, 0, 0, time.UTC)
 
 		// No contract code

--- a/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
+++ b/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
@@ -11,7 +11,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -39,7 +38,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 	fscPriceDifferenceInCents := (fscFuelPrice - baseGHCDieselFuelPrice).Float64() / 1000.0
 	fscMultiplier := fscWeightDistanceMultiplier * fscTestDistance.Float64()
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success using PaymentServiceItemParams", func() {
 		priceCents, displayParams, err := fuelSurchargePricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(fscPriceCents, priceCents)
@@ -51,13 +50,13 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
 		priceCents, _, err := fuelSurchargePricer.Price(fscActualPickupDate, fscTestDistance, fscTestWeight, fscWeightDistanceMultiplier, fscFuelPrice)
 		suite.NoError(err)
 		suite.Equal(fscPriceCents, priceCents)
 	})
 
-	suite.T().Run("sending PaymentServiceItemParams without expected param", func(t *testing.T) {
+	suite.Run("sending PaymentServiceItemParams without expected param", func() {
 		_, _, err := fuelSurchargePricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
@@ -65,10 +64,10 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 	paramsWithBelowMinimumWeight := paymentServiceItem.PaymentServiceItemParams
 	weightBilledActualIndex := 3
 	if paramsWithBelowMinimumWeight[weightBilledActualIndex].ServiceItemParamKey.Key != models.ServiceItemParamNameWeightBilledActual {
-		suite.T().Fatalf("Test needs to adjust the weight of %s but the index is pointing to %s ", models.ServiceItemParamNameWeightBilledActual, paramsWithBelowMinimumWeight[4].ServiceItemParamKey.Key)
+		suite.Fail("Test needs to adjust the weight of %s but the index is pointing to %s ", models.ServiceItemParamNameWeightBilledActual, paramsWithBelowMinimumWeight[4].ServiceItemParamKey.Key)
 	}
 	paramsWithBelowMinimumWeight[weightBilledActualIndex].Value = "200"
-	suite.T().Run("fails using PaymentServiceItemParams with below minimum weight for WeightBilledActual", func(t *testing.T) {
+	suite.Run("fails using PaymentServiceItemParams with below minimum weight for WeightBilledActual", func() {
 		priceCents, _, err := fuelSurchargePricer.PriceUsingParams(paramsWithBelowMinimumWeight)
 		if suite.Error(err) {
 			suite.Equal("Weight must be a minimum of 500", err.Error())
@@ -76,13 +75,13 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 		}
 	})
 
-	suite.T().Run("FSC is negative if fuel price from EIA is below $2.50", func(t *testing.T) {
+	suite.Run("FSC is negative if fuel price from EIA is below $2.50", func() {
 		priceCents, _, err := fuelSurchargePricer.Price(fscActualPickupDate, fscTestDistance, fscTestWeight, fscWeightDistanceMultiplier, 242400)
 		suite.NoError(err)
 		suite.Equal(unit.Cents(-721), priceCents)
 	})
 
-	suite.T().Run("Price validation errors", func(t *testing.T) {
+	suite.Run("Price validation errors", func() {
 		// No actual pickup date
 		_, _, err := fuelSurchargePricer.Price(time.Time{}, fscTestDistance, fscTestWeight, fscWeightDistanceMultiplier, fscFuelPrice)
 		suite.Error(err)
@@ -109,7 +108,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 		suite.Equal("EIAFuelPrice is required", err.Error())
 	})
 
-	suite.T().Run("PriceUsingParams validation errors", func(t *testing.T) {
+	suite.Run("PriceUsingParams validation errors", func() {
 		// No ActualPickupDate
 		missingActualPickupDate := suite.removeOnePaymentServiceItem(paymentServiceItem.PaymentServiceItemParams, models.ServiceItemParamNameActualPickupDate)
 		_, _, err := fuelSurchargePricer.PriceUsingParams(missingActualPickupDate)
@@ -135,7 +134,7 @@ func (suite *GHCRateEngineServiceSuite) TestPriceFuelSurcharge() {
 		suite.Equal("could not find param with key EIAFuelPrice", err.Error())
 	})
 
-	suite.T().Run("can't find distance", func(t *testing.T) {
+	suite.Run("can't find distance", func() {
 		paramsWithBadReference := paymentServiceItem.PaymentServiceItemParams
 		paramsWithBadReference[0].PaymentServiceItemID = uuid.Nil
 		_, _, err := fuelSurchargePricer.PriceUsingParams(paramsWithBadReference)

--- a/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
+++ b/pkg/services/ghcrateengine/ghc_rate_engine_service_test.go
@@ -18,14 +18,9 @@ type GHCRateEngineServiceSuite struct {
 	logger Logger
 }
 
-func (suite *GHCRateEngineServiceSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 func TestGHCRateEngineServiceSuite(t *testing.T) {
 	ts := &GHCRateEngineServiceSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 		logger:       zap.NewNop(), // Use a no-op logger during testing
 	}
 	suite.Run(t, ts)

--- a/pkg/services/ghcrateengine/management_services_pricer_test.go
+++ b/pkg/services/ghcrateengine/management_services_pricer_test.go
@@ -1,7 +1,6 @@
 package ghcrateengine
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -17,11 +16,11 @@ const (
 var msAvailableToPrimeAt = time.Date(testdatagen.TestYear, time.June, 3, 12, 57, 33, 123, time.UTC)
 
 func (suite *GHCRateEngineServiceSuite) TestPriceManagementServices() {
-	suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
-	paymentServiceItem := suite.setupManagementServicesItem()
-	managementServicesPricer := NewManagementServicesPricer(suite.DB())
+	suite.Run("success using PaymentServiceItemParams", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
+		paymentServiceItem := suite.setupManagementServicesItem()
+		managementServicesPricer := NewManagementServicesPricer(suite.DB())
 
-	suite.T().Run("success using PaymentServiceItemParams", func(t *testing.T) {
 		priceCents, displayParams, err := managementServicesPricer.PriceUsingParams(paymentServiceItem.PaymentServiceItemParams)
 		suite.NoError(err)
 		suite.Equal(msPriceCents, priceCents)
@@ -33,18 +32,27 @@ func (suite *GHCRateEngineServiceSuite) TestPriceManagementServices() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("success without PaymentServiceItemParams", func(t *testing.T) {
+	suite.Run("success without PaymentServiceItemParams", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
+		managementServicesPricer := NewManagementServicesPricer(suite.DB())
+
 		priceCents, _, err := managementServicesPricer.Price(testdatagen.DefaultContractCode, msAvailableToPrimeAt)
 		suite.NoError(err)
 		suite.Equal(msPriceCents, priceCents)
 	})
 
-	suite.T().Run("sending PaymentServiceItemParams without expected param", func(t *testing.T) {
+	suite.Run("sending PaymentServiceItemParams without expected param", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
+		managementServicesPricer := NewManagementServicesPricer(suite.DB())
+
 		_, _, err := managementServicesPricer.PriceUsingParams(models.PaymentServiceItemParams{})
 		suite.Error(err)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, msPriceCents)
+		managementServicesPricer := NewManagementServicesPricer(suite.DB())
+
 		_, _, err := managementServicesPricer.Price("BOGUS", msAvailableToPrimeAt)
 		suite.Error(err)
 	})

--- a/pkg/services/ghcrateengine/param_convert_test.go
+++ b/pkg/services/ghcrateengine/param_convert_test.go
@@ -1,7 +1,6 @@
 package ghcrateengine
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -14,13 +13,13 @@ func (suite *GHCRateEngineServiceSuite) Test_getPaymentServiceItemParam() {
 		setupParamConvertParam(models.ServiceItemParamNameMTOAvailableToPrimeAt, models.ServiceItemParamTypeTimestamp, time.Now().Format(TimestampParamFormat)),
 	}
 
-	suite.T().Run("finding expected param", func(t *testing.T) {
+	suite.Run("finding expected param", func() {
 		param := getPaymentServiceItemParam(params, models.ServiceItemParamNameMTOAvailableToPrimeAt)
 		suite.NotNil(param)
 		suite.Equal(models.ServiceItemParamNameMTOAvailableToPrimeAt, param.ServiceItemParamKey.Key)
 	})
 
-	suite.T().Run("param not found", func(t *testing.T) {
+	suite.Run("param not found", func() {
 		param := getPaymentServiceItemParam(params, models.ServiceItemParamNameWeightEstimated)
 		suite.Nil(param)
 	})
@@ -31,19 +30,19 @@ func (suite *GHCRateEngineServiceSuite) Test_getParamInt() {
 		setupParamConvertParam(models.ServiceItemParamNameDistanceZip5, models.ServiceItemParamTypeInteger, "1234"),
 	}
 
-	suite.T().Run("finding expected param value", func(t *testing.T) {
+	suite.Run("finding expected param value", func() {
 		value, err := getParamInt(params, models.ServiceItemParamNameDistanceZip5)
 		suite.NoError(err)
 		suite.Equal(1234, value)
 	})
 
-	suite.T().Run("param not found", func(t *testing.T) {
+	suite.Run("param not found", func() {
 		_, err := getParamInt(params, models.ServiceItemParamNameWeightEstimated)
 		suite.Error(err)
 		suite.Equal("could not find param with key WeightEstimated", err.Error())
 	})
 
-	suite.T().Run("unexpected type", func(t *testing.T) {
+	suite.Run("unexpected type", func() {
 		badParams := models.PaymentServiceItemParams{
 			setupParamConvertParam(models.ServiceItemParamNameContractCode, models.ServiceItemParamTypeTimestamp, testdatagen.DefaultContractCode),
 		}
@@ -58,19 +57,19 @@ func (suite *GHCRateEngineServiceSuite) Test_getParamFloat() {
 		setupParamConvertParam(models.ServiceItemParamNameFSCWeightBasedDistanceMultiplier, models.ServiceItemParamTypeDecimal, "0.0006255"),
 	}
 
-	suite.T().Run("finding expected param value", func(t *testing.T) {
+	suite.Run("finding expected param value", func() {
 		value, err := getParamFloat(params, models.ServiceItemParamNameFSCWeightBasedDistanceMultiplier)
 		suite.NoError(err)
 		suite.Equal(0.0006255, value)
 	})
 
-	suite.T().Run("param not found", func(t *testing.T) {
+	suite.Run("param not found", func() {
 		_, err := getParamFloat(params, models.ServiceItemParamNameWeightEstimated)
 		suite.Error(err)
 		suite.Equal("could not find param with key WeightEstimated", err.Error())
 	})
 
-	suite.T().Run("unexpected type", func(t *testing.T) {
+	suite.Run("unexpected type", func() {
 		badParams := models.PaymentServiceItemParams{
 			setupParamConvertParam(models.ServiceItemParamNameContractCode, models.ServiceItemParamTypeTimestamp, testdatagen.DefaultContractCode),
 		}
@@ -85,19 +84,19 @@ func (suite *GHCRateEngineServiceSuite) Test_getParamString() {
 		setupParamConvertParam(models.ServiceItemParamNameContractCode, models.ServiceItemParamTypeString, testdatagen.DefaultContractCode),
 	}
 
-	suite.T().Run("finding expected param value", func(t *testing.T) {
+	suite.Run("finding expected param value", func() {
 		value, err := getParamString(params, models.ServiceItemParamNameContractCode)
 		suite.NoError(err)
 		suite.Equal(testdatagen.DefaultContractCode, value)
 	})
 
-	suite.T().Run("param not found", func(t *testing.T) {
+	suite.Run("param not found", func() {
 		_, err := getParamString(params, models.ServiceItemParamNameWeightEstimated)
 		suite.Error(err)
 		suite.Equal("could not find param with key WeightEstimated", err.Error())
 	})
 
-	suite.T().Run("unexpected type", func(t *testing.T) {
+	suite.Run("unexpected type", func() {
 		badParams := models.PaymentServiceItemParams{
 			setupParamConvertParam(models.ServiceItemParamNameContractCode, models.ServiceItemParamTypeTimestamp, testdatagen.DefaultContractCode),
 		}
@@ -115,14 +114,14 @@ func (suite *GHCRateEngineServiceSuite) Test_getParamTime() {
 		setupParamConvertParam(models.ServiceItemParamNameRequestedPickupDate, models.ServiceItemParamTypeDate, testDate.Format(DateParamFormat)),
 	}
 
-	suite.T().Run("finding expected timestamp param value", func(t *testing.T) {
+	suite.Run("finding expected timestamp param value", func() {
 		value, err := getParamTime(params, models.ServiceItemParamNameMTOAvailableToPrimeAt)
 		suite.NoError(err)
 		suite.Equal(testDate.Unix(), value.Unix())
 		// Note: The current format of time.RFC3339 does not preserve fractions of a second
 	})
 
-	suite.T().Run("finding expected date param value", func(t *testing.T) {
+	suite.Run("finding expected date param value", func() {
 		value, err := getParamTime(params, models.ServiceItemParamNameRequestedPickupDate)
 		suite.NoError(err)
 		suite.Equal(testDate.Year(), value.Year())
@@ -130,13 +129,13 @@ func (suite *GHCRateEngineServiceSuite) Test_getParamTime() {
 		suite.Equal(testDate.Day(), value.Day())
 	})
 
-	suite.T().Run("param not found", func(t *testing.T) {
+	suite.Run("param not found", func() {
 		_, err := getParamTime(params, models.ServiceItemParamNameWeightEstimated)
 		suite.Error(err)
 		suite.Equal("could not find param with key WeightEstimated", err.Error())
 	})
 
-	suite.T().Run("unexpected type", func(t *testing.T) {
+	suite.Run("unexpected type", func() {
 		badParams := models.PaymentServiceItemParams{
 			setupParamConvertParam(models.ServiceItemParamNameMTOAvailableToPrimeAt, models.ServiceItemParamTypeString, testDate.Format(TimestampParamFormat)),
 		}

--- a/pkg/services/ghcrateengine/pricer_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_helpers_test.go
@@ -2,7 +2,6 @@ package ghcrateengine
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -13,9 +12,9 @@ import (
 )
 
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticFirstDaySIT() {
-	suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
+	suite.Run("destination golden path", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
 
-	suite.T().Run("destination golden path", func(t *testing.T) {
 		priceCents, displayParams, err := priceDomesticFirstDaySIT(suite.DB(), models.ReServiceCodeDDFSIT, DefaultContractCode, ddfsitTestRequestedPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.NoError(err)
 		suite.Equal(ddfsitTestPriceCents, priceCents)
@@ -29,26 +28,34 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticFirstDaySIT() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("invalid service code", func(t *testing.T) {
+	suite.Run("invalid service code", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
+
 		_, _, err := priceDomesticFirstDaySIT(suite.DB(), models.ReServiceCodeCS, DefaultContractCode, ddfsitTestRequestedPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "unsupported first day sit code")
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
+
 		badWeight := unit.Pound(250)
 		_, _, err := priceDomesticFirstDaySIT(suite.DB(), models.ReServiceCodeDDFSIT, DefaultContractCode, ddfsitTestRequestedPickupDate, badWeight, ddfsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 250 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
+
 		_, _, err := priceDomesticFirstDaySIT(suite.DB(), models.ReServiceCodeDDFSIT, "BOGUS", ddfsitTestRequestedPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination first day SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDFSIT, ddfsitTestServiceArea, ddfsitTestIsPeakPeriod, ddfsitTestBasePriceCents, ddfsitTestContractYearName, ddfsitTestEscalationCompounded)
+
 		twoYearsLaterPickupDate := ddfsitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := priceDomesticFirstDaySIT(suite.DB(), models.ReServiceCodeDDFSIT, DefaultContractCode, twoYearsLaterPickupDate, ddfsitTestWeight, ddfsitTestServiceArea)
 		suite.Error(err)
@@ -57,9 +64,10 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticFirstDaySIT() {
 }
 
 func (suite *GHCRateEngineServiceSuite) Test_priceDomesticAdditionalDaysSIT() {
-	suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
 
-	suite.T().Run("destination golden path", func(t *testing.T) {
+	suite.Run("destination golden path", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
+
 		priceCents, displayParams, err := priceDomesticAdditionalDaysSIT(suite.DB(), models.ReServiceCodeDDASIT, DefaultContractCode, ddasitTestRequestedPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.NoError(err)
 		suite.Equal(ddasitTestPriceCents, priceCents)
@@ -73,26 +81,34 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticAdditionalDaysSIT() {
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("invalid service code", func(t *testing.T) {
+	suite.Run("invalid service code", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
+
 		_, _, err := priceDomesticAdditionalDaysSIT(suite.DB(), models.ReServiceCodeDDFSIT, DefaultContractCode, ddasitTestRequestedPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "unsupported additional day sit code")
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
+
 		badWeight := unit.Pound(499)
 		_, _, err := priceDomesticAdditionalDaysSIT(suite.DB(), models.ReServiceCodeDDASIT, DefaultContractCode, ddasitTestRequestedPickupDate, badWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "weight of 499 less than the minimum")
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
+
 		_, _, err := priceDomesticAdditionalDaysSIT(suite.DB(), models.ReServiceCodeDDASIT, "BOGUS", ddasitTestRequestedPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination additional days SIT rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDDASIT, ddasitTestServiceArea, ddasitTestIsPeakPeriod, ddasitTestBasePriceCents, ddasitTestContractYearName, ddasitTestEscalationCompounded)
+
 		twoYearsLaterPickupDate := ddasitTestRequestedPickupDate.AddDate(2, 0, 0)
 		_, _, err := priceDomesticAdditionalDaysSIT(suite.DB(), models.ReServiceCodeDDASIT, DefaultContractCode, twoYearsLaterPickupDate, ddasitTestWeight, ddasitTestServiceArea, ddasitTestNumberOfDaysInSIT)
 		suite.Error(err)
@@ -106,7 +122,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZ
 	dshDistance := unit.Miles(15)
 	dshContractName := "dshTestYear"
 
-	suite.T().Run("destination golden path for same zip3s", func(t *testing.T) {
+	suite.Run("destination golden path for same zip3s", func() {
 		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDSH, dddsitTestServiceArea, dddsitTestIsPeakPeriod, dddsitTestDomesticServiceAreaBasePriceCents, dshContractName, dddsitTestEscalationCompounded)
 		priceCents, displayParams, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dshZipDest, dshZipSITDest, dshDistance)
 		suite.NoError(err)
@@ -122,13 +138,13 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZ
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("invalid service code", func(t *testing.T) {
+	suite.Run("invalid service code", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeCS, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dshZipDest, dshZipSITDest, dshDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "unsupported pickup/delivery SIT code")
 	})
 
-	suite.T().Run("invalid weight", func(t *testing.T) {
+	suite.Run("invalid weight", func() {
 		badWeight := unit.Pound(250)
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, badWeight, dddsitTestServiceArea, dddsitTestSchedule, dshZipDest, dshZipSITDest, dshDistance)
 		suite.Error(err)
@@ -136,19 +152,19 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySITSameZ
 		suite.Contains(err.Error(), expectedError)
 	})
 
-	suite.T().Run("bad destination zip", func(t *testing.T) {
+	suite.Run("bad destination zip", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, "309", dshZipSITDest, dshDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid destination postal code")
 	})
 
-	suite.T().Run("bad SIT final destination zip", func(t *testing.T) {
+	suite.Run("bad SIT final destination zip", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dshZipDest, "1234", dshDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "invalid SIT final destination postal code")
 	})
 
-	suite.T().Run("error from shorthaul pricer", func(t *testing.T) {
+	suite.Run("error from shorthaul pricer", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, "BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dshZipDest, dshZipSITDest, dshDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price shorthaul")
@@ -161,7 +177,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Plu
 	dlhDistance := unit.Miles(305) // > 50 miles
 	dlhContractName := "dhlTestYear"
 
-	suite.T().Run("destination golden path for > 50 miles with different zip3s", func(t *testing.T) {
+	suite.Run("destination golden path for > 50 miles with different zip3s", func() {
 		suite.setupDomesticLinehaulPrice(dddsitTestServiceArea, dddsitTestIsPeakPeriod, dddsitTestWeightLower, dddsitTestWeightUpper, dddsitTestMilesLower, dddsitTestMilesUpper, dddsitTestDomesticLinehaulBasePriceMillicents, dlhContractName, dddsitTestEscalationCompounded)
 		priceCents, displayParams, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dlhZipDest, dlhZipSITDest, dlhDistance)
 		suite.NoError(err)
@@ -179,7 +195,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Plu
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("error from linehaul pricer", func(t *testing.T) {
+	suite.Run("error from linehaul pricer", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, "BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, dlhZipDest, dlhZipSITDest, dlhDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not price linehaul")
@@ -192,7 +208,7 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Mil
 	domOtherDistance := unit.Miles(37) // <= 50 miles
 	domContractName := "domTestYear"
 
-	suite.T().Run("destination golden path for <= 50 miles with different zip3s", func(t *testing.T) {
+	suite.Run("destination golden path for <= 50 miles with different zip3s", func() {
 		suite.setupDomesticOtherPrice(models.ReServiceCodeDDDSIT, dddsitTestSchedule, dddsitTestIsPeakPeriod, dddsitTestDomesticOtherBasePriceCents, domContractName, dddsitTestEscalationCompounded)
 		priceCents, displayParams, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
 		suite.NoError(err)
@@ -208,22 +224,32 @@ func (suite *GHCRateEngineServiceSuite) Test_priceDomesticPickupDeliverySIT50Mil
 		suite.validatePricerCreatedParams(expectedParams, displayParams)
 	})
 
-	suite.T().Run("not finding a rate record", func(t *testing.T) {
+	suite.Run("not finding a rate record", func() {
 		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, "BOGUS", dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch domestic destination SIT delivery rate")
 	})
 
-	suite.T().Run("not finding a contract year record", func(t *testing.T) {
+	suite.Run("not finding a contract year record", func() {
+		suite.setupDomesticOtherPrice(models.ReServiceCodeDDDSIT, dddsitTestSchedule, dddsitTestIsPeakPeriod, dddsitTestDomesticOtherBasePriceCents, domContractName, dddsitTestEscalationCompounded)
+		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, dddsitTestRequestedPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
+		suite.NoError(err)
+
 		twoYearsLaterPickupDate := dddsitTestRequestedPickupDate.AddDate(2, 0, 0)
-		_, _, err := priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
+		_, _, err = priceDomesticPickupDeliverySIT(suite.DB(), models.ReServiceCodeDDDSIT, testdatagen.DefaultContractCode, twoYearsLaterPickupDate, dddsitTestWeight, dddsitTestServiceArea, dddsitTestSchedule, domOtherZipDest, domOtherZipSITDest, domOtherDistance)
 		suite.Error(err)
 		suite.Contains(err.Error(), "could not fetch contract year")
 	})
 }
 
-func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
-	params := services.PricingDisplayParams{
+type pricerParamsSubtestData struct {
+	params             services.PricingDisplayParams
+	paymentServiceItem models.PaymentServiceItem
+}
+
+func (suite *GHCRateEngineServiceSuite) makePricerParamsSubtestData() (subtestData *pricerParamsSubtestData) {
+	subtestData = &pricerParamsSubtestData{}
+	subtestData.params = services.PricingDisplayParams{
 		{
 			Key:   models.ServiceItemParamNamePriceRateOrFactor,
 			Value: "4000.90",
@@ -272,13 +298,18 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 		},
 	})
 
-	paymentServiceItem := testdatagen.MakePaymentServiceItem(
+	subtestData.paymentServiceItem = testdatagen.MakePaymentServiceItem(
 		suite.DB(),
 		testdatagen.Assertions{},
 	)
 
-	suite.T().Run("payment service item params created for the pricer", func(t *testing.T) {
-		paymentServiceItemParams, err := createPricerGeneratedParams(suite.DB(), paymentServiceItem.ID, params)
+	return subtestData
+}
+
+func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
+	suite.Run("payment service item params created for the pricer", func() {
+		subtestData := suite.makePricerParamsSubtestData()
+		paymentServiceItemParams, err := createPricerGeneratedParams(suite.DB(), subtestData.paymentServiceItem.ID, subtestData.params)
 		suite.NoError(err)
 		expectedValues := [4]string{"4000.90", "1.06", "True", "TRUSS_TEST"}
 		for _, paymentServiceItemParam := range paymentServiceItemParams {
@@ -295,15 +326,17 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 		}
 	})
 
-	suite.T().Run("errors if PaymentServiceItemID is invalid", func(t *testing.T) {
+	suite.Run("errors if PaymentServiceItemID is invalid", func() {
+		subtestData := suite.makePricerParamsSubtestData()
 		invalidID, _ := uuid.FromString("00000000-0000-0000-0000-000000000000")
 
-		_, err := createPricerGeneratedParams(suite.DB(), invalidID, params)
+		_, err := createPricerGeneratedParams(suite.DB(), invalidID, subtestData.params)
 		suite.Error(err)
 		suite.Contains(err.Error(), "validation error with creating payment service item param")
 	})
 
-	suite.T().Run("errors if PricingParm points to a serviceItem that doesnt originate from the Pricer", func(t *testing.T) {
+	suite.Run("errors if PricingParm points to a serviceItem that doesnt originate from the Pricer", func() {
+		subtestData := suite.makePricerParamsSubtestData()
 		invalidParam := services.PricingDisplayParams{
 			{
 				Key:   models.ServiceItemParamNameServiceAreaOrigin,
@@ -320,15 +353,16 @@ func (suite *GHCRateEngineServiceSuite) Test_createPricerGeneratedParams() {
 			},
 		})
 
-		_, err := createPricerGeneratedParams(suite.DB(), paymentServiceItem.ID, invalidParam)
+		_, err := createPricerGeneratedParams(suite.DB(), subtestData.paymentServiceItem.ID, invalidParam)
 		suite.Error(err)
 		suite.Contains(err.Error(), "Service item param key is not a pricer param")
 	})
 
-	suite.T().Run("errors if no PricingParms passed from the Pricer", func(t *testing.T) {
+	suite.Run("errors if no PricingParms passed from the Pricer", func() {
+		subtestData := suite.makePricerParamsSubtestData()
 		emptyParams := services.PricingDisplayParams{}
 
-		_, err := createPricerGeneratedParams(suite.DB(), paymentServiceItem.ID, emptyParams)
+		_, err := createPricerGeneratedParams(suite.DB(), subtestData.paymentServiceItem.ID, emptyParams)
 		suite.Error(err)
 		suite.Contains(err.Error(), "PricingDisplayParams must not be empty")
 	})

--- a/pkg/services/ghcrateengine/pricer_query_helpers_test.go
+++ b/pkg/services/ghcrateengine/pricer_query_helpers_test.go
@@ -1,7 +1,6 @@
 package ghcrateengine
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -12,15 +11,17 @@ import (
 func (suite *GHCRateEngineServiceSuite) Test_fetchTaskOrderFee() {
 	testCents := unit.Cents(10000)
 	testAvailableToPrimeAt := time.Date(testdatagen.TestYear, time.June, 17, 8, 45, 44, 333, time.UTC)
-	suite.setupTaskOrderFeeData(models.ReServiceCodeMS, testCents)
+	suite.Run("golden path", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, testCents)
 
-	suite.T().Run("golden path", func(t *testing.T) {
 		taskOrderFee, err := fetchTaskOrderFee(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeMS, testAvailableToPrimeAt)
 		suite.NoError(err)
 		suite.Equal(testCents, taskOrderFee.PriceCents)
 	})
 
-	suite.T().Run("no records found", func(t *testing.T) {
+	suite.Run("no records found", func() {
+		suite.setupTaskOrderFeeData(models.ReServiceCodeMS, testCents)
+
 		// Look for service code CS that we haven't added
 		_, err := fetchTaskOrderFee(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeCS, testAvailableToPrimeAt)
 		suite.Error(err)
@@ -31,9 +32,10 @@ func (suite *GHCRateEngineServiceSuite) Test_fetchDomOtherPrice() {
 	testCents := unit.Cents(146)
 	servicesSchedule := 1
 	isPeakPeriod := true
-	suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDPK)
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
+		suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDPK)
+
 		domOtherPrice, err := fetchDomOtherPrice(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeDPK, servicesSchedule, isPeakPeriod)
 		suite.NoError(err)
 		suite.Equal(testCents, domOtherPrice.PriceCents)
@@ -44,9 +46,10 @@ func (suite *GHCRateEngineServiceSuite) Test_unpackFetchDomOtherPrice() {
 	testCents := unit.Cents(146)
 	servicesSchedule := 1
 	isPeakPeriod := true
-	suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDUPK)
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
+		suite.setUpDomesticPackAndUnpackData(models.ReServiceCodeDUPK)
+
 		domOtherPrice, err := fetchDomOtherPrice(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeDUPK, servicesSchedule, isPeakPeriod)
 		suite.NoError(err)
 		suite.Equal(testCents, domOtherPrice.PriceCents)
@@ -57,15 +60,18 @@ func (suite *GHCRateEngineServiceSuite) Test_fetchDomServiceAreaPrice() {
 	testServiceArea := "123"
 	testIsPeakPeriod := true
 	testCents := unit.Cents(353)
-	suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Test Contract Year", 1.125)
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Test Contract Year", 1.125)
+
 		domServiceAreaPrice, err := fetchDomServiceAreaPrice(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod)
 		suite.NoError(err)
 		suite.Equal(testCents, domServiceAreaPrice.PriceCents)
 	})
 
-	suite.T().Run("no records found", func(t *testing.T) {
+	suite.Run("no records found", func() {
+		suite.setupDomesticServiceAreaPrice(models.ReServiceCodeDOFSIT, testServiceArea, testIsPeakPeriod, testCents, "Test Contract Year", 1.125)
+
 		// Look for service code DDFSIT that we haven't added
 		_, err := fetchDomServiceAreaPrice(suite.DB(), testdatagen.DefaultContractCode, models.ReServiceCodeDDFSIT, testServiceArea, testIsPeakPeriod)
 		suite.Error(err)
@@ -75,20 +81,28 @@ func (suite *GHCRateEngineServiceSuite) Test_fetchDomServiceAreaPrice() {
 func (suite *GHCRateEngineServiceSuite) Test_fetchContractYear() {
 	testDate := time.Date(testdatagen.TestYear, time.June, 17, 8, 45, 44, 333, time.UTC)
 	testEscalationCompounded := 1.0512
-	newContractYear := testdatagen.MakeReContractYear(suite.DB(),
-		testdatagen.Assertions{
-			ReContractYear: models.ReContractYear{
-				EscalationCompounded: testEscalationCompounded,
-			},
-		})
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
+		newContractYear := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: testEscalationCompounded,
+				},
+			})
+
 		contractYear, err := fetchContractYear(suite.DB(), newContractYear.ContractID, testDate)
 		suite.NoError(err)
 		suite.Equal(testEscalationCompounded, contractYear.EscalationCompounded)
 	})
 
-	suite.T().Run("no records found", func(t *testing.T) {
+	suite.Run("no records found", func() {
+		newContractYear := testdatagen.MakeReContractYear(suite.DB(),
+			testdatagen.Assertions{
+				ReContractYear: models.ReContractYear{
+					EscalationCompounded: testEscalationCompounded,
+				},
+			})
+
 		// Look for a testDate that's a couple of years later.
 		_, err := fetchContractYear(suite.DB(), newContractYear.ContractID, testDate.AddDate(2, 0, 0))
 		suite.Error(err)

--- a/pkg/services/ghcrateengine/shared_test.go
+++ b/pkg/services/ghcrateengine/shared_test.go
@@ -1,40 +1,39 @@
 package ghcrateengine
 
 import (
-	"testing"
 	"time"
 )
 
 func (suite *GHCRateEngineServiceSuite) TestIsPeakPeriod() {
-	suite.T().Run("within peak", func(t *testing.T) {
+	suite.Run("within peak", func() {
 		dateInYear := peakStart.addDate(1, 0)
 		date := time.Date(2019, dateInYear.month, 1, 0, 0, 0, 0, time.UTC)
 		suite.True(IsPeakPeriod(date))
 	})
 
-	suite.T().Run("on peak start date", func(t *testing.T) {
+	suite.Run("on peak start date", func() {
 		date := time.Date(2019, peakStart.month, peakStart.day, 0, 0, 0, 0, time.UTC)
 		suite.True(IsPeakPeriod(date))
 	})
 
-	suite.T().Run("on peak end date", func(t *testing.T) {
+	suite.Run("on peak end date", func() {
 		date := time.Date(2019, peakEnd.month, peakEnd.day, 0, 0, 0, 0, time.UTC)
 		suite.True(IsPeakPeriod(date))
 	})
 
-	suite.T().Run("just before peak start date", func(t *testing.T) {
+	suite.Run("just before peak start date", func() {
 		dateInYear := peakStart.addDate(0, -1)
 		date := time.Date(2019, dateInYear.month, dateInYear.day, 0, 0, 0, 0, time.UTC)
 		suite.False(IsPeakPeriod(date))
 	})
 
-	suite.T().Run("just outside peak start date", func(t *testing.T) {
+	suite.Run("just outside peak start date", func() {
 		dateInYear := peakEnd.addDate(0, 1)
 		date := time.Date(2019, dateInYear.month, dateInYear.day, 0, 0, 0, 0, time.UTC)
 		suite.False(IsPeakPeriod(date))
 	})
 
-	suite.T().Run("outside peak", func(t *testing.T) {
+	suite.Run("outside peak", func() {
 		dateInYear := peakEnd.addDate(1, 0)
 		date := time.Date(2019, dateInYear.month, 1, 0, 0, 0, 0, time.UTC)
 		suite.False(IsPeakPeriod(date))

--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -1,7 +1,6 @@
 package movetaskorder_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -18,13 +17,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 	notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 	mtoChecker := NewMoveTaskOrderChecker(suite.DB())
 
-	suite.T().Run("MTO is available and visible - success", func(t *testing.T) {
+	suite.RunWithRollback("MTO is available and visible - success", func() {
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(availableMTO.ID)
 		suite.Equal(availableToPrime, true)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("MTO is available but hidden - failure", func(t *testing.T) {
+	suite.RunWithRollback("MTO is available but hidden - failure", func() {
 		now := time.Now()
 		hide := false
 		availableHiddenMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
@@ -41,13 +40,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 		suite.Equal(availableToPrime, false)
 	})
 
-	suite.T().Run("MTO is not available - no failure, but returns false", func(t *testing.T) {
+	suite.RunWithRollback("MTO is not available - no failure, but returns false", func() {
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(notAvailableMTO.ID)
 		suite.Equal(availableToPrime, false)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("MTO ID is not valid - failure", func(t *testing.T) {
+	suite.RunWithRollback("MTO ID is not valid - failure", func() {
 		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(badUUID)
 		suite.Error(err)

--- a/pkg/services/move_task_order/move_task_order_creator_test.go
+++ b/pkg/services/move_task_order/move_task_order_creator_test.go
@@ -1,8 +1,6 @@
 package movetaskorder_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -42,8 +40,5 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderCreatorIntegration() {
 	suite.NoError(err)
 	suite.Empty(verrs)
 
-	suite.T().Run("move task order is created", func(t *testing.T) {
-		// testing mto
-		suite.NotZero(actualMTO.ID)
-	})
+	suite.NotZero(actualMTO.ID, "move task order is created")
 }

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -1,7 +1,6 @@
 package movetaskorder_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/services"
@@ -47,7 +46,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 	})
 	mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-	suite.T().Run("implicitly non-hidden move task orders", func(t *testing.T) {
+	suite.RunWithRollback("implicitly non-hidden move task orders", func() {
 		searchParams := services.MoveTaskOrderFetcherParams{} // should default to IncludeHidden being false
 		moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID, &searchParams)
 		suite.NoError(err)
@@ -68,7 +67,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 		suite.NotEqual(actualMTO.Status, models.MoveStatusCANCELED)
 	})
 
-	suite.T().Run("include hidden move task orders", func(t *testing.T) {
+	suite.RunWithRollback("include hidden move task orders", func() {
 		searchParams := services.MoveTaskOrderFetcherParams{
 			IncludeHidden: true,
 		}
@@ -87,7 +86,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {
 		suite.Equal(len(moveTaskOrders), 2)
 	})
 
-	suite.T().Run("default search - excludes hidden move task orders", func(t *testing.T) {
+	suite.RunWithRollback("default search - excludes hidden move task orders", func() {
 		moveTaskOrders, err := mtoFetcher.ListMoveTaskOrders(expectedOrder.ID, nil)
 		suite.NoError(err)
 
@@ -112,7 +111,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 	mtoFetcher := NewMoveTaskOrderFetcher(suite.DB())
 
-	suite.T().Run("all move task orders", func(t *testing.T) {
+	suite.RunWithRollback("all move task orders", func() {
 		searchParams := services.MoveTaskOrderFetcherParams{
 			IsAvailableToPrime: false,
 			IncludeHidden:      true,
@@ -130,7 +129,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		suite.NotNil(move.Orders.NewDutyStation)
 	})
 
-	suite.T().Run("default search - excludes hidden move task orders", func(t *testing.T) {
+	suite.RunWithRollback("default search - excludes hidden move task orders", func() {
 		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(nil)
 		suite.NoError(err)
 
@@ -142,7 +141,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		suite.Equal(1, len(moveTaskOrders)) // minus the one hidden MTO
 	})
 
-	suite.T().Run("all move task orders that are available to prime and using since", func(t *testing.T) {
+	suite.RunWithRollback("all move task orders that are available to prime and using since", func() {
 		now := time.Now()
 
 		testdatagen.MakeAvailableMove(suite.DB())

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -3,7 +3,6 @@ package movetaskorder_test
 import (
 	"encoding/json"
 	"fmt"
-	"testing"
 
 	"github.com/go-openapi/swag"
 
@@ -81,14 +80,14 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 
 	mtoHider := NewMoveTaskOrderHider(suite.DB())
 
-	suite.T().Run("valid MTO, none to hide", func(t *testing.T) {
+	suite.RunWithRollback("valid MTO, none to hide", func() {
 		result, err := mtoHider.Hide()
 		suite.NoError(err)
 
 		suite.Len(result, 0)
 	})
 
-	suite.T().Run("invalid MTO, one to hide", func(t *testing.T) {
+	suite.RunWithRollback("invalid MTO, one to hide", func() {
 		// Change an MTO agent name to an invalid name.
 		mtoAgent.FirstName = swag.String("Beyonce")
 		suite.MustSave(&mtoAgent)
@@ -190,7 +189,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 	}
 
 	for idx, invalidData := range invalidFakeData {
-		suite.T().Run(fmt.Sprintf("invalid fake Service Member data %d", idx), func(t *testing.T) {
+		suite.RunWithRollback(fmt.Sprintf("invalid fake Service Member data %d", idx), func() {
 			sm := testdatagen.MakeServiceMember(suite.DB(), invalidData)
 			result, reasons, err := IsValidFakeModelServiceMember(sm)
 			suite.NoError(err)
@@ -221,7 +220,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 		{MTOAgent: models.MTOAgent{Email: swag.String("billy@move.mil")}},
 	}
 	for idx, badData := range badFakeData {
-		suite.T().Run(fmt.Sprintf("invalid fake MTOAgent data %d", idx), func(t *testing.T) {
+		suite.RunWithRollback(fmt.Sprintf("invalid fake MTOAgent data %d", idx), func() {
 			agent := testdatagen.MakeMTOAgent(suite.DB(), badData)
 			result, err := IsValidFakeModelMTOAgent(agent)
 			suite.NoError(err)
@@ -231,6 +230,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelBackupContact() {
+
 	phone := "999-999-9999"
 	validBackupContact := testdatagen.MakeBackupContact(suite.DB(), testdatagen.Assertions{
 		BackupContact: models.BackupContact{
@@ -250,9 +250,10 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelB
 	}
 
 	for idx, invalidData := range invalidFakeData {
-		suite.T().Run(fmt.Sprintf("invalid fake Backup Contact data %d", idx), func(t *testing.T) {
+		suite.RunWithRollback(fmt.Sprintf("invalid fake Backup Contact data %d", idx), func() {
+
 			bc := testdatagen.MakeBackupContact(suite.DB(), invalidData)
-			result, err := IsValidFakeModelBackupContact(bc)
+			result, err = IsValidFakeModelBackupContact(bc)
 			suite.NoError(err)
 			suite.Equal(false, result)
 		})
@@ -260,7 +261,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelB
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelAddress() {
-	suite.T().Run("valid fake address data", func(t *testing.T) {
+	suite.Run("valid fake address data", func() {
 		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
 			Address: models.Address{
 				StreetAddress1: "3373 NW Martin Luther King Jr Blvd",
@@ -271,7 +272,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelA
 		suite.Equal(true, result)
 	})
 
-	suite.T().Run("invalid fake address data", func(t *testing.T) {
+	suite.Run("invalid fake address data", func() {
 		address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
 			Address: models.Address{
 				StreetAddress1: "1600 pennsylvania ave",
@@ -367,7 +368,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 		invalidMTO4,
 	}
 	for idx, invalidData := range invalidFakeData {
-		suite.T().Run(fmt.Sprintf("invalid fake MTOShipment data %d", idx), func(t *testing.T) {
+		suite.RunWithRollback(fmt.Sprintf("invalid fake MTOShipment data %d", idx), func() {
 			shipment := testdatagen.MakeMTOShipment(suite.DB(), invalidData)
 			result, reasons, err := IsValidFakeModelMTOShipment(shipment)
 			suite.NoError(err)

--- a/pkg/services/move_task_order/move_task_order_service_test.go
+++ b/pkg/services/move_task_order/move_task_order_service_test.go
@@ -12,14 +12,9 @@ type MoveTaskOrderServiceSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *MoveTaskOrderServiceSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
-}
-
 func TestMoveTaskOrderServiceSuite(t *testing.T) {
 	ts := &MoveTaskOrderServiceSuite{
-		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()

--- a/pkg/services/payment_request/payment_request_service_test.go
+++ b/pkg/services/payment_request/payment_request_service_test.go
@@ -9,33 +9,24 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/transcom/mymove/pkg/db/sequence"
-	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // PaymentRequestServiceSuite is a suite for testing payment requests
 type PaymentRequestServiceSuite struct {
 	testingsuite.PopTestSuite
-	logger       Logger
-	fs           *afero.Afero
-	icnSequencer sequence.Sequencer
-}
-
-func (suite *PaymentRequestServiceSuite) SetupTest() {
-	err := suite.TruncateAll()
-	suite.FatalNoError(err)
+	logger Logger
+	fs     *afero.Afero
 }
 
 func TestPaymentRequestServiceSuite(t *testing.T) {
 	var f = afero.NewMemMapFs()
 	file := &afero.Afero{Fs: f}
 	ts := &PaymentRequestServiceSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
 		logger:       zap.NewNop(),
 		fs:           file,
 	}
-	ts.icnSequencer = sequence.NewDatabaseSequencer(ts.DB(), ediinvoice.ICNSequenceName)
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()
 }

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -423,11 +423,11 @@ func (suite *PopTestSuite) MustSave(model interface{}) {
 }
 
 // MustCreate requires creating without errors
-func (suite *PopTestSuite) MustCreate(db *pop.Connection, model interface{}) {
+func (suite *PopTestSuite) MustCreate(model interface{}) {
 	t := suite.T()
 	t.Helper()
 
-	verrs, err := db.ValidateAndCreate(model)
+	verrs, err := suite.DB().ValidateAndCreate(model)
 	if err != nil {
 		suite.T().Errorf("Errors encountered creating %v: %v", model, err)
 	}

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -111,6 +111,10 @@ func (suite *PopTestSuite) openTxnPopConnection() *pop.Connection {
 		suite.lowPrivConnDetails.Port,
 		suite.lowPrivConnDetails.Database,
 		suite.lowPrivConnDetails.OptionsString(""))
+
+	// See https://github.com/DATA-DOG/go-txdb for more information
+	// about how txdb works and why we need to register a fake driver
+	// and then connect to a fake database name
 	if !containsString(sql.Drivers(), fakePopSqlxDriverName) {
 		txdb.Register(fakePopSqlxDriverName, "postgres", dataSourceName)
 	}

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -56,7 +56,12 @@ func (store *PopSuiteTxnStore) Transaction() (*pop.Tx, error) {
 		Tx: tx,
 	}
 	store.txList = append(store.txList, t)
-	store.popConn.TX = t
+	// Fake out POP!
+	// Because we are using go-txdb to manage the transactions, we can
+	// handle nested transactions. Setting TX on the pop connection
+	// means the connection can only have a single TX, which breaks
+	// some tests
+	store.popConn.TX = nil
 	return t, nil
 }
 

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -1,0 +1,147 @@
+package testingsuite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/DATA-DOG/go-txdb"
+	"github.com/gobuffalo/pop/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+// use a driver that sqlx knows uses a dollar binding like postgres
+// https://github.com/jmoiron/sqlx/blob/master/bind.go
+const fakePopSqlxDriverName = "cloudsqlpostgres"
+
+func containsString(slice []string, target string) bool {
+	for _, d := range slice {
+		if d == target {
+			return true
+		}
+	}
+	return false
+}
+
+// PopSuiteTxnStore is a pop.Store that uses go-txdb to wrap the
+// connection in a transaction that will be rolled back when closed
+type PopSuiteTxnStore struct {
+	*sqlx.DB
+	popConn *pop.Connection
+	txList  []*pop.Tx
+}
+
+// Commit the transaction if it exists
+// Needed to implement the pop.store interface, but won't actually be called
+func (store *PopSuiteTxnStore) Commit() error {
+	return nil
+}
+
+// Rollback the transaction if it exists
+// Needed to implement the pop.store interface, but won't actually be called
+func (store *PopSuiteTxnStore) Rollback() error {
+	return nil
+}
+
+// Transaction starts a pop.Transaction
+func (store *PopSuiteTxnStore) Transaction() (*pop.Tx, error) {
+	tx, err := store.DB.Beginx()
+	if err != nil {
+		return nil, fmt.Errorf("could not create new transaction %w", err)
+	}
+	t := &pop.Tx{
+		ID: seededRand.Int(),
+		Tx: tx,
+	}
+	store.txList = append(store.txList, t)
+	store.popConn.TX = t
+	return t, nil
+}
+
+// Close closes any open transactions and db connections
+func (store *PopSuiteTxnStore) Close() error {
+	if store.popConn != nil {
+		for txLen := len(store.txList); txLen > 0; txLen-- {
+			tx := store.txList[txLen-1]
+			err := tx.Close()
+			if err != nil {
+				log.Fatalf("TX close failed: %v", err)
+			}
+		}
+		store.txList = []*pop.Tx{}
+		err := store.DB.Close()
+		if err != nil {
+			log.Fatalf("DB close failed: %v", err)
+		}
+		store.DB = nil
+		store.popConn = nil
+	}
+	return nil
+}
+
+// TransactionContext returns the current pop.Transaction
+// Needed to implement the pop.store interface, but won't actually be called
+func (store *PopSuiteTxnStore) TransactionContext(ctx context.Context) (*pop.Tx, error) {
+	return nil, nil
+}
+
+// TransactionContextOptions returns the current pop.Transaction
+// Needed to implement the pop.store interface, but won't actually be called
+func (store *PopSuiteTxnStore) TransactionContextOptions(ctx context.Context, _ *sql.TxOptions) (*pop.Tx, error) {
+	return nil, nil
+}
+
+// openTxnPopConnection sets up the pop Connection for this test
+// suite using a per test connection that will run inside a transaction
+func (suite *PopTestSuite) openTxnPopConnection() *pop.Connection {
+	packageName := suite.PackageName.String()
+	testName := suite.T().Name()
+
+	s := "postgres://%s:%s@%s:%s/%s?%s"
+	dataSourceName := fmt.Sprintf(s, suite.lowPrivConnDetails.User,
+		suite.lowPrivConnDetails.Password,
+		suite.lowPrivConnDetails.Host,
+		suite.lowPrivConnDetails.Port,
+		suite.lowPrivConnDetails.Database,
+		suite.lowPrivConnDetails.OptionsString(""))
+	if !containsString(sql.Drivers(), fakePopSqlxDriverName) {
+		txdb.Register(fakePopSqlxDriverName, "postgres", dataSourceName)
+	}
+
+	dbSanitizer := regexp.MustCompile("[^a-zA-Z0-9_]")
+	fakeDbName := dbSanitizer.ReplaceAllString(packageName+"_"+testName, "_")
+	db := sqlx.MustOpen(fakePopSqlxDriverName, fakeDbName)
+
+	suite.lowPrivConnDetails.Driver = fakePopSqlxDriverName
+	suite.lowPrivConnDetails.Options["application_name"] = fakeDbName
+	suite.lowPrivConnDetails.Database = fakeDbName
+	popConn, err := pop.NewConnection(suite.lowPrivConnDetails)
+	if err != nil {
+		log.Panic(err)
+	}
+	suiteStore := &PopSuiteTxnStore{
+		db,
+		popConn,
+		[]*pop.Tx{},
+	}
+	popConn.Store = suiteStore
+
+	return popConn
+}
+
+// tearDownTxnTest closes the db connection established for this test
+func (suite *PopTestSuite) tearDownTxnTest() {
+	if !suite.usePerTestTransaction {
+		return
+	}
+	if suite.lowPrivConn == nil {
+		return
+	}
+	err := suite.lowPrivConn.Close()
+	if err != nil {
+		log.Panicf("Error closing lowPrivConn: %v", err)
+	}
+	suite.lowPrivConn = nil
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -178,6 +178,7 @@ These scripts are primarily used for working with the database
 | ---------------------------- | -------------------------------------------------------------------------------------- |
 | `db-backup`                  | Backup the contents of the development database for later restore.                     |
 | `db-cleanup`                 | Remove the database backup.                                                            |
+| `db-truncate`                | Truncates the configured database. Used in testing.                                    |
 | `db-restore`                 | Restore the contents of the development database from an earlier backup.               |
 | `psql-dev`                   | Convenience script to drop into development postgres DB                                |
 | `psql-deployed-migrations`   | Convenience script to drop into deployed migrations postgres DB                        |

--- a/scripts/db-truncate
+++ b/scripts/db-truncate
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+# Truncate the tables in the database
+
+set -eu -o pipefail
+
+psql_url="postgres://${DB_USER}:${PGPASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable"
+exec psql "${psql_url}" -c "
+DO \$\$ DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
+        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+    END LOOP;
+END \$\$;
+"


### PR DESCRIPTION
## Description

This uses go-txdb to create a transaction that is rolled back at the end of each test. This should give some speedups

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

I tried to make each commit independent and as self contained as possible, so reviewing each commit in turn might be a good strategy.

## Setup

```sh
make server_test_setup
time make server_test_standalone
```

For example:
```
# on master
$ go test -count=1 ./pkg/handlers/internalapi/
ok  	github.com/transcom/mymove/pkg/handlers/internalapi	44.086s
# on this branch
$ go test -count=1 ./pkg/handlers/internalapi/
ok  	github.com/transcom/mymove/pkg/handlers/internalapi	26.561s
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [investigate go-txdb to speed up test suite](MB-8384) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
