### PR TITLE
[MB-8170] Draft implementation of Proposal 2 for refactoring the paymentRequestStatusUpdator service

### DIFF
--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -60,7 +60,7 @@ func NewGhcAPIHandler(context handlers.HandlerContext) *ghcops.MymoveAPI {
 		PaymentRequestListFetcher: paymentrequest.NewPaymentRequestListFetcher(context.DB()),
 	}
 
-	ghcAPI.PaymentRequestsUpdatePaymentRequestStatusHandler = UpdatePaymentRequestStatusHandler{
+	ghcAPI.PaymentRequestsUpdatePaymentRequestStatusHandler = UpdateReviewedPaymentRequestStatusHandler{
 		HandlerContext:              context,
 		PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 		PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(context.DB()),

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -101,15 +101,15 @@ func (h GetPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentReque
 	return response
 }
 
-// UpdatePaymentRequestStatusHandler updates payment requests status
-type UpdatePaymentRequestStatusHandler struct {
+// UpdateReviewedPaymentRequestStatusHandler updates payment requests status
+type UpdateReviewedPaymentRequestStatusHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestStatusUpdater
 	services.PaymentRequestFetcher
 }
 
 // Handle updates payment requests status
-func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
+func (h UpdateReviewedPaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
 	if !session.IsOfficeUser() || !session.Roles.HasRole(roles.RoleTypeTIO) {

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -336,7 +336,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		})
 
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(&paymentRequest, nil).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(&paymentRequest, nil).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -370,7 +370,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		availablePaymentRequestID := availablePaymentRequest.ID
 
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(&availablePaymentRequest, nil).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(&availablePaymentRequest, nil).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(availablePaymentRequest, nil).Once()
@@ -401,7 +401,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request (500)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, errors.New("Something bad happened")).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, errors.New("Something bad happened")).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -429,7 +429,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request, not found (404)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.NewNotFoundError(paymentRequest.ID, "")).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.NewNotFoundError(paymentRequest.ID, "")).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -457,7 +457,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request, precondition failed (412)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.PreconditionFailedError{}).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.PreconditionFailedError{}).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -485,7 +485,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request, validation errors (422)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.NewInvalidInputError(paymentRequestID, nil, nil, "")).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.NewInvalidInputError(paymentRequestID, nil, nil, "")).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -223,7 +223,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 	})
 }
 
-func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
+func (suite *HandlerSuite) TestUpdateReviewedPaymentRequestStatusHandler() {
 	paymentRequestID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
 	officeUserUUID, _ := uuid.NewV4()
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true, OfficeUser: models.OfficeUser{ID: officeUserUUID}})
@@ -256,7 +256,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -286,7 +286,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -318,7 +318,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 				PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 			}
 
-			handler := UpdatePaymentRequestStatusHandler{
+			handler := UpdateReviewedPaymentRequestStatusHandler{
 				HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 				PaymentRequestStatusUpdater: statusUpdater,
 				PaymentRequestFetcher:       paymentRequestFetcher,
@@ -350,7 +350,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -384,7 +384,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(availablePaymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -415,7 +415,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -443,7 +443,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -471,7 +471,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -499,7 +499,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,

--- a/pkg/handlers/supportapi/api.go
+++ b/pkg/handlers/supportapi/api.go
@@ -58,7 +58,7 @@ func NewSupportAPIHandler(context handlers.HandlerContext) http.Handler {
 		internalmovetaskorder.NewInternalMoveTaskOrderCreator(context.DB()),
 	}
 
-	supportAPI.PaymentRequestUpdatePaymentRequestStatusHandler = UpdatePaymentRequestStatusHandler{
+	supportAPI.PaymentRequestUpdatePaymentRequestStatusHandler = UpdateReviewedPaymentRequestStatusHandler{
 		HandlerContext:              context,
 		PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 		PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(context.DB()),

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -30,15 +30,15 @@ import (
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 )
 
-// UpdatePaymentRequestStatusHandler updates payment requests status
-type UpdatePaymentRequestStatusHandler struct {
+// UpdateReviewedPaymentRequestStatusHandler updates payment requests status
+type UpdateReviewedPaymentRequestStatusHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestStatusUpdater
 	services.PaymentRequestFetcher
 }
 
 // Handle updates payment requests status
-func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
+func (h UpdateReviewedPaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
 

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -113,7 +113,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request (500)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, errors.New("Something bad happened")).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, errors.New("Something bad happened")).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -145,7 +145,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request, not found (404)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.NewNotFoundError(paymentRequest.ID, "")).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.NewNotFoundError(paymentRequest.ID, "")).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -174,7 +174,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 
 	suite.T().Run("unsuccessful status update of payment request, precondition failed (412)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.PreconditionFailedError{}).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.PreconditionFailedError{}).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -202,7 +202,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 	})
 	suite.T().Run("unsuccessful status update of payment request, conflict error (409)", func(t *testing.T) {
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(nil, services.ConflictError{}).Once()
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "reviewed").Return(nil, services.ConflictError{}).Once()
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(paymentRequest, nil).Once()
@@ -555,7 +555,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 	paymentRequestReviewedFetcher.On("FetchReviewedPaymentRequest", mock.Anything, mock.Anything).Return(reviewedPRs, nil)
 
 	paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-	paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(&paymentRequestForUpdate, nil)
+	paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "processed").Return(&paymentRequestForUpdate, nil)
 
 	paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 	paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(reviewedPRs[0], nil)
@@ -705,7 +705,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestReviewedFetcher.On("FetchReviewedPaymentRequest", mock.Anything, mock.Anything).Return(reviewedPRs, nil)
 
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(&paymentRequestForUpdate, nil)
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "processed").Return(&paymentRequestForUpdate, nil)
 
 		var nilPr models.PaymentRequest
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
@@ -745,7 +745,7 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestReviewedFetcher.On("FetchReviewedPaymentRequest", mock.Anything, mock.Anything).Return(nilReviewedPrs, errors.New("Reviewed Payment Requests notretrieved"))
 
 		paymentRequestStatusUpdater := &mocks.PaymentRequestStatusUpdater{}
-		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything).Return(&paymentRequestForUpdate, nil)
+		paymentRequestStatusUpdater.On("UpdatePaymentRequestStatus", mock.Anything, mock.Anything, "processed").Return(&paymentRequestForUpdate, nil)
 
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.Anything).Return(reviewedPRs[0], nil)

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
+func (suite *HandlerSuite) TestUpdateReviewedPaymentRequestStatusHandler() {
 	paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 	paymentRequestID := paymentRequest.ID
 
@@ -59,7 +59,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(suite.DB()),
@@ -92,7 +92,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder(suite.DB())
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(suite.DB()),
@@ -128,7 +128,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -160,7 +160,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -189,7 +189,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
@@ -217,7 +217,7 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		handler := UpdatePaymentRequestStatusHandler{
+		handler := UpdateReviewedPaymentRequestStatusHandler{
 			HandlerContext:              handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,

--- a/pkg/services/mocks/PaymentRequestStatusUpdater.go
+++ b/pkg/services/mocks/PaymentRequestStatusUpdater.go
@@ -12,13 +12,13 @@ type PaymentRequestStatusUpdater struct {
 	mock.Mock
 }
 
-// UpdatePaymentRequestStatus provides a mock function with given fields: paymentRequest, eTag
-func (_m *PaymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string) (*models.PaymentRequest, error) {
-	ret := _m.Called(paymentRequest, eTag)
+// UpdatePaymentRequestStatus provides a mock function with given fields: paymentRequest, eTag, statusType
+func (_m *PaymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string, statusType string) (*models.PaymentRequest, error) {
+	ret := _m.Called(paymentRequest, eTag, statusType)
 
 	var r0 *models.PaymentRequest
-	if rf, ok := ret.Get(0).(func(*models.PaymentRequest, string) *models.PaymentRequest); ok {
-		r0 = rf(paymentRequest, eTag)
+	if rf, ok := ret.Get(0).(func(*models.PaymentRequest, string, string) *models.PaymentRequest); ok {
+		r0 = rf(paymentRequest, eTag, statusType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.PaymentRequest)
@@ -26,8 +26,8 @@ func (_m *PaymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.PaymentRequest, string) error); ok {
-		r1 = rf(paymentRequest, eTag)
+	if rf, ok := ret.Get(1).(func(*models.PaymentRequest, string, string) error); ok {
+		r1 = rf(paymentRequest, eTag, statusType)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -37,7 +37,7 @@ type PaymentRequestReviewedFetcher interface {
 // PaymentRequestStatusUpdater is the exported interface for updating the status of a payment request
 //go:generate mockery --name PaymentRequestStatusUpdater
 type PaymentRequestStatusUpdater interface {
-	UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string) (*models.PaymentRequest, error)
+	UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string, statusType string) (*models.PaymentRequest, error)
 }
 
 // PaymentRequestUploadCreator is the exported interface for creating a payment request upload

--- a/pkg/services/payment_request/payment_request_status_updater.go
+++ b/pkg/services/payment_request/payment_request_status_updater.go
@@ -1,6 +1,8 @@
 package paymentrequest
 
 import (
+	"time"
+
 	"github.com/gobuffalo/validate/v3"
 	"github.com/pkg/errors"
 
@@ -23,26 +25,71 @@ func NewPaymentRequestStatusUpdater(builder paymentRequestStatusQueryBuilder) se
 	return &paymentRequestStatusUpdater{builder}
 }
 
-func (p *paymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string) (*models.PaymentRequest, error) {
+func (p *paymentRequestStatusUpdater) UpdatePaymentRequestStatus(paymentRequest *models.PaymentRequest, eTag string, statusType string) (*models.PaymentRequest, error) {
 	id := paymentRequest.ID
 	status := paymentRequest.Status
 
-	// Prevent changing status to REVIEWED if any service items are not reviewed
-	if status == models.PaymentRequestStatusReviewed {
-		var paymentServiceItems models.PaymentServiceItems
-		serviceItemFilter := []services.QueryFilter{
-			query.NewQueryFilter("payment_request_id", "=", id),
-			query.NewQueryFilter("status", "=", models.PaymentServiceItemStatusRequested),
-		}
-		error := p.builder.FetchMany(&paymentServiceItems, serviceItemFilter, nil, nil, nil)
+	if statusType == "reviewed" {
+		// Prevent changing status to REVIEWED if any service items are not reviewed
+		if status == models.PaymentRequestStatusReviewed {
+			var paymentServiceItems models.PaymentServiceItems
+			serviceItemFilter := []services.QueryFilter{
+				query.NewQueryFilter("payment_request_id", "=", id),
+				query.NewQueryFilter("status", "=", models.PaymentServiceItemStatusRequested),
+			}
+			error := p.builder.FetchMany(&paymentServiceItems, serviceItemFilter, nil, nil, nil)
 
-		if error != nil {
-			return nil, error
+			if error != nil {
+				return nil, error
+			}
+
+			if len(paymentServiceItems) > 0 {
+				return nil, services.NewConflictError(id, "All PaymentServiceItems must be approved or denied to review this PaymentRequest")
+			}
+		}
+		// Payment request being updated with the UpdateReviewedPaymentRequestStatus can only be:
+		// REVIEWED or REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED
+		if status != models.PaymentRequestStatusReviewed && status != models.PaymentRequestStatusReviewedAllRejected {
+			return nil, services.NewInvalidInputError(id, nil, nil, "Payment Request status can only be updated to REVIEWED or REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED")
 		}
 
-		if len(paymentServiceItems) > 0 {
-			return nil, services.NewConflictError(id, "All PaymentServiceItems must be approved or denied to review this PaymentRequest")
+		now := time.Now()
+		paymentRequest.ReviewedAt = &now
+	} else if statusType == "processed" {
+		// Payment request being updated with the UpdateProcessedPaymentRequestStatus can only be:
+		// SENT_TO_GEX, RECEIVED_BY_GEX, EDI_ERROR and PAID
+		if status != models.PaymentRequestStatusSentToGex && status != models.PaymentRequestStatusEDIError &&
+			status != models.PaymentRequestStatusReceivedByGex && status != models.PaymentRequestStatusPaid {
+			return nil, services.NewInvalidInputError(id, nil, nil, "Payment Request status can only be updated to SENT_TO_GEX, RECEIVED_BY_GEX, EDI_ERROR or PAID")
 		}
+
+		var recGexDate time.Time
+		var sentGexDate time.Time
+		var paidAtDate time.Time
+
+		if paymentRequest.ReceivedByGexAt != nil {
+			recGexDate = *paymentRequest.ReceivedByGexAt
+		}
+		if paymentRequest.SentToGexAt != nil {
+			sentGexDate = *paymentRequest.SentToGexAt
+		}
+		if paymentRequest.PaidAt != nil {
+			paidAtDate = *paymentRequest.PaidAt
+		}
+
+		switch status {
+		case models.PaymentRequestStatusSentToGex:
+			sentGexDate = time.Now()
+			paymentRequest.SentToGexAt = &sentGexDate
+		case models.PaymentRequestStatusReceivedByGex:
+			recGexDate = time.Now()
+			paymentRequest.ReceivedByGexAt = &recGexDate
+		case models.PaymentRequestStatusPaid:
+			paidAtDate = time.Now()
+			paymentRequest.PaidAt = &paidAtDate
+		}
+	} else {
+		return nil, services.NewInvalidInputError(id, nil, nil, "A valid status type of reviewed or processed is required")
 	}
 
 	var verrs *validate.Errors


### PR DESCRIPTION
## Description

This PR  is a draft PR to illustrate the second proposed way of refactoring the paymentRequestStatusUpdater service. More context on both proposals can be found in the [discovery doc](https://docs.google.com/document/d/1FocswpJeJC-hvGntm7tbE77OnCGo3QgAM4j-ifPpPBQ/edit?pli=1).

The desire(need?) to refactor paymementRequestStatusUpdator service  was identified in a PR to address a [bug](https://github.com/transcom/mymove/pull/6660#discussion_r636189811) where the GHC API was allowing payment request status updates to SENT_TO_GEX, EDI_ERROR, RECEIVED_BY_GEX and PAID. We only ever want payment request to be updated to those statuses via our [job runner](https://github.com/transcom/mymove/blob/master/pkg/services/payment_request/payment_request_reviewed_processor.go). This also adheres to a guideline of removing logic from handlers

This PR adds a new parameter called statusType. If "reviewed" is passed in the service implements checks to ensure the status is only updated to REVIEWED or REVIEWED_AND_ALL_SERVICE_ITEMS_REJECTED and if "processed" is passed in it ensures the status is only updated to SENT_TO_GEX, RECEIVED_BY_GEX, EDI_ERROR or PAID (the statuses relevant to the payment request processor/job runner). 


## Reviewer Notes

- the statusType is a string "reviewed" or "processed". If this approach is taken, the PR can be updated to create a statusType type to use instead of hard coded strings 
- this pr is the second proposal for refactoring the paymentRequestStatusUpdater service. The first proposal can be found here 

## Set up

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make server_test
```

You can also trigger the job runner to check that the payment request status changes to SENT_TO_GEX

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8170) for this change
* [discovery doc](https://docs.google.com/document/d/1FocswpJeJC-hvGntm7tbE77OnCGo3QgAM4j-ifPpPBQ/edit?pli=1) 