### PR TITLE
MB-7956 Update create item and crate with DCRT service item

### DIFF
--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -288,7 +288,7 @@ func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions
 
 	mtoServiceItem := MakeMTOServiceItem(db, assertions)
 
-	// Create crating item
+	// Create item
 	MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItem: mtoServiceItem,
 		MTOServiceItemDimension: models.MTOServiceItemDimension{

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -274,3 +274,40 @@ func MakeRealMTOServiceItemWithAllDeps(db *pop.Connection, serviceCode models.Re
 	log.Panicf("couldn't create service item service code %s not defined", serviceCode)
 	return models.MTOServiceItem{}
 }
+
+// MakeMTOServiceItemDomesticCrating makes a domestic crating service item and its associated item and crate
+func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions) models.MTOServiceItem {
+	// Set service item type
+	assertions.ReService = models.ReService{
+		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
+	}
+
+	// Add description
+	description := "Decorated horse head to be crated."
+	assertions.MTOServiceItem.Description = &description
+
+	mtoServiceItem := MakeMTOServiceItem(db, assertions)
+
+	// Create crating item
+	MakeMTOServiceItemDimension(db, Assertions{
+		MTOServiceItem: mtoServiceItem,
+		MTOServiceItemDimension: models.MTOServiceItemDimension{
+			Length: 10000,
+			Height: 5000,
+			Width:  2500,
+		},
+	})
+
+	// Creat crate
+	MakeMTOServiceItemDimension(db, Assertions{
+		MTOServiceItem: mtoServiceItem,
+		MTOServiceItemDimension: models.MTOServiceItemDimension{
+			Type:   models.DimensionTypeCrate,
+			Length: 11000,
+			Height: 6000,
+			Width:  3500,
+		},
+	})
+
+	return mtoServiceItem
+}

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -282,30 +282,18 @@ func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions
 		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
 	}
 
-	// Add description
-	description := "Decorated horse head to be crated."
-	assertions.MTOServiceItem.Description = &description
-
 	mtoServiceItem := MakeMTOServiceItem(db, assertions)
 
 	// Create item
 	MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItem: mtoServiceItem,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Length: 10000,
-			Height: 5000,
-			Width:  2500,
-		},
 	})
 
 	// Creat crate
 	MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItem: mtoServiceItem,
 		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Type:   models.DimensionTypeCrate,
-			Length: 11000,
-			Height: 6000,
-			Width:  3500,
+			Type: models.DimensionTypeCrate,
 		},
 	})
 

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -287,17 +287,19 @@ func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions
 	})
 
 	// Create item
-	MakeMTOServiceItemDimension(db, Assertions{
+	dimensionItem := MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItemDimension: assertions.MTOServiceItemDimension,
 		MTOServiceItem:          mtoServiceItem,
 	})
 
 	// Creat crate
 	assertions.MTOServiceItemCrate.Type = models.DimensionTypeCrate
-	MakeMTOServiceItemDimension(db, Assertions{
+	crateItem := MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItemDimension: assertions.MTOServiceItemCrate,
 		MTOServiceItem:          mtoServiceItem,
 	})
