### PR TITLE
MB-3728 update interface for future refactoring

### DIFF
--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -198,7 +198,7 @@ func (h UpdateShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipmentPar
 	mtoShipment := payloads.MTOShipmentModelFromUpdate(payload)
 	mtoShipment.ID = shipmentID
 
-	updatedMtoShipment, err := h.MTOShipmentUpdater.UpdateMTOShipmentGHC(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
+	updatedMtoShipment, err := h.MTOShipmentUpdater.UpdateMTOShipmentCustomer(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
 
 	if err != nil {
 		logger.Error("ghcapi.UpdateShipmentHandler", zap.Error(err))

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -198,7 +198,7 @@ func (h UpdateShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipmentPar
 	mtoShipment := payloads.MTOShipmentModelFromUpdate(payload)
 	mtoShipment.ID = shipmentID
 
-	updatedMtoShipment, err := h.MTOShipmentUpdater.UpdateMTOShipment(mtoShipment, params.IfMatch)
+	updatedMtoShipment, err := h.MTOShipmentUpdater.UpdateMTOShipmentGHC(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
 
 	if err != nil {
 		logger.Error("ghcapi.UpdateShipmentHandler", zap.Error(err))

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -112,7 +112,7 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 				h.GetTraceID()))
 	}
 
-	updatedMtoShipment, err := h.mtoShipmentUpdater.UpdateMTOShipmentInternal(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
+	updatedMtoShipment, err := h.mtoShipmentUpdater.UpdateMTOShipmentCustomer(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
 
 	if err != nil {
 		logger.Error("internalapi.UpdateMTOShipmentHandler", zap.Error(err))

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -112,7 +112,7 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 				h.GetTraceID()))
 	}
 
-	updatedMtoShipment, err := h.mtoShipmentUpdater.UpdateMTOShipment(mtoShipment, params.IfMatch)
+	updatedMtoShipment, err := h.mtoShipmentUpdater.UpdateMTOShipmentInternal(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
 
 	if err != nil {
 		logger.Error("internalapi.UpdateMTOShipmentHandler", zap.Error(err))

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -595,7 +595,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		err := errors.New("ServerError")
 
-		mockUpdater.On("UpdateMTOShipment",
+		mockUpdater.On("UpdateMTOShipmentInternal",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, err)

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -595,7 +595,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 		err := errors.New("ServerError")
 
-		mockUpdater.On("UpdateMTOShipmentInternal",
+		mockUpdater.On("UpdateMTOShipmentCustomer",
 			mock.Anything,
 			mock.Anything,
 			mock.Anything,

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -247,7 +247,7 @@ func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipment
 		eTag := params.IfMatch
 
 		logger.Info("primeapi.UpdateMTOShipmentHandler info", zap.String("pointOfContact", params.Body.PointOfContact))
-		mtoShipment, err = h.mtoShipmentUpdater.UpdateMTOShipment(mtoShipment, eTag)
+		mtoShipment, err = h.mtoShipmentUpdater.UpdateMTOShipmentPrime(params.HTTPRequest.Context(), mtoShipment, eTag)
 		if err != nil {
 			logger.Error("primeapi.UpdateMTOShipmentHandler error", zap.Error(err))
 			switch e := err.(type) {

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -377,7 +377,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			mock.Anything,
 		).Return(true, nil)
 
-		mockUpdater.On("UpdateMTOShipment",
+		mockUpdater.On("UpdateMTOShipmentPrime",
+			mock.Anything,
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, internalServerErr)

--- a/pkg/services/mocks/MTOShipmentUpdater.go
+++ b/pkg/services/mocks/MTOShipmentUpdater.go
@@ -3,8 +3,11 @@
 package mocks
 
 import (
-	mock "github.com/stretchr/testify/mock"
+	context "context"
+
 	auth "github.com/transcom/mymove/pkg/auth"
+
+	mock "github.com/stretchr/testify/mock"
 
 	models "github.com/transcom/mymove/pkg/models"
 
@@ -81,13 +84,13 @@ func (_m *MTOShipmentUpdater) RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*mod
 	return r0, r1
 }
 
-// UpdateMTOShipment provides a mock function with given fields: mtoShipment, eTag
-func (_m *MTOShipmentUpdater) UpdateMTOShipment(mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
-	ret := _m.Called(mtoShipment, eTag)
+// UpdateMTOShipmentGHC provides a mock function with given fields: ctx, mtoShipment, eTag
+func (_m *MTOShipmentUpdater) UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	ret := _m.Called(ctx, mtoShipment, eTag)
 
 	var r0 *models.MTOShipment
-	if rf, ok := ret.Get(0).(func(*models.MTOShipment, string) *models.MTOShipment); ok {
-		r0 = rf(mtoShipment, eTag)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.MTOShipment, string) *models.MTOShipment); ok {
+		r0 = rf(ctx, mtoShipment, eTag)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.MTOShipment)
@@ -95,8 +98,54 @@ func (_m *MTOShipmentUpdater) UpdateMTOShipment(mtoShipment *models.MTOShipment,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.MTOShipment, string) error); ok {
-		r1 = rf(mtoShipment, eTag)
+	if rf, ok := ret.Get(1).(func(context.Context, *models.MTOShipment, string) error); ok {
+		r1 = rf(ctx, mtoShipment, eTag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateMTOShipmentInternal provides a mock function with given fields: ctx, mtoShipment, eTag
+func (_m *MTOShipmentUpdater) UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	ret := _m.Called(ctx, mtoShipment, eTag)
+
+	var r0 *models.MTOShipment
+	if rf, ok := ret.Get(0).(func(context.Context, *models.MTOShipment, string) *models.MTOShipment); ok {
+		r0 = rf(ctx, mtoShipment, eTag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.MTOShipment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.MTOShipment, string) error); ok {
+		r1 = rf(ctx, mtoShipment, eTag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateMTOShipmentPrime provides a mock function with given fields: ctx, mtoShipment, eTag
+func (_m *MTOShipmentUpdater) UpdateMTOShipmentPrime(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	ret := _m.Called(ctx, mtoShipment, eTag)
+
+	var r0 *models.MTOShipment
+	if rf, ok := ret.Get(0).(func(context.Context, *models.MTOShipment, string) *models.MTOShipment); ok {
+		r0 = rf(ctx, mtoShipment, eTag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.MTOShipment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.MTOShipment, string) error); ok {
+		r1 = rf(ctx, mtoShipment, eTag)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/mocks/MTOShipmentUpdater.go
+++ b/pkg/services/mocks/MTOShipmentUpdater.go
@@ -84,8 +84,8 @@ func (_m *MTOShipmentUpdater) RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*mod
 	return r0, r1
 }
 
-// UpdateMTOShipmentGHC provides a mock function with given fields: ctx, mtoShipment, eTag
-func (_m *MTOShipmentUpdater) UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+// UpdateMTOShipmentCustomer provides a mock function with given fields: ctx, mtoShipment, eTag
+func (_m *MTOShipmentUpdater) UpdateMTOShipmentCustomer(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	ret := _m.Called(ctx, mtoShipment, eTag)
 
 	var r0 *models.MTOShipment
@@ -107,8 +107,8 @@ func (_m *MTOShipmentUpdater) UpdateMTOShipmentGHC(ctx context.Context, mtoShipm
 	return r0, r1
 }
 
-// UpdateMTOShipmentInternal provides a mock function with given fields: ctx, mtoShipment, eTag
-func (_m *MTOShipmentUpdater) UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+// UpdateMTOShipmentOffice provides a mock function with given fields: ctx, mtoShipment, eTag
+func (_m *MTOShipmentUpdater) UpdateMTOShipmentOffice(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	ret := _m.Called(ctx, mtoShipment, eTag)
 
 	var r0 *models.MTOShipment

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -13,7 +15,9 @@ type MTOShipmentUpdater interface {
 	CheckIfMTOShipmentCanBeUpdated(mtoShipment *models.MTOShipment, session *auth.Session) (bool, error)
 	MTOShipmentsMTOAvailableToPrime(mtoShipmentID uuid.UUID) (bool, error)
 	RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*models.MTOShipment, error)
-	UpdateMTOShipment(mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
+	UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
+	UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
+	UpdateMTOShipmentPrime(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
 }
 
 //ShipmentDeleter is the service object interface for deleting a shipment

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -15,8 +15,8 @@ type MTOShipmentUpdater interface {
 	CheckIfMTOShipmentCanBeUpdated(mtoShipment *models.MTOShipment, session *auth.Session) (bool, error)
 	MTOShipmentsMTOAvailableToPrime(mtoShipmentID uuid.UUID) (bool, error)
 	RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*models.MTOShipment, error)
-	UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
-	UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
+	UpdateMTOShipmentOffice(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
+	UpdateMTOShipmentCustomer(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
 	UpdateMTOShipmentPrime(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
 }
 

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -1,6 +1,7 @@
 package mtoshipment
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -221,8 +222,29 @@ func (f *mtoShipmentUpdater) RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*mode
 	return &shipment, nil
 }
 
-//UpdateMTOShipment updates the mto shipment
-func (f *mtoShipmentUpdater) UpdateMTOShipment(mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+// UpdateMTOShipmentGHC updates the mto shipment
+// TODO: apply the subset of business logic validations
+// that would be appropriate for the OFFICE USER
+func (f *mtoShipmentUpdater) UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+}
+
+// UpdateMTOShipmentInternal updates the mto shipment
+// TODO: apply the subset of business logic validations
+// that would be appropriate for the CUSTOMER
+func (f *mtoShipmentUpdater) UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+}
+
+// UpdateMTOShipmentPrime updates the mto shipment
+// TODO: apply the subset of business logic validations
+// that would be appropriate for the PRIME
+func (f *mtoShipmentUpdater) UpdateMTOShipmentPrime(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+}
+
+//updateMTOShipment updates the mto shipment
+func (f *mtoShipmentUpdater) updateMTOShipment(_ context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	oldShipment, err := f.RetrieveMTOShipment(mtoShipment.ID)
 
 	if err != nil {

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -222,17 +222,17 @@ func (f *mtoShipmentUpdater) RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*mode
 	return &shipment, nil
 }
 
-// UpdateMTOShipmentGHC updates the mto shipment
+// UpdateMTOShipmentOffice updates the mto shipment
 // TODO: apply the subset of business logic validations
 // that would be appropriate for the OFFICE USER
-func (f *mtoShipmentUpdater) UpdateMTOShipmentGHC(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+func (f *mtoShipmentUpdater) UpdateMTOShipmentOffice(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	return f.updateMTOShipment(ctx, mtoShipment, eTag)
 }
 
-// UpdateMTOShipmentInternal updates the mto shipment
+// UpdateMTOShipmentCustomer updates the mto shipment
 // TODO: apply the subset of business logic validations
 // that would be appropriate for the CUSTOMER
-func (f *mtoShipmentUpdater) UpdateMTOShipmentInternal(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+func (f *mtoShipmentUpdater) UpdateMTOShipmentCustomer(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	return f.updateMTOShipment(ctx, mtoShipment, eTag)
 }
 

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -10,6 +10,7 @@
 package mtoshipment
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -158,14 +159,14 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 	suite.T().Run("Etag is stale", func(t *testing.T) {
 		eTag := etag.GenerateEtag(time.Now())
-		_, err := mtoShipmentUpdater.UpdateMTOShipment(&mtoShipment, eTag)
+		_, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment, eTag)
 		suite.Error(err)
 		suite.IsType(services.PreconditionFailedError{}, err)
 	})
 
 	suite.T().Run("If-Unmodified-Since is equal to the updated_at date", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment.UpdatedAt)
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&mtoShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment, eTag)
 		suite.NoError(err)
 
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -189,7 +190,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment2.UpdatedAt)
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&mtoShipment2, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment2, eTag)
 		suite.NoError(err)
 
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -217,7 +218,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			SecondaryDeliveryAddressID: &secondaryDeliveryAddress.ID,
 		}
 
-		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipment(updatedShipment, eTag)
+		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), updatedShipment, eTag)
 		suite.NoError(err)
 		suite.Equal(newDestinationAddress.ID, *updatedShipment.DestinationAddressID)
 		suite.Equal(newDestinationAddress.StreetAddress1, updatedShipment.DestinationAddress.StreetAddress1)
@@ -271,7 +272,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			CounselorRemarks:                 &counselorRemarks,
 		}
 
-		newShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&updatedShipment, eTag)
+		newShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
 		suite.NoError(err)
 		suite.True(requestedPickupDate.Equal(*newShipment.RequestedPickupDate))
 		suite.True(scheduledPickupDate.Equal(*newShipment.ScheduledPickupDate))
@@ -334,7 +335,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			MTOAgents: updatedAgents,
 		}
 
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&updatedShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
 
 		suite.NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -378,7 +379,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			MTOAgents: updatedAgents,
 		}
 
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipment(&updatedShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
 
 		suite.NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -159,14 +159,14 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 	suite.T().Run("Etag is stale", func(t *testing.T) {
 		eTag := etag.GenerateEtag(time.Now())
-		_, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment, eTag)
+		_, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment, eTag)
 		suite.Error(err)
 		suite.IsType(services.PreconditionFailedError{}, err)
 	})
 
 	suite.T().Run("If-Unmodified-Since is equal to the updated_at date", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment.UpdatedAt)
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment, eTag)
 		suite.NoError(err)
 
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -190,7 +190,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment2.UpdatedAt)
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &mtoShipment2, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment2, eTag)
 		suite.NoError(err)
 
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -218,7 +218,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			SecondaryDeliveryAddressID: &secondaryDeliveryAddress.ID,
 		}
 
-		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), updatedShipment, eTag)
+		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), updatedShipment, eTag)
 		suite.NoError(err)
 		suite.Equal(newDestinationAddress.ID, *updatedShipment.DestinationAddressID)
 		suite.Equal(newDestinationAddress.StreetAddress1, updatedShipment.DestinationAddress.StreetAddress1)
@@ -272,7 +272,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			CounselorRemarks:                 &counselorRemarks,
 		}
 
-		newShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
+		newShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 		suite.NoError(err)
 		suite.True(requestedPickupDate.Equal(*newShipment.RequestedPickupDate))
 		suite.True(scheduledPickupDate.Equal(*newShipment.ScheduledPickupDate))
@@ -335,7 +335,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			MTOAgents: updatedAgents,
 		}
 
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
 		suite.NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
@@ -379,7 +379,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 			MTOAgents: updatedAgents,
 		}
 
-		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentInternal(context.Background(), &updatedShipment, eTag)
+		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
 		suite.NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)


### PR DESCRIPTION
## Description

In the spirit of smaller PRs, this is the first in a series.
This is mostly a non-functional change, meaning I changed the shape of some interfaces, but there is almost no logic/functionality that is different.
This change buys me some flexibility so that I can eventually build in some extensible business logic validation stuff in the service layer, like I did on #6810. This will also let me start moving some business logic stuff that the handlers are currently doing back into the service layer, where they belong.