### PR TITLE
Update shipment tests

### DIFF
--- a/pkg/services/mto_shipment/shipment_approver_test.go
+++ b/pkg/services/mto_shipment/shipment_approver_test.go
@@ -238,5 +238,6 @@ func (suite *MTOShipmentServiceSuite) TestApproveShipment() {
 		_, err := approver.ApproveShipment(shipment.ID, eTag)
 
 		suite.NoError(err)
+		shipmentRouter.AssertNumberOfCalls(t, "Approve", 1)
 	})
 }

--- a/pkg/services/mto_shipment/shipment_cancellation_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_cancellation_requester_test.go
@@ -97,5 +97,6 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentCancellation() {
 		_, err = requester.RequestShipmentCancellation(shipment.ID, eTag)
 
 		suite.NoError(err)
+		shipmentRouter.AssertNumberOfCalls(t, "RequestCancellation", 1)
 	})
 }

--- a/pkg/services/mto_shipment/shipment_diversion_approver_test.go
+++ b/pkg/services/mto_shipment/shipment_diversion_approver_test.go
@@ -97,5 +97,6 @@ func (suite *MTOShipmentServiceSuite) TestApproveShipmentDiversion() {
 		_, err = approver.ApproveShipmentDiversion(shipment.ID, eTag)
 
 		suite.NoError(err)
+		shipmentRouter.AssertNumberOfCalls(t, "ApproveDiversion", 1)
 	})
 }

--- a/pkg/services/mto_shipment/shipment_diversion_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_diversion_requester_test.go
@@ -97,5 +97,6 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentDiversion() {
 		_, err = requester.RequestShipmentDiversion(shipment.ID, eTag)
 
 		suite.NoError(err)
+		shipmentRouter.AssertNumberOfCalls(t, "RequestDiversion", 1)
 	})
 }

--- a/pkg/services/mto_shipment/shipment_rejecter_test.go
+++ b/pkg/services/mto_shipment/shipment_rejecter_test.go
@@ -98,5 +98,6 @@ func (suite *MTOShipmentServiceSuite) TestRejectShipment() {
 		_, err = rejecter.RejectShipment(shipment.ID, eTag, &reason)
 
 		suite.NoError(err)
+		shipmentRouter.AssertNumberOfCalls(t, "Reject", 1)
 	})
 }

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -19,15 +19,15 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 
 	suite.Nil(shipment.ApprovedDate)
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 			// special case for diversion requested
 			shipment.Diversion = true
@@ -37,21 +37,21 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusApproved, shipment.Status)
 			suite.NotNil(shipment.ApprovedDate)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Approved", models.MTOShipmentStatusApproved},
-			{"Draft", models.MTOShipmentStatusDraft},
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Approved", models.MTOShipmentStatusApproved},
+		{"Draft", models.MTOShipmentStatusDraft},
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Approve(&shipment)
@@ -60,8 +60,8 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status 'APPROVED' from [\"SUBMITTED\" \"DIVERSION_REQUESTED\"]", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 
 	suite.Run("does not approve a shipment if the move is not Approved or Approvals Requested", func() {
 		submittedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -78,36 +78,36 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter(suite.DB())
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Submit(&shipment)
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusSubmitted, shipment.Status)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-			{"Approved", models.MTOShipmentStatusApproved},
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+		{"Approved", models.MTOShipmentStatusApproved},
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Submit(&shipment)
@@ -116,44 +116,44 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status 'SUBMITTED' from [\"DRAFT\"]", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }
 
 func (suite *MTOShipmentServiceSuite) TestCancel() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter(suite.DB())
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Cancel(&shipment)
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusCanceled, shipment.Status)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-			{"Approved", models.MTOShipmentStatusApproved},
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+		{"Approved", models.MTOShipmentStatusApproved},
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Cancel(&shipment)
@@ -162,8 +162,8 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }
 
 func (suite *MTOShipmentServiceSuite) TestReject() {
@@ -171,14 +171,14 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 	shipmentRouter := NewShipmentRouter(suite.DB())
 	rejectionReason := "reason"
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Reject(&shipment, &rejectionReason)
@@ -186,22 +186,22 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusRejected, shipment.Status)
 			suite.Equal(&rejectionReason, shipment.RejectionReason)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-			{"Approved", models.MTOShipmentStatusApproved},
-			{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+		{"Approved", models.MTOShipmentStatusApproved},
+		{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Reject(&shipment, &rejectionReason)
@@ -210,44 +210,44 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter(suite.DB())
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Approved", models.MTOShipmentStatusApproved},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Approved", models.MTOShipmentStatusApproved},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.RequestDiversion(&shipment)
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusDiversionRequested, shipment.Status)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.RequestDiversion(&shipment)
@@ -256,44 +256,44 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }
 
 func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter(suite.DB())
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Approved", models.MTOShipmentStatusDiversionRequested},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Approved", models.MTOShipmentStatusDiversionRequested},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.ApproveDiversion(&shipment)
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusApproved, shipment.Status)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Diversion Requested", models.MTOShipmentStatusApproved},
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Diversion Requested", models.MTOShipmentStatusApproved},
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.ApproveDiversion(&shipment)
@@ -302,44 +302,44 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter(suite.DB())
 
-	suite.Run("from valid statuses", func() {
-		validStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Approved", models.MTOShipmentStatusApproved},
-		}
-		for _, validStatus := range validStatuses {
+	validStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Approved", models.MTOShipmentStatusApproved},
+	}
+	for _, validStatus := range validStatuses {
+		suite.Run("from valid status: "+string(validStatus.status), func() {
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.RequestCancellation(&shipment)
 
 			suite.NoError(err)
 			suite.Equal(models.MTOShipmentStatusCancellationRequested, shipment.Status)
-		}
-	})
+		})
+	}
 
-	suite.Run("from invalid statuses", func() {
-		invalidStatuses := []struct {
-			desc   string
-			status models.MTOShipmentStatus
-		}{
-			{"Canceled", models.MTOShipmentStatusCanceled},
-			{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
-			{"Rejected", models.MTOShipmentStatusRejected},
-			{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
-			{"Submitted", models.MTOShipmentStatusSubmitted},
-			{"Draft", models.MTOShipmentStatusDraft},
-		}
-		for _, invalidStatus := range invalidStatuses {
+	invalidStatuses := []struct {
+		desc   string
+		status models.MTOShipmentStatus
+	}{
+		{"Canceled", models.MTOShipmentStatusCanceled},
+		{"CANCELLATION_REQUESTED", models.MTOShipmentStatusCancellationRequested},
+		{"Rejected", models.MTOShipmentStatusRejected},
+		{"Diversion Requested", models.MTOShipmentStatusDiversionRequested},
+		{"Submitted", models.MTOShipmentStatusSubmitted},
+		{"Draft", models.MTOShipmentStatusDraft},
+	}
+	for _, invalidStatus := range invalidStatuses {
+		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.RequestCancellation(&shipment)
@@ -348,6 +348,6 @@ func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 			suite.IsType(ConflictStatusError{}, err)
 			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
 			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		}
-	})
+		})
+	}
 }


### PR DESCRIPTION
## Description

Small updates to tests based on PR feedback in #6767.

One thing that I just discovered and that was surprising to me is that using `.On` when mocking doesn't test that the mocked object was actually called in the case where it doesn't get called at all. For example, the ShipmentApprover service calls the ShipmentRouter service. We expect `ShipmentRouter` to receive a call to `Approve`. If in the test, we do this:

```golang
shipmentRouter.On("Approve", &createdShipment).Return(nil)
```
and then we comment out the call to `router.Approve` in the ShipmentApprover, the test still passes!

However, if the `ShipmentApprover` passes in the wrong object to `router.Approve`, the test will catch that.

So, to make sure the call is indeed made, we can add another assertion after the service call is made:

```golang
shipmentRouter.AssertNumberOfCalls(t, "Approve", 1)
```

Testify also has a `AssertCalled` function, but I couldn't get it to work. It was complaining about the memory address of the shipment being wrong and I couldn't figure out why.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
