### PR TITLE
MB-7448: parallelize the niprnet deployments to stg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1375,6 +1375,14 @@ jobs:
           compare_host: my.stg.move.mil
           health_check_hosts: my.stg.move.mil,office.stg.move.mil,admin.stg.move.mil
           ecr_env: stg
+
+  # `deploy_stg_app_niprnet` updates the server-TLS app service in stg environment for NIPRNet
+  deploy_stg_app_niprnet:
+    executor: mymove_small
+    environment:
+      - APP_ENVIRONMENT: 'stg'
+    steps:
+      - aws_vars_stg
       - deploy_app_niprnet_steps:
           compare_host: my.stg.move.mil
           health_check_hosts: my.stg.move.mil,office.stg.move.mil,admin.stg.move.mil
@@ -1391,6 +1399,14 @@ jobs:
           compare_host: gex.stg.move.mil
           health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
           ecr_env: stg
+
+  # `deploy_stg_app_client_tls_niprnet` updates the mutual-TLS service in the stg environment for NIPRNet
+  deploy_stg_app_client_tls_niprnet:
+    executor: mymove_small
+    environment:
+      - APP_ENVIRONMENT: 'stg'
+    steps:
+      - aws_vars_stg
       - deploy_app_client_tls_niprnet_steps:
           compare_host: gex.stg.move.mil
           health_check_hosts: gex.stg.move.mil,orders.stg.move.mil
@@ -1704,7 +1720,21 @@ workflows:
             branches:
               only: master
 
+      - deploy_stg_app_niprnet:
+          requires:
+            - deploy_stg_migrations
+          filters:
+            branches:
+              only: master
+
       - deploy_stg_app_client_tls:
+          requires:
+            - deploy_stg_migrations
+          filters:
+            branches:
+              only: master
+
+      - deploy_stg_app_client_tls_niprnet:
           requires:
             - deploy_stg_migrations
           filters:
@@ -1723,7 +1753,9 @@ workflows:
           requires:
             - deploy_stg_tasks
             - deploy_stg_app
+            - deploy_stg_app_niprnet
             - deploy_stg_app_client_tls
+            - deploy_stg_app_client_tls_niprnet
             - deploy_stg_webhook_client
 
       - deploy_storybook_dp3:


### PR DESCRIPTION
## Description

After seeing the deploy_stg_app_client_tls task double in time to complete, I realized that the CircleCI configuration would likely benefit from parallelization of the deployment of the app/app-niprnet and app-client-tls/app-client-tls-niprnet jobs. So that's what this PR does. Instead of serializing app with app-niprnet and app-client-tls with app-client-tls-niprnet, they should all now deploy in parallel.

## Setup

Watch CircleCI once this gets merged to master.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7448) for this change