### PR TITLE
MB-8088 Cypress test services counselor flow

### DIFF
--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -48,6 +48,12 @@ describe('Office authorization', () => {
     cy.url().should('eq', officeBaseURL + '/');
   });
 
+  it('redirects Services Counselor to Services Counselor homepage', () => {
+    cy.signInAsNewServicesCounselorUser();
+    cy.contains('Moves');
+    cy.url().should('eq', officeBaseURL + '/');
+  });
+
   it('redirects PPM office user to old office queue', () => {
     cy.signInAsNewPPMOfficeUser();
     cy.contains('New moves');

--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -30,6 +30,9 @@ describe('Office Home Page', function () {
 describe('Office authorization', () => {
   before(() => {
     cy.prepareOfficeApp();
+    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc').as(
+      'getCounselingSortedOrders',
+    );
   });
 
   beforeEach(() => {
@@ -50,7 +53,10 @@ describe('Office authorization', () => {
 
   it('redirects Services Counselor to Services Counselor homepage', () => {
     cy.signInAsNewServicesCounselorUser();
+    cy.waitFor('@getCounselingSortedOrders');
+
     cy.contains('Moves');
+    cy.contains('Needs counseling');
     cy.url().should('eq', officeBaseURL + '/');
   });
 

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -1,0 +1,154 @@
+import { ServicesCounselorOfficeUserType } from 'cypress/support/constants';
+
+describe('Services counselor user', () => {
+  before(() => {
+    cy.prepareOfficeApp();
+  });
+
+  beforeEach(() => {
+    cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
+    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc').as('getSortedOrders');
+    // cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    // cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    // cy.intercept('**/ghc/v1/orders/**/move-task-orders').as('getMoveTaskOrders');
+    // cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
+    // cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
+    // cy.intercept('PATCH', '**/ghc/v1/move_task_orders/**/mto_shipments/**/status').as('patchMTOShipmentStatus');
+    // cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/status').as('patchMTOStatus');
+    // cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/service-items/**/status').as('patchMTOServiceItems');
+
+    const userId = 'a6c8663f-998f-4626-a978-ad60da2476ec';
+    cy.apiSignInAsUser(userId, ServicesCounselorOfficeUserType);
+  });
+  // it('is able to edit orders', () => {
+  //   const moveLocator = 'TEST12';
+  //
+  //   // TOO Moves queue
+  //   cy.wait(['@getSortedOrders']);
+  //   cy.contains(moveLocator).click();
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  //
+  //   // Move Details page
+  //   cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+  //
+  //   // Navigate to Edit orders page
+  //   cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
+  //
+  //   // Toggle between Edit Allowances and Edit Orders page
+  //   cy.get('[data-testid="view-allowances"]').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/allowances`);
+  //   cy.get('[data-testid="view-orders"]').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/orders`);
+  //
+  //   // Edit orders fields
+  //
+  //   cy.get('form').within(($form) => {
+  //     cy.get('[class*="-control"]')
+  //       .first()
+  //       .click(0, 0)
+  //       .type('Fort Irwin')
+  //       .get('[class*="-menu"]')
+  //       .find('[class*="-option"]')
+  //       .first()
+  //       .click(0, 0);
+  //
+  //     cy.get('[class*="-control"]')
+  //       .eq(1)
+  //       .click(0, 0)
+  //       .type('JB McGuire-Dix-Lakehurst')
+  //       .get('[class*="-menu"]')
+  //       .find('[class*="-option"]')
+  //       .eq(1)
+  //       .click(0, 0);
+  //
+  //     cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
+  //     cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
+  //     cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
+  //     cy.get('input[name="ordersNumber"]').click().clear().type('ORDER66');
+  //     cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
+  //     cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
+  //     cy.get('input[name="tac"]').click().clear().type('F123');
+  //     cy.get('input[name="sac"]').click().clear().type('4K988AS098F');
+  //
+  //     // Edit orders page | Save
+  //     cy.get('button').contains('Save').click();
+  //   });
+  //
+  //   // Verify edited values are saved
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  //   cy.get('[data-testid="currentDutyStation"]').contains('Fort Irwin');
+  //   cy.get('[data-testid="newDutyStation"]').contains('JB Lewis-McChord');
+  //   cy.get('[data-testid="issuedDate"]').contains('16 Mar 2018');
+  //   cy.get('[data-testid="reportByDate"]').contains('22 Mar 2018');
+  //   cy.get('[data-testid="departmentIndicator"]').contains('Army');
+  //   cy.get('[data-testid="ordersNumber"]').contains('ORDER66');
+  //   cy.get('[data-testid="ordersType"]').contains('Permanent Change Of Station (PCS)');
+  //   cy.get('[data-testid="ordersTypeDetail"]').contains('Shipment of HHG Permitted');
+  //   cy.get('[data-testid="tacMDC"]').contains('F123');
+  //   cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
+  //
+  //   // Edit orders page | Cancel
+  //   cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
+  //   cy.get('button').contains('Cancel').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  // });
+
+  // it('is able to edit allowances', () => {
+  //   const moveLocator = 'TEST12';
+  //
+  //   // TOO Moves queue
+  //   cy.wait(['@getSortedOrders']);
+  //   cy.contains(moveLocator).click();
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  //
+  //   // Move Details page
+  //   cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+  //
+  //   // Navigate to Edit allowances page
+  //   cy.get('[data-testid="edit-allowances"]').contains('Edit allowances').click();
+  //
+  //   // Toggle between Edit Allowances and Edit Orders page
+  //   cy.get('[data-testid="view-orders"]').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/orders`);
+  //   cy.get('[data-testid="view-allowances"]').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/allowances`);
+  //
+  //   cy.get('form').within(($form) => {
+  //     // Edit pro-gear, pro-gear spouse, RME, and OCIE fields
+  //     cy.get('input[name="proGearWeight"]').clear().type('1999');
+  //     cy.get('input[name="proGearWeightSpouse"]').clear().type('499');
+  //     cy.get('input[name="requiredMedicalEquipmentWeight"]').clear().type('999');
+  //     cy.get('input[name="organizationalClothingAndIndividualEquipment"]').click({ force: true });
+  //
+  //     // Edit grade and authorized weight
+  //     cy.get('select[name=agency]').contains('Army');
+  //     cy.get('select[name=agency]').select('Navy');
+  //     cy.get('select[name="grade"]').contains('E-1');
+  //     cy.get('select[name="grade"]').select('W-2');
+  //     cy.get('input[name="authorizedWeight"]').clear().type('11111');
+  //
+  //     //Edit DependentsAuthorized
+  //     cy.get('input[name="dependentsAuthorized"]').click({ force: true });
+  //
+  //     // Edit allowances page | Save
+  //     cy.get('button').contains('Save').click();
+  //   });
+  //
+  //   // Verify edited values are saved
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  //   cy.get('[data-testid="progear"]').contains('1,999');
+  //   cy.get('[data-testid="spouseProgear"]').contains('499');
+  //   cy.get('[data-testid="rme"]').contains('999');
+  //   cy.get('[data-testid="ocie"]').contains('Unauthorized');
+  //
+  //   cy.get('[data-testid="authorizedWeight"]').contains('11,111');
+  //   cy.get('[data-testid="branchRank"]').contains('Navy');
+  //   cy.get('[data-testid="branchRank"]').contains('W-2');
+  //   cy.get('[data-testid="dependents"]').contains('Unauthorized');
+  //
+  //   // Edit allowances page | Cancel
+  //   cy.get('[data-testid="edit-allowances"]').contains('Edit allowances').click();
+  //   cy.get('button').contains('Cancel').click();
+  //   cy.url().should('include', `/moves/${moveLocator}/details`);
+  // });
+});

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -23,7 +23,7 @@ describe('Services counselor user', () => {
     cy.apiSignInAsUser(userId, ServicesCounselorOfficeUserType);
   });
 
-  it('is able to click on move after using the move code filter', () => {
+  it('is able to click on move and submit after using the move code filter', () => {
     const moveLocator = 'SCE2ET';
 
     /**

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -1,4 +1,4 @@
-import { ServicesCounselorOfficeUserType } from 'cypress/support/constants';
+import { ServicesCounselorOfficeUserType } from '../../../support/constants';
 
 describe('Services counselor user', () => {
   before(() => {

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -22,135 +22,46 @@ describe('Services counselor user', () => {
     const userId = 'a6c8663f-998f-4626-a978-ad60da2476ec';
     cy.apiSignInAsUser(userId, ServicesCounselorOfficeUserType);
   });
-  // it('is able to edit orders', () => {
-  //   const moveLocator = 'TEST12';
-  //
-  //   // TOO Moves queue
-  //   cy.wait(['@getSortedOrders']);
-  //   cy.contains(moveLocator).click();
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  //
-  //   // Move Details page
-  //   cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
-  //
-  //   // Navigate to Edit orders page
-  //   cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
-  //
-  //   // Toggle between Edit Allowances and Edit Orders page
-  //   cy.get('[data-testid="view-allowances"]').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/allowances`);
-  //   cy.get('[data-testid="view-orders"]').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/orders`);
-  //
-  //   // Edit orders fields
-  //
-  //   cy.get('form').within(($form) => {
-  //     cy.get('[class*="-control"]')
-  //       .first()
-  //       .click(0, 0)
-  //       .type('Fort Irwin')
-  //       .get('[class*="-menu"]')
-  //       .find('[class*="-option"]')
-  //       .first()
-  //       .click(0, 0);
-  //
-  //     cy.get('[class*="-control"]')
-  //       .eq(1)
-  //       .click(0, 0)
-  //       .type('JB McGuire-Dix-Lakehurst')
-  //       .get('[class*="-menu"]')
-  //       .find('[class*="-option"]')
-  //       .eq(1)
-  //       .click(0, 0);
-  //
-  //     cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
-  //     cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
-  //     cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
-  //     cy.get('input[name="ordersNumber"]').click().clear().type('ORDER66');
-  //     cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
-  //     cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
-  //     cy.get('input[name="tac"]').click().clear().type('F123');
-  //     cy.get('input[name="sac"]').click().clear().type('4K988AS098F');
-  //
-  //     // Edit orders page | Save
-  //     cy.get('button').contains('Save').click();
-  //   });
-  //
-  //   // Verify edited values are saved
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  //   cy.get('[data-testid="currentDutyStation"]').contains('Fort Irwin');
-  //   cy.get('[data-testid="newDutyStation"]').contains('JB Lewis-McChord');
-  //   cy.get('[data-testid="issuedDate"]').contains('16 Mar 2018');
-  //   cy.get('[data-testid="reportByDate"]').contains('22 Mar 2018');
-  //   cy.get('[data-testid="departmentIndicator"]').contains('Army');
-  //   cy.get('[data-testid="ordersNumber"]').contains('ORDER66');
-  //   cy.get('[data-testid="ordersType"]').contains('Permanent Change Of Station (PCS)');
-  //   cy.get('[data-testid="ordersTypeDetail"]').contains('Shipment of HHG Permitted');
-  //   cy.get('[data-testid="tacMDC"]').contains('F123');
-  //   cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
-  //
-  //   // Edit orders page | Cancel
-  //   cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
-  //   cy.get('button').contains('Cancel').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  // });
 
-  // it('is able to edit allowances', () => {
-  //   const moveLocator = 'TEST12';
-  //
-  //   // TOO Moves queue
-  //   cy.wait(['@getSortedOrders']);
-  //   cy.contains(moveLocator).click();
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  //
-  //   // Move Details page
-  //   cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
-  //
-  //   // Navigate to Edit allowances page
-  //   cy.get('[data-testid="edit-allowances"]').contains('Edit allowances').click();
-  //
-  //   // Toggle between Edit Allowances and Edit Orders page
-  //   cy.get('[data-testid="view-orders"]').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/orders`);
-  //   cy.get('[data-testid="view-allowances"]').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/allowances`);
-  //
-  //   cy.get('form').within(($form) => {
-  //     // Edit pro-gear, pro-gear spouse, RME, and OCIE fields
-  //     cy.get('input[name="proGearWeight"]').clear().type('1999');
-  //     cy.get('input[name="proGearWeightSpouse"]').clear().type('499');
-  //     cy.get('input[name="requiredMedicalEquipmentWeight"]').clear().type('999');
-  //     cy.get('input[name="organizationalClothingAndIndividualEquipment"]').click({ force: true });
-  //
-  //     // Edit grade and authorized weight
-  //     cy.get('select[name=agency]').contains('Army');
-  //     cy.get('select[name=agency]').select('Navy');
-  //     cy.get('select[name="grade"]').contains('E-1');
-  //     cy.get('select[name="grade"]').select('W-2');
-  //     cy.get('input[name="authorizedWeight"]').clear().type('11111');
-  //
-  //     //Edit DependentsAuthorized
-  //     cy.get('input[name="dependentsAuthorized"]').click({ force: true });
-  //
-  //     // Edit allowances page | Save
-  //     cy.get('button').contains('Save').click();
-  //   });
-  //
-  //   // Verify edited values are saved
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  //   cy.get('[data-testid="progear"]').contains('1,999');
-  //   cy.get('[data-testid="spouseProgear"]').contains('499');
-  //   cy.get('[data-testid="rme"]').contains('999');
-  //   cy.get('[data-testid="ocie"]').contains('Unauthorized');
-  //
-  //   cy.get('[data-testid="authorizedWeight"]').contains('11,111');
-  //   cy.get('[data-testid="branchRank"]').contains('Navy');
-  //   cy.get('[data-testid="branchRank"]').contains('W-2');
-  //   cy.get('[data-testid="dependents"]').contains('Unauthorized');
-  //
-  //   // Edit allowances page | Cancel
-  //   cy.get('[data-testid="edit-allowances"]').contains('Edit allowances').click();
-  //   cy.get('button').contains('Cancel').click();
-  //   cy.url().should('include', `/moves/${moveLocator}/details`);
-  // });
+  it('is able to click on move after using the move code filter', () => {
+    const moveLocator = 'SCE2ET';
+
+    /**
+     * SC Moves queue
+     */
+    cy.wait(['@getSortedMoves']);
+    cy.get('input[name="locator"]').as('moveCodeFilterInput');
+
+    // type in move code/locator to filter
+    cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+    cy.wait(['@getFilterSortedMoves']);
+
+    // check if results appear, should be 1
+    // and see if result have move code
+    cy.get('tbody > tr').as('results');
+    cy.get('@results').should('have.length', 1);
+    cy.get('@results').first().contains(moveLocator);
+
+    // click result to navigate to move details page
+    cy.get('@results').first().click();
+    cy.url().should('include', `/counseling/moves/${moveLocator}/details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    /**
+     * Move Details page
+     */
+    // click to trigger confirmation modal
+    cy.contains('Submit move details').click();
+
+    // modal should pop up with text
+    cy.get('h2').contains('Are you sure?');
+    cy.get('p').contains('You can’t make changes after you submit the move.');
+
+    // click submit
+    cy.get('button').contains('Yes, submit').click();
+    cy.waitFor(['@patchServiceCounselingCompleted', '@getMoves']);
+
+    // verify success alert
+    cy.contains('Move submitted.');
+  });
 });

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -7,15 +7,17 @@ describe('Services counselor user', () => {
 
   beforeEach(() => {
     cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
-    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc').as('getSortedOrders');
-    // cy.intercept('**/ghc/v1/move/**').as('getMoves');
-    // cy.intercept('**/ghc/v1/orders/**').as('getOrders');
-    // cy.intercept('**/ghc/v1/orders/**/move-task-orders').as('getMoveTaskOrders');
-    // cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
-    // cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
-    // cy.intercept('PATCH', '**/ghc/v1/move_task_orders/**/mto_shipments/**/status').as('patchMTOShipmentStatus');
-    // cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/status').as('patchMTOStatus');
-    // cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/service-items/**/status').as('patchMTOServiceItems');
+    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc').as('getSortedMoves');
+    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc&locator=SCE2ET').as(
+      'getFilterSortedMoves',
+    );
+    cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
+    cy.intercept('**/ghc/v1/move-task-orders/**/status/service-counseling-completed').as(
+      'patchServiceCounselingCompleted',
+    );
 
     const userId = 'a6c8663f-998f-4626-a978-ad60da2476ec';
     cy.apiSignInAsUser(userId, ServicesCounselorOfficeUserType);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,6 +10,7 @@ import {
   PPMOfficeUserType,
   TOOOfficeUserType,
   TIOOfficeUserType,
+  ServicesCounselorOfficeUserType,
   longPageLoadTimeout,
 } from './constants';
 
@@ -94,6 +95,10 @@ Cypress.Commands.add('signInAsNewTOOUser', () => {
 
 Cypress.Commands.add('signInAsNewTIOUser', () => {
   cy.signInAsNewUser(TIOOfficeUserType);
+});
+
+Cypress.Commands.add('signInAsNewServicesCounselorUser', () => {
+  cy.signInAsNewUser(ServicesCounselorOfficeUserType);
 });
 
 Cypress.Commands.add('signInAsNewAdminUser', () => {

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -16,6 +16,7 @@ export const milmoveUserType = 'milmove';
 export const PPMOfficeUserType = 'PPM office';
 export const TOOOfficeUserType = 'TOO office';
 export const TIOOfficeUserType = 'TIO office';
+export const ServicesCounselorOfficeUserType = 'Services Counselor office';
 export const dpsUserType = 'dps';
 
 // User Types to Base URLs
@@ -25,5 +26,6 @@ userTypeToBaseURL[milmoveUserType] = milmoveBaseURL;
 userTypeToBaseURL[PPMOfficeUserType] = officeBaseURL;
 userTypeToBaseURL[TOOOfficeUserType] = officeBaseURL;
 userTypeToBaseURL[TIOOfficeUserType] = officeBaseURL;
+userTypeToBaseURL[ServicesCounselorOfficeUserType] = officeBaseURL;
 userTypeToBaseURL[dpsUserType] = milmoveBaseURL;
 /* eslint-enable security/detect-object-injection */

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -16,10 +16,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
-
-	"github.com/transcom/mymove/pkg/random"
-
 	"github.com/stretchr/testify/mock"
 
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_request"
@@ -3438,107 +3434,6 @@ func createHHGNeedsServicesCounseling(db *pop.Connection) {
 			Status:                models.MTOShipmentStatusSubmitted,
 			RequestedPickupDate:   &requestedPickupDate,
 			RequestedDeliveryDate: &requestedDeliveryDate,
-		},
-	})
-}
-
-func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, allDutyStations []models.DutyStation, dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) {
-	randDays, err := random.GetRandomInt(366)
-	if err != nil {
-		log.Panic(fmt.Errorf("Unable to generate random integer for submitted move date"), zap.Error(err))
-	}
-	submittedAt := time.Now().AddDate(0, 0, randDays*-1)
-
-	if assertions.ServiceMember.Affiliation == nil {
-		randomAffiliation, err := random.GetRandomInt(5)
-		if err != nil {
-			log.Panic(fmt.Errorf("Unable to generate random integer for affiliation"), zap.Error(err))
-		}
-		assertions.ServiceMember.Affiliation = &[]models.ServiceMemberAffiliation{
-			models.AffiliationARMY,
-			models.AffiliationAIRFORCE,
-			models.AffiliationNAVY,
-			models.AffiliationCOASTGUARD,
-			models.AffiliationMARINES}[randomAffiliation]
-	}
-
-	dutyStationCount := len(allDutyStations)
-	if assertions.Order.OriginDutyStationID == nil {
-		// We can pick any origin duty station not only one in the office user's GBLOC
-		if *assertions.ServiceMember.Affiliation == models.AffiliationMARINES {
-			randDutyStaionIndex, err := random.GetRandomInt(dutyStationCount)
-			if err != nil {
-				log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
-			}
-			assertions.Order.OriginDutyStation = &allDutyStations[randDutyStaionIndex]
-			assertions.Order.OriginDutyStationID = &assertions.Order.OriginDutyStation.ID
-		} else {
-			randDutyStaionIndex, err := random.GetRandomInt(len(dutyStationsInGBLOC))
-			if err != nil {
-				log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
-			}
-			assertions.Order.OriginDutyStation = &dutyStationsInGBLOC[randDutyStaionIndex]
-			assertions.Order.OriginDutyStationID = &assertions.Order.OriginDutyStation.ID
-		}
-	}
-
-	if assertions.Order.NewDutyStationID == uuid.Nil {
-		randDutyStaionIndex, err := random.GetRandomInt(dutyStationCount)
-		if err != nil {
-			log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
-		}
-		assertions.Order.NewDutyStation = allDutyStations[randDutyStaionIndex]
-		assertions.Order.NewDutyStationID = assertions.Order.NewDutyStation.ID
-	}
-
-	randomFirst, randomLast := fakedata.RandomName()
-	assertions.ServiceMember.FirstName = &randomFirst
-	assertions.ServiceMember.LastName = &randomLast
-
-	orders := testdatagen.MakeOrderWithoutDefaults(db, assertions)
-
-	if assertions.Move.SubmittedAt == nil {
-		assertions.Move.SubmittedAt = &submittedAt
-	}
-
-	if assertions.Move.Status == "" {
-		randStatusIndex, err := random.GetRandomInt(len(possibleStatuses))
-		if err != nil {
-			log.Panic(fmt.Errorf("Unable to generate random integer for move status"), zap.Error(err))
-		}
-		assertions.Move.Status = possibleStatuses[randStatusIndex]
-
-		if assertions.Move.Status == models.MoveStatusServiceCounselingCompleted {
-			counseledAt := submittedAt.Add(3 * 24 * time.Hour)
-			assertions.Move.ServiceCounselingCompletedAt = &counseledAt
-		}
-	}
-	move := testdatagen.MakeMove(db, testdatagen.Assertions{
-		Move:  assertions.Move,
-		Order: orders,
-	})
-
-	laterRequestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
-	laterRequestedDeliveryDate := laterRequestedPickupDate.Add(7 * 24 * time.Hour)
-	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		Move: move,
-		MTOShipment: models.MTOShipment{
-			ShipmentType:          models.MTOShipmentTypeHHG,
-			Status:                models.MTOShipmentStatusSubmitted,
-			RequestedPickupDate:   &laterRequestedPickupDate,
-			RequestedDeliveryDate: &laterRequestedDeliveryDate,
-		},
-	})
-
-	earlierRequestedPickupDate := submittedAt.Add(30 * 24 * time.Hour)
-	earlierRequestedDeliveryDate := earlierRequestedPickupDate.Add(7 * 24 * time.Hour)
-	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
-		Move: move,
-		MTOShipment: models.MTOShipment{
-			ShipmentType:          models.MTOShipmentTypeHHG,
-			Status:                models.MTOShipmentStatusSubmitted,
-			RequestedPickupDate:   &earlierRequestedPickupDate,
-			RequestedDeliveryDate: &earlierRequestedDeliveryDate,
 		},
 	})
 }

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1,7 +1,16 @@
 package scenario
 
 import (
+	"fmt"
+	"log"
 	"time"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
+	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/random"
 
 	"github.com/pkg/errors"
 
@@ -36,4 +45,106 @@ func save(db *pop.Connection, model interface{}) error {
 		return errors.Errorf("Validation errors encountered saving model: %v", verrs)
 	}
 	return nil
+}
+
+// createRandomMove creates a random move with fake data that has been approved for usage
+func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, allDutyStations []models.DutyStation, dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) {
+	randDays, err := random.GetRandomInt(366)
+	if err != nil {
+		log.Panic(fmt.Errorf("Unable to generate random integer for submitted move date"), zap.Error(err))
+	}
+	submittedAt := time.Now().AddDate(0, 0, randDays*-1)
+
+	if assertions.ServiceMember.Affiliation == nil {
+		randomAffiliation, err := random.GetRandomInt(5)
+		if err != nil {
+			log.Panic(fmt.Errorf("Unable to generate random integer for affiliation"), zap.Error(err))
+		}
+		assertions.ServiceMember.Affiliation = &[]models.ServiceMemberAffiliation{
+			models.AffiliationARMY,
+			models.AffiliationAIRFORCE,
+			models.AffiliationNAVY,
+			models.AffiliationCOASTGUARD,
+			models.AffiliationMARINES}[randomAffiliation]
+	}
+
+	dutyStationCount := len(allDutyStations)
+	if assertions.Order.OriginDutyStationID == nil {
+		// We can pick any origin duty station not only one in the office user's GBLOC
+		if *assertions.ServiceMember.Affiliation == models.AffiliationMARINES {
+			randDutyStaionIndex, err := random.GetRandomInt(dutyStationCount)
+			if err != nil {
+				log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
+			}
+			assertions.Order.OriginDutyStation = &allDutyStations[randDutyStaionIndex]
+			assertions.Order.OriginDutyStationID = &assertions.Order.OriginDutyStation.ID
+		} else {
+			randDutyStaionIndex, err := random.GetRandomInt(len(dutyStationsInGBLOC))
+			if err != nil {
+				log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
+			}
+			assertions.Order.OriginDutyStation = &dutyStationsInGBLOC[randDutyStaionIndex]
+			assertions.Order.OriginDutyStationID = &assertions.Order.OriginDutyStation.ID
+		}
+	}
+
+	if assertions.Order.NewDutyStationID == uuid.Nil {
+		randDutyStaionIndex, err := random.GetRandomInt(dutyStationCount)
+		if err != nil {
+			log.Panic(fmt.Errorf("Unable to generate random integer for duty station"), zap.Error(err))
+		}
+		assertions.Order.NewDutyStation = allDutyStations[randDutyStaionIndex]
+		assertions.Order.NewDutyStationID = assertions.Order.NewDutyStation.ID
+	}
+
+	randomFirst, randomLast := fakedata.RandomName()
+	assertions.ServiceMember.FirstName = &randomFirst
+	assertions.ServiceMember.LastName = &randomLast
+
+	orders := testdatagen.MakeOrderWithoutDefaults(db, assertions)
+
+	if assertions.Move.SubmittedAt == nil {
+		assertions.Move.SubmittedAt = &submittedAt
+	}
+
+	if assertions.Move.Status == "" {
+		randStatusIndex, err := random.GetRandomInt(len(possibleStatuses))
+		if err != nil {
+			log.Panic(fmt.Errorf("Unable to generate random integer for move status"), zap.Error(err))
+		}
+		assertions.Move.Status = possibleStatuses[randStatusIndex]
+
+		if assertions.Move.Status == models.MoveStatusServiceCounselingCompleted {
+			counseledAt := submittedAt.Add(3 * 24 * time.Hour)
+			assertions.Move.ServiceCounselingCompletedAt = &counseledAt
+		}
+	}
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move:  assertions.Move,
+		Order: orders,
+	})
+
+	laterRequestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
+	laterRequestedDeliveryDate := laterRequestedPickupDate.Add(7 * 24 * time.Hour)
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:          models.MTOShipmentTypeHHG,
+			Status:                models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:   &laterRequestedPickupDate,
+			RequestedDeliveryDate: &laterRequestedDeliveryDate,
+		},
+	})
+
+	earlierRequestedPickupDate := submittedAt.Add(30 * 24 * time.Hour)
+	earlierRequestedDeliveryDate := earlierRequestedPickupDate.Add(7 * 24 * time.Hour)
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:          models.MTOShipmentTypeHHG,
+			Status:                models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:   &earlierRequestedPickupDate,
+			RequestedDeliveryDate: &earlierRequestedDeliveryDate,
+		},
+	})
 }


### PR DESCRIPTION
## Description

This PR expands e2e tests around the services counselor flow on the office app. 

> AC:
> There is a cypress test that acts as the Services Counselor and steps through the SC flow ensuring that:
> 
> - SC can view the Services Counselor queue 
> 
> - SC can choose a move from the queue via the move code filter
> 
> - SC can submit the move and sees a modal confirmation
> 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- Moved the `createRandomMove` function to the shared.go file
- Re-used that `createRandomMove` function in the e2ebasic.go file to create the move for services counselor
- Let me know if you want a refactor of the `createRandomMove` function to use the service objects instead of the testdatagen since I know there's been talks about trying to make our e2e test to use the service objects more. I suspect if we truly want an e2e test data, that would be more work than using the service objects sporadically.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_test_reset
make e2e_test
```

Once cypress is up and running...
0. If you need to run the flow more than once it'll be good to back up the db first
0a. Run `make db_test_e2e_backup` to back up the db
1. Scroll down to the `Office` section
2. Click on `homepage.js` to start the test
3. Once done, go back to cypress and click on `servicesCounselingFlows.js`

If you need to restore the db just run `make db_test_e2e_restore` (make sure you run step 0a first before the test)

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8088) for this change