### PR TITLE
[MB-7971] Disable submit move when there are no shipments

### DIFF
--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3654,6 +3654,24 @@ func createHHGServicesCounselingCompleted(db *pop.Connection) {
 	})
 }
 
+func createHHGNoShipments(db *pop.Connection) {
+	submittedAt := time.Now()
+	orders := testdatagen.MakeOrderWithoutDefaults(db, testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			ProvidesServicesCounseling: true,
+		},
+	})
+
+	testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			Locator:     "NOSHIP",
+			Status:      models.MoveStatusNeedsServiceCounseling,
+			SubmittedAt: &submittedAt,
+		},
+		Order: orders,
+	})
+}
+
 // Run does that data load thing
 func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, routePlanner route.Planner, logger Logger) {
 	// Testdatagen factories will create new random duty stations so let's get the standard ones in the migrations
@@ -3684,6 +3702,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	createHHGNeedsServicesCounselingUSMC(db, userUploader)
 	createHHGNeedsServicesCounselingUSMC2(db, userUploader)
 	createHHGServicesCounselingCompleted(db)
+	createHHGNoShipments(db)
 
 	for i := 0; i < 12; i++ {
 		validStatuses := []models.MoveStatus{models.MoveStatusNeedsServiceCounseling, models.MoveStatusServiceCounselingCompleted}

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -143,7 +143,7 @@ const ServicesCounselingMoveDetails = () => {
             </Grid>
             <Grid col={6} className={scMoveDetailsStyles.submitMoveDetailsContainer}>
               {counselorCanEdit && (
-                <Button type="button" onClick={handleShowCancellationModal}>
+                <Button disabled={!mtoShipments.length} type="button" onClick={handleShowCancellationModal}>
                   Submit move details
                 </Button>
               )}

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -305,6 +305,15 @@ describe('MoveDetails page', () => {
       expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
     });
 
+    it('submit move details button is disabled when there are no shipments', async () => {
+      useMoveDetailsQueries.mockImplementation(() => ({ ...newMoveDetailsQuery, mtoShipments: [] }));
+
+      render(mockedComponent);
+
+      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeDisabled();
+    });
+
     it('renders the Orders Definition List', async () => {
       useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
 


### PR DESCRIPTION
## Description

Disable `Submit Move Details` button when there are no shipments for the move

## Reviewer Notes
- currently, the queue does not show moves that have no shipments. This will be handled in https://dp3.atlassian.net/browse/MB-8228

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
Go to file `pkg/services/order/order_fetcher.go`
Delete line 76
1. Log in to services counselor
2. Go into move with Move Code `NOSHIP`
Expected result: Submit Move Detail button should be disabled

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7971) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/119678190-2ed03900-bdf4-11eb-86f7-2020a0288cbf.png)
