### PR TITLE
[MB-8365] Adjust automatic service item creation/approval rules for diversion case

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -580,6 +580,9 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 
 // createShipmentServiceItems creates shipment level service items
 func (o *mtoShipmentStatusUpdater) createShipmentServiceItems(shipment *models.MTOShipment) error {
+	if len(shipment.MTOServiceItems) > 0 {
+		return nil
+	}
 	reServiceCodes := reServiceCodesForShipment(*shipment)
 	serviceItemsToCreate := constructMTOServiceItemModels(shipment.ID, shipment.MoveTaskOrderID, reServiceCodes)
 	for _, serviceItem := range serviceItemsToCreate {

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -578,10 +578,69 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 	return shipment, nil
 }
 
+// isStandardServiceItem checks to see if the given service item code is one of the standard
+// service items. See: https://docs.google.com/spreadsheets/d/1zeS5J2LVd_cyB2TW2rQPu1hHqKSXT-UY7RpUzfvTi0k/edit#gid=637942482
+func isStandardServiceItem(serviceItemCode models.ReServiceCode) bool {
+	standardServiceItemCodes := []models.ReServiceCode{
+		models.ReServiceCodeCS,
+		models.ReServiceCodeDBHF,
+		models.ReServiceCodeDBTF,
+		models.ReServiceCodeDCRTSA,
+		models.ReServiceCodeDDP,
+		models.ReServiceCodeDLH,
+		models.ReServiceCodeDMHF,
+		models.ReServiceCodeDNPKF,
+		models.ReServiceCodeDOP,
+		models.ReServiceCodeDPK,
+		models.ReServiceCodeDSH,
+		models.ReServiceCodeDUPK,
+		models.ReServiceCodeFSC,
+		models.ReServiceCodeIBHF,
+		models.ReServiceCodeIBTF,
+		models.ReServiceCodeICOLH,
+		models.ReServiceCodeICOUB,
+		models.ReServiceCodeICRT,
+		models.ReServiceCodeICRTSA,
+		models.ReServiceCodeIDASIT,
+		models.ReServiceCodeIDDSIT,
+		models.ReServiceCodeIDFSIT,
+		models.ReServiceCodeIDSHUT,
+		models.ReServiceCodeIHPK,
+		models.ReServiceCodeIHUPK,
+		models.ReServiceCodeINPKF,
+		models.ReServiceCodeIOASIT,
+		models.ReServiceCodeIOCLH,
+		models.ReServiceCodeIOCUB,
+		models.ReServiceCodeIOFSIT,
+		models.ReServiceCodeIOOLH,
+		models.ReServiceCodeIOOUB,
+		models.ReServiceCodeIOPSIT,
+		models.ReServiceCodeIOSHUT,
+		models.ReServiceCodeIUBPK,
+		models.ReServiceCodeIUBUPK,
+		models.ReServiceCodeIUCRT,
+		models.ReServiceCodeMS,
+		models.ReServiceCodeNSTH,
+		models.ReServiceCodeNSTUB,
+	}
+	for _, c := range standardServiceItemCodes {
+		if c == serviceItemCode {
+			return true
+		}
+	}
+	return false
+}
+
 // createShipmentServiceItems creates shipment level service items
 func (o *mtoShipmentStatusUpdater) createShipmentServiceItems(shipment *models.MTOShipment) error {
 	if len(shipment.MTOServiceItems) > 0 {
-		return nil
+		// check if the shipment has a standard service items are standard. If it already does,
+		// don't add them again.
+		for _, si := range shipment.MTOServiceItems {
+			if isStandardServiceItem(si.ReService.Code) {
+				return nil
+			}
+		}
 	}
 	reServiceCodes := reServiceCodesForShipment(*shipment)
 	serviceItemsToCreate := constructMTOServiceItemModels(shipment.ID, shipment.MoveTaskOrderID, reServiceCodes)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -540,6 +540,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		}
 	})
 
+	suite.T().Run("A shipment with existing service items does not create more", func(t *testing.T) {
+		// TODO
+	})
+
 	suite.T().Run("If we act on a shipment with a weight that has a 0 upper weight it should still work", func(t *testing.T) {
 		// This is testing that the Required Delivery Date is calculated correctly.
 		// In order for the Required Delivery Date to be calculated, the following conditions must be true:

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -444,24 +444,6 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		},
 	})
 
-	shipmentWithExistingServiceItem := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
-	})
-	serviceItemID, _ := uuid.NewV4()
-	testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			ID: serviceItemID,
-		},
-		Move:        mto,
-		MTOShipment: shipmentWithExistingServiceItem,
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDLH,
-		},
-	})
-
 	shipment.Status = models.MTOShipmentStatusSubmitted
 	eTag := etag.GenerateEtag(shipment.UpdatedAt)
 	status := models.MTOShipmentStatusApproved
@@ -560,6 +542,23 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 	})
 
 	suite.T().Run("A shipment with existing service items does not create more", func(t *testing.T) {
+		shipmentWithExistingServiceItem := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		serviceItemID, _ := uuid.NewV4()
+		testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				ID: serviceItemID,
+			},
+			Move:        mto,
+			MTOShipment: shipmentWithExistingServiceItem,
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDLH,
+			},
+		})
 		eTag = etag.GenerateEtag(shipmentWithExistingServiceItem.UpdatedAt)
 		fetchedShipment := models.MTOShipment{}
 		serviceItems := models.MTOServiceItems{}

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1126,7 +1126,7 @@ func createHHGMoveWith10ServiceItems(db *pop.Connection, userUploader *uploader.
 			PrimeActualWeight:    &actualWeight,
 			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
 			ApprovedDate:         swag.Time(time.Now()),
-			Status:               models.MTOShipmentStatusSubmitted,
+			Status:               models.MTOShipmentStatusApproved,
 		},
 		Move: move8,
 	})


### PR DESCRIPTION
## Description

Given I'm a TOO using the milmove system
Then I need certain service items to be created without duplicates and in the approved
When I approve a diverted shipment

This also relates to https://dp3.atlassian.net/browse/MB-8310, which will actually allow the Prime contractor to get a move into this state. Reading that ticket might be helpful for understanding.

## Reviewer Notes

I could use help setting up a shipment with existing service items for the blank test.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Login to office app as TOO, look at the move with `EXSTS1` locater. Approve the shipment, and notice that there is just one service item on it: domestic line haul (which is correct, in this case, as it was the only existing service item and so no others were auto-created.)

Comment out the changes I made in `pkg/services/mto_shipment/mto_shipment_updater.go` and then re-populate the dev DB and go to the same move as above. Approve the shipment, but this time note that, incorrectly, there are now the default service items as well as the existing service item.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8365) for this change