### PR TITLE
MB-7695 Services Counselor can view the secondary destination address

### DIFF
--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -70,6 +70,8 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 		query.NewQueryAssociation("MTOAgents"),
 		query.NewQueryAssociation("PickupAddress"),
 		query.NewQueryAssociation("DestinationAddress"),
+		query.NewQueryAssociation("SecondaryPickupAddress"),
+		query.NewQueryAssociation("SecondaryDeliveryAddress"),
 	})
 
 	var shipments models.MTOShipments

--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -148,7 +148,7 @@ const RequestedShipments = ({
                     displayInfo={{
                       heading: shipmentTypeLabels[shipment.shipmentType],
                       requestedMoveDate: shipment.requestedPickupDate,
-                      currentAddress: shipment.pickupAddress,
+                      originAddress: shipment.pickupAddress,
                       destinationAddress: shipment.destinationAddress || dutyStationPostal,
                     }}
                     /* eslint-disable-next-line react/jsx-props-no-spreading */
@@ -210,7 +210,7 @@ const RequestedShipments = ({
                   displayInfo={{
                     heading: shipmentTypeLabels[shipment.shipmentType],
                     requestedMoveDate: shipment.requestedPickupDate,
-                    currentAddress: shipment.pickupAddress,
+                    originAddress: shipment.pickupAddress,
                     destinationAddress: shipment.destinationAddress || dutyStationPostal,
                   }}
                   isSubmitted={false}

--- a/src/components/Office/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview.jsx
@@ -79,7 +79,7 @@ const ShipmentApprovalPreview = ({
                           </tr>
                           <tr>
                             <th className="text-bold" scope="row">
-                              Current Address
+                              Origin Address
                             </th>
                             <td>{shipment.pickupAddress && formatAddress(shipment.pickupAddress)}</td>
                           </tr>

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -44,8 +44,8 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             <dd>{formatDate(displayInfo.requestedMoveDate, 'DD MMM YYYY')}</dd>
           </div>
           <div className={styles.row}>
-            <dt>Current address</dt>
-            <dd>{displayInfo.currentAddress && formatAddress(displayInfo.currentAddress)}</dd>
+            <dt>Origin address</dt>
+            <dd>{displayInfo.originAddress && formatAddress(displayInfo.originAddress)}</dd>
           </div>
           <div className={styles.row}>
             <dt className={styles.label}>Destination address</dt>
@@ -94,7 +94,7 @@ ShipmentDisplay.propTypes = {
   displayInfo: PropTypes.shape({
     heading: PropTypes.string.isRequired,
     requestedMoveDate: PropTypes.string.isRequired,
-    currentAddress: AddressShape.isRequired,
+    originAddress: AddressShape.isRequired,
     destinationAddress: AddressShape,
     secondDestinationAddress: AddressShape,
     counselorRemarks: PropTypes.string,

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -51,6 +51,14 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             <dt className={styles.label}>Destination address</dt>
             <dd data-testid="shipmentDestinationAddress">{formatAddress(displayInfo.destinationAddress)}</dd>
           </div>
+          {displayInfo.secondDestinationAddress && (
+            <div className={styles.row}>
+              <dt className={styles.label}>Second destination address</dt>
+              <dd data-testid="shipmentSecondDestinationAddress">
+                {formatAddress(displayInfo.secondDestinationAddress)}
+              </dd>
+            </div>
+          )}
           <div className={styles.row}>
             <dt className={styles.label}>Counselor remarks</dt>
             <dd data-testid="counselorRemarks">{displayInfo.counselorRemarks || '—'}</dd>
@@ -88,6 +96,7 @@ ShipmentDisplay.propTypes = {
     requestedMoveDate: PropTypes.string.isRequired,
     currentAddress: AddressShape.isRequired,
     destinationAddress: AddressShape,
+    secondDestinationAddress: AddressShape,
     counselorRemarks: PropTypes.string,
   }).isRequired,
   showIcon: PropTypes.bool,

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -21,7 +21,7 @@ const hhgInfo = {
   heading: 'HHG',
   shipmentId: 'testShipmentId394',
   requestedMoveDate: '26 Mar 2020',
-  currentAddress: {
+  originAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',
@@ -39,7 +39,7 @@ const ntsInfo = {
   heading: 'NTS',
   requestedMoveDate: '26 Mar 2020',
   shipmentId: 'testShipmentId394',
-  currentAddress: {
+  originAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',
@@ -57,7 +57,7 @@ const postalOnlyInfo = {
   heading: 'HHG',
   requestedMoveDate: '26 Mar 2020',
   shipmentId: 'testShipmentId394',
-  currentAddress: {
+  originAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -19,6 +19,12 @@ const info = {
     state: 'WA',
     postal_code: '98421',
   },
+  secondDestinationAddress: {
+    street_address_1: '987 Fairway Dr',
+    city: 'Tacoma',
+    state: 'WA',
+    postal_code: '98421',
+  },
   counselorRemarks: 'counselor approved',
 };
 

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -7,7 +7,7 @@ import ShipmentDisplay from './ShipmentDisplay';
 const info = {
   heading: 'HHG',
   requestedMoveDate: '26 Mar 2020',
-  currentAddress: {
+  originAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',
@@ -31,7 +31,7 @@ const info = {
 const postalOnly = {
   heading: 'HHG',
   requestedMoveDate: '26 Mar 2020',
-  currentAddress: {
+  originAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -61,6 +61,7 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
           destinationAddress: shipment.destinationAddress || {
             postal_code: order.destinationDutyStation.address.postal_code,
           },
+          secondDestinationAddress: shipment.secondaryDeliveryAddress,
           counselorRemarks: shipment.counselorRemarks,
         },
         editURL,

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -57,7 +57,7 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
           id: shipment.id,
           heading: SHIPMENT_OPTIONS.HHG,
           requestedMoveDate: shipment.requestedPickupDate,
-          currentAddress: shipment.pickupAddress,
+          originAddress: shipment.pickupAddress,
           destinationAddress: shipment.destinationAddress || {
             postal_code: order.destinationDutyStation.address.postal_code,
           },

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -234,15 +234,14 @@ describe('MoveDetails page', () => {
       );
     }
 
-    const currentAddressTerms = screen.getAllByText('Current address');
+    const originAddressTerms = screen.getAllByText('Origin address');
 
-    expect(currentAddressTerms.length).toBe(3); // Third one is in customer info section
+    expect(originAddressTerms.length).toBe(2);
 
-    // only loop through the ones in the shipments section
     for (let i = 0; i < 2; i += 1) {
       const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].pickupAddress;
 
-      const addressText = currentAddressTerms[i].nextElementSibling.textContent;
+      const addressText = originAddressTerms[i].nextElementSibling.textContent;
 
       expect(addressText).toContain(street_address_1);
       expect(addressText).toContain(city);

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -52,6 +52,17 @@ const mtoShipments = [
       street_address_2: 'P.O. Box 12345',
       street_address_3: 'c/o Some Person',
     },
+    secondaryDeliveryAddress: {
+      city: 'Beverly Hills',
+      country: 'US',
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
+      id: '1686751b-ab36-43cf-eeee-c0f467d13c19',
+      postal_code: '90215',
+      state: 'CA',
+      street_address_1: '123 Any Street',
+      street_address_2: 'P.O. Box 12345',
+      street_address_3: 'c/o Some Person',
+    },
     requestedPickupDate: '2020-06-04',
     scheduledPickupDate: '2020-06-05',
     shipmentType: 'HHG',
@@ -253,6 +264,19 @@ describe('MoveDetails page', () => {
       expect(addressText).toContain(state);
       expect(addressText).toContain(postal_code);
     }
+
+    const secondDestinationAddressTerms = screen.getAllByText('Second destination address');
+
+    // This is not a required field, and only one of our shipments has it filled out:
+    expect(secondDestinationAddressTerms.length).toBe(1);
+
+    const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[0].secondaryDeliveryAddress;
+    const addressText = secondDestinationAddressTerms[0].nextElementSibling.textContent;
+
+    expect(addressText).toContain(street_address_1);
+    expect(addressText).toContain(city);
+    expect(addressText).toContain(state);
+    expect(addressText).toContain(postal_code);
 
     const counselorRemarksTerms = screen.getAllByText('Counselor remarks');
 


### PR DESCRIPTION
## Description

This PR makes the `secondaryDeliveryAddress` field visible to the Services Counselor when they are reviewing a customer's shipments. It also updates the label "**Current address**" > "**Origin address**", which is more accurate. This change will be visible for the SC and TXO users. 

**NOTE:** We divided the work up so that someone else is adding the "**Secondary pickup address**" - apologies if it looks a lil goofy as-is!

## Setup

First populate your DB and run your server:
```sh
make db_dev_e2e_populate server_run
```

Then start your client:
```sh
make office_client_run
```

* Login as a Services Counselor. 
* Select a move and navigate to the move details page.
* In the shipments, you should see a line for **"Second destination address**" if there is one.
  * If you do not see this, first take a peek at this shipment in your database viewer (or grab it by using the `getMoveTaskOrder` endpoint in the Support API) and verify that it does not have any values for `secondDeliveryAddress`. 
  * Feel free to add one by hand and refresh the page to see that it is now there!
* Verify that you see an **Origin address** label in the shipments card, and not a **Current address** label.
* Switch user type to TOO.
* Find a move as the TOO and go to its details page.
* Verify that you also see an **Origin address** label in the shipments card here.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7695) for this change.

## Screenshots

Services counselor view:
<img width="493" alt="Screen Shot 2021-06-04 at 12 29 52 PM" src="https://user-images.githubusercontent.com/62574202/120841254-e5d55e80-c530-11eb-970a-c52bb339531e.png">

TOO view:
<img width="655" alt="Screen Shot 2021-06-04 at 12 28 50 PM" src="https://user-images.githubusercontent.com/62574202/120841387-0c939500-c531-11eb-9ce6-ce84684239a5.png">
<img width="825" alt="Screen Shot 2021-06-04 at 12 29 16 PM" src="https://user-images.githubusercontent.com/62574202/120841398-10271c00-c531-11eb-9657-0b9cd744f3c7.png">

