### PR TITLE
MB-8189 Update services counseling edit shipment URL

### DIFF
--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -39,5 +39,5 @@ export const servicesCounselingRoutes = {
   ORDERS_EDIT_PATH: `${BASE_MOVE_PATH}/orders`,
   QUEUE_VIEW_PATH: '/counseling/queue',
   SHIPMENT_ADD_PATH: `${BASE_MOVE_PATH}/new-HHG`,
-  SHIPMENT_EDIT_PATH: `${BASE_MOVE_PATH}/:shipmentId/edit`,
+  SHIPMENT_EDIT_PATH: `${BASE_MOVE_PATH}/shipments/:shipmentId`,
 };

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -406,31 +406,23 @@ describe('Office App', () => {
         },
       };
 
-      it('handles a ServicesCounselorEditShipmentDetails URL', () => {
+      it.each([
+        [
+          'ServicesCounselorEditShipmentDetails',
+          '/counseling/moves/AU67C6/shipments/a05d0a28-3bd4-4180-88ba-0a0e7f22b14e',
+          '/counseling/moves/:moveCode/shipments/:shipmentId',
+        ],
+        ['ServicesCounselingMoveInfo', '/counseling/moves/AU67C6', '/counseling/moves/:moveCode'],
+      ])('handles a %s URL (%s) with a given path of %s', (pageName, initialURL, pathToMatch) => {
         const app = mount(
-          <MockProviders
-            initialState={loggedInServicesCounselorState}
-            initialEntries={['/counseling/moves/AU67C6/a05d0a28-3bd4-4180-88ba-0a0e7f22b14e/edit']}
-          >
+          <MockProviders initialState={loggedInServicesCounselorState} initialEntries={[initialURL]}>
             <ConnectedOffice />
           </MockProviders>,
         );
 
         const renderedRoute = app.find('PrivateRoute');
         expect(renderedRoute).toHaveLength(1);
-        expect(renderedRoute.prop('path')).toEqual('/counseling/moves/:moveCode/:shipmentId/edit');
-      });
-
-      it('handles the ServicesCounselingMoveInfo URL', () => {
-        const app = mount(
-          <MockProviders initialState={loggedInServicesCounselorState} initialEntries={['/counseling/moves/AU67C6']}>
-            <ConnectedOffice />
-          </MockProviders>,
-        );
-
-        const renderedRoute = app.find('PrivateRoute');
-        expect(renderedRoute).toHaveLength(1);
-        expect(renderedRoute.prop('path')).toEqual('/counseling/moves/:moveCode');
+        expect(renderedRoute.prop('path')).toEqual(pathToMatch);
       });
     });
   });


### PR DESCRIPTION
## Description

When we were initially setting up the edit page, we didn't have the URL fully set. Now we do so this pr is to align with the decision.

## Reviewer Notes

This is based on another branch at the moment rather than main because it depends on some constant variable renaming done in that PR. Once #6685 merges, this should go into main. I guess this one could also merge into the other one.

## Setup

1. Run server & office client:

    ```sh
    make server_run
    ```

    ```sh
    make office_client_run
    ```

2. Log in as a services counselor.
3. Select an editable move (one that still needs counseling).
4. Click one of the "Edit shipment" buttons.
5. Note the URL now follows the new structure.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8189)