### PR TITLE
MB-8012 Update createMTOShipments to allow only one agent of each type

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_creator.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator.go
@@ -175,6 +175,13 @@ func (f mtoShipmentCreator) CreateMTOShipment(shipment *models.MTOShipment, serv
 				if err != nil {
 					return err
 				}
+
+				for _, agentInList := range agentsList {
+					if agentInList.MTOAgentType == copyOfAgent.MTOAgentType {
+						return services.NewInvalidInputError(uuid.Nil, nil, nil, "MTOAgents can only contain one agent of each type")
+					}
+				}
+
 				agentsList = append(agentsList, copyOfAgent)
 			}
 			shipment.MTOAgents = agentsList

--- a/pkg/services/mto_shipment/mto_shipment_creator_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_creator_test.go
@@ -200,6 +200,43 @@ func (suite *MTOShipmentServiceSuite) TestCreateMTOShipmentRequest() {
 		suite.Error(err)
 		suite.IsType(services.InvalidInputError{}, err)
 	})
+
+	suite.T().Run("422 Validation Error - only one mto agent of each type", func(t *testing.T) {
+		firstName := "First"
+		lastName := "Last"
+		email := "test@gmail.com"
+
+		var agents models.MTOAgents
+
+		agent1 := models.MTOAgent{
+			FirstName:    &firstName,
+			LastName:     &lastName,
+			Email:        &email,
+			MTOAgentType: models.MTOAgentReceiving,
+		}
+
+		agent2 := models.MTOAgent{
+			FirstName:    &firstName,
+			LastName:     &lastName,
+			Email:        &email,
+			MTOAgentType: models.MTOAgentReceiving,
+		}
+
+		agents = append(agents, agent1, agent2)
+
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				MTOAgents: agents,
+			},
+		})
+
+		serviceItemsList := models.MTOServiceItems{}
+		createdShipment, err := creator.CreateMTOShipment(&shipment, serviceItemsList)
+
+		suite.Nil(createdShipment)
+		suite.Error(err)
+		suite.IsType(services.InvalidInputError{}, err)
+	})
 }
 
 // Clears all the ID fields that we need to be null for a new shipment to get created:


### PR DESCRIPTION
## Description

This PR adds validation to ensure that when a shipment is created, only one of each agent type can be created.

## Reviewer Notes

This validation also needs to be added for updateMTOShipment. I didn't want to include it in this PR because Nelz is currently refactoring that endpoint, so I created another ticket for it (https://dp3.atlassian.net/browse/MB-8378).

## Setup

You can test this in postman. Create a post request for createMTOShipment. The request body should look like this:

```
{
    "moveTaskOrderID": "<YOUR MOVE ID HERE>",
    "requestedPickupDate": "1985-12-17",
    "pickupAddress": {
        "streetAddress1": "123 Main Ave",
        "city": "Anytown",
        "state": "NV",
        "postalCode": "90210",
        "streetAddress2": "Apartment 9000",
        "streetAddress3": "Montmârtre",
        "country": "USA"
    },
    "destinationAddress": {
        "streetAddress1": "123 Main Ave",
        "city": "Anytown",
        "state": "ND",
        "postalCode": "90210",
        "streetAddress2": "Apartment 9000",
        "streetAddress3": "Montmârtre",
        "country": "USA",
        "eTag": "quis"
    },
    "shipmentType": "HHG",
    "customerRemarks": "handle with care",
    "agents": [
        {
            "firstName":"TEst",
            "lastName":"test",
            "email":"test@testmail.com",
            "phone":"999-999-9999",
            "agentType":"RECEIVING_AGENT"
        },
        {
            "firstName":"TEst",
            "lastName":"test",
            "email":"test@gmail.com",
            "phone":"999-999-9999",
            "agentType":"RECEIVING_AGENT"
        }
    ]
}
```

This request should return a 422. 

You can also run the tests: `make server_test`

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8012) for this change
