### PR TITLE
fix yaml for load testing

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3609,7 +3609,6 @@ func init() {
           "$ref": "#/definitions/Affiliation"
         },
         "backup_mailing_address": {
-          "title": "Backup Mailing Address",
           "$ref": "#/definitions/Address"
         },
         "current_station_id": {
@@ -3668,7 +3667,6 @@ func init() {
           "$ref": "#/definitions/ServiceMemberRank"
         },
         "residential_address": {
-          "title": "Residential Address",
           "$ref": "#/definitions/Address"
         },
         "secondary_telephone": {
@@ -3751,7 +3749,6 @@ func init() {
           "type": "string"
         },
         "certification_type": {
-          "x-nullable": true,
           "$ref": "#/definitions/SignedCertificationTypeCreate"
         },
         "date": {
@@ -4116,7 +4113,6 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "office_user": {
-          "x-nullable": true,
           "$ref": "#/definitions/OfficeUser"
         },
         "roles": {
@@ -4126,7 +4122,6 @@ func init() {
           }
         },
         "service_member": {
-          "x-nullable": true,
           "$ref": "#/definitions/ServiceMemberPayload"
         }
       }
@@ -5252,7 +5247,6 @@ func init() {
           "$ref": "#/definitions/Affiliation"
         },
         "backup_mailing_address": {
-          "title": "Backup Mailing Address",
           "$ref": "#/definitions/Address"
         },
         "current_station_id": {
@@ -5311,7 +5305,6 @@ func init() {
           "$ref": "#/definitions/ServiceMemberRank"
         },
         "residential_address": {
-          "title": "Residential Address",
           "$ref": "#/definitions/Address"
         },
         "secondary_telephone": {
@@ -5960,7 +5953,6 @@ func init() {
           "type": "string"
         },
         "certification_type": {
-          "x-nullable": true,
           "$ref": "#/definitions/SignedCertificationType"
         },
         "created_at": {
@@ -6259,7 +6251,6 @@ func init() {
       "type": "object",
       "properties": {
         "agents": {
-          "x-nullable": true,
           "$ref": "#/definitions/MTOAgents"
         },
         "customerRemarks": {
@@ -10102,7 +10093,6 @@ func init() {
           "$ref": "#/definitions/Affiliation"
         },
         "backup_mailing_address": {
-          "title": "Backup Mailing Address",
           "$ref": "#/definitions/Address"
         },
         "current_station_id": {
@@ -10161,7 +10151,6 @@ func init() {
           "$ref": "#/definitions/ServiceMemberRank"
         },
         "residential_address": {
-          "title": "Residential Address",
           "$ref": "#/definitions/Address"
         },
         "secondary_telephone": {
@@ -10244,7 +10233,6 @@ func init() {
           "type": "string"
         },
         "certification_type": {
-          "x-nullable": true,
           "$ref": "#/definitions/SignedCertificationTypeCreate"
         },
         "date": {
@@ -10622,7 +10610,6 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "office_user": {
-          "x-nullable": true,
           "$ref": "#/definitions/OfficeUser"
         },
         "roles": {
@@ -10632,7 +10619,6 @@ func init() {
           }
         },
         "service_member": {
-          "x-nullable": true,
           "$ref": "#/definitions/ServiceMemberPayload"
         }
       }
@@ -11762,7 +11748,6 @@ func init() {
           "$ref": "#/definitions/Affiliation"
         },
         "backup_mailing_address": {
-          "title": "Backup Mailing Address",
           "$ref": "#/definitions/Address"
         },
         "current_station_id": {
@@ -11821,7 +11806,6 @@ func init() {
           "$ref": "#/definitions/ServiceMemberRank"
         },
         "residential_address": {
-          "title": "Residential Address",
           "$ref": "#/definitions/Address"
         },
         "secondary_telephone": {
@@ -12472,7 +12456,6 @@ func init() {
           "type": "string"
         },
         "certification_type": {
-          "x-nullable": true,
           "$ref": "#/definitions/SignedCertificationType"
         },
         "created_at": {
@@ -12774,7 +12757,6 @@ func init() {
       "type": "object",
       "properties": {
         "agents": {
-          "x-nullable": true,
           "$ref": "#/definitions/MTOAgents"
         },
         "customerRemarks": {

--- a/pkg/gen/internalmessages/create_service_member_payload.go
+++ b/pkg/gen/internalmessages/create_service_member_payload.go
@@ -20,7 +20,7 @@ type CreateServiceMemberPayload struct {
 	// affiliation
 	Affiliation *Affiliation `json:"affiliation,omitempty"`
 
-	// Backup Mailing Address
+	// backup mailing address
 	BackupMailingAddress *Address `json:"backup_mailing_address,omitempty"`
 
 	// current station id
@@ -55,7 +55,7 @@ type CreateServiceMemberPayload struct {
 	// rank
 	Rank *ServiceMemberRank `json:"rank,omitempty"`
 
-	// Residential Address
+	// residential address
 	ResidentialAddress *Address `json:"residential_address,omitempty"`
 
 	// Alternate phone

--- a/pkg/gen/internalmessages/patch_service_member_payload.go
+++ b/pkg/gen/internalmessages/patch_service_member_payload.go
@@ -20,7 +20,7 @@ type PatchServiceMemberPayload struct {
 	// affiliation
 	Affiliation *Affiliation `json:"affiliation,omitempty"`
 
-	// Backup Mailing Address
+	// backup mailing address
 	BackupMailingAddress *Address `json:"backup_mailing_address,omitempty"`
 
 	// current station id
@@ -55,7 +55,7 @@ type PatchServiceMemberPayload struct {
 	// rank
 	Rank *ServiceMemberRank `json:"rank,omitempty"`
 
-	// Residential Address
+	// residential address
 	ResidentialAddress *Address `json:"residential_address,omitempty"`
 
 	// Alternate Phone

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -33,10 +33,8 @@ definitions:
         readOnly: true
       service_member:
         $ref: '#/definitions/ServiceMemberPayload'
-        x-nullable: true
       office_user:
         $ref: '#/definitions/OfficeUser'
-        x-nullable: true
       roles:
         type: array
         items:
@@ -1320,10 +1318,8 @@ definitions:
         x-nullable: true
       residential_address:
         $ref: '#/definitions/Address'
-        title: Residential Address
       backup_mailing_address:
         $ref: '#/definitions/Address'
-        title: Backup Mailing Address
   PatchServiceMemberPayload:
     type: object
     properties:
@@ -1400,10 +1396,8 @@ definitions:
         x-nullable: true
       residential_address:
         $ref: '#/definitions/Address'
-        title: Residential Address
       backup_mailing_address:
         $ref: '#/definitions/Address'
-        title: Backup Mailing Address
   ServiceMemberBackupContactPayload:
     type: object
     properties:
@@ -1550,7 +1544,6 @@ definitions:
         x-nullable: true
       certification_type:
         $ref: '#/definitions/SignedCertificationType'
-        x-nullable: true
     required:
       - id
       - move_id
@@ -1577,7 +1570,6 @@ definitions:
         x-nullable: true
       certification_type:
         $ref: '#/definitions/SignedCertificationTypeCreate'
-        x-nullable: true
     required:
       - date
       - signature
@@ -2669,7 +2661,6 @@ definitions:
         x-nullable: true
       agents:
         $ref: '#/definitions/MTOAgents'
-        x-nullable: true
   ClientError:
     type: object
     properties:
@@ -2747,23 +2738,23 @@ paths:
           type: integer
           required: true
       responses:
-        200:
+        '200':
           description: Made estimate of PPM cost range
           schema:
             $ref: '#/definitions/PPMEstimateRange'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: ppm discount not found for provided postal codes and original move date
-        409:
+        '409':
           description: distance is less than 50 miles (no short haul moves)
-        422:
+        '422':
           description: cannot process request with given information
-        500:
+        '500':
           description: internal server error
   /estimates/ppm_sit:
     get:
@@ -2803,21 +2794,21 @@ paths:
           type: integer
           required: true
       responses:
-        200:
+        '200':
           description: show PPM SIT estimate
           schema:
             $ref: '#/definitions/PPMSitEstimate'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        409:
+        '409':
           description: distance is less than 50 miles (no short haul moves)
-        422:
+        '422':
           description: the payload was unprocessable
-        500:
+        '500':
           description: internal server error
   /users/logged_in:
     get:
@@ -2827,15 +2818,15 @@ paths:
       tags:
         - users
       responses:
-        200:
+        '200':
           description: Currently logged in user
           schema:
             $ref: '#/definitions/LoggedInUserPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        500:
+        '500':
           description: server error
   /users/is_logged_in:
     get:
@@ -2845,13 +2836,13 @@ paths:
       tags:
         - users
       responses:
-        200:
+        '200':
           description: Currently logged in user
           schema:
             type: boolean
-        400:
+        '400':
           description: invalid request
-        500:
+        '500':
           description: server error
   /orders:
     post:
@@ -2867,17 +2858,17 @@ paths:
           schema:
             $ref: '#/definitions/CreateUpdateOrders'
       responses:
-        201:
+        '201':
           description: created instance of orders
           schema:
             $ref: '#/definitions/Orders'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /orders/{ordersId}:
     put:
@@ -2899,19 +2890,19 @@ paths:
           schema:
             $ref: '#/definitions/CreateUpdateOrders'
       responses:
-        200:
+        '200':
           description: updated instance of orders
           schema:
             $ref: '#/definitions/Orders'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: orders not found
-        500:
+        '500':
           description: internal server error
     get:
       summary: Returns the given order
@@ -2927,19 +2918,19 @@ paths:
           required: true
           description: UUID of the order
       responses:
-        200:
+        '200':
           description: the instance of the order
           schema:
             $ref: '#/definitions/Orders'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: order is not found
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}:
     patch:
@@ -2961,19 +2952,19 @@ paths:
           schema:
             $ref: '#/definitions/PatchMovePayload'
       responses:
-        201:
+        '201':
           description: updated instance of move
           schema:
             $ref: '#/definitions/MovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move is not found
-        500:
+        '500':
           description: internal server error
     get:
       summary: Returns the given move
@@ -2989,19 +2980,19 @@ paths:
           required: true
           description: UUID of the move
       responses:
-        200:
+        '200':
           description: the instance of the move
           schema:
             $ref: '#/definitions/MovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move is not found
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/signed_certifications:
     post:
@@ -3023,19 +3014,19 @@ paths:
           schema:
             $ref: '#/definitions/CreateSignedCertificationPayload'
       responses:
-        201:
+        '201':
           description: created instance of signed_certification
           schema:
             $ref: '#/definitions/SignedCertificationPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized to sign for this move
-        404:
+        '404':
           description: move not found
-        500:
+        '500':
           description: internal server error
     get:
       summary: gets the signed certifications for the given move ID
@@ -3050,19 +3041,19 @@ paths:
           format: uuid
           required: true
       responses:
-        200:
+        '200':
           description: returns a list of signed certifications
           schema:
             $ref: '#/definitions/SignedCertifications'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move not found
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/personally_procured_move:
     post:
@@ -3084,19 +3075,19 @@ paths:
           schema:
             $ref: '#/definitions/CreatePersonallyProcuredMovePayload'
       responses:
-        201:
+        '201':
           description: created instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move not found
-        500:
+        '500':
           description: server error
     get:
       summary: Returns a list of all PPMs associated with this move
@@ -3112,15 +3103,15 @@ paths:
           required: true
           description: UUID of the move these PPMs are associated with
       responses:
-        200:
+        '200':
           description: returns list of personally_procured_move
           schema:
             $ref: '#/definitions/IndexPersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
   /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId}/estimate:
     patch:
@@ -3143,21 +3134,21 @@ paths:
           required: true
           description: UUID of the PPM being patched
       responses:
-        200:
+        '200':
           description: updated instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: ppm is not found or ppm discount not found for provided postal codes and original move date
-        422:
+        '422':
           description: cannot process request with given information
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/personally_procured_move/{personallyProcuredMoveId}:
     put:
@@ -3185,17 +3176,17 @@ paths:
           schema:
             $ref: '#/definitions/UpdatePersonallyProcuredMovePayload'
       responses:
-        200:
+        '200':
           description: updated instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
     patch:
       summary: Patches the PPM
@@ -3222,21 +3213,21 @@ paths:
           schema:
             $ref: '#/definitions/PatchPersonallyProcuredMovePayload'
       responses:
-        200:
+        '200':
           description: updated instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: ppm is not found or ppm discount not found for provided postal codes and original move date
-        422:
+        '422':
           description: cannot process request with given information
-        500:
+        '500':
           description: internal server error
     get:
       summary: Returns the given PPM
@@ -3258,15 +3249,15 @@ paths:
           required: true
           description: UUID of the PPM
       responses:
-        200:
+        '200':
           description: the instance of personally_procured_move
           schema:
             $ref: '#/definitions/IndexPersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
   /personally_procured_move/{personallyProcuredMoveId}/submit:
     post:
@@ -3288,19 +3279,19 @@ paths:
           schema:
             $ref: '#/definitions/SubmitPersonallyProcuredMovePayload'
       responses:
-        200:
+        '200':
           description: updated instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: ppm is not found
-        500:
+        '500':
           description: internal server error
   /personally_procured_move/{personallyProcuredMoveId}/expense_summary:
     get:
@@ -3317,19 +3308,19 @@ paths:
           required: true
           description: UUID of the PPM
       responses:
-        200:
+        '200':
           description: Successfully calculated expense summary
           schema:
             $ref: '#/definitions/ExpenseSummaryPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: personally procured move not found
-        500:
+        '500':
           description: server error
   /personally_procured_move/{personallyProcuredMoveId}/request_payment:
     post:
@@ -3346,19 +3337,19 @@ paths:
           required: true
           description: UUID of the PPM
       responses:
-        200:
+        '200':
           description: Sucesssfully requested payment
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move not found
-        500:
+        '500':
           description: server error
   /reimbursement/{reimbursementId}/approve:
     post:
@@ -3375,17 +3366,17 @@ paths:
           required: true
           description: UUID of the reimbursement being approved
       responses:
-        200:
+        '200':
           description: updated instance of reimbursement
           schema:
             $ref: '#/definitions/Reimbursement'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/orders:
     get:
@@ -3402,19 +3393,19 @@ paths:
           required: true
           description: UUID of the move
       responses:
-        200:
+        '200':
           description: the orders information for a move for office use
           schema:
             $ref: '#/definitions/Orders'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move not found
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/move_documents:
     get:
@@ -3431,15 +3422,15 @@ paths:
           required: true
           description: UUID of the move
       responses:
-        200:
+        '200':
           description: returns list of move douments
           schema:
             $ref: '#/definitions/MoveDocuments'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
     post:
       summary: Creates a move document
@@ -3460,17 +3451,17 @@ paths:
           schema:
             $ref: '#/definitions/CreateGenericMoveDocumentPayload'
       responses:
-        200:
+        '200':
           description: returns new move document object
           schema:
             $ref: '#/definitions/MoveDocumentPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to modify this move
-        500:
+        '500':
           description: server error
   /move_documents/{moveDocumentId}:
     put:
@@ -3492,19 +3483,19 @@ paths:
           schema:
             $ref: '#/definitions/MoveDocumentPayload'
       responses:
-        200:
+        '200':
           description: updated instance of move document
           schema:
             $ref: '#/definitions/MoveDocumentPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: move document not found
-        500:
+        '500':
           description: internal server error
     delete:
       summary: Deletes a move document
@@ -3520,17 +3511,17 @@ paths:
           required: true
           description: UUID of the move document model
       responses:
-        204:
+        '204':
           description: deleted
-        400:
+        '400':
           description: invalid request
           schema:
             $ref: '#/definitions/InvalidRequestResponsePayload'
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        500:
+        '500':
           description: server error
   /moves/{moveId}/moving_expense_documents:
     post:
@@ -3552,17 +3543,17 @@ paths:
           schema:
             $ref: '#/definitions/CreateMovingExpenseDocumentPayload'
       responses:
-        200:
+        '200':
           description: returns new moving expense document object
           schema:
             $ref: '#/definitions/MoveDocumentPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to modify this move
-        500:
+        '500':
           description: server error
   /moves/{moveId}/approve:
     post:
@@ -3579,21 +3570,21 @@ paths:
           required: true
           description: UUID of the move
       responses:
-        200:
+        '200':
           description: returns updated (approved) move object
           schema:
             $ref: '#/definitions/MovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to approve this move
-        409:
+        '409':
           description: the move is not in a state to be approved
           schema:
             $ref: '#/definitions/MovePayload'
-        500:
+        '500':
           description: server error
   /moves/{moveId}/submit:
     post:
@@ -3615,21 +3606,21 @@ paths:
           schema:
             $ref: '#/definitions/SubmitMoveForApprovalPayload'
       responses:
-        200:
+        '200':
           description: returns updated (submitted) move object
           schema:
             $ref: '#/definitions/MovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to approve this move
-        409:
+        '409':
           description: the move is not in a state to be approved
           schema:
             $ref: '#/definitions/MovePayload'
-        500:
+        '500':
           description: server error
   /moves/{moveId}/cancel:
     post:
@@ -3651,21 +3642,21 @@ paths:
           schema:
             $ref: '#/definitions/CancelMove'
       responses:
-        200:
+        '200':
           description: returns updated (canceled) move object
           schema:
             $ref: '#/definitions/MovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to cancel this move
-        409:
+        '409':
           description: the move is not in a state to be canceled
           schema:
             $ref: '#/definitions/MovePayload'
-        500:
+        '500':
           description: server error
   /moves/{moveId}/move_dates_summary:
     get:
@@ -3688,17 +3679,17 @@ paths:
           required: true
           description: The chosen move date
       responses:
-        200:
+        '200':
           description: List of projected move-related dates
           schema:
             $ref: '#/definitions/MoveDatesSummary'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/shipment_summary_worksheet:
     get:
@@ -3723,7 +3714,7 @@ paths:
       produces:
         - application/pdf
       responses:
-        200:
+        '200':
           headers:
             Content-Disposition:
               type: string
@@ -3732,13 +3723,13 @@ paths:
           schema:
             format: binary
             type: file
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /personally_procured_moves/{personallyProcuredMoveId}/create_ppm_attachments:
     post:
@@ -3764,23 +3755,23 @@ paths:
           collectionFormat: csv
           description: Restrict the list to documents with matching docType.
       responses:
-        200:
+        '200':
           description: returns a PPM attachments upload
           schema:
             $ref: '#/definitions/UploadPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to perform this action
-        413:
+        '413':
           description: payload is too large
-        422:
+        '422':
           description: malformed PDF contained in uploads
-        424:
+        '424':
           description: no files to be processed into attachments PDF
-        500:
+        '500':
           description: server error
   /personally_procured_moves/{personallyProcuredMoveId}/approve:
     post:
@@ -3802,17 +3793,17 @@ paths:
           schema:
             $ref: '#/definitions/ApprovePersonallyProcuredMovePayload'
       responses:
-        200:
+        '200':
           description: updated instance of personally_procured_move
           schema:
             $ref: '#/definitions/PersonallyProcuredMovePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /personally_procured_moves/incentive:
     get:
@@ -3849,19 +3840,19 @@ paths:
           type: integer
           required: true
       responses:
-        200:
+        '200':
           description: Made calculation of PPM incentive
           schema:
             $ref: '#/definitions/PPMIncentive'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        409:
+        '409':
           description: distance is less than 50 miles (no short haul moves)
-        500:
+        '500':
           description: internal server error
   /documents:
     post:
@@ -3877,13 +3868,13 @@ paths:
           schema:
             $ref: '#/definitions/PostDocumentPayload'
       responses:
-        201:
+        '201':
           description: created document
           schema:
             $ref: '#/definitions/DocumentPayload'
-        400:
+        '400':
           description: invalid request
-        500:
+        '500':
           description: server error
   /documents/{documentId}:
     get:
@@ -3900,19 +3891,19 @@ paths:
           required: true
           description: UUID of the document to return
       responses:
-        200:
+        '200':
           description: the requested document
           schema:
             $ref: '#/definitions/DocumentPayload'
-        400:
+        '400':
           description: invalid request
           schema:
             $ref: '#/definitions/InvalidRequestResponsePayload'
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        500:
+        '500':
           description: server error
   /uploads/{uploadId}:
     delete:
@@ -3929,17 +3920,17 @@ paths:
           required: true
           description: UUID of the upload to be deleted
       responses:
-        204:
+        '204':
           description: deleted
-        400:
+        '400':
           description: invalid request
           schema:
             $ref: '#/definitions/InvalidRequestResponsePayload'
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        500:
+        '500':
           description: server error
   /uploads:
     post:
@@ -3963,21 +3954,21 @@ paths:
           description: The file to upload.
           required: true
       responses:
-        201:
+        '201':
           description: created upload
           schema:
             $ref: '#/definitions/UploadPayload'
-        400:
+        '400':
           description: invalid request
           schema:
             $ref: '#/definitions/InvalidRequestResponsePayload'
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        413:
+        '413':
           description: payload is too large
-        500:
+        '500':
           description: server error
     delete:
       summary: Deletes a collection of uploads
@@ -3995,17 +3986,17 @@ paths:
           required: true
           description: Array of UUIDs to be deleted
       responses:
-        204:
+        '204':
           description: deleted
-        400:
+        '400':
           description: invalid request
           schema:
             $ref: '#/definitions/InvalidRequestResponsePayload'
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        500:
+        '500':
           description: server error
   /service_members:
     post:
@@ -4021,19 +4012,19 @@ paths:
           schema:
             $ref: '#/definitions/CreateServiceMemberPayload'
       responses:
-        201:
+        '201':
           description: created instance of service member
           schema:
             $ref: '#/definitions/ServiceMemberPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: service member not found
-        500:
+        '500':
           description: internal server error
   /service_members/{serviceMemberId}:
     get:
@@ -4050,19 +4041,19 @@ paths:
           required: true
           description: UUID of the service member
       responses:
-        200:
+        '200':
           description: the instance of the service member
           schema:
             $ref: '#/definitions/ServiceMemberPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: service member not found
-        500:
+        '500':
           description: internal server error
     patch:
       summary: Patches the service member
@@ -4083,19 +4074,19 @@ paths:
           schema:
             $ref: '#/definitions/PatchServiceMemberPayload'
       responses:
-        200:
+        '200':
           description: updated instance of service member
           schema:
             $ref: '#/definitions/ServiceMemberPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: service member not found
-        500:
+        '500':
           description: internal server error
   /service_members/{serviceMemberId}/current_orders:
     get:
@@ -4112,19 +4103,19 @@ paths:
           required: true
           description: UUID of the service member
       responses:
-        200:
+        '200':
           description: the instance of the service member
           schema:
             $ref: '#/definitions/Orders'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: service member not found
-        500:
+        '500':
           description: internal server error
   /service_members/{serviceMemberId}/backup_contacts:
     post:
@@ -4146,19 +4137,19 @@ paths:
           required: true
           description: UUID of the service member
       responses:
-        201:
+        '201':
           description: created instance of service member backup contact
           schema:
             $ref: '#/definitions/ServiceMemberBackupContactPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized to create this backup contact
-        404:
+        '404':
           description: contact not found
-        500:
+        '500':
           description: internal server error
     get:
       summary: List all service member backup contacts
@@ -4174,19 +4165,19 @@ paths:
           required: true
           description: UUID of the service member
       responses:
-        200:
+        '200':
           description: list of service member backup contacts
           schema:
             $ref: '#/definitions/IndexServiceMemberBackupContactsPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized to see this backup contact
-        404:
+        '404':
           description: contact not found
-        500:
+        '500':
           description: internal server error
   /backup_contacts/{backupContactId}:
     get:
@@ -4203,19 +4194,19 @@ paths:
           required: true
           description: UUID of the service member backup contact
       responses:
-        200:
+        '200':
           description: the instance of the service member backup contact
           schema:
             $ref: '#/definitions/ServiceMemberBackupContactPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: backup contact not found
-        500:
+        '500':
           description: internal server error
     put:
       summary: Updates a service member backup contact
@@ -4236,19 +4227,19 @@ paths:
           required: true
           description: UUID of the service member backup contact
       responses:
-        201:
+        '201':
           description: updated instance of backup contact
           schema:
             $ref: '#/definitions/ServiceMemberBackupContactPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: backup contact not found
-        500:
+        '500':
           description: internal server error
   /duty_stations:
     get:
@@ -4264,19 +4255,19 @@ paths:
           required: true
           description: Search string for duty stations
       responses:
-        200:
+        '200':
           description: the instance of the duty station
           schema:
             $ref: '#/definitions/DutyStationsPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: matching duty station not found
-        500:
+        '500':
           description: internal server error
   /duty_stations/{dutyStationId}/transportation_office:
     get:
@@ -4293,19 +4284,19 @@ paths:
           required: true
           description: UUID of the duty station
       responses:
-        200:
+        '200':
           description: the instance of the transportation office for a duty station
           schema:
             $ref: '#/definitions/TransportationOffice'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        404:
+        '404':
           description: transportation office not found
-        500:
+        '500':
           description: internal server error
   /queues/{queueType}:
     get:
@@ -4327,19 +4318,19 @@ paths:
           required: true
           description: Queue type to show
       responses:
-        200:
+        '200':
           description: list all moves in the specified queue
           schema:
             type: array
             items:
               $ref: '#/definitions/MoveQueueItem'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized to access this queue
-        404:
+        '404':
           description: move queue item is not found
   /entitlements:
     get:
@@ -4349,7 +4340,7 @@ paths:
       tags:
         - entitlements
       responses:
-        200:
+        '200':
           description: List of weights allotted entitlement
           schema:
             $ref: '#/definitions/IndexEntitlements'
@@ -4368,11 +4359,11 @@ paths:
           required: true
           description: UUID of the move
       responses:
-        200:
+        '200':
           description: weight estimate is below allotted entitlement
-        404:
+        '404':
           description: personally procured move not found
-        409:
+        '409':
           description: Requested weight estimate is above allotted entitlement
   /calendar/available_move_dates:
     get:
@@ -4389,17 +4380,17 @@ paths:
           required: true
           description: Look for future available dates starting from (and including) this date
       responses:
-        200:
+        '200':
           description: List of available dates
           schema:
             $ref: '#/definitions/AvailableMoveDates'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: request requires user authentication
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /dps_auth/cookie_url:
     post:
@@ -4420,15 +4411,15 @@ paths:
           description: The DPS URL to redirec to
           required: false
       responses:
-        200:
+        '200':
           description: Success
           schema:
             $ref: '#/definitions/DPSAuthCookieURLPayload'
-        400:
+        '400':
           description: invalid request
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: internal server error
   /moves/{moveId}/weight_ticket:
     post:
@@ -4450,17 +4441,17 @@ paths:
           schema:
             $ref: '#/definitions/CreateWeightTicketDocumentsPayload'
       responses:
-        200:
+        '200':
           description: returns new weight ticket document object
           schema:
             $ref: '#/definitions/MoveDocumentPayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: not authorized to modify this move
-        500:
+        '500':
           description: server error
   /rate_engine_postal_codes/{postal_code}:
     get:
@@ -4484,17 +4475,17 @@ paths:
             - origin
             - destination
       responses:
-        200:
+        '200':
           description: postal_code is valid or invalid
           schema:
             $ref: '#/definitions/RateEnginePostalCodePayload'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: must be authenticated to use this endpoint
-        403:
+        '403':
           description: user is not authorized
-        500:
+        '500':
           description: server error
   /access_codes:
     get:
@@ -4504,17 +4495,17 @@ paths:
       tags:
         - accesscode
       responses:
-        200:
+        '200':
           description: access code has been found in system
           schema:
             $ref: '#/definitions/AccessCode'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: not authorized to fetch access code
-        404:
+        '404':
           description: access code not found in system
-        500:
+        '500':
           description: server error
   /access_codes/valid:
     get:
@@ -4531,17 +4522,17 @@ paths:
           pattern: '^(HHG|PPM)-[A-Z0-9]{6}$'
           x-nullable: false
       responses:
-        200:
+        '200':
           description: access code is invalid or valid
           schema:
             $ref: '#/definitions/AccessCode'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: not authorized to validate access code
-        404:
+        '404':
           description: access code not found in system
-        500:
+        '500':
           description: server error
   /access_codes/invalid:
     patch:
@@ -4563,17 +4554,17 @@ paths:
               code:
                 type: string
       responses:
-        200:
+        '200':
           description: access code is invalid or valid
           schema:
             $ref: '#/definitions/AccessCode'
-        400:
+        '400':
           description: invalid request
-        401:
+        '401':
           description: not authorized to validate access code
-        404:
+        '404':
           description: access code not found in system
-        500:
+        '500':
           description: server error
   /addresses/{addressId}:
     get:
@@ -4590,17 +4581,17 @@ paths:
           required: true
           description: UUID of the address to return
       responses:
-        200:
+        '200':
           description: the requested address
           schema:
             $ref: '#/definitions/Address'
-        400:
+        '400':
           description: invalid request
-        403:
+        '403':
           description: not authorized
-        404:
+        '404':
           description: not found
-        500:
+        '500':
           description: server error
   '/mto_shipments':
     post:


### PR DESCRIPTION
## Description

Fix `internal.yaml` file in order to begin load testing for moves routing to services counseling.

This PR ensures that the yaml file passes validation. 
You can check it out using the [apitools swagger pareser](https://apitools.dev/swagger-parser/online/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftranscom%2Fmymove%2Fd42d1ecd68004884bcc0c241014e6647efa3350a%2Fswagger%2Finternal.yaml)

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8202) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
