### PR TITLE
MB-8203 show existing agents

### DIFF
--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
@@ -52,9 +52,9 @@ const ServicesCounselingShipmentForm = ({
   const { showDeliveryFields, showPickupFields, schema } = getShipmentOptions(shipmentType);
   const isNTS = shipmentType === SHIPMENT_OPTIONS.NTS;
   const shipmentNumber = shipmentType === SHIPMENT_OPTIONS.HHG ? getShipmentNumber() : null;
-
-  const initialValues = formatMtoShipmentForDisplay(isCreatePage ? {} : mtoShipment);
-
+  const initialValues = formatMtoShipmentForDisplay(
+    isCreatePage ? {} : { agents: mtoShipment.mtoAgents, ...mtoShipment },
+  );
   const optionalLabel = <span className={formStyles.optional}>Optional</span>;
 
   const submitMTOShipment = ({

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
@@ -57,6 +57,22 @@ const mockMtoShipment = {
     state: 'WA',
     postal_code: '98421',
   },
+  mtoAgents: [
+    {
+      agentType: 'RELEASING_AGENT',
+      email: 'jasn@email.com',
+      firstName: 'Jason',
+      lastName: 'Ash',
+      phone: '999-999-9999',
+    },
+    {
+      agentType: 'RECEIVING_AGENT',
+      email: 'rbaker@email.com',
+      firstName: 'Riley',
+      lastName: 'Baker',
+      phone: '863-555-9664',
+    },
+  ],
 };
 
 describe('ServicesCounselingShipmentForm component', () => {
@@ -167,6 +183,10 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('City')[0]).toHaveValue('San Antonio');
       expect(screen.getAllByLabelText('State')[0]).toHaveValue('TX');
       expect(screen.getAllByLabelText('ZIP')[0]).toHaveValue('78234');
+      expect(screen.getAllByLabelText('First name')[0]).toHaveValue('Jason');
+      expect(screen.getAllByLabelText('Last name')[0]).toHaveValue('Ash');
+      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('9999999999'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Email')[0]).toHaveValue('jasn@email.com');
       expect(screen.getByLabelText('Requested delivery date')).toHaveValue('30 Mar 2020');
       expect(screen.getByLabelText('Yes')).toBeChecked();
       expect(screen.getAllByLabelText('Address 1')[1]).toHaveValue('441 SW Rio de la Plata Drive');
@@ -174,6 +194,10 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('City')[1]).toHaveValue('Tacoma');
       expect(screen.getAllByLabelText('State')[1]).toHaveValue('WA');
       expect(screen.getAllByLabelText('ZIP')[1]).toHaveValue('98421');
+      expect(screen.getAllByLabelText('First name')[1]).toHaveValue('Riley');
+      expect(screen.getAllByLabelText('Last name')[1]).toHaveValue('Baker');
+      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('8635559664'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Email')[1]).toHaveValue('rbaker@email.com');
       expect(screen.getByLabelText('Customer remarks')).toHaveValue('mock customer remarks');
       expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');
     });
@@ -317,6 +341,22 @@ describe('ServicesCounselingShipmentForm component', () => {
             postal_code: '78234',
             street_address_2: '',
           },
+          agents: [
+            {
+              agentType: 'RELEASING_AGENT',
+              email: 'jasn@email.com',
+              firstName: 'Jason',
+              lastName: 'Ash',
+              phone: '999-999-9999',
+            },
+            {
+              agentType: 'RECEIVING_AGENT',
+              email: 'rbaker@email.com',
+              firstName: 'Riley',
+              lastName: 'Baker',
+              phone: '863-555-9664',
+            },
+          ],
           requestedDeliveryDate: '2020-03-30',
           requestedPickupDate: '2020-03-01',
           shipmentType: 'HHG',


### PR DESCRIPTION
## Description

Fixes a bug where existing agents weren't shown on the shipment edit form

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make office_client_run
make server_run
```
I think you should be able to hit this website and see the form here: http://officelocal:3000/counseling/moves/SRVCSL/3cc2d807-2905-4ff5-9ce6-147c101652b4/edit
Neither of the shipments have agents yet, so edit one of them and add a shipment. Then try to edit the shipment again, and the agent fields should be filled in.

## Code Review Verification Steps
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8203) for this change