+
+	mtoServiceItem.Dimensions = append(mtoServiceItem.Dimensions, dimensionItem, crateItem)
 
 	return mtoServiceItem
 }

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -278,13 +278,11 @@ func MakeRealMTOServiceItemWithAllDeps(db *pop.Connection, serviceCode models.Re
 // MakeMTOServiceItemDomesticCrating makes a domestic crating service item and its associated item and crate
 func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions) models.MTOServiceItem {
 	// Set service item type
-	assertions.MTOServiceItem.ReService = models.ReService{
+	assertions.ReService = models.ReService{
 		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
 	}
 
-	mtoServiceItem := MakeMTOServiceItem(db, Assertions{
-		MTOServiceItem: assertions.MTOServiceItem,
-	})
+	mtoServiceItem := MakeMTOServiceItem(db, assertions)
 
 	// Create item
 	dimensionItem := MakeMTOServiceItemDimension(db, Assertions{

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -278,23 +278,25 @@ func MakeRealMTOServiceItemWithAllDeps(db *pop.Connection, serviceCode models.Re
 // MakeMTOServiceItemDomesticCrating makes a domestic crating service item and its associated item and crate
 func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions) models.MTOServiceItem {
 	// Set service item type
-	assertions.ReService = models.ReService{
+	assertions.MTOServiceItem.ReService = models.ReService{
 		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
 	}
 
-	mtoServiceItem := MakeMTOServiceItem(db, assertions)
+	mtoServiceItem := MakeMTOServiceItem(db, Assertions{
+		MTOServiceItem: assertions.MTOServiceItem,
+	})
 
 	// Create item
 	MakeMTOServiceItemDimension(db, Assertions{
-		MTOServiceItem: mtoServiceItem,
+		MTOServiceItemDimension: assertions.MTOServiceItemDimension,
+		MTOServiceItem:          mtoServiceItem,
 	})
 
 	// Creat crate
+	assertions.MTOServiceItemCrate.Type = models.DimensionTypeCrate
 	MakeMTOServiceItemDimension(db, Assertions{
-		MTOServiceItem: mtoServiceItem,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Type: models.DimensionTypeCrate,
-		},
+		MTOServiceItemDimension: assertions.MTOServiceItemCrate,
+		MTOServiceItem:          mtoServiceItem,
 	})
 
 	return mtoServiceItem

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -293,9 +293,9 @@ func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions
 	})
 
 	// Creat crate
-	assertions.MTOServiceItemCrate.Type = models.DimensionTypeCrate
+	assertions.MTOServiceItemDimensionCrate.Type = models.DimensionTypeCrate
 	crateItem := MakeMTOServiceItemDimension(db, Assertions{
-		MTOServiceItemDimension: assertions.MTOServiceItemCrate,
+		MTOServiceItemDimension: assertions.MTOServiceItemDimensionCrate,
 		MTOServiceItem:          mtoServiceItem,
 	})
 

--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -166,12 +166,9 @@ func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment
 	})
 
 	dcrtCost := unit.Cents(99999)
-	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		Move:        move,
 		MTOShipment: shipment,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic crating
-		},
 	})
 
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1033,14 +1033,13 @@ func createHHGMoveWithPaymentRequest(db *pop.Connection, userUploader *uploader.
 	})
 
 	// setup service item
-	reService := models.ReService{
-		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic crating, Default
-	}
-	testdatagen.MergeModels(&reService, assertions.ReService)
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	mtoServiceItem := testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
+		MTOServiceItem: models.MTOServiceItem{
+			ID:     uuid.Must(uuid.NewV4()),
+			Status: models.MTOServiceItemStatusApproved,
+		},
 		Move:        mto,
 		MTOShipment: MTOShipment,
-		ReService:   reService,
 	})
 
 	// using handler to create service item params
@@ -1377,26 +1376,12 @@ func createHHGMoveWith10ServiceItems(db *pop.Connection, userUploader *uploader.
 		MTOServiceItem: serviceItemDDFSIT,
 	})
 
-	dcrtDescription := "Decorated horse head to be crated."
-	serviceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:          uuid.FromStringOrNil("9b2b7cae-e8fa-4447-9a00-dcfc4ffc9b6f"),
-			Description: &dcrtDescription,
+			ID: uuid.FromStringOrNil("9b2b7cae-e8fa-4447-9a00-dcfc4ffc9b6f"),
 		},
 		Move:        move8,
 		MTOShipment: mtoShipment8,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
-		},
-	})
-
-	testdatagen.MakeMTOServiceItemDimension(db, testdatagen.Assertions{
-		MTOServiceItem: serviceItemDCRT,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Length: 10000,
-			Height: 5000,
-			Width:  2500,
-		},
 	})
 }
 
@@ -1924,27 +1909,13 @@ func createMoveWithHHGAndNTSRPaymentRequest(db *pop.Connection, userUploader *up
 		MTOServiceItem: serviceItemDDFSIT,
 	})
 
-	dcrtDescription := "Decorated horse head to be crated."
-	serviceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	serviceItemDCRT := testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:          uuid.Must(uuid.NewV4()),
-			Status:      models.MTOServiceItemStatusApproved,
-			Description: &dcrtDescription,
+			ID:     uuid.Must(uuid.NewV4()),
+			Status: models.MTOServiceItemStatusApproved,
 		},
 		Move:        move,
 		MTOShipment: hhgShipment,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
-		},
-	})
-
-	testdatagen.MakeMTOServiceItemDimension(db, testdatagen.Assertions{
-		MTOServiceItem: serviceItemDCRT,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Length: 10000,
-			Height: 5000,
-			Width:  2500,
-		},
 	})
 
 	dcrtCost := unit.Cents(55555)
