### PR TITLE
MB-8270 TOO can approve diversion requested shipment via api

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -566,6 +566,7 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 
 	// after updating shipment
 	// create shipment level service items if shipment status was NOT diversion requested before it was updated
+	// and current status is approved
 	createSSI := shipment.Status == models.MTOShipmentStatusApproved && !wasShipmentDiversionRequested
 	if createSSI {
 		err = o.createShipmentServiceItems(shipment)

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -516,6 +516,8 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 		rejectionReason = nil
 	}
 
+	// here we determine if the current shipment status is diversion requested before updating
+	wasShipmentDiversionRequested := shipment.Status == models.MTOShipmentStatusDiversionRequested
 	shipmentRouter := NewShipmentRouter(o.db)
 
 	switch status {
@@ -563,10 +565,10 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 	}
 
 	// after updating shipment
-	// create shipment level service items if it is not a diversion
-	createSSI := shipment.Status == models.MTOShipmentStatusApproved && !shipment.Diversion
+	// create shipment level service items if shipment status was NOT diversion requested before it was updated
+	createSSI := shipment.Status == models.MTOShipmentStatusApproved && !wasShipmentDiversionRequested
 	if createSSI {
-		err := o.createShipmentServiceItems(shipment)
+		err = o.createShipmentServiceItems(shipment)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -575,22 +575,6 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 	return shipment, nil
 }
 
-// setRequiredDeliveryDate set the calculated delivery date for the shipment
-func (o *mtoShipmentStatusUpdater) setRequiredDeliveryDate(shipment *models.MTOShipment) error {
-	if shipment.ScheduledPickupDate != nil &&
-		shipment.RequiredDeliveryDate == nil &&
-		shipment.PrimeEstimatedWeight != nil {
-		requiredDeliveryDate, calcErr := CalculateRequiredDeliveryDate(o.planner, o.db, *shipment.PickupAddress, *shipment.DestinationAddress, *shipment.ScheduledPickupDate, shipment.PrimeEstimatedWeight.Int())
-		if calcErr != nil {
-			return calcErr
-		}
-
-		shipment.RequiredDeliveryDate = requiredDeliveryDate
-	}
-
-	return nil
-}
-
 // createShipmentServiceItems creates shipment level service items
 func (o *mtoShipmentStatusUpdater) createShipmentServiceItems(shipment *models.MTOShipment) error {
 	reServiceCodes := reServiceCodesForShipment(*shipment)
@@ -607,6 +591,22 @@ func (o *mtoShipmentStatusUpdater) createShipmentServiceItems(shipment *models.M
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// setRequiredDeliveryDate set the calculated delivery date for the shipment
+func (o *mtoShipmentStatusUpdater) setRequiredDeliveryDate(shipment *models.MTOShipment) error {
+	if shipment.ScheduledPickupDate != nil &&
+		shipment.RequiredDeliveryDate == nil &&
+		shipment.PrimeEstimatedWeight != nil {
+		requiredDeliveryDate, calcErr := CalculateRequiredDeliveryDate(o.planner, o.db, *shipment.PickupAddress, *shipment.DestinationAddress, *shipment.ScheduledPickupDate, shipment.PrimeEstimatedWeight.Int())
+		if calcErr != nil {
+			return calcErr
+		}
+
+		shipment.RequiredDeliveryDate = requiredDeliveryDate
 	}
 
 	return nil

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -803,7 +803,6 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		err = suite.DB().Where("mto_shipment_id = $1", updatedShipment.ID).All(&shipmentServiceItems)
 		suite.NoError(err)
 		suite.Len(shipmentServiceItems, 0, "should not have created shipment level service items for diversion shipment after approving")
-
 	})
 }
 

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -782,11 +782,14 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Equal(models.MTOShipmentStatusDiversionRequested, shipmentToDivert.Status)
 	})
 
-	suite.T().Run("A DIVERSION_REQUESTED shipment can change to APPROVED", func(t *testing.T) {
+	suite.T().Run("A diversion or diverted shipment can change to APPROVED", func(t *testing.T) {
+		// a diversion or diverted shipment is when the PRIME sets the diversion field to true
+		// the status must also be in diversion requested status to be approvable as well
 		diversionRequestedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: testdatagen.MakeAvailableMove(suite.DB()),
 			MTOShipment: models.MTOShipment{
-				Status: models.MTOShipmentStatusDiversionRequested,
+				Status:    models.MTOShipmentStatusDiversionRequested,
+				Diversion: true,
 			},
 		})
 		eTag = etag.GenerateEtag(diversionRequestedShipment.UpdatedAt)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -786,8 +786,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		diversionRequestedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: testdatagen.MakeAvailableMove(suite.DB()),
 			MTOShipment: models.MTOShipment{
-				Status:    models.MTOShipmentStatusDiversionRequested,
-				Diversion: true,
+				Status: models.MTOShipmentStatusDiversionRequested,
 			},
 		})
 		eTag = etag.GenerateEtag(diversionRequestedShipment.UpdatedAt)

