### PR TITLE
MB-7448: move one of the deployments to prd to stg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1375,6 +1375,10 @@ jobs:
           compare_host: my.stg.move.mil
           health_check_hosts: my.stg.move.mil,office.stg.move.mil,admin.stg.move.mil
           ecr_env: stg
+      - deploy_app_niprnet_steps:
+          compare_host: my.stg.move.mil
+          health_check_hosts: my.stg.move.mil,office.stg.move.mil,admin.stg.move.mil
+          ecr_env: stg
 
   # `deploy_stg_app_client_tls` updates the mutual-TLS service in the stg environment
   deploy_stg_app_client_tls:
@@ -1449,10 +1453,6 @@ jobs:
     steps:
       - aws_vars_prd
       - deploy_app_client_tls_steps:
-          compare_host: gex.move.mil
-          health_check_hosts: gex.move.mil,orders.move.mil
-          ecr_env: prd
-      - deploy_app_client_tls_niprnet_steps:
           compare_host: gex.move.mil
           health_check_hosts: gex.move.mil,orders.move.mil
           ecr_env: prd


### PR DESCRIPTION
## Description

This removes an deployment to prd that is not ready yet. We're still working on staging. This also adds a missing step in staging that should have been added with https://github.com/transcom/mymove/pull/6777

## Setup

Watch CircleCI.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7448) for this change