### PR TITLE
MB-7448: deploy niprnet services via circleci to stg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,42 @@ commands:
           name: Check deployed commits
           command: scripts/check-deployed-commit "<< parameters.health_check_hosts >>" "$CIRCLE_SHA1"
       - announce_failure
+  deploy_app_niprnet_steps:
+    parameters:
+      compare_host:
+        type: string
+      health_check_hosts:
+        type: string
+      ecr_env:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Compare against deployed commit
+          command: |
+            [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1
+      - restore_cache:
+          keys:
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
+      - attach_workspace:
+          at: /home/circleci/transcom/mymove/bin
+      - run:
+          name: Get Digest from filesystem
+          command: echo 'export ECR_DIGEST=$(cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_app_<< parameters.ecr_env >>)' | tee -a "${BASH_ENV}"
+      - deploy:
+          name: Deploy app-niprnet service
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-service-container app-niprnet "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app@${ECR_DIGEST}" "${APP_ENVIRONMENT}" "/bin/milmove serve"
+          no_output_timeout: 20m
+      - run:
+          name: Health Check
+          command: bin/health-checker --schemes http,https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 15m
+      - run:
+          name: TLS Check
+          command: bin/tls-checker --schemes https --hosts << parameters.health_check_hosts >> --log-level info --timeout 15m
+      - run:
+          name: Check deployed commits
+          command: scripts/check-deployed-commit "<< parameters.health_check_hosts >>" "$CIRCLE_SHA1"
+      - announce_failure
   deploy_app_client_tls_steps:
     parameters:
       compare_host:
@@ -283,6 +319,44 @@ commands:
       - deploy:
           name: Deploy app-client-tls service
           command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-service-container app-client-tls "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app@${ECR_DIGEST}" "${APP_ENVIRONMENT}" "/bin/milmove serve"
+          no_output_timeout: 20m
+      - run:
+          name: Health Check
+          command: |
+            bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} --cert ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} --ca ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA} --tries 10 --backoff 3 --log-level info --timeout 15m
+      - run:
+          name: TLS Check
+          command: |
+            bin/tls-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} --cert ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} --ca ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA} --log-level info --timeout 15m
+      - run:
+          name: Check deployed commits
+          command: scripts/check-deployed-commit "<< parameters.health_check_hosts >>" "$CIRCLE_SHA1" ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA}
+      - announce_failure
+  deploy_app_client_tls_niprnet_steps:
+    parameters:
+      compare_host:
+        type: string
+      health_check_hosts:
+        type: string
+      ecr_env:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Compare against deployed commit
+          command: |
+            [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1 ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA}
+      - restore_cache:
+          keys:
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
+      - attach_workspace:
+          at: /home/circleci/transcom/mymove/bin
+      - run:
+          name: Get Digest from filesystem
+          command: echo 'export ECR_DIGEST=$(cat /home/circleci/transcom/mymove/bin/sha/ECR_DIGEST_app_<< parameters.ecr_env >>)' | tee -a "${BASH_ENV}"
+      - deploy:
+          name: Deploy app-client-tls-niprnet service
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-service-container app-client-tls-niprnet "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app@${ECR_DIGEST}" "${APP_ENVIRONMENT}" "/bin/milmove serve"
           no_output_timeout: 20m
       - run:
           name: Health Check
@@ -1313,6 +1387,10 @@ jobs:
           compare_host: gex.stg.move.mil
           health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
           ecr_env: stg
+      - deploy_app_client_tls_niprnet_steps:
+          compare_host: gex.stg.move.mil
+          health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
+          ecr_env: stg
 
   # `deploy_stg_webhook_client` deploys the webhook client to stg
   deploy_stg_webhook_client:
@@ -1371,6 +1449,10 @@ jobs:
     steps:
       - aws_vars_prd
       - deploy_app_client_tls_steps:
+          compare_host: gex.move.mil
+          health_check_hosts: gex.move.mil,orders.move.mil
+          ecr_env: prd
+      - deploy_app_client_tls_niprnet_steps:
           compare_host: gex.move.mil
           health_check_hosts: gex.move.mil,orders.move.mil
           ecr_env: prd


### PR DESCRIPTION
## Description

This adds CircleCI jobs to the existing staging deployment so that each deployment to staging will deploy to both the internet-facing ECS services as well as the NIPRNet-facing ECS services.

I used the existing app and app-client-tls jobs to write these new jobs.

I am unable to test this in experimental since anything related to the BCAP must only exist within the ATO boundary, which currently only includes stg and prd. Therefore, this is entirely untested. If it breaks things, we can revert it.

## Setup

Watch CircleCI once this is merged to master.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7448) for this change