--- a/pkg/services/mto_shipment/shipment_router.go
+++ b/pkg/services/mto_shipment/shipment_router.go
@@ -123,6 +123,7 @@ func (router shipmentRouter) RequestDiversion(shipment *models.MTOShipment) erro
 		}
 	}
 	shipment.Status = models.MTOShipmentStatusDiversionRequested
+	shipment.Diversion = true
 
 	return nil
 }

--- a/pkg/services/mto_shipment/shipment_router.go
+++ b/pkg/services/mto_shipment/shipment_router.go
@@ -123,7 +123,6 @@ func (router shipmentRouter) RequestDiversion(shipment *models.MTOShipment) erro
 		}
 	}
 	shipment.Status = models.MTOShipmentStatusDiversionRequested
-	shipment.Diversion = true
 
 	return nil
 }

--- a/pkg/services/mto_shipment/shipment_router.go
+++ b/pkg/services/mto_shipment/shipment_router.go
@@ -128,7 +128,17 @@ func (router shipmentRouter) RequestDiversion(shipment *models.MTOShipment) erro
 }
 
 func (router shipmentRouter) approvable(shipment *models.MTOShipment) bool {
-	return statusSliceContains(validStatusesBeforeApproval, shipment.Status)
+	// first check if the status is in list
+	isApprovable := statusSliceContains(validStatusesBeforeApproval, shipment.Status)
+
+	// then check special case for diversion requested status
+	if shipment.Status == models.MTOShipmentStatusDiversionRequested {
+		// a shipment is considered diverted or part of a diversion if
+		// the prime sets the Diversion field to true
+		isApprovable = shipment.Diversion
+	}
+
+	return isApprovable
 }
 
 func statusSliceContains(statusSlice []models.MTOShipmentStatus, status models.MTOShipmentStatus) bool {

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -224,7 +224,6 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusDiversionRequested, shipment.Status)
-			suite.Equal(true, shipment.Diversion)
 		}
 	})
 

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -224,6 +224,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusDiversionRequested, shipment.Status)
+			suite.Equal(true, shipment.Diversion)
 		}
 	})
 

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -27,6 +27,8 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 		}
 		for _, validStatus := range validStatuses {
 			shipment.Status = validStatus.status
+			// special case for diversion requested
+			shipment.Diversion = true
 
 			err := shipmentRouter.Approve(&shipment)
 


### PR DESCRIPTION
## Description

This PR piggybacks off of [Moncef's PR](https://github.com/transcom/mymove/pull/6731) that adds in the shipment router. TOO will now be able to approve the diverted shipment via api.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- Did a refactor to clean up the calculated required delivery date and when we create the shipment level service items
- Diverted shipments doesn't auto-create the shipment level service items since they were already created when the shipment was approved the first time around
- There's a special case regarding the `DIVERSION_REQUESTED` status before approving. The `Diversion` field on the shipment must also be set to true. The PRIME actually will update that field to indicate they have "accepted" the requested diversion by setting that field.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

Test
1. Make sure that you have your [postman setup properly](https://github.com/transcom/mymove/wiki/How-to-setup-the-GHC-API-in-Postman)
2. We'll be hitting the `/move_task_orders/:moveTaskOrderID/mto_shipments/:shipmentID/status` patch endpoint
3. In the office app, find any move that has been `APPROVED`
4. Grab the ID of the mto_shipment and move (move task order) either from the network tab or react-query dev tools
5. Grab the eTag from the mto_shipment either from the network tab or react-query
![image](https://user-images.githubusercontent.com/1522549/120847194-fdf4b000-c527-11eb-94ad-a23765a16ab0.png)

6. Fill in `moveTaskOrderID` and `shipmentID` with IDs in Postman
![image](https://user-images.githubusercontent.com/1522549/120846289-c0435780-c526-11eb-9a67-84334c86c434.png)
7. Fill in the `If-Match` header
![image](https://user-images.githubusercontent.com/1522549/120846504-10bab500-c527-11eb-9023-dba8b19080ae.png)
8. Fill in the body, we'll first divert a shipment
![image](https://user-images.githubusercontent.com/1522549/120846618-3f389000-c527-11eb-9ecd-4ab98b298e41.png)
9. Click `Send` to request diversion for PRIME for the shipment

Since the prime usually sets the `Diversion` field, let's just set that value in the database locally. Set the `diversion` column to `true` on your shipment `mto_shipments` table

10.  Then update the body in postman to approve the shipment (don't forget to also update the etag)
![image](https://user-images.githubusercontent.com/1522549/120846761-7149f200-c527-11eb-91d0-33d9580c5c3f.png)
11. Click `Send` to approve the diverted shipment

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8270) for this change