### PR TITLE
MMDM-2790 migration to remove shimona cac access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1504,7 +1504,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - integration_tests:
           requires:
@@ -1518,7 +1518,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: remove_shimona_cac
+              ignore: placeholder_branch_name
 
       - integration_tests_mtls:
           requires:
@@ -1531,7 +1531,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: remove_shimona_cac
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -1539,7 +1539,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: remove_shimona_cac
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -1547,7 +1547,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: remove_shimona_cac
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1591,28 +1591,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - deploy_exp_migrations:
           requires:
@@ -1627,35 +1627,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: remove_shimona_cac
+              only: placeholder_branch_name
 
       - push_app_stg:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1504,7 +1504,7 @@ workflows:
             - pre_deps_golang
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - integration_tests:
           requires:
@@ -1518,7 +1518,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: remove_shimona_cac
 
       - integration_tests_mtls:
           requires:
@@ -1531,7 +1531,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: remove_shimona_cac
 
       - client_test:
           requires:
@@ -1539,7 +1539,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: remove_shimona_cac
 
       - server_test:
           requires:
@@ -1547,7 +1547,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: remove_shimona_cac
 
       - build_app:
           requires:
@@ -1591,28 +1591,28 @@ workflows:
             - build_app
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - push_migrations_exp:
           requires:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - push_tasks_exp:
           requires:
             - build_tasks
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - push_webhook_client_exp:
           requires:
             - build_webhook_client
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - deploy_exp_migrations:
           requires:
@@ -1627,35 +1627,35 @@ workflows:
             - push_webhook_client_exp
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - deploy_exp_tasks:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - deploy_exp_app:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - deploy_exp_app_client_tls:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - deploy_exp_webhook_client:
           requires:
             - deploy_exp_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: remove_shimona_cac
 
       - push_app_stg:
           requires:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -642,3 +642,4 @@
 20210514045435_update_payment_request_to_interchange_control_numbers_constraint.up.sql
 20210521220916_remove_old_cac_certs.up.sql
 20210608162156_add_uploaded_amended_orders_id_to_orders.up.sql
+20210611202542_remove_shimona_cac.up.sql

--- a/migrations/app/schema/20210611202542_remove_shimona_cac.up.sql
+++ b/migrations/app/schema/20210611202542_remove_shimona_cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove shimona CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='46d6dc9b5624db0b0c319f13871d94f60e7fc43f212e76ae499ada702506539b';


### PR DESCRIPTION
## Description

Removing cac access for Shimona.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* [x] If the change is risky, it has been tested in experimental before merging.
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [x] Have been communicated to #g-database
  * [x] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MMDM-2790) for this change

