### PR TITLE
MB-8176 return additional destination addresses to customer

### DIFF
--- a/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/internalapi/internal/payloads/model_to_payload.go
@@ -67,18 +67,19 @@ func MTOAgents(mtoAgents *models.MTOAgents) *internalmessages.MTOAgents {
 // MTOShipment payload
 func MTOShipment(mtoShipment *models.MTOShipment) *internalmessages.MTOShipment {
 	payload := &internalmessages.MTOShipment{
-		ID:                     strfmt.UUID(mtoShipment.ID.String()),
-		Agents:                 *MTOAgents(&mtoShipment.MTOAgents),
-		MoveTaskOrderID:        strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-		ShipmentType:           internalmessages.MTOShipmentType(mtoShipment.ShipmentType),
-		CustomerRemarks:        mtoShipment.CustomerRemarks,
-		PickupAddress:          Address(mtoShipment.PickupAddress),
-		SecondaryPickupAddress: Address(mtoShipment.SecondaryPickupAddress),
-		DestinationAddress:     Address(mtoShipment.DestinationAddress),
-		CreatedAt:              strfmt.DateTime(mtoShipment.CreatedAt),
-		UpdatedAt:              strfmt.DateTime(mtoShipment.UpdatedAt),
-		Status:                 internalmessages.MTOShipmentStatus(mtoShipment.Status),
-		ETag:                   etag.GenerateEtag(mtoShipment.UpdatedAt),
+		ID:                       strfmt.UUID(mtoShipment.ID.String()),
+		Agents:                   *MTOAgents(&mtoShipment.MTOAgents),
+		MoveTaskOrderID:          strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
+		ShipmentType:             internalmessages.MTOShipmentType(mtoShipment.ShipmentType),
+		CustomerRemarks:          mtoShipment.CustomerRemarks,
+		PickupAddress:            Address(mtoShipment.PickupAddress),
+		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
+		DestinationAddress:       Address(mtoShipment.DestinationAddress),
+		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
+		CreatedAt:                strfmt.DateTime(mtoShipment.CreatedAt),
+		UpdatedAt:                strfmt.DateTime(mtoShipment.UpdatedAt),
+		Status:                   internalmessages.MTOShipmentStatus(mtoShipment.Status),
+		ETag:                     etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 
 	if mtoShipment.RequestedPickupDate != nil && !mtoShipment.RequestedPickupDate.IsZero() {

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -514,15 +514,27 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		},
 	})
 	altDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
+	secondaryDeliveryAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			StreetAddress1: "5432 Everywhere",
+			StreetAddress2: swag.String("P.O. Box 111"),
+			StreetAddress3: swag.String("c/o Some Other Person"),
+			City:           "Portsmouth",
+			State:          "NH",
+			PostalCode:     "03801",
+			Country:        swag.String("US"),
+		},
+	})
 
 	mtoShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 		Move: mto,
 		MTOShipment: models.MTOShipment{
-			Status:                 models.MTOShipmentStatusSubmitted,
-			RequestedPickupDate:    &requestedPickupDate,
-			PickupAddress:          &altPickupAddress,
-			SecondaryPickupAddress: &secondaryPickupAddress,
-			DestinationAddress:     &altDeliveryAddress,
+			Status:                   models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:      &requestedPickupDate,
+			PickupAddress:            &altPickupAddress,
+			SecondaryPickupAddress:   &secondaryPickupAddress,
+			DestinationAddress:       &altDeliveryAddress,
+			SecondaryDeliveryAddress: &secondaryDeliveryAddress,
 		},
 	})
 
@@ -588,6 +600,13 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 			suite.Equal(expectedShipment.DestinationAddress.City, *returnedShipment.DestinationAddress.City)
 			suite.Equal(expectedShipment.DestinationAddress.State, *returnedShipment.DestinationAddress.State)
 			suite.Equal(expectedShipment.DestinationAddress.PostalCode, *returnedShipment.DestinationAddress.PostalCode)
+
+			suite.Equal(expectedShipment.SecondaryDeliveryAddress.StreetAddress1, *returnedShipment.SecondaryDeliveryAddress.StreetAddress1)
+			suite.Equal(*expectedShipment.SecondaryDeliveryAddress.StreetAddress2, *returnedShipment.SecondaryDeliveryAddress.StreetAddress2)
+			suite.Equal(*expectedShipment.SecondaryDeliveryAddress.StreetAddress3, *returnedShipment.SecondaryDeliveryAddress.StreetAddress3)
+			suite.Equal(expectedShipment.SecondaryDeliveryAddress.City, *returnedShipment.SecondaryDeliveryAddress.City)
+			suite.Equal(expectedShipment.SecondaryDeliveryAddress.State, *returnedShipment.SecondaryDeliveryAddress.State)
+			suite.Equal(expectedShipment.SecondaryDeliveryAddress.PostalCode, *returnedShipment.SecondaryDeliveryAddress.PostalCode)
 		}
 	})
 


### PR DESCRIPTION
## Description

We want shipments that are returned is customer responses to include the secondary delivery address so this adds it to the model_to_payload function. The yaml file already defined the responses as having this in there, so I didn't need to change that.


## Setup

```sh
make server_run
make client_run
```

1. Log in as a customer who has a secondary pickup address (I used the HHG only one to test because it gets generated with a secondary pickup address already).

2. Check the network tab and look for the mto_shipments request.

3. Look at the response and see that secondary pickup address is now part of the response.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8176) for this change



