### PR TITLE
MB-7682 TOO can view cancelled shipment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,6 +738,18 @@ rerun_e2e_tests_with_new_data: db_e2e_up
 .PHONY: db_e2e_init
 db_e2e_init: db_test_reset db_test_migrate redis_reset db_e2e_up ## Initialize e2e (end-to-end) DB (reset, migrate, up)
 
+.PHONY: db_dev_e2e_backup
+db_dev_e2e_backup: ## Backup Dev DB as 'e2e_dev'
+	DB_NAME=$(DB_NAME_DEV) DB_PORT=$(DB_PORT_DEV) ./scripts/db-backup e2e_dev
+
+.PHONY: db_dev_e2e_restore
+db_dev_e2e_restore: ## Restore Dev DB from 'e2e_dev'
+	DB_NAME=$(DB_NAME_DEV) DB_PORT=$(DB_PORT_DEV) ./scripts/db-restore e2e_dev
+
+.PHONY: db_dev_e2e_cleanup
+db_dev_e2e_cleanup: ## Clean up Dev DB backup `e2e_dev`
+	./scripts/db-cleanup e2e_dev
+
 .PHONY: db_test_e2e_backup
 db_test_e2e_backup: ## Backup Test DB as 'e2e_test'
 	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) ./scripts/db-backup e2e_test

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -180,6 +180,7 @@ func main() {
 
 	scenario := v.GetInt(scenarioFlag)
 	namedScenario := v.GetString(namedScenarioFlag)
+	namedSubScenario := v.GetString(namedSubScenarioFlag)
 
 	if scenario == 4 {
 		err = tdgs.RunPPMSITEstimateScenario1(dbConnection)
@@ -253,7 +254,7 @@ func main() {
 				logger.Fatal("Failed to initialize GHC route planner")
 			}
 
-			tdgs.DevSeedScenario.Run(dbConnection, userUploader, primeUploader, routePlanner, logger)
+			tdgs.DevSeedScenario.Run(dbConnection, userUploader, primeUploader, routePlanner, logger, namedSubScenario)
 		} else if namedScenario == tdgs.BandwidthScenario.Name {
 			tdgs.BandwidthScenario.Run(dbConnection, userUploader, primeUploader)
 		}

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -33,8 +33,9 @@ func stringSliceContains(stringSlice []string, value string) bool {
 }
 
 const (
-	scenarioFlag      string = "scenario"
-	namedScenarioFlag string = "named-scenario"
+	scenarioFlag         string = "scenario"
+	namedScenarioFlag    string = "named-scenario"
+	namedSubScenarioFlag string = "named-sub-scenario" // name of the sub scenario in the main scenario
 )
 
 type errInvalidScenario struct {
@@ -77,6 +78,8 @@ func initFlags(flag *pflag.FlagSet) {
 	// Scenario config
 	flag.Int(scenarioFlag, 0, "Specify which scenario you'd like to run. Current options: 1, 2, 3, 4, 5, 6, 7.")
 	flag.String(namedScenarioFlag, "", "It's like a scenario, but more descriptive.")
+	flag.String(namedSubScenarioFlag, "", "Specify a named-sub-scenario after specifying a named-scenario. "+
+		"This is meant to run specific seed data setup in the main named-scenario without having to seed everything.")
 
 	// DB Config
 	cli.InitDatabaseFlags(flag)

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,11 +31,11 @@ const (
 )
 
 type errInvalidScenario struct {
-	Scenario int
+	Name string
 }
 
 func (e *errInvalidScenario) Error() string {
-	return fmt.Sprintf("invalid scenario %d", e.Scenario)
+	return fmt.Sprintf("invalid scenario: %s", e.Name)
 }
 
 func checkConfig(v *viper.Viper, logger logger) error {
@@ -43,7 +44,7 @@ func checkConfig(v *viper.Viper, logger logger) error {
 
 	scenario := v.GetInt(scenarioFlag)
 	if scenario < 0 || scenario > 7 {
-		return errors.Wrap(&errInvalidScenario{Scenario: scenario}, fmt.Sprintf("%s is invalid, expected value between 0 and 7 not %d", scenarioFlag, scenario))
+		return errors.Wrap(&errInvalidScenario{Name: strconv.Itoa(scenario)}, fmt.Sprintf("%s is invalid, expected value between 0 and 7 not %d", scenarioFlag, scenario))
 	}
 
 	namedScenario := v.GetString(namedScenarioFlag)
@@ -76,7 +77,7 @@ func checkConfigNamedSubScenarioFlag(v *viper.Viper, namedScenarioStruct *tdgs.N
 
 	// continue, check if named sub scenarios matches expectations
 	if !stringSliceContains(namedScenarioStruct.SubScenarios, namedSubScenario) {
-		return errors.Wrap(&errInvalidScenario{}, fmt.Sprintf("%s is invalid, expected "+
+		return errors.Wrap(&errInvalidScenario{Name: namedSubScenario}, fmt.Sprintf("%s is invalid, expected "+
 			"a value from %v or empty value", namedSubScenario, namedScenarioStruct.SubScenarios))
 	}
 
@@ -127,7 +128,7 @@ func findNamedScenarioByName(name string) (*tdgs.NamedScenario, error) {
 		namedScenarioStringList = append(namedScenarioStringList, namedScenario.Name)
 	}
 
-	return nil, errors.Wrap(&errInvalidScenario{}, fmt.Sprintf("%s is invalid, expected "+
+	return nil, errors.Wrap(&errInvalidScenario{Name: name}, fmt.Sprintf("%s is invalid, expected "+
 		"a value from %v", name, namedScenarioStringList))
 }
 

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -23,15 +23,6 @@ import (
 	"github.com/transcom/mymove/pkg/uploader"
 )
 
-func stringSliceContains(stringSlice []string, value string) bool {
-	for _, x := range stringSlice {
-		if value == x {
-			return true
-		}
-	}
-	return false
-}
-
 const (
 	scenarioFlag         string = "scenario"
 	namedScenarioFlag    string = "named-scenario"
@@ -55,19 +46,38 @@ func checkConfig(v *viper.Viper, logger logger) error {
 		return errors.Wrap(&errInvalidScenario{Scenario: scenario}, fmt.Sprintf("%s is invalid, expected value between 0 and 7 not %d", scenarioFlag, scenario))
 	}
 
-	namedScenarios := []string{
-		tdgs.E2eBasicScenario.Name,
-		tdgs.DevSeedScenario.Name,
-		tdgs.BandwidthScenario.Name,
-	}
 	namedScenario := v.GetString(namedScenarioFlag)
-	if !stringSliceContains(namedScenarios, namedScenario) {
-		return errors.Wrap(&errInvalidScenario{Scenario: scenario}, fmt.Sprintf("%s is invalid, expected a value from %v", namedScenarioFlag, namedScenarios))
-	}
-
-	err := cli.CheckDatabase(v, logger)
+	namedScenarioStruct, err := findNamedScenarioByName(namedScenario)
 	if err != nil {
 		return err
+	}
+
+	// check named sub scenario
+	// optional flag
+	if err = checkConfigNamedSubScenarioFlag(v, namedScenarioStruct); err != nil {
+		return err
+	}
+
+	err = cli.CheckDatabase(v, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkConfigNamedSubScenarioFlag(v *viper.Viper, namedScenarioStruct *tdgs.NamedScenario) error {
+	namedSubScenario := v.GetString(namedSubScenarioFlag)
+	// optional flag, ok if value is empty
+	// ok if there are not any named sub scenarios
+	if namedSubScenario == "" || len(namedScenarioStruct.SubScenarios) == 0 {
+		return nil
+	}
+
+	// continue, check if named sub scenarios matches expectations
+	if !stringSliceContains(namedScenarioStruct.SubScenarios, namedSubScenario) {
+		return errors.Wrap(&errInvalidScenario{}, fmt.Sprintf("%s is invalid, expected "+
+			"a value from %v or empty value", namedSubScenario, namedScenarioStruct.SubScenarios))
 	}
 
 	return nil
@@ -92,6 +102,39 @@ func initFlags(flag *pflag.FlagSet) {
 
 	// Don't sort flags
 	flag.SortFlags = false
+}
+
+func stringSliceContains(stringSlice []string, value string) bool {
+	for _, x := range stringSlice {
+		if value == x {
+			return true
+		}
+	}
+	return false
+}
+
+func findNamedScenarioByName(name string) (*tdgs.NamedScenario, error) {
+	for _, scenario := range namedScenarios {
+		result := scenario
+		if name == scenario.Name {
+			return &result, nil
+		}
+	}
+
+	// to get the list of names
+	var namedScenarioStringList []string
+	for _, namedScenario := range namedScenarios {
+		namedScenarioStringList = append(namedScenarioStringList, namedScenario.Name)
+	}
+
+	return nil, errors.Wrap(&errInvalidScenario{}, fmt.Sprintf("%s is invalid, expected "+
+		"a value from %v", name, namedScenarioStringList))
+}
+
+var namedScenarios = []tdgs.NamedScenario{
+	tdgs.NamedScenario(tdgs.E2eBasicScenario),
+	tdgs.NamedScenario(tdgs.DevSeedScenario),
+	tdgs.NamedScenario(tdgs.BandwidthScenario),
 }
 
 // Hey, refactoring self: you can pull the UUIDs from the objects rather than

--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -26,7 +26,7 @@ import (
 type bandwidthScenario NamedScenario
 
 // BandwidthScenario is the thing
-var BandwidthScenario = bandwidthScenario{"bandwidth"}
+var BandwidthScenario = bandwidthScenario{Name: "bandwidth"}
 
 func createHHGMove150Kb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
 	filterFile := &[]string{"150Kb.png"}

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -47,6 +47,8 @@ import (
 	"github.com/transcom/mymove/pkg/uploader"
 )
 
+var subScenarioShipmentHHGCancelled = "shipment_hhg_cancelled"
+
 // devSeedScenario builds a basic set of data for e2e testing
 type devSeedScenario NamedScenario
 
@@ -54,7 +56,7 @@ type devSeedScenario NamedScenario
 var DevSeedScenario = devSeedScenario{
 	Name: "dev_seed",
 	SubScenarios: []string{
-		"shipment_hhg_cancelled",
+		subScenarioShipmentHHGCancelled,
 	},
 }
 
@@ -3533,7 +3535,8 @@ func createHHGNoShipments(db *pop.Connection) {
 }
 
 // Run does that data load thing
-func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, routePlanner route.Planner, logger Logger) {
+func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader,
+	routePlanner route.Planner, logger Logger, namedSubScenario string) {
 	// Testdatagen factories will create new random duty stations so let's get the standard ones in the migrations
 	var allDutyStations []models.DutyStation
 	db.All(&allDutyStations)
@@ -3542,6 +3545,24 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 	db.Where("transportation_offices.GBLOC = ?", "LKNQ").
 		InnerJoin("transportation_offices", "duty_stations.transportation_office_id = transportation_offices.id").
 		All(&originDutyStationsInGBLOC)
+
+	/*
+		RUN ONLY SUB SCENARIO SEED DATA
+	*/
+	if namedSubScenario == subScenarioShipmentHHGCancelled {
+		validStatuses := []models.MoveStatus{models.MoveStatusNeedsServiceCounseling, models.MoveStatusServiceCounselingCompleted}
+		cancelledShipment := models.MTOShipment{Status: models.MTOShipmentStatusCanceled}
+		createRandomMove(db, validStatuses, allDutyStations, originDutyStationsInGBLOC, testdatagen.Assertions{
+			MTOShipment: cancelledShipment,
+		})
+
+		// to short circuit Run function
+		return
+	}
+
+	/*
+		RUN ALL THE SEED DATA
+	*/
 
 	// PPM Office Queue
 	createPPMOfficeUser(db)

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3561,7 +3561,7 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		ordersTypeDetail := internalmessages.OrdersTypeDetailHHGPERMITTED
 		tac := "1234"
 		// make sure to create moves that does not go to US marines affiliation
-		createRandomMove(db, validStatuses, allDutyStations, originDutyStationsInGBLOC, testdatagen.Assertions{
+		move := createRandomMove(db, validStatuses, allDutyStations, originDutyStationsInGBLOC, testdatagen.Assertions{
 			Order: models.Order{
 				DepartmentIndicator: (*string)(&affiliationAirForce),
 				OrdersNumber:        &ordersNumber,
@@ -3570,6 +3570,15 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 			},
 			ServiceMember: models.ServiceMember{Affiliation: &affiliationAirForce},
 			MTOShipment:   cancelledShipment,
+		})
+		moveManagementUUID := "1130e612-94eb-49a7-973d-72f33685e551"
+		testdatagen.MakeMTOServiceItemBasic(db, testdatagen.Assertions{
+			ReService: models.ReService{ID: uuid.FromStringOrNil(moveManagementUUID)},
+			MTOServiceItem: models.MTOServiceItem{
+				MoveTaskOrderID: move.ID,
+				Status:          models.MTOServiceItemStatusApproved,
+				ApprovedAt:      &approvedDate,
+			},
 		})
 
 		logger.Info("finished seeding sub scenario: " + namedSubScenario)

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -50,8 +50,13 @@ import (
 // devSeedScenario builds a basic set of data for e2e testing
 type devSeedScenario NamedScenario
 
-// DevSeedScenario Is the thing
-var DevSeedScenario = devSeedScenario{"dev_seed"}
+// DevSeedScenario setup information for the dev seed
+var DevSeedScenario = devSeedScenario{
+	Name: "dev_seed",
+	SubScenarios: []string{
+		"shipment_hhg_cancelled",
+	},
+}
 
 var estimatedWeight = unit.Pound(1400)
 var actualWeight = unit.Pound(2000)

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -3550,12 +3550,29 @@ func (e devSeedScenario) Run(db *pop.Connection, userUploader *uploader.UserUplo
 		RUN ONLY SUB SCENARIO SEED DATA
 	*/
 	if namedSubScenario == subScenarioShipmentHHGCancelled {
-		validStatuses := []models.MoveStatus{models.MoveStatusNeedsServiceCounseling, models.MoveStatusServiceCounselingCompleted}
-		cancelledShipment := models.MTOShipment{Status: models.MTOShipmentStatusCanceled}
+		logger.Info("start seeding sub scenario: " + namedSubScenario)
+
+		validStatuses := []models.MoveStatus{models.MoveStatusAPPROVED}
+		// shipment cancelled was approved before
+		approvedDate := time.Now()
+		cancelledShipment := models.MTOShipment{Status: models.MTOShipmentStatusCanceled, ApprovedDate: &approvedDate}
+		affiliationAirForce := models.AffiliationAIRFORCE
+		ordersNumber := "Order1234"
+		ordersTypeDetail := internalmessages.OrdersTypeDetailHHGPERMITTED
+		tac := "1234"
+		// make sure to create moves that does not go to US marines affiliation
 		createRandomMove(db, validStatuses, allDutyStations, originDutyStationsInGBLOC, testdatagen.Assertions{
-			MTOShipment: cancelledShipment,
+			Order: models.Order{
+				DepartmentIndicator: (*string)(&affiliationAirForce),
+				OrdersNumber:        &ordersNumber,
+				OrdersTypeDetail:    &ordersTypeDetail,
+				TAC:                 &tac,
+			},
+			ServiceMember: models.ServiceMember{Affiliation: &affiliationAirForce},
+			MTOShipment:   cancelledShipment,
 		})
 
+		logger.Info("finished seeding sub scenario: " + namedSubScenario)
 		// to short circuit Run function
 		return
 	}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -41,7 +41,7 @@ We should not be creating random data in e2ebasic! Tests should be deterministic
 type e2eBasicScenario NamedScenario
 
 // E2eBasicScenario Is the thing
-var E2eBasicScenario = e2eBasicScenario{"e2e_basic"}
+var E2eBasicScenario = e2eBasicScenario{Name: "e2e_basic"}
 
 // Often weekends and holidays are not allowable dates
 var cal = dates.NewUSCalendar()

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -49,7 +49,8 @@ func save(db *pop.Connection, model interface{}) error {
 }
 
 // createRandomMove creates a random move with fake data that has been approved for usage
-func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, allDutyStations []models.DutyStation, dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) {
+func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, allDutyStations []models.DutyStation,
+	dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) {
 	randDays, err := random.GetRandomInt(366)
 	if err != nil {
 		log.Panic(fmt.Errorf("Unable to generate random integer for submitted move date"), zap.Error(err))
@@ -139,6 +140,7 @@ func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, 
 			Status:                shipmentStatus,
 			RequestedPickupDate:   &laterRequestedPickupDate,
 			RequestedDeliveryDate: &laterRequestedDeliveryDate,
+			ApprovedDate:          assertions.MTOShipment.ApprovedDate,
 			Diversion:             assertions.MTOShipment.Diversion,
 		},
 	})
@@ -152,6 +154,7 @@ func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, 
 			Status:                shipmentStatus,
 			RequestedPickupDate:   &earlierRequestedPickupDate,
 			RequestedDeliveryDate: &earlierRequestedDeliveryDate,
+			ApprovedDate:          assertions.MTOShipment.ApprovedDate,
 			Diversion:             assertions.MTOShipment.Diversion,
 		},
 	})

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -50,7 +50,7 @@ func save(db *pop.Connection, model interface{}) error {
 
 // createRandomMove creates a random move with fake data that has been approved for usage
 func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, allDutyStations []models.DutyStation,
-	dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) {
+	dutyStationsInGBLOC []models.DutyStation, assertions testdatagen.Assertions) models.Move {
 	randDays, err := random.GetRandomInt(366)
 	if err != nil {
 		log.Panic(fmt.Errorf("Unable to generate random integer for submitted move date"), zap.Error(err))
@@ -158,4 +158,6 @@ func createRandomMove(db *pop.Connection, possibleStatuses []models.MoveStatus, 
 			Diversion:             assertions.MTOShipment.Diversion,
 		},
 	})
+
+	return move
 }

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -21,7 +21,8 @@ import (
 
 // NamedScenario is a data generation scenario that has a name
 type NamedScenario struct {
-	Name string
+	Name         string
+	SubScenarios []string
 }
 
 // May15TestYear is a May 15 of TestYear

--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -13,7 +13,6 @@ import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
 import { formatDateFromIso } from 'shared/formatters';
 import shipmentCardsStyles from 'styles/shipmentCards.module.scss';
 import { MTOShipmentShape, MoveTaskOrderShape, MTOServiceItemShape, OrdersInfoShape } from 'types/order';
-import { shipmentStatuses } from 'constants/shipments';
 
 const RequestedShipments = ({
   mtoShipments,
@@ -39,7 +38,7 @@ const RequestedShipments = ({
     return {
       heading: shipmentTypeLabels[shipment.shipmentType],
       isDiversion: shipment.diversion,
-      isCancelled: shipment.status === shipmentStatuses.CANCELED,
+      shipmentStatus: shipment.status,
       requestedPickupDate: shipment.requestedPickupDate,
       pickupAddress: shipment.pickupAddress,
       secondaryPickupAddress: shipment.secondaryPickupAddress,

--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -13,6 +13,7 @@ import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
 import { formatDateFromIso } from 'shared/formatters';
 import shipmentCardsStyles from 'styles/shipmentCards.module.scss';
 import { MTOShipmentShape, MoveTaskOrderShape, MTOServiceItemShape, OrdersInfoShape } from 'types/order';
+import { shipmentStatuses } from 'constants/shipments';
 
 const RequestedShipments = ({
   mtoShipments,
@@ -38,6 +39,7 @@ const RequestedShipments = ({
     return {
       heading: shipmentTypeLabels[shipment.shipmentType],
       isDiversion: shipment.diversion,
+      isCancelled: shipment.status === shipmentStatuses.CANCELED,
       requestedPickupDate: shipment.requestedPickupDate,
       pickupAddress: shipment.pickupAddress,
       secondaryPickupAddress: shipment.secondaryPickupAddress,

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -11,6 +11,8 @@ import DataPoint from '../../DataPoint/index';
 
 import styles from './ShipmentAddresses.module.scss';
 
+import { shipmentStatuses } from 'constants/shipments';
+
 const ShipmentAddresses = ({
   pickupAddress,
   destinationAddress,
@@ -25,13 +27,15 @@ const ShipmentAddresses = ({
         columnHeaders={[
           'Authorized addresses',
           <div className={styles.rightAlignButtonWrapper}>
-            <Button
-              type="button"
-              onClick={() => handleDivertShipment(shipmentInfo.shipmentID, shipmentInfo.ifMatchEtag)}
-              unstyled
-            >
-              Request diversion
-            </Button>
+            {shipmentInfo.shipmentStatus !== shipmentStatuses.CANCELED && (
+              <Button
+                type="button"
+                onClick={() => handleDivertShipment(shipmentInfo.shipmentID, shipmentInfo.ifMatchEtag)}
+                unstyled
+              >
+                Request diversion
+              </Button>
+            )}
           </div>,
         ]}
         dataRow={[formatAddress(originDutyStation), formatAddress(destinationDutyStation)]}
@@ -55,6 +59,7 @@ ShipmentAddresses.propTypes = {
   shipmentInfo: PropTypes.shape({
     shipmentID: PropTypes.string.isRequired,
     ifMatchEtag: PropTypes.string.isRequired,
+    shipmentStatus: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ShipmentAddresses from './ShipmentAddresses';
@@ -33,13 +33,47 @@ const testProps = {
   shipmentInfo: {
     shipmentID: '456',
     ifMatchEtag: 'abc123',
+    shipmentStatus: 'APPROVED',
+  },
+};
+
+const cancelledShipment = {
+  pickupAddress: {
+    city: 'Fairfax',
+    state: 'VA',
+    postal_code: '12345',
+    street_address_1: '123 Fake Street',
+    street_address_2: '',
+    street_address_3: '',
+    country: 'USA',
+  },
+  destinationAddress: {
+    city: 'Boston',
+    state: 'MA',
+    postal_code: '01054',
+    street_address_1: '5 Main Street',
+    street_address_2: '',
+    street_address_3: '',
+    country: 'USA',
+  },
+  destinationDutyStation: {
+    street_address_1: '',
+    city: 'Fort Irwin',
+    state: 'CA',
+    postal_code: '92310',
+  },
+  handleDivertShipment: jest.fn(),
+  shipmentInfo: {
+    shipmentID: '456',
+    ifMatchEtag: 'abc123',
+    shipmentStatus: 'CANCELED',
   },
 };
 
 describe('ShipmentAddresses', () => {
   it('calls props.handleDivertShipment on request diversion button click', async () => {
-    const { getByRole } = render(<ShipmentAddresses {...testProps} />);
-    const requestDiversionBtn = getByRole('button', { name: 'Request diversion' });
+    render(<ShipmentAddresses {...testProps} />);
+    const requestDiversionBtn = screen.getByRole('button', { name: 'Request diversion' });
 
     userEvent.click(requestDiversionBtn);
     await waitFor(() => {
@@ -48,6 +82,15 @@ describe('ShipmentAddresses', () => {
         testProps.shipmentInfo.shipmentID,
         testProps.shipmentInfo.ifMatchEtag,
       );
+    });
+  });
+
+  it('hides the request diversion button for a cancelled shipment', async () => {
+    render(<ShipmentAddresses {...cancelledShipment} />);
+    const requestDiversionBtn = screen.queryByRole('button', { name: 'Request diversion' });
+
+    await waitFor(() => {
+      expect(requestDiversionBtn).toBeNull();
     });
   });
 });

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -29,7 +29,7 @@ const ShipmentDetailsMain = ({ className, shipment, dutyStationAddresses, handle
         destinationAddress={destinationAddress || destinationDutyStationAddress?.postal_code}
         originDutyStation={originDutyStationAddress}
         destinationDutyStation={destinationDutyStationAddress}
-        shipmentInfo={{ shipmentID: shipment.id, ifMatchEtag: shipment.eTag }}
+        shipmentInfo={{ shipmentID: shipment.id, ifMatchEtag: shipment.eTag, shipmentStatus: shipment.status }}
         handleDivertShipment={handleDivertShipment}
       />
       <ShipmentWeightDetails estimatedWeight={primeEstimatedWeight} actualWeight={primeActualWeight} />

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -35,7 +35,16 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             <h3>
               <label id={`shipment-display-label-${shipmentId}`}>{displayInfo.heading}</label>
             </h3>
-            {displayInfo.isDiversion && <Tag>diversion</Tag>}
+            {displayInfo.isDiversion && (
+              <div>
+                <Tag>diversion</Tag>
+              </div>
+            )}
+            {displayInfo.isCancelled && (
+              <div>
+                <Tag className="usa-tag--red">cancelled</Tag>
+              </div>
+            )}
           </div>
 
           <FontAwesomeIcon icon="chevron-down" />
@@ -71,6 +80,7 @@ ShipmentDisplay.propTypes = {
   displayInfo: PropTypes.shape({
     heading: PropTypes.string.isRequired,
     isDiversion: PropTypes.bool,
+    isCancelled: PropTypes.bool,
     requestedPickupDate: PropTypes.string.isRequired,
     pickupAddress: AddressShape.isRequired,
     secondaryPickupAddress: AddressShape,

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -10,6 +10,7 @@ import ShipmentInfoList from 'components/Office/DefinitionLists/ShipmentInfoList
 import styles from 'components/Office/ShipmentDisplay/ShipmentDisplay.module.scss';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { AddressShape } from 'types/address';
+import { shipmentStatuses } from 'constants/shipments';
 
 const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSubmitted, showIcon, editURL }) => {
   const containerClasses = classnames(styles.container, { [styles.noIcon]: !showIcon });
@@ -35,16 +36,8 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             <h3>
               <label id={`shipment-display-label-${shipmentId}`}>{displayInfo.heading}</label>
             </h3>
-            {displayInfo.isDiversion && (
-              <div>
-                <Tag>diversion</Tag>
-              </div>
-            )}
-            {displayInfo.isCancelled && (
-              <div>
-                <Tag className="usa-tag--red">cancelled</Tag>
-              </div>
-            )}
+            {displayInfo.isDiversion && <Tag>diversion</Tag>}
+            {displayInfo.shipmentStatus === shipmentStatuses.CANCELED && <Tag className="usa-tag--red">cancelled</Tag>}
           </div>
 
           <FontAwesomeIcon icon="chevron-down" />
@@ -80,7 +73,7 @@ ShipmentDisplay.propTypes = {
   displayInfo: PropTypes.shape({
     heading: PropTypes.string.isRequired,
     isDiversion: PropTypes.bool,
-    isCancelled: PropTypes.bool,
+    shipmentStatus: PropTypes.string,
     requestedPickupDate: PropTypes.string.isRequired,
     pickupAddress: AddressShape.isRequired,
     secondaryPickupAddress: AddressShape,

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
@@ -32,7 +32,7 @@
 
     .headingTagWrapper {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       flex-grow: 1;
     }
 

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.module.scss
@@ -25,6 +25,11 @@
       background-color: $info-light;
     }
 
+    :global(.usa-tag--red) {
+      @include u-font-size('body', 3xs);
+      background-color: $error-light;
+    }
+
     .headingTagWrapper {
       display: flex;
       align-items: flex-start;

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -87,6 +87,26 @@ const diversionInfo = {
   },
 };
 
+const cancelledInfo = {
+  heading: 'HHG',
+  shipmentId: 'testShipmentId394',
+  isDiversion: false,
+  isCancelled: true,
+  requestedPickupDate: '26 Mar 2020',
+  pickupAddress: {
+    street_address_1: '812 S 129th St',
+    city: 'San Antonio',
+    state: 'TX',
+    postal_code: '78234',
+  },
+  destinationAddress: {
+    street_address_1: '441 SW Rio de la Plata Drive',
+    city: 'Tacoma',
+    state: 'WA',
+    postal_code: '98421',
+  },
+};
+
 export const HHGShipment = () => (
   <div style={{ padding: '20px' }}>
     <ShipmentDisplay displayInfo={object('displayInfo', hhgInfo)} isSubmitted />
@@ -141,5 +161,11 @@ export const PostalOnlyDestination = () => (
 export const DivertedShipment = () => (
   <div style={{ padding: '20px' }}>
     <ShipmentDisplay shipmentId="1" displayInfo={object('displayInfo', diversionInfo)} isSubmitted />
+  </div>
+);
+
+export const CancelledShipment = () => (
+  <div style={{ padding: '20px' }}>
+    <ShipmentDisplay shipmentId="1" displayInfo={object('displayInfo', cancelledInfo)} isSubmitted />
   </div>
 );

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.stories.jsx
@@ -91,7 +91,7 @@ const cancelledInfo = {
   heading: 'HHG',
   shipmentId: 'testShipmentId394',
   isDiversion: false,
-  isCancelled: true,
+  shipmentStatus: 'CANCELED',
   requestedPickupDate: '26 Mar 2020',
   pickupAddress: {
     street_address_1: '812 S 129th St',

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -74,7 +74,7 @@ const diversion = {
 const cancelled = {
   heading: 'HHG',
   isDiversion: false,
-  isCancelled: true,
+  shipmentStatus: 'CANCELED',
   requestedPickupDate: '26 Mar 2020',
   pickupAddress: {
     street_address_1: '812 S 129th St',

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.test.jsx
@@ -56,7 +56,27 @@ const diversion = {
   heading: 'HHG',
   isDiversion: true,
   requestedPickupDate: '26 Mar 2020',
-  currentAddress: {
+  pickupAddress: {
+    street_address_1: '812 S 129th St',
+    city: 'San Antonio',
+    state: 'TX',
+    postal_code: '78234',
+  },
+  destinationAddress: {
+    street_address_1: '441 SW Rio de la Plata Drive',
+    city: 'Tacoma',
+    state: 'WA',
+    postal_code: '98421',
+  },
+  counselorRemarks: 'counselor approved',
+};
+
+const cancelled = {
+  heading: 'HHG',
+  isDiversion: false,
+  isCancelled: true,
+  requestedPickupDate: '26 Mar 2020',
+  pickupAddress: {
     street_address_1: '812 S 129th St',
     city: 'San Antonio',
     state: 'TX',
@@ -110,5 +130,9 @@ describe('Shipment Container', () => {
   it('renders with diversion tag', () => {
     render(<ShipmentDisplay shipmentId="1" displayInfo={diversion} onChange={jest.fn()} isSubmitted={false} />);
     expect(screen.getByText('diversion')).toBeInTheDocument();
+  });
+  it('renders with cancelled tag', () => {
+    render(<ShipmentDisplay shipmentId="1" displayInfo={cancelled} onChange={jest.fn()} isSubmitted={false} />);
+    expect(screen.getByText('cancelled')).toBeInTheDocument();
   });
 });

--- a/src/components/Office/ShipmentHeading.jsx
+++ b/src/components/Office/ShipmentHeading.jsx
@@ -23,6 +23,7 @@ function ShipmentHeading({ shipmentInfo, handleShowCancellationModal }) {
     <div className={classNames(styles.shipmentHeading, 'shipment-heading')}>
       <div className={styles.shipmentHeadingType}>
         <h2>{shipmentInfo.shipmentType}</h2>
+        {shipmentInfo.shipmentStatus === shipmentStatuses.CANCELED && <Tag className="usa-tag--red">cancelled</Tag>}
         {shipmentInfo.isDiversion && <Tag>diversion</Tag>}
         {!shipmentInfo.isDiversion && shipmentInfo.shipmentStatus === shipmentStatuses.DIVERSION_REQUESTED && (
           <Tag>diversion requested</Tag>
@@ -33,16 +34,18 @@ function ShipmentHeading({ shipmentInfo, handleShowCancellationModal }) {
           {`${shipmentInfo.originCity}, ${shipmentInfo.originState} ${shipmentInfo.originPostalCode} to
         ${formatDestinationAddress(shipmentInfo.destinationAddress)} on ${shipmentInfo.scheduledPickupDate}`}
         </small>
-        <Button
-          type="button"
-          onClick={() => handleShowCancellationModal(shipmentInfo)}
-          unstyled
-          disabled={shipmentInfo.shipmentStatus === shipmentStatuses.CANCELLATION_REQUESTED}
-        >
-          {shipmentInfo.shipmentStatus === shipmentStatuses.CANCELLATION_REQUESTED
-            ? 'Cancellation Requested'
-            : 'Request Cancellation'}
-        </Button>
+        {shipmentInfo.shipmentStatus !== shipmentStatuses.CANCELED && (
+          <Button
+            type="button"
+            onClick={() => handleShowCancellationModal(shipmentInfo)}
+            unstyled
+            disabled={shipmentInfo.shipmentStatus === shipmentStatuses.CANCELLATION_REQUESTED}
+          >
+            {shipmentInfo.shipmentStatus === shipmentStatuses.CANCELLATION_REQUESTED
+              ? 'Cancellation Requested'
+              : 'Request Cancellation'}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/Office/ShipmentHeading.test.jsx
+++ b/src/components/Office/ShipmentHeading.test.jsx
@@ -16,6 +16,7 @@ const shipmentDestinationAddress = {
 
 const headingInfo = {
   shipmentID: '1',
+  moveTaskOrderID: '2',
   shipmentType: 'Household Goods',
   originCity: 'San Antonio',
   originState: 'TX',
@@ -23,11 +24,18 @@ const headingInfo = {
   destinationAddress: shipmentDestinationAddress,
   scheduledPickupDate: '27 Mar 2020',
   shipmentStatus: 'SUBMITTED',
+  ifMatchEtag: '1234',
 };
 
 describe('Shipment Heading with full destination address', () => {
   it('should render the data passed to it within the heading', () => {
-    const wrapper = shallow(<ShipmentHeading shipmentInfo={headingInfo} handleUpdateMTOShipmentStatus={jest.fn()} />);
+    const wrapper = shallow(
+      <ShipmentHeading
+        shipmentInfo={headingInfo}
+        handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
+      />,
+    );
     expect(wrapper.find('h2').text()).toEqual('Household Goods');
     expect(wrapper.find('small').text()).toContain('San Antonio, TX 98421');
     expect(wrapper.find('small').text()).toContain('Tacoma, WA 98421');
@@ -38,7 +46,13 @@ describe('Shipment Heading with full destination address', () => {
 describe('Shipment Heading with missing destination address', () => {
   it("only renders the postal_code of the order's new duty station", () => {
     headingInfo.destinationAddress = shipmentDestinationAddressWithPostalOnly;
-    const wrapper = shallow(<ShipmentHeading shipmentInfo={headingInfo} handleUpdateMTOShipmentStatus={jest.fn()} />);
+    const wrapper = shallow(
+      <ShipmentHeading
+        shipmentInfo={headingInfo}
+        handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
+      />,
+    );
     expect(wrapper.find('h2').text()).toEqual('Household Goods');
     expect(wrapper.find('small').text()).toContain('San Antonio, TX 98421');
     expect(wrapper.find('small').text()).toContain('98421');
@@ -52,6 +66,7 @@ describe('Shipment Heading with diverted shipment', () => {
       <ShipmentHeading
         shipmentInfo={{ isDiversion: true, ...headingInfo }}
         handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
       />,
     );
     expect(wrapper.find('h2').text()).toEqual('Household Goods');
@@ -68,8 +83,27 @@ describe('Shipment Heading with diversion requested shipment', () => {
       <ShipmentHeading
         shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: 'DIVERSION_REQUESTED' }}
         handleUpdateMTOShipmentStatus={jest.fn()}
+        handleShowCancellationModal={jest.fn()}
       />,
     );
     expect(wrapper.find({ 'data-testid': 'tag' }).text()).toEqual('diversion requested');
+  });
+});
+
+describe('Shipment Heading with cancelled shipment', () => {
+  const wrapper = mount(
+    <ShipmentHeading
+      shipmentInfo={{ isDiversion: false, ...headingInfo, shipmentStatus: 'CANCELED' }}
+      handleUpdateMTOShipmentStatus={jest.fn()}
+      handleShowCancellationModal={jest.fn()}
+    />,
+  );
+
+  it('renders the cancelled tag next to the shipment type', () => {
+    expect(wrapper.find({ 'data-testid': 'tag' }).text()).toEqual('cancelled');
+  });
+
+  it('hides the request cancellation button', () => {
+    expect(wrapper.find('button').length).toBeFalsy();
   });
 });

--- a/src/components/Office/shipmentHeading.module.scss
+++ b/src/components/Office/shipmentHeading.module.scss
@@ -6,17 +6,23 @@
   .shipmentHeadingType {
     @include u-display(flex);
     @include u-padding-top(2);
-    align-items: flex-start;
+    @include u-margin-bottom(1);
+    align-items: center;
 
     h2 {
-      @include u-margin-top(0);
-      @include u-margin-bottom(1);
+      @include u-margin-y(0);
     }
 
     :global(.usa-tag) {
       @include u-font-size('body', 3xs);
       @include u-margin-left(1);
       background-color: $info-light;
+    }
+
+    :global(.usa-tag--red) {
+      @include u-font-size('body', 3xs);
+      @include u-margin-left(1);
+      background-color: $error-light;
     }
   }
 

--- a/src/components/Office/shipmentheading.stories.jsx
+++ b/src/components/Office/shipmentheading.stories.jsx
@@ -42,4 +42,25 @@ export const shipmentHeadingDiversion = () => (
   />
 );
 
+export const shipmentHeadingCancelled = () => (
+  <ShipmentHeading
+    shipmentInfo={{
+      shipmentID: text('ShipmentInfo.shipmentID', '1'),
+      shipmentStatus: text('ShipmentInfo.shipmentStatus', 'CANCELED'),
+      shipmentType: text('ShipmentInfo.shipmentType', 'Household Goods'),
+      isDiversion: boolean('ShipmentInfo.isDiversion', false),
+      originCity: text('ShipmentInfo.originCity', 'San Antonio'),
+      originState: text('ShipmentInfo.originState', 'TX'),
+      originPostalCode: text('ShipmentInfo.originPostalCode', '98421'),
+      destinationAddress: object('MTOShipment.destinationAddress', {
+        street_address_1: '123 Any Street',
+        city: 'Tacoma',
+        state: 'WA',
+        postal_code: '98421',
+      }),
+      scheduledPickupDate: text('ShipmentInfo.scheduledPickupDate', '27 Mar 2020'),
+    }}
+  />
+);
+
 export default { title: 'Office Components/ShipmentHeading' };

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -88,7 +88,9 @@ const MoveDetails = ({ setUnapprovedShipmentCount, setUnapprovedServiceItemCount
   const submittedShipments = mtoShipments?.filter(
     (shipment) => shipment.status === shipmentStatuses.SUBMITTED && !shipment.deletedAt,
   );
-  const approvedShipments = mtoShipments?.filter((shipment) => shipment.status === shipmentStatuses.APPROVED);
+  const approvedOrCanceledShipments = mtoShipments?.filter(
+    (shipment) => shipment.status === shipmentStatuses.APPROVED || shipment.status === shipmentStatuses.CANCELED,
+  );
 
   useEffect(() => {
     const shipmentCount = submittedShipments?.length || 0;
@@ -101,22 +103,22 @@ const MoveDetails = ({ setUnapprovedShipmentCount, setUnapprovedServiceItemCount
       if (
         serviceItem.status === SERVICE_ITEM_STATUSES.SUBMITTED &&
         serviceItem.mtoShipmentID &&
-        approvedShipments?.find((shipment) => shipment.id === serviceItem.mtoShipmentID)
+        approvedOrCanceledShipments?.find((shipment) => shipment.id === serviceItem.mtoShipmentID)
       ) {
         serviceItemCount += 1;
       }
     });
     setUnapprovedServiceItemCount(serviceItemCount);
-  }, [approvedShipments, mtoServiceItems, setUnapprovedServiceItemCount]);
+  }, [approvedOrCanceledShipments, mtoServiceItems, setUnapprovedServiceItemCount]);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
   const { customer, entitlement: allowances } = order;
 
-  if (submittedShipments.length > 0 && approvedShipments.length > 0) {
+  if (submittedShipments.length > 0 && approvedOrCanceledShipments.length > 0) {
     sections = ['requested-shipments', 'approved-shipments', ...sections];
-  } else if (approvedShipments.length > 0) {
+  } else if (approvedOrCanceledShipments.length > 0) {
     sections = ['approved-shipments', ...sections];
   } else if (submittedShipments.length > 0) {
     sections = ['requested-shipments', ...sections];
@@ -207,11 +209,11 @@ const MoveDetails = ({ setUnapprovedShipmentCount, setUnapprovedServiceItemCount
               />
             </div>
           )}
-          {approvedShipments.length > 0 && (
+          {approvedOrCanceledShipments.length > 0 && (
             <div className={styles.section} id="approved-shipments">
               <RequestedShipments
                 moveTaskOrder={move}
-                mtoShipments={approvedShipments}
+                mtoShipments={approvedOrCanceledShipments}
                 ordersInfo={ordersInfo}
                 allowancesInfo={allowancesInfo}
                 customerInfo={customerInfo}

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -39,11 +39,12 @@ function formatShipmentDate(shipmentDateString) {
   return `${weekday}, ${day} ${month} ${year}`;
 }
 
-function approvedFilter(shipment) {
+function showShipmentFilter(shipment) {
   return (
     shipment.status === shipmentStatuses.APPROVED ||
     shipment.status === shipmentStatuses.CANCELLATION_REQUESTED ||
-    shipment.status === shipmentStatuses.DIVERSION_REQUESTED
+    shipment.status === shipmentStatuses.DIVERSION_REQUESTED ||
+    shipment.status === shipmentStatuses.CANCELED
   );
 }
 
@@ -222,7 +223,8 @@ export const MoveTaskOrder = ({ match, ...props }) => {
       if (
         shipment.status === shipmentStatuses.APPROVED ||
         shipment.status === shipmentStatuses.CANCELLATION_REQUESTED ||
-        shipment.status === shipmentStatuses.DIVERSION_REQUESTED
+        shipment.status === shipmentStatuses.DIVERSION_REQUESTED ||
+        shipment.status === shipmentStatuses.CANCELED
       ) {
         shipmentSections.push({
           id: shipment.id,
@@ -273,7 +275,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
-  if (moveTaskOrder.status === MOVE_STATUSES.SUBMITTED || !mtoShipments.some(approvedFilter)) {
+  if (moveTaskOrder.status === MOVE_STATUSES.SUBMITTED || !mtoShipments.some(showShipmentFilter)) {
     return (
       <div className={styles.tabContent}>
         <GridContainer className={styles.gridContainer} data-testid="too-shipment-container">
@@ -330,7 +332,8 @@ export const MoveTaskOrder = ({ match, ...props }) => {
             if (
               mtoShipment.status !== shipmentStatuses.APPROVED &&
               mtoShipment.status !== shipmentStatuses.CANCELLATION_REQUESTED &&
-              mtoShipment.status !== shipmentStatuses.DIVERSION_REQUESTED
+              mtoShipment.status !== shipmentStatuses.DIVERSION_REQUESTED &&
+              mtoShipment.status !== shipmentStatuses.CANCELED
             ) {
               return false;
             }

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -45,6 +45,7 @@ const unapprovedMTOQuery = {
   mtoShipments: [
     {
       id: '3',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.HHG,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -61,9 +62,11 @@ const unapprovedMTOQuery = {
         postal_code: '08401',
       },
       status: shipmentStatuses.SUBMITTED,
+      eTag: '1234',
     },
     {
       id: '4',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.NTS,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -80,6 +83,7 @@ const unapprovedMTOQuery = {
         postal_code: '08401',
       },
       status: shipmentStatuses.SUBMITTED,
+      eTag: '1234',
     },
   ],
   mtoServiceItems: undefined,
@@ -128,6 +132,7 @@ const someShipmentsApprovedMTOQuery = {
         city: 'Chicago',
         state: 'IL',
         postal_code: '60601',
+        eTag: '1234',
       },
       destinationAddress: {
         street_address_1: '10 Park Place',
@@ -136,9 +141,11 @@ const someShipmentsApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: shipmentStatuses.APPROVED,
+      eTag: '1234',
     },
     {
       id: '4',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.NTS,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -155,6 +162,7 @@ const someShipmentsApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: shipmentStatuses.SUBMITTED,
+      eTag: '1234',
     },
   ],
   mtoServiceItems: [
@@ -240,6 +248,7 @@ const allApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: 'APPROVED',
+      eTag: '1234',
     },
     {
       id: '4',
@@ -260,10 +269,11 @@ const allApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: 'APPROVED',
+      eTag: '1234',
     },
     {
       id: '5',
-      mtoShipmentID: '2',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.NTSR,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -280,9 +290,11 @@ const allApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: 'APPROVED',
+      eTag: '1234',
     },
     {
       id: '6',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -299,9 +311,11 @@ const allApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: 'APPROVED',
+      eTag: '1234',
     },
     {
       id: '7',
+      moveTaskOrderID: '2',
       shipmentType: SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,
       scheduledPickupDate: '2020-03-16',
       requestedPickupDate: '2020-03-15',
@@ -318,6 +332,7 @@ const allApprovedMTOQuery = {
         postal_code: '08401',
       },
       status: 'APPROVED',
+      eTag: '1234',
     },
   ],
   mtoServiceItems: [
@@ -334,6 +349,72 @@ const allApprovedMTOQuery = {
       reServiceName: "Domestic origin add'l SIT",
       status: SERVICE_ITEM_STATUS.SUBMITTED,
       reServiceCode: 'DOASIT',
+    },
+  ],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
+const approvedMTOWithCancelledShipmentQuery = {
+  orders: {
+    1: {
+      id: '1',
+      originDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Knox',
+          state: 'KY',
+          postal_code: '40121',
+        },
+      },
+      destinationDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Irwin',
+          state: 'CA',
+          postal_code: '92310',
+        },
+      },
+    },
+  },
+  moveTaskOrders: {
+    2: {
+      id: '2',
+      status: MOVE_STATUSES.APPROVED,
+      availableToPrimeAt: '2020-03-01T00:00:00.000Z',
+    },
+  },
+  mtoShipments: [
+    {
+      id: '3',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: 'CANCELED',
+      eTag: '1234',
+    },
+  ],
+  mtoServiceItems: [
+    {
+      id: '8',
+      mtoShipmentID: '3',
+      reServiceName: 'Domestic origin 1st day SIT',
+      status: SERVICE_ITEM_STATUS.SUBMITTED,
+      reServiceCode: 'DOFSIT',
     },
   ],
   isLoading: false,
@@ -519,6 +600,70 @@ describe('MoveTaskOrder', () => {
       expect(requestedServiceItemsTable.length).toBe(2);
       expect(requestedServiceItemsTable.at(0).prop('statusForTableType')).toBe(SERVICE_ITEM_STATUS.SUBMITTED);
       expect(requestedServiceItemsTable.at(1).prop('statusForTableType')).toBe(SERVICE_ITEM_STATUS.SUBMITTED);
+    });
+
+    it('updates the unapproved shipments tag state', () => {
+      expect(setUnapprovedShipmentCount).toHaveBeenCalledWith(0);
+    });
+
+    it('updates the unapproved service items tag state', () => {
+      expect(setUnapprovedServiceItemCount).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('approved mto with cancelled shipment', () => {
+    useMoveTaskOrderQueries.mockImplementation(() => approvedMTOWithCancelledShipmentQuery);
+    const wrapper = mount(
+      <MockProviders>
+        <MoveTaskOrder
+          {...requiredProps}
+          setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+          setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+        />
+      </MockProviders>,
+    );
+
+    it('renders the h1', () => {
+      expect(wrapper.find({ 'data-testid': 'too-shipment-container' }).exists()).toBe(true);
+      expect(wrapper.find('h1').text()).toBe('Move task order');
+    });
+
+    it('renders the left nav with shipments', () => {
+      expect(wrapper.find('LeftNav').exists()).toBe(true);
+
+      const navLinks = wrapper.find('LeftNav a');
+      expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(0).contains('1'));
+      expect(navLinks.at(0).prop('href')).toBe('#shipment-3');
+    });
+
+    it('renders the ShipmentContainer', () => {
+      expect(wrapper.find('ShipmentContainer').length).toBe(1);
+    });
+
+    it('renders the ShipmentHeading', () => {
+      expect(wrapper.find('ShipmentHeading').exists()).toBe(true);
+      expect(wrapper.find('h2').at(0).text()).toEqual('Household goods');
+      expect(wrapper.find('span[data-testid="tag"]').text()).toEqual('cancelled');
+    });
+
+    it('renders the ImportantShipmentDates', () => {
+      expect(wrapper.find('ImportantShipmentDates').exists()).toBe(true);
+    });
+
+    it('renders the ShipmentAddresses', () => {
+      expect(wrapper.find('ShipmentAddresses').exists()).toBe(true);
+    });
+
+    it('renders the ShipmentWeightDetails', () => {
+      expect(wrapper.find('ShipmentWeightDetails').exists()).toBe(true);
+    });
+
+    it('renders the RequestedServiceItemsTable for SUBMITTED service item', () => {
+      const requestedServiceItemsTable = wrapper.find('RequestedServiceItemsTable');
+      // There are no approved or rejected service item tables to display
+      expect(requestedServiceItemsTable.length).toBe(1);
+      expect(requestedServiceItemsTable.at(0).prop('statusForTableType')).toBe(SERVICE_ITEM_STATUS.SUBMITTED);
     });
 
     it('updates the unapproved shipments tag state', () => {

--- a/src/types/shipment.js
+++ b/src/types/shipment.js
@@ -30,4 +30,5 @@ export const ShipmentShape = PropTypes.shape({
   diversion: PropTypes.bool,
   counselorRemarks: PropTypes.string,
   customerRemarks: PropTypes.string,
+  status: PropTypes.string,
 });


### PR DESCRIPTION
## Description

This PR enables the TOO to be able to see the cancelled shipments. TOO will request the shipment to be cancelled and then the Prime will follow up by pushing the shipment status to be cancelled.

## Reviewer Notes

- Took the liberty of refactoring the devseed script a bit. There's a new flag `namedSubScenario` that will run a specific scenario within the main script file. This will shorten the time the db will take to seed data.
- Added new make commands that will backup, restore and cleanup the dev database.
- Noticed that the status name is `CANCELED` instead of `CANCELLED` which we should fix later. I'll make a new story to capture this.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

Reset and migrate the database. Delete bin file and build the generate-test-data tool.
```sh
make db_dev_reset db_dev_migrate

rm -rf bin/generate-test-data
make bin/generate-test-data
```

Generate seed data shipment hhg cancelled.
```sh
generate-test-data --named-scenario="dev_seed" --named-sub-scenario="shipment_hhg_cancelled" --db-env="development"
```

Run app
```sh
make server_run
make office_client_run
```

### Test
1. In office app, create a new TOO user to log in
2. Click on generated move in queue
3. On move details page, see that the shipment card shows the `CANCELLED` tag
4. Navigate to move task order page by clicking on the `Move task order` link at the top
5. On page, notice that `CANCELLED` tag shows next to the header and no action buttons are showing

### Storybook

```sh
make storybook
```

1. See `CANCELLED` tag on Shipment display component: http://localhost:6006/?path=/story/office-components-shipment-display--cancelled-shipment
2. See `CANCELLED` tag on Shipment heading component: http://localhost:6006/?path=/story/office-components-shipmentheading--shipment-heading-cancelled

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7682) for this change

## Screenshots

Move details page
![image](https://user-images.githubusercontent.com/1522549/122295925-a30b7300-ceae-11eb-8c38-a9dd4af81e4d.png)


Move task order page
![image](https://user-images.githubusercontent.com/1522549/122295857-92f39380-ceae-11eb-980c-d73f983ad37e.png)