@@ -2374,27 +2345,13 @@ func createMoveWith2ShipmentsAndPaymentRequest(db *pop.Connection, userUploader 
 		},
 	})
 
-	dcrtDescription := "Decorated horse head to be crated."
-	serviceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	serviceItemDCRT := testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:          uuid.Must(uuid.NewV4()),
-			Status:      models.MTOServiceItemStatusApproved,
-			Description: &dcrtDescription,
+			ID:     uuid.Must(uuid.NewV4()),
+			Status: models.MTOServiceItemStatusApproved,
 		},
 		Move:        move,
 		MTOShipment: hhgShipment,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
-		},
-	})
-
-	testdatagen.MakeMTOServiceItemDimension(db, testdatagen.Assertions{
-		MTOServiceItem: serviceItemDCRT,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Length: 10000,
-			Height: 5000,
-			Width:  2500,
-		},
 	})
 
 	dcrtCost := unit.Cents(55555)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1387,15 +1387,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 	})
 
 	dcrtCost := unit.Cents(99999)
-	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
 			ID: uuid.FromStringOrNil("998caacf-ab9e-496e-8cf2-360723eb3e2d"),
 		},
 		Move:        mto,
 		MTOShipment: MTOShipment,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic crating
-		},
 	})
 
 	testdatagen.MakePaymentServiceItem(db, testdatagen.Assertions{
@@ -1737,26 +1734,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		MTOServiceItem: serviceItemDDFSIT,
 	})
 
-	dcrtDescription := "Decorated horse head to be crated."
-	serviceItemDCRT := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+	testdatagen.MakeMTOServiceItemDomesticCrating(db, testdatagen.Assertions{
 		MTOServiceItem: models.MTOServiceItem{
-			ID:          uuid.FromStringOrNil("9b2b7cae-e8fa-4447-9a00-dcfc4ffc9b6f"),
-			Description: &dcrtDescription,
+			ID: uuid.FromStringOrNil("9b2b7cae-e8fa-4447-9a00-dcfc4ffc9b6f"),
 		},
 		Move:        move8,
 		MTOShipment: mtoShipment8,
-		ReService: models.ReService{
-			ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
-		},
-	})
-
-	testdatagen.MakeMTOServiceItemDimension(db, testdatagen.Assertions{
-		MTOServiceItem: serviceItemDCRT,
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Length: 10000,
-			Height: 5000,
-			Width:  2500,
-		},
 	})
 
 	/* Customer with two payment requests */

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -48,6 +48,7 @@ type Assertions struct {
 	MTOAgent                                 models.MTOAgent
 	MTOServiceItem                           models.MTOServiceItem
 	MTOServiceItemDimension                  models.MTOServiceItemDimension
+	MTOServiceItemCrate                      models.MTOServiceItemDimension
 	MTOServiceItemCustomerContact            models.MTOServiceItemCustomerContact
 	MTOShipment                              models.MTOShipment
 	Notification                             models.Notification

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -48,7 +48,7 @@ type Assertions struct {
 	MTOAgent                                 models.MTOAgent
 	MTOServiceItem                           models.MTOServiceItem
 	MTOServiceItemDimension                  models.MTOServiceItemDimension
-	MTOServiceItemCrate                      models.MTOServiceItemDimension
+	MTOServiceItemDimensionCrate             models.MTOServiceItemDimension
 	MTOServiceItemCustomerContact            models.MTOServiceItemCustomerContact
 	MTOShipment                              models.MTOShipment
 	Notification                             models.Notification


### PR DESCRIPTION
## Description

This PR creates a new tesdatagen func `MakeMTOServiceItemDomesticCrating`.  This function creates a DCRT service item and its associated item and crate. I updated devseed, e2e populate and another file to use this function when generating DCRT service items. 

## Reviewer Notes

I saw a DCRT service item was created in `bandwidth.go`. I'm not sure what the file is used for, but it also creates a DCRT service item, so I updated it to use the new function as well. Is that okay?

## Setup

To verify complete the following steps:

- Execute `make db_dev_reset`
- Execute `make db_dev_e2e_populate`
- Execute `make server_run`
- Check with `fetchMTOUpdates` using postman and verify that all crating service items (DCRT) have an ITEM and CRATE. You can search for `DCRT` in the response to quickly find the crating service items.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7956) for this change