### PR TITLE
MB-8050 Add link/button for services counselors to add an HHG shipment

### DIFF
--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
@@ -89,7 +89,7 @@ const ServicesCounselingShipmentForm = ({
       body: pendingMtoShipment,
     };
 
-    const moveDetailsPath = generatePath(servicesCounselingRoutes.MOVE_DETAILS_INFO_PATH, { moveCode });
+    const moveDetailsPath = generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode });
 
     if (isCreatePage) {
       createMTOShipment(pendingMtoShipment)

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -29,7 +29,15 @@ export const customerRoutes = {
   CONTACT_INFO_EDIT_PATH: '/moves/review/edit-contact-info',
 };
 
+const BASE_MOVE_PATH = '/counseling/moves/:moveCode';
+
 export const servicesCounselingRoutes = {
-  EDIT_SHIPMENT_INFO_PATH: '/counseling/moves/:moveCode/:shipmentId/edit',
-  MOVE_DETAILS_INFO_PATH: '/counseling/moves/:moveCode/details',
+  ALLOWANCES_EDIT_PATH: `${BASE_MOVE_PATH}/allowances`,
+  BASE_MOVE_PATH,
+  CUSTOMER_INFO_EDIT_PATH: `${BASE_MOVE_PATH}/customer`,
+  MOVE_VIEW_PATH: `${BASE_MOVE_PATH}/details`,
+  ORDERS_EDIT_PATH: `${BASE_MOVE_PATH}/orders`,
+  QUEUE_VIEW_PATH: '/counseling/queue',
+  SHIPMENT_ADD_PATH: `${BASE_MOVE_PATH}/new-HHG`,
+  SHIPMENT_EDIT_PATH: `${BASE_MOVE_PATH}/:shipmentId/edit`,
 };

--- a/src/pages/Office/CustomerInfo/CustomerInfo.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.jsx
@@ -1,26 +1,28 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useHistory, useParams } from 'react-router-dom';
 import { queryCache, useMutation } from 'react-query';
+import { generatePath } from 'react-router';
+import { useHistory, useParams } from 'react-router-dom';
 import { GridContainer } from '@trussworks/react-uswds';
 
 import CustomerContactInfoForm from '../../../components/Office/CustomerContactInfoForm/CustomerContactInfoForm';
 
 import styles from './CustomerInfo.module.scss';
 
+import { CUSTOMER, ORDERS } from 'constants/queryKeys';
+import { servicesCounselingRoutes } from 'constants/routes';
 import { updateCustomerInfo } from 'services/ghcApi';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { CustomerShape } from 'types/order';
-import { CUSTOMER, ORDERS } from 'constants/queryKeys';
 
 const CustomerInfo = ({ customer, isLoading, isError, ordersId }) => {
   const { moveCode } = useParams();
   const history = useHistory();
 
   const handleClose = () => {
-    history.push(`/counseling/moves/${moveCode}/details`);
+    history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
   };
 
   const [mutateCustomerInfo] = useMutation(updateCustomerInfo, {

--- a/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.jsx
+++ b/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react';
+import { generatePath } from 'react-router';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { Button } from '@trussworks/react-uswds';
 import { Formik } from 'formik';
@@ -10,13 +11,14 @@ import * as Yup from 'yup';
 import documentWrapperStyles from '../ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.module.scss';
 import AllowancesDetailForm from '../../../components/Office/AllowancesDetailForm/AllowancesDetailForm';
 
+import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
+import { ORDERS } from 'constants/queryKeys';
+import { servicesCounselingRoutes } from 'constants/routes';
+import { useOrdersDocumentQueries } from 'hooks/queries';
 import { updateAllowance } from 'services/ghcApi';
+import { dropdownInputOptions } from 'shared/formatters';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
-import { useOrdersDocumentQueries } from 'hooks/queries';
-import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
-import { dropdownInputOptions } from 'shared/formatters';
-import { ORDERS } from 'constants/queryKeys';
 
 const rankDropdownOptions = dropdownInputOptions(ORDERS_RANK_OPTIONS);
 
@@ -47,7 +49,7 @@ const ServicesCounselingMoveAllowances = () => {
   const orderId = move?.ordersId;
 
   const handleClose = () => {
-    history.push(`/counseling/moves/${moveCode}/details`);
+    history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
   };
 
   const [mutateOrders] = useMutation(updateAllowance, {

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -42,7 +42,7 @@ const ServicesCounselingMoveDetails = () => {
   if (mtoShipments) {
     shipmentsInfo = mtoShipments.map((shipment) => {
       const editURL = counselorCanEdit
-        ? generatePath(servicesCounselingRoutes.EDIT_SHIPMENT_INFO_PATH, {
+        ? generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
             moveCode,
             shipmentId: shipment.id,
           })

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -9,7 +9,6 @@ import styles from '../ServicesCounselingMoveInfo/ServicesCounselingTab.module.s
 
 import scMoveDetailsStyles from './ServicesCounselingMoveDetails.module.scss';
 
-import formattedCustomerName from 'utils/formattedCustomerName';
 import 'styles/office.scss';
 import { MOVES } from 'constants/queryKeys';
 import { servicesCounselingRoutes } from 'constants/routes';
@@ -25,6 +24,7 @@ import { MOVE_STATUSES, SHIPMENT_OPTIONS } from 'shared/constants';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import shipmentCardsStyles from 'styles/shipmentCards.module.scss';
+import formattedCustomerName from 'utils/formattedCustomerName';
 
 const ServicesCounselingMoveDetails = () => {
   const { moveCode } = useParams();
@@ -151,7 +151,20 @@ const ServicesCounselingMoveDetails = () => {
           </Grid>
 
           <div className={styles.section} id="shipments">
-            <DetailsPanel title="Shipments" className={scMoveDetailsStyles.noPaddingBottom}>
+            <DetailsPanel
+              className={scMoveDetailsStyles.noPaddingBottom}
+              editButton={
+                counselorCanEdit && (
+                  <Link
+                    className="usa-button usa-button--secondary"
+                    to={generatePath(servicesCounselingRoutes.SHIPMENT_ADD_PATH, { moveCode })}
+                  >
+                    Add a new shipment
+                  </Link>
+                )
+              }
+              title="Shipments"
+            >
               <div className={shipmentCardsStyles.shipmentCards}>
                 {shipmentsInfo.map((shipment) => (
                   <ShipmentDisplay

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -186,7 +186,10 @@ const ServicesCounselingMoveDetails = () => {
               title="Orders"
               editButton={
                 counselorCanEdit && (
-                  <Link className="usa-button usa-button--secondary" to="orders">
+                  <Link
+                    className="usa-button usa-button--secondary"
+                    to={generatePath(servicesCounselingRoutes.ORDERS_EDIT_PATH, { moveCode })}
+                  >
                     View and edit orders
                   </Link>
                 )
@@ -200,7 +203,10 @@ const ServicesCounselingMoveDetails = () => {
               title="Allowances"
               editButton={
                 counselorCanEdit && (
-                  <Link className="usa-button usa-button--secondary" to="allowances">
+                  <Link
+                    className="usa-button usa-button--secondary"
+                    to={generatePath(servicesCounselingRoutes.ALLOWANCES_EDIT_PATH, { moveCode })}
+                  >
                     Edit allowances
                   </Link>
                 )
@@ -214,7 +220,11 @@ const ServicesCounselingMoveDetails = () => {
               title="Customer info"
               editButton={
                 counselorCanEdit && (
-                  <Link className="usa-button usa-button--secondary" data-testid="edit-customer-info" to="customer">
+                  <Link
+                    className="usa-button usa-button--secondary"
+                    data-testid="edit-customer-info"
+                    to={generatePath(servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH, { moveCode })}
+                  >
                     Edit customer info
                   </Link>
                 )

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -176,8 +176,10 @@ const counselingCompletedMoveDetailsQuery = {
   },
 };
 
+const detailsURL = generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode: mockRequestedMoveCode });
+
 const mockedComponent = (
-  <MockProviders initialEntries={[`counseling/moves/${mockRequestedMoveCode}/details`]}>
+  <MockProviders initialEntries={[detailsURL]}>
     <ServicesCounselingMoveDetails />
   </MockProviders>
 );
@@ -346,13 +348,13 @@ describe('MoveDetails page', () => {
 
       render(mockedComponent);
 
-      const editShipmentButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
+      const shipmentEditButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
 
-      expect(editShipmentButtons.length).toBe(2);
+      expect(shipmentEditButtons.length).toBe(2);
 
-      for (let i = 0; i < editShipmentButtons.length; i += 1) {
-        expect(editShipmentButtons[i].getAttribute('data-testid')).toBe(
-          generatePath(servicesCounselingRoutes.EDIT_SHIPMENT_INFO_PATH, {
+      for (let i = 0; i < shipmentEditButtons.length; i += 1) {
+        expect(shipmentEditButtons[i].getAttribute('data-testid')).toBe(
+          generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
             moveCode: mockRequestedMoveCode,
             shipmentId: newMoveDetailsQuery.mtoShipments[i].id,
           }),

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { generatePath } from 'react-router';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ServicesCounselingMoveDetails from './ServicesCounselingMoveDetails';
@@ -11,7 +11,7 @@ import { ORDERS_TYPE, ORDERS_TYPE_DETAILS } from 'constants/orders';
 import { servicesCounselingRoutes } from 'constants/routes';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import { formatDate } from 'shared/dates';
-import { MockProviders } from 'testUtils';
+import { MockProviders, renderWithRouter } from 'testUtils';
 
 const mockRequestedMoveCode = 'LR4T8V';
 
@@ -343,6 +343,31 @@ describe('MoveDetails page', () => {
       expect(screen.queryByRole('heading', { name: 'Are you sure?', level: 2 }));
     });
 
+    it.each([
+      ['Add a new shipment', servicesCounselingRoutes.SHIPMENT_ADD_PATH],
+      ['View and edit orders', servicesCounselingRoutes.ORDERS_EDIT_PATH],
+      ['Edit allowances', servicesCounselingRoutes.ALLOWANCES_EDIT_PATH],
+      ['Edit customer info', servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH],
+    ])('shows the "%s" link as expected: %s', async (linkText, route) => {
+      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
+
+      const { history } = renderWithRouter(<ServicesCounselingMoveDetails />, { route: detailsURL });
+
+      const link = await screen.findByRole('link', { name: linkText });
+
+      expect(link).toBeInTheDocument();
+
+      userEvent.click(link);
+
+      const path = generatePath(route, {
+        moveCode: mockRequestedMoveCode,
+      });
+
+      await waitFor(() => {
+        expect(history.location.pathname).toEqual(path);
+      });
+    });
+
     it('shows the edit shipment buttons', async () => {
       useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
 
@@ -364,16 +389,17 @@ describe('MoveDetails page', () => {
   });
 
   describe('service counseling completed', () => {
-    it('hides submit and view/edit buttons', async () => {
+    it('hides submit and view/edit buttons/links', async () => {
       useMoveDetailsQueries.mockImplementation(() => counselingCompletedMoveDetailsQuery);
 
       render(mockedComponent);
 
       expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Add a new shipment' })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'View and edit orders' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Edit allowances' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Edit customer info' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'View and edit orders' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Edit customer info' })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.jsx
@@ -4,11 +4,12 @@ import { matchPath, useLocation, useParams } from 'react-router-dom';
 import styles from './ServicesCounselingMoveDocumentWrapper.module.scss';
 
 import DocumentViewer from 'components/DocumentViewer/DocumentViewer';
-import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { servicesCounselingRoutes } from 'constants/routes';
 import { useOrdersDocumentQueries } from 'hooks/queries';
 import ServicesCounselingMoveAllowances from 'pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances';
 import ServicesCounselingOrders from 'pages/Office/ServicesCounselingOrders/ServicesCounselingOrders';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 
 const ServicesCounselingMoveDocumentWrapper = () => {
   const { moveCode } = useParams();
@@ -22,7 +23,7 @@ const ServicesCounselingMoveDocumentWrapper = () => {
   const documentsForViewer = Object.values(upload);
 
   const showOrders = matchPath(pathname, {
-    path: '/counseling/moves/:moveCode/orders',
+    path: servicesCounselingRoutes.ORDERS_EDIT_PATH,
     exact: true,
   });
 

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -2,9 +2,10 @@ import React, { Suspense, lazy } from 'react';
 import { Switch, useParams, Redirect, Route } from 'react-router-dom';
 
 import 'styles/office.scss';
-import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import CustomerHeader from 'components/CustomerHeader';
+import { servicesCounselingRoutes } from 'constants/routes';
 import { useTXOMoveInfoQueries } from 'hooks/queries';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 
 const ServicesCounselingMoveDocumentWrapper = lazy(() =>
@@ -29,20 +30,23 @@ const ServicesCounselingMoveInfo = () => {
       <Suspense fallback={<LoadingPlaceholder />}>
         <Switch>
           {/* TODO - Routes not finalized, revisit */}
-          <Route path="/counseling/moves/:moveCode/details" exact>
+          <Route path={servicesCounselingRoutes.MOVE_VIEW_PATH} exact>
             <ServicesCounselingMoveDetails />
           </Route>
 
-          <Route path={['/counseling/moves/:moveCode/allowances', '/counseling/moves/:moveCode/orders']} exact>
+          <Route
+            path={[servicesCounselingRoutes.ALLOWANCES_EDIT_PATH, servicesCounselingRoutes.ORDERS_EDIT_PATH]}
+            exact
+          >
             <ServicesCounselingMoveDocumentWrapper />
           </Route>
 
-          <Route path="/counseling/moves/:moveCode/customer" exact>
+          <Route path={servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH} exact>
             <CustomerInfo ordersId={order.id} customer={customerData} isLoading={isLoading} isError={isError} />
           </Route>
 
           {/* TODO - clarify role/tab access */}
-          <Redirect from="/counseling/moves/:moveCode" to="/counseling/moves/:moveCode/details" />
+          <Redirect from={servicesCounselingRoutes.BASE_MOVE_PATH} to={servicesCounselingRoutes.MOVE_VIEW_PATH} />
         </Switch>
       </Suspense>
     </>

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react';
+import { generatePath } from 'react-router';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { Button } from '@trussworks/react-uswds';
 import * as Yup from 'yup';
@@ -9,14 +10,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from '../ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.module.scss';
 
-import { updateOrder } from 'services/ghcApi';
-import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import SomethingWentWrong from 'shared/SomethingWentWrong';
 import OrdersDetailForm from 'components/Office/OrdersDetailForm/OrdersDetailForm';
-import { dropdownInputOptions, formatSwaggerDate } from 'shared/formatters';
 import { ORDERS_TYPE_OPTIONS } from 'constants/orders';
 import { ORDERS } from 'constants/queryKeys';
+import { servicesCounselingRoutes } from 'constants/routes';
 import { useOrdersDocumentQueries } from 'hooks/queries';
+import { updateOrder } from 'services/ghcApi';
+import { dropdownInputOptions, formatSwaggerDate } from 'shared/formatters';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 
 const ordersTypeDropdownOptions = dropdownInputOptions(ORDERS_TYPE_OPTIONS);
 
@@ -39,7 +41,7 @@ const ServicesCounselingOrders = () => {
   const orderId = move?.ordersId;
 
   const handleClose = () => {
-    history.push(`/counseling/moves/${moveCode}/details`);
+    history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode }));
   };
 
   const [mutateOrders] = useMutation(updateOrder, {

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
+import { generatePath } from 'react-router';
 import { useHistory } from 'react-router-dom';
 
 import styles from './ServicesCounselingQueue.module.scss';
 
-import { useServicesCounselingQueueQueries, useUserQueries } from 'hooks/queries';
 import { createHeader } from 'components/Table/utils';
+import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
+import SelectFilter from 'components/Table/Filters/SelectFilter';
+import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
+import TableQueue from 'components/Table/TableQueue';
 import {
   BRANCH_OPTIONS,
   SERVICE_COUNSELING_MOVE_STATUS_OPTIONS,
   GBLOC,
   SERVICE_COUNSELING_MOVE_STATUS_LABELS,
 } from 'constants/queues';
+import { servicesCounselingRoutes } from 'constants/routes';
+import { useServicesCounselingQueueQueries, useUserQueries } from 'hooks/queries';
 import { formatDateFromIso, serviceMemberAgencyLabel } from 'shared/formatters';
-import MultiSelectCheckBoxFilter from 'components/Table/Filters/MultiSelectCheckBoxFilter';
-import SelectFilter from 'components/Table/Filters/SelectFilter';
-import DateSelectFilter from 'components/Table/Filters/DateSelectFilter';
-import TableQueue from 'components/Table/TableQueue';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 
@@ -113,7 +115,7 @@ const ServicesCounselingQueue = () => {
   const isMarineCorpsUser = office_user?.transportation_office?.gbloc === GBLOC.USMC;
 
   const handleClick = (values) => {
-    history.push(`/counseling/moves/${values.locator}/details`);
+    history.push(generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode: values.locator }));
   };
 
   if (isLoading) return <LoadingPlaceholder />;

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -187,7 +187,7 @@ export class OfficeApp extends Component {
                     <PrivateRoute
                       key="servicesCounselingEditShipmentDetailsRoute"
                       exact
-                      path={servicesCounselingRoutes.EDIT_SHIPMENT_INFO_PATH}
+                      path={servicesCounselingRoutes.SHIPMENT_EDIT_PATH}
                       component={ServicesCounselingEditShipmentDetails}
                       requiredRoles={[roleTypes.SERVICES_COUNSELOR]}
                     />

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -192,14 +192,14 @@ export class OfficeApp extends Component {
                       requiredRoles={[roleTypes.SERVICES_COUNSELOR]}
                     />
                     <PrivateRoute
-                      path="/counseling/queue"
+                      path={servicesCounselingRoutes.QUEUE_VIEW_PATH}
                       exact
                       component={ServicesCounselingQueue}
                       requiredRoles={[roleTypes.SERVICES_COUNSELOR]}
                     />
                     <PrivateRoute
                       key="servicesCounselingMoveInfoRoute"
-                      path="/counseling/moves/:moveCode"
+                      path={servicesCounselingRoutes.BASE_MOVE_PATH}
                       component={ServicesCounselingMoveInfo}
                       requiredRoles={[roleTypes.SERVICES_COUNSELOR]}
                     />


### PR DESCRIPTION
## Description

The main work for this story is to add a button/link to the Services Counseling move details shipments section that will allow them to "Add a new shipment". The link currently won't actually redirect because the page to add hasn't been added yet (but will be soon!). 

Other work I did was mainly refactoring and cleaning up. I added the rest of the services counseling URLs that are currently defined to the constants and changed any hard-coded paths in the code (not in tests) to use the constants. I sorted some imports as well, but didn't change component/style load order to avoid dealing with any changes in loaded css.

## Reviewer Notes

Is there anything you think would cause issues?

## Setup

1. Run server & office client:

    ```sh
    make server_run
    ```

    ```sh
    make office_client_run
    ```

2. Log in as a services counselor.
3. Select an editable move (one that still needs counseling).
4. Note the new link/button on the top right of the "Shipments" section for adding a move.
    1. If you click on it, it won't change the page, though you may see that the URL for your browser changes very briefly. It's because it's trying to go to the new page but since it doesn't exist, it ends up back on the same page based on how the routing is set up.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8050) for this change

## Screenshots

### Editable Shipments
![Screen Shot 2021-05-24 at 18 54 06](https://user-images.githubusercontent.com/35938642/119420159-6b4f4800-bcc1-11eb-973e-95a5e0e363ad.png)

### Non-editable Shipments
![Screen Shot 2021-05-25 at 14 29 52](https://user-images.githubusercontent.com/35938642/119558285-d30b9e80-bd66-11eb-9f92-b58354d92304.png)