### PR TITLE
[MB-3557] SupportAPI: Unneeded ReferenceID on creation of move task order

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1804,7 +1804,7 @@ func init() {
           ]
         },
         "referenceId": {
-          "description": "Unique ID associated with this Order.\n\nNo two MoveTaskOrders may have the same ID.\nAttempting to create a MoveTaskOrder may fail if this referenceId has been used already.\n",
+          "description": "Unique ID associated with this Order. Generated upon creation of a MoveTaskOrder\n\nNo two MoveTaskOrders may have the same ID.\n",
           "type": "string",
           "readOnly": true,
           "example": "1001-3456"
@@ -4505,7 +4505,7 @@ func init() {
           ]
         },
         "referenceId": {
-          "description": "Unique ID associated with this Order.\n\nNo two MoveTaskOrders may have the same ID.\nAttempting to create a MoveTaskOrder may fail if this referenceId has been used already.\n",
+          "description": "Unique ID associated with this Order. Generated upon creation of a MoveTaskOrder\n\nNo two MoveTaskOrders may have the same ID.\n",
           "type": "string",
           "readOnly": true,
           "example": "1001-3456"

--- a/pkg/gen/supportmessages/move_task_order.go
+++ b/pkg/gen/supportmessages/move_task_order.go
@@ -81,10 +81,9 @@ type MoveTaskOrder struct {
 	// Enum: [FULL PARTIAL]
 	PpmType string `json:"ppmType,omitempty"`
 
-	// Unique ID associated with this Order.
+	// Unique ID associated with this Order. Generated upon creation of a MoveTaskOrder
 	//
 	// No two MoveTaskOrders may have the same ID.
-	// Attempting to create a MoveTaskOrder may fail if this referenceId has been used already.
 	//
 	// Read Only: true
 	ReferenceID string `json:"referenceId,omitempty"`

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -456,38 +456,6 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		suite.Equal((models.MoveStatus)(responsePayload.Status), models.MoveStatusCANCELED)
 
 	})
-	suite.T().Run("Success createMoveTaskOrder discarded readOnly referenceID", func(t *testing.T) {
-
-		// TESTCASE SCENARIO
-		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
-		// Mocked:     None
-		// Set up:     We pass in a new moveTaskOrder, order, and existing customer.
-		//             We use a nonsense referenceID. ReferenceID is readOnly, this should not be applied.
-		// Expected outcome:
-		//             A new referenceID is generated.
-		//             Default status is draft.
-
-		// Running the same request should result in the same reference id
-		mtoPayload.ReferenceID = "some terrible reference id"
-		params := movetaskorderops.CreateMoveTaskOrderParams{
-			HTTPRequest: request,
-			Body:        mtoPayload,
-		}
-
-		// CALL FUNCTION UNDER TEST
-		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
-
-		// VERIFY RESULTS
-		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
-		moveTaskOrdersResponse := response.(*movetaskorderops.CreateMoveTaskOrderCreated)
-		responsePayload := moveTaskOrdersResponse.Payload
-
-		// Check that the referenceID DOES NOT match what was sent in
-		suite.NotEqual(mtoPayload.ReferenceID, responsePayload.ReferenceID)
-		// Check that moveTaskOrder was populated, including nested objects
-		suite.moveTaskOrderPopulated(moveTaskOrdersResponse, &destinationDutyStation, &originDutyStation)
-	})
 
 	suite.T().Run("Failed createMoveTaskOrder 422 UnprocessableEntity due to no customer", func(t *testing.T) {
 

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -343,7 +343,6 @@ func MoveTaskOrderModel(mtoPayload *supportmessages.MoveTaskOrder) *models.Move 
 	ppmEstimatedWeight := unit.Pound(mtoPayload.PpmEstimatedWeight)
 	contractorID := uuid.FromStringOrNil(mtoPayload.ContractorID.String())
 	model := &models.Move{
-		ReferenceID:        &mtoPayload.ReferenceID,
 		Locator:            mtoPayload.MoveCode,
 		PPMEstimatedWeight: &ppmEstimatedWeight,
 		PPMType:            &mtoPayload.PpmType,

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -940,10 +940,9 @@ definitions:
         type: string
         readOnly: true
         description: |
-          Unique ID associated with this Order.
+          Unique ID associated with this Order. Generated upon creation of a MoveTaskOrder
 
           No two MoveTaskOrders may have the same ID.
-          Attempting to create a MoveTaskOrder may fail if this referenceId has been used already.
       availableToPrimeAt:
         format: date-time
         type: string


### PR DESCRIPTION
## Description

Removes test checking for ReferenceID that is not used since it is automatically generated

## Setup
`make server_test`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-3557) for this change
