### PR TITLE
[MB-3669]  use zip3 when determining line haul vs short haul

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
@@ -55,7 +55,10 @@ func (r DistanceZip3Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
-	if distanceMiles >= 50 {
+	pickupZip3 := pickupZip[:3]
+	destinationZip3 := destinationZip[:3]
+
+	if pickupZip3 != destinationZip3 {
 		miles := unit.Miles(distanceMiles)
 		mtoShipment.Distance = &miles
 		err = db.Save(&mtoShipment)

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
@@ -2,6 +2,7 @@ package serviceparamvaluelookups
 
 import (
 	"database/sql"
+	"fmt"
 	"strconv"
 
 	"github.com/gofrs/uuid"
@@ -55,9 +56,12 @@ func (r DistanceZip3Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
+	if len(pickupZip) != 5 || len(destinationZip) != 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup and destination zip codes"), nil, "")
+	}
+
 	pickupZip3 := pickupZip[:3]
 	destinationZip3 := destinationZip[:3]
-
 	if pickupZip3 != destinationZip3 {
 		miles := unit.Miles(distanceMiles)
 		mtoShipment.Distance = &miles

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
@@ -56,11 +56,13 @@ func (r DistanceZip3Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
+	errorMsgForPickupZip := fmt.Sprintf("Shipment must have valid pickup zipcode. Received: %s", pickupZip)
+	errorMsgForDestinationZip := fmt.Sprintf("Shipment must have valid destination zipcode. Received: %s", destinationZip)
 	if len(pickupZip) < 5 {
-		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup zipcode. Received: %s", pickupZip), nil, fmt.Sprintf("Shipment must have valid pickup zipcode. Received: %s", pickupZip))
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf(errorMsgForPickupZip), nil, errorMsgForPickupZip)
 	}
 	if len(destinationZip) < 5 {
-		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid destination zipcode. Received: %s", destinationZip), nil, fmt.Sprintf("Shipment must have valid destination zipcode. Received: %s", destinationZip))
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf(errorMsgForDestinationZip), nil, errorMsgForDestinationZip)
 	}
 
 	pickupZip3 := pickupZip[:3]

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
@@ -56,8 +56,11 @@ func (r DistanceZip3Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
-	if len(pickupZip) != 5 || len(destinationZip) != 5 {
-		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup and destination zip codes"), nil, "")
+	if len(pickupZip) < 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup zipcode. Received: %s", pickupZip), nil, fmt.Sprintf("Shipment must have valid pickup zipcode. Received: %s", pickupZip))
+	}
+	if len(destinationZip) < 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid destination zipcode. Received: %s", destinationZip), nil, fmt.Sprintf("Shipment must have valid destination zipcode. Received: %s", destinationZip))
 	}
 
 	pickupZip3 := pickupZip[:3]

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
@@ -1,12 +1,3 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
-// nolint:errcheck
 package serviceparamvaluelookups
 
 import (
@@ -53,7 +44,8 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Equal(expected, distanceStr)
 
 		var mtoShipment models.MTOShipment
-		suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		err = suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		suite.NoError(err)
 
 		suite.Equal(unit.Miles(defaultZip3Distance), *mtoShipment.Distance)
 	})
@@ -90,7 +82,8 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Equal(expected, distanceStr)
 
 		var mtoShipment models.MTOShipment
-		suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		err = suite.DB().Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		suite.NoError(err)
 		suite.Nil(mtoShipment.Distance)
 	})
 
@@ -166,7 +159,8 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Equal(expected, distanceStr)
 
 		var mtoShipment models.MTOShipment
-		suite.DB().Find(&mtoShipment, mtoServiceItemDLH.MTOShipmentID)
+		err = suite.DB().Find(&mtoShipment, mtoServiceItemDLH.MTOShipmentID)
+		suite.NoError(err)
 
 		suite.Equal(unit.Miles(defaultZip3Distance), *mtoShipment.Distance)
 

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
@@ -168,4 +168,33 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		paramCacheValue := paramCache.ParamValue(*mtoServiceItemDLH.MTOShipmentID, key)
 		suite.Equal(expected, *paramCacheValue)
 	})
+
+	suite.T().Run("returns invalid input error if the pickup or destination zips aren't 5 digits", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+					Address: models.Address{
+						PostalCode: "33",
+					},
+				}),
+				DestinationAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+					Address: models.Address{
+						PostalCode: "90103434",
+					},
+				}),
+			}),
+		})
+
+		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: mtoServiceItem.MoveTaskOrder,
+			})
+
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+
+		_, err = paramLookup.ServiceParamValue(key)
+		suite.Error(err)
+		suite.Contains(err.Error(), "Invalid Input")
+	})
 }

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
@@ -2,6 +2,7 @@ package serviceparamvaluelookups
 
 import (
 	"database/sql"
+	"fmt"
 	"strconv"
 
 	"github.com/gofrs/uuid"
@@ -53,6 +54,10 @@ func (r DistanceZip5Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 	distanceMiles, err := planner.Zip5TransitDistance(pickupZip, destinationZip)
 	if err != nil {
 		return "", err
+	}
+
+	if len(pickupZip) != 5 || len(destinationZip) != 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup and destination zip codes"), nil, "")
 	}
 
 	pickupZip3 := pickupZip[:3]

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
@@ -56,8 +56,11 @@ func (r DistanceZip5Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
-	if len(pickupZip) != 5 || len(destinationZip) != 5 {
-		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup and destination zip codes"), nil, "")
+	if len(pickupZip) < 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid pickup zipcode. Received: %s", pickupZip), nil, fmt.Sprintf("Shipment must have valid pickup zipcode. Received: %s", pickupZip))
+	}
+	if len(destinationZip) < 5 {
+		return "", services.NewInvalidInputError(*mtoServiceItem.MTOShipmentID, fmt.Errorf("Shipment must have valid destination zipcode. Received: %s", destinationZip), nil, fmt.Sprintf("Shipment must have valid destination zipcode. Received: %s", destinationZip))
 	}
 
 	pickupZip3 := pickupZip[:3]

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup.go
@@ -55,7 +55,10 @@ func (r DistanceZip5Lookup) lookup(keyData *ServiceItemParamKeyData) (string, er
 		return "", err
 	}
 
-	if distanceMiles < 50 {
+	pickupZip3 := pickupZip[:3]
+	destinationZip3 := destinationZip[:3]
+
+	if pickupZip3 == destinationZip3 {
 		miles := unit.Miles(distanceMiles)
 		mtoShipment.Distance = &miles
 		err := db.Save(&mtoShipment)

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
@@ -1,6 +1,7 @@
 package serviceparamvaluelookups
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -27,7 +28,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 				}),
 			}),
 		})
-
+		fmt.Printf("dafs")
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 			testdatagen.Assertions{
 				Move: mtoServiceItem.MoveTaskOrder,
@@ -42,17 +43,9 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		suite.Equal(expected, distanceStr)
 
 		var mtoShipment models.MTOShipment
-		//RA Summary: gosec - errcheck - Unchecked return value
-		//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-		//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-		//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-		//RA: in a unit test, then there is no risk
-		//RA Developer Status: Mitigated
-		//RA Validator Status: Mitigated
-		//RA Modified Severity: N/A
-		// nolint:errcheck
-		suite.DB().
+		err = suite.DB().
 			Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		suite.NoError(err)
 		suite.Equal(unit.Miles(defaultZip5Distance), *mtoShipment.Distance)
 	})
 
@@ -86,17 +79,9 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		suite.Equal(expected, distanceStr)
 
 		var mtoShipment models.MTOShipment
-		//RA Summary: gosec - errcheck - Unchecked return value
-		//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-		//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-		//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-		//RA: in a unit test, then there is no risk
-		//RA Developer Status: Mitigated
-		//RA Validator Status: Mitigated
-		//RA Modified Severity: N/A
-		// nolint:errcheck
-		suite.DB().
+		err = suite.DB().
 			Find(&mtoShipment, mtoServiceItem.MTOShipmentID)
+		suite.NoError(err)
 		suite.Nil(mtoShipment.Distance)
 	})
 }


### PR DESCRIPTION
## Description

This PR updates our distanceZip3 and DistanceZip5 lookups to no longer use `50 miles` as the discriminator between linehaul and shorthaul. Instead the check should is if the zip3 is the same.

If pickup zip3 == destination zip3 --> shorthaul
If pickup zip3 != destination zip3 --> linehaul

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3669) for this change