### PR TITLE
MB-8237 log user activation and deactivation

### DIFF
--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -175,7 +175,7 @@ func (h UpdateAdminUserHandler) Handle(params adminuserop.UpdateAdminUserParams)
 	if payload.Active != nil {
 		_, err = audit.CaptureAccountStatus(updatedAdminUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
-			logger.Error("Error capturing account status audit record", zap.Error(err))
+			logger.Error("Error capturing account status audit record in UpdateAdminUserHandler", zap.Error(err))
 		}
 	}
 

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -171,6 +171,14 @@ func (h UpdateAdminUserHandler) Handle(params adminuserop.UpdateAdminUserParams)
 		return adminuserop.NewUpdateAdminUserInternalServerError()
 	}
 
+	// Log if the account was enabled or disabled (POAM requirement)
+	if payload.Active != nil {
+		_, err = audit.CaptureAccountStatus(updatedAdminUser, payload, logger, session, params.HTTPRequest)
+		if err != nil {
+			logger.Error("Error capturing account status audit record", zap.Error(err))
+		}
+	}
+
 	_, err = audit.Capture(updatedAdminUser, payload, logger, session, params.HTTPRequest)
 	if err != nil {
 		logger.Error("Error capturing audit record", zap.Error(err))

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -173,7 +173,7 @@ func (h UpdateAdminUserHandler) Handle(params adminuserop.UpdateAdminUserParams)
 
 	// Log if the account was enabled or disabled (POAM requirement)
 	if payload.Active != nil {
-		_, err = audit.CaptureAccountStatus(updatedAdminUser, payload, logger, session, params.HTTPRequest)
+		_, err = audit.CaptureAccountStatus(updatedAdminUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
 			logger.Error("Error capturing account status audit record", zap.Error(err))
 		}

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -243,6 +243,14 @@ func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserPara
 		}
 	}
 
+	// Log if the account was enabled or disabled (POAM requirement)
+	if payload.Active != nil {
+		_, err = audit.CaptureAccountStatus(updatedOfficeUser, payload, logger, session, params.HTTPRequest)
+		if err != nil {
+			logger.Error("Error capturing account status audit record", zap.Error(err))
+		}
+	}
+
 	_, err = audit.Capture(updatedOfficeUser, payload, logger, session, params.HTTPRequest)
 	if err != nil {
 		logger.Error("Error capturing audit record", zap.Error(err))

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -247,7 +247,7 @@ func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserPara
 	if payload.Active != nil {
 		_, err = audit.CaptureAccountStatus(updatedOfficeUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
-			logger.Error("Error capturing account status audit record", zap.Error(err))
+			logger.Error("Error capturing account status audit record in UpdateOfficeUserHandler", zap.Error(err))
 		}
 	}
 

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -245,7 +245,7 @@ func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserPara
 
 	// Log if the account was enabled or disabled (POAM requirement)
 	if payload.Active != nil {
-		_, err = audit.CaptureAccountStatus(updatedOfficeUser, payload, logger, session, params.HTTPRequest)
+		_, err = audit.CaptureAccountStatus(updatedOfficeUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
 			logger.Error("Error capturing account status audit record", zap.Error(err))
 		}

--- a/pkg/handlers/adminapi/users.go
+++ b/pkg/handlers/adminapi/users.go
@@ -176,7 +176,7 @@ func (h UpdateUserHandler) Handle(params userop.UpdateUserParams) middleware.Res
 	if payload.Active != nil {
 		_, err = audit.CaptureAccountStatus(updatedUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
-			logger.Error("Error capturing account status audit record", zap.Error(err))
+			logger.Error("Error capturing account status audit record in UpdateUserHandler", zap.Error(err))
 		}
 	}
 

--- a/pkg/handlers/adminapi/users.go
+++ b/pkg/handlers/adminapi/users.go
@@ -172,6 +172,14 @@ func (h UpdateUserHandler) Handle(params userop.UpdateUserParams) middleware.Res
 		return userop.NewUpdateUserInternalServerError()
 	}
 
+	// Log if the account was enabled or disabled (POAM requirement)
+	if payload.Active != nil {
+		_, err = audit.CaptureAccountStatus(updatedUser, payload, logger, session, params.HTTPRequest)
+		if err != nil {
+			logger.Error("Error capturing account status audit record", zap.Error(err))
+		}
+	}
+
 	_, err = audit.Capture(updatedUser, params.User, logger, session, params.HTTPRequest)
 	if err != nil {
 		logger.Error("Error capturing audit record", zap.Error(err))

--- a/pkg/handlers/adminapi/users.go
+++ b/pkg/handlers/adminapi/users.go
@@ -174,7 +174,7 @@ func (h UpdateUserHandler) Handle(params userop.UpdateUserParams) middleware.Res
 
 	// Log if the account was enabled or disabled (POAM requirement)
 	if payload.Active != nil {
-		_, err = audit.CaptureAccountStatus(updatedUser, payload, logger, session, params.HTTPRequest)
+		_, err = audit.CaptureAccountStatus(updatedUser, *payload.Active, logger, session, params.HTTPRequest)
 		if err != nil {
 			logger.Error("Error capturing account status audit record", zap.Error(err))
 		}

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -81,6 +81,8 @@ func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, se
 	logItems = extractResponsibleUser(logItems, session)
 
 	item, err := validateInterface(model)
+	fmt.Print("TESTTEST")
+	fmt.Printf("%+v\n", model)
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
 		logItems = extractRecordInformation(item, model, logItems)
 
@@ -129,8 +131,8 @@ func extractRecordInformation(item reflect.Type, model interface{}, logItems []z
 	}
 
 	var updatedAt string
-	if elem.FieldByName("updatedAt").IsValid() {
-		updatedAt = elem.FieldByName("updatedAt").Interface().(time.Time).String()
+	if elem.FieldByName("UpdatedAt").IsValid() {
+		updatedAt = elem.FieldByName("UpdatedAt").Interface().(time.Time).String()
 	} else {
 		updatedAt = time.Now().String()
 	}

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -25,11 +25,11 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 	msg := flect.Titleize(eventType)
 
 	logItems = append(logItems, zap.String("event_type", eventType))
-	logItems = extractResponsibleUser(logItems, session)
+	logItems = append(logItems, extractResponsibleUser(session)...)
 
 	item, err := validateInterface(model)
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
-		logItems = extractRecordInformation(item, model, logItems)
+		logItems = append(logItems, extractRecordInformation(item, model)...)
 
 		if payload != nil {
 			_, err = validateInterface(payload)
@@ -77,12 +77,11 @@ func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, se
 	eventType := extractEventType(request)
 	msg := flect.Titleize(eventType)
 	logItems = append(logItems, zap.String("event_type", eventType))
-
-	logItems = extractResponsibleUser(logItems, session)
+	logItems = append(logItems, extractResponsibleUser(session)...)
 
 	item, err := validateInterface(model)
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
-		logItems = extractRecordInformation(item, model, logItems)
+		logItems = append(logItems, extractRecordInformation(item, model)...)
 
 		// Create log message and view value of active
 		activeMessage := "disabled"
@@ -103,7 +102,8 @@ func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, se
 	return logItems, nil
 }
 
-func extractResponsibleUser(logItems []zap.Field, session *auth.Session) []zap.Field {
+func extractResponsibleUser(session *auth.Session) []zap.Field {
+	var logItems []zap.Field
 	logItems = append(logItems,
 		zap.String("responsible_user_id", session.UserID.String()),
 		zap.String("responsible_user_email", session.Email),
@@ -117,7 +117,8 @@ func extractResponsibleUser(logItems []zap.Field, session *auth.Session) []zap.F
 	return logItems
 }
 
-func extractRecordInformation(item reflect.Type, model interface{}, logItems []zap.Field) []zap.Field {
+func extractRecordInformation(item reflect.Type, model interface{}) []zap.Field {
+	var logItems []zap.Field
 	recordType := parseRecordType(item.String())
 	elem := reflect.ValueOf(model).Elem()
 

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,50 +24,12 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 	eventType := extractEventType(request)
 	msg := flect.Titleize(eventType)
 
-	logItems = append(logItems,
-		zap.String("event_type", eventType),
-		zap.String("responsible_user_id", session.UserID.String()),
-		zap.String("responsible_user_email", session.Email),
-	)
+	logItems = append(logItems, zap.String("event_type", eventType))
+	logItems = extractResponsibleUser(logItems, session)
 
-	if session.IsAdminUser() || session.IsOfficeUser() {
-		logItems = append(logItems,
-			zap.String("responsible_user_name", fullName(session.FirstName, session.LastName)),
-		)
-	}
-
-	t, err := validateInterface(model)
+	item, err := validateInterface(model)
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
-		recordType := parseRecordType(t.String())
-		elem := reflect.ValueOf(model).Elem()
-
-		var createdAt string
-		if elem.FieldByName("CreatedAt").IsValid() {
-			createdAt = elem.FieldByName("CreatedAt").Interface().(time.Time).String()
-		} else {
-			createdAt = time.Now().String()
-		}
-
-		var updatedAt string
-		if elem.FieldByName("updatedAt").IsValid() {
-			updatedAt = elem.FieldByName("updatedAt").Interface().(time.Time).String()
-		} else {
-			updatedAt = time.Now().String()
-		}
-
-		var id string
-		if elem.FieldByName("ID").IsValid() {
-			id = elem.FieldByName("ID").Interface().(uuid.UUID).String()
-		} else {
-			id = ""
-		}
-
-		logItems = append(logItems,
-			zap.String("record_id", id),
-			zap.String("record_type", recordType),
-			zap.String("record_created_at", createdAt),
-			zap.String("record_updated_at", updatedAt),
-		)
+		logItems = extractRecordInformation(item, model, logItems)
 
 		if payload != nil {
 			_, err = validateInterface(payload)
@@ -80,7 +43,6 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 				fieldFromType := payloadValue.Type().Field(i)
 				fieldFromValue := payloadValue.Field(i)
 				fieldName := flect.Underscore(fieldFromType.Name)
-
 				if !fieldFromValue.IsZero() {
 					payloadFields = append(payloadFields, fieldName)
 				}
@@ -107,6 +69,89 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 	logger.Info(msg, logItems...)
 
 	return logItems, nil
+}
+
+// CaptureAccountStatus captures an audit record when a user account is enabled or disabled
+func CaptureAccountStatus(model interface{}, payload interface{}, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
+	var logItems []zap.Field
+	eventType := extractEventType(request)
+	msg := flect.Titleize(eventType)
+	logItems = append(logItems, zap.String("event_type", eventType))
+
+	logItems = extractResponsibleUser(logItems, session)
+
+	item, err := validateInterface(model)
+	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
+		logItems = extractRecordInformation(item, model, logItems)
+
+		// Create log message
+		activeMessage := "enabled"
+		if false {
+			activeMessage = "disabled"
+		}
+
+		logItems = append(logItems, zap.String("active_value", strconv.FormatBool(false)))
+
+		msg += fmt.Sprintf(" account %s 🎉", activeMessage)
+	} else {
+		msg += " invalid or zero or nil model interface received from request handler"
+		logItems = append(logItems,
+			zap.Error(err),
+		)
+	}
+
+	logger.Info(msg, logItems...)
+
+	return logItems, nil
+}
+
+func extractResponsibleUser(logItems []zap.Field, session *auth.Session) []zap.Field {
+	logItems = append(logItems,
+		zap.String("responsible_user_id", session.UserID.String()),
+		zap.String("responsible_user_email", session.Email),
+	)
+
+	if session.IsAdminUser() || session.IsOfficeUser() {
+		logItems = append(logItems,
+			zap.String("responsible_user_name", fullName(session.FirstName, session.LastName)),
+		)
+	}
+	return logItems
+}
+
+func extractRecordInformation(item reflect.Type, model interface{}, logItems []zap.Field) []zap.Field {
+	recordType := parseRecordType(item.String())
+	elem := reflect.ValueOf(model).Elem()
+
+	var createdAt string
+	if elem.FieldByName("CreatedAt").IsValid() {
+		createdAt = elem.FieldByName("CreatedAt").Interface().(time.Time).String()
+	} else {
+		createdAt = time.Now().String()
+	}
+
+	var updatedAt string
+	if elem.FieldByName("updatedAt").IsValid() {
+		updatedAt = elem.FieldByName("updatedAt").Interface().(time.Time).String()
+	} else {
+		updatedAt = time.Now().String()
+	}
+
+	var id string
+	if elem.FieldByName("ID").IsValid() {
+		id = elem.FieldByName("ID").Interface().(uuid.UUID).String()
+	} else {
+		id = ""
+	}
+
+	logItems = append(logItems,
+		zap.String("record_id", id),
+		zap.String("record_type", recordType),
+		zap.String("record_created_at", createdAt),
+		zap.String("record_updated_at", updatedAt),
+	)
+
+	return logItems
 }
 
 func parseRecordType(rt string) string {

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -84,15 +84,26 @@ func CaptureAccountStatus(model interface{}, payload interface{}, logger Logger,
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
 		logItems = extractRecordInformation(item, model, logItems)
 
-		// Create log message
-		activeMessage := "enabled"
-		if false {
-			activeMessage = "disabled"
+		// Create log message and view value of active
+		elem := reflect.ValueOf(model).Elem()
+		var activeValue bool
+		if elem.FieldByName("Active").IsValid() {
+			activeValue = elem.FieldByName("Active").Bool()
+		} else {
+			msg += " invalid model interface received from request handler - active not in model"
+			logItems = append(logItems,
+				zap.Error(err),
+			)
 		}
 
-		logItems = append(logItems, zap.String("active_value", strconv.FormatBool(false)))
+		activeMessage := "disabled"
+		if activeValue {
+			activeMessage = "enabled"
+		}
 
-		msg += fmt.Sprintf(" account %s 🎉", activeMessage)
+		logItems = append(logItems, zap.String("active_value", strconv.FormatBool(activeValue)))
+
+		msg += fmt.Sprintf(" - account %s 🎉🍑", activeMessage)
 	} else {
 		msg += " invalid or zero or nil model interface received from request handler"
 		logItems = append(logItems,

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -72,7 +72,7 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 }
 
 // CaptureAccountStatus captures an audit record when a user account is enabled or disabled
-func CaptureAccountStatus(model interface{}, payload interface{}, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
+func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
 	var logItems []zap.Field
 	eventType := extractEventType(request)
 	msg := flect.Titleize(eventType)
@@ -85,24 +85,12 @@ func CaptureAccountStatus(model interface{}, payload interface{}, logger Logger,
 		logItems = extractRecordInformation(item, model, logItems)
 
 		// Create log message and view value of active
-		elem := reflect.ValueOf(model).Elem()
-		var activeValue bool
-		if elem.FieldByName("Active").IsValid() {
-			activeValue = elem.FieldByName("Active").Bool()
-		} else {
-			msg += " invalid model interface received from request handler - active not in model"
-			logItems = append(logItems,
-				zap.Error(err),
-			)
-		}
-
 		activeMessage := "disabled"
 		if activeValue {
 			activeMessage = "enabled"
 		}
 
 		logItems = append(logItems, zap.String("active_value", strconv.FormatBool(activeValue)))
-
 		msg += fmt.Sprintf(" - account %s 🎉🍑", activeMessage)
 	} else {
 		msg += " invalid or zero or nil model interface received from request handler"
@@ -112,7 +100,6 @@ func CaptureAccountStatus(model interface{}, payload interface{}, logger Logger,
 	}
 
 	logger.Info(msg, logItems...)
-
 	return logItems, nil
 }
 

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -81,8 +81,6 @@ func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, se
 	logItems = extractResponsibleUser(logItems, session)
 
 	item, err := validateInterface(model)
-	fmt.Print("TESTTEST")
-	fmt.Printf("%+v\n", model)
 	if err == nil && reflect.ValueOf(model).IsValid() && !reflect.ValueOf(model).IsNil() && !reflect.ValueOf(model).IsZero() {
 		logItems = extractRecordInformation(item, model, logItems)
 

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -74,7 +74,7 @@ func Capture(model interface{}, payload interface{}, logger Logger, session *aut
 // CaptureAccountStatus captures an audit record when a user account is enabled or disabled
 func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
 	var logItems []zap.Field
-	eventType := extractEventType(request)
+	eventType := extractEventType(request) + "_active_status_changed"
 	msg := flect.Titleize(eventType)
 	logItems = append(logItems, zap.String("event_type", eventType))
 	logItems = append(logItems, extractResponsibleUser(session)...)

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -91,7 +91,7 @@ func CaptureAccountStatus(model interface{}, activeValue bool, logger Logger, se
 		}
 
 		logItems = append(logItems, zap.String("active_value", strconv.FormatBool(activeValue)))
-		msg += fmt.Sprintf(" - account %s 🎉🍑", activeMessage)
+		msg += fmt.Sprintf(" - account %s", activeMessage)
 	} else {
 		msg += " invalid or zero or nil model interface received from request handler"
 		logItems = append(logItems,

--- a/pkg/services/audit/audit_test.go
+++ b/pkg/services/audit/audit_test.go
@@ -265,29 +265,3 @@ func TestExtractResponsibleUser(t *testing.T) {
 		}
 	})
 }
-
-func TestExtractRecordInformation(t *testing.T) {
-	uuidStringUser := "4ad12fe7-1514-4b6b-a35d-ce68e6c5b1fb"
-
-	model := map[string]interface{}{
-		"CreatedAt": "userID",
-		"ID":        uuidStringUser,
-		"UpdatedAt": "userID",
-	}
-
-	item, _ := validateInterface(model)
-
-	var zapFields []zap.Field
-	t.Run("Returns the require fields", func(t *testing.T) {
-		zapFields = extractRecordInformation(item, model, zapFields)
-
-		if assert.NotEmpty(t, zapFields) {
-			assert.Equal(t, "record_id", zapFields[1].Key)
-			assert.Equal(t, uuidStringUser, zapFields[1].String)
-			assert.Equal(t, "record_created_at", zapFields[2].Key)
-			assert.Equal(t, "", zapFields[2].String)
-			assert.Equal(t, "record_updated_at", zapFields[3].Key)
-			assert.Equal(t, "John Doe", zapFields[3].String)
-		}
-	})
-}

--- a/pkg/services/audit/audit_test.go
+++ b/pkg/services/audit/audit_test.go
@@ -265,3 +265,31 @@ func TestExtractResponsibleUser(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractRecordInformation(t *testing.T) {
+	uuidStringUser := "4ad12fe7-1514-4b6b-a35d-ce68e6c5b1fb"
+	userID, _ := uuid.FromString(uuidStringUser)
+
+	model := &models.OfficeUser{
+		CreatedAt: time.Now(),
+		ID:        userID,
+		UpdatedAt: time.Now(),
+	}
+
+	item, _ := validateInterface(model)
+	var zapFields []zap.Field
+	t.Run("Returns the require fields", func(t *testing.T) {
+		zapFields = extractRecordInformation(item, model, zapFields)
+
+		if assert.NotEmpty(t, zapFields) {
+			assert.Equal(t, "record_id", zapFields[0].Key)
+			assert.Equal(t, uuidStringUser, zapFields[0].String)
+			assert.Equal(t, "record_type", zapFields[1].Key)
+			assert.Equal(t, "OfficeUser", zapFields[1].String)
+			assert.Equal(t, "record_created_at", zapFields[2].Key)
+			assert.Equal(t, model.CreatedAt.String(), zapFields[2].String)
+			assert.Equal(t, "record_updated_at", zapFields[3].Key)
+			assert.Equal(t, model.UpdatedAt.String(), zapFields[3].String)
+		}
+	})
+}

--- a/pkg/services/audit/audit_test.go
+++ b/pkg/services/audit/audit_test.go
@@ -78,7 +78,7 @@ func TestCapture(t *testing.T) {
 		}
 
 		session := auth.Session{
-			UserID: adminUserID,
+			AdminUserID: adminUserID,
 		}
 
 		req := &http.Request{
@@ -192,44 +192,28 @@ func TestCaptureAccountStatus(t *testing.T) {
 	t.Run("Sucessfully logs account enabled", func(t *testing.T) {
 		zapFields, _ := CaptureAccountStatus(&model, true, logger, &session, req)
 
-		var eventType string
-		var activeValue string
-		for _, field := range zapFields {
-			if field.Key == "event_type" {
-				eventType = field.String
-			}
-			if field.Key == "active_value" {
-				activeValue = field.String
-			}
+		fieldsMap := map[string]string{}
+		for _, f := range zapFields {
+			fieldsMap[f.Key] = f.String
 		}
 
 		if assert.NotEmpty(t, zapFields) {
-			assert.Equal(t, "event_type", zapFields[0].Key)
-			assert.Equal(t, "audit_post_admin_users", eventType)
-			assert.Equal(t, "active_value", zapFields[8].Key)
-			assert.Equal(t, "true", activeValue)
+			assert.Equal(t, "audit_post_admin_users_active_status_changed", fieldsMap["event_type"])
+			assert.Equal(t, "true", fieldsMap["active_value"])
 		}
 	})
 
 	t.Run("Sucessfully logs account disabled", func(t *testing.T) {
 		zapFields, _ := CaptureAccountStatus(&model, false, logger, &session, req)
 
-		var eventType string
-		var activeValue string
-		for _, field := range zapFields {
-			if field.Key == "event_type" {
-				eventType = field.String
-			}
-			if field.Key == "active_value" {
-				activeValue = field.String
-			}
+		fieldsMap := map[string]string{}
+		for _, f := range zapFields {
+			fieldsMap[f.Key] = f.String
 		}
 
 		if assert.NotEmpty(t, zapFields) {
-			assert.Equal(t, "event_type", zapFields[0].Key)
-			assert.Equal(t, "audit_post_admin_users", eventType)
-			assert.Equal(t, "active_value", zapFields[8].Key)
-			assert.Equal(t, "false", activeValue)
+			assert.Equal(t, "audit_post_admin_users_active_status_changed", fieldsMap["event_type"])
+			assert.Equal(t, "false", fieldsMap["active_value"])
 		}
 	})
 }
@@ -255,13 +239,15 @@ func TestExtractResponsibleUser(t *testing.T) {
 	t.Run("Returns the require fields", func(t *testing.T) {
 		zapFields = extractResponsibleUser(&session)
 
+		fieldsMap := map[string]string{}
+		for _, f := range zapFields {
+			fieldsMap[f.Key] = f.String
+		}
+
 		if assert.NotEmpty(t, zapFields) {
-			assert.Equal(t, "responsible_user_id", zapFields[0].Key)
-			assert.Equal(t, uuidStringUser, zapFields[0].String)
-			assert.Equal(t, "responsible_user_email", zapFields[1].Key)
-			assert.Equal(t, userEmail, zapFields[1].String)
-			assert.Equal(t, "responsible_user_name", zapFields[2].Key)
-			assert.Equal(t, "John Doe", zapFields[2].String)
+			assert.Equal(t, uuidStringUser, fieldsMap["responsible_user_id"])
+			assert.Equal(t, userEmail, fieldsMap["responsible_user_email"])
+			assert.Equal(t, "John Doe", fieldsMap["responsible_user_name"])
 		}
 	})
 }
@@ -281,15 +267,16 @@ func TestExtractRecordInformation(t *testing.T) {
 	t.Run("Returns the require fields", func(t *testing.T) {
 		zapFields = extractRecordInformation(item, model)
 
+		fieldsMap := map[string]string{}
+		for _, f := range zapFields {
+			fieldsMap[f.Key] = f.String
+		}
+
 		if assert.NotEmpty(t, zapFields) {
-			assert.Equal(t, "record_id", zapFields[0].Key)
-			assert.Equal(t, uuidStringUser, zapFields[0].String)
-			assert.Equal(t, "record_type", zapFields[1].Key)
-			assert.Equal(t, "OfficeUser", zapFields[1].String)
-			assert.Equal(t, "record_created_at", zapFields[2].Key)
-			assert.Equal(t, model.CreatedAt.String(), zapFields[2].String)
-			assert.Equal(t, "record_updated_at", zapFields[3].Key)
-			assert.Equal(t, model.UpdatedAt.String(), zapFields[3].String)
+			assert.Equal(t, uuidStringUser, fieldsMap["record_id"])
+			assert.Equal(t, "OfficeUser", fieldsMap["record_type"])
+			assert.Equal(t, model.CreatedAt.String(), fieldsMap["record_created_at"])
+			assert.Equal(t, model.UpdatedAt.String(), fieldsMap["record_updated_at"])
 		}
 	})
 }

--- a/pkg/services/audit/audit_test.go
+++ b/pkg/services/audit/audit_test.go
@@ -34,7 +34,7 @@ func TestCapture(t *testing.T) {
 		adminUserID, _ := uuid.FromString(uuidString)
 
 		session := auth.Session{
-			UserID: adminUserID,
+			AdminUserID: adminUserID,
 		}
 
 		req := &http.Request{
@@ -253,7 +253,7 @@ func TestExtractResponsibleUser(t *testing.T) {
 	var zapFields []zap.Field
 
 	t.Run("Returns the require fields", func(t *testing.T) {
-		zapFields = extractResponsibleUser(zapFields, &session)
+		zapFields = extractResponsibleUser(&session)
 
 		if assert.NotEmpty(t, zapFields) {
 			assert.Equal(t, "responsible_user_id", zapFields[0].Key)
@@ -279,7 +279,7 @@ func TestExtractRecordInformation(t *testing.T) {
 	item, _ := validateInterface(model)
 	var zapFields []zap.Field
 	t.Run("Returns the require fields", func(t *testing.T) {
-		zapFields = extractRecordInformation(item, model, zapFields)
+		zapFields = extractRecordInformation(item, model)
 
 		if assert.NotEmpty(t, zapFields) {
 			assert.Equal(t, "record_id", zapFields[0].Key)

--- a/pkg/services/audit/audit_test.go
+++ b/pkg/services/audit/audit_test.go
@@ -192,12 +192,12 @@ func TestCaptureAccountStatus(t *testing.T) {
 	t.Run("Sucessfully logs account enabled", func(t *testing.T) {
 		zapFields, _ := CaptureAccountStatus(&model, true, logger, &session, req)
 
-		fieldsMap := map[string]string{}
-		for _, f := range zapFields {
-			fieldsMap[f.Key] = f.String
-		}
-
 		if assert.NotEmpty(t, zapFields) {
+			fieldsMap := map[string]string{}
+			for _, f := range zapFields {
+				fieldsMap[f.Key] = f.String
+			}
+
 			assert.Equal(t, "audit_post_admin_users_active_status_changed", fieldsMap["event_type"])
 			assert.Equal(t, "true", fieldsMap["active_value"])
 		}
@@ -206,12 +206,12 @@ func TestCaptureAccountStatus(t *testing.T) {
 	t.Run("Sucessfully logs account disabled", func(t *testing.T) {
 		zapFields, _ := CaptureAccountStatus(&model, false, logger, &session, req)
 
-		fieldsMap := map[string]string{}
-		for _, f := range zapFields {
-			fieldsMap[f.Key] = f.String
-		}
-
 		if assert.NotEmpty(t, zapFields) {
+			fieldsMap := map[string]string{}
+			for _, f := range zapFields {
+				fieldsMap[f.Key] = f.String
+			}
+
 			assert.Equal(t, "audit_post_admin_users_active_status_changed", fieldsMap["event_type"])
 			assert.Equal(t, "false", fieldsMap["active_value"])
 		}
@@ -239,12 +239,12 @@ func TestExtractResponsibleUser(t *testing.T) {
 	t.Run("Returns the require fields", func(t *testing.T) {
 		zapFields = extractResponsibleUser(&session)
 
-		fieldsMap := map[string]string{}
-		for _, f := range zapFields {
-			fieldsMap[f.Key] = f.String
-		}
-
 		if assert.NotEmpty(t, zapFields) {
+			fieldsMap := map[string]string{}
+			for _, f := range zapFields {
+				fieldsMap[f.Key] = f.String
+			}
+
 			assert.Equal(t, uuidStringUser, fieldsMap["responsible_user_id"])
 			assert.Equal(t, userEmail, fieldsMap["responsible_user_email"])
 			assert.Equal(t, "John Doe", fieldsMap["responsible_user_name"])
@@ -267,12 +267,12 @@ func TestExtractRecordInformation(t *testing.T) {
 	t.Run("Returns the require fields", func(t *testing.T) {
 		zapFields = extractRecordInformation(item, model)
 
-		fieldsMap := map[string]string{}
-		for _, f := range zapFields {
-			fieldsMap[f.Key] = f.String
-		}
-
 		if assert.NotEmpty(t, zapFields) {
+			fieldsMap := map[string]string{}
+			for _, f := range zapFields {
+				fieldsMap[f.Key] = f.String
+			}
+
 			assert.Equal(t, uuidStringUser, fieldsMap["record_id"])
 			assert.Equal(t, "OfficeUser", fieldsMap["record_type"])
 			assert.Equal(t, model.CreatedAt.String(), fieldsMap["record_created_at"])


### PR DESCRIPTION
## Description

This PR adds logging to the adminApi user, office user and admin user handlers. It also adds a function, `audit.CaptureAccountStatus`, and refactors a little bit of the audit.go file to make parts reusable. 

The output of the log for when a user is activated or deactivated is sent to cloudWatch and looks like: 
```
{
"level": "info",
    "ts": "2021-05-25T21:23:24.092Z",
    "caller": "audit/audit.go:107",
    "git_branch": "master",
    "git_commit": "1cfe3ab0a1d9728adcafe4893102fd6404ee8df1",
    "ecs_cluster": "arn:aws-us-gov:ecs:us-gov-west-1:015932076428:cluster/app-stg",
    "ecs_task_def_family": "app-stg",
    "ecs_task_def_revision": "1375",
    "milmove_trace_id": "8b15b762-67eb-4a6b-9b4d-43f0036e0553",
  "msg": "Audit Patch Office Users - account disabled"
  "event_type": "audit_patch_office_users", 
  "responsible_user_id": "4bbca4a9-2e97-4eab-8ee7-e29bc6c97b59", 
  "responsible_user_email": "20210602201721-8bf9bc264766@example.com", 
  "responsible_user_name": "Leo Spaceman", 
  "record_id": "144503a6-485c-463e-b943-d3c3bad11b09", 
  "record_type": "OfficeUser", 
  "record_created_at": "2021-05-27 18:32:56.571802 +0000 +0000", 
  "record_updated_at": "2021-06-04 17:56:01.82926 +0000 UTC m=+32.322890319", 
  "active_value": "false"
}
``` 

## Reviewer Notes

You can view this log in your local developer environment in your terminal.

I am working on adding another test for extractRecordInformation. I just wanted to get this PR in front of people :)

## Setup

* Start the admin app locally
* Navigate to an office user edit page
* Change the active value and hit save
* You should see the log in your terminal

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8237) for this change
