### PR TITLE
[MB-8174] Update devseed data for multiple pickup addresses

### DIFF
--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -130,6 +130,7 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 	if shipmentHasPickupDetails {
 		MTOShipment.PickupAddress = &pickupAddress
 		MTOShipment.PickupAddressID = &pickupAddress.ID
+		MTOShipment.SecondaryPickupAddressID = &secondaryPickupAddress.ID
 		MTOShipment.SecondaryPickupAddress = &secondaryPickupAddress
 	}
 

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -596,17 +596,14 @@ func createUnsubmittedHHGMoveMultiplePickup(db *pop.Connection) {
 		},
 	})
 
-	estimatedHHGWeight := unit.Pound(1400)
-	actualHHGWeight := unit.Pound(2000)
 	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
 		MTOShipment: models.MTOShipment{
 			ID:                       uuid.FromStringOrNil("a35b1247-b4c2-48f6-9846-8e96050fbc95"),
 			PickupAddress:            &pickupAddress1,
 			PickupAddressID:          &pickupAddress1.ID,
 			SecondaryPickupAddress:   &pickupAddress2,
 			SecondaryPickupAddressID: &pickupAddress2.ID,
-			PrimeEstimatedWeight:     &estimatedHHGWeight,
-			PrimeActualWeight:        &actualHHGWeight,
 			ShipmentType:             models.MTOShipmentTypeHHG,
 			ApprovedDate:             swag.Time(time.Now()),
 			Status:                   models.MTOShipmentStatusSubmitted,

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -529,6 +529,93 @@ func createUnsubmittedHHGMove(db *pop.Connection) {
 	})
 }
 
+func createUnsubmittedHHGMoveMultiplePickup(db *pop.Connection) {
+	/*
+	 * A service member with an hhg only, unsubmitted move
+	 */
+	email := "hhg@multiple.pickup"
+	uuidStr := "47fb0e80-6675-4ceb-b4eb-4f8e164c0f6e"
+	loginGovUUID := uuid.Must(uuid.NewV4())
+
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovUUID:  &loginGovUUID,
+			LoginGovEmail: email,
+			Active:        true,
+		},
+	})
+
+	smWithHHGID := "92927bbd-5271-4a8c-b06b-fea07df84691"
+	smWithHHG := testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil(smWithHHGID),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("MultiplePickup"),
+			LastName:      models.StringPointer("Hhg"),
+			Edipi:         models.StringPointer("5833908165"),
+			PersonalEmail: models.StringPointer(email),
+		},
+	})
+
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Order: models.Order{
+			ServiceMemberID: uuid.FromStringOrNil(smWithHHGID),
+			ServiceMember:   smWithHHG,
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("390341ca-2b76-4655-9555-161f4a0c9817"),
+			Locator:          "TWOPIC",
+			SelectedMoveType: &hhgMoveType,
+		},
+	})
+
+	pickupAddress1 := testdatagen.MakeAddress(db, testdatagen.Assertions{
+		Address: models.Address{
+			ID:             uuid.Must(uuid.NewV4()),
+			StreetAddress1: "1 First St",
+			StreetAddress2: swag.String("Apt 1"),
+			StreetAddress3: swag.String("Suite A"),
+			City:           "Columbia",
+			State:          "SC",
+			PostalCode:     "29212",
+			Country:        swag.String("US"),
+		},
+	})
+
+	pickupAddress2 := testdatagen.MakeAddress(db, testdatagen.Assertions{
+		Address: models.Address{
+			ID:             uuid.Must(uuid.NewV4()),
+			StreetAddress1: "2 Second St",
+			StreetAddress2: swag.String("Apt 2"),
+			StreetAddress3: swag.String("Suite B"),
+			City:           "Columbia",
+			State:          "SC",
+			PostalCode:     "29212",
+			Country:        swag.String("US"),
+		},
+	})
+
+	estimatedHHGWeight := unit.Pound(1400)
+	actualHHGWeight := unit.Pound(2000)
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			ID:                       uuid.FromStringOrNil("a35b1247-b4c2-48f6-9846-8e96050fbc95"),
+			PickupAddress:            &pickupAddress1,
+			PickupAddressID:          &pickupAddress1.ID,
+			SecondaryPickupAddress:   &pickupAddress2,
+			SecondaryPickupAddressID: &pickupAddress2.ID,
+			PrimeEstimatedWeight:     &estimatedHHGWeight,
+			PrimeActualWeight:        &actualHHGWeight,
+			ShipmentType:             models.MTOShipmentTypeHHG,
+			ApprovedDate:             swag.Time(time.Now()),
+			Status:                   models.MTOShipmentStatusSubmitted,
+			MoveTaskOrder:            move,
+			MoveTaskOrderID:          move.ID,
+		},
+	})
+}
+
 func createUnsubmittedMoveWithNTSAndNTSR(db *pop.Connection) {
 	/*
 	 * A service member with an NTS, NTS-R shipment, & unsubmitted move
@@ -1633,8 +1720,6 @@ func createMoveWithHHGAndNTSRPaymentRequest(db *pop.Connection, userUploader *up
 			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
 			ApprovedDate:         swag.Time(time.Now()),
 			Status:               models.MTOShipmentStatusApproved,
-			PickupAddress:        &pickupAddress,
-			PickupAddressID:      &pickupAddress.ID,
 			DestinationAddress:   &destinationAddress,
 			DestinationAddressID: &destinationAddress.ID,
 		},
@@ -3548,6 +3633,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 
 	// Onboarding
 	createUnsubmittedHHGMove(db)
+	createUnsubmittedHHGMoveMultiplePickup(db)
 	createUnsubmittedMoveWithNTSAndNTSR(db)
 	createServiceMemberWithOrdersButNoMoveType(db)
 	createServiceMemberWithNoUploadedOrders(db)


### PR DESCRIPTION
## Description

Update devseed data to have an account with multiple pickup addresses and verify review page displays secondary pickup address

## Reviewer Notes
- data correctly shows in the review page
- Data generation functions create a secondary pickup address by default. The secondary pickup address is identical to the pickup address default.
- Should secondary pickup address default to something? We usually have a default for fields that are required and leave optional fields up to the discretion of the developer whether or not to include one

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make client_run`
Local sign in to `hhg@multiple.pickup`
Review and submit move
HHG card should have a different pickup and secondary pickup fields

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8174) for this change

