### PR TITLE
[MB-8098] prevent GHC api handler from updating PR status to unapproved statuses

### DIFF
--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -136,17 +136,14 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 	now := time.Now()
 	existingPaymentRequest.Status = models.PaymentRequestStatus(params.Body.Status)
 
-	// Let's map the incoming status to our enumeration type
-	switch existingPaymentRequest.Status {
-	case models.PaymentRequestStatusReviewed, models.PaymentRequestStatusReviewedAllRejected:
-		existingPaymentRequest.ReviewedAt = &now
-	case models.PaymentRequestStatusSentToGex:
-		existingPaymentRequest.SentToGexAt = &now
-	case models.PaymentRequestStatusReceivedByGex:
-		existingPaymentRequest.ReceivedByGexAt = &now
-	case models.PaymentRequestStatusPaid:
-		existingPaymentRequest.PaidAt = &now
+	if existingPaymentRequest.Status != models.PaymentRequestStatusReviewed && existingPaymentRequest.Status != models.PaymentRequestStatusReviewedAllRejected {
+		payload := payloadForValidationError("Unable to complete request",
+			fmt.Sprintf("Incoming payment request status should be REVIEWED or REVIEWEDALLREJECTED instead it was: %s", existingPaymentRequest.Status.String()),
+			h.GetTraceID(), validate.NewErrors())
+		return paymentrequestop.NewUpdatePaymentRequestStatusUnprocessableEntity().WithPayload(payload)
 	}
+
+	existingPaymentRequest.ReviewedAt = &now
 
 	// If we got a rejection reason let's use it
 	if params.Body.RejectionReason != nil {

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -138,7 +138,7 @@ func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.Update
 
 	if existingPaymentRequest.Status != models.PaymentRequestStatusReviewed && existingPaymentRequest.Status != models.PaymentRequestStatusReviewedAllRejected {
 		payload := payloadForValidationError("Unable to complete request",
-			fmt.Sprintf("Incoming payment request status should be REVIEWED or REVIEWEDALLREJECTED instead it was: %s", existingPaymentRequest.Status.String()),
+			fmt.Sprintf("Incoming payment request status should be REVIEWED or REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED instead it was: %s", existingPaymentRequest.Status.String()),
 			h.GetTraceID(), validate.NewErrors())
 		return paymentrequestop.NewUpdatePaymentRequestStatusUnprocessableEntity().WithPayload(payload)
 	}

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -301,6 +301,34 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		suite.NotNil(payload.ReviewedAt)
 	})
 
+	suite.T().Run("prevent handler from updating payment request status to unapproved statuses", func(t *testing.T) {
+		nonApprovedPRStatuses := [5]ghcmessages.PaymentRequestStatus{"SENT_TO_GEX", "RECEIVED_BY_GEX", "PAID", "EDI_ERROR", "PENDING"}
+
+		for _, nonApprovedPRStatus := range nonApprovedPRStatuses {
+			pendingPaymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
+
+			paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
+			paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(pendingPaymentRequest, nil).Once()
+
+			req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", pendingPaymentRequest.ID), nil)
+			req = suite.AuthenticateOfficeRequest(req, officeUser)
+			params := paymentrequestop.UpdatePaymentRequestStatusParams{
+				HTTPRequest:      req,
+				Body:             &ghcmessages.UpdatePaymentRequestStatusPayload{Status: nonApprovedPRStatus, RejectionReason: nil, ETag: etag.GenerateEtag(paymentRequest.UpdatedAt)},
+				PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
+			}
+
+			handler := UpdatePaymentRequestStatusHandler{
+				HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+				PaymentRequestStatusUpdater: statusUpdater,
+				PaymentRequestFetcher:       paymentRequestFetcher,
+			}
+
+			response := handler.Handle(params)
+			suite.IsType(paymentrequestop.NewUpdatePaymentRequestStatusUnprocessableEntity(), response)
+		}
+	})
+
 	suite.T().Run("failed status update of payment request - forbidden", func(t *testing.T) {
 		officeUserTOO := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -305,10 +305,10 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		nonApprovedPRStatuses := [5]ghcmessages.PaymentRequestStatus{"SENT_TO_GEX", "RECEIVED_BY_GEX", "PAID", "EDI_ERROR", "PENDING"}
 
 		for _, nonApprovedPRStatus := range nonApprovedPRStatuses {
-			pendingPaymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
+			pendingPaymentRequest := testdatagen.MakeStubbedPaymentRequest(suite.DB())
 
 			paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
-			paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(pendingPaymentRequest, nil).Once()
+			paymentRequestFetcher.On("FetchPaymentRequest", pendingPaymentRequest.ID).Return(pendingPaymentRequest, nil).Once()
 
 			req := httptest.NewRequest("PATCH", fmt.Sprintf("/payment_request/%s/status", pendingPaymentRequest.ID), nil)
 			req = suite.AuthenticateOfficeRequest(req, officeUser)


### PR DESCRIPTION
## Description

This PR fixes a bug where the GHC UpdatePaymentRequestStatusHandler had support for changing the payment request to _any_ status. This PR restricts the handler to only being able to update a payment request to REVIEWED or REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED

## Reviewer Notes

It wasn't specifically called out in the ticket, but this PR also restricts the handler from updating a PR to a pending status. I'm assuming that's desired as well

## Setup

I don't think theres a way to review this other than a review of the code and unit test

```sh
make server_test
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8098) for this change
* Relevant [slack thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1620857715412400) 
