### PR TITLE
MB-8022 MTOShipments - Improve null date display

### DIFF
--- a/cmd/prime-api-dev/scripts/payment_requests.go
+++ b/cmd/prime-api-dev/scripts/payment_requests.go
@@ -609,7 +609,7 @@ func (pr *paymentRequestsData) displayUpdateShipmentMenu() (bool, menuType, erro
 			if err != nil {
 				log.Fatal("Cannot get date input", err)
 			}
-			shipment.RequestedPickupDate = strFmtDate
+			shipment.RequestedPickupDate = &strFmtDate
 			fieldValue := updateInfo{
 				value:    strFmtDate.String(),
 				isString: true,

--- a/cmd/prime-api-dev/scripts/payment_requests.go
+++ b/cmd/prime-api-dev/scripts/payment_requests.go
@@ -596,7 +596,7 @@ func (pr *paymentRequestsData) displayUpdateShipmentMenu() (bool, menuType, erro
 			if err != nil {
 				log.Fatal("Cannot get date input", err)
 			}
-			shipment.ActualPickupDate = strFmtDate
+			shipment.ActualPickupDate = &strFmtDate
 			fieldValue := updateInfo{
 				value:    strFmtDate.String(),
 				isString: true,
@@ -622,7 +622,7 @@ func (pr *paymentRequestsData) displayUpdateShipmentMenu() (bool, menuType, erro
 			if err != nil {
 				log.Fatal("Cannot get date input", err)
 			}
-			shipment.ScheduledPickupDate = strFmtDate
+			shipment.ScheduledPickupDate = &strFmtDate
 			fieldValue := updateInfo{
 				value:    strFmtDate.String(),
 				isString: true,

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1736,6 +1736,8 @@ func init() {
           "description": "The date when the Transportation Ordering Officer first approved this shipment for the move.",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "createdAt": {
@@ -1770,7 +1772,9 @@ func init() {
         "firstAvailableDeliveryDate": {
           "description": "The date the Prime provides to the customer as the first possible delivery date so that they can plan their travel accordingly.\n",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "id": {
           "description": "The ID of the shipment.",
@@ -1819,6 +1823,8 @@ func init() {
           "description": "The date when the Prime contractor recorded the shipment's estimated weight.",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "rejectionReason": {
@@ -1838,6 +1844,8 @@ func init() {
           "description": "The latest date by which the Prime can deliver a customer's shipment without violating the contract. This is calculated based on weight, distance, and the scheduled pickup date. It cannot be modified.\n",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "scheduledPickupDate": {
@@ -4562,6 +4570,8 @@ func init() {
           "description": "The date when the Transportation Ordering Officer first approved this shipment for the move.",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "createdAt": {
@@ -4596,7 +4606,9 @@ func init() {
         "firstAvailableDeliveryDate": {
           "description": "The date the Prime provides to the customer as the first possible delivery date so that they can plan their travel accordingly.\n",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "id": {
           "description": "The ID of the shipment.",
@@ -4645,6 +4657,8 @@ func init() {
           "description": "The date when the Prime contractor recorded the shipment's estimated weight.",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "rejectionReason": {
@@ -4664,6 +4678,8 @@ func init() {
           "description": "The latest date by which the Prime can deliver a customer's shipment without violating the contract. This is calculated based on weight, distance, and the scheduled pickup date. It cannot be modified.\n",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "scheduledPickupDate": {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1725,7 +1725,9 @@ func init() {
         "actualPickupDate": {
           "description": "The date when the Prime contractor actually picked up the shipment. Updated after-the-fact.",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "agents": {
           "$ref": "#/definitions/MTOAgents"
@@ -1841,7 +1843,9 @@ func init() {
         "scheduledPickupDate": {
           "description": "The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "secondaryDeliveryAddress": {
           "description": "A second delivery address for this shipment, if the customer entered one. An optional field.",
@@ -4547,7 +4551,9 @@ func init() {
         "actualPickupDate": {
           "description": "The date when the Prime contractor actually picked up the shipment. Updated after-the-fact.",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "agents": {
           "$ref": "#/definitions/MTOAgents"
@@ -4663,7 +4669,9 @@ func init() {
         "scheduledPickupDate": {
           "description": "The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.",
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "secondaryDeliveryAddress": {
           "description": "A second delivery address for this shipment, if the customer entered one. An optional field.",

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1838,6 +1838,8 @@ func init() {
           "description": "The date the customer selects during onboarding as their preferred pickup date. Other dates, such as required delivery date and (outside MilMove) the pack date, are derived from this date.\n",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "requiredDeliveryDate": {
@@ -4672,6 +4674,8 @@ func init() {
           "description": "The date the customer selects during onboarding as their preferred pickup date. Other dates, such as required delivery date and (outside MilMove) the pack date, are derived from this date.\n",
           "type": "string",
           "format": "date",
+          "x-nullable": true,
+          "x-omitempty": false,
           "readOnly": true
         },
         "requiredDeliveryDate": {

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -25,7 +25,7 @@ type MTOShipment struct {
 
 	// The date when the Prime contractor actually picked up the shipment. Updated after-the-fact.
 	// Format: date
-	ActualPickupDate strfmt.Date `json:"actualPickupDate,omitempty"`
+	ActualPickupDate *strfmt.Date `json:"actualPickupDate"`
 
 	// agents
 	Agents MTOAgents `json:"agents,omitempty"`
@@ -126,7 +126,7 @@ type MTOShipment struct {
 
 	// The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.
 	// Format: date
-	ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
+	ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate"`
 
 	// A second delivery address for this shipment, if the customer entered one. An optional field.
 	SecondaryDeliveryAddress struct {
@@ -166,7 +166,7 @@ func (m *MTOShipment) SetMtoServiceItems(val []MTOServiceItem) {
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
 func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 	var data struct {
-		ActualPickupDate strfmt.Date `json:"actualPickupDate,omitempty"`
+		ActualPickupDate *strfmt.Date `json:"actualPickupDate"`
 
 		Agents MTOAgents `json:"agents,omitempty"`
 
@@ -210,7 +210,7 @@ func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 
 		RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
 
-		ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
+		ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate"`
 
 		SecondaryDeliveryAddress struct {
 			Address
@@ -333,7 +333,7 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 	var b1, b2, b3 []byte
 	var err error
 	b1, err = json.Marshal(struct {
-		ActualPickupDate strfmt.Date `json:"actualPickupDate,omitempty"`
+		ActualPickupDate *strfmt.Date `json:"actualPickupDate"`
 
 		Agents MTOAgents `json:"agents,omitempty"`
 
@@ -375,7 +375,7 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 
 		RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
 
-		ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
+		ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate"`
 
 		SecondaryDeliveryAddress struct {
 			Address

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -116,7 +116,7 @@ type MTOShipment struct {
 	//
 	// Read Only: true
 	// Format: date
-	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
+	RequestedPickupDate *strfmt.Date `json:"requestedPickupDate"`
 
 	// The latest date by which the Prime can deliver a customer's shipment without violating the contract. This is calculated based on weight, distance, and the scheduled pickup date. It cannot be modified.
 	//
@@ -206,7 +206,7 @@ func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
 
-		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
+		RequestedPickupDate *strfmt.Date `json:"requestedPickupDate"`
 
 		RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate"`
 
@@ -371,7 +371,7 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
 
-		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
+		RequestedPickupDate *strfmt.Date `json:"requestedPickupDate"`
 
 		RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate"`
 

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -33,7 +33,7 @@ type MTOShipment struct {
 	// The date when the Transportation Ordering Officer first approved this shipment for the move.
 	// Read Only: true
 	// Format: date
-	ApprovedDate strfmt.Date `json:"approvedDate,omitempty"`
+	ApprovedDate *strfmt.Date `json:"approvedDate"`
 
 	// created at
 	// Read Only: true
@@ -72,7 +72,7 @@ type MTOShipment struct {
 	// The date the Prime provides to the customer as the first possible delivery date so that they can plan their travel accordingly.
 	//
 	// Format: date
-	FirstAvailableDeliveryDate strfmt.Date `json:"firstAvailableDeliveryDate,omitempty"`
+	FirstAvailableDeliveryDate *strfmt.Date `json:"firstAvailableDeliveryDate"`
 
 	// The ID of the shipment.
 	// Read Only: true
@@ -106,7 +106,7 @@ type MTOShipment struct {
 	// The date when the Prime contractor recorded the shipment's estimated weight.
 	// Read Only: true
 	// Format: date
-	PrimeEstimatedWeightRecordedDate strfmt.Date `json:"primeEstimatedWeightRecordedDate,omitempty"`
+	PrimeEstimatedWeightRecordedDate *strfmt.Date `json:"primeEstimatedWeightRecordedDate"`
 
 	// The reason why this shipment was rejected by the TOO.
 	// Read Only: true
@@ -122,7 +122,7 @@ type MTOShipment struct {
 	//
 	// Read Only: true
 	// Format: date
-	RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
+	RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate"`
 
 	// The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.
 	// Format: date
@@ -170,7 +170,7 @@ func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 
 		Agents MTOAgents `json:"agents,omitempty"`
 
-		ApprovedDate strfmt.Date `json:"approvedDate,omitempty"`
+		ApprovedDate *strfmt.Date `json:"approvedDate"`
 
 		CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
@@ -184,7 +184,7 @@ func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 
 		ETag string `json:"eTag,omitempty"`
 
-		FirstAvailableDeliveryDate strfmt.Date `json:"firstAvailableDeliveryDate,omitempty"`
+		FirstAvailableDeliveryDate *strfmt.Date `json:"firstAvailableDeliveryDate"`
 
 		ID strfmt.UUID `json:"id,omitempty"`
 
@@ -202,13 +202,13 @@ func (m *MTOShipment) UnmarshalJSON(raw []byte) error {
 
 		PrimeEstimatedWeight int64 `json:"primeEstimatedWeight,omitempty"`
 
-		PrimeEstimatedWeightRecordedDate strfmt.Date `json:"primeEstimatedWeightRecordedDate,omitempty"`
+		PrimeEstimatedWeightRecordedDate *strfmt.Date `json:"primeEstimatedWeightRecordedDate"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
-		RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
+		RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate"`
 
 		ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate"`
 
@@ -337,7 +337,7 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 
 		Agents MTOAgents `json:"agents,omitempty"`
 
-		ApprovedDate strfmt.Date `json:"approvedDate,omitempty"`
+		ApprovedDate *strfmt.Date `json:"approvedDate"`
 
 		CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
@@ -351,7 +351,7 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 
 		ETag string `json:"eTag,omitempty"`
 
-		FirstAvailableDeliveryDate strfmt.Date `json:"firstAvailableDeliveryDate,omitempty"`
+		FirstAvailableDeliveryDate *strfmt.Date `json:"firstAvailableDeliveryDate"`
 
 		ID strfmt.UUID `json:"id,omitempty"`
 
@@ -367,13 +367,13 @@ func (m MTOShipment) MarshalJSON() ([]byte, error) {
 
 		PrimeEstimatedWeight int64 `json:"primeEstimatedWeight,omitempty"`
 
-		PrimeEstimatedWeightRecordedDate strfmt.Date `json:"primeEstimatedWeightRecordedDate,omitempty"`
+		PrimeEstimatedWeightRecordedDate *strfmt.Date `json:"primeEstimatedWeightRecordedDate"`
 
 		RejectionReason *string `json:"rejectionReason,omitempty"`
 
 		RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
-		RequiredDeliveryDate strfmt.Date `json:"requiredDeliveryDate,omitempty"`
+		RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate"`
 
 		ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate"`
 

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -73,6 +73,7 @@ func (h GetMoveTaskOrderHandlerFunc) Handle(params movetaskorderops.GetMoveTaskO
 		}
 	}
 	moveTaskOrderPayload := payloads.MoveTaskOrder(mto)
+
 	return movetaskorderops.NewGetMoveTaskOrderOK().WithPayload(moveTaskOrderPayload)
 }
 

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -125,18 +125,19 @@ func UpdateMTOShipmentModel(mtoShipmentID strfmt.UUID, payload *primemessages.MT
 	if !updatedAt.IsZero() {
 		fieldsInError.Add("updatedAt", "cannot be manually modified - updated automatically")
 	}
-	primeEstimatedWeightRecordedDate := time.Time(payload.PrimeEstimatedWeightRecordedDate)
-	if !primeEstimatedWeightRecordedDate.IsZero() {
+
+	if payload.PrimeEstimatedWeightRecordedDate != nil {
 		fieldsInError.Add("primeEstimatedWeightRecordedDate", "cannot be manually modified - updated automatically")
 	}
-	requiredDeliveryDate := time.Time(payload.RequiredDeliveryDate)
-	if !requiredDeliveryDate.IsZero() {
+
+	if payload.RequiredDeliveryDate != nil {
 		fieldsInError.Add("requiredDeliveryDate", "cannot be manually modified - updated automatically")
 	}
-	approvedDate := time.Time(payload.ApprovedDate)
-	if !approvedDate.IsZero() {
+
+	if payload.ApprovedDate != nil {
 		fieldsInError.Add("approvedDate", "cannot be manually modified - updated automatically with status change")
 	}
+
 	if payload.Status != "" {
 		fieldsInError.Add("status", "cannot be updated")
 	}

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -704,7 +704,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		// Let's double check our maths.
 		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 12)
-		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
+		actualRDD := time.Time(*responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
@@ -776,7 +776,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		// Let's double check our maths.
 		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 22)
-		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
+		actualRDD := time.Time(*responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
@@ -850,7 +850,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		// Let's double check our maths.
 		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 32)
-		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
+		actualRDD := time.Time(*responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -670,10 +670,11 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			},
 		})
 		eTag := etag.GenerateEtag(oldShipment.UpdatedAt)
+		schedDate := strfmt.Date(tenDaysFromNow)
 		payload := primemessages.MTOShipment{
 			ID:                   strfmt.UUID(oldShipment.ID.String()),
 			PrimeEstimatedWeight: int64(primeEstimatedWeight),
-			ScheduledPickupDate:  strfmt.Date(tenDaysFromNow),
+			ScheduledPickupDate:  &schedDate,
 		}
 
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto_shipments/%s", oldShipment.ID.String()), nil)
@@ -699,9 +700,10 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		responsePayload := okResponse.Payload
 		suite.Equal(oldShipment.ID.String(), responsePayload.ID.String())
 		suite.NotNil(responsePayload.RequiredDeliveryDate)
+		suite.NotNil(responsePayload.ScheduledPickupDate)
 
 		// Let's double check our maths.
-		expectedRDD := time.Time(responsePayload.ScheduledPickupDate).AddDate(0, 0, 12)
+		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 12)
 		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
@@ -741,10 +743,11 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			StreetAddress2: akAddress.StreetAddress2,
 			StreetAddress3: akAddress.StreetAddress3,
 		}
+		schedDate := strfmt.Date(tenDaysFromNow)
 		payload := primemessages.MTOShipment{
 			ID:                   strfmt.UUID(oldShipment.ID.String()),
 			PrimeEstimatedWeight: int64(primeEstimatedWeight),
-			ScheduledPickupDate:  strfmt.Date(tenDaysFromNow),
+			ScheduledPickupDate:  &schedDate,
 		}
 		payload.DestinationAddress.Address = payloadAKAddress
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto_shipments/%s", oldShipment.ID.String()), nil)
@@ -769,9 +772,10 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		responsePayload := okResponse.Payload
 		suite.Equal(oldShipment.ID.String(), responsePayload.ID.String())
 		suite.NotNil(responsePayload.RequiredDeliveryDate)
+		suite.NotNil(responsePayload.ScheduledPickupDate)
 
 		// Let's double check our maths.
-		expectedRDD := time.Time(responsePayload.ScheduledPickupDate).AddDate(0, 0, 22)
+		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 22)
 		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
@@ -812,11 +816,11 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			StreetAddress2: adakAddress.StreetAddress2,
 			StreetAddress3: adakAddress.StreetAddress3,
 		}
-
+		schedDate := strfmt.Date(tenDaysFromNow)
 		payload := primemessages.MTOShipment{
 			ID:                   strfmt.UUID(oldShipment.ID.String()),
 			PrimeEstimatedWeight: int64(primeEstimatedWeight),
-			ScheduledPickupDate:  strfmt.Date(tenDaysFromNow),
+			ScheduledPickupDate:  &schedDate,
 		}
 		payload.DestinationAddress.Address = payloadAdakAddress
 
@@ -842,14 +846,14 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		responsePayload := okResponse.Payload
 		suite.Equal(oldShipment.ID.String(), responsePayload.ID.String())
 		suite.NotNil(responsePayload.RequiredDeliveryDate)
+		suite.NotNil(responsePayload.ScheduledPickupDate)
 
 		// Let's double check our maths.
-		expectedRDD := time.Time(responsePayload.ScheduledPickupDate).AddDate(0, 0, 32)
+		expectedRDD := time.Time(*responsePayload.ScheduledPickupDate).AddDate(0, 0, 32)
 		actualRDD := time.Time(responsePayload.RequiredDeliveryDate)
 		suite.Equal(expectedRDD.Year(), actualRDD.Year())
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
-
 		// Confirm PATCH working as expected; non-updated value still exists
 		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -408,7 +408,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentOK)
 		suite.Equal(mtoShipment.ID.String(), okResponse.Payload.ID.String())
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(mtoShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(mtoShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 	})
 
 	suite.T().Run("PATCH failure - Shipment is not part of MTO available to prime", func(t *testing.T) {
@@ -444,7 +445,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(minimalMtoShipment.PrimeActualWeight.Int64(), okResponse.Payload.PrimeActualWeight)
 		suite.Equal(minimalMtoShipment.PrimeEstimatedWeight.Int64(), okResponse.Payload.PrimeEstimatedWeight)
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(minimalMtoShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(minimalMtoShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 
 	})
 
@@ -583,7 +585,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(mtoShipment2.ID.String(), okResponse.Payload.ID.String())
 
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(mtoShipment2.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(mtoShipment2.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 
 	})
 	//}
@@ -656,7 +659,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(oldShipment.ID.String(), okResponse.Payload.ID.String())
 
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 
 	})
 
@@ -710,7 +714,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
 
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 
 	})
 
@@ -782,7 +787,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
 
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 	})
 
 	suite.T().Run("Successful case in Adak, Alaska, should add 20 days to required delivery date", func(t *testing.T) {
@@ -855,7 +861,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(expectedRDD.Month(), actualRDD.Month())
 		suite.Equal(expectedRDD.Day(), actualRDD.Day())
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 
 	})
 
@@ -935,7 +942,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(oldShipment.ID.String(), responsePayload.ID.String())
 		suite.NotNil(responsePayload.RequiredDeliveryDate)
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 	})
 
 	suite.T().Run("Failed case if approved date is less than 3 days from scheduled move date but estimated weight recorded date isn't at least 1 day prior to scheduled move date", func(t *testing.T) {
@@ -1013,7 +1021,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(oldShipment.ID.String(), responsePayload.ID.String())
 		suite.NotNil(responsePayload.RequiredDeliveryDate)
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 	})
 
 	suite.T().Run("Successful case for valid and complete payload including approved date and re service code", func(t *testing.T) {
@@ -1088,7 +1097,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		suite.Equal(string(reService.Code), serviceItemDDFSITCode)
 		suite.Equal(oldShipment.ApprovedDate, &now)
 		// Confirm PATCH working as expected; non-updated value still exists
-		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
+		suite.NotNil(okResponse.Payload.RequestedPickupDate)
+		suite.Equal(oldShipment.RequestedPickupDate.Format(time.ANSIC), time.Time(*okResponse.Payload.RequestedPickupDate).Format(time.ANSIC))
 	})
 }
 

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -334,16 +334,18 @@ func PaymentServiceItemParams(paymentServiceItemParams *models.PaymentServiceIte
 // MTOShipment converts MTOShipment model to payload
 func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	payload := &primemessages.MTOShipment{
-		ID:              strfmt.UUID(mtoShipment.ID.String()),
-		Agents:          *MTOAgents(&mtoShipment.MTOAgents),
-		MoveTaskOrderID: strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-		ShipmentType:    primemessages.MTOShipmentType(mtoShipment.ShipmentType),
-		CustomerRemarks: mtoShipment.CustomerRemarks,
-		Status:          string(mtoShipment.Status),
-		Diversion:       bool(mtoShipment.Diversion),
-		CreatedAt:       strfmt.DateTime(mtoShipment.CreatedAt),
-		UpdatedAt:       strfmt.DateTime(mtoShipment.UpdatedAt),
-		ETag:            etag.GenerateEtag(mtoShipment.UpdatedAt),
+		ID:                  strfmt.UUID(mtoShipment.ID.String()),
+		ActualPickupDate:    handlers.FmtDatePtr(mtoShipment.ActualPickupDate),
+		ScheduledPickupDate: handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate),
+		Agents:              *MTOAgents(&mtoShipment.MTOAgents),
+		MoveTaskOrderID:     strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
+		ShipmentType:        primemessages.MTOShipmentType(mtoShipment.ShipmentType),
+		CustomerRemarks:     mtoShipment.CustomerRemarks,
+		Status:              string(mtoShipment.Status),
+		Diversion:           bool(mtoShipment.Diversion),
+		CreatedAt:           strfmt.DateTime(mtoShipment.CreatedAt),
+		UpdatedAt:           strfmt.DateTime(mtoShipment.UpdatedAt),
+		ETag:                etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 
 	// Set up address payloads
@@ -369,16 +371,8 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		payload.ApprovedDate = strfmt.Date(*mtoShipment.ApprovedDate)
 	}
 
-	if mtoShipment.ScheduledPickupDate != nil {
-		payload.ScheduledPickupDate = strfmt.Date(*mtoShipment.ScheduledPickupDate)
-	}
-
 	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {
 		payload.RequestedPickupDate = strfmt.Date(*mtoShipment.RequestedPickupDate)
-	}
-
-	if mtoShipment.ActualPickupDate != nil && !mtoShipment.ActualPickupDate.IsZero() {
-		payload.ActualPickupDate = strfmt.Date(*mtoShipment.ActualPickupDate)
 	}
 
 	if mtoShipment.FirstAvailableDeliveryDate != nil && !mtoShipment.FirstAvailableDeliveryDate.IsZero() {

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -339,6 +339,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		ApprovedDate:                     handlers.FmtDatePtr(mtoShipment.ApprovedDate),
 		FirstAvailableDeliveryDate:       handlers.FmtDatePtr(mtoShipment.FirstAvailableDeliveryDate),
 		PrimeEstimatedWeightRecordedDate: handlers.FmtDatePtr(mtoShipment.PrimeEstimatedWeightRecordedDate),
+		RequestedPickupDate:              handlers.FmtDatePtr(mtoShipment.RequestedPickupDate),
 		RequiredDeliveryDate:             handlers.FmtDatePtr(mtoShipment.RequiredDeliveryDate),
 		ScheduledPickupDate:              handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate),
 		Agents:                           *MTOAgents(&mtoShipment.MTOAgents),
@@ -368,10 +369,6 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 
 	if mtoShipment.MTOServiceItems != nil {
 		payload.SetMtoServiceItems(*MTOServiceItems(&mtoShipment.MTOServiceItems))
-	}
-
-	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {
-		payload.RequestedPickupDate = strfmt.Date(*mtoShipment.RequestedPickupDate)
 	}
 
 	if mtoShipment.PrimeEstimatedWeight != nil {

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -334,18 +334,22 @@ func PaymentServiceItemParams(paymentServiceItemParams *models.PaymentServiceIte
 // MTOShipment converts MTOShipment model to payload
 func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	payload := &primemessages.MTOShipment{
-		ID:                  strfmt.UUID(mtoShipment.ID.String()),
-		ActualPickupDate:    handlers.FmtDatePtr(mtoShipment.ActualPickupDate),
-		ScheduledPickupDate: handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate),
-		Agents:              *MTOAgents(&mtoShipment.MTOAgents),
-		MoveTaskOrderID:     strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-		ShipmentType:        primemessages.MTOShipmentType(mtoShipment.ShipmentType),
-		CustomerRemarks:     mtoShipment.CustomerRemarks,
-		Status:              string(mtoShipment.Status),
-		Diversion:           bool(mtoShipment.Diversion),
-		CreatedAt:           strfmt.DateTime(mtoShipment.CreatedAt),
-		UpdatedAt:           strfmt.DateTime(mtoShipment.UpdatedAt),
-		ETag:                etag.GenerateEtag(mtoShipment.UpdatedAt),
+		ID:                               strfmt.UUID(mtoShipment.ID.String()),
+		ActualPickupDate:                 handlers.FmtDatePtr(mtoShipment.ActualPickupDate),
+		ApprovedDate:                     handlers.FmtDatePtr(mtoShipment.ApprovedDate),
+		FirstAvailableDeliveryDate:       handlers.FmtDatePtr(mtoShipment.FirstAvailableDeliveryDate),
+		PrimeEstimatedWeightRecordedDate: handlers.FmtDatePtr(mtoShipment.PrimeEstimatedWeightRecordedDate),
+		RequiredDeliveryDate:             handlers.FmtDatePtr(mtoShipment.RequiredDeliveryDate),
+		ScheduledPickupDate:              handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate),
+		Agents:                           *MTOAgents(&mtoShipment.MTOAgents),
+		MoveTaskOrderID:                  strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
+		ShipmentType:                     primemessages.MTOShipmentType(mtoShipment.ShipmentType),
+		CustomerRemarks:                  mtoShipment.CustomerRemarks,
+		Status:                           string(mtoShipment.Status),
+		Diversion:                        bool(mtoShipment.Diversion),
+		CreatedAt:                        strfmt.DateTime(mtoShipment.CreatedAt),
+		UpdatedAt:                        strfmt.DateTime(mtoShipment.UpdatedAt),
+		ETag:                             etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 
 	// Set up address payloads
@@ -363,32 +367,15 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	}
 
 	if mtoShipment.MTOServiceItems != nil {
-		// sets MTOServiceItems
 		payload.SetMtoServiceItems(*MTOServiceItems(&mtoShipment.MTOServiceItems))
-	}
-
-	if mtoShipment.ApprovedDate != nil {
-		payload.ApprovedDate = strfmt.Date(*mtoShipment.ApprovedDate)
 	}
 
 	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {
 		payload.RequestedPickupDate = strfmt.Date(*mtoShipment.RequestedPickupDate)
 	}
 
-	if mtoShipment.FirstAvailableDeliveryDate != nil && !mtoShipment.FirstAvailableDeliveryDate.IsZero() {
-		payload.FirstAvailableDeliveryDate = strfmt.Date(*mtoShipment.FirstAvailableDeliveryDate)
-	}
-
-	if mtoShipment.RequiredDeliveryDate != nil && !mtoShipment.RequiredDeliveryDate.IsZero() {
-		payload.RequiredDeliveryDate = strfmt.Date(*mtoShipment.RequiredDeliveryDate)
-	}
-
 	if mtoShipment.PrimeEstimatedWeight != nil {
 		payload.PrimeEstimatedWeight = int64(*mtoShipment.PrimeEstimatedWeight)
-	}
-
-	if mtoShipment.PrimeEstimatedWeightRecordedDate != nil && !mtoShipment.PrimeEstimatedWeightRecordedDate.IsZero() {
-		payload.PrimeEstimatedWeightRecordedDate = strfmt.Date(*mtoShipment.PrimeEstimatedWeightRecordedDate)
 	}
 
 	if mtoShipment.PrimeActualWeight != nil {

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -147,26 +147,18 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 	}
 
 	model := &models.MTOShipment{
-		ID:                  uuid.FromStringOrNil(mtoShipment.ID.String()),
-		ActualPickupDate:    handlers.FmtDatePtrToPopPtr(mtoShipment.ActualPickupDate),
-		ScheduledPickupDate: handlers.FmtDatePtrToPopPtr(mtoShipment.ScheduledPickupDate),
-		ShipmentType:        models.MTOShipmentType(mtoShipment.ShipmentType),
-		Diversion:           bool(mtoShipment.Diversion),
-	}
-
-	firstAvailableDeliveryDate := time.Time(mtoShipment.FirstAvailableDeliveryDate)
-	if !firstAvailableDeliveryDate.IsZero() {
-		model.FirstAvailableDeliveryDate = &firstAvailableDeliveryDate
+		ID:                         uuid.FromStringOrNil(mtoShipment.ID.String()),
+		ActualPickupDate:           handlers.FmtDatePtrToPopPtr(mtoShipment.ActualPickupDate),
+		FirstAvailableDeliveryDate: handlers.FmtDatePtrToPopPtr(mtoShipment.FirstAvailableDeliveryDate),
+		RequiredDeliveryDate:       handlers.FmtDatePtrToPopPtr(mtoShipment.RequiredDeliveryDate),
+		ScheduledPickupDate:        handlers.FmtDatePtrToPopPtr(mtoShipment.ScheduledPickupDate),
+		ShipmentType:               models.MTOShipmentType(mtoShipment.ShipmentType),
+		Diversion:                  bool(mtoShipment.Diversion),
 	}
 
 	requestedPickupDate := time.Time(mtoShipment.RequestedPickupDate)
 	if !requestedPickupDate.IsZero() {
 		model.RequestedPickupDate = &requestedPickupDate
-	}
-
-	requiredDeliveryDate := time.Time(mtoShipment.RequiredDeliveryDate)
-	if !requiredDeliveryDate.IsZero() {
-		model.RequiredDeliveryDate = &requiredDeliveryDate
 	}
 
 	if mtoShipment.PrimeActualWeight > 0 {

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -147,14 +147,11 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 	}
 
 	model := &models.MTOShipment{
-		ID:           uuid.FromStringOrNil(mtoShipment.ID.String()),
-		ShipmentType: models.MTOShipmentType(mtoShipment.ShipmentType),
-		Diversion:    bool(mtoShipment.Diversion),
-	}
-
-	scheduledPickupDate := time.Time(mtoShipment.ScheduledPickupDate)
-	if !scheduledPickupDate.IsZero() {
-		model.ScheduledPickupDate = &scheduledPickupDate
+		ID:                  uuid.FromStringOrNil(mtoShipment.ID.String()),
+		ActualPickupDate:    handlers.FmtDatePtrToPopPtr(mtoShipment.ActualPickupDate),
+		ScheduledPickupDate: handlers.FmtDatePtrToPopPtr(mtoShipment.ScheduledPickupDate),
+		ShipmentType:        models.MTOShipmentType(mtoShipment.ShipmentType),
+		Diversion:           bool(mtoShipment.Diversion),
 	}
 
 	firstAvailableDeliveryDate := time.Time(mtoShipment.FirstAvailableDeliveryDate)
@@ -165,11 +162,6 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 	requestedPickupDate := time.Time(mtoShipment.RequestedPickupDate)
 	if !requestedPickupDate.IsZero() {
 		model.RequestedPickupDate = &requestedPickupDate
-	}
-
-	actualPickupDate := time.Time(mtoShipment.ActualPickupDate)
-	if !actualPickupDate.IsZero() {
-		model.ActualPickupDate = &actualPickupDate
 	}
 
 	requiredDeliveryDate := time.Time(mtoShipment.RequiredDeliveryDate)

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -151,14 +151,10 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 		ActualPickupDate:           handlers.FmtDatePtrToPopPtr(mtoShipment.ActualPickupDate),
 		FirstAvailableDeliveryDate: handlers.FmtDatePtrToPopPtr(mtoShipment.FirstAvailableDeliveryDate),
 		RequiredDeliveryDate:       handlers.FmtDatePtrToPopPtr(mtoShipment.RequiredDeliveryDate),
+		RequestedPickupDate:        handlers.FmtDatePtrToPopPtr(mtoShipment.RequestedPickupDate),
 		ScheduledPickupDate:        handlers.FmtDatePtrToPopPtr(mtoShipment.ScheduledPickupDate),
 		ShipmentType:               models.MTOShipmentType(mtoShipment.ShipmentType),
 		Diversion:                  bool(mtoShipment.Diversion),
-	}
-
-	requestedPickupDate := time.Time(mtoShipment.RequestedPickupDate)
-	if !requestedPickupDate.IsZero() {
-		model.RequestedPickupDate = &requestedPickupDate
 	}
 
 	if mtoShipment.PrimeActualWeight > 0 {

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1536,10 +1536,14 @@ definitions:
         description: The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.
         format: date
         type: string
+        x-omitempty: false
+        x-nullable: true
       actualPickupDate:
         description: The date when the Prime contractor actually picked up the shipment. Updated after-the-fact.
         format: date
         type: string
+        x-omitempty: false
+        x-nullable: true
       firstAvailableDeliveryDate:
         description: >
           The date the Prime provides to the customer as the first possible delivery date so that they can plan their

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1534,6 +1534,8 @@ definitions:
         format: date
         type: string
         readOnly: true
+        x-omitempty: false
+        x-nullable: true
       scheduledPickupDate:
         description: The date the Prime contractor scheduled to pick up this shipment after consultation with the customer.
         format: date

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1525,6 +1525,8 @@ definitions:
         format: date
         type: string
         readOnly: true
+        x-omitempty: false
+        x-nullable: true
       requestedPickupDate:
         description: >
           The date the customer selects during onboarding as their preferred pickup date. Other dates, such as
@@ -1550,6 +1552,8 @@ definitions:
           travel accordingly.
         format: date
         type: string
+        x-omitempty: false
+        x-nullable: true
       requiredDeliveryDate:
         description: >
           The latest date by which the Prime can deliver a customer's shipment without violating the contract. This is
@@ -1557,6 +1561,8 @@ definitions:
         format: date
         type: string
         readOnly: true
+        x-omitempty: false
+        x-nullable: true
       primeEstimatedWeight:
         description: >
           The estimated weight of this shipment, determined by the movers during the pre-move survey.
@@ -1569,6 +1575,8 @@ definitions:
         format: date
         type: string
         readOnly: true
+        x-omitempty: false
+        x-nullable: true
       primeActualWeight:
         description: The actual weight of the shipment, provided after the Prime packs, picks up, and weighs a customer's shipment.
         type: integer


### PR DESCRIPTION
## Description

Sets the dates in mtoshipment to be `x-nullable: true` and `x-omitempty: false`.
Basically this means yes, they can be null when the server returns the payload, and no, don't omit them from the payload if so.
So what you want to see is, dates that are null in the db, should show up as follows:
``` 
"scheduledPickupDate": null`
```

## Setup

Delete all the date values in a shipment using a db tool like dBeaver. 
Then use `getMTO` endpoint to view the associated MTO. All dates should be listed but set to null in the shipment.
```
actualPickupDate
approvedDate
firstAvailableDeliveryDate
primeEstimatedWeightRecordedDate
requiredDeliveryDate
scheduledPickupDate
requestedPickupDate
```

Also check that you can update the following:
```
actualPickupDate
firstAvailableDeliveryDate
scheduledPickupDate
requestedPickupDate
```

And that you get an error on updating these dates (cannot be updated)
```
approvedDate
primeEstimatedWeightRecordedDate
requiredDeliveryDate
```

