### PR TITLE
MB-7653 Services counselor sees visual cues on allowances view

### DIFF
--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -35,6 +35,7 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dd data-testid="dependents">{info.dependents ? 'Authorized' : 'Unauthorized'}</dd>
         </div>
         <div
+          data-testid="progear-row"
           className={classNames(descriptionListStyles.row, {
             [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
           })}
@@ -43,6 +44,7 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dd data-testid="progear">{formatWeight(info.progear)}</dd>
         </div>
         <div
+          data-testid="spouseprogear-row"
           className={classNames(descriptionListStyles.row, {
             [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
           })}
@@ -51,6 +53,7 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dd data-testid="spouseProgear">{formatWeight(info.spouseProgear)}</dd>
         </div>
         <div
+          data-testid="rme-row"
           className={classNames(descriptionListStyles.row, {
             [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
           })}
@@ -59,6 +62,7 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dd data-testid="rme">{formatWeight(info.requiredMedicalEquipmentWeight)}</dd>
         </div>
         <div
+          data-testid="ocie-row"
           className={classNames(descriptionListStyles.row, {
             [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
           })}

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -9,6 +9,10 @@ import { formatWeight, formatDaysInTransit } from 'shared/formatters';
 import friendlyBranchRank from 'utils/branchRankFormatters';
 
 const AllowancesList = ({ info, showVisualCues }) => {
+  const visualCuesStyle = classNames(descriptionListStyles.row, {
+    [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
+  });
+
   return (
     <div className={styles.OfficeDefinitionLists}>
       <dl className={descriptionListStyles.descriptionList}>
@@ -34,39 +38,19 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dt>Dependents</dt>
           <dd data-testid="dependents">{info.dependents ? 'Authorized' : 'Unauthorized'}</dd>
         </div>
-        <div
-          data-testid="progear-row"
-          className={classNames(descriptionListStyles.row, {
-            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
-          })}
-        >
+        <div data-testid="progear-row" className={visualCuesStyle}>
           <dt>Pro-gear</dt>
           <dd data-testid="progear">{formatWeight(info.progear)}</dd>
         </div>
-        <div
-          data-testid="spouseprogear-row"
-          className={classNames(descriptionListStyles.row, {
-            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
-          })}
-        >
+        <div data-testid="spouseprogear-row" className={visualCuesStyle}>
           <dt>Spouse pro-gear</dt>
           <dd data-testid="spouseProgear">{formatWeight(info.spouseProgear)}</dd>
         </div>
-        <div
-          data-testid="rme-row"
-          className={classNames(descriptionListStyles.row, {
-            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
-          })}
-        >
+        <div data-testid="rme-row" className={visualCuesStyle}>
           <dt>RME</dt>
           <dd data-testid="rme">{formatWeight(info.requiredMedicalEquipmentWeight)}</dd>
         </div>
-        <div
-          data-testid="ocie-row"
-          className={classNames(descriptionListStyles.row, {
-            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
-          })}
-        >
+        <div data-testid="ocie-row" className={visualCuesStyle}>
           <dt>OCIE</dt>
           <dd data-testid="ocie">
             {info.organizationalClothingAndIndividualEquipment ? 'Authorized' : 'Unauthorized'}

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -38,19 +38,19 @@ const AllowancesList = ({ info, showVisualCues }) => {
           <dt>Dependents</dt>
           <dd data-testid="dependents">{info.dependents ? 'Authorized' : 'Unauthorized'}</dd>
         </div>
-        <div data-testid="progear-row" className={visualCuesStyle}>
+        <div className={visualCuesStyle}>
           <dt>Pro-gear</dt>
           <dd data-testid="progear">{formatWeight(info.progear)}</dd>
         </div>
-        <div data-testid="spouseprogear-row" className={visualCuesStyle}>
+        <div className={visualCuesStyle}>
           <dt>Spouse pro-gear</dt>
           <dd data-testid="spouseProgear">{formatWeight(info.spouseProgear)}</dd>
         </div>
-        <div data-testid="rme-row" className={visualCuesStyle}>
+        <div className={visualCuesStyle}>
           <dt>RME</dt>
           <dd data-testid="rme">{formatWeight(info.requiredMedicalEquipmentWeight)}</dd>
         </div>
-        <div data-testid="ocie-row" className={visualCuesStyle}>
+        <div className={visualCuesStyle}>
           <dt>OCIE</dt>
           <dd data-testid="ocie">
             {info.organizationalClothingAndIndividualEquipment ? 'Authorized' : 'Unauthorized'}

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -8,7 +8,7 @@ import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { formatWeight, formatDaysInTransit } from 'shared/formatters';
 import friendlyBranchRank from 'utils/branchRankFormatters';
 
-const AllowancesList = ({ info }) => {
+const AllowancesList = ({ info, showVisualCues }) => {
   return (
     <div className={styles.OfficeDefinitionLists}>
       <dl className={descriptionListStyles.descriptionList}>
@@ -34,19 +34,35 @@ const AllowancesList = ({ info }) => {
           <dt>Dependents</dt>
           <dd data-testid="dependents">{info.dependents ? 'Authorized' : 'Unauthorized'}</dd>
         </div>
-        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
+        <div
+          className={classNames(descriptionListStyles.row, {
+            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
+          })}
+        >
           <dt>Pro-gear</dt>
           <dd data-testid="progear">{formatWeight(info.progear)}</dd>
         </div>
-        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
+        <div
+          className={classNames(descriptionListStyles.row, {
+            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
+          })}
+        >
           <dt>Spouse pro-gear</dt>
           <dd data-testid="spouseProgear">{formatWeight(info.spouseProgear)}</dd>
         </div>
-        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
+        <div
+          className={classNames(descriptionListStyles.row, {
+            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
+          })}
+        >
           <dt>RME</dt>
           <dd data-testid="rme">{formatWeight(info.requiredMedicalEquipmentWeight)}</dd>
         </div>
-        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
+        <div
+          className={classNames(descriptionListStyles.row, {
+            [`${descriptionListStyles.rowWithVisualCue}`]: showVisualCues,
+          })}
+        >
           <dt>OCIE</dt>
           <dd data-testid="ocie">
             {info.organizationalClothingAndIndividualEquipment ? 'Authorized' : 'Unauthorized'}
@@ -70,6 +86,11 @@ AllowancesList.propTypes = {
     requiredMedicalEquipmentWeight: PropTypes.number,
     organizationalClothingAndIndividualEquipment: PropTypes.bool,
   }).isRequired,
+  showVisualCues: PropTypes.bool,
+};
+
+AllowancesList.defaultProps = {
+  showVisualCues: false,
 };
 
 export default AllowancesList;

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import styles from './OfficeDefinitionLists.module.scss';
 
@@ -33,19 +34,19 @@ const AllowancesList = ({ info }) => {
           <dt>Dependents</dt>
           <dd data-testid="dependents">{info.dependents ? 'Authorized' : 'Unauthorized'}</dd>
         </div>
-        <div className={descriptionListStyles.row}>
+        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
           <dt>Pro-gear</dt>
           <dd data-testid="progear">{formatWeight(info.progear)}</dd>
         </div>
-        <div className={descriptionListStyles.row}>
+        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
           <dt>Spouse pro-gear</dt>
           <dd data-testid="spouseProgear">{formatWeight(info.spouseProgear)}</dd>
         </div>
-        <div className={descriptionListStyles.row}>
+        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
           <dt>RME</dt>
           <dd data-testid="rme">{formatWeight(info.requiredMedicalEquipmentWeight)}</dd>
         </div>
-        <div className={descriptionListStyles.row}>
+        <div className={classNames(descriptionListStyles.row, descriptionListStyles.rowWithVisualCue)}>
           <dt>OCIE</dt>
           <dd data-testid="ocie">
             {info.organizationalClothingAndIndividualEquipment ? 'Authorized' : 'Unauthorized'}

--- a/src/components/Office/DefinitionLists/AllowancesList.stories.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.stories.jsx
@@ -6,6 +6,11 @@ import AllowancesList from './AllowancesList';
 export default {
   title: 'Office Components/AllowancesList',
   component: AllowancesList,
+  argTypes: {
+    showVisualCues: {
+      defaultValue: true,
+    },
+  },
 };
 
 const info = {
@@ -22,3 +27,7 @@ const info = {
 };
 
 export const Basic = () => <AllowancesList info={object('info', info)} />;
+
+export const VisualCues = (argTypes) => (
+  <AllowancesList info={object('info', info)} showVisualCues={argTypes.showVisualCues} />
+);

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -77,8 +77,8 @@ describe('AllowancesList', () => {
   it('renders visual cues classname', () => {
     render(<AllowancesList info={info} showVisualCues />);
     expect(screen.getByTestId('progear-row').className).toContain('rowWithVisualCue');
-    expect(screen.getByTestId('spouseprogear-row').className).toEqual('rowWithVisualCue');
-    expect(screen.getByTestId('rme-row').className).toEqual('rowWithVisualCue');
-    expect(screen.getByTestId('ocie-row').className).toEqual('rowWithVisualCue');
+    expect(screen.getByTestId('spouseprogear-row').className).toContain('rowWithVisualCue');
+    expect(screen.getByTestId('rme-row').className).toContain('rowWithVisualCue');
+    expect(screen.getByTestId('ocie-row').className).toContain('rowWithVisualCue');
   });
 });

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -73,4 +73,12 @@ describe('AllowancesList', () => {
     render(<AllowancesList info={withUnauthorizedOcie} />);
     expect(screen.getByTestId('ocie').textContent).toEqual('Unauthorized');
   });
+
+  it('renders visual cues classname', () => {
+    render(<AllowancesList info={info} showVisualCues />);
+    expect(screen.getByTestId('progear-row').className).toContain('rowWithVisualCue');
+    expect(screen.getByTestId('spouseprogear-row').className).toEqual('rowWithVisualCue');
+    expect(screen.getByTestId('rme-row').className).toEqual('rowWithVisualCue');
+    expect(screen.getByTestId('ocie-row').className).toEqual('rowWithVisualCue');
+  });
 });

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -76,9 +76,9 @@ describe('AllowancesList', () => {
 
   it('renders visual cues classname', () => {
     render(<AllowancesList info={info} showVisualCues />);
-    expect(screen.getByTestId('progear-row').className).toContain('rowWithVisualCue');
-    expect(screen.getByTestId('spouseprogear-row').className).toContain('rowWithVisualCue');
-    expect(screen.getByTestId('rme-row').className).toContain('rowWithVisualCue');
-    expect(screen.getByTestId('ocie-row').className).toContain('rowWithVisualCue');
+    expect(screen.getByText('Pro-gear').parentElement.className).toContain('rowWithVisualCue');
+    expect(screen.getByText('Spouse pro-gear').parentElement.className).toContain('rowWithVisualCue');
+    expect(screen.getByText('RME').parentElement.className).toContain('rowWithVisualCue');
+    expect(screen.getByText('OCIE').parentElement.className).toContain('rowWithVisualCue');
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -190,7 +190,7 @@ const ServicesCounselingMoveDetails = () => {
                 )
               }
             >
-              <AllowancesList info={allowancesInfo} />
+              <AllowancesList info={allowancesInfo} showVisualCues />
             </DetailsPanel>
           </div>
           <div className={styles.section} id="customer-info">

--- a/src/styles/descriptionList.module.scss
+++ b/src/styles/descriptionList.module.scss
@@ -14,12 +14,26 @@
     }
   }
 
+  .rowWithVisualCue {
+    dt {
+      @include u-padding-left(1.5);
+    }
+  }
+
+  .rowWithVisualCue::before {
+    @include u-border-right(0.5, solid);
+    content: " ";
+    border-color: $mm-gold;
+    margin-top: 0.15rem;
+    margin-bottom: 0.05rem;
+  }
+
   dt,
   dd {
     @include u-border-top('1px');
     @include u-border-top('base-lighter');
 
-    @include u-padding-x(1);
+    @include u-padding-x(2);
     @include u-padding-y(1.5);
   }
 

--- a/src/styles/descriptionList.module.scss
+++ b/src/styles/descriptionList.module.scss
@@ -16,7 +16,13 @@
 
   .rowWithVisualCue::before {
     @include u-margin-y(0.5);
-    @include u-outline(2px); // only valid values were 1px, 2px, 0 and 05
+    // only valid values were 1px, 2px, 0 and 05
+    // 2px were needed for the outline
+    @include u-outline(2px);
+    // this is to offset the position of the outline
+    // so it lines up next to the row
+    @include u-margin-left(-2px);
+    @include u-margin-right(2px);
     outline-color: $mm-gold;
     content: "";
   }

--- a/src/styles/descriptionList.module.scss
+++ b/src/styles/descriptionList.module.scss
@@ -14,18 +14,11 @@
     }
   }
 
-  .rowWithVisualCue {
-    dt {
-      @include u-padding-left(1.5);
-    }
-  }
-
   .rowWithVisualCue::before {
-    @include u-border-right(0.5, solid);
-    content: " ";
-    border-color: $mm-gold;
-    margin-top: 0.15rem;
-    margin-bottom: 0.05rem;
+    @include u-margin-y(0.5);
+    @include u-outline(2px); // only valid values were 1px, 2px, 0 and 05
+    outline-color: $mm-gold;
+    content: "";
   }
 
   dt,


### PR DESCRIPTION
## Description

> As a services counseling user
> When there are special allowances fields in the allowances table that need my attention
> Then I see a visual indicator on following fields to catch my attention: Pro-gear, Spouse pro-gear, RME, OCIE

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- I used an outline styling to produce the visual cue. I chose this route since outlines don't change the position of the elements on the page.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

Test
1. Login as services counselor on office app
2. Click on any move
3. Scroll down to allowances section
4. Note the visual cues

Storybook
```sh
make storybook
```

1. Navigate to `http://localhost:6006/?path=/story/office-components-allowanceslist--visual-cues`
2. Note the component with visual cues

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7653) for this change

## Screenshots

<img width="998" alt="Screen Shot 2021-05-19 at 12 41 31 PM" src="https://user-images.githubusercontent.com/1522549/118874275-925fe100-b89f-11eb-86c8-2ca37e9b9d69.png">
