### PR TITLE
MB-8284 fix flaky e2e test for services counselor

### DIFF
--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -30,38 +30,38 @@ describe('Services counselor user', () => {
      * SC Moves queue
      */
     cy.wait(['@getSortedMoves']);
-    cy.get('input[name="locator"]').as('moveCodeFilterInput');
+    // cy.get('input[name="locator"]').as('moveCodeFilterInput');
 
-    // type in move code/locator to filter
-    cy.get('@moveCodeFilterInput').type(moveLocator).blur();
-    cy.wait(['@getFilterSortedMoves']);
+    // // type in move code/locator to filter
+    // cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+    // cy.wait(['@getFilterSortedMoves']);
 
-    // check if results appear, should be 1
-    // and see if result have move code
-    cy.get('tbody > tr').as('results');
-    cy.get('@results').should('have.length', 1);
-    cy.get('@results').first().contains(moveLocator);
+    // // check if results appear, should be 1
+    // // and see if result have move code
+    // cy.get('tbody > tr').as('results');
+    // cy.get('@results').should('have.length', 1);
+    // cy.get('@results').first().contains(moveLocator);
 
-    // click result to navigate to move details page
-    cy.get('@results').first().click();
-    cy.url().should('include', `/counseling/moves/${moveLocator}/details`);
-    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    // // click result to navigate to move details page
+    // cy.get('@results').first().click();
+    // cy.url().should('include', `/counseling/moves/${moveLocator}/details`);
+    // cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
 
-    /**
-     * Move Details page
-     */
-    // click to trigger confirmation modal
-    cy.contains('Submit move details').click();
+    // /**
+    //  * Move Details page
+    //  */
+    // // click to trigger confirmation modal
+    // cy.contains('Submit move details').click();
 
-    // modal should pop up with text
-    cy.get('h2').contains('Are you sure?');
-    cy.get('p').contains('You can’t make changes after you submit the move.');
+    // // modal should pop up with text
+    // cy.get('h2').contains('Are you sure?');
+    // cy.get('p').contains('You can’t make changes after you submit the move.');
 
-    // click submit
-    cy.get('button').contains('Yes, submit').click();
-    cy.waitFor(['@patchServiceCounselingCompleted', '@getMoves']);
+    // // click submit
+    // cy.get('button').contains('Yes, submit').click();
+    // cy.waitFor(['@patchServiceCounselingCompleted', '@getMoves']);
 
-    // verify success alert
-    cy.contains('Move submitted.');
+    // // verify success alert
+    // cy.contains('Move submitted.');
   });
 });

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -8,7 +8,7 @@ describe('Services counselor user', () => {
   beforeEach(() => {
     cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
     cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc').as('getSortedMoves');
-    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc&locator=SCE2ET').as(
+    cy.intercept('**/ghc/v1/queues/counseling?page=1&perPage=20&sort=submittedAt&order=asc&locator=SCE4ET').as(
       'getFilterSortedMoves',
     );
     cy.intercept('**/ghc/v1/move/**').as('getMoves');
@@ -24,44 +24,44 @@ describe('Services counselor user', () => {
   });
 
   it('is able to click on move and submit after using the move code filter', () => {
-    const moveLocator = 'SCE2ET';
+    const moveLocator = 'SCE4ET';
 
     /**
      * SC Moves queue
      */
     cy.wait(['@getSortedMoves']);
-    // cy.get('input[name="locator"]').as('moveCodeFilterInput');
+    cy.get('input[name="locator"]').as('moveCodeFilterInput');
 
-    // // type in move code/locator to filter
-    // cy.get('@moveCodeFilterInput').type(moveLocator).blur();
-    // cy.wait(['@getFilterSortedMoves']);
+    // type in move code/locator to filter
+    cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+    cy.wait(['@getFilterSortedMoves']);
 
-    // // check if results appear, should be 1
-    // // and see if result have move code
-    // cy.get('tbody > tr').as('results');
-    // cy.get('@results').should('have.length', 1);
-    // cy.get('@results').first().contains(moveLocator);
+    // check if results appear, should be 1
+    // and see if result have move code
+    cy.get('tbody > tr').as('results');
+    cy.get('@results').should('have.length', 1);
+    cy.get('@results').first().contains(moveLocator);
 
-    // // click result to navigate to move details page
-    // cy.get('@results').first().click();
-    // cy.url().should('include', `/counseling/moves/${moveLocator}/details`);
-    // cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    // click result to navigate to move details page
+    cy.get('@results').first().click();
+    cy.url().should('include', `/counseling/moves/${moveLocator}/details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
 
-    // /**
-    //  * Move Details page
-    //  */
-    // // click to trigger confirmation modal
-    // cy.contains('Submit move details').click();
+    /**
+     * Move Details page
+     */
+    // click to trigger confirmation modal
+    cy.contains('Submit move details').click();
 
-    // // modal should pop up with text
-    // cy.get('h2').contains('Are you sure?');
-    // cy.get('p').contains('You can’t make changes after you submit the move.');
+    // modal should pop up with text
+    cy.get('h2').contains('Are you sure?');
+    cy.get('p').contains('You can’t make changes after you submit the move.');
 
-    // // click submit
-    // cy.get('button').contains('Yes, submit').click();
-    // cy.waitFor(['@patchServiceCounselingCompleted', '@getMoves']);
+    // click submit
+    cy.get('button').contains('Yes, submit').click();
+    cy.waitFor(['@patchServiceCounselingCompleted', '@getMoves']);
 
-    // // verify success alert
-    // cy.contains('Move submitted.');
+    // verify success alert
+    cy.contains('Move submitted.');
   });
 });

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -31,6 +31,12 @@ import (
 	"github.com/transcom/mymove/pkg/uploader"
 )
 
+/**************
+
+We should not be creating random data in e2ebasic! Tests should be deterministic.
+
+***************/
+
 // E2eBasicScenario builds a basic set of data for e2e testing
 type e2eBasicScenario NamedScenario
 
@@ -2307,12 +2313,29 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		},
 	})
 
-	// Create a move specific for Services Counselor role
-	validStatuses := []models.MoveStatus{models.MoveStatusNeedsServiceCounseling}
-	createRandomMove(db, validStatuses, allDutyStations, originDutyStationsInGBLOC, testdatagen.Assertions{
-		UserUploader: userUploader,
-		Move: models.Move{
-			Locator: "SCE2ET", // Services counselor e2e test
+	customerNeedsServicesCounselling := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID: uuid.FromStringOrNil("a5cc1277-37dd-4588-a982-df3c9fa7fcsc"),
 		},
 	})
+	ordersNeedsServicesCounselling := testdatagen.MakeOrder(db, testdatagen.Assertions{
+		Order: models.Order{
+			ID:              uuid.FromStringOrNil("42f9cd3b-d630-4762-9762-542e9a3a67sc"),
+			ServiceMemberID: customerNeedsServicesCounselling.ID,
+			ServiceMember:   customerNeedsServicesCounselling,
+		},
+		UserUploader: userUploader,
+	})
+
+	selectedMoveTypeHHG := models.SelectedMoveTypeHHG
+	testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("302f3509-562c-4f5c-81c5-b770f4af30sc"),
+			Locator:          "SCE2ET",
+			OrdersID:         ordersNeedsServicesCounselling.ID,
+			Status:           models.MoveStatusNeedsServiceCounseling,
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+	})
+
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2315,7 +2315,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 
 	customerNeedsServicesCounselling := testdatagen.MakeServiceMember(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
-			ID: uuid.FromStringOrNil("a5cc1277-37dd-4588-a982-df3c9fa7fcsc"),
+			ID:            uuid.FromStringOrNil("a5cc1277-37dd-4588-a982-df3c9fa7fcsc"),
+			DutyStation:   originDutyStationsInGBLOC[0],
+			DutyStationID: &originDutyStationsInGBLOC[0].ID,
 		},
 	})
 	ordersNeedsServicesCounselling := testdatagen.MakeOrder(db, testdatagen.Assertions{
@@ -2336,6 +2338,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 			Status:           models.MoveStatusNeedsServiceCounseling,
 			SelectedMoveType: &selectedMoveTypeHHG,
 		},
+		Order: ordersNeedsServicesCounselling,
 	})
-
 }


### PR DESCRIPTION
## Description

- Added a function to create multiple moves that need Services Counseling with custom locator
- Swapped randomly generated move for specific move

## Reviewer Notes

In looking into this, there were no obvious bugs and the test passes consistently. I have an unconfirmed theory that the flakiness is caused by the tests running in sequence that causes the this test to fail because the move has already been handled in another test (probably something that grabs the first move).

My solution is to add multiple moves that need services counseling to the queue and choose the last one for this test.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make e2e_test
```

## Code Review Verification Steps
When running Cypress locally, the Services Counseling flow test should pass consistently.

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
