### PR TITLE
MB-8148 Show roles not deleted

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -177,7 +177,14 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 		return nil, ErrFetchNotFound
 	}
 	identity := &identities[0]
-	roleError := db.Load(identity, "Roles")
+	roleError := db.RawQuery(`SELECT roles.created_at,
+									   roles.id,
+									   roles.role_name,
+									   roles.role_type,
+									   roles.updated_at
+									FROM roles AS roles
+									WHERE id in (select role_id from users_roles
+										where deleted_at is null and user_id = ?)`, identity.ID).All(&identity.Roles)
 	if roleError != nil {
 		return nil, roleError
 	}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -177,8 +177,7 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 		return nil, ErrFetchNotFound
 	}
 	identity := &identities[0]
-	roleError := db.RawQuery(`SELECT *
-									FROM roles AS roles
+	roleError := db.RawQuery(`SELECT * FROM roles
 									WHERE id in (select role_id from users_roles
 										where deleted_at is null and user_id = ?)`, identity.ID).All(&identity.Roles)
 	if roleError != nil {

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -177,11 +177,7 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 		return nil, ErrFetchNotFound
 	}
 	identity := &identities[0]
-	roleError := db.RawQuery(`SELECT roles.created_at,
-									   roles.id,
-									   roles.role_name,
-									   roles.role_type,
-									   roles.updated_at
+	roleError := db.RawQuery(`SELECT *
 									FROM roles AS roles
 									WHERE id in (select role_id from users_roles
 										where deleted_at is null and user_id = ?)`, identity.ID).All(&identity.Roles)

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -227,7 +227,7 @@ func (suite *ModelSuite) TestFetchUserIdentityDeletedRoles() {
 	identity, err := FetchUserIdentity(suite.DB(), multiRoleUser.User.LoginGovUUID.String())
 	suite.Nil(err, "failed to fetch user identity")
 	suite.Equal(*multiRoleUser.UserID, identity.ID)
-	suite.Condition(compareRoleTypeLists(multiRoleUser.User.Roles, identity.Roles)) //(multiRoleUser.User.Roles, identity.Roles)
+	suite.Condition(compareRoleTypeLists(multiRoleUser.User.Roles, identity.Roles))
 
 	/*
 		Test that user identity is properly fetched after deleting roles

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -299,6 +299,22 @@ func MakeOfficeUserWithMultipleRoles(db *pop.Connection, assertions Assertions) 
 		Stub: assertions.Stub,
 	})
 
+	// save roles to db
+	rolesList := officeUser.User.Roles
+	for _, role := range rolesList {
+		newRole := MakeRole(db, Assertions{
+			Role: role,
+			Stub: assertions.Stub,
+		})
+		MakeUsersRoles(db, Assertions{
+			UsersRoles: models.UsersRoles{
+				UserID: officeUser.User.ID,
+				RoleID: newRole.ID,
+			},
+			Stub: assertions.Stub,
+		})
+	}
+
 	return officeUser
 }
 

--- a/pkg/testdatagen/make_role.go
+++ b/pkg/testdatagen/make_role.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
 )
 
@@ -21,6 +22,22 @@ func MakeRole(db *pop.Connection, assertions Assertions) roles.Role {
 	mustCreate(db, &role, assertions.Stub)
 
 	return role
+}
+
+// MakeUsersRoles ties roles to the user
+func MakeUsersRoles(db *pop.Connection, assertions Assertions) models.UsersRoles {
+	usersRoles := models.UsersRoles{
+		ID:     uuid.Must(uuid.NewV4()),
+		UserID: assertions.User.ID,
+		RoleID: assertions.UsersRoles.RoleID,
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&usersRoles, assertions.UsersRoles)
+
+	mustCreate(db, &usersRoles, assertions.Stub)
+
+	return usersRoles
 }
 
 // MakeServicesCounselorRole creates a single services counselor role.

--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -11,7 +11,9 @@ import (
 // It will not replace a true assertion with false.
 func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 
+	loginGovUUID := uuid.Must(uuid.NewV4())
 	user := models.User{
+		LoginGovUUID:  &loginGovUUID,
 		LoginGovEmail: "first.last@login.gov.test",
 		Active:        false,
 	}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -98,6 +98,7 @@ type Assertions struct {
 	UserUpload                               models.UserUpload
 	UserUploader                             *uploader.UserUploader
 	User                                     models.User
+	UsersRoles                               models.UsersRoles
 	WebhookNotification                      models.WebhookNotification
 	WebhookSubscription                      models.WebhookSubscription
 	Zip3Distance                             models.Zip3Distance


### PR DESCRIPTION
## Description

This PR fixes a bug that the soft deleted roles were being populated in the session. The soft deleted roles don't show anymore after logging out and back in.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- Caveat is that the deleted roles will still be in the session while the user is still logged in. After logging out and back in, the user roles will be properly populated.
- The model `Role` being used in the `User` model is actually suppose to use `UsersRoles`. `Role` is meant to reference the actual roles we have that exists while the `UsersRoles` references what roles the user is tied to. I'll make a new story to capture this.
- There's a custom assertion condition logic to check if roles match the fetched list in the test. The assertion doesn't check for duplication but that shouldn't be a problem since the list of roles are unique. Something to keep note of while reviewing.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

### Test with local sign-in (works with Login.gov too!)
1. Open up both the office app and admin app in separate tabs

**Office app (http://officelocal:3000)**

2. In the office app, log in as a multi-role user `too_tio_services_counselor_role@office.mil`
3. Click `Change user role` link at the top left corner
4. Note the current roles: `TOO`, `TIO`, and `Services Counselor`

**Admin app (http://adminlocal:3000)**

5. Switch to the admin app and log in as the admin
6. Navigate to office users queue by clicking on the left tab `Office Users`
7. Search office user `too_tio_services_counselor_role@office.mil`
8. Click on user
9. Click `Edit`
10. De-select any user role that's checked

**Office app (http://officelocal:3000)**

11. Back to Office app tab
12. Log out
13. Log back in with same user
14. Click on `Change user role` and note the difference 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8148) for this change