### PR TITLE
MB-8173 Add secondary pickup address to customer return info

### DIFF
--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -7,6 +7,9 @@ import (
 	"path"
 	"path/filepath"
 	"runtime/debug"
+	"time"
+
+	"github.com/go-openapi/strfmt"
 
 	"github.com/gofrs/uuid"
 
@@ -228,4 +231,17 @@ func (suite *BaseHandlerTestSuite) Fixture(name string) *runtime.File {
 	suite.CloseFile(returnFile)
 
 	return returnFile
+}
+
+// EqualDatePtr compares the time.Time from the model with the strfmt.date from the payload
+// If one is nil, both should be nil, else they should match in value
+// This is to be strictly used for dates as it drops any time parameters in the comparison
+func (suite *BaseHandlerTestSuite) EqualDatePtr(expected *time.Time, actual *strfmt.Date) {
+	if expected == nil || actual == nil {
+		suite.Nil(expected)
+		suite.Nil(actual)
+	} else {
+		isoDate := "2006-01-02" // Create a date format
+		suite.Equal(expected.Format(isoDate), time.Time(*actual).Format(isoDate))
+	}
 }

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -3,9 +3,6 @@ package internalapi
 import (
 	"log"
 	"testing"
-	"time"
-
-	"github.com/go-openapi/strfmt"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 
@@ -55,17 +52,4 @@ func TestHandlerSuite(t *testing.T) {
 
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()
-}
-
-// EqualDatePtr compares the time.Time from the model with the strfmt.date from the payload
-// If one is nil, both should be nil, else they should match in value
-// This is to be strictly used for dates as it drops any time parameters in the comparison
-func (suite *HandlerSuite) EqualDatePtr(expected *time.Time, actual *strfmt.Date) {
-	if expected == nil || actual == nil {
-		suite.Nil(expected)
-		suite.Nil(actual)
-	} else {
-		isoDate := "2006-01-02" // Create a date format
-		suite.Equal(expected.Format(isoDate), time.Time(*actual).Format(isoDate))
-	}
 }

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -3,6 +3,9 @@ package internalapi
 import (
 	"log"
 	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 
@@ -52,4 +55,17 @@ func TestHandlerSuite(t *testing.T) {
 
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()
+}
+
+// EqualDatePtr compares the time.Time from the model with the strfmt.date from the payload
+// If one is nil, both should be nil, else they should match in value
+// This is to be strictly used for dates as it drops any time parameters in the comparison
+func (suite *HandlerSuite) EqualDatePtr(expected *time.Time, actual *strfmt.Date) {
+	if expected == nil || actual == nil {
+		suite.Nil(expected)
+		suite.Nil(actual)
+	} else {
+		isoDate := "2006-01-02" // Create a date format
+		suite.Equal(expected.Format(isoDate), time.Time(*actual).Format(isoDate))
+	}
 }

--- a/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
@@ -67,17 +67,18 @@ func MTOAgents(mtoAgents *models.MTOAgents) *internalmessages.MTOAgents {
 // MTOShipment payload
 func MTOShipment(mtoShipment *models.MTOShipment) *internalmessages.MTOShipment {
 	payload := &internalmessages.MTOShipment{
-		ID:                 strfmt.UUID(mtoShipment.ID.String()),
-		Agents:             *MTOAgents(&mtoShipment.MTOAgents),
-		MoveTaskOrderID:    strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-		ShipmentType:       internalmessages.MTOShipmentType(mtoShipment.ShipmentType),
-		CustomerRemarks:    mtoShipment.CustomerRemarks,
-		PickupAddress:      Address(mtoShipment.PickupAddress),
-		DestinationAddress: Address(mtoShipment.DestinationAddress),
-		CreatedAt:          strfmt.DateTime(mtoShipment.CreatedAt),
-		UpdatedAt:          strfmt.DateTime(mtoShipment.UpdatedAt),
-		Status:             internalmessages.MTOShipmentStatus(mtoShipment.Status),
-		ETag:               etag.GenerateEtag(mtoShipment.UpdatedAt),
+		ID:                     strfmt.UUID(mtoShipment.ID.String()),
+		Agents:                 *MTOAgents(&mtoShipment.MTOAgents),
+		MoveTaskOrderID:        strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
+		ShipmentType:           internalmessages.MTOShipmentType(mtoShipment.ShipmentType),
+		CustomerRemarks:        mtoShipment.CustomerRemarks,
+		PickupAddress:          Address(mtoShipment.PickupAddress),
+		SecondaryPickupAddress: Address(mtoShipment.SecondaryPickupAddress),
+		DestinationAddress:     Address(mtoShipment.DestinationAddress),
+		CreatedAt:              strfmt.DateTime(mtoShipment.CreatedAt),
+		UpdatedAt:              strfmt.DateTime(mtoShipment.UpdatedAt),
+		Status:                 internalmessages.MTOShipmentStatus(mtoShipment.Status),
+		ETag:                   etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 
 	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -501,7 +501,7 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 
 	requestedPickupDate := time.Date(testdatagen.GHCTestYear, time.September, 15, 0, 0, 0, 0, time.UTC)
 
-	altPickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
+	pickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
 	secondaryPickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
 		Address: models.Address{
 			StreetAddress1: "123 Nowhere",
@@ -513,16 +513,17 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			Country:        swag.String("US"),
 		},
 	})
-	altDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
+
+	deliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
 
 	mtoShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		MTOShipment: models.MTOShipment{
 			Status:                 models.MTOShipmentStatusSubmitted,
 			RequestedPickupDate:    &requestedPickupDate,
-			PickupAddress:          &altPickupAddress,
+			PickupAddress:          &pickupAddress,
 			SecondaryPickupAddress: &secondaryPickupAddress,
-			DestinationAddress:     &altDeliveryAddress,
+			DestinationAddress:     &deliveryAddress,
 		},
 	})
 

--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -3,11 +3,9 @@ package primeapi
 import (
 	"log"
 	"testing"
-	"time"
 
 	"github.com/transcom/mymove/pkg/testingsuite"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -89,17 +87,4 @@ func (suite *HandlerSuite) EqualAddressPayload(expected *primemessages.Address, 
 	suite.Equal(expected.State, actual.State)
 	suite.Equal(expected.PostalCode, actual.PostalCode)
 	suite.Equal(expected.Country, actual.Country)
-}
-
-// EqualDatePtr compares the time.Time from the model with the strfmt.date from the payload
-// If one is nil, both should be nil, else they should match in value
-// This is to be strictly used for dates as it drops any time parameters in the comparison
-func (suite *HandlerSuite) EqualDatePtr(expected *time.Time, actual *strfmt.Date) {
-	if expected == nil || actual == nil {
-		suite.Nil(expected)
-		suite.Nil(actual)
-	} else {
-		isoDate := "2006-01-02" // Create a date format
-		suite.Equal(expected.Format(isoDate), time.Time(*actual).Format(isoDate))
-	}
 }


### PR DESCRIPTION
## Description

We want shipments that are returned is customer responses to include the secondary pickup address so this adds it to the model_to_payload function. The yaml file already defined the responses as having this in there, so I didn't need to change that.

## Reviewer Notes

Is the way I moved `EqualDatePtr` ok? It's a nice thing to have for internal too, and likely ghc, so I figure this is better in a shared spot rather than each having their own version.

I also was looking at potentially modifying the tests for Add/Edit because they also should return the shipment with the secondary pickup address included, but the way they're written now, I think it might be easier to just handle that in the story where we'll update the handlers to accept secondary pickup address. What do you think?

## Setup

1. Run server and customer client

    ```sh
    make server_run
    ```
    ```sh
    make client_run
    ```

2. Log in as a customer who has a secondary pickup address (I used the HHG only one to test because it gets generated with a secondary pickup address already).
3. Check the network tab and look for the `mto_shipments` request. 
4. Look at the response and see that secondary pickup address is now part of the response.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8173) for this change