### PR TITLE
[MB-8079] Migrate Modal component from React-USWDS package

### DIFF
--- a/src/components/MigratedModal/MigratedModal.jsx
+++ b/src/components/MigratedModal/MigratedModal.jsx
@@ -1,0 +1,84 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import styles from './MigratedModal.module.scss';
+
+/** This is a straightforward port of the Modal component from React-USWDS 1.17
+ *  into the MilMove project, as the component is being deprecated in USWDS 2.x. */
+
+/** Modal UI component */
+export const Modal = ({ title, children, actions, className }) => {
+  const classes = classnames(styles.modal, className);
+
+  return (
+    <div data-testid="modal" className={classes}>
+      <div className={styles.title}>{title}</div>
+      <div className={styles.content}>{children}</div>
+      <div className={styles.actions}>{actions}</div>
+    </div>
+  );
+};
+
+Modal.propTypes = {
+  title: PropTypes.node,
+  children: PropTypes.node.isRequired,
+  actions: PropTypes.node,
+  className: PropTypes.string,
+};
+
+Modal.defaultProps = {
+  title: '',
+  actions: '',
+  className: '',
+};
+
+/** Overlay UI component (grey background) */
+export const Overlay = () => <div className={styles.overlay} />;
+
+/** Modal positioning component */
+export const ModalContainer = ({ children }) => {
+  return <div className={styles.modalContainer}>{children}</div>;
+};
+
+ModalContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const connectModal = (Component) => {
+  const ConnectedModal = ({ isOpen, ...props }) => {
+    if (!isOpen) return null;
+    return (
+      <>
+        <Overlay />
+        <ModalContainer>
+          <Component {...props} />
+        </ModalContainer>
+      </>
+    );
+  };
+
+  ConnectedModal.propTypes = {
+    isOpen: PropTypes.bool,
+  };
+
+  ConnectedModal.defaultProps = {
+    isOpen: false,
+  };
+
+  return ConnectedModal;
+};
+
+export const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  return { isOpen, openModal, closeModal };
+};

--- a/src/components/MigratedModal/MigratedModal.module.scss
+++ b/src/components/MigratedModal/MigratedModal.module.scss
@@ -1,0 +1,59 @@
+@import 'shared/styles/colors';
+@import 'shared/styles/_basics';
+
+/** This is a straightforward port of the Modal component from React-USWDS 1.17
+ *  into the MilMove project, as the component is being deprecated in USWDS 2.x. */
+
+.title {
+  h2 {
+    margin: 0;
+  }
+}
+
+.actions {
+  text-align: right;
+}
+
+.title + .content,
+.content + .actions {
+  @include u-border-top(1px);
+  @include u-border-top($theme-color-base-lighter);
+}
+
+.modal {
+  @include u-bg('white');
+  @include u-shadow(3);
+  @include u-radius('sm');
+
+  // TODO - adapt these for different screen sizes/modal sizes?
+  max-width: 630px;
+  min-width: 400px;
+
+  .title,
+  .content,
+  .actions {
+    padding: units(2);
+  }
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.3);
+  height: 100vh;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 999;
+}
+
+.modalContainer {
+  align-items: center;
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 1000;
+}

--- a/src/components/MigratedModal/MigratedModal.stories.jsx
+++ b/src/components/MigratedModal/MigratedModal.stories.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Button } from '@trussworks/react-uswds';
+
+import { Modal, Overlay, ModalContainer, connectModal, useModal } from './MigratedModal';
+
+export default {
+  title: 'Components/MigratedModal',
+};
+
+/** This is a straightforward port of the Modal component from React-USWDS 1.17
+ *  into the MilMove project, as the component is being deprecated in USWDS 2.x. */
+
+const testTitle = <h2>My Modal</h2>;
+
+const testActions = (
+  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <Button type="button" secondary>
+      Cancel
+    </Button>
+    <Button type="button">Close</Button>
+  </div>
+);
+
+const closeCaseActions = (
+  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <Button type="button" secondary>
+      Cancel
+    </Button>
+    <Button type="button">Close Investigation</Button>
+  </div>
+);
+
+export const basic = () => (
+  <div
+    style={{
+      margin: '100px',
+    }}
+  >
+    <Modal>
+      <p>This is a basic modal!</p>
+    </Modal>
+  </div>
+);
+
+export const withTitle = () => (
+  <div
+    style={{
+      margin: '100px',
+    }}
+  >
+    <Modal title={testTitle}>
+      <p>This is a basic modal!</p>
+    </Modal>
+  </div>
+);
+
+export const withActions = () => (
+  <div
+    style={{
+      margin: '100px',
+    }}
+  >
+    <Modal actions={testActions}>
+      <p>This is a basic modal!</p>
+    </Modal>
+  </div>
+);
+
+export const withTitleAndActions = () => (
+  <div
+    style={{
+      margin: '100px',
+    }}
+  >
+    <Modal title={testTitle} actions={testActions}>
+      <p>This is a basic modal!</p>
+    </Modal>
+  </div>
+);
+
+export const closeCaseModal = () => (
+  <div
+    style={{
+      margin: '100px',
+    }}
+  >
+    <Modal
+      title={<h2>Close case?</h2>}
+      actions={
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button type="button" secondary>
+            Cancel
+          </Button>
+          <Button type="button">Close investigation</Button>
+        </div>
+      }
+    >
+      <p>
+        This will close your investigative work for <strong>Case #590381450</strong> and forward the case to
+        adjudication.
+      </p>
+    </Modal>
+  </div>
+);
+
+export const withOverlay = () => (
+  <div>
+    <Overlay />
+    <ModalContainer>
+      <Modal title={<h2>Close case?</h2>} actions={closeCaseActions}>
+        <p>
+          This will close your investigative work for <strong>Case #590381450</strong> and forward the case to
+          adjudication.
+        </p>
+      </Modal>
+    </ModalContainer>
+  </div>
+);
+
+export const FullExample = () => {
+  const { isOpen, openModal, closeModal } = useModal();
+
+  const TestModal = () => (
+    <Modal
+      title={<h2>Test Modal</h2>}
+      actions={
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button type="button" secondary onClick={closeModal}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={closeModal}>
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <p>This is a test modal!</p>
+    </Modal>
+  );
+
+  const ConnectedTestModal = connectModal(TestModal);
+
+  return (
+    <div>
+      <Button type="button" onClick={openModal}>
+        Click me!
+      </Button>
+      <ConnectedTestModal isOpen={isOpen} onClose={closeModal} />
+    </div>
+  );
+};

--- a/src/components/MigratedModal/MigratedModal.test.jsx
+++ b/src/components/MigratedModal/MigratedModal.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { Modal, connectModal, useModal } from './MigratedModal';
+
+/** This is a straightforward port of the Modal component from React-USWDS 1.17
+ *  into the MilMove project, as the component is being deprecated in USWDS 2.x. */
+
+describe('Modal component', () => {
+  it('renders without errors', () => {
+    const { queryByText } = render(<Modal>My Modal</Modal>);
+    expect(queryByText('My Modal')).toBeInTheDocument();
+  });
+});
+
+const TestModal = () => <div>My Modal</div>;
+
+describe('connectModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const mockClose = jest.fn();
+
+  describe('if isOpen is false', () => {
+    it('does not render its children', () => {
+      const TestConnectedModal = connectModal(TestModal);
+      const { queryByText } = render(<TestConnectedModal isOpen={false} onClose={mockClose} />);
+      expect(queryByText('My Modal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('if isOpen is true', () => {
+    it('renders its children', () => {
+      const TestConnectedModal = connectModal(TestModal);
+      const { queryByText } = render(<TestConnectedModal isOpen onClose={mockClose} />);
+      expect(queryByText('My Modal')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('useModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('provides state and functions for opening/closing a modal', () => {
+    const { result } = renderHook(() => useModal());
+    expect(result.current.isOpen).toEqual(false);
+    expect(typeof result.current.openModal).toBe('function');
+    expect(typeof result.current.closeModal).toBe('function');
+
+    act(() => {
+      result.current.openModal();
+    });
+
+    expect(result.current.isOpen).toEqual(true);
+
+    act(() => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.isOpen).toEqual(false);
+  });
+});

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Modal.module.scss';
 
-import { Modal as USWDSModal, connectModal as connectUSWDSModal } from 'components/MigratedModal/MigratedModal';
+import { Modal as MigratedModal, connectModal as connectMigratedModal } from 'components/MigratedModal/MigratedModal';
 
 const Modal = ({ className, ...props }) => {
   const classes = classnames(styles.Modal, className);
@@ -32,7 +32,7 @@ const Modal = ({ className, ...props }) => {
     return () => {};
   });
 
-  return <USWDSModal className={classes} {...props} />;
+  return <MigratedModal className={classes} {...props} />;
 };
 
 Modal.displayName = 'MilMoveModal';
@@ -88,17 +88,17 @@ export const connectModal = (Component) => {
   }
 
   const ConnectedModal = (props) => {
-    // connectUSWDSModal handles isOpen prop & renders with container & overlay
-    const ConnectedUSWDSModal = connectUSWDSModal(Component);
+    // connectMigratedModal handles isOpen prop & renders with container & overlay
+    const ConnectedMigratedModal = connectMigratedModal(Component);
 
     // Render into portal element if it exists
     const MODAL_ROOT_ID = 'modal-root';
     const modalContainer = document.getElementById(MODAL_ROOT_ID);
     if (modalContainer) {
-      return ReactDOM.createPortal(<ConnectedUSWDSModal {...props} />, modalContainer);
+      return ReactDOM.createPortal(<ConnectedMigratedModal {...props} />, modalContainer);
     }
 
-    return <ConnectedUSWDSModal {...props} />;
+    return <ConnectedMigratedModal {...props} />;
   };
 
   ConnectedModal.displayName = `Connected${getDisplayName(Component)}`;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -3,10 +3,12 @@ import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Modal as USWDSModal, connectModal as connectUSWDSModal, Button } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import styles from './Modal.module.scss';
+
+import { Modal as USWDSModal, connectModal as connectUSWDSModal } from 'components/MigratedModal/MigratedModal';
 
 const Modal = ({ className, ...props }) => {
   const classes = classnames(styles.Modal, className);

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,7 +1,7 @@
 @import 'shared/styles/colors';
 @import 'shared/styles/_basics';
 
-.Modal {
+div.Modal {
   @include u-bg('white');
   @include u-padding-y(3);
   @include u-padding-x(4);

--- a/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
+++ b/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { Modal, Button, ModalContainer, Overlay } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as Yup from 'yup';
@@ -10,6 +10,7 @@ import styles from './RejectServiceItemModal.module.scss';
 
 import { Form } from 'components/form';
 import TextField from 'components/form/fields/TextField';
+import { Modal, ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import ServiceItemDetails from 'components/Office/ServiceItemDetails/ServiceItemDetails';
 import { formatDateFromIso } from 'shared/formatters';
 import { SERVICE_ITEM_STATUS } from 'shared/constants';

--- a/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.jsx
+++ b/src/components/Office/RequestShipmentCancellationModal/RequestShipmentCancellationModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Overlay, ModalContainer } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 
+import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import Modal, { ModalTitle, ModalClose, ModalActions, connectModal } from 'components/Modal/Modal';
 
 export const RequestShipmentCancellationModal = ({ onClose, onSubmit, shipmentInfo }) => (

--- a/src/components/Office/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview.jsx
@@ -1,4 +1,4 @@
-import { Button, Modal, ModalContainer, Overlay } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 import React, { Fragment } from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -12,6 +12,7 @@ import AllowancesList from 'components/Office/DefinitionLists/AllowancesList';
 import CustomerInfoList from 'components/Office/DefinitionLists/CustomerInfoList';
 import ShipmentContainer from 'components/Office/ShipmentContainer';
 import ShipmentServiceItemsTable from 'components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable';
+import { Modal, ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import { MTOShipmentShape, OrdersInfoShape } from 'types/order';
 import { formatAddress } from 'utils/shipmentDisplay';
 

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ModalContainer, Overlay } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 
+import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import Modal, { connectModal, ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 
 export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (


### PR DESCRIPTION
## Description

The `Modal` component in the React-USWDS library is deprecated, and will be removed with that library's 2.x release sometime in June.

This pull request:
1. wholesale ports the entire soon-to-be-deprecated component (including logic, stories, tests, and SCSS) into `/src/components/MigratedModal`, 
2. refactors it to match MM coding conventions, 
3. makes the stories look slightly prettier given the global styling in MM, 
4. and then updates the import targets of any components which had previously imported any (`Modal` or `Modal`-related subcomponent) from React-USWDS.

(The component is named as such because we already have a `Modal` component in `/src/components`, which primarily encapsulates the deprecated USWDS version. However, as other components in this project are also importing directly from the deprecated USWDS components, without the pre-existing wrapper, it didn't seem sensible to me to migrate this as a subcomponent of the existing MM `Modal`.)

## Reviewer Notes

* Ensure that everything looks good in storybook and Happo -- as we're just porting over the logic from one location to another, there should be no visual changes
* Ensure that all tests pass
* Ensure that the revised modals work within the relevant contexts of the application
* Ensure that all references to the deprecated `Modal` component and sub-components have been removed:
  * Clone `@trussworks/react-uswds` locally
  * In that repo, delete the entire directory of `/src/components/Modal`, and all content after `/** Truss-designed components */` in `/src/index.ts`
  * Run`yarn build` in that repo
  * In the MyMove repo, `yarn add ~/path/to/react-uswds`
  * Run `yarn storybook` and check that modal components load and operate correctly

## Setup

```sh
make client_run
```

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8079](https://dp3.atlassian.net/browse/MB-8079).