### PR TITLE
[MB-8067] Load testing SC & TOO Move Details orders, shipments, and service item APIs

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -866,6 +866,12 @@ func init() {
               "$ref": "#/definitions/MTOServiceItems"
             }
           },
+          "401": {
+            "$ref": "#/responses/PermissionDenied"
+          },
+          "403": {
+            "$ref": "#/responses/PermissionDenied"
+          },
           "404": {
             "$ref": "#/responses/NotFound"
           },
@@ -4987,6 +4993,18 @@ func init() {
             "description": "Successfully retrieved all line items for a move task order",
             "schema": {
               "$ref": "#/definitions/MTOServiceItems"
+            }
+          },
+          "401": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "The request was denied",
+            "schema": {
+              "$ref": "#/definitions/Error"
             }
           },
           "404": {

--- a/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items_responses.go
+++ b/pkg/gen/ghcapi/ghcoperations/mto_service_item/list_m_t_o_service_items_responses.go
@@ -60,6 +60,94 @@ func (o *ListMTOServiceItemsOK) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
+// ListMTOServiceItemsUnauthorizedCode is the HTTP code returned for type ListMTOServiceItemsUnauthorized
+const ListMTOServiceItemsUnauthorizedCode int = 401
+
+/*ListMTOServiceItemsUnauthorized The request was denied
+
+swagger:response listMTOServiceItemsUnauthorized
+*/
+type ListMTOServiceItemsUnauthorized struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *ghcmessages.Error `json:"body,omitempty"`
+}
+
+// NewListMTOServiceItemsUnauthorized creates ListMTOServiceItemsUnauthorized with default headers values
+func NewListMTOServiceItemsUnauthorized() *ListMTOServiceItemsUnauthorized {
+
+	return &ListMTOServiceItemsUnauthorized{}
+}
+
+// WithPayload adds the payload to the list m t o service items unauthorized response
+func (o *ListMTOServiceItemsUnauthorized) WithPayload(payload *ghcmessages.Error) *ListMTOServiceItemsUnauthorized {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the list m t o service items unauthorized response
+func (o *ListMTOServiceItemsUnauthorized) SetPayload(payload *ghcmessages.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ListMTOServiceItemsUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(401)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
+// ListMTOServiceItemsForbiddenCode is the HTTP code returned for type ListMTOServiceItemsForbidden
+const ListMTOServiceItemsForbiddenCode int = 403
+
+/*ListMTOServiceItemsForbidden The request was denied
+
+swagger:response listMTOServiceItemsForbidden
+*/
+type ListMTOServiceItemsForbidden struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *ghcmessages.Error `json:"body,omitempty"`
+}
+
+// NewListMTOServiceItemsForbidden creates ListMTOServiceItemsForbidden with default headers values
+func NewListMTOServiceItemsForbidden() *ListMTOServiceItemsForbidden {
+
+	return &ListMTOServiceItemsForbidden{}
+}
+
+// WithPayload adds the payload to the list m t o service items forbidden response
+func (o *ListMTOServiceItemsForbidden) WithPayload(payload *ghcmessages.Error) *ListMTOServiceItemsForbidden {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the list m t o service items forbidden response
+func (o *ListMTOServiceItemsForbidden) SetPayload(payload *ghcmessages.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ListMTOServiceItemsForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(403)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ListMTOServiceItemsNotFoundCode is the HTTP code returned for type ListMTOServiceItemsNotFound
 const ListMTOServiceItemsNotFoundCode int = 404
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -601,7 +601,7 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 		queueMoves[i] = &ghcmessages.QueueMove{
 			Customer:               Customer(&customer),
 			Status:                 ghcmessages.QueueMoveStatus(move.Status),
-			ID:                     *handlers.FmtUUID(move.Orders.ID),
+			ID:                     *handlers.FmtUUID(move.ID),
 			Locator:                move.Locator,
 			SubmittedAt:            handlers.FmtDateTimePtr(move.SubmittedAt),
 			RequestedMoveDate:      handlers.FmtDatePtr(earliestRequestedPickup),

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -3,6 +3,8 @@ package ghcapi
 import (
 	"fmt"
 
+	"github.com/transcom/mymove/pkg/models/roles"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
@@ -117,7 +119,11 @@ type ListMTOServiceItemsHandler struct {
 
 // Handle handler that lists mto service items for the move task order
 func (h ListMTOServiceItemsHandler) Handle(params mtoserviceitemop.ListMTOServiceItemsParams) middleware.Responder {
-	logger := h.LoggerFromRequest(params.HTTPRequest)
+	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
+
+	if !session.IsOfficeUser() || (!session.Roles.HasRole(roles.RoleTypeTOO) && !session.Roles.HasRole(roles.RoleTypeTIO)) {
+		return mtoserviceitemop.NewListMTOServiceItemsForbidden()
+	}
 
 	moveTaskOrderID, err := uuid.FromString(params.MoveTaskOrderID.String())
 	// return any parsing error

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -122,6 +122,7 @@ func (h ListMTOServiceItemsHandler) Handle(params mtoserviceitemop.ListMTOServic
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	if !session.IsOfficeUser() || (!session.Roles.HasRole(roles.RoleTypeTOO) && !session.Roles.HasRole(roles.RoleTypeTIO)) {
+		logger.Error("Unauthorized request from a non-office user or an office user without TOO or TIO roles")
 		return mtoserviceitemop.NewListMTOServiceItemsForbidden()
 	}
 

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -82,6 +82,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandler() {
 	result := payload.QueueMoves[0]
 	deptIndicator := *result.DepartmentIndicator
 	suite.Len(payload.QueueMoves, 1)
+	suite.Equal(hhgMove.ID.String(), result.ID.String())
 	suite.Equal(order.ServiceMember.ID.String(), result.Customer.ID.String())
 	suite.Equal(*order.DepartmentIndicator, string(deptIndicator))
 	suite.Equal(order.OriginDutyStation.TransportationOffice.Gbloc, string(result.OriginGBLOC))

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -386,6 +386,10 @@ paths:
           description: Successfully retrieved all line items for a move task order
           schema:
             $ref: '#/definitions/MTOServiceItems'
+        '401':
+          $ref: '#/responses/PermissionDenied'
+        '403':
+          $ref: '#/responses/PermissionDenied'
         '404':
           $ref: '#/responses/NotFound'
         '422':


### PR DESCRIPTION
## Description

This PR is part of the load testing the GHC API work for additional queries for orders, shipments, and service items on the move details page of SC and TOO users.  The PR to add the tasks to the load testing tool is here https://github.com/transcom/milmove_load_testing/pull/71.

Changes are required in the mymove repo to address the move queue queries returning the order id instead of the move id in the payload response.  This was something that stuck around because the initial implementation relied on the orders id more than the move id at the time.  Now the move locator is standardized in our URLs so we can replace the order id in the queue payloads now.

The other change I noticed was that the ListMTOServiceItems endpoint was accessible from the Services Counselor user, which should not be the case.  I added a basic authorization check to return forbidden for Services Counselor because the move will never have any service items until after the TOO approves the move/shipments.

## Reviewer Notes

If I have extra time I'll try to add more fidelity to the seed file when it comes to shipments and service items in our generated moves.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Verifying the move id is now in the payload instead of the orders id:
1. Login as the TOO or SC user
2. Inspect the data returned from the queue for a single move and note the id value (in the react-query developer tools or in the chrome dev inspector)
3. Check in your local database whether this id matches what is in the database for that move.

Verifying the services counselor can not make requests for service items:
1. Launch Postman with your GHC API collection and turn on the cookie interceptor
2. Login to the office app as a Services Counselor user
3. Return to postman and make an API request to the ListMTOServiceItems endpoint at `move_task_orders/:moveId/mto_service_items`

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8067) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
