### PR TITLE
MB-8154 Update customer api endpoints to allow setting/editing secondary pickup address

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3732,6 +3732,9 @@ func init() {
           "type": "string",
           "format": "date"
         },
+        "secondaryPickupAddress": {
+          "$ref": "#/definitions/Address"
+        },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
         }
@@ -6272,6 +6275,9 @@ func init() {
         "requestedPickupDate": {
           "type": "string",
           "format": "date"
+        },
+        "secondaryPickupAddress": {
+          "$ref": "#/definitions/Address"
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
@@ -10216,6 +10222,9 @@ func init() {
           "type": "string",
           "format": "date"
         },
+        "secondaryPickupAddress": {
+          "$ref": "#/definitions/Address"
+        },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
         }
@@ -12778,6 +12787,9 @@ func init() {
         "requestedPickupDate": {
           "type": "string",
           "format": "date"
+        },
+        "secondaryPickupAddress": {
+          "$ref": "#/definitions/Address"
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"

--- a/pkg/gen/internalmessages/create_shipment.go
+++ b/pkg/gen/internalmessages/create_shipment.go
@@ -42,6 +42,9 @@ type CreateShipment struct {
 	// Format: date
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
+	// secondary pickup address
+	SecondaryPickupAddress *Address `json:"secondaryPickupAddress,omitempty"`
+
 	// shipment type
 	// Required: true
 	ShipmentType MTOShipmentType `json:"shipmentType"`
@@ -72,6 +75,10 @@ func (m *CreateShipment) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRequestedPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSecondaryPickupAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -171,6 +178,24 @@ func (m *CreateShipment) validateRequestedPickupDate(formats strfmt.Registry) er
 
 	if err := validate.FormatOf("requestedPickupDate", "body", "date", m.RequestedPickupDate.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *CreateShipment) validateSecondaryPickupAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SecondaryPickupAddress) { // not required
+		return nil
+	}
+
+	if m.SecondaryPickupAddress != nil {
+		if err := m.SecondaryPickupAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("secondaryPickupAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/gen/internalmessages/update_shipment.go
+++ b/pkg/gen/internalmessages/update_shipment.go
@@ -37,6 +37,9 @@ type UpdateShipment struct {
 	// Format: date
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
+	// secondary pickup address
+	SecondaryPickupAddress *Address `json:"secondaryPickupAddress,omitempty"`
+
 	// shipment type
 	ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
 
@@ -65,6 +68,10 @@ func (m *UpdateShipment) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRequestedPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSecondaryPickupAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -155,6 +162,24 @@ func (m *UpdateShipment) validateRequestedPickupDate(formats strfmt.Registry) er
 
 	if err := validate.FormatOf("requestedPickupDate", "body", "date", m.RequestedPickupDate.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *UpdateShipment) validateSecondaryPickupAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SecondaryPickupAddress) { // not required
+		return nil
+	}
+
+	if m.SecondaryPickupAddress != nil {
+		if err := m.SecondaryPickupAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("secondaryPickupAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -808,7 +808,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 
 		updatedShipment := response.(*mtoshipmentops.UpdateMTOShipmentOK).Payload
 		suite.Equal(oldShipment.ID.String(), updatedShipment.ID.String())
-		suite.Equal(params.Body.CounselorRemarks, updatedShipment.CounselorRemarks)
+		suite.Equal(params.Body.CustomerRemarks, updatedShipment.CustomerRemarks)
 		suite.Equal(params.Body.CounselorRemarks, updatedShipment.CounselorRemarks)
 		suite.Equal(params.Body.PickupAddress.StreetAddress1, updatedShipment.PickupAddress.StreetAddress1)
 		suite.Equal(params.Body.DestinationAddress.StreetAddress1, updatedShipment.DestinationAddress.StreetAddress1)

--- a/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
@@ -77,6 +77,7 @@ func MTOShipmentModelFromCreate(mtoShipment *internalmessages.CreateShipment) *m
 	}
 
 	model.PickupAddress = AddressModel(mtoShipment.PickupAddress)
+	model.SecondaryPickupAddress = AddressModel(mtoShipment.SecondaryPickupAddress)
 	model.DestinationAddress = AddressModel(mtoShipment.DestinationAddress)
 
 	if mtoShipment.Agents != nil {

--- a/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
@@ -104,6 +104,7 @@ func MTOShipmentModelFromUpdate(mtoShipment *internalmessages.UpdateShipment) *m
 	}
 
 	model.PickupAddress = AddressModel(mtoShipment.PickupAddress)
+	model.SecondaryPickupAddress = AddressModel(mtoShipment.SecondaryPickupAddress)
 	model.DestinationAddress = AddressModel(mtoShipment.DestinationAddress)
 
 	if mtoShipment.Agents != nil {

--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -128,6 +128,14 @@ func (f mtoShipmentCreator) CreateMTOShipment(shipment *models.MTOShipment, serv
 			return services.NewInvalidInputError(uuid.Nil, nil, nil, "PickupAddress is required to create an HHG or NTS type MTO shipment")
 		}
 
+		if shipment.SecondaryPickupAddress != nil {
+			verrs, err = txBuilder.CreateOne(shipment.SecondaryPickupAddress)
+			if verrs != nil || err != nil {
+				return fmt.Errorf("failed to create secondary pickup address %#v %e", verrs, err)
+			}
+			shipment.SecondaryPickupAddressID = &shipment.SecondaryPickupAddress.ID
+		}
+
 		if shipment.DestinationAddress != nil {
 			verrs, err = txBuilder.CreateOne(shipment.DestinationAddress)
 			if verrs != nil || err != nil {

--- a/pkg/services/mto_shipment/mto_shipment_creator_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator_test.go
@@ -91,6 +91,9 @@ func (suite *MTOShipmentServiceSuite) TestCreateMTOShipmentRequest() {
 		suite.NoError(err)
 		suite.NotNil(createdShipment)
 		suite.Equal(models.MTOShipmentStatusDraft, createdShipment.Status)
+		suite.NotEmpty(createdShipment.PickupAddressID)
+		suite.NotEmpty(createdShipment.SecondaryPickupAddressID)
+		suite.NotEmpty(createdShipment.DestinationAddressID)
 	})
 
 	suite.T().Run("If the shipment is created successfully with submitted status it should be returned", func(t *testing.T) {
@@ -209,8 +212,10 @@ func clearShipmentIDFields(shipment *models.MTOShipment) *models.MTOShipment {
 		shipment.DestinationAddressID = nil
 		shipment.DestinationAddress.ID = uuid.Nil
 	}
-	shipment.SecondaryPickupAddressID = nil
-	shipment.SecondaryPickupAddress = nil
+	if shipment.SecondaryPickupAddress != nil {
+		shipment.SecondaryPickupAddressID = nil
+		shipment.SecondaryPickupAddress.ID = uuid.Nil
+	}
 	shipment.SecondaryDeliveryAddressID = nil
 	shipment.SecondaryDeliveryAddress = nil
 	shipment.ID = uuid.Nil

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2630,6 +2630,8 @@ definitions:
         x-nullable: true
       pickupAddress:
         $ref: '#/definitions/Address'
+      secondaryPickupAddress:
+        $ref: '#/definitions/Address'
       destinationAddress:
         $ref: '#/definitions/Address'
       agents:
@@ -2655,6 +2657,8 @@ definitions:
         example: handle with care
         x-nullable: true
       pickupAddress:
+        $ref: '#/definitions/Address'
+      secondaryPickupAddress:
         $ref: '#/definitions/Address'
       destinationAddress:
         $ref: '#/definitions/Address'


### PR DESCRIPTION
## Description

We want customers to be able to create/edit secondary pickup addresses when creating or editing shipments. This pr contains the changes to enable this in the internal api endpoints.

## Reviewer Notes

Anything you think is missing?

## Setup

### General

1. Start the server and customer client:

    ```sh
    make server_run
    ```
    ```sh
    make client_run
    ```

2. Log in as a service member that hasn't submitted their move. Either create one or use an existing one; I used the `hhg@only.unsubmitted` account.
3. Set up postman as indicated in [these instructions](https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman), with a few caveats
    1. Instead of the office or admin urls, you'll use `http://milmovelocal:3000/internal` as the base url for requests.
    2. The session token for the internal side is called `mil_session_token`
4. Pick a shipment to edit. 
5. In postman, make a request to `http://milmovelocal:3000/internal/moves/<move id>/mto_shipments`
    1. Replace `<move id>` with the move ID which you can get from the edit shipment page url.

### Updates

1. Set up a patch request in postman to `http://milmovelocal:3000/internal/mto-shipments/<shipment id>` 
    1. Replace `<shipment id>` with the correct shipment ID
2. You'll need to set up your cookies and headers correctly, see https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman#form-a-working-get-and-patch-request-in-postman
3. The body should be similar to this (but with the correct move id in the body, and other details as you see fit):

    ```json
    {
        "moveTaskOrderID": "3a8c9f4f-7344-4f18-9ab5-0de3ef57b901",
        "shipmentType": "HHG",
        "customerRemarks": "Please treat gently",
        "requestedPickupDate": "2020-03-15",
        "pickupAddress": {
            "street_address_1": "9999 Any Street",
            "street_address_2": "P.O. Box 12345",
            "city": "Beverly Hills",
            "state": "CA",
            "postal_code": "90210",
            "country": "US",
            "street_address_3": "c/o Some Person"
        },
        "secondaryPickupAddress": {
            "city": "Beverly Hills",
            "country": "US",
            "postal_code": "90210",
            "state": "CA",
            "street_address_1": "55555 Everywhere Street",
            "street_address_2": "P.O. Box 12345",
            "street_address_3": "c/o Some Person"
        },
        "requestedDeliveryDate": "2020-03-15",
        "destinationAddress": {
            "street_address_1": "987 Any Avenue",
            "street_address_2": "P.O. Box 9876",
            "city": "Fairfield",
            "state": "CA",
            "postal_code": "94535",
            "country": "US",
            "street_address_3": "c/o Some Person"
        }
    }
    ```
3. Make your request and check that the secondary pickup address updated correctly (either by checking the shipment in the response, or making another get request).

### Creating


1. Set up a post request in postman to `http://milmovelocal:3000/internal/mto-shipments`
2. You'll need to set up your cookies and headers correctly, see https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman#form-a-working-get-and-patch-request-in-postman
3. The body should be similar to this (but with the correct moveTaskOrderID in the body and other data as you want it to be):

    ```json
    {
        "moveTaskOrderID": "3a8c9f4f-7344-4f18-9ab5-0de3ef57b901",
        "shipmentType": "HHG",
        "requestedPickupDate": "2021-06-03",
        "requestedDeliveryDate": "2021-06-07",
        "customerRemarks": "handle with care",
        "pickupAddress": {
            "city": "Beverly Hills",
            "country": "US",
            "postal_code": "90210",
            "state": "CA",
            "street_address_1": "838 Other",
            "street_address_2": "P.O. Box 12345",
            "street_address_3": "c/o Some Person"
        },
        "secondaryPickupAddress": {
            "city": "Beverly Hills",
            "country": "US",
            "postal_code": "90210",
            "state": "CA",
            "street_address_1": "777 Cat Street",
            "street_address_2": "P.O. Box 12345",
            "street_address_3": "c/o Some Person"
        },
        "destinationAddress": {
            "city": "Fairfield",
            "country": "US",
            "postal_code": "94535",
            "state": "CA",
            "street_address_1": "111 Dog Avenue",
            "street_address_2": "P.O. Box 9876",
            "street_address_3": "c/o Some Person"
        }
    }
    ```
3. Make your request and check that a new shipment was added with the secondary pickup address set correctly (either by checking the shipment in the response, or making another get request).

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8154) for this change