### PR TITLE
use latest milmove-cypress image: MB-8269

### DIFF
--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-4d97b75de90930baa2ef395cd7ef6b0a0666427a
+FROM milmove/circleci-docker:milmove-cypress-d1f3b463c56ff48eceea1991804ab042b07a9dac
 
 # use the WORKDIR from the CI image
 # hadolint ignore=DL3045


### PR DESCRIPTION
## Description

We have a [repo `circleci-docker`](https://github.com/transcom/circleci-docker) that contains a build of cypress for our integration tests. When we update any packages in `circleci-docker`, we should pull the latest image of into `mymove`.

## Reviewer Notes

Did I get the correct hash from Dockerhub image?

## Setup

the integration tests should run w/o an issue on circle

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8269) for this change
