### PR TITLE
[MB-7596] Return error on nil OriginDutyStation

### DIFF
--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -86,15 +86,16 @@ func (router moveRouter) needsServiceCounseling(move *models.Move) (bool, error)
 
 	var originDutyStation models.DutyStation
 
-	if orders.OriginDutyStationID != nil && *orders.OriginDutyStationID != uuid.Nil {
-		originDutyStation, err = models.FetchDutyStation(router.db, *orders.OriginDutyStationID)
-		if err != nil {
-			router.logger.Error("failure finding the origin duty station", zap.Error(err))
-			return false, services.NewInvalidInputError(*orders.OriginDutyStationID, err, nil, "unable to find origin duty station")
-		}
-		return originDutyStation.ProvidesServicesCounseling, nil
+	if orders.OriginDutyStationID == nil || *orders.OriginDutyStationID != uuid.Nil {
+		return false, services.NewInvalidInputError(orders.ID, err, nil, "orders missing OriginDutyStation")
 	}
-	return false, nil
+
+	originDutyStation, err = models.FetchDutyStation(router.db, *orders.OriginDutyStationID)
+	if err != nil {
+		router.logger.Error("failure finding the origin duty station", zap.Error(err))
+		return false, services.NewInvalidInputError(*orders.OriginDutyStationID, err, nil, "unable to find origin duty station")
+	}
+	return originDutyStation.ProvidesServicesCounseling, nil
 }
 
 // sendToServiceCounselor makes the move available for a Service Counselor to review

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -86,7 +86,7 @@ func (router moveRouter) needsServiceCounseling(move *models.Move) (bool, error)
 
 	var originDutyStation models.DutyStation
 
-	if orders.OriginDutyStationID == nil || *orders.OriginDutyStationID != uuid.Nil {
+	if orders.OriginDutyStationID == nil || *orders.OriginDutyStationID == uuid.Nil {
 		return false, services.NewInvalidInputError(orders.ID, err, nil, "orders missing OriginDutyStation")
 	}
 

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -62,6 +62,16 @@ func (suite *MoveServiceSuite) TestSubmitted() {
 		suite.Contains(err.Error(), "not found looking for move.OrdersID")
 	})
 
+	suite.Run("returns error when needsServicesCounseling cannot find move", func() {
+		move := testdatagen.MakeDefaultMove(suite.DB())
+		move.Orders.OriginDutyStation = nil
+		move.Orders.OriginDutyStationID = nil
+		suite.NoError(suite.DB().Update(&move))
+		err := moveRouter.Submit(&move)
+		suite.Error(err)
+		suite.Contains(err.Error(), "orders missing OriginDutyStation")
+	})
+
 	suite.Run("moves going to the TOO return errors if the move doesn't have DRAFT status", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
 

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -62,11 +62,13 @@ func (suite *MoveServiceSuite) TestSubmitted() {
 		suite.Contains(err.Error(), "not found looking for move.OrdersID")
 	})
 
-	suite.Run("returns error when needsServicesCounseling cannot find move", func() {
+	suite.Run("returns error when OriginDutyStation is missing", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
-		move.Orders.OriginDutyStation = nil
-		move.Orders.OriginDutyStationID = nil
-		suite.NoError(suite.DB().Update(&move))
+		order := move.Orders
+		order.OriginDutyStation = nil
+		order.OriginDutyStationID = nil
+		suite.NoError(suite.DB().Update(&order))
+
 		err := moveRouter.Submit(&move)
 		suite.Error(err)
 		suite.Contains(err.Error(), "orders missing OriginDutyStation")


### PR DESCRIPTION
## Description
When a move with a nil OriginDutyStation in its orders went through routing, we were assuming that the move shouldn't go through services counseling. 
I think we should return an error instead, because it doesn't really make sense to route a move without an OriginDutyStation; its got no GBLOC, so it's not going to show up in the TOO queue.

You can't create a move without an OriginDutyStation from the UI, so this case should only occur if there's a bug somewhere else.

If a user does hit this case, it won't let them submit their move and they won't see a useful error message, which isn't great,
but I think it's better than being able to submit their move into the void?

## Reviewer Notes


## Setup
Go through the signup flow for a new service member, and stop when you get to the page where you enter your signature and submit the move.

Get the order id for the move (this query gets the most recently updated)
```sql
select id from orders order by updated_at desc limit 1;
```
Set the OriginDutyStation to NULL (replace the id with the result from the last query):
```sql
UPDATE orders
SET origin_duty_station_id = NULL
WHERE id = 'a833e56d-1a75-497c-95fb-aeae8f5c763c';
```

Now attempt to submit the move. It should fail to submit, with an error message that looks like this:
![image](https://user-images.githubusercontent.com/2627844/119199984-e5bd6500-ba40-11eb-93e1-d5d335290e53.png)

## Acceptance
You can't trigger this error with the UI or API, so I think all you can do is make sure I didn't break routing by creating a move that requires services counseling, and making sure it shows up in the services counselor queue.


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7596) for this change
