### PR TITLE
MB-8147 Update SC move details to default to dest duty station zip

### DIFF
--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -54,7 +54,9 @@ const ServicesCounselingMoveDetails = () => {
           heading: SHIPMENT_OPTIONS.HHG,
           requestedMoveDate: shipment.requestedPickupDate,
           currentAddress: shipment.pickupAddress,
-          destinationAddress: shipment.destinationAddress,
+          destinationAddress: shipment.destinationAddress || {
+            postal_code: order.destinationDutyStation.address.postal_code,
+          },
           counselorRemarks: shipment.counselorRemarks,
         },
         editURL,

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -252,6 +252,40 @@ describe('MoveDetails page', () => {
       );
     }
   });
+
+  it('renders shipments info even if destination address is missing', async () => {
+    const moveDetailsQuery = {
+      ...newMoveDetailsQuery,
+      mtoShipments: [
+        // Want to create a "new" mtoShipment to be able to delete things without messing up existing tests
+        { ...newMoveDetailsQuery.mtoShipments[0] },
+        newMoveDetailsQuery.mtoShipments[1],
+      ],
+    };
+
+    delete moveDetailsQuery.mtoShipments[0].destinationAddress;
+
+    useMoveDetailsQueries.mockImplementation(() => moveDetailsQuery);
+
+    render(mockedComponent);
+
+    const destinationAddressTerms = screen.getAllByText('Destination address');
+
+    expect(destinationAddressTerms.length).toBe(2);
+
+    expect(destinationAddressTerms[0].nextElementSibling.textContent).toBe(
+      moveDetailsQuery.order.destinationDutyStation.address.postal_code,
+    );
+
+    const { street_address_1, city, state, postal_code } = moveDetailsQuery.mtoShipments[1].destinationAddress;
+
+    const addressText = destinationAddressTerms[1].nextElementSibling.textContent;
+
+    expect(addressText).toContain(street_address_1);
+    expect(addressText).toContain(city);
+    expect(addressText).toContain(state);
+    expect(addressText).toContain(postal_code);
+  });
   /* eslint-enable camelcase */
 
   it('renders customer info', async () => {


### PR DESCRIPTION
## Description

#6631 Introduced a bug when shipments don't have a destination address. This fixes it by defaulting to the destination duty station zip code.

## Reviewer Notes

I added a test to make sure this works as expected. I didn't realize that js doesn't have any deep cloning built in...but I think what I did works. If I just used shallow cloning, other tests would break since I'd be messing with data they're expecting to have. I guess I could have also just added a shipment to the fake data that was missing it from the get go...

## Setup

### Tests
1. Start yarn tests

    ```sh
    yarn test
    ```

2. Type `a` to run all the tests.

### UI

1. Start server, office client, and customer client (will need to run on another port, or bring up only one at at time).

    ```sh
    make server_run
    ```

    ```sh
    make office_client_run
    ```

    ```sh
    make client_run
    ```

2. As a customer, create a move that has a shipment without a destination address.
3. Log in as a services counselor.
4. Open the move you created and see that the shipment has the destination duty station zip code in the destination address field.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8147) for this change

## Screenshots
![Screen Shot 2021-05-19 at 14 00 47](https://user-images.githubusercontent.com/35938642/118869126-9e04d500-b8aa-11eb-9fa8-8eceeb02ff52.png)