### PR TITLE
[MB-8385] Upgrade xlsx to version 3.x

### DIFF
--- a/cmd/ghc-pricing-parser/main.go
+++ b/cmd/ghc-pricing-parser/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging"

--- a/cmd/ghc-transit-time-parser/main.go
+++ b/cmd/ghc-transit-time-parser/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging"

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
-	github.com/tealeg/xlsx/v2 v2.0.1
+	github.com/tealeg/xlsx/v3 v3.2.3
 	github.com/tiaguinho/gosoap v1.4.4
 	github.com/vektra/mockery/v2 v2.8.0
 	go.mozilla.org/pkcs7 v0.0.0-20181213175627-3cffc6fbfe83

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,7 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -774,6 +775,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
+github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -782,6 +785,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
+github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1 h1:I2qBYMChEhIjOgazfJmV3/mZM256btk6wkCDRmW7JYs=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -813,6 +818,7 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rickar/cal v1.0.5 h1:ccTH7okdpqbT+X7hlWgQM4Hv3rTvpV8Stu7enQx7ywY=
 github.com/rickar/cal v1.0.5/go.mod h1:3GBx8OBrvh4/y/JTxM0e1bUUIHMnqILl1rMANHWExxQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -836,6 +842,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa h1:2cO3RojjYl3hVTbEvJVqrMaFmORhL6O06qdW42toftk=
+github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa/go.mod h1:Yjr3bdWaVWyME1kha7X0jsz3k2DgXNa1Pj3XGyUAbx8=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc h1:jUIKcSPO9MoMJBbEoyE/RJoE8vz7Mb8AjvifMMwSyvY=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -899,8 +907,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8 h1:RB0v+/pc8oMzPsN97aZYEwNuJ6ouRJ2uhjxemJ9zvrY=
 github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8/go.mod h1:IlWNj9v/13q7xFbaK4mbyzMNwrZLaWSHx/aibKIZuIg=
-github.com/tealeg/xlsx/v2 v2.0.1 h1:RP+VEscpPFjH2FnpKh1p9HVLAk1htqb9Urcxi2AU1ns=
-github.com/tealeg/xlsx/v2 v2.0.1/go.mod h1:l9GvhCCjdaIGkAyZcFedDALcYcXUOei55f6umRMOz9c=
+github.com/tealeg/xlsx/v3 v3.2.3 h1:MXnVh+9Y8cUglowItTy2HL3Kv6z+q/0aNjeKuTsVqZQ=
+github.com/tealeg/xlsx/v3 v3.2.3/go.mod h1:0hGmAEoZ48SS1ZAE6eqZJkJVXgOMY+8a33vjXa8S8HA=
 github.com/tiaguinho/gosoap v1.4.4 h1:4XZlaqf/y2UAbCPFGcZS4uLKrEvnMr+5pccIyQAUVg4=
 github.com/tiaguinho/gosoap v1.4.4/go.mod h1:4vv86Jl19UkOeoJW/aawihXYNJ/Iy2NHkhgmBUJ2Ibk=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gocarina/gocsv"
 	"github.com/pkg/errors"
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/parser/pricing/parse_access_and_add_prices.go
+++ b/pkg/parser/pricing/parse_access_and_add_prices.go
@@ -26,9 +26,9 @@ var parseDomesticMoveAccessorialPrices processXlsxSheet = func(params ParamConfi
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := domAccessorialRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageDomesticMoveAccessorialPrice{
-			ServicesSchedule: getCell(sheet, rowIndex, firstColumnIndexStart),
-			ServiceProvided:  getCell(sheet, rowIndex, secondColumnIndexStart),
-			PricePerUnit:     getCell(sheet, rowIndex, thirdColumnIndexStart),
+			ServicesSchedule: mustGetCell(sheet, rowIndex, firstColumnIndexStart),
+			ServiceProvided:  mustGetCell(sheet, rowIndex, secondColumnIndexStart),
+			PricePerUnit:     mustGetCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -61,9 +61,9 @@ var parseInternationalMoveAccessorialPrices processXlsxSheet = func(params Param
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := intlAccessorialRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageInternationalMoveAccessorialPrice{
-			Market:          getCell(sheet, rowIndex, firstColumnIndexStart),
-			ServiceProvided: getCell(sheet, rowIndex, secondColumnIndexStart),
-			PricePerUnit:    getCell(sheet, rowIndex, thirdColumnIndexStart),
+			Market:          mustGetCell(sheet, rowIndex, firstColumnIndexStart),
+			ServiceProvided: mustGetCell(sheet, rowIndex, secondColumnIndexStart),
+			PricePerUnit:    mustGetCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -96,9 +96,9 @@ var parseDomesticInternationalAdditionalPrices processXlsxSheet = func(params Pa
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := additionalPricesRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageDomesticInternationalAdditionalPrice{
-			Market:       getCell(sheet, rowIndex, firstColumnIndexStart),
-			ShipmentType: getCell(sheet, rowIndex, secondColumnIndexStart),
-			Factor:       getCell(sheet, rowIndex, thirdColumnIndexStart),
+			Market:       mustGetCell(sheet, rowIndex, firstColumnIndexStart),
+			ShipmentType: mustGetCell(sheet, rowIndex, secondColumnIndexStart),
+			Factor:       mustGetCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -161,13 +161,13 @@ func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeade
 	const thirdColumnIndexStart = 4
 
 	for rowIndex := dataRowsIndexBegin; rowIndex < dataRowsIndexEnd; rowIndex++ {
-		if header := getCell(sheet, rowIndex, firstColumnIndexStart); header != firstHeader {
+		if header := mustGetCell(sheet, rowIndex, firstColumnIndexStart); header != firstHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
 		}
-		if header := getCell(sheet, rowIndex, secondColumnIndexStart); header != secondHeader {
+		if header := mustGetCell(sheet, rowIndex, secondColumnIndexStart); header != secondHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, thirdColumnIndexStart)); header != thirdHeader {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, thirdColumnIndexStart)); header != thirdHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
 		}
 	}

--- a/pkg/parser/pricing/parse_access_and_add_prices.go
+++ b/pkg/parser/pricing/parse_access_and_add_prices.go
@@ -1,179 +1,194 @@
 package pricing
 
 import (
-	"fmt"
-
-	"github.com/tealeg/xlsx/v2"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
+	"github.com/tealeg/xlsx/v3"
 )
 
 var parseDomesticMoveAccessorialPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-	const domAccessorialRowIndexStart int = 11
-	const firstColumnIndexStart = 2
-	const secondColumnIndexStart = 3
-	const thirdColumnIndexStart = 4
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+		const domAccessorialRowIndexStart int = 11
+		const firstColumnIndexStart = 2
+		const secondColumnIndexStart = 3
+		const thirdColumnIndexStart = 4
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing domestic move accessorial prices")
-	var prices []models.StageDomesticMoveAccessorialPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart:]
-	for _, row := range dataRows {
-		price := models.StageDomesticMoveAccessorialPrice{
-			ServicesSchedule: getCell(row.Cells, firstColumnIndexStart),
-			ServiceProvided:  getCell(row.Cells, secondColumnIndexStart),
-			PricePerUnit:     getCell(row.Cells, thirdColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if price.ServicesSchedule == "" {
-			break
-		}
+		logger.Info("Parsing domestic move accessorial prices")
+		var prices []models.StageDomesticMoveAccessorialPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart:]
+		for _, row := range dataRows {
+			price := models.StageDomesticMoveAccessorialPrice{
+				ServicesSchedule: getCell(row.Cells, firstColumnIndexStart),
+				ServiceProvided:  getCell(row.Cells, secondColumnIndexStart),
+				PricePerUnit:     getCell(row.Cells, thirdColumnIndexStart),
+			}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageDomesticMoveAccessorialPrice", price))
+			// All the rows are consecutive, if we get a blank we're done
+			if price.ServicesSchedule == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageDomesticMoveAccessorialPrice", price))
+			}
+			prices = append(prices, price)
 		}
-		prices = append(prices, price)
-	}
-	return prices, nil
+		return prices, nil
+	*/
 }
 
 var parseInternationalMoveAccessorialPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-	const intlAccessorialRowIndexStart int = 25
-	const firstColumnIndexStart = 2
-	const secondColumnIndexStart = 3
-	const thirdColumnIndexStart = 4
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+		const intlAccessorialRowIndexStart int = 25
+		const firstColumnIndexStart = 2
+		const secondColumnIndexStart = 3
+		const thirdColumnIndexStart = 4
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseInternationalMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing international move accessorial prices")
-	var prices []models.StageInternationalMoveAccessorialPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart:]
-	for _, row := range dataRows {
-		price := models.StageInternationalMoveAccessorialPrice{
-			Market:          getCell(row.Cells, firstColumnIndexStart),
-			ServiceProvided: getCell(row.Cells, secondColumnIndexStart),
-			PricePerUnit:    getCell(row.Cells, thirdColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseInternationalMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if price.Market == "" {
-			break
-		}
+		logger.Info("Parsing international move accessorial prices")
+		var prices []models.StageInternationalMoveAccessorialPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart:]
+		for _, row := range dataRows {
+			price := models.StageInternationalMoveAccessorialPrice{
+				Market:          getCell(row.Cells, firstColumnIndexStart),
+				ServiceProvided: getCell(row.Cells, secondColumnIndexStart),
+				PricePerUnit:    getCell(row.Cells, thirdColumnIndexStart),
+			}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageInternationalMoveAccessorialPrice", price))
+			// All the rows are consecutive, if we get a blank we're done
+			if price.Market == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageInternationalMoveAccessorialPrice", price))
+			}
+			prices = append(prices, price)
 		}
-		prices = append(prices, price)
-	}
-	return prices, nil
+		return prices, nil
+	*/
 }
 
 var parseDomesticInternationalAdditionalPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-	const additionalPricesRowIndexStart int = 39
-	const firstColumnIndexStart = 2
-	const secondColumnIndexStart = 3
-	const thirdColumnIndexStart = 4
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+		const additionalPricesRowIndexStart int = 39
+		const firstColumnIndexStart = 2
+		const secondColumnIndexStart = 3
+		const thirdColumnIndexStart = 4
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticInternationalAdditionalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing domestic/international additional prices")
-	var prices []models.StageDomesticInternationalAdditionalPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart:]
-	for _, row := range dataRows {
-		price := models.StageDomesticInternationalAdditionalPrice{
-			Market:       getCell(row.Cells, firstColumnIndexStart),
-			ShipmentType: getCell(row.Cells, secondColumnIndexStart),
-			Factor:       getCell(row.Cells, thirdColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticInternationalAdditionalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if price.Market == "" {
-			break
-		}
+		logger.Info("Parsing domestic/international additional prices")
+		var prices []models.StageDomesticInternationalAdditionalPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart:]
+		for _, row := range dataRows {
+			price := models.StageDomesticInternationalAdditionalPrice{
+				Market:       getCell(row.Cells, firstColumnIndexStart),
+				ShipmentType: getCell(row.Cells, secondColumnIndexStart),
+				Factor:       getCell(row.Cells, thirdColumnIndexStart),
+			}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageDomesticInternationalAdditionalPrice", price))
+			// All the rows are consecutive, if we get a blank we're done
+			if price.Market == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageDomesticInternationalAdditionalPrice", price))
+			}
+			prices = append(prices, price)
 		}
-		prices = append(prices, price)
-	}
-	return prices, nil
+		return prices, nil
+	*/
 }
 
 var verifyAccessAndAddPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum = 17 // 5a) Access. and Add. Prices
-	const domAccessorialRowIndexStart = 11
-	const intlAccessorialRowIndexStart = 25
-	const additionalPricesRowIndexStart = 39
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum = 17 // 5a) Access. and Add. Prices
+		const domAccessorialRowIndexStart = 11
+		const intlAccessorialRowIndexStart = 25
+		const additionalPricesRowIndexStart = 39
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyAccessAndAddPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyAccessAndAddPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-2 : domAccessorialRowIndexStart-1]
-	err := helperCheckHeadersFor5a("Services Schedule", "Service Provided", "PricePerUnitofMeasure", dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-2 : domAccessorialRowIndexStart-1]
+		err := helperCheckHeadersFor5a("Services Schedule", "Service Provided", "PricePerUnitofMeasure", dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-1 : domAccessorialRowIndexStart]
-	err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-1 : domAccessorialRowIndexStart]
+		err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-2 : intlAccessorialRowIndexStart-1]
-	err = helperCheckHeadersFor5a("Market", "Service Provided", "PricePerUnitofMeasure", dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-2 : intlAccessorialRowIndexStart-1]
+		err = helperCheckHeadersFor5a("Market", "Service Provided", "PricePerUnitofMeasure", dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-1 : intlAccessorialRowIndexStart]
-	err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-1 : intlAccessorialRowIndexStart]
+		err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-2 : additionalPricesRowIndexStart-1]
-	err = helperCheckHeadersFor5a("Market", "Shipment Type", "Factor", dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-2 : additionalPricesRowIndexStart-1]
+		err = helperCheckHeadersFor5a("Market", "Shipment Type", "Factor", dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-1 : additionalPricesRowIndexStart]
-	return helperCheckHeadersFor5a("CONUS / OCONUS", "EXAMPLE", "X.XX", dataRows)
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-1 : additionalPricesRowIndexStart]
+		return helperCheckHeadersFor5a("CONUS / OCONUS", "EXAMPLE", "X.XX", dataRows)
+	*/
 }
 
 func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeader string, dataRows []*xlsx.Row) error {
-	const firstColumnIndexStart = 2
-	const secondColumnIndexStart = 3
-	const thirdColumnIndexStart = 4
-
-	for _, dataRow := range dataRows {
-		if header := getCell(dataRow.Cells, firstColumnIndexStart); header != firstHeader {
-			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
-		}
-		if header := getCell(dataRow.Cells, secondColumnIndexStart); header != secondHeader {
-			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
-		}
-		if header := removeWhiteSpace(getCell(dataRow.Cells, thirdColumnIndexStart)); header != thirdHeader {
-			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
-		}
-	}
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		const firstColumnIndexStart = 2
+		const secondColumnIndexStart = 3
+		const thirdColumnIndexStart = 4
+
+		for _, dataRow := range dataRows {
+			if header := getCell(dataRow.Cells, firstColumnIndexStart); header != firstHeader {
+				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
+			}
+			if header := getCell(dataRow.Cells, secondColumnIndexStart); header != secondHeader {
+				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
+			}
+			if header := removeWhiteSpace(getCell(dataRow.Cells, thirdColumnIndexStart)); header != thirdHeader {
+				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
+			}
+		}
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_access_and_add_prices.go
+++ b/pkg/parser/pricing/parse_access_and_add_prices.go
@@ -1,194 +1,178 @@
 package pricing
 
 import (
+	"fmt"
+
 	"github.com/tealeg/xlsx/v3"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 var parseDomesticMoveAccessorialPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-		const domAccessorialRowIndexStart int = 11
-		const firstColumnIndexStart = 2
-		const secondColumnIndexStart = 3
-		const thirdColumnIndexStart = 4
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+	const domAccessorialRowIndexStart int = 11
+	const firstColumnIndexStart = 2
+	const secondColumnIndexStart = 3
+	const thirdColumnIndexStart = 4
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing domestic move accessorial prices")
+	var prices []models.StageDomesticMoveAccessorialPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := domAccessorialRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		price := models.StageDomesticMoveAccessorialPrice{
+			ServicesSchedule: getCell(sheet, rowIdx, firstColumnIndexStart),
+			ServiceProvided:  getCell(sheet, rowIdx, secondColumnIndexStart),
+			PricePerUnit:     getCell(sheet, rowIdx, thirdColumnIndexStart),
 		}
 
-		logger.Info("Parsing domestic move accessorial prices")
-		var prices []models.StageDomesticMoveAccessorialPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart:]
-		for _, row := range dataRows {
-			price := models.StageDomesticMoveAccessorialPrice{
-				ServicesSchedule: getCell(row.Cells, firstColumnIndexStart),
-				ServiceProvided:  getCell(row.Cells, secondColumnIndexStart),
-				PricePerUnit:     getCell(row.Cells, thirdColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if price.ServicesSchedule == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageDomesticMoveAccessorialPrice", price))
-			}
-			prices = append(prices, price)
+		// All the rows are consecutive, if we get a blank we're done
+		if price.ServicesSchedule == "" {
+			break
 		}
-		return prices, nil
-	*/
+
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageDomesticMoveAccessorialPrice", price))
+		}
+		prices = append(prices, price)
+	}
+	return prices, nil
 }
 
 var parseInternationalMoveAccessorialPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-		const intlAccessorialRowIndexStart int = 25
-		const firstColumnIndexStart = 2
-		const secondColumnIndexStart = 3
-		const thirdColumnIndexStart = 4
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+	const intlAccessorialRowIndexStart int = 25
+	const firstColumnIndexStart = 2
+	const secondColumnIndexStart = 3
+	const thirdColumnIndexStart = 4
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseInternationalMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseInternationalMoveAccessorialPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing international move accessorial prices")
+	var prices []models.StageInternationalMoveAccessorialPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := intlAccessorialRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		price := models.StageInternationalMoveAccessorialPrice{
+			Market:          getCell(sheet, rowIdx, firstColumnIndexStart),
+			ServiceProvided: getCell(sheet, rowIdx, secondColumnIndexStart),
+			PricePerUnit:    getCell(sheet, rowIdx, thirdColumnIndexStart),
 		}
 
-		logger.Info("Parsing international move accessorial prices")
-		var prices []models.StageInternationalMoveAccessorialPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart:]
-		for _, row := range dataRows {
-			price := models.StageInternationalMoveAccessorialPrice{
-				Market:          getCell(row.Cells, firstColumnIndexStart),
-				ServiceProvided: getCell(row.Cells, secondColumnIndexStart),
-				PricePerUnit:    getCell(row.Cells, thirdColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if price.Market == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageInternationalMoveAccessorialPrice", price))
-			}
-			prices = append(prices, price)
+		// All the rows are consecutive, if we get a blank we're done
+		if price.Market == "" {
+			break
 		}
-		return prices, nil
-	*/
+
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageInternationalMoveAccessorialPrice", price))
+		}
+		prices = append(prices, price)
+	}
+	return prices, nil
 }
 
 var parseDomesticInternationalAdditionalPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
-		const additionalPricesRowIndexStart int = 39
-		const firstColumnIndexStart = 2
-		const secondColumnIndexStart = 3
-		const thirdColumnIndexStart = 4
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 17 // 5a) Access. and Add. Prices
+	const additionalPricesRowIndexStart int = 39
+	const firstColumnIndexStart = 2
+	const secondColumnIndexStart = 3
+	const thirdColumnIndexStart = 4
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticInternationalAdditionalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticInternationalAdditionalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing domestic/international additional prices")
+	var prices []models.StageDomesticInternationalAdditionalPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := additionalPricesRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		price := models.StageDomesticInternationalAdditionalPrice{
+			Market:       getCell(sheet, rowIdx, firstColumnIndexStart),
+			ShipmentType: getCell(sheet, rowIdx, secondColumnIndexStart),
+			Factor:       getCell(sheet, rowIdx, thirdColumnIndexStart),
 		}
 
-		logger.Info("Parsing domestic/international additional prices")
-		var prices []models.StageDomesticInternationalAdditionalPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart:]
-		for _, row := range dataRows {
-			price := models.StageDomesticInternationalAdditionalPrice{
-				Market:       getCell(row.Cells, firstColumnIndexStart),
-				ShipmentType: getCell(row.Cells, secondColumnIndexStart),
-				Factor:       getCell(row.Cells, thirdColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if price.Market == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageDomesticInternationalAdditionalPrice", price))
-			}
-			prices = append(prices, price)
+		// All the rows are consecutive, if we get a blank we're done
+		if price.Market == "" {
+			break
 		}
-		return prices, nil
-	*/
+
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageDomesticInternationalAdditionalPrice", price))
+		}
+		prices = append(prices, price)
+	}
+	return prices, nil
 }
 
 var verifyAccessAndAddPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum = 17 // 5a) Access. and Add. Prices
-		const domAccessorialRowIndexStart = 11
-		const intlAccessorialRowIndexStart = 25
-		const additionalPricesRowIndexStart = 39
+	// XLSX Sheet consts
+	const xlsxDataSheetNum = 17 // 5a) Access. and Add. Prices
+	const domAccessorialRowIndexStart = 11
+	const intlAccessorialRowIndexStart = 25
+	const additionalPricesRowIndexStart = 39
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyAccessAndAddPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyAccessAndAddPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-2 : domAccessorialRowIndexStart-1]
-		err := helperCheckHeadersFor5a("Services Schedule", "Service Provided", "PricePerUnitofMeasure", dataRows)
-		if err != nil {
-			return err
-		}
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[domAccessorialRowIndexStart-1 : domAccessorialRowIndexStart]
-		err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
-		if err != nil {
-			return err
-		}
+	err := helperCheckHeadersFor5a("Services Schedule", "Service Provided", "PricePerUnitofMeasure", sheet, domAccessorialRowIndexStart-2, domAccessorialRowIndexStart-1)
+	if err != nil {
+		return err
+	}
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-2 : intlAccessorialRowIndexStart-1]
-		err = helperCheckHeadersFor5a("Market", "Service Provided", "PricePerUnitofMeasure", dataRows)
-		if err != nil {
-			return err
-		}
+	err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", sheet, domAccessorialRowIndexStart-1, domAccessorialRowIndexStart)
+	if err != nil {
+		return err
+	}
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[intlAccessorialRowIndexStart-1 : intlAccessorialRowIndexStart]
-		err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", dataRows)
-		if err != nil {
-			return err
-		}
+	err = helperCheckHeadersFor5a("Market", "Service Provided", "PricePerUnitofMeasure", sheet, intlAccessorialRowIndexStart-2, intlAccessorialRowIndexStart-1)
+	if err != nil {
+		return err
+	}
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-2 : additionalPricesRowIndexStart-1]
-		err = helperCheckHeadersFor5a("Market", "Shipment Type", "Factor", dataRows)
-		if err != nil {
-			return err
-		}
+	err = helperCheckHeadersFor5a("X", "EXAMPLE (per unit of measure)", "$X.XX", sheet, intlAccessorialRowIndexStart-1, intlAccessorialRowIndexStart)
+	if err != nil {
+		return err
+	}
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[additionalPricesRowIndexStart-1 : additionalPricesRowIndexStart]
-		return helperCheckHeadersFor5a("CONUS / OCONUS", "EXAMPLE", "X.XX", dataRows)
-	*/
+	err = helperCheckHeadersFor5a("Market", "Shipment Type", "Factor", sheet, additionalPricesRowIndexStart-2, additionalPricesRowIndexStart-1)
+	if err != nil {
+		return err
+	}
+
+	return helperCheckHeadersFor5a("CONUS / OCONUS", "EXAMPLE", "X.XX", sheet, additionalPricesRowIndexStart-1, additionalPricesRowIndexStart)
 }
 
-func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeader string, dataRows []*xlsx.Row) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		const firstColumnIndexStart = 2
-		const secondColumnIndexStart = 3
-		const thirdColumnIndexStart = 4
+func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeader string, sheet *xlsx.Sheet, dataRowsIdxBegin, dataRowsIdxEnd int) error {
+	const firstColumnIndexStart = 2
+	const secondColumnIndexStart = 3
+	const thirdColumnIndexStart = 4
 
-		for _, dataRow := range dataRows {
-			if header := getCell(dataRow.Cells, firstColumnIndexStart); header != firstHeader {
-				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
-			}
-			if header := getCell(dataRow.Cells, secondColumnIndexStart); header != secondHeader {
-				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
-			}
-			if header := removeWhiteSpace(getCell(dataRow.Cells, thirdColumnIndexStart)); header != thirdHeader {
-				return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
-			}
+	for rowIdx := dataRowsIdxBegin; rowIdx < dataRowsIdxEnd; rowIdx++ {
+		if header := getCell(sheet, rowIdx, firstColumnIndexStart); header != firstHeader {
+			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
 		}
-		return nil
-	*/
+		if header := getCell(sheet, rowIdx, secondColumnIndexStart); header != secondHeader {
+			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, thirdColumnIndexStart)); header != thirdHeader {
+			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
+		}
+	}
+	return nil
 }

--- a/pkg/parser/pricing/parse_access_and_add_prices.go
+++ b/pkg/parser/pricing/parse_access_and_add_prices.go
@@ -23,13 +23,12 @@ var parseDomesticMoveAccessorialPrices processXlsxSheet = func(params ParamConfi
 
 	logger.Info("Parsing domestic move accessorial prices")
 	var prices []models.StageDomesticMoveAccessorialPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := domAccessorialRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := domAccessorialRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageDomesticMoveAccessorialPrice{
-			ServicesSchedule: getCell(sheet, rowIdx, firstColumnIndexStart),
-			ServiceProvided:  getCell(sheet, rowIdx, secondColumnIndexStart),
-			PricePerUnit:     getCell(sheet, rowIdx, thirdColumnIndexStart),
+			ServicesSchedule: getCell(sheet, rowIndex, firstColumnIndexStart),
+			ServiceProvided:  getCell(sheet, rowIndex, secondColumnIndexStart),
+			PricePerUnit:     getCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -59,13 +58,12 @@ var parseInternationalMoveAccessorialPrices processXlsxSheet = func(params Param
 
 	logger.Info("Parsing international move accessorial prices")
 	var prices []models.StageInternationalMoveAccessorialPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := intlAccessorialRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := intlAccessorialRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageInternationalMoveAccessorialPrice{
-			Market:          getCell(sheet, rowIdx, firstColumnIndexStart),
-			ServiceProvided: getCell(sheet, rowIdx, secondColumnIndexStart),
-			PricePerUnit:    getCell(sheet, rowIdx, thirdColumnIndexStart),
+			Market:          getCell(sheet, rowIndex, firstColumnIndexStart),
+			ServiceProvided: getCell(sheet, rowIndex, secondColumnIndexStart),
+			PricePerUnit:    getCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -95,13 +93,12 @@ var parseDomesticInternationalAdditionalPrices processXlsxSheet = func(params Pa
 
 	logger.Info("Parsing domestic/international additional prices")
 	var prices []models.StageDomesticInternationalAdditionalPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := additionalPricesRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := additionalPricesRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		price := models.StageDomesticInternationalAdditionalPrice{
-			Market:       getCell(sheet, rowIdx, firstColumnIndexStart),
-			ShipmentType: getCell(sheet, rowIdx, secondColumnIndexStart),
-			Factor:       getCell(sheet, rowIdx, thirdColumnIndexStart),
+			Market:       getCell(sheet, rowIndex, firstColumnIndexStart),
+			ShipmentType: getCell(sheet, rowIndex, secondColumnIndexStart),
+			Factor:       getCell(sheet, rowIndex, thirdColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -158,19 +155,19 @@ var verifyAccessAndAddPrices verifyXlsxSheet = func(params ParamConfig, sheetInd
 	return helperCheckHeadersFor5a("CONUS / OCONUS", "EXAMPLE", "X.XX", sheet, additionalPricesRowIndexStart-1, additionalPricesRowIndexStart)
 }
 
-func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeader string, sheet *xlsx.Sheet, dataRowsIdxBegin, dataRowsIdxEnd int) error {
+func helperCheckHeadersFor5a(firstHeader string, secondHeader string, thirdHeader string, sheet *xlsx.Sheet, dataRowsIndexBegin, dataRowsIndexEnd int) error {
 	const firstColumnIndexStart = 2
 	const secondColumnIndexStart = 3
 	const thirdColumnIndexStart = 4
 
-	for rowIdx := dataRowsIdxBegin; rowIdx < dataRowsIdxEnd; rowIdx++ {
-		if header := getCell(sheet, rowIdx, firstColumnIndexStart); header != firstHeader {
+	for rowIndex := dataRowsIndexBegin; rowIndex < dataRowsIndexEnd; rowIndex++ {
+		if header := getCell(sheet, rowIndex, firstColumnIndexStart); header != firstHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", firstHeader, header)
 		}
-		if header := getCell(sheet, rowIdx, secondColumnIndexStart); header != secondHeader {
+		if header := getCell(sheet, rowIndex, secondColumnIndexStart); header != secondHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", secondHeader, header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, thirdColumnIndexStart)); header != thirdHeader {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, thirdColumnIndexStart)); header != thirdHeader {
 			return fmt.Errorf("verifyAccessAndAddPrices expected to find header '%s', but received header '%s'", thirdHeader, header)
 		}
 	}

--- a/pkg/parser/pricing/parse_domestic_linehaul_prices.go
+++ b/pkg/parser/pricing/parse_domestic_linehaul_prices.go
@@ -1,154 +1,155 @@
 package pricing
 
+import (
+	"fmt"
+	"strconv"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 // parseDomesticLinehaulPrices: parser for 2a) Domestic Linehaul Prices
 var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
-		const feeColIndexStart int = 6  // start at column 6 to get the rates
-		const feeRowIndexStart int = 14 // start at row 14 to get the rates
-		const serviceAreaNumberColumn int = 2
-		const originServiceAreaColumn int = 3
-		const serviceScheduleColumn int = 4
-		const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 14 // start at row 14 to get the rates
+	const serviceAreaNumberColumn int = 2
+	const originServiceAreaColumn int = 3
+	const serviceScheduleColumn int = 4
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		logger.Info("Parsing domestic linehaul prices")
+	logger.Info("Parsing domestic linehaul prices")
 
-		var domPrices []models.StageDomesticLinehaulPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For number of baseline + Escalation years
-			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-				// For each Rate Season
-				for _, r := range rateSeasons {
-					// For each weight band
-					for _, w := range dlhWeightBands {
-						// For each mileage range
-						for _, m := range dlhMilesRanges {
-							domPrice := models.StageDomesticLinehaulPrice{
-								ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
-								OriginServiceArea: getCell(row.Cells, originServiceAreaColumn),
-								ServicesSchedule:  getCell(row.Cells, serviceScheduleColumn),
-								Season:            r,
-								WeightLower:       strconv.Itoa(w.lowerLbs),
-								WeightUpper:       strconv.Itoa(w.upperLbs),
-								MilesLower:        strconv.Itoa(m.lower),
-								MilesUpper:        strconv.Itoa(m.upper),
-								EscalationNumber:  strconv.Itoa(escalation),
-								Rate:              getCell(row.Cells, colIndex),
-							}
-							colIndex++
-							if params.ShowOutput {
-								logger.Info("", zap.Any("StageDomesticLinehaulPrice", domPrice))
-							}
-							domPrices = append(domPrices, domPrice)
+	var domPrices []models.StageDomesticLinehaulPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				// For each weight band
+				for _, w := range dlhWeightBands {
+					// For each mileage range
+					for _, m := range dlhMilesRanges {
+						domPrice := models.StageDomesticLinehaulPrice{
+							ServiceAreaNumber: getCell(sheet, rowIdx, serviceAreaNumberColumn),
+							OriginServiceArea: getCell(sheet, rowIdx, originServiceAreaColumn),
+							ServicesSchedule:  getCell(sheet, rowIdx, serviceScheduleColumn),
+							Season:            r,
+							WeightLower:       strconv.Itoa(w.lowerLbs),
+							WeightUpper:       strconv.Itoa(w.upperLbs),
+							MilesLower:        strconv.Itoa(m.lower),
+							MilesUpper:        strconv.Itoa(m.upper),
+							EscalationNumber:  strconv.Itoa(escalation),
+							Rate:              getCell(sheet, rowIdx, colIndex),
 						}
+						colIndex++
+						if params.ShowOutput {
+							logger.Info("", zap.Any("StageDomesticLinehaulPrice", domPrice))
+						}
+						domPrices = append(domPrices, domPrice)
 					}
-					colIndex++ // skip 1 column (empty column) before starting next Rate type
 				}
+				colIndex++ // skip 1 column (empty column) before starting next Rate type
 			}
 		}
+	}
 
-		return domPrices, nil
-	*/
+	return domPrices, nil
 }
 
 // verifyDomesticLinehaulPrices: verification for 2a) Domestic Linehaul Prices
 var verifyDomesticLinehaulPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
+	if dlhWeightBandNumCells != dlhWeightBandNumCellsExpected {
+		return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d columns per weight band, found %d defined in golang parser", dlhWeightBandNumCellsExpected, dlhWeightBandNumCells)
+	}
 
-		if dlhWeightBandNumCells != dlhWeightBandNumCellsExpected {
-			return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d columns per weight band, found %d defined in golang parser", dlhWeightBandNumCellsExpected, dlhWeightBandNumCells)
-		}
+	if len(dlhWeightBands) != dlhWeightBandCountExpected {
+		return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d weight bands, found %d defined in golang parser", dlhWeightBandCountExpected, len(dlhWeightBands))
+	}
 
-		if len(dlhWeightBands) != dlhWeightBandCountExpected {
-			return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d weight bands, found %d defined in golang parser", dlhWeightBandCountExpected, len(dlhWeightBands))
-		}
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 14 // start at row 14 to get the rates
+	const serviceAreaNumberColumn int = 2
+	const originServiceAreaColumn int = 3
+	const serviceScheduleColumn int = 4
+	const numEscalationYearsToProcess int = 2
 
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
-		const feeColIndexStart int = 6  // start at column 6 to get the rates
-		const feeRowIndexStart int = 14 // start at row 14 to get the rates
-		const serviceAreaNumberColumn int = 2
-		const originServiceAreaColumn int = 3
-		const serviceScheduleColumn int = 4
-		const numEscalationYearsToProcess int = 2
+	// Check headers
+	const feeRowMilageHeaderIndexStart = feeRowIndexStart - 3
+	const verifyHeaderIndexEnd = feeRowMilageHeaderIndexStart + 2
 
-		// Check headers
-		const feeRowMilageHeaderIndexStart = feeRowIndexStart - 3
-		const verifyHeaderIndexEnd = feeRowMilageHeaderIndexStart + 2
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
-
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMilageHeaderIndexStart:verifyHeaderIndexEnd]
-		for dataRowsIndex, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For number of baseline + Escalation years
-			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-				// For each Rate Season
-				for _, r := range rateSeasons {
-					// For each weight band
-					for _, w := range dlhWeightBands {
-						// For each milage range
-						for dlhMilesRangesIndex, m := range dlhMilesRanges {
-							// skip the last index because the text is not easily checked
-							if dlhMilesRangesIndex == len(dlhMilesRanges)-1 {
-								colIndex++
-								continue
-							}
-							verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
-								dataRowsIndex, colIndex, escalation, r, w)
-							if dataRowsIndex == 0 {
-								fromMilesCell := getCell(row.Cells, colIndex)
-								fromMiles, err := getInt(fromMilesCell)
-								if err != nil {
-									return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
-								}
-								if m.lower != fromMiles {
-									return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(row.Cells, colIndex), verificationLog)
-								}
-								if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
-									return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
-								}
-								if "OriginServiceArea" != removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)) {
-									return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)), verificationLog)
-								}
-								if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
-									return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
-								}
-							} else if dataRowsIndex == 1 {
-								toMilesCell := getCell(row.Cells, colIndex)
-								toMiles, err := getInt(toMilesCell)
-								if err != nil {
-									return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
-								}
-								if m.upper != toMiles {
-									return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(row.Cells, colIndex), verificationLog)
-								}
-							} else if dataRowsIndex == 2 {
-								if "EXAMPLE" != getCell(row.Cells, originServiceAreaColumn) {
-									return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(row.Cells, originServiceAreaColumn), verificationLog)
-								}
-							}
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx, dataRowsIndex := feeRowMilageHeaderIndexStart, 0; rowIdx < verifyHeaderIndexEnd && rowIdx < sheet.MaxRow; rowIdx, dataRowsIndex = rowIdx+1, dataRowsIndex+1 {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				// For each weight band
+				for _, w := range dlhWeightBands {
+					// For each milage range
+					for dlhMilesRangesIndex, m := range dlhMilesRanges {
+						// skip the last index because the text is not easily checked
+						if dlhMilesRangesIndex == len(dlhMilesRanges)-1 {
 							colIndex++
+							continue
 						}
+						verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
+							dataRowsIndex, colIndex, escalation, r, w)
+						if dataRowsIndex == 0 {
+							fromMilesCell := getCell(sheet, rowIdx, colIndex)
+							fromMiles, err := getInt(fromMilesCell)
+							if err != nil {
+								return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
+							}
+							if m.lower != fromMiles {
+								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(sheet, rowIdx, colIndex), verificationLog)
+							}
+							if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)) {
+								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)), verificationLog)
+							}
+							if "OriginServiceArea" != removeWhiteSpace(getCell(sheet, rowIdx, originServiceAreaColumn)) {
+								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, originServiceAreaColumn)), verificationLog)
+							}
+							if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)) {
+								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)), verificationLog)
+							}
+						} else if dataRowsIndex == 1 {
+							toMilesCell := getCell(sheet, rowIdx, colIndex)
+							toMiles, err := getInt(toMilesCell)
+							if err != nil {
+								return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
+							}
+							if m.upper != toMiles {
+								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(sheet, rowIdx, colIndex), verificationLog)
+							}
+						} else if dataRowsIndex == 2 {
+							if "EXAMPLE" != getCell(sheet, rowIdx, originServiceAreaColumn) {
+								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(sheet, rowIdx, originServiceAreaColumn), verificationLog)
+							}
+						}
+						colIndex++
 					}
-					colIndex++ // skip 1 column (empty column) before starting next Rate type
 				}
+				colIndex++ // skip 1 column (empty column) before starting next Rate type
 			}
 		}
+	}
 
-		return nil
-	*/
+	return nil
 }

--- a/pkg/parser/pricing/parse_domestic_linehaul_prices.go
+++ b/pkg/parser/pricing/parse_domestic_linehaul_prices.go
@@ -27,9 +27,8 @@ var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, shee
 	logger.Info("Parsing domestic linehaul prices")
 
 	var domPrices []models.StageDomesticLinehaulPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For number of baseline + Escalation years
 		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
@@ -40,16 +39,16 @@ var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, shee
 					// For each mileage range
 					for _, m := range dlhMilesRanges {
 						domPrice := models.StageDomesticLinehaulPrice{
-							ServiceAreaNumber: getCell(sheet, rowIdx, serviceAreaNumberColumn),
-							OriginServiceArea: getCell(sheet, rowIdx, originServiceAreaColumn),
-							ServicesSchedule:  getCell(sheet, rowIdx, serviceScheduleColumn),
+							ServiceAreaNumber: getCell(sheet, rowIndex, serviceAreaNumberColumn),
+							OriginServiceArea: getCell(sheet, rowIndex, originServiceAreaColumn),
+							ServicesSchedule:  getCell(sheet, rowIndex, serviceScheduleColumn),
 							Season:            r,
 							WeightLower:       strconv.Itoa(w.lowerLbs),
 							WeightUpper:       strconv.Itoa(w.upperLbs),
 							MilesLower:        strconv.Itoa(m.lower),
 							MilesUpper:        strconv.Itoa(m.upper),
 							EscalationNumber:  strconv.Itoa(escalation),
-							Rate:              getCell(sheet, rowIdx, colIndex),
+							Rate:              getCell(sheet, rowIndex, colIndex),
 						}
 						colIndex++
 						if params.ShowOutput {
@@ -94,7 +93,7 @@ var verifyDomesticLinehaulPrices verifyXlsxSheet = func(params ParamConfig, shee
 	}
 
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx, dataRowsIndex := feeRowMilageHeaderIndexStart, 0; rowIdx < verifyHeaderIndexEnd && rowIdx < sheet.MaxRow; rowIdx, dataRowsIndex = rowIdx+1, dataRowsIndex+1 {
+	for rowIndex, dataRowsIndex := feeRowMilageHeaderIndexStart, 0; rowIndex < verifyHeaderIndexEnd && rowIndex < sheet.MaxRow; rowIndex, dataRowsIndex = rowIndex+1, dataRowsIndex+1 {
 		colIndex := feeColIndexStart
 		// For number of baseline + Escalation years
 		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
@@ -112,35 +111,35 @@ var verifyDomesticLinehaulPrices verifyXlsxSheet = func(params ParamConfig, shee
 						verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
 							dataRowsIndex, colIndex, escalation, r, w)
 						if dataRowsIndex == 0 {
-							fromMilesCell := getCell(sheet, rowIdx, colIndex)
+							fromMilesCell := getCell(sheet, rowIndex, colIndex)
 							fromMiles, err := getInt(fromMilesCell)
 							if err != nil {
 								return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
 							}
 							if m.lower != fromMiles {
-								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(sheet, rowIdx, colIndex), verificationLog)
+								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(sheet, rowIndex, colIndex), verificationLog)
 							}
-							if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)) {
-								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)), verificationLog)
+							if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)) {
+								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
 							}
-							if "OriginServiceArea" != removeWhiteSpace(getCell(sheet, rowIdx, originServiceAreaColumn)) {
-								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, originServiceAreaColumn)), verificationLog)
+							if "OriginServiceArea" != removeWhiteSpace(getCell(sheet, rowIndex, originServiceAreaColumn)) {
+								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, originServiceAreaColumn)), verificationLog)
 							}
-							if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)) {
-								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)), verificationLog)
+							if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)) {
+								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
 							}
 						} else if dataRowsIndex == 1 {
-							toMilesCell := getCell(sheet, rowIdx, colIndex)
+							toMilesCell := getCell(sheet, rowIndex, colIndex)
 							toMiles, err := getInt(toMilesCell)
 							if err != nil {
 								return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
 							}
 							if m.upper != toMiles {
-								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(sheet, rowIdx, colIndex), verificationLog)
+								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(sheet, rowIndex, colIndex), verificationLog)
 							}
 						} else if dataRowsIndex == 2 {
-							if "EXAMPLE" != getCell(sheet, rowIdx, originServiceAreaColumn) {
-								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(sheet, rowIdx, originServiceAreaColumn), verificationLog)
+							if "EXAMPLE" != getCell(sheet, rowIndex, originServiceAreaColumn) {
+								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(sheet, rowIndex, originServiceAreaColumn), verificationLog)
 							}
 						}
 						colIndex++

--- a/pkg/parser/pricing/parse_domestic_linehaul_prices.go
+++ b/pkg/parser/pricing/parse_domestic_linehaul_prices.go
@@ -1,155 +1,154 @@
 package pricing
 
-import (
-	"fmt"
-	"strconv"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 // parseDomesticLinehaulPrices: parser for 2a) Domestic Linehaul Prices
 var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 14 // start at row 14 to get the rates
-	const serviceAreaNumberColumn int = 2
-	const originServiceAreaColumn int = 3
-	const serviceScheduleColumn int = 4
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
+		const feeColIndexStart int = 6  // start at column 6 to get the rates
+		const feeRowIndexStart int = 14 // start at row 14 to get the rates
+		const serviceAreaNumberColumn int = 2
+		const originServiceAreaColumn int = 3
+		const serviceScheduleColumn int = 4
+		const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	logger.Info("Parsing domestic linehaul prices")
+		logger.Info("Parsing domestic linehaul prices")
 
-	var domPrices []models.StageDomesticLinehaulPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				// For each weight band
-				for _, w := range dlhWeightBands {
-					// For each mileage range
-					for _, m := range dlhMilesRanges {
-						domPrice := models.StageDomesticLinehaulPrice{
-							ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
-							OriginServiceArea: getCell(row.Cells, originServiceAreaColumn),
-							ServicesSchedule:  getCell(row.Cells, serviceScheduleColumn),
-							Season:            r,
-							WeightLower:       strconv.Itoa(w.lowerLbs),
-							WeightUpper:       strconv.Itoa(w.upperLbs),
-							MilesLower:        strconv.Itoa(m.lower),
-							MilesUpper:        strconv.Itoa(m.upper),
-							EscalationNumber:  strconv.Itoa(escalation),
-							Rate:              getCell(row.Cells, colIndex),
+		var domPrices []models.StageDomesticLinehaulPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For number of baseline + Escalation years
+			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+				// For each Rate Season
+				for _, r := range rateSeasons {
+					// For each weight band
+					for _, w := range dlhWeightBands {
+						// For each mileage range
+						for _, m := range dlhMilesRanges {
+							domPrice := models.StageDomesticLinehaulPrice{
+								ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
+								OriginServiceArea: getCell(row.Cells, originServiceAreaColumn),
+								ServicesSchedule:  getCell(row.Cells, serviceScheduleColumn),
+								Season:            r,
+								WeightLower:       strconv.Itoa(w.lowerLbs),
+								WeightUpper:       strconv.Itoa(w.upperLbs),
+								MilesLower:        strconv.Itoa(m.lower),
+								MilesUpper:        strconv.Itoa(m.upper),
+								EscalationNumber:  strconv.Itoa(escalation),
+								Rate:              getCell(row.Cells, colIndex),
+							}
+							colIndex++
+							if params.ShowOutput {
+								logger.Info("", zap.Any("StageDomesticLinehaulPrice", domPrice))
+							}
+							domPrices = append(domPrices, domPrice)
 						}
-						colIndex++
-						if params.ShowOutput {
-							logger.Info("", zap.Any("StageDomesticLinehaulPrice", domPrice))
-						}
-						domPrices = append(domPrices, domPrice)
 					}
+					colIndex++ // skip 1 column (empty column) before starting next Rate type
 				}
-				colIndex++ // skip 1 column (empty column) before starting next Rate type
 			}
 		}
-	}
 
-	return domPrices, nil
+		return domPrices, nil
+	*/
 }
 
 // verifyDomesticLinehaulPrices: verification for 2a) Domestic Linehaul Prices
 var verifyDomesticLinehaulPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
 
-	if dlhWeightBandNumCells != dlhWeightBandNumCellsExpected {
-		return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d columns per weight band, found %d defined in golang parser", dlhWeightBandNumCellsExpected, dlhWeightBandNumCells)
-	}
+		if dlhWeightBandNumCells != dlhWeightBandNumCellsExpected {
+			return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d columns per weight band, found %d defined in golang parser", dlhWeightBandNumCellsExpected, dlhWeightBandNumCells)
+		}
 
-	if len(dlhWeightBands) != dlhWeightBandCountExpected {
-		return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d weight bands, found %d defined in golang parser", dlhWeightBandCountExpected, len(dlhWeightBands))
-	}
+		if len(dlhWeightBands) != dlhWeightBandCountExpected {
+			return fmt.Errorf("parseDomesticLinehaulPrices(): Exepected %d weight bands, found %d defined in golang parser", dlhWeightBandCountExpected, len(dlhWeightBands))
+		}
 
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 14 // start at row 14 to get the rates
-	const serviceAreaNumberColumn int = 2
-	const originServiceAreaColumn int = 3
-	const serviceScheduleColumn int = 4
-	const numEscalationYearsToProcess int = 2
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 6  // 2a) Domestic Linehaul Prices
+		const feeColIndexStart int = 6  // start at column 6 to get the rates
+		const feeRowIndexStart int = 14 // start at row 14 to get the rates
+		const serviceAreaNumberColumn int = 2
+		const originServiceAreaColumn int = 3
+		const serviceScheduleColumn int = 4
+		const numEscalationYearsToProcess int = 2
 
-	// Check headers
-	const feeRowMilageHeaderIndexStart = feeRowIndexStart - 3
-	const verifyHeaderIndexEnd = feeRowMilageHeaderIndexStart + 2
+		// Check headers
+		const feeRowMilageHeaderIndexStart = feeRowIndexStart - 3
+		const verifyHeaderIndexEnd = feeRowMilageHeaderIndexStart + 2
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMilageHeaderIndexStart:verifyHeaderIndexEnd]
-	for dataRowsIndex, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				// For each weight band
-				for _, w := range dlhWeightBands {
-					// For each milage range
-					for dlhMilesRangesIndex, m := range dlhMilesRanges {
-						// skip the last index because the text is not easily checked
-						if dlhMilesRangesIndex == len(dlhMilesRanges)-1 {
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMilageHeaderIndexStart:verifyHeaderIndexEnd]
+		for dataRowsIndex, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For number of baseline + Escalation years
+			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+				// For each Rate Season
+				for _, r := range rateSeasons {
+					// For each weight band
+					for _, w := range dlhWeightBands {
+						// For each milage range
+						for dlhMilesRangesIndex, m := range dlhMilesRanges {
+							// skip the last index because the text is not easily checked
+							if dlhMilesRangesIndex == len(dlhMilesRanges)-1 {
+								colIndex++
+								continue
+							}
+							verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
+								dataRowsIndex, colIndex, escalation, r, w)
+							if dataRowsIndex == 0 {
+								fromMilesCell := getCell(row.Cells, colIndex)
+								fromMiles, err := getInt(fromMilesCell)
+								if err != nil {
+									return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
+								}
+								if m.lower != fromMiles {
+									return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(row.Cells, colIndex), verificationLog)
+								}
+								if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
+									return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
+								}
+								if "OriginServiceArea" != removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)) {
+									return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)), verificationLog)
+								}
+								if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
+									return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
+								}
+							} else if dataRowsIndex == 1 {
+								toMilesCell := getCell(row.Cells, colIndex)
+								toMiles, err := getInt(toMilesCell)
+								if err != nil {
+									return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
+								}
+								if m.upper != toMiles {
+									return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(row.Cells, colIndex), verificationLog)
+								}
+							} else if dataRowsIndex == 2 {
+								if "EXAMPLE" != getCell(row.Cells, originServiceAreaColumn) {
+									return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(row.Cells, originServiceAreaColumn), verificationLog)
+								}
+							}
 							colIndex++
-							continue
 						}
-						verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
-							dataRowsIndex, colIndex, escalation, r, w)
-						if dataRowsIndex == 0 {
-							fromMilesCell := getCell(row.Cells, colIndex)
-							fromMiles, err := getInt(fromMilesCell)
-							if err != nil {
-								return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
-							}
-							if m.lower != fromMiles {
-								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(row.Cells, colIndex), verificationLog)
-							}
-							if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
-								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
-							}
-							if "OriginServiceArea" != removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)) {
-								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originServiceAreaColumn)), verificationLog)
-							}
-							if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
-								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
-							}
-						} else if dataRowsIndex == 1 {
-							toMilesCell := getCell(row.Cells, colIndex)
-							toMiles, err := getInt(toMilesCell)
-							if err != nil {
-								return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
-							}
-							if m.upper != toMiles {
-								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(row.Cells, colIndex), verificationLog)
-							}
-						} else if dataRowsIndex == 2 {
-							if "EXAMPLE" != getCell(row.Cells, originServiceAreaColumn) {
-								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(row.Cells, originServiceAreaColumn), verificationLog)
-							}
-						}
-						colIndex++
 					}
+					colIndex++ // skip 1 column (empty column) before starting next Rate type
 				}
-				colIndex++ // skip 1 column (empty column) before starting next Rate type
 			}
 		}
-	}
 
-	return nil
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_domestic_linehaul_prices.go
+++ b/pkg/parser/pricing/parse_domestic_linehaul_prices.go
@@ -39,16 +39,16 @@ var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, shee
 					// For each mileage range
 					for _, m := range dlhMilesRanges {
 						domPrice := models.StageDomesticLinehaulPrice{
-							ServiceAreaNumber: getCell(sheet, rowIndex, serviceAreaNumberColumn),
-							OriginServiceArea: getCell(sheet, rowIndex, originServiceAreaColumn),
-							ServicesSchedule:  getCell(sheet, rowIndex, serviceScheduleColumn),
+							ServiceAreaNumber: mustGetCell(sheet, rowIndex, serviceAreaNumberColumn),
+							OriginServiceArea: mustGetCell(sheet, rowIndex, originServiceAreaColumn),
+							ServicesSchedule:  mustGetCell(sheet, rowIndex, serviceScheduleColumn),
 							Season:            r,
 							WeightLower:       strconv.Itoa(w.lowerLbs),
 							WeightUpper:       strconv.Itoa(w.upperLbs),
 							MilesLower:        strconv.Itoa(m.lower),
 							MilesUpper:        strconv.Itoa(m.upper),
 							EscalationNumber:  strconv.Itoa(escalation),
-							Rate:              getCell(sheet, rowIndex, colIndex),
+							Rate:              mustGetCell(sheet, rowIndex, colIndex),
 						}
 						colIndex++
 						if params.ShowOutput {
@@ -111,35 +111,35 @@ var verifyDomesticLinehaulPrices verifyXlsxSheet = func(params ParamConfig, shee
 						verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v, dlhWeightBands %v",
 							dataRowsIndex, colIndex, escalation, r, w)
 						if dataRowsIndex == 0 {
-							fromMilesCell := getCell(sheet, rowIndex, colIndex)
+							fromMilesCell := mustGetCell(sheet, rowIndex, colIndex)
 							fromMiles, err := getInt(fromMilesCell)
 							if err != nil {
 								return fmt.Errorf("could not convert %s to int: %w", fromMilesCell, err)
 							}
 							if m.lower != fromMiles {
-								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, getCell(sheet, rowIndex, colIndex), verificationLog)
+								return fmt.Errorf("format error: From Miles --> does not match expected number expected %d got %s\n%s", m.lower, mustGetCell(sheet, rowIndex, colIndex), verificationLog)
 							}
-							if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)) {
-								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
+							if "ServiceAreaNumber" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNumberColumn)) {
+								return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
 							}
-							if "OriginServiceArea" != removeWhiteSpace(getCell(sheet, rowIndex, originServiceAreaColumn)) {
-								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, originServiceAreaColumn)), verificationLog)
+							if "OriginServiceArea" != removeWhiteSpace(mustGetCell(sheet, rowIndex, originServiceAreaColumn)) {
+								return fmt.Errorf("format error: Header <OriginServiceArea> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, originServiceAreaColumn)), verificationLog)
 							}
-							if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)) {
-								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
+							if "ServicesSchedule" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceScheduleColumn)) {
+								return fmt.Errorf("format error: Header <SServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
 							}
 						} else if dataRowsIndex == 1 {
-							toMilesCell := getCell(sheet, rowIndex, colIndex)
+							toMilesCell := mustGetCell(sheet, rowIndex, colIndex)
 							toMiles, err := getInt(toMilesCell)
 							if err != nil {
 								return fmt.Errorf("could not convert %s to int: %w", toMilesCell, err)
 							}
 							if m.upper != toMiles {
-								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, getCell(sheet, rowIndex, colIndex), verificationLog)
+								return fmt.Errorf("format error: To Miles --> does not match expected number expected %d got %s\n%s", m.upper, mustGetCell(sheet, rowIndex, colIndex), verificationLog)
 							}
 						} else if dataRowsIndex == 2 {
-							if "EXAMPLE" != getCell(sheet, rowIndex, originServiceAreaColumn) {
-								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", getCell(sheet, rowIndex, originServiceAreaColumn), verificationLog)
+							if "EXAMPLE" != mustGetCell(sheet, rowIndex, originServiceAreaColumn) {
+								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", mustGetCell(sheet, rowIndex, originServiceAreaColumn), verificationLog)
 							}
 						}
 						colIndex++

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -27,10 +27,10 @@ var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, she
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := rowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		packPrice := models.StageDomesticOtherPackPrice{
-			ServicesSchedule:   getCell(sheet, rowIndex, servicesScheduleColumn),
-			ServiceProvided:    getCell(sheet, rowIndex, serviceProvidedColumn),
-			NonPeakPricePerCwt: getCell(sheet, rowIndex, nonPeakPriceColumn),
-			PeakPricePerCwt:    getCell(sheet, rowIndex, peakPriceColumn),
+			ServicesSchedule:   mustGetCell(sheet, rowIndex, servicesScheduleColumn),
+			ServiceProvided:    mustGetCell(sheet, rowIndex, serviceProvidedColumn),
+			NonPeakPricePerCwt: mustGetCell(sheet, rowIndex, nonPeakPriceColumn),
+			PeakPricePerCwt:    mustGetCell(sheet, rowIndex, peakPriceColumn),
 		}
 
 		if packPrice.ServicesSchedule != "" {
@@ -65,10 +65,10 @@ var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, shee
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := rowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		sitPrice := models.StageDomesticOtherSitPrice{
-			SITPickupDeliverySchedule: getCell(sheet, rowIndex, servicesScheduleColumn),
-			ServiceProvided:           getCell(sheet, rowIndex, serviceProvidedColumn),
-			NonPeakPricePerCwt:        getCell(sheet, rowIndex, nonPeakPriceColumn),
-			PeakPricePerCwt:           getCell(sheet, rowIndex, peakPriceColumn),
+			SITPickupDeliverySchedule: mustGetCell(sheet, rowIndex, servicesScheduleColumn),
+			ServiceProvided:           mustGetCell(sheet, rowIndex, serviceProvidedColumn),
+			NonPeakPricePerCwt:        mustGetCell(sheet, rowIndex, nonPeakPriceColumn),
+			PeakPricePerCwt:           mustGetCell(sheet, rowIndex, peakPriceColumn),
 		}
 
 		if sitPrice.SITPickupDeliverySchedule != "" {
@@ -115,16 +115,16 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 	sheet := params.XlsxFile.Sheets[sheetIndex]
 	for rowIndex := headerIndexStart; rowIndex < headerIndexEnd; rowIndex++ {
 		// for _, row := range dataRows {
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, servicesScheduleColumn)); header != "ServicesSchedule" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, servicesScheduleColumn)); header != "ServicesSchedule" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, serviceProvidedColumn)); header != "ServiceProvided" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceProvidedColumn)); header != "ServiceProvided" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
 		}
 	}
@@ -136,16 +136,16 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 	// Verify example row strings
 	for rowIndex := exampleIndexStart; rowIndex < exampleIndexEnd; rowIndex++ {
 		// for _, row := range exampleRows {
-		if example := getCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
+		if example := mustGetCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+		if example := mustGetCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
+		if example := mustGetCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
+		if example := mustGetCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
 		}
 	}
@@ -171,19 +171,19 @@ func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
 	sheet := params.XlsxFile.Sheets[sheetIndex]
 
 	for rowIndex := sitHeaderIndexStart; rowIndex < sitHeaderIndexEnd; rowIndex++ {
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
 		}
 	}
 
 	for rowIndex := headerIndexStart; rowIndex < headerIndexEnd; rowIndex++ {
-		if header := getCell(sheet, rowIndex, serviceProvidedColumn); header != "Service Provided" {
+		if header := mustGetCell(sheet, rowIndex, serviceProvidedColumn); header != "Service Provided" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
 		}
 	}
@@ -194,16 +194,16 @@ func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
 
 	// Verify example row strings
 	for rowIndex := exampleIndexStart; rowIndex < exampleIndexEnd; rowIndex++ {
-		if example := getCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
+		if example := mustGetCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+		if example := mustGetCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
+		if example := mustGetCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
+		if example := mustGetCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
 		}
 	}

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -24,14 +24,13 @@ var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, she
 	}
 
 	var packUnpackPrices []models.StageDomesticOtherPackPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := rowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := rowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		packPrice := models.StageDomesticOtherPackPrice{
-			ServicesSchedule:   getCell(sheet, rowIdx, servicesScheduleColumn),
-			ServiceProvided:    getCell(sheet, rowIdx, serviceProvidedColumn),
-			NonPeakPricePerCwt: getCell(sheet, rowIdx, nonPeakPriceColumn),
-			PeakPricePerCwt:    getCell(sheet, rowIdx, peakPriceColumn),
+			ServicesSchedule:   getCell(sheet, rowIndex, servicesScheduleColumn),
+			ServiceProvided:    getCell(sheet, rowIndex, serviceProvidedColumn),
+			NonPeakPricePerCwt: getCell(sheet, rowIndex, nonPeakPriceColumn),
+			PeakPricePerCwt:    getCell(sheet, rowIndex, peakPriceColumn),
 		}
 
 		if packPrice.ServicesSchedule != "" {
@@ -63,14 +62,13 @@ var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, shee
 	}
 
 	var sitPrices []models.StageDomesticOtherSitPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := rowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := rowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		sitPrice := models.StageDomesticOtherSitPrice{
-			SITPickupDeliverySchedule: getCell(sheet, rowIdx, servicesScheduleColumn),
-			ServiceProvided:           getCell(sheet, rowIdx, serviceProvidedColumn),
-			NonPeakPricePerCwt:        getCell(sheet, rowIdx, nonPeakPriceColumn),
-			PeakPricePerCwt:           getCell(sheet, rowIdx, peakPriceColumn),
+			SITPickupDeliverySchedule: getCell(sheet, rowIndex, servicesScheduleColumn),
+			ServiceProvided:           getCell(sheet, rowIndex, serviceProvidedColumn),
+			NonPeakPricePerCwt:        getCell(sheet, rowIndex, nonPeakPriceColumn),
+			PeakPricePerCwt:           getCell(sheet, rowIndex, peakPriceColumn),
 		}
 
 		if sitPrice.SITPickupDeliverySchedule != "" {
@@ -115,18 +113,18 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 
 	// Verify header strings
 	sheet := params.XlsxFile.Sheets[sheetIndex]
-	for rowIdx := headerIndexStart; rowIdx < headerIndexEnd; rowIdx++ {
+	for rowIndex := headerIndexStart; rowIndex < headerIndexEnd; rowIndex++ {
 		// for _, row := range dataRows {
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, servicesScheduleColumn)); header != "ServicesSchedule" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, servicesScheduleColumn)); header != "ServicesSchedule" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, serviceProvidedColumn)); header != "ServiceProvided" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, serviceProvidedColumn)); header != "ServiceProvided" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, peakPriceColumn)); header != "Peak(percwt)" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
 		}
 	}
@@ -136,18 +134,18 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 	const exampleIndexEnd = exampleIndexStart + 1
 
 	// Verify example row strings
-	for rowIdx := exampleIndexStart; rowIdx < exampleIndexEnd; rowIdx++ {
+	for rowIndex := exampleIndexStart; rowIndex < exampleIndexEnd; rowIndex++ {
 		// for _, row := range exampleRows {
-		if example := getCell(sheet, rowIdx, servicesScheduleColumn); example != "X" {
+		if example := getCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+		if example := getCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, nonPeakPriceColumn); example != "$X.XX" {
+		if example := getCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, peakPriceColumn); example != "$X.XX" {
+		if example := getCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
 		}
 	}
@@ -171,20 +169,21 @@ func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
 
 	// Verify header strings
 	sheet := params.XlsxFile.Sheets[sheetIndex]
-	for rowIdx := sitHeaderIndexStart; rowIdx < sitHeaderIndexEnd; rowIdx++ {
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
+
+	for rowIndex := sitHeaderIndexStart; rowIndex < sitHeaderIndexEnd; rowIndex++ {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
 		}
 	}
 
-	for rowIdx := headerIndexStart; rowIdx < headerIndexEnd; rowIdx++ {
-		if header := getCell(sheet, rowIdx, serviceProvidedColumn); header != "Service Provided" {
+	for rowIndex := headerIndexStart; rowIndex < headerIndexEnd; rowIndex++ {
+		if header := getCell(sheet, rowIndex, serviceProvidedColumn); header != "Service Provided" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, peakPriceColumn)); header != "Peak(percwt)" {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, peakPriceColumn)); header != "Peak(percwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
 		}
 	}
@@ -194,17 +193,17 @@ func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
 	const exampleIndexEnd = exampleIndexStart + 1
 
 	// Verify example row strings
-	for rowIdx := exampleIndexStart; rowIdx < exampleIndexEnd; rowIdx++ {
-		if example := getCell(sheet, rowIdx, servicesScheduleColumn); example != "X" {
+	for rowIndex := exampleIndexStart; rowIndex < exampleIndexEnd; rowIndex++ {
+		if example := getCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+		if example := getCell(sheet, rowIndex, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, nonPeakPriceColumn); example != "$X.XX" {
+		if example := getCell(sheet, rowIndex, nonPeakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
 		}
-		if example := getCell(sheet, rowIdx, peakPriceColumn); example != "$X.XX" {
+		if example := getCell(sheet, rowIndex, peakPriceColumn); example != "$X.XX" {
 			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
 		}
 	}

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -1,212 +1,224 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-	const rowIndexStart int = 12
-	const servicesScheduleColumn int = 2
-	const serviceProvidedColumn int = 3
-	const nonPeakPriceColumn int = 4
-	const peakPriceColumn int = 5
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+		const rowIndexStart int = 12
+		const servicesScheduleColumn int = 2
+		const serviceProvidedColumn int = 3
+		const nonPeakPriceColumn int = 4
+		const peakPriceColumn int = 5
 
-	logger.Info("Parsing domestic other (pack/unpack) prices")
+		logger.Info("Parsing domestic other (pack/unpack) prices")
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	var packUnpackPrices []models.StageDomesticOtherPackPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
-	for _, row := range dataRows {
-		packPrice := models.StageDomesticOtherPackPrice{
-			ServicesSchedule:   getCell(row.Cells, servicesScheduleColumn),
-			ServiceProvided:    getCell(row.Cells, serviceProvidedColumn),
-			NonPeakPricePerCwt: getCell(row.Cells, nonPeakPriceColumn),
-			PeakPricePerCwt:    getCell(row.Cells, peakPriceColumn),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		if packPrice.ServicesSchedule != "" {
-			packUnpackPrices = append(packUnpackPrices, packPrice)
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageDomesticOtherPackPrice", packPrice))
+		var packUnpackPrices []models.StageDomesticOtherPackPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
+		for _, row := range dataRows {
+			packPrice := models.StageDomesticOtherPackPrice{
+				ServicesSchedule:   getCell(row.Cells, servicesScheduleColumn),
+				ServiceProvided:    getCell(row.Cells, serviceProvidedColumn),
+				NonPeakPricePerCwt: getCell(row.Cells, nonPeakPriceColumn),
+				PeakPricePerCwt:    getCell(row.Cells, peakPriceColumn),
 			}
-		} else {
-			break
-		}
-	}
 
-	return packUnpackPrices, nil
+			if packPrice.ServicesSchedule != "" {
+				packUnpackPrices = append(packUnpackPrices, packPrice)
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageDomesticOtherPackPrice", packPrice))
+				}
+			} else {
+				break
+			}
+		}
+
+		return packUnpackPrices, nil
+	*/
 }
 
 var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-	const rowIndexStart int = 24
-	const servicesScheduleColumn int = 2
-	const serviceProvidedColumn int = 3
-	const nonPeakPriceColumn int = 4
-	const peakPriceColumn int = 5
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+		const rowIndexStart int = 24
+		const servicesScheduleColumn int = 2
+		const serviceProvidedColumn int = 3
+		const nonPeakPriceColumn int = 4
+		const peakPriceColumn int = 5
 
-	logger.Info("Parsing domestic other (SIT pickup/delivery) prices")
+		logger.Info("Parsing domestic other (SIT pickup/delivery) prices")
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	var sitPrices []models.StageDomesticOtherSitPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
-	for _, row := range dataRows {
-		sitPrice := models.StageDomesticOtherSitPrice{
-			SITPickupDeliverySchedule: getCell(row.Cells, servicesScheduleColumn),
-			ServiceProvided:           getCell(row.Cells, serviceProvidedColumn),
-			NonPeakPricePerCwt:        getCell(row.Cells, nonPeakPriceColumn),
-			PeakPricePerCwt:           getCell(row.Cells, peakPriceColumn),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		if sitPrice.SITPickupDeliverySchedule != "" {
-			sitPrices = append(sitPrices, sitPrice)
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageDomesticOtherSitPrice", sitPrice))
+		var sitPrices []models.StageDomesticOtherSitPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
+		for _, row := range dataRows {
+			sitPrice := models.StageDomesticOtherSitPrice{
+				SITPickupDeliverySchedule: getCell(row.Cells, servicesScheduleColumn),
+				ServiceProvided:           getCell(row.Cells, serviceProvidedColumn),
+				NonPeakPricePerCwt:        getCell(row.Cells, nonPeakPriceColumn),
+				PeakPricePerCwt:           getCell(row.Cells, peakPriceColumn),
 			}
-		} else {
-			break
-		}
-	}
 
-	return sitPrices, nil
+			if sitPrice.SITPickupDeliverySchedule != "" {
+				sitPrices = append(sitPrices, sitPrice)
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageDomesticOtherSitPrice", sitPrice))
+				}
+			} else {
+				break
+			}
+		}
+
+		return sitPrices, nil
+	*/
 }
 
 // verifyDomesticOtherPrices: verification 2c) Dom. Other Prices
 var verifyDomesticOtherPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-	if err := verifyPackUnpackPrices(params, sheetIndex); err != nil {
-		return err
-	}
-	if err := verifySITPickupPrices(params, sheetIndex); err != nil {
-		return err
-	}
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
+		if err := verifyPackUnpackPrices(params, sheetIndex); err != nil {
+			return err
+		}
+		if err := verifySITPickupPrices(params, sheetIndex); err != nil {
+			return err
+		}
+		return nil
+	*/
 }
 
 func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const rowIndexStart int = 12
-	const servicesScheduleColumn int = 2
-	const serviceProvidedColumn int = 3
-	const nonPeakPriceColumn int = 4
-	const peakPriceColumn int = 5
-
-	// Check headers
-	const headerIndexStart = rowIndexStart - 2
-	const headerIndexEnd = headerIndexStart + 1
-
-	// Verify header strings
-	dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
-	for _, row := range dataRows {
-		if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "ServicesSchedule" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(row.Cells, serviceProvidedColumn)); header != "ServiceProvided" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
-		}
-	}
-
-	// Check example row
-	const exampleIndexStart = headerIndexStart + 1
-	const exampleIndexEnd = exampleIndexStart + 1
-
-	// Verify example row strings
-	exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
-	for _, row := range exampleRows {
-		if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
-			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
-		}
-	}
-
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		// XLSX Sheet consts
+		const rowIndexStart int = 12
+		const servicesScheduleColumn int = 2
+		const serviceProvidedColumn int = 3
+		const nonPeakPriceColumn int = 4
+		const peakPriceColumn int = 5
+
+		// Check headers
+		const headerIndexStart = rowIndexStart - 2
+		const headerIndexEnd = headerIndexStart + 1
+
+		// Verify header strings
+		dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
+		for _, row := range dataRows {
+			if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "ServicesSchedule" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(row.Cells, serviceProvidedColumn)); header != "ServiceProvided" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
+			}
+		}
+
+		// Check example row
+		const exampleIndexStart = headerIndexStart + 1
+		const exampleIndexEnd = exampleIndexStart + 1
+
+		// Verify example row strings
+		exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
+		for _, row := range exampleRows {
+			if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
+				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+			}
+		}
+
+		return nil
+	*/
 }
 
 func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const rowIndexStart int = 24
-	const servicesScheduleColumn int = 2
-	const serviceProvidedColumn int = 3
-	const nonPeakPriceColumn int = 4
-	const peakPriceColumn int = 5
-
-	// Check headers
-	const headerIndexStart = rowIndexStart - 2
-	const headerIndexEnd = headerIndexStart + 1
-	const sitHeaderIndexStart = headerIndexStart - 1
-	const sitHeaderIndexEnd = headerIndexStart
-
-	// Verify header strings
-	firstHeaderRows := params.XlsxFile.Sheets[sheetIndex].Rows[sitHeaderIndexStart:sitHeaderIndexEnd]
-	for _, row := range firstHeaderRows {
-		if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
-		}
-	}
-
-	dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
-	for _, row := range dataRows {
-		if header := getCell(row.Cells, serviceProvidedColumn); header != "Service Provided" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
-		}
-	}
-
-	// Check example row
-	const exampleIndexStart = headerIndexStart + 1
-	const exampleIndexEnd = exampleIndexStart + 1
-
-	// Verify example row strings
-	exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
-	for _, row := range exampleRows {
-		if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
-		}
-		if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
-			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
-		}
-	}
-
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		// XLSX Sheet consts
+		const rowIndexStart int = 24
+		const servicesScheduleColumn int = 2
+		const serviceProvidedColumn int = 3
+		const nonPeakPriceColumn int = 4
+		const peakPriceColumn int = 5
+
+		// Check headers
+		const headerIndexStart = rowIndexStart - 2
+		const headerIndexEnd = headerIndexStart + 1
+		const sitHeaderIndexStart = headerIndexStart - 1
+		const sitHeaderIndexEnd = headerIndexStart
+
+		// Verify header strings
+		firstHeaderRows := params.XlsxFile.Sheets[sheetIndex].Rows[sitHeaderIndexStart:sitHeaderIndexEnd]
+		for _, row := range firstHeaderRows {
+			if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
+			}
+		}
+
+		dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
+		for _, row := range dataRows {
+			if header := getCell(row.Cells, serviceProvidedColumn); header != "Service Provided" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
+			}
+		}
+
+		// Check example row
+		const exampleIndexStart = headerIndexStart + 1
+		const exampleIndexEnd = exampleIndexStart + 1
+
+		// Verify example row strings
+		exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
+		for _, row := range exampleRows {
+			if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+			}
+			if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
+				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+			}
+		}
+
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -114,7 +114,6 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 	// Verify header strings
 	sheet := params.XlsxFile.Sheets[sheetIndex]
 	for rowIndex := headerIndexStart; rowIndex < headerIndexEnd; rowIndex++ {
-		// for _, row := range dataRows {
 		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, servicesScheduleColumn)); header != "ServicesSchedule" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
 		}
@@ -135,7 +134,6 @@ func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
 
 	// Verify example row strings
 	for rowIndex := exampleIndexStart; rowIndex < exampleIndexEnd; rowIndex++ {
-		// for _, row := range exampleRows {
 		if example := mustGetCell(sheet, rowIndex, servicesScheduleColumn); example != "X" {
 			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
 		}

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -1,224 +1,213 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-		const rowIndexStart int = 12
-		const servicesScheduleColumn int = 2
-		const serviceProvidedColumn int = 3
-		const nonPeakPriceColumn int = 4
-		const peakPriceColumn int = 5
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	const rowIndexStart int = 12
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
 
-		logger.Info("Parsing domestic other (pack/unpack) prices")
+	logger.Info("Parsing domestic other (pack/unpack) prices")
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var packUnpackPrices []models.StageDomesticOtherPackPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := rowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		packPrice := models.StageDomesticOtherPackPrice{
+			ServicesSchedule:   getCell(sheet, rowIdx, servicesScheduleColumn),
+			ServiceProvided:    getCell(sheet, rowIdx, serviceProvidedColumn),
+			NonPeakPricePerCwt: getCell(sheet, rowIdx, nonPeakPriceColumn),
+			PeakPricePerCwt:    getCell(sheet, rowIdx, peakPriceColumn),
 		}
 
-		var packUnpackPrices []models.StageDomesticOtherPackPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
-		for _, row := range dataRows {
-			packPrice := models.StageDomesticOtherPackPrice{
-				ServicesSchedule:   getCell(row.Cells, servicesScheduleColumn),
-				ServiceProvided:    getCell(row.Cells, serviceProvidedColumn),
-				NonPeakPricePerCwt: getCell(row.Cells, nonPeakPriceColumn),
-				PeakPricePerCwt:    getCell(row.Cells, peakPriceColumn),
+		if packPrice.ServicesSchedule != "" {
+			packUnpackPrices = append(packUnpackPrices, packPrice)
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageDomesticOtherPackPrice", packPrice))
 			}
-
-			if packPrice.ServicesSchedule != "" {
-				packUnpackPrices = append(packUnpackPrices, packPrice)
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageDomesticOtherPackPrice", packPrice))
-				}
-			} else {
-				break
-			}
+		} else {
+			break
 		}
+	}
 
-		return packUnpackPrices, nil
-	*/
+	return packUnpackPrices, nil
 }
 
 var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-		const rowIndexStart int = 24
-		const servicesScheduleColumn int = 2
-		const serviceProvidedColumn int = 3
-		const nonPeakPriceColumn int = 4
-		const peakPriceColumn int = 5
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	const rowIndexStart int = 24
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
 
-		logger.Info("Parsing domestic other (SIT pickup/delivery) prices")
+	logger.Info("Parsing domestic other (SIT pickup/delivery) prices")
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var sitPrices []models.StageDomesticOtherSitPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := rowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		sitPrice := models.StageDomesticOtherSitPrice{
+			SITPickupDeliverySchedule: getCell(sheet, rowIdx, servicesScheduleColumn),
+			ServiceProvided:           getCell(sheet, rowIdx, serviceProvidedColumn),
+			NonPeakPricePerCwt:        getCell(sheet, rowIdx, nonPeakPriceColumn),
+			PeakPricePerCwt:           getCell(sheet, rowIdx, peakPriceColumn),
 		}
 
-		var sitPrices []models.StageDomesticOtherSitPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
-		for _, row := range dataRows {
-			sitPrice := models.StageDomesticOtherSitPrice{
-				SITPickupDeliverySchedule: getCell(row.Cells, servicesScheduleColumn),
-				ServiceProvided:           getCell(row.Cells, serviceProvidedColumn),
-				NonPeakPricePerCwt:        getCell(row.Cells, nonPeakPriceColumn),
-				PeakPricePerCwt:           getCell(row.Cells, peakPriceColumn),
+		if sitPrice.SITPickupDeliverySchedule != "" {
+			sitPrices = append(sitPrices, sitPrice)
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageDomesticOtherSitPrice", sitPrice))
 			}
-
-			if sitPrice.SITPickupDeliverySchedule != "" {
-				sitPrices = append(sitPrices, sitPrice)
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageDomesticOtherSitPrice", sitPrice))
-				}
-			} else {
-				break
-			}
+		} else {
+			break
 		}
+	}
 
-		return sitPrices, nil
-	*/
+	return sitPrices, nil
 }
 
 // verifyDomesticOtherPrices: verification 2c) Dom. Other Prices
 var verifyDomesticOtherPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+	if err := verifyPackUnpackPrices(params, sheetIndex); err != nil {
+		return err
+	}
+	if err := verifySITPickupPrices(params, sheetIndex); err != nil {
+		return err
+	}
 	return nil
-	/*
-		const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
-		if err := verifyPackUnpackPrices(params, sheetIndex); err != nil {
-			return err
-		}
-		if err := verifySITPickupPrices(params, sheetIndex); err != nil {
-			return err
-		}
-		return nil
-	*/
 }
 
 func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
+	// XLSX Sheet consts
+	const rowIndexStart int = 12
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	// Check headers
+	const headerIndexStart = rowIndexStart - 2
+	const headerIndexEnd = headerIndexStart + 1
+
+	// Verify header strings
+	sheet := params.XlsxFile.Sheets[sheetIndex]
+	for rowIdx := headerIndexStart; rowIdx < headerIndexEnd; rowIdx++ {
+		// for _, row := range dataRows {
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, servicesScheduleColumn)); header != "ServicesSchedule" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, serviceProvidedColumn)); header != "ServiceProvided" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, peakPriceColumn)); header != "Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
+		}
+	}
+
+	// Check example row
+	const exampleIndexStart = headerIndexStart + 1
+	const exampleIndexEnd = exampleIndexStart + 1
+
+	// Verify example row strings
+	for rowIdx := exampleIndexStart; rowIdx < exampleIndexEnd; rowIdx++ {
+		// for _, row := range exampleRows {
+		if example := getCell(sheet, rowIdx, servicesScheduleColumn); example != "X" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, nonPeakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, peakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+		}
+	}
+
 	return nil
-	/*
-		// XLSX Sheet consts
-		const rowIndexStart int = 12
-		const servicesScheduleColumn int = 2
-		const serviceProvidedColumn int = 3
-		const nonPeakPriceColumn int = 4
-		const peakPriceColumn int = 5
-
-		// Check headers
-		const headerIndexStart = rowIndexStart - 2
-		const headerIndexEnd = headerIndexStart + 1
-
-		// Verify header strings
-		dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
-		for _, row := range dataRows {
-			if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "ServicesSchedule" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(row.Cells, serviceProvidedColumn)); header != "ServiceProvided" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
-			}
-		}
-
-		// Check example row
-		const exampleIndexStart = headerIndexStart + 1
-		const exampleIndexEnd = exampleIndexStart + 1
-
-		// Verify example row strings
-		exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
-		for _, row := range exampleRows {
-			if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
-				return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
-			}
-		}
-
-		return nil
-	*/
 }
 
 func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
+	// XLSX Sheet consts
+	const rowIndexStart int = 24
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	// Check headers
+	const headerIndexStart = rowIndexStart - 2
+	const headerIndexEnd = headerIndexStart + 1
+	const sitHeaderIndexStart = headerIndexStart - 1
+	const sitHeaderIndexEnd = headerIndexStart
+
+	// Verify header strings
+	sheet := params.XlsxFile.Sheets[sheetIndex]
+	for rowIdx := sitHeaderIndexStart; rowIdx < sitHeaderIndexEnd; rowIdx++ {
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
+		}
+	}
+
+	for rowIdx := headerIndexStart; rowIdx < headerIndexEnd; rowIdx++ {
+		if header := getCell(sheet, rowIdx, serviceProvidedColumn); header != "Service Provided" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, peakPriceColumn)); header != "Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
+		}
+	}
+
+	// Check example row
+	const exampleIndexStart = headerIndexStart + 1
+	const exampleIndexEnd = exampleIndexStart + 1
+
+	// Verify example row strings
+	for rowIdx := exampleIndexStart; rowIdx < exampleIndexEnd; rowIdx++ {
+		if example := getCell(sheet, rowIdx, servicesScheduleColumn); example != "X" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, nonPeakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+		}
+		if example := getCell(sheet, rowIdx, peakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+		}
+	}
+
 	return nil
-	/*
-		// XLSX Sheet consts
-		const rowIndexStart int = 24
-		const servicesScheduleColumn int = 2
-		const serviceProvidedColumn int = 3
-		const nonPeakPriceColumn int = 4
-		const peakPriceColumn int = 5
-
-		// Check headers
-		const headerIndexStart = rowIndexStart - 2
-		const headerIndexEnd = headerIndexStart + 1
-		const sitHeaderIndexStart = headerIndexStart - 1
-		const sitHeaderIndexEnd = headerIndexStart
-
-		// Verify header strings
-		firstHeaderRows := params.XlsxFile.Sheets[sheetIndex].Rows[sitHeaderIndexStart:sitHeaderIndexEnd]
-		for _, row := range firstHeaderRows {
-			if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
-			}
-		}
-
-		dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
-		for _, row := range dataRows {
-			if header := getCell(row.Cells, serviceProvidedColumn); header != "Service Provided" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
-			}
-		}
-
-		// Check example row
-		const exampleIndexStart = headerIndexStart + 1
-		const exampleIndexEnd = exampleIndexStart + 1
-
-		// Verify example row strings
-		exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
-		for _, row := range exampleRows {
-			if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
-			}
-			if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
-				return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
-			}
-		}
-
-		return nil
-	*/
 }

--- a/pkg/parser/pricing/parse_domestic_service_area_prices.go
+++ b/pkg/parser/pricing/parse_domestic_service_area_prices.go
@@ -1,141 +1,141 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 // parseDomesticServiceAreaPrices: parser for: 2b) Dom. Service Area Prices
 var parseDomesticServiceAreaPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 7  // 2b) Domestic Service Area Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const serviceAreaNumberColumn int = 2
-	const serviceAreaNameColumn int = 3
-	const serviceScheduleColumn int = 4
-	const sitPickupDeliveryScheduleColumn int = 5
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 7  // 2b) Domestic Service Area Prices
+		const feeColIndexStart int = 6  // start at column 6 to get the rates
+		const feeRowIndexStart int = 10 // start at row 10 to get the rates
+		const serviceAreaNumberColumn int = 2
+		const serviceAreaNameColumn int = 3
+		const serviceScheduleColumn int = 4
+		const sitPickupDeliveryScheduleColumn int = 5
+		const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	logger.Info("Parsing domestic service area prices")
+		logger.Info("Parsing domestic service area prices")
 
-	var domPrices []models.StageDomesticServiceAreaPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				domPrice := models.StageDomesticServiceAreaPrice{
-					ServiceAreaNumber:         getCell(row.Cells, serviceAreaNumberColumn),
-					ServiceAreaName:           getCell(row.Cells, serviceAreaNameColumn),
-					ServicesSchedule:          getCell(row.Cells, serviceScheduleColumn),
-					SITPickupDeliverySchedule: getCell(row.Cells, sitPickupDeliveryScheduleColumn),
-					Season:                    r,
+		var domPrices []models.StageDomesticServiceAreaPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For number of baseline + Escalation years
+			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+				// For each Rate Season
+				for _, r := range rateSeasons {
+					domPrice := models.StageDomesticServiceAreaPrice{
+						ServiceAreaNumber:         getCell(row.Cells, serviceAreaNumberColumn),
+						ServiceAreaName:           getCell(row.Cells, serviceAreaNameColumn),
+						ServicesSchedule:          getCell(row.Cells, serviceScheduleColumn),
+						SITPickupDeliverySchedule: getCell(row.Cells, sitPickupDeliveryScheduleColumn),
+						Season:                    r,
+					}
+
+					domPrice.ShorthaulPrice = getCell(row.Cells, colIndex)
+					colIndex++
+					domPrice.OriginDestinationPrice = getCell(row.Cells, colIndex)
+					colIndex += 3 // skip 2 columns pack and unpack
+					domPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
+					colIndex++
+					domPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
+					colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
+
+					if params.ShowOutput {
+						logger.Info("", zap.Any("StageDomesticServiceAreaPrice", domPrice))
+					}
+					domPrices = append(domPrices, domPrice)
+
+					colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 				}
-
-				domPrice.ShorthaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				domPrice.OriginDestinationPrice = getCell(row.Cells, colIndex)
-				colIndex += 3 // skip 2 columns pack and unpack
-				domPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
-				colIndex++
-				domPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
-				colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
-
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageDomesticServiceAreaPrice", domPrice))
-				}
-				domPrices = append(domPrices, domPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 			}
 		}
-	}
 
-	return domPrices, nil
+		return domPrices, nil
+	*/
 }
 
 // verifyDomesticServiceAreaPrices: verification 2b) Dom. Service Area Prices
 var verifyDomesticServiceAreaPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 7  // 2a) Domestic Linehaul Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const serviceAreaNumberColumn int = 2
-	const serviceAreaNameColumn int = 3
-	const serviceScheduleColumn int = 4
-	const sITPickupDeliveryScheduleColumn int = 5
-	const numEscalationYearsToProcess int = 4
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 7  // 2a) Domestic Linehaul Prices
+		const feeColIndexStart int = 6  // start at column 6 to get the rates
+		const feeRowIndexStart int = 10 // start at row 10 to get the rates
+		const serviceAreaNumberColumn int = 2
+		const serviceAreaNameColumn int = 3
+		const serviceScheduleColumn int = 4
+		const sITPickupDeliveryScheduleColumn int = 5
+		const numEscalationYearsToProcess int = 4
 
-	// Check headers
-	const feeRowMileageHeaderIndexStart = feeRowIndexStart - 2
-	const verifyHeaderIndexEnd = feeRowMileageHeaderIndexStart + 2
+		// Check headers
+		const feeRowMileageHeaderIndexStart = feeRowIndexStart - 2
+		const verifyHeaderIndexEnd = feeRowMileageHeaderIndexStart + 2
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	// Verify header strings
-	repeatingHeaders := []string{
-		"Shorthaul Price (per cwt per mile)",
-		"Origin / Destination Price (per cwt)",
-		"Origin Pack Price (per cwt)",
-		"Destination Unpack Price (per cwt)",
-		"Origin / Destination SIT First Day & Warehouse Handling (per cwt)",
-		"Origin / Destination SIT Add'l Days (per cwt)",
-		"SIT Pickup / Delivery ≤50 miles (per cwt)",
-	}
+		// Verify header strings
+		repeatingHeaders := []string{
+			"Shorthaul Price (per cwt per mile)",
+			"Origin / Destination Price (per cwt)",
+			"Origin Pack Price (per cwt)",
+			"Destination Unpack Price (per cwt)",
+			"Origin / Destination SIT First Day & Warehouse Handling (per cwt)",
+			"Origin / Destination SIT Add'l Days (per cwt)",
+			"SIT Pickup / Delivery ≤50 miles (per cwt)",
+		}
 
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMileageHeaderIndexStart:verifyHeaderIndexEnd]
-	for dataRowsIndex, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
-					dataRowsIndex, colIndex, escalation, r)
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMileageHeaderIndexStart:verifyHeaderIndexEnd]
+		for dataRowsIndex, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For number of baseline + Escalation years
+			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+				// For each Rate Season
+				for _, r := range rateSeasons {
+					verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
+						dataRowsIndex, colIndex, escalation, r)
 
-				if dataRowsIndex == 0 {
-					if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
-					}
-					if "ServiceAreaName" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
-					}
-					if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
-						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
-					}
-
-					if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)) {
-						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)), verificationLog)
-					}
-
-					for _, repeatingHeader := range repeatingHeaders {
-						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
-							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
+					if dataRowsIndex == 0 {
+						if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
+							return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
 						}
-						colIndex++
+						if "ServiceAreaName" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
+							return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
+						}
+						if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
+							return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
+						}
+
+						if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)) {
+							return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)), verificationLog)
+						}
+
+						for _, repeatingHeader := range repeatingHeaders {
+							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
+								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
+							}
+							colIndex++
+						}
+						colIndex++ // skip 1 column (empty column) before starting next Rate type
+					} else if dataRowsIndex == 1 {
+						if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
+							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
+						}
 					}
-					colIndex++ // skip 1 column (empty column) before starting next Rate type
-				} else if dataRowsIndex == 1 {
-					if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
-					}
+
 				}
 
 			}
-
 		}
-	}
-	return nil
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_domestic_service_area_prices.go
+++ b/pkg/parser/pricing/parse_domestic_service_area_prices.go
@@ -1,141 +1,142 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 // parseDomesticServiceAreaPrices: parser for: 2b) Dom. Service Area Prices
 var parseDomesticServiceAreaPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 7  // 2b) Domestic Service Area Prices
-		const feeColIndexStart int = 6  // start at column 6 to get the rates
-		const feeRowIndexStart int = 10 // start at row 10 to get the rates
-		const serviceAreaNumberColumn int = 2
-		const serviceAreaNameColumn int = 3
-		const serviceScheduleColumn int = 4
-		const sitPickupDeliveryScheduleColumn int = 5
-		const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 7  // 2b) Domestic Service Area Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const serviceAreaNumberColumn int = 2
+	const serviceAreaNameColumn int = 3
+	const serviceScheduleColumn int = 4
+	const sitPickupDeliveryScheduleColumn int = 5
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		logger.Info("Parsing domestic service area prices")
+	logger.Info("Parsing domestic service area prices")
 
-		var domPrices []models.StageDomesticServiceAreaPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For number of baseline + Escalation years
-			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-				// For each Rate Season
-				for _, r := range rateSeasons {
-					domPrice := models.StageDomesticServiceAreaPrice{
-						ServiceAreaNumber:         getCell(row.Cells, serviceAreaNumberColumn),
-						ServiceAreaName:           getCell(row.Cells, serviceAreaNameColumn),
-						ServicesSchedule:          getCell(row.Cells, serviceScheduleColumn),
-						SITPickupDeliverySchedule: getCell(row.Cells, sitPickupDeliveryScheduleColumn),
-						Season:                    r,
-					}
+	var domPrices []models.StageDomesticServiceAreaPrice
 
-					domPrice.ShorthaulPrice = getCell(row.Cells, colIndex)
-					colIndex++
-					domPrice.OriginDestinationPrice = getCell(row.Cells, colIndex)
-					colIndex += 3 // skip 2 columns pack and unpack
-					domPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
-					colIndex++
-					domPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
-					colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
-
-					if params.ShowOutput {
-						logger.Info("", zap.Any("StageDomesticServiceAreaPrice", domPrice))
-					}
-					domPrices = append(domPrices, domPrice)
-
-					colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				domPrice := models.StageDomesticServiceAreaPrice{
+					ServiceAreaNumber:         getCell(sheet, rowIdx, serviceAreaNumberColumn),
+					ServiceAreaName:           getCell(sheet, rowIdx, serviceAreaNameColumn),
+					ServicesSchedule:          getCell(sheet, rowIdx, serviceScheduleColumn),
+					SITPickupDeliverySchedule: getCell(sheet, rowIdx, sitPickupDeliveryScheduleColumn),
+					Season:                    r,
 				}
+
+				domPrice.ShorthaulPrice = getCell(sheet, rowIdx, colIndex)
+				colIndex++
+				domPrice.OriginDestinationPrice = getCell(sheet, rowIdx, colIndex)
+				colIndex += 3 // skip 2 columns pack and unpack
+				domPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIdx, colIndex)
+				colIndex++
+				domPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIdx, colIndex)
+				colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
+
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageDomesticServiceAreaPrice", domPrice))
+				}
+				domPrices = append(domPrices, domPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 			}
 		}
+	}
 
-		return domPrices, nil
-	*/
+	return domPrices, nil
 }
 
 // verifyDomesticServiceAreaPrices: verification 2b) Dom. Service Area Prices
 var verifyDomesticServiceAreaPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 7  // 2a) Domestic Linehaul Prices
-		const feeColIndexStart int = 6  // start at column 6 to get the rates
-		const feeRowIndexStart int = 10 // start at row 10 to get the rates
-		const serviceAreaNumberColumn int = 2
-		const serviceAreaNameColumn int = 3
-		const serviceScheduleColumn int = 4
-		const sITPickupDeliveryScheduleColumn int = 5
-		const numEscalationYearsToProcess int = 4
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 7  // 2a) Domestic Linehaul Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const serviceAreaNumberColumn int = 2
+	const serviceAreaNameColumn int = 3
+	const serviceScheduleColumn int = 4
+	const sITPickupDeliveryScheduleColumn int = 5
+	const numEscalationYearsToProcess int = 4
 
-		// Check headers
-		const feeRowMileageHeaderIndexStart = feeRowIndexStart - 2
-		const verifyHeaderIndexEnd = feeRowMileageHeaderIndexStart + 2
+	// Check headers
+	const feeRowMileageHeaderIndexStart = feeRowIndexStart - 2
+	const verifyHeaderIndexEnd = feeRowMileageHeaderIndexStart + 2
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		// Verify header strings
-		repeatingHeaders := []string{
-			"Shorthaul Price (per cwt per mile)",
-			"Origin / Destination Price (per cwt)",
-			"Origin Pack Price (per cwt)",
-			"Destination Unpack Price (per cwt)",
-			"Origin / Destination SIT First Day & Warehouse Handling (per cwt)",
-			"Origin / Destination SIT Add'l Days (per cwt)",
-			"SIT Pickup / Delivery ≤50 miles (per cwt)",
-		}
+	// Verify header strings
+	repeatingHeaders := []string{
+		"Shorthaul Price (per cwt per mile)",
+		"Origin / Destination Price (per cwt)",
+		"Origin Pack Price (per cwt)",
+		"Destination Unpack Price (per cwt)",
+		"Origin / Destination SIT First Day & Warehouse Handling (per cwt)",
+		"Origin / Destination SIT Add'l Days (per cwt)",
+		"SIT Pickup / Delivery ≤50 miles (per cwt)",
+	}
 
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowMileageHeaderIndexStart:verifyHeaderIndexEnd]
-		for dataRowsIndex, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For number of baseline + Escalation years
-			for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-				// For each Rate Season
-				for _, r := range rateSeasons {
-					verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
-						dataRowsIndex, colIndex, escalation, r)
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowMileageHeaderIndexStart; rowIdx < verifyHeaderIndexEnd; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
+					rowIdx, colIndex, escalation, r)
 
-					if dataRowsIndex == 0 {
-						if "ServiceAreaNumber" != removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)) {
-							return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNumberColumn)), verificationLog)
-						}
-						if "ServiceAreaName" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
-							return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
-						}
-						if "ServicesSchedule" != removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)) {
-							return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceScheduleColumn)), verificationLog)
-						}
-
-						if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)) {
-							return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, sITPickupDeliveryScheduleColumn)), verificationLog)
-						}
-
-						for _, repeatingHeader := range repeatingHeaders {
-							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
-								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
-							}
-							colIndex++
-						}
-						colIndex++ // skip 1 column (empty column) before starting next Rate type
-					} else if dataRowsIndex == 1 {
-						if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)) {
-							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, serviceAreaNameColumn)), verificationLog)
-						}
+				if rowIdx == 0 {
+					if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)), verificationLog)
+					}
+					if "ServiceAreaName" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)), verificationLog)
+					}
+					if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)) {
+						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)), verificationLog)
 					}
 
+					if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(sheet, rowIdx, sITPickupDeliveryScheduleColumn)) {
+						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, sITPickupDeliveryScheduleColumn)), verificationLog)
+					}
+
+					for _, repeatingHeader := range repeatingHeaders {
+						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, rowIdx, colIndex)) {
+							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, rowIdx, colIndex)), verificationLog)
+						}
+						colIndex++
+					}
+					colIndex++ // skip 1 column (empty column) before starting next Rate type
+				} else if rowIdx == 1 {
+					if "EXAMPLE" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)), verificationLog)
+					}
 				}
 
 			}
+
 		}
-		return nil
-	*/
+	}
+	return nil
 }

--- a/pkg/parser/pricing/parse_domestic_service_area_prices.go
+++ b/pkg/parser/pricing/parse_domestic_service_area_prices.go
@@ -27,29 +27,28 @@ var parseDomesticServiceAreaPrices processXlsxSheet = func(params ParamConfig, s
 	logger.Info("Parsing domestic service area prices")
 
 	var domPrices []models.StageDomesticServiceAreaPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For number of baseline + Escalation years
 		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
 			// For each Rate Season
 			for _, r := range rateSeasons {
 				domPrice := models.StageDomesticServiceAreaPrice{
-					ServiceAreaNumber:         getCell(sheet, rowIdx, serviceAreaNumberColumn),
-					ServiceAreaName:           getCell(sheet, rowIdx, serviceAreaNameColumn),
-					ServicesSchedule:          getCell(sheet, rowIdx, serviceScheduleColumn),
-					SITPickupDeliverySchedule: getCell(sheet, rowIdx, sitPickupDeliveryScheduleColumn),
+					ServiceAreaNumber:         getCell(sheet, rowIndex, serviceAreaNumberColumn),
+					ServiceAreaName:           getCell(sheet, rowIndex, serviceAreaNameColumn),
+					ServicesSchedule:          getCell(sheet, rowIndex, serviceScheduleColumn),
+					SITPickupDeliverySchedule: getCell(sheet, rowIndex, sitPickupDeliveryScheduleColumn),
 					Season:                    r,
 				}
 
-				domPrice.ShorthaulPrice = getCell(sheet, rowIdx, colIndex)
+				domPrice.ShorthaulPrice = getCell(sheet, rowIndex, colIndex)
 				colIndex++
-				domPrice.OriginDestinationPrice = getCell(sheet, rowIdx, colIndex)
+				domPrice.OriginDestinationPrice = getCell(sheet, rowIndex, colIndex)
 				colIndex += 3 // skip 2 columns pack and unpack
-				domPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIdx, colIndex)
+				domPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIndex, colIndex)
 				colIndex++
-				domPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIdx, colIndex)
+				domPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIndex, colIndex)
 				colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
 
 				if params.ShowOutput {
@@ -97,40 +96,40 @@ var verifyDomesticServiceAreaPrices verifyXlsxSheet = func(params ParamConfig, s
 	}
 
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowMileageHeaderIndexStart; rowIdx < verifyHeaderIndexEnd; rowIdx++ {
+	for rowIndex := feeRowMileageHeaderIndexStart; rowIndex < verifyHeaderIndexEnd; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For number of baseline + Escalation years
 		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
 			// For each Rate Season
 			for _, r := range rateSeasons {
 				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
-					rowIdx, colIndex, escalation, r)
+					rowIndex, colIndex, escalation, r)
 
-				if rowIdx == 0 {
-					if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNumberColumn)), verificationLog)
+				if rowIndex == 0 {
+					if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
 					}
-					if "ServiceAreaName" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)), verificationLog)
+					if "ServiceAreaName" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
 					}
-					if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)) {
-						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceScheduleColumn)), verificationLog)
+					if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)) {
+						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
 					}
 
-					if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(sheet, rowIdx, sITPickupDeliveryScheduleColumn)) {
-						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, sITPickupDeliveryScheduleColumn)), verificationLog)
+					if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)) {
+						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)), verificationLog)
 					}
 
 					for _, repeatingHeader := range repeatingHeaders {
-						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, rowIdx, colIndex)) {
-							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, rowIdx, colIndex)), verificationLog)
+						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, rowIndex, colIndex)) {
+							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, rowIndex, colIndex)), verificationLog)
 						}
 						colIndex++
 					}
 					colIndex++ // skip 1 column (empty column) before starting next Rate type
-				} else if rowIdx == 1 {
-					if "EXAMPLE" != removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIdx, serviceAreaNameColumn)), verificationLog)
+				} else if rowIndex == 1 {
+					if "EXAMPLE" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
 					}
 				}
 

--- a/pkg/parser/pricing/parse_domestic_service_area_prices.go
+++ b/pkg/parser/pricing/parse_domestic_service_area_prices.go
@@ -35,20 +35,20 @@ var parseDomesticServiceAreaPrices processXlsxSheet = func(params ParamConfig, s
 			// For each Rate Season
 			for _, r := range rateSeasons {
 				domPrice := models.StageDomesticServiceAreaPrice{
-					ServiceAreaNumber:         getCell(sheet, rowIndex, serviceAreaNumberColumn),
-					ServiceAreaName:           getCell(sheet, rowIndex, serviceAreaNameColumn),
-					ServicesSchedule:          getCell(sheet, rowIndex, serviceScheduleColumn),
-					SITPickupDeliverySchedule: getCell(sheet, rowIndex, sitPickupDeliveryScheduleColumn),
+					ServiceAreaNumber:         mustGetCell(sheet, rowIndex, serviceAreaNumberColumn),
+					ServiceAreaName:           mustGetCell(sheet, rowIndex, serviceAreaNameColumn),
+					ServicesSchedule:          mustGetCell(sheet, rowIndex, serviceScheduleColumn),
+					SITPickupDeliverySchedule: mustGetCell(sheet, rowIndex, sitPickupDeliveryScheduleColumn),
 					Season:                    r,
 				}
 
-				domPrice.ShorthaulPrice = getCell(sheet, rowIndex, colIndex)
+				domPrice.ShorthaulPrice = mustGetCell(sheet, rowIndex, colIndex)
 				colIndex++
-				domPrice.OriginDestinationPrice = getCell(sheet, rowIndex, colIndex)
+				domPrice.OriginDestinationPrice = mustGetCell(sheet, rowIndex, colIndex)
 				colIndex += 3 // skip 2 columns pack and unpack
-				domPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIndex, colIndex)
+				domPrice.OriginDestinationSITFirstDayWarehouse = mustGetCell(sheet, rowIndex, colIndex)
 				colIndex++
-				domPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIndex, colIndex)
+				domPrice.OriginDestinationSITAddlDays = mustGetCell(sheet, rowIndex, colIndex)
 				colIndex++ // skip column SIT Pickup / Delivery ≤50 miles (per cwt)
 
 				if params.ShowOutput {
@@ -106,30 +106,30 @@ var verifyDomesticServiceAreaPrices verifyXlsxSheet = func(params ParamConfig, s
 					rowIndex, colIndex, escalation, r)
 
 				if rowIndex == 0 {
-					if "ServiceAreaNumber" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
+					if "ServiceAreaNumber" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNumberColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaNumber> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNumberColumn)), verificationLog)
 					}
-					if "ServiceAreaName" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
+					if "ServiceAreaName" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Header <ServiceAreaName> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
 					}
-					if "ServicesSchedule" != removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)) {
-						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
+					if "ServicesSchedule" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceScheduleColumn)) {
+						return fmt.Errorf("format error: Header <ServicesSchedule> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceScheduleColumn)), verificationLog)
 					}
 
-					if "SITPickup/DeliverySchedule" != removeWhiteSpace(getCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)) {
-						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)), verificationLog)
+					if "SITPickup/DeliverySchedule" != removeWhiteSpace(mustGetCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)) {
+						return fmt.Errorf("format error: Header <SIT Pickup / Delivery> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, sITPickupDeliveryScheduleColumn)), verificationLog)
 					}
 
 					for _, repeatingHeader := range repeatingHeaders {
-						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, rowIndex, colIndex)) {
-							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, rowIndex, colIndex)), verificationLog)
+						if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(mustGetCell(sheet, rowIndex, colIndex)) {
+							return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(mustGetCell(sheet, rowIndex, colIndex)), verificationLog)
 						}
 						colIndex++
 					}
 					colIndex++ // skip 1 column (empty column) before starting next Rate type
 				} else if rowIndex == 1 {
-					if "EXAMPLE" != removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)) {
-						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
+					if "EXAMPLE" != removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNameColumn)) {
+						return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, rowIndex, serviceAreaNameColumn)), verificationLog)
 					}
 				}
 

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -28,23 +28,22 @@ var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetI
 	logger.Info("Parsing OCONUS to OCONUS prices")
 
 	var oconusToOconusPrices []models.StageOconusToOconusPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			oconusToOconusPrice := models.StageOconusToOconusPrice{
-				OriginIntlPriceAreaID:      getCell(sheet, rowIdx, originPriceAreaIDColumn),
-				OriginIntlPriceArea:        getCell(sheet, rowIdx, originPriceAreaColumn),
-				DestinationIntlPriceAreaID: getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:   getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				OriginIntlPriceAreaID:      getCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginIntlPriceArea:        getCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationIntlPriceAreaID: getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:   getCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                     r,
 			}
 
-			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			oconusToOconusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+			oconusToOconusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
@@ -69,23 +68,22 @@ var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 	logger.Info("Parsing CONUS to OCONUS prices")
 
 	var conusToOconusPrices []models.StageConusToOconusPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			conusToOconusPrice := models.StageConusToOconusPrice{
-				OriginDomesticPriceAreaCode: getCell(sheet, rowIdx, originPriceAreaIDColumn),
-				OriginDomesticPriceArea:     getCell(sheet, rowIdx, originPriceAreaColumn),
-				DestinationIntlPriceAreaID:  getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:    getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				OriginDomesticPriceAreaCode: getCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginDomesticPriceArea:     getCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationIntlPriceAreaID:  getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:    getCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                      r,
 			}
 
-			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			conusToOconusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+			conusToOconusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
@@ -110,23 +108,22 @@ var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 	logger.Info("Parsing OCONUS to CONUS prices")
 
 	var oconusToConusPrices []models.StageOconusToConusPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			oconusToConusPrice := models.StageOconusToConusPrice{
-				OriginIntlPriceAreaID:            getCell(sheet, rowIdx, originPriceAreaIDColumn),
-				OriginIntlPriceArea:              getCell(sheet, rowIdx, originPriceAreaColumn),
-				DestinationDomesticPriceAreaCode: getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
-				DestinationDomesticPriceArea:     getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				OriginIntlPriceAreaID:            getCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginIntlPriceArea:              getCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationDomesticPriceAreaCode: getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationDomesticPriceArea:     getCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                           r,
 			}
 
-			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			oconusToConusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+			oconusToConusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
@@ -160,71 +157,71 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 	}
 
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for dataRowIdx := headerIndexStart; dataRowIdx < verifyHeaderIndexEnd; dataRowIdx++ {
+	for dataRowIndex := headerIndexStart; dataRowIndex < verifyHeaderIndexEnd; dataRowIndex++ {
 		colIndex := feeColIndexStart
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
-				dataRowIdx, colIndex, r)
+				dataRowIndex, colIndex, r)
 
-			if dataRowIdx == 0 {
+			if dataRowIndex == 0 {
 				if xlsxSheetNum == 10 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
+					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
 				if xlsxSheetNum == 11 {
-					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
+					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
+					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
 				if xlsxSheetNum == 12 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
+					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
-				for repeatingRowIdx := repeatingHeaderIndexStart; repeatingRowIdx < verifyHeaderIndexEnd2; repeatingRowIdx++ {
-					if repeatingRowIdx == 0 {
+				for repeatingRowIndex := repeatingHeaderIndexStart; repeatingRowIndex < verifyHeaderIndexEnd2; repeatingRowIndex++ {
+					if repeatingRowIndex == 0 {
 						colIndex := feeColIndexStart
 						for _, repeatingHeader := range repeatingHeaders {
-							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, repeatingRowIdx, colIndex)) {
-								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, repeatingRowIdx, colIndex)), verificationLog)
+							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, repeatingRowIndex, colIndex)) {
+								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, repeatingRowIndex, colIndex)), verificationLog)
 							}
 							colIndex++
 						}
-					} else if dataRowIdx == 1 {
-						if "EXAMPLE" != removeWhiteSpace(getCell(sheet, repeatingRowIdx, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, repeatingRowIdx, originPriceAreaColumn)), verificationLog)
+					} else if dataRowIndex == 1 {
+						if "EXAMPLE" != removeWhiteSpace(getCell(sheet, repeatingRowIndex, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, repeatingRowIndex, originPriceAreaColumn)), verificationLog)
 						}
 					}
 				}

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -34,16 +34,16 @@ var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetI
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			oconusToOconusPrice := models.StageOconusToOconusPrice{
-				OriginIntlPriceAreaID:      getCell(sheet, rowIndex, originPriceAreaIDColumn),
-				OriginIntlPriceArea:        getCell(sheet, rowIndex, originPriceAreaColumn),
-				DestinationIntlPriceAreaID: getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:   getCell(sheet, rowIndex, destinationPriceAreaColumn),
+				OriginIntlPriceAreaID:      mustGetCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginIntlPriceArea:        mustGetCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationIntlPriceAreaID: mustGetCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:   mustGetCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                     r,
 			}
 
-			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
+			oconusToOconusPrice.HHGShippingLinehaulPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			oconusToOconusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
+			oconusToOconusPrice.UBPrice = mustGetCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
@@ -74,16 +74,16 @@ var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			conusToOconusPrice := models.StageConusToOconusPrice{
-				OriginDomesticPriceAreaCode: getCell(sheet, rowIndex, originPriceAreaIDColumn),
-				OriginDomesticPriceArea:     getCell(sheet, rowIndex, originPriceAreaColumn),
-				DestinationIntlPriceAreaID:  getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:    getCell(sheet, rowIndex, destinationPriceAreaColumn),
+				OriginDomesticPriceAreaCode: mustGetCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginDomesticPriceArea:     mustGetCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationIntlPriceAreaID:  mustGetCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:    mustGetCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                      r,
 			}
 
-			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
+			conusToOconusPrice.HHGShippingLinehaulPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			conusToOconusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
+			conusToOconusPrice.UBPrice = mustGetCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
@@ -114,16 +114,16 @@ var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 		// For each Rate Season
 		for _, r := range rateSeasons {
 			oconusToConusPrice := models.StageOconusToConusPrice{
-				OriginIntlPriceAreaID:            getCell(sheet, rowIndex, originPriceAreaIDColumn),
-				OriginIntlPriceArea:              getCell(sheet, rowIndex, originPriceAreaColumn),
-				DestinationDomesticPriceAreaCode: getCell(sheet, rowIndex, destinationPriceAreaIDColumn),
-				DestinationDomesticPriceArea:     getCell(sheet, rowIndex, destinationPriceAreaColumn),
+				OriginIntlPriceAreaID:            mustGetCell(sheet, rowIndex, originPriceAreaIDColumn),
+				OriginIntlPriceArea:              mustGetCell(sheet, rowIndex, originPriceAreaColumn),
+				DestinationDomesticPriceAreaCode: mustGetCell(sheet, rowIndex, destinationPriceAreaIDColumn),
+				DestinationDomesticPriceArea:     mustGetCell(sheet, rowIndex, destinationPriceAreaColumn),
 				Season:                           r,
 			}
 
-			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIndex, colIndex)
+			oconusToConusPrice.HHGShippingLinehaulPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			oconusToConusPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
+			oconusToConusPrice.UBPrice = mustGetCell(sheet, rowIndex, colIndex)
 
 			if params.ShowOutput {
 				logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
@@ -166,47 +166,47 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 
 			if dataRowIndex == 0 {
 				if xlsxSheetNum == 10 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
+					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
 				if xlsxSheetNum == 11 {
-					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
+					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
+					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
 				if xlsxSheetNum == 12 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaIDColumn)), verificationLog)
 					}
-					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
+					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, originPriceAreaColumn)), verificationLog)
 					}
-					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
+					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaIDColumn)), verificationLog)
 					}
-					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
+					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, dataRowIndex, destinationPriceAreaColumn)), verificationLog)
 					}
 				}
 
@@ -214,14 +214,14 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 					if repeatingRowIndex == 0 {
 						colIndex := feeColIndexStart
 						for _, repeatingHeader := range repeatingHeaders {
-							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, repeatingRowIndex, colIndex)) {
-								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, repeatingRowIndex, colIndex)), verificationLog)
+							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(mustGetCell(sheet, repeatingRowIndex, colIndex)) {
+								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(mustGetCell(sheet, repeatingRowIndex, colIndex)), verificationLog)
 							}
 							colIndex++
 						}
 					} else if dataRowIndex == 1 {
-						if "EXAMPLE" != removeWhiteSpace(getCell(sheet, repeatingRowIndex, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, repeatingRowIndex, originPriceAreaColumn)), verificationLog)
+						if "EXAMPLE" != removeWhiteSpace(mustGetCell(sheet, repeatingRowIndex, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(mustGetCell(sheet, repeatingRowIndex, originPriceAreaColumn)), verificationLog)
 						}
 					}
 				}

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -1,13 +1,5 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 //same values used in each parse and verify function
 const feeColIndexStart int = 6  // start at column 6 to get the rates
 const feeRowIndexStart int = 10 // start at row 10 to get the rates
@@ -18,218 +10,234 @@ const destinationPriceAreaColumn int = 5
 
 // parseOconusToOconusPrices: parser for 3a) OCONUS to OCONUS Prices
 var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing OCONUS to OCONUS prices")
-
-	var oconusToOconusPrices []models.StageOconusToOconusPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For each Rate Season
-		for _, r := range rateSeasons {
-			oconusToOconusPrice := models.StageOconusToOconusPrice{
-				OriginIntlPriceAreaID:      getCell(row.Cells, originPriceAreaIDColumn),
-				OriginIntlPriceArea:        getCell(row.Cells, originPriceAreaColumn),
-				DestinationIntlPriceAreaID: getCell(row.Cells, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:   getCell(row.Cells, destinationPriceAreaColumn),
-				Season:                     r,
-			}
-
-			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
-			}
-			oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
-
-			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
-	}
-	return oconusToOconusPrices, nil
+
+		logger.Info("Parsing OCONUS to OCONUS prices")
+
+		var oconusToOconusPrices []models.StageOconusToOconusPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				oconusToOconusPrice := models.StageOconusToOconusPrice{
+					OriginIntlPriceAreaID:      getCell(row.Cells, originPriceAreaIDColumn),
+					OriginIntlPriceArea:        getCell(row.Cells, originPriceAreaColumn),
+					DestinationIntlPriceAreaID: getCell(row.Cells, destinationPriceAreaIDColumn),
+					DestinationIntlPriceArea:   getCell(row.Cells, destinationPriceAreaColumn),
+					Season:                     r,
+				}
+
+				oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
+				}
+				oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+		return oconusToOconusPrices, nil
+	*/
 }
 
 // parseConusToOconusPrices: parser for 3b) CONUS to OCONUS Prices
 var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing CONUS to OCONUS prices")
-
-	var conusToOconusPrices []models.StageConusToOconusPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For each Rate Season
-		for _, r := range rateSeasons {
-			conusToOconusPrice := models.StageConusToOconusPrice{
-				OriginDomesticPriceAreaCode: getCell(row.Cells, originPriceAreaIDColumn),
-				OriginDomesticPriceArea:     getCell(row.Cells, originPriceAreaColumn),
-				DestinationIntlPriceAreaID:  getCell(row.Cells, destinationPriceAreaIDColumn),
-				DestinationIntlPriceArea:    getCell(row.Cells, destinationPriceAreaColumn),
-				Season:                      r,
-			}
-
-			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
-			}
-			conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
-
-			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
-	}
-	return conusToOconusPrices, nil
+
+		logger.Info("Parsing CONUS to OCONUS prices")
+
+		var conusToOconusPrices []models.StageConusToOconusPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				conusToOconusPrice := models.StageConusToOconusPrice{
+					OriginDomesticPriceAreaCode: getCell(row.Cells, originPriceAreaIDColumn),
+					OriginDomesticPriceArea:     getCell(row.Cells, originPriceAreaColumn),
+					DestinationIntlPriceAreaID:  getCell(row.Cells, destinationPriceAreaIDColumn),
+					DestinationIntlPriceArea:    getCell(row.Cells, destinationPriceAreaColumn),
+					Season:                      r,
+				}
+
+				conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
+				}
+				conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+		return conusToOconusPrices, nil
+	*/
 }
 
 // parseOconusToConusPrices: parser for 3c) OCONUS to CONUS Prices
 var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing OCONUS to CONUS prices")
-
-	var oconusToConusPrices []models.StageOconusToConusPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For each Rate Season
-		for _, r := range rateSeasons {
-			oconusToConusPrice := models.StageOconusToConusPrice{
-				OriginIntlPriceAreaID:            getCell(row.Cells, originPriceAreaIDColumn),
-				OriginIntlPriceArea:              getCell(row.Cells, originPriceAreaColumn),
-				DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationPriceAreaIDColumn),
-				DestinationDomesticPriceArea:     getCell(row.Cells, destinationPriceAreaColumn),
-				Season:                           r,
-			}
-
-			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
-			}
-			oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
-
-			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
-	}
-	return oconusToConusPrices, nil
+
+		logger.Info("Parsing OCONUS to CONUS prices")
+
+		var oconusToConusPrices []models.StageOconusToConusPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				oconusToConusPrice := models.StageOconusToConusPrice{
+					OriginIntlPriceAreaID:            getCell(row.Cells, originPriceAreaIDColumn),
+					OriginIntlPriceArea:              getCell(row.Cells, originPriceAreaColumn),
+					DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationPriceAreaIDColumn),
+					DestinationDomesticPriceArea:     getCell(row.Cells, destinationPriceAreaColumn),
+					Season:                           r,
+				}
+
+				oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
+				}
+				oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+		return oconusToConusPrices, nil
+	*/
 }
 
 func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum int) error {
-	// XLSX Sheet consts
-	xlsxDataSheetNum := xlsxSheetNum
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		// XLSX Sheet consts
+		xlsxDataSheetNum := xlsxSheetNum
 
-	// Check headers
-	const headerIndexStart = feeRowIndexStart - 3
-	const verifyHeaderIndexEnd = headerIndexStart + 2
-	const repeatingHeaderIndexStart = feeRowIndexStart - 2
-	const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
+		// Check headers
+		const headerIndexStart = feeRowIndexStart - 3
+		const verifyHeaderIndexEnd = headerIndexStart + 2
+		const repeatingHeaderIndexStart = feeRowIndexStart - 2
+		const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyInternationalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyInternationalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	// Verify header strings
-	repeatingHeaders := []string{
-		"HHG Shipping / Linehaul Price (except SIT) (per cwt)",
-		"UB Price (except SIT) (per cwt)",
-	}
+		// Verify header strings
+		repeatingHeaders := []string{
+			"HHG Shipping / Linehaul Price (except SIT) (per cwt)",
+			"UB Price (except SIT) (per cwt)",
+		}
 
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart:verifyHeaderIndexEnd]
-	repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[repeatingHeaderIndexStart:verifyHeaderIndexEnd2]
-	for dataRowsIndex, row := range dataRows {
-		colIndex := feeColIndexStart
-		// For each Rate Season
-		for _, r := range rateSeasons {
-			verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
-				dataRowsIndex, colIndex, r)
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart:verifyHeaderIndexEnd]
+		repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[repeatingHeaderIndexStart:verifyHeaderIndexEnd2]
+		for dataRowsIndex, row := range dataRows {
+			colIndex := feeColIndexStart
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
+					dataRowsIndex, colIndex, r)
 
-			if dataRowsIndex == 0 {
-				if xlsxSheetNum == 10 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-					}
-					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-					}
-				}
-
-				if xlsxSheetNum == 11 {
-					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-					}
-					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-					}
-					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-					}
-					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-					}
-				}
-
-				if xlsxSheetNum == 12 {
-					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-					}
-					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-					}
-					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-					}
-					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-					}
-				}
-
-				for repeatingRowsIndex, row := range repeatingRows {
-					if repeatingRowsIndex == 0 {
-						colIndex := feeColIndexStart
-						for _, repeatingHeader := range repeatingHeaders {
-							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
-								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
-							}
-							colIndex++
+				if dataRowsIndex == 0 {
+					if xlsxSheetNum == 10 {
+						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
 						}
-					} else if dataRowsIndex == 1 {
-						if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					if xlsxSheetNum == 11 {
+						if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+						}
+						if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					if xlsxSheetNum == 12 {
+						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+						}
+						if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+						if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					for repeatingRowsIndex, row := range repeatingRows {
+						if repeatingRowsIndex == 0 {
+							colIndex := feeColIndexStart
+							for _, repeatingHeader := range repeatingHeaders {
+								if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
+									return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
+								}
+								colIndex++
+							}
+						} else if dataRowsIndex == 1 {
+							if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+							}
 						}
 					}
 				}
 			}
 		}
-	}
-	return nil
+		return nil
+	*/
 }
 
 var verifyIntlOconusToOconusPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -1,5 +1,13 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 //same values used in each parse and verify function
 const feeColIndexStart int = 6  // start at column 6 to get the rates
 const feeRowIndexStart int = 10 // start at row 10 to get the rates
@@ -10,234 +18,220 @@ const destinationPriceAreaColumn int = 5
 
 // parseOconusToOconusPrices: parser for 3a) OCONUS to OCONUS Prices
 var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		logger.Info("Parsing OCONUS to OCONUS prices")
+	logger.Info("Parsing OCONUS to OCONUS prices")
 
-		var oconusToOconusPrices []models.StageOconusToOconusPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				oconusToOconusPrice := models.StageOconusToOconusPrice{
-					OriginIntlPriceAreaID:      getCell(row.Cells, originPriceAreaIDColumn),
-					OriginIntlPriceArea:        getCell(row.Cells, originPriceAreaColumn),
-					DestinationIntlPriceAreaID: getCell(row.Cells, destinationPriceAreaIDColumn),
-					DestinationIntlPriceArea:   getCell(row.Cells, destinationPriceAreaColumn),
-					Season:                     r,
-				}
+	var oconusToOconusPrices []models.StageOconusToOconusPrice
 
-				oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
-				}
-				oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			oconusToOconusPrice := models.StageOconusToOconusPrice{
+				OriginIntlPriceAreaID:      getCell(sheet, rowIdx, originPriceAreaIDColumn),
+				OriginIntlPriceArea:        getCell(sheet, rowIdx, originPriceAreaColumn),
+				DestinationIntlPriceAreaID: getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:   getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				Season:                     r,
 			}
+
+			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			oconusToOconusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageOconusToOconusPrice", oconusToOconusPrice))
+			}
+			oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
-		return oconusToOconusPrices, nil
-	*/
+	}
+	return oconusToOconusPrices, nil
 }
 
 // parseConusToOconusPrices: parser for 3b) CONUS to OCONUS Prices
 var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		logger.Info("Parsing CONUS to OCONUS prices")
+	logger.Info("Parsing CONUS to OCONUS prices")
 
-		var conusToOconusPrices []models.StageConusToOconusPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				conusToOconusPrice := models.StageConusToOconusPrice{
-					OriginDomesticPriceAreaCode: getCell(row.Cells, originPriceAreaIDColumn),
-					OriginDomesticPriceArea:     getCell(row.Cells, originPriceAreaColumn),
-					DestinationIntlPriceAreaID:  getCell(row.Cells, destinationPriceAreaIDColumn),
-					DestinationIntlPriceArea:    getCell(row.Cells, destinationPriceAreaColumn),
-					Season:                      r,
-				}
+	var conusToOconusPrices []models.StageConusToOconusPrice
 
-				conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
-				}
-				conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			conusToOconusPrice := models.StageConusToOconusPrice{
+				OriginDomesticPriceAreaCode: getCell(sheet, rowIdx, originPriceAreaIDColumn),
+				OriginDomesticPriceArea:     getCell(sheet, rowIdx, originPriceAreaColumn),
+				DestinationIntlPriceAreaID:  getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:    getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				Season:                      r,
 			}
+
+			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			conusToOconusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageConusToOconusPrice", conusToOconusPrice))
+			}
+			conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
-		return conusToOconusPrices, nil
-	*/
+	}
+	return conusToOconusPrices, nil
 }
 
 // parseOconusToConusPrices: parser for 3c) OCONUS to CONUS Prices
 var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		logger.Info("Parsing OCONUS to CONUS prices")
+	logger.Info("Parsing OCONUS to CONUS prices")
 
-		var oconusToConusPrices []models.StageOconusToConusPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				oconusToConusPrice := models.StageOconusToConusPrice{
-					OriginIntlPriceAreaID:            getCell(row.Cells, originPriceAreaIDColumn),
-					OriginIntlPriceArea:              getCell(row.Cells, originPriceAreaColumn),
-					DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationPriceAreaIDColumn),
-					DestinationDomesticPriceArea:     getCell(row.Cells, destinationPriceAreaColumn),
-					Season:                           r,
-				}
+	var oconusToConusPrices []models.StageOconusToConusPrice
 
-				oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
-				}
-				oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			oconusToConusPrice := models.StageOconusToConusPrice{
+				OriginIntlPriceAreaID:            getCell(sheet, rowIdx, originPriceAreaIDColumn),
+				OriginIntlPriceArea:              getCell(sheet, rowIdx, originPriceAreaColumn),
+				DestinationDomesticPriceAreaCode: getCell(sheet, rowIdx, destinationPriceAreaIDColumn),
+				DestinationDomesticPriceArea:     getCell(sheet, rowIdx, destinationPriceAreaColumn),
+				Season:                           r,
 			}
+
+			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			oconusToConusPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageOconusToConusPrice", oconusToConusPrice))
+			}
+			oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
-		return oconusToConusPrices, nil
-	*/
+	}
+	return oconusToConusPrices, nil
 }
 
 func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		// XLSX Sheet consts
-		xlsxDataSheetNum := xlsxSheetNum
+	// XLSX Sheet consts
+	xlsxDataSheetNum := xlsxSheetNum
 
-		// Check headers
-		const headerIndexStart = feeRowIndexStart - 3
-		const verifyHeaderIndexEnd = headerIndexStart + 2
-		const repeatingHeaderIndexStart = feeRowIndexStart - 2
-		const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
+	// Check headers
+	const headerIndexStart = feeRowIndexStart - 3
+	const verifyHeaderIndexEnd = headerIndexStart + 2
+	const repeatingHeaderIndexStart = feeRowIndexStart - 2
+	const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyInternationalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyInternationalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		// Verify header strings
-		repeatingHeaders := []string{
-			"HHG Shipping / Linehaul Price (except SIT) (per cwt)",
-			"UB Price (except SIT) (per cwt)",
-		}
+	// Verify header strings
+	repeatingHeaders := []string{
+		"HHG Shipping / Linehaul Price (except SIT) (per cwt)",
+		"UB Price (except SIT) (per cwt)",
+	}
 
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart:verifyHeaderIndexEnd]
-		repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[repeatingHeaderIndexStart:verifyHeaderIndexEnd2]
-		for dataRowsIndex, row := range dataRows {
-			colIndex := feeColIndexStart
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
-					dataRowsIndex, colIndex, r)
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for dataRowIdx := headerIndexStart; dataRowIdx < verifyHeaderIndexEnd; dataRowIdx++ {
+		colIndex := feeColIndexStart
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
+				dataRowIdx, colIndex, r)
 
-				if dataRowsIndex == 0 {
-					if xlsxSheetNum == 10 {
-						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+			if dataRowIdx == 0 {
+				if xlsxSheetNum == 10 {
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
 					}
-
-					if xlsxSheetNum == 11 {
-						if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
 					}
-
-					if xlsxSheetNum == 12 {
-						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-						if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
 					}
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
 
-					for repeatingRowsIndex, row := range repeatingRows {
-						if repeatingRowsIndex == 0 {
-							colIndex := feeColIndexStart
-							for _, repeatingHeader := range repeatingHeaders {
-								if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
-									return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
-								}
-								colIndex++
+				if xlsxSheetNum == 11 {
+					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
+					}
+					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
+					}
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
+					}
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
+
+				if xlsxSheetNum == 12 {
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaIDColumn)), verificationLog)
+					}
+					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, originPriceAreaColumn)), verificationLog)
+					}
+					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaIDColumn)), verificationLog)
+					}
+					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, dataRowIdx, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
+
+				for repeatingRowIdx := repeatingHeaderIndexStart; repeatingRowIdx < verifyHeaderIndexEnd2; repeatingRowIdx++ {
+					if repeatingRowIdx == 0 {
+						colIndex := feeColIndexStart
+						for _, repeatingHeader := range repeatingHeaders {
+							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(sheet, repeatingRowIdx, colIndex)) {
+								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(sheet, repeatingRowIdx, colIndex)), verificationLog)
 							}
-						} else if dataRowsIndex == 1 {
-							if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-							}
+							colIndex++
+						}
+					} else if dataRowIdx == 1 {
+						if "EXAMPLE" != removeWhiteSpace(getCell(sheet, repeatingRowIdx, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(sheet, repeatingRowIdx, originPriceAreaColumn)), verificationLog)
 						}
 					}
 				}
 			}
 		}
-		return nil
-	*/
+	}
+	return nil
 }
 
 var verifyIntlOconusToOconusPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {

--- a/pkg/parser/pricing/parse_management_counseling_transition_prices.go
+++ b/pkg/parser/pricing/parse_management_counseling_transition_prices.go
@@ -25,8 +25,8 @@ var parseShipmentManagementServicesPrices processXlsxSheet = func(params ParamCo
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := mgmtRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
-			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
+			ContractYear:      mustGetCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: mustGetCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -59,8 +59,8 @@ var parseCounselingServicesPrices processXlsxSheet = func(params ParamConfig, sh
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := counRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		cnslSrvcPrice := models.StageCounselingServicesPrice{
-			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
+			ContractYear:      mustGetCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: mustGetCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -93,8 +93,8 @@ var parseTransitionPrices processXlsxSheet = func(params ParamConfig, sheetIndex
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := tranRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		tranPrice := models.StageTransitionPrice{
-			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
+			ContractYear:      mustGetCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: mustGetCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -155,10 +155,10 @@ var verifyManagementCounselTransitionPrices verifyXlsxSheet = func(params ParamC
 
 func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, sheet *xlsx.Sheet, dataRowsIndexBegin, dataRowsIndexEnd int) error {
 	for rowIndex := dataRowsIndexBegin; rowIndex < dataRowsIndexEnd; rowIndex++ {
-		if header := getCell(sheet, rowIndex, contractYearColIndexStart); header != contractYearHeader {
+		if header := mustGetCell(sheet, rowIndex, contractYearColIndexStart); header != contractYearHeader {
 			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIndex, priceColumnIndexStart)); header != priceColumnHeader {
+		if header := removeWhiteSpace(mustGetCell(sheet, rowIndex, priceColumnIndexStart)); header != priceColumnHeader {
 			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
 		}
 	}

--- a/pkg/parser/pricing/parse_management_counseling_transition_prices.go
+++ b/pkg/parser/pricing/parse_management_counseling_transition_prices.go
@@ -1,169 +1,184 @@
 package pricing
 
 import (
-	"fmt"
-
-	"github.com/tealeg/xlsx/v2"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
+	"github.com/tealeg/xlsx/v3"
 )
 
 var parseShipmentManagementServicesPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-	const mgmtRowIndexStart int = 9
-	const contractYearColIndexStart int = 2
-	const priceColumnIndexStart int = 3
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+		const mgmtRowIndexStart int = 9
+		const contractYearColIndexStart int = 2
+		const priceColumnIndexStart int = 3
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseShipmentManagementServices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing shipment management services prices")
-	var mgmtPrices []models.StageShipmentManagementServicesPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart:]
-	for _, row := range dataRows {
-		shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
-			ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseShipmentManagementServices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if shipMgmtSrvcPrice.ContractYear == "" {
-			break
+		logger.Info("Parsing shipment management services prices")
+		var mgmtPrices []models.StageShipmentManagementServicesPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart:]
+		for _, row := range dataRows {
+			shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
+				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
+				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+			}
+
+			// All the rows are consecutive, if we get a blank we're done
+			if shipMgmtSrvcPrice.ContractYear == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageShipmentManagementServicesPrice", shipMgmtSrvcPrice))
+			}
+			mgmtPrices = append(mgmtPrices, shipMgmtSrvcPrice)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageShipmentManagementServicesPrice", shipMgmtSrvcPrice))
-		}
-		mgmtPrices = append(mgmtPrices, shipMgmtSrvcPrice)
-	}
-
-	return mgmtPrices, nil
+		return mgmtPrices, nil
+	*/
 }
 
 var parseCounselingServicesPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-	const counRowIndexStart int = 22
-	const contractYearColIndexStart int = 2
-	const priceColumnIndexStart int = 3
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+		const counRowIndexStart int = 22
+		const contractYearColIndexStart int = 2
+		const priceColumnIndexStart int = 3
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseCounselingServicesPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing counseling services prices")
-	var counPrices []models.StageCounselingServicesPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart:]
-	for _, row := range dataRows {
-		cnslSrvcPrice := models.StageCounselingServicesPrice{
-			ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseCounselingServicesPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if cnslSrvcPrice.ContractYear == "" {
-			break
+		logger.Info("Parsing counseling services prices")
+		var counPrices []models.StageCounselingServicesPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart:]
+		for _, row := range dataRows {
+			cnslSrvcPrice := models.StageCounselingServicesPrice{
+				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
+				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+			}
+
+			// All the rows are consecutive, if we get a blank we're done
+			if cnslSrvcPrice.ContractYear == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageCounselingServicesPrice", cnslSrvcPrice))
+			}
+			counPrices = append(counPrices, cnslSrvcPrice)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageCounselingServicesPrice", cnslSrvcPrice))
-		}
-		counPrices = append(counPrices, cnslSrvcPrice)
-	}
-
-	return counPrices, nil
+		return counPrices, nil
+	*/
 }
 
 var parseTransitionPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-	const tranRowIndexStart int = 34
-	const contractYearColIndexStart int = 2
-	const priceColumnIndexStart int = 3
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+		const tranRowIndexStart int = 34
+		const contractYearColIndexStart int = 2
+		const priceColumnIndexStart int = 3
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing transition prices")
-	var tranPrices []models.StageTransitionPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart:]
-	for _, row := range dataRows {
-		tranPrice := models.StageTransitionPrice{
-			ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		// All the rows are consecutive, if we get a blank we're done
-		if tranPrice.ContractYear == "" {
-			break
+		logger.Info("Parsing transition prices")
+		var tranPrices []models.StageTransitionPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart:]
+		for _, row := range dataRows {
+			tranPrice := models.StageTransitionPrice{
+				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
+				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
+			}
+
+			// All the rows are consecutive, if we get a blank we're done
+			if tranPrice.ContractYear == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageTransitionPrice", tranPrice))
+			}
+			tranPrices = append(tranPrices, tranPrice)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageTransitionPrice", tranPrice))
-		}
-		tranPrices = append(tranPrices, tranPrice)
-	}
-
-	return tranPrices, nil
+		return tranPrices, nil
+	*/
 }
 
 // verifyManagementCounselTransitionPrices: verification for: 4a) Mgmt., Coun., Trans. Prices
 var verifyManagementCounselTransitionPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-	const mgmtRowIndexStart int = 9
-	const counRowIndexStart int = 22
-	const tranRowIndexStart int = 34
-	const contractYearColIndexStart int = 2
-	const priceColumnIndexStart int = 3
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+		const mgmtRowIndexStart int = 9
+		const counRowIndexStart int = 22
+		const tranRowIndexStart int = 34
+		const contractYearColIndexStart int = 2
+		const priceColumnIndexStart int = 3
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyManagementCounselTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	// Shipment Management Services Headers
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-1 : mgmtRowIndexStart]
-	err := helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-	if err != nil {
-		return err
-	}
+		// Shipment Management Services Headers
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-1 : mgmtRowIndexStart]
+		err := helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-2 : mgmtRowIndexStart-1]
-	err = helperCheckHeadersFor4b("Contract Year", "ShipmentManagementServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-2 : mgmtRowIndexStart-1]
+		err = helperCheckHeadersFor4b("Contract Year", "ShipmentManagementServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+		if err != nil {
+			return err
+		}
 
-	// Counseling Services
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-1 : counRowIndexStart]
-	err = helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-	if err != nil {
-		return err
-	}
+		// Counseling Services
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-1 : counRowIndexStart]
+		err = helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+		if err != nil {
+			return err
+		}
 
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-2 : counRowIndexStart-1]
-	err = helperCheckHeadersFor4b("Contract Year", "CounselingServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-	if err != nil {
-		return err
-	}
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-2 : counRowIndexStart-1]
+		err = helperCheckHeadersFor4b("Contract Year", "CounselingServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+		if err != nil {
+			return err
+		}
 
-	// Transition
-	dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart-1 : tranRowIndexStart]
-	return helperCheckHeadersFor4b("Contract Year", "TransitionPrice($totalcost)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+		// Transition
+		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart-1 : tranRowIndexStart]
+		return helperCheckHeadersFor4b("Contract Year", "TransitionPrice($totalcost)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
+	*/
 }
 
 func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, dataRows []*xlsx.Row) error {
-	for _, dataRow := range dataRows {
-		if header := getCell(dataRow.Cells, contractYearColIndexStart); header != contractYearHeader {
-			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
-		}
-		if header := removeWhiteSpace(getCell(dataRow.Cells, priceColumnIndexStart)); header != priceColumnHeader {
-			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
-		}
-	}
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		for _, dataRow := range dataRows {
+			if header := getCell(dataRow.Cells, contractYearColIndexStart); header != contractYearHeader {
+				return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
+			}
+			if header := removeWhiteSpace(getCell(dataRow.Cells, priceColumnIndexStart)); header != priceColumnHeader {
+				return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
+			}
+		}
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_management_counseling_transition_prices.go
+++ b/pkg/parser/pricing/parse_management_counseling_transition_prices.go
@@ -1,184 +1,169 @@
 package pricing
 
 import (
+	"fmt"
+
 	"github.com/tealeg/xlsx/v3"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 var parseShipmentManagementServicesPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-		const mgmtRowIndexStart int = 9
-		const contractYearColIndexStart int = 2
-		const priceColumnIndexStart int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+	const mgmtRowIndexStart int = 9
+	const contractYearColIndexStart int = 2
+	const priceColumnIndexStart int = 3
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseShipmentManagementServices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseShipmentManagementServices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing shipment management services prices")
+	var mgmtPrices []models.StageShipmentManagementServicesPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := mgmtRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
+			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
 		}
 
-		logger.Info("Parsing shipment management services prices")
-		var mgmtPrices []models.StageShipmentManagementServicesPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart:]
-		for _, row := range dataRows {
-			shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
-				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if shipMgmtSrvcPrice.ContractYear == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageShipmentManagementServicesPrice", shipMgmtSrvcPrice))
-			}
-			mgmtPrices = append(mgmtPrices, shipMgmtSrvcPrice)
+		// All the rows are consecutive, if we get a blank we're done
+		if shipMgmtSrvcPrice.ContractYear == "" {
+			break
 		}
 
-		return mgmtPrices, nil
-	*/
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageShipmentManagementServicesPrice", shipMgmtSrvcPrice))
+		}
+		mgmtPrices = append(mgmtPrices, shipMgmtSrvcPrice)
+	}
+
+	return mgmtPrices, nil
 }
 
 var parseCounselingServicesPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-		const counRowIndexStart int = 22
-		const contractYearColIndexStart int = 2
-		const priceColumnIndexStart int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+	const counRowIndexStart int = 22
+	const contractYearColIndexStart int = 2
+	const priceColumnIndexStart int = 3
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseCounselingServicesPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseCounselingServicesPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing counseling services prices")
+	var counPrices []models.StageCounselingServicesPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := counRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		cnslSrvcPrice := models.StageCounselingServicesPrice{
+			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
 		}
 
-		logger.Info("Parsing counseling services prices")
-		var counPrices []models.StageCounselingServicesPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart:]
-		for _, row := range dataRows {
-			cnslSrvcPrice := models.StageCounselingServicesPrice{
-				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if cnslSrvcPrice.ContractYear == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageCounselingServicesPrice", cnslSrvcPrice))
-			}
-			counPrices = append(counPrices, cnslSrvcPrice)
+		// All the rows are consecutive, if we get a blank we're done
+		if cnslSrvcPrice.ContractYear == "" {
+			break
 		}
 
-		return counPrices, nil
-	*/
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageCounselingServicesPrice", cnslSrvcPrice))
+		}
+		counPrices = append(counPrices, cnslSrvcPrice)
+	}
+
+	return counPrices, nil
 }
 
 var parseTransitionPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-		const tranRowIndexStart int = 34
-		const contractYearColIndexStart int = 2
-		const priceColumnIndexStart int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+	const tranRowIndexStart int = 34
+	const contractYearColIndexStart int = 2
+	const priceColumnIndexStart int = 3
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing transition prices")
+	var tranPrices []models.StageTransitionPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := tranRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		tranPrice := models.StageTransitionPrice{
+			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
 		}
 
-		logger.Info("Parsing transition prices")
-		var tranPrices []models.StageTransitionPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart:]
-		for _, row := range dataRows {
-			tranPrice := models.StageTransitionPrice{
-				ContractYear:      getCell(row.Cells, contractYearColIndexStart),
-				PricePerTaskOrder: getCell(row.Cells, priceColumnIndexStart),
-			}
-
-			// All the rows are consecutive, if we get a blank we're done
-			if tranPrice.ContractYear == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageTransitionPrice", tranPrice))
-			}
-			tranPrices = append(tranPrices, tranPrice)
+		// All the rows are consecutive, if we get a blank we're done
+		if tranPrice.ContractYear == "" {
+			break
 		}
 
-		return tranPrices, nil
-	*/
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageTransitionPrice", tranPrice))
+		}
+		tranPrices = append(tranPrices, tranPrice)
+	}
+
+	return tranPrices, nil
 }
 
 // verifyManagementCounselTransitionPrices: verification for: 4a) Mgmt., Coun., Trans. Prices
 var verifyManagementCounselTransitionPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
-		const mgmtRowIndexStart int = 9
-		const counRowIndexStart int = 22
-		const tranRowIndexStart int = 34
-		const contractYearColIndexStart int = 2
-		const priceColumnIndexStart int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 16 // 4a) Mgmt., Coun., Trans. Prices
+	const mgmtRowIndexStart int = 9
+	const counRowIndexStart int = 22
+	const tranRowIndexStart int = 34
+	const contractYearColIndexStart int = 2
+	const priceColumnIndexStart int = 3
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyManagementCounselTransitionPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		// Shipment Management Services Headers
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-1 : mgmtRowIndexStart]
-		err := helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-		if err != nil {
-			return err
-		}
+	// Shipment Management Services Headers
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[mgmtRowIndexStart-2 : mgmtRowIndexStart-1]
-		err = helperCheckHeadersFor4b("Contract Year", "ShipmentManagementServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-		if err != nil {
-			return err
-		}
+	err := helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, sheet, mgmtRowIndexStart-1, mgmtRowIndexStart)
+	if err != nil {
+		return err
+	}
 
-		// Counseling Services
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-1 : counRowIndexStart]
-		err = helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-		if err != nil {
-			return err
-		}
+	err = helperCheckHeadersFor4b("Contract Year", "ShipmentManagementServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, sheet, mgmtRowIndexStart-2, mgmtRowIndexStart-1)
+	if err != nil {
+		return err
+	}
 
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[counRowIndexStart-2 : counRowIndexStart-1]
-		err = helperCheckHeadersFor4b("Contract Year", "CounselingServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-		if err != nil {
-			return err
-		}
+	// Counseling Services
+	err = helperCheckHeadersFor4b("EXAMPLE", "$X.XX", contractYearColIndexStart, priceColumnIndexStart, sheet, counRowIndexStart-1, counRowIndexStart)
+	if err != nil {
+		return err
+	}
 
-		// Transition
-		dataRows = params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[tranRowIndexStart-1 : tranRowIndexStart]
-		return helperCheckHeadersFor4b("Contract Year", "TransitionPrice($totalcost)", contractYearColIndexStart, priceColumnIndexStart, dataRows)
-	*/
+	err = helperCheckHeadersFor4b("Contract Year", "CounselingServicesPrice($pertaskorder)", contractYearColIndexStart, priceColumnIndexStart, sheet, counRowIndexStart-2, counRowIndexStart-1)
+	if err != nil {
+		return err
+	}
+
+	// Transition
+	return helperCheckHeadersFor4b("Contract Year", "TransitionPrice($totalcost)", contractYearColIndexStart, priceColumnIndexStart, sheet, tranRowIndexStart-1, tranRowIndexStart)
 }
 
-func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, dataRows []*xlsx.Row) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		for _, dataRow := range dataRows {
-			if header := getCell(dataRow.Cells, contractYearColIndexStart); header != contractYearHeader {
-				return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
-			}
-			if header := removeWhiteSpace(getCell(dataRow.Cells, priceColumnIndexStart)); header != priceColumnHeader {
-				return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
-			}
+func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, sheet *xlsx.Sheet, dataRowsIdxBegin, dataRowsIdxEnd int) error {
+	for rowIdx := dataRowsIdxBegin; rowIdx < dataRowsIdxEnd; rowIdx++ {
+		if header := getCell(sheet, rowIdx, contractYearColIndexStart); header != contractYearHeader {
+			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
 		}
-		return nil
-	*/
+		if header := removeWhiteSpace(getCell(sheet, rowIdx, priceColumnIndexStart)); header != priceColumnHeader {
+			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
+		}
+	}
+	return nil
 }

--- a/pkg/parser/pricing/parse_management_counseling_transition_prices.go
+++ b/pkg/parser/pricing/parse_management_counseling_transition_prices.go
@@ -22,12 +22,11 @@ var parseShipmentManagementServicesPrices processXlsxSheet = func(params ParamCo
 
 	logger.Info("Parsing shipment management services prices")
 	var mgmtPrices []models.StageShipmentManagementServicesPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := mgmtRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := mgmtRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		shipMgmtSrvcPrice := models.StageShipmentManagementServicesPrice{
-			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
+			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -57,12 +56,11 @@ var parseCounselingServicesPrices processXlsxSheet = func(params ParamConfig, sh
 
 	logger.Info("Parsing counseling services prices")
 	var counPrices []models.StageCounselingServicesPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := counRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := counRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		cnslSrvcPrice := models.StageCounselingServicesPrice{
-			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
+			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -92,12 +90,11 @@ var parseTransitionPrices processXlsxSheet = func(params ParamConfig, sheetIndex
 
 	logger.Info("Parsing transition prices")
 	var tranPrices []models.StageTransitionPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := tranRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := tranRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		tranPrice := models.StageTransitionPrice{
-			ContractYear:      getCell(sheet, rowIdx, contractYearColIndexStart),
-			PricePerTaskOrder: getCell(sheet, rowIdx, priceColumnIndexStart),
+			ContractYear:      getCell(sheet, rowIndex, contractYearColIndexStart),
+			PricePerTaskOrder: getCell(sheet, rowIndex, priceColumnIndexStart),
 		}
 
 		// All the rows are consecutive, if we get a blank we're done
@@ -156,12 +153,12 @@ var verifyManagementCounselTransitionPrices verifyXlsxSheet = func(params ParamC
 	return helperCheckHeadersFor4b("Contract Year", "TransitionPrice($totalcost)", contractYearColIndexStart, priceColumnIndexStart, sheet, tranRowIndexStart-1, tranRowIndexStart)
 }
 
-func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, sheet *xlsx.Sheet, dataRowsIdxBegin, dataRowsIdxEnd int) error {
-	for rowIdx := dataRowsIdxBegin; rowIdx < dataRowsIdxEnd; rowIdx++ {
-		if header := getCell(sheet, rowIdx, contractYearColIndexStart); header != contractYearHeader {
+func helperCheckHeadersFor4b(contractYearHeader string, priceColumnHeader string, contractYearColIndexStart int, priceColumnIndexStart int, sheet *xlsx.Sheet, dataRowsIndexBegin, dataRowsIndexEnd int) error {
+	for rowIndex := dataRowsIndexBegin; rowIndex < dataRowsIndexEnd; rowIndex++ {
+		if header := getCell(sheet, rowIndex, contractYearColIndexStart); header != contractYearHeader {
 			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", contractYearHeader, header)
 		}
-		if header := removeWhiteSpace(getCell(sheet, rowIdx, priceColumnIndexStart)); header != priceColumnHeader {
+		if header := removeWhiteSpace(getCell(sheet, rowIndex, priceColumnIndexStart)); header != priceColumnHeader {
 			return fmt.Errorf("verifyManagementCounselTransitionPrices expected to find header '%s', but received header '%s'", priceColumnHeader, header)
 		}
 	}

--- a/pkg/parser/pricing/parse_nonstandard_location_prices.go
+++ b/pkg/parser/pricing/parse_nonstandard_location_prices.go
@@ -1,140 +1,138 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 // parseNonStandardLocnPrices: parser for 3e) Non-Standard Loc'n Prices
 var parseNonStandardLocnPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 14        // 3e) Non-Standard Loc'n Prices
+	const feeColIndexStart int = 7         // start at column 7 to get the rates
+	const feeRowIndexStart int = 10        // start at row 10 to get the rates (NSRA to NSRA)
+	const feeRowNToOIndexStart int = 243   // start at row 243 to get the NSRA to OCONUS rates
+	const feeRowOToNIndexStart int = 1031  // start at row 1031 to get the OCONUS to NSRA rates
+	const feeRowNToCIndexStart int = 1819  // start at row 1819 to get the NSRA to CONUS rates
+	const feeRowOCToNIndexStart int = 2622 // start at row 2622 to get the CONUS to NSRA rates
+	const originIDColumn int = 2
+	const originAreaColumn int = 3
+	const destinationIDColumn int = 4
+	const destinationAreaColumn int = 5
+	const moveType int = 6
 
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 14        // 3e) Non-Standard Loc'n Prices
-		const feeColIndexStart int = 7         // start at column 7 to get the rates
-		const feeRowIndexStart int = 10        // start at row 10 to get the rates (NSRA to NSRA)
-		const feeRowNToOIndexStart int = 243   // start at row 243 to get the NSRA to OCONUS rates
-		const feeRowOToNIndexStart int = 1031  // start at row 1031 to get the OCONUS to NSRA rates
-		const feeRowNToCIndexStart int = 1819  // start at row 1819 to get the NSRA to CONUS rates
-		const feeRowOCToNIndexStart int = 2622 // start at row 2622 to get the CONUS to NSRA rates
-		const originIDColumn int = 2
-		const originAreaColumn int = 3
-		const destinationIDColumn int = 4
-		const destinationAreaColumn int = 5
-		const moveType int = 6
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	logger.Info("Parsing non-standard location prices")
 
-		logger.Info("Parsing non-standard location prices")
+	var nonStandardLocationPrices []models.StageNonStandardLocnPrice
 
-		var nonStandardLocationPrices []models.StageNonStandardLocnPrice
-		nToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-		nToORows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToOIndexStart:]
-		oToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOToNIndexStart:]
-		nToCRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToCIndexStart:]
-		cToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOCToNIndexStart:]
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 
-		moveTypeSections := [][]*xlsx.Row{
-			nToNRows,
-			nToORows,
-			oToNRows,
-			nToCRows,
-			cToNRows,
-		}
-		for _, section := range moveTypeSections {
-			for _, row := range section {
-				colIndex := feeColIndexStart
-				// All the rows are consecutive, if we get to a blank one we're done
-				if getCell(row.Cells, colIndex) == "" {
-					break
+	moveTypeSections := []int{
+		feeRowIndexStart,
+		feeRowNToOIndexStart,
+		feeRowOToNIndexStart,
+		feeRowNToCIndexStart,
+		feeRowOCToNIndexStart,
+	}
+	for _, section := range moveTypeSections {
+		for rowIdx := section; rowIdx < sheet.MaxRow; rowIdx++ {
+			// for _, row := range section {
+			colIndex := feeColIndexStart
+			// All the rows are consecutive, if we get to a blank one we're done
+			if getCell(sheet, rowIdx, colIndex) == "" {
+				break
+			}
+
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				nonStandardLocationPrice := models.StageNonStandardLocnPrice{
+					OriginID:        getCell(sheet, rowIdx, originIDColumn),
+					OriginArea:      getCell(sheet, rowIdx, originAreaColumn),
+					DestinationID:   getCell(sheet, rowIdx, destinationIDColumn),
+					DestinationArea: getCell(sheet, rowIdx, destinationAreaColumn),
+					MoveType:        getCell(sheet, rowIdx, moveType),
+					Season:          r,
 				}
+				nonStandardLocationPrice.HHGPrice = getCell(sheet, rowIdx, colIndex)
+				colIndex++
+				nonStandardLocationPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
 
-				// For each Rate Season
-				for _, r := range rateSeasons {
-					nonStandardLocationPrice := models.StageNonStandardLocnPrice{
-						OriginID:        getCell(row.Cells, originIDColumn),
-						OriginArea:      getCell(row.Cells, originAreaColumn),
-						DestinationID:   getCell(row.Cells, destinationIDColumn),
-						DestinationArea: getCell(row.Cells, destinationAreaColumn),
-						MoveType:        getCell(row.Cells, moveType),
-						Season:          r,
-					}
-					nonStandardLocationPrice.HHGPrice = getCell(row.Cells, colIndex)
-					colIndex++
-					nonStandardLocationPrice.UBPrice = getCell(row.Cells, colIndex)
-
-					if params.ShowOutput {
-						logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))
-					}
-					nonStandardLocationPrices = append(nonStandardLocationPrices, nonStandardLocationPrice)
-
-					colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))
 				}
+				nonStandardLocationPrices = append(nonStandardLocationPrices, nonStandardLocationPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 			}
 		}
+	}
 
-		return nonStandardLocationPrices, nil
-	*/
+	return nonStandardLocationPrices, nil
 }
 
 var verifyNonStandardLocnPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		const xlsxDataSheetNum = 14
+	const xlsxDataSheetNum = 14
 
-		const feeRowIndexStart int = 10 // this should match the same const in parse fn
-		const headerRowIndex int = feeRowIndexStart - 2
-		const originIDCol int = 2
-		const originAreaCol int = 3
-		const destinationIDCol int = 4
-		const destinationAreaCol int = 5
-		const moveTypeCol int = 6
-		const feeColIndexStart int = 7
+	const feeRowIndexStart int = 10 // this should match the same const in parse fn
+	const headerRowIndex int = feeRowIndexStart - 2
+	const originIDCol int = 2
+	const originAreaCol int = 3
+	const destinationIDCol int = 4
+	const destinationAreaCol int = 5
+	const moveTypeCol int = 6
+	const feeColIndexStart int = 7
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		repeatingHeaders := []string{
-			"HHGPrice(exceptSIT)(percwt)",
-			"UBPrice(exceptSIT)(percwt)",
-		}
+	repeatingHeaders := []string{
+		"HHGPrice(exceptSIT)(percwt)",
+		"UBPrice(exceptSIT)(percwt)",
+	}
 
-		mergedHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex-1 : headerRowIndex][0] // merged cell uses lower bound
-		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex : headerRowIndex+1][0]
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 
-		if err := verifyHeader(mergedHeaderRow, originIDCol, "OriginID"); err != nil {
-			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-		}
+	mergedHeaderRowIndex := headerRowIndex - 1 // merged cell uses lower bound
 
-		if err := verifyHeader(mergedHeaderRow, originAreaCol, "OriginArea"); err != nil {
-			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-		}
+	if err := verifyHeader(sheet, mergedHeaderRowIndex, originIDCol, "OriginID"); err != nil {
+		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+	}
 
-		if err := verifyHeader(mergedHeaderRow, destinationIDCol, "DestinationID"); err != nil {
-			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-		}
+	if err := verifyHeader(sheet, mergedHeaderRowIndex, originAreaCol, "OriginArea"); err != nil {
+		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+	}
 
-		if err := verifyHeader(mergedHeaderRow, destinationAreaCol, "DestinationArea"); err != nil {
-			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-		}
+	if err := verifyHeader(sheet, mergedHeaderRowIndex, destinationIDCol, "DestinationID"); err != nil {
+		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+	}
 
-		// note: Move Type row is not merged like the other non-price headers
-		if err := verifyHeader(headerRow, moveTypeCol, "MoveType"); err != nil {
-			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-		}
+	if err := verifyHeader(sheet, mergedHeaderRowIndex, destinationAreaCol, "DestinationArea"); err != nil {
+		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+	}
 
-		colIndex := feeColIndexStart
-		for _, season := range rateSeasons {
-			for _, header := range repeatingHeaders {
-				// don't use verifyHeader fn here so that we can name the season
-				if header != removeWhiteSpace(getCell(headerRow.Cells, colIndex)) {
-					return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(getCell(headerRow.Cells, colIndex)))
-				}
-				colIndex++
+	// note: Move Type row is not merged like the other non-price headers
+	if err := verifyHeader(sheet, headerRowIndex, moveTypeCol, "MoveType"); err != nil {
+		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+	}
+
+	colIndex := feeColIndexStart
+	for _, season := range rateSeasons {
+		for _, header := range repeatingHeaders {
+			// don't use verifyHeader fn here so that we can name the season
+			if header != removeWhiteSpace(getCell(sheet, headerRowIndex, colIndex)) {
+				return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(getCell(sheet, headerRowIndex, colIndex)))
 			}
 			colIndex++
 		}
-		return nil
-	*/
+		colIndex++
+	}
+	return nil
 }

--- a/pkg/parser/pricing/parse_nonstandard_location_prices.go
+++ b/pkg/parser/pricing/parse_nonstandard_location_prices.go
@@ -42,27 +42,26 @@ var parseNonStandardLocnPrices processXlsxSheet = func(params ParamConfig, sheet
 		feeRowOCToNIndexStart,
 	}
 	for _, section := range moveTypeSections {
-		for rowIdx := section; rowIdx < sheet.MaxRow; rowIdx++ {
-			// for _, row := range section {
+		for rowIndex := section; rowIndex < sheet.MaxRow; rowIndex++ {
 			colIndex := feeColIndexStart
 			// All the rows are consecutive, if we get to a blank one we're done
-			if getCell(sheet, rowIdx, colIndex) == "" {
+			if getCell(sheet, rowIndex, colIndex) == "" {
 				break
 			}
 
 			// For each Rate Season
 			for _, r := range rateSeasons {
 				nonStandardLocationPrice := models.StageNonStandardLocnPrice{
-					OriginID:        getCell(sheet, rowIdx, originIDColumn),
-					OriginArea:      getCell(sheet, rowIdx, originAreaColumn),
-					DestinationID:   getCell(sheet, rowIdx, destinationIDColumn),
-					DestinationArea: getCell(sheet, rowIdx, destinationAreaColumn),
-					MoveType:        getCell(sheet, rowIdx, moveType),
+					OriginID:        getCell(sheet, rowIndex, originIDColumn),
+					OriginArea:      getCell(sheet, rowIndex, originAreaColumn),
+					DestinationID:   getCell(sheet, rowIndex, destinationIDColumn),
+					DestinationArea: getCell(sheet, rowIndex, destinationAreaColumn),
+					MoveType:        getCell(sheet, rowIndex, moveType),
 					Season:          r,
 				}
-				nonStandardLocationPrice.HHGPrice = getCell(sheet, rowIdx, colIndex)
+				nonStandardLocationPrice.HHGPrice = getCell(sheet, rowIndex, colIndex)
 				colIndex++
-				nonStandardLocationPrice.UBPrice = getCell(sheet, rowIdx, colIndex)
+				nonStandardLocationPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
 
 				if params.ShowOutput {
 					logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))

--- a/pkg/parser/pricing/parse_nonstandard_location_prices.go
+++ b/pkg/parser/pricing/parse_nonstandard_location_prices.go
@@ -45,23 +45,23 @@ var parseNonStandardLocnPrices processXlsxSheet = func(params ParamConfig, sheet
 		for rowIndex := section; rowIndex < sheet.MaxRow; rowIndex++ {
 			colIndex := feeColIndexStart
 			// All the rows are consecutive, if we get to a blank one we're done
-			if getCell(sheet, rowIndex, colIndex) == "" {
+			if mustGetCell(sheet, rowIndex, colIndex) == "" {
 				break
 			}
 
 			// For each Rate Season
 			for _, r := range rateSeasons {
 				nonStandardLocationPrice := models.StageNonStandardLocnPrice{
-					OriginID:        getCell(sheet, rowIndex, originIDColumn),
-					OriginArea:      getCell(sheet, rowIndex, originAreaColumn),
-					DestinationID:   getCell(sheet, rowIndex, destinationIDColumn),
-					DestinationArea: getCell(sheet, rowIndex, destinationAreaColumn),
-					MoveType:        getCell(sheet, rowIndex, moveType),
+					OriginID:        mustGetCell(sheet, rowIndex, originIDColumn),
+					OriginArea:      mustGetCell(sheet, rowIndex, originAreaColumn),
+					DestinationID:   mustGetCell(sheet, rowIndex, destinationIDColumn),
+					DestinationArea: mustGetCell(sheet, rowIndex, destinationAreaColumn),
+					MoveType:        mustGetCell(sheet, rowIndex, moveType),
 					Season:          r,
 				}
-				nonStandardLocationPrice.HHGPrice = getCell(sheet, rowIndex, colIndex)
+				nonStandardLocationPrice.HHGPrice = mustGetCell(sheet, rowIndex, colIndex)
 				colIndex++
-				nonStandardLocationPrice.UBPrice = getCell(sheet, rowIndex, colIndex)
+				nonStandardLocationPrice.UBPrice = mustGetCell(sheet, rowIndex, colIndex)
 
 				if params.ShowOutput {
 					logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))
@@ -126,8 +126,8 @@ var verifyNonStandardLocnPrices verifyXlsxSheet = func(params ParamConfig, sheet
 	for _, season := range rateSeasons {
 		for _, header := range repeatingHeaders {
 			// don't use verifyHeader fn here so that we can name the season
-			if header != removeWhiteSpace(getCell(sheet, headerRowIndex, colIndex)) {
-				return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(getCell(sheet, headerRowIndex, colIndex)))
+			if header != removeWhiteSpace(mustGetCell(sheet, headerRowIndex, colIndex)) {
+				return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(mustGetCell(sheet, headerRowIndex, colIndex)))
 			}
 			colIndex++
 		}

--- a/pkg/parser/pricing/parse_nonstandard_location_prices.go
+++ b/pkg/parser/pricing/parse_nonstandard_location_prices.go
@@ -1,141 +1,140 @@
 package pricing
 
-import (
-	"fmt"
-
-	"github.com/tealeg/xlsx/v2"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 // parseNonStandardLocnPrices: parser for 3e) Non-Standard Loc'n Prices
 var parseNonStandardLocnPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
 
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 14        // 3e) Non-Standard Loc'n Prices
-	const feeColIndexStart int = 7         // start at column 7 to get the rates
-	const feeRowIndexStart int = 10        // start at row 10 to get the rates (NSRA to NSRA)
-	const feeRowNToOIndexStart int = 243   // start at row 243 to get the NSRA to OCONUS rates
-	const feeRowOToNIndexStart int = 1031  // start at row 1031 to get the OCONUS to NSRA rates
-	const feeRowNToCIndexStart int = 1819  // start at row 1819 to get the NSRA to CONUS rates
-	const feeRowOCToNIndexStart int = 2622 // start at row 2622 to get the CONUS to NSRA rates
-	const originIDColumn int = 2
-	const originAreaColumn int = 3
-	const destinationIDColumn int = 4
-	const destinationAreaColumn int = 5
-	const moveType int = 6
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 14        // 3e) Non-Standard Loc'n Prices
+		const feeColIndexStart int = 7         // start at column 7 to get the rates
+		const feeRowIndexStart int = 10        // start at row 10 to get the rates (NSRA to NSRA)
+		const feeRowNToOIndexStart int = 243   // start at row 243 to get the NSRA to OCONUS rates
+		const feeRowOToNIndexStart int = 1031  // start at row 1031 to get the OCONUS to NSRA rates
+		const feeRowNToCIndexStart int = 1819  // start at row 1819 to get the NSRA to CONUS rates
+		const feeRowOCToNIndexStart int = 2622 // start at row 2622 to get the CONUS to NSRA rates
+		const originIDColumn int = 2
+		const originAreaColumn int = 3
+		const destinationIDColumn int = 4
+		const destinationAreaColumn int = 5
+		const moveType int = 6
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	logger.Info("Parsing non-standard location prices")
+		logger.Info("Parsing non-standard location prices")
 
-	var nonStandardLocationPrices []models.StageNonStandardLocnPrice
-	nToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-	nToORows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToOIndexStart:]
-	oToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOToNIndexStart:]
-	nToCRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToCIndexStart:]
-	cToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOCToNIndexStart:]
+		var nonStandardLocationPrices []models.StageNonStandardLocnPrice
+		nToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+		nToORows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToOIndexStart:]
+		oToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOToNIndexStart:]
+		nToCRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToCIndexStart:]
+		cToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowOCToNIndexStart:]
 
-	moveTypeSections := [][]*xlsx.Row{
-		nToNRows,
-		nToORows,
-		oToNRows,
-		nToCRows,
-		cToNRows,
-	}
-	for _, section := range moveTypeSections {
-		for _, row := range section {
-			colIndex := feeColIndexStart
-			// All the rows are consecutive, if we get to a blank one we're done
-			if getCell(row.Cells, colIndex) == "" {
-				break
-			}
-
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				nonStandardLocationPrice := models.StageNonStandardLocnPrice{
-					OriginID:        getCell(row.Cells, originIDColumn),
-					OriginArea:      getCell(row.Cells, originAreaColumn),
-					DestinationID:   getCell(row.Cells, destinationIDColumn),
-					DestinationArea: getCell(row.Cells, destinationAreaColumn),
-					MoveType:        getCell(row.Cells, moveType),
-					Season:          r,
+		moveTypeSections := [][]*xlsx.Row{
+			nToNRows,
+			nToORows,
+			oToNRows,
+			nToCRows,
+			cToNRows,
+		}
+		for _, section := range moveTypeSections {
+			for _, row := range section {
+				colIndex := feeColIndexStart
+				// All the rows are consecutive, if we get to a blank one we're done
+				if getCell(row.Cells, colIndex) == "" {
+					break
 				}
-				nonStandardLocationPrice.HHGPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				nonStandardLocationPrice.UBPrice = getCell(row.Cells, colIndex)
 
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))
+				// For each Rate Season
+				for _, r := range rateSeasons {
+					nonStandardLocationPrice := models.StageNonStandardLocnPrice{
+						OriginID:        getCell(row.Cells, originIDColumn),
+						OriginArea:      getCell(row.Cells, originAreaColumn),
+						DestinationID:   getCell(row.Cells, destinationIDColumn),
+						DestinationArea: getCell(row.Cells, destinationAreaColumn),
+						MoveType:        getCell(row.Cells, moveType),
+						Season:          r,
+					}
+					nonStandardLocationPrice.HHGPrice = getCell(row.Cells, colIndex)
+					colIndex++
+					nonStandardLocationPrice.UBPrice = getCell(row.Cells, colIndex)
+
+					if params.ShowOutput {
+						logger.Info("", zap.Any("StageNonStandardLocnPrice", nonStandardLocationPrice))
+					}
+					nonStandardLocationPrices = append(nonStandardLocationPrices, nonStandardLocationPrice)
+
+					colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 				}
-				nonStandardLocationPrices = append(nonStandardLocationPrices, nonStandardLocationPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 			}
 		}
-	}
 
-	return nonStandardLocationPrices, nil
+		return nonStandardLocationPrices, nil
+	*/
 }
 
 var verifyNonStandardLocnPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	const xlsxDataSheetNum = 14
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		const xlsxDataSheetNum = 14
 
-	const feeRowIndexStart int = 10 // this should match the same const in parse fn
-	const headerRowIndex int = feeRowIndexStart - 2
-	const originIDCol int = 2
-	const originAreaCol int = 3
-	const destinationIDCol int = 4
-	const destinationAreaCol int = 5
-	const moveTypeCol int = 6
-	const feeColIndexStart int = 7
+		const feeRowIndexStart int = 10 // this should match the same const in parse fn
+		const headerRowIndex int = feeRowIndexStart - 2
+		const originIDCol int = 2
+		const originAreaCol int = 3
+		const destinationIDCol int = 4
+		const destinationAreaCol int = 5
+		const moveTypeCol int = 6
+		const feeColIndexStart int = 7
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
 
-	repeatingHeaders := []string{
-		"HHGPrice(exceptSIT)(percwt)",
-		"UBPrice(exceptSIT)(percwt)",
-	}
+		repeatingHeaders := []string{
+			"HHGPrice(exceptSIT)(percwt)",
+			"UBPrice(exceptSIT)(percwt)",
+		}
 
-	mergedHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex-1 : headerRowIndex][0] // merged cell uses lower bound
-	headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex : headerRowIndex+1][0]
+		mergedHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex-1 : headerRowIndex][0] // merged cell uses lower bound
+		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerRowIndex : headerRowIndex+1][0]
 
-	if err := verifyHeader(mergedHeaderRow, originIDCol, "OriginID"); err != nil {
-		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-	}
+		if err := verifyHeader(mergedHeaderRow, originIDCol, "OriginID"); err != nil {
+			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+		}
 
-	if err := verifyHeader(mergedHeaderRow, originAreaCol, "OriginArea"); err != nil {
-		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-	}
+		if err := verifyHeader(mergedHeaderRow, originAreaCol, "OriginArea"); err != nil {
+			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+		}
 
-	if err := verifyHeader(mergedHeaderRow, destinationIDCol, "DestinationID"); err != nil {
-		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-	}
+		if err := verifyHeader(mergedHeaderRow, destinationIDCol, "DestinationID"); err != nil {
+			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+		}
 
-	if err := verifyHeader(mergedHeaderRow, destinationAreaCol, "DestinationArea"); err != nil {
-		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-	}
+		if err := verifyHeader(mergedHeaderRow, destinationAreaCol, "DestinationArea"); err != nil {
+			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+		}
 
-	// note: Move Type row is not merged like the other non-price headers
-	if err := verifyHeader(headerRow, moveTypeCol, "MoveType"); err != nil {
-		return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
-	}
+		// note: Move Type row is not merged like the other non-price headers
+		if err := verifyHeader(headerRow, moveTypeCol, "MoveType"); err != nil {
+			return fmt.Errorf("verifyNonStandardLocnPrices verification failure: %w", err)
+		}
 
-	colIndex := feeColIndexStart
-	for _, season := range rateSeasons {
-		for _, header := range repeatingHeaders {
-			// don't use verifyHeader fn here so that we can name the season
-			if header != removeWhiteSpace(getCell(headerRow.Cells, colIndex)) {
-				return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(getCell(headerRow.Cells, colIndex)))
+		colIndex := feeColIndexStart
+		for _, season := range rateSeasons {
+			for _, header := range repeatingHeaders {
+				// don't use verifyHeader fn here so that we can name the season
+				if header != removeWhiteSpace(getCell(headerRow.Cells, colIndex)) {
+					return fmt.Errorf("format error: Header for '%s' season '%s' is missing, got '%s' instead", season, header, removeWhiteSpace(getCell(headerRow.Cells, colIndex)))
+				}
+				colIndex++
 			}
 			colIndex++
 		}
-		colIndex++
-	}
-	return nil
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_other_intl_prices.go
+++ b/pkg/parser/pricing/parse_other_intl_prices.go
@@ -1,124 +1,124 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 // parseOtherIntlPrices: parser for: 3d) Other International Prices
 var parseOtherIntlPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 13 // 3d) International Other Prices
-	const feeColIndexStart int = 4  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const priceAreaCodeColumn int = 2
-	const priceAreaNameColumn int = 3
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 13 // 3d) International Other Prices
+		const feeColIndexStart int = 4  // start at column 6 to get the rates
+		const feeRowIndexStart int = 10 // start at row 10 to get the rates
+		const priceAreaCodeColumn int = 2
+		const priceAreaNameColumn int = 3
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing other international prices")
-
-	var otherIntlPrices []models.StageOtherIntlPrice
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-
-	for _, row := range dataRows {
-		colIndex := feeColIndexStart
-		// All the rows are consecutive, if we get to a blank one we're done
-		if getCell(row.Cells, colIndex) == "" {
-			break
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		for _, s := range rateSeasons {
-			otherIntlPrice := models.StageOtherIntlPrice{
-				RateAreaCode: getCell(row.Cells, priceAreaCodeColumn),
-				RateAreaName: getCell(row.Cells, priceAreaNameColumn),
-				Season:       s,
-			}
-			otherIntlPrice.HHGOriginPackPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.HHGDestinationUnPackPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.UBOriginPackPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.UBDestinationUnPackPrice = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.SITLte50Miles = getCell(row.Cells, colIndex)
-			colIndex++
-			otherIntlPrice.SITGt50Miles = getCell(row.Cells, colIndex)
-			colIndex += 2
+		logger.Info("Parsing other international prices")
 
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageOtherIntlPrice", otherIntlPrice))
+		var otherIntlPrices []models.StageOtherIntlPrice
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+
+		for _, row := range dataRows {
+			colIndex := feeColIndexStart
+			// All the rows are consecutive, if we get to a blank one we're done
+			if getCell(row.Cells, colIndex) == "" {
+				break
 			}
-			otherIntlPrices = append(otherIntlPrices, otherIntlPrice)
+
+			for _, s := range rateSeasons {
+				otherIntlPrice := models.StageOtherIntlPrice{
+					RateAreaCode: getCell(row.Cells, priceAreaCodeColumn),
+					RateAreaName: getCell(row.Cells, priceAreaNameColumn),
+					Season:       s,
+				}
+				otherIntlPrice.HHGOriginPackPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.HHGDestinationUnPackPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.UBOriginPackPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.UBDestinationUnPackPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.SITLte50Miles = getCell(row.Cells, colIndex)
+				colIndex++
+				otherIntlPrice.SITGt50Miles = getCell(row.Cells, colIndex)
+				colIndex += 2
+
+				if params.ShowOutput {
+					logger.Info("", zap.Any("StageOtherIntlPrice", otherIntlPrice))
+				}
+				otherIntlPrices = append(otherIntlPrices, otherIntlPrice)
+			}
 		}
-	}
 
-	return otherIntlPrices, nil
+		return otherIntlPrices, nil
+	*/
 }
 
 var verifyOtherIntlPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 13 // 3d) International Other Prices
-	const feeColIndexStart int = 4  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const priceAreaCodeColumn int = 2
-	const priceAreaNameColumn int = 3
-
-	repeatingHeaders := []string{
-		"HHGOriginPackPrice(percwt)",
-		"HHGDestinationUnpackPrice(percwt)",
-		"UBOriginPackPrice(percwt)",
-		"UBDestinationUnpackPrice(percwt)",
-		"Origin/DestinationSITFirstDay&WarehouseHandling(percwt)",
-		"Origin/DestinationSITAdd'lDays(percwt)",
-		"SITPickup/Delivery≤50Miles(percwt)",
-		"SITPickup/Delivery>50Miles(percwtpermile)",
-	}
-
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	nonPriceHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-3 : feeRowIndexStart-2][0]
-	headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-2 : feeRowIndexStart-1][0]
-
-	if err := verifyHeader(nonPriceHeaderRow, priceAreaCodeColumn, "PriceAreaCode/ID"); err != nil {
-		return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-
-	}
-
-	priceAreaNameHeader := "InternationalPriceArea(PPIRA)/DomesticPriceArea(PPDRA)/Non-StandardRateArea"
-	if err := verifyHeader(nonPriceHeaderRow, priceAreaNameColumn, priceAreaNameHeader); err != nil {
-		return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-	}
-
-	// NonPeak season headers
-	colIndex := feeColIndexStart
-	for _, repeatingHeader := range repeatingHeaders {
-		if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
-			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-		}
-		colIndex++
-	}
-	colIndex++
-
-	// Peak season headers
-	for _, repeatingHeader := range repeatingHeaders {
-		if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
-			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-		}
-		colIndex++
-	}
-
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 13 // 3d) International Other Prices
+		const feeColIndexStart int = 4  // start at column 6 to get the rates
+		const feeRowIndexStart int = 10 // start at row 10 to get the rates
+		const priceAreaCodeColumn int = 2
+		const priceAreaNameColumn int = 3
+
+		repeatingHeaders := []string{
+			"HHGOriginPackPrice(percwt)",
+			"HHGDestinationUnpackPrice(percwt)",
+			"UBOriginPackPrice(percwt)",
+			"UBDestinationUnpackPrice(percwt)",
+			"Origin/DestinationSITFirstDay&WarehouseHandling(percwt)",
+			"Origin/DestinationSITAdd'lDays(percwt)",
+			"SITPickup/Delivery≤50Miles(percwt)",
+			"SITPickup/Delivery>50Miles(percwtpermile)",
+		}
+
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
+
+		nonPriceHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-3 : feeRowIndexStart-2][0]
+		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-2 : feeRowIndexStart-1][0]
+
+		if err := verifyHeader(nonPriceHeaderRow, priceAreaCodeColumn, "PriceAreaCode/ID"); err != nil {
+			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+
+		}
+
+		priceAreaNameHeader := "InternationalPriceArea(PPIRA)/DomesticPriceArea(PPDRA)/Non-StandardRateArea"
+		if err := verifyHeader(nonPriceHeaderRow, priceAreaNameColumn, priceAreaNameHeader); err != nil {
+			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+		}
+
+		// NonPeak season headers
+		colIndex := feeColIndexStart
+		for _, repeatingHeader := range repeatingHeaders {
+			if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
+				return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+			}
+			colIndex++
+		}
+		colIndex++
+
+		// Peak season headers
+		for _, repeatingHeader := range repeatingHeaders {
+			if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
+				return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+			}
+			colIndex++
+		}
+
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_other_intl_prices.go
+++ b/pkg/parser/pricing/parse_other_intl_prices.go
@@ -1,124 +1,127 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 // parseOtherIntlPrices: parser for: 3d) Other International Prices
 var parseOtherIntlPrices processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 13 // 3d) International Other Prices
-		const feeColIndexStart int = 4  // start at column 6 to get the rates
-		const feeRowIndexStart int = 10 // start at row 10 to get the rates
-		const priceAreaCodeColumn int = 2
-		const priceAreaNameColumn int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 13 // 3d) International Other Prices
+	const feeColIndexStart int = 4  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const priceAreaCodeColumn int = 2
+	const priceAreaNameColumn int = 3
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing other international prices")
+
+	var otherIntlPrices []models.StageOtherIntlPrice
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+
+	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		colIndex := feeColIndexStart
+		// All the rows are consecutive, if we get to a blank one we're done
+		if getCell(sheet, rowIdx, colIndex) == "" {
+			break
 		}
 
-		logger.Info("Parsing other international prices")
-
-		var otherIntlPrices []models.StageOtherIntlPrice
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
-
-		for _, row := range dataRows {
-			colIndex := feeColIndexStart
-			// All the rows are consecutive, if we get to a blank one we're done
-			if getCell(row.Cells, colIndex) == "" {
-				break
+		for _, s := range rateSeasons {
+			otherIntlPrice := models.StageOtherIntlPrice{
+				RateAreaCode: getCell(sheet, rowIdx, priceAreaCodeColumn),
+				RateAreaName: getCell(sheet, rowIdx, priceAreaNameColumn),
+				Season:       s,
 			}
+			otherIntlPrice.HHGOriginPackPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.HHGDestinationUnPackPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.UBOriginPackPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.UBDestinationUnPackPrice = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.SITLte50Miles = getCell(sheet, rowIdx, colIndex)
+			colIndex++
+			otherIntlPrice.SITGt50Miles = getCell(sheet, rowIdx, colIndex)
+			colIndex += 2
 
-			for _, s := range rateSeasons {
-				otherIntlPrice := models.StageOtherIntlPrice{
-					RateAreaCode: getCell(row.Cells, priceAreaCodeColumn),
-					RateAreaName: getCell(row.Cells, priceAreaNameColumn),
-					Season:       s,
-				}
-				otherIntlPrice.HHGOriginPackPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.HHGDestinationUnPackPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.UBOriginPackPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.UBDestinationUnPackPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.OriginDestinationSITAddlDays = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.SITLte50Miles = getCell(row.Cells, colIndex)
-				colIndex++
-				otherIntlPrice.SITGt50Miles = getCell(row.Cells, colIndex)
-				colIndex += 2
-
-				if params.ShowOutput {
-					logger.Info("", zap.Any("StageOtherIntlPrice", otherIntlPrice))
-				}
-				otherIntlPrices = append(otherIntlPrices, otherIntlPrice)
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageOtherIntlPrice", otherIntlPrice))
 			}
+			otherIntlPrices = append(otherIntlPrices, otherIntlPrice)
 		}
+	}
 
-		return otherIntlPrices, nil
-	*/
+	return otherIntlPrices, nil
 }
 
 var verifyOtherIntlPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 13 // 3d) International Other Prices
-		const feeColIndexStart int = 4  // start at column 6 to get the rates
-		const feeRowIndexStart int = 10 // start at row 10 to get the rates
-		const priceAreaCodeColumn int = 2
-		const priceAreaNameColumn int = 3
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 13 // 3d) International Other Prices
+	const feeColIndexStart int = 4  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const priceAreaCodeColumn int = 2
+	const priceAreaNameColumn int = 3
 
-		repeatingHeaders := []string{
-			"HHGOriginPackPrice(percwt)",
-			"HHGDestinationUnpackPrice(percwt)",
-			"UBOriginPackPrice(percwt)",
-			"UBDestinationUnpackPrice(percwt)",
-			"Origin/DestinationSITFirstDay&WarehouseHandling(percwt)",
-			"Origin/DestinationSITAdd'lDays(percwt)",
-			"SITPickup/Delivery≤50Miles(percwt)",
-			"SITPickup/Delivery>50Miles(percwtpermile)",
-		}
+	repeatingHeaders := []string{
+		"HHGOriginPackPrice(percwt)",
+		"HHGDestinationUnpackPrice(percwt)",
+		"UBOriginPackPrice(percwt)",
+		"UBDestinationUnpackPrice(percwt)",
+		"Origin/DestinationSITFirstDay&WarehouseHandling(percwt)",
+		"Origin/DestinationSITAdd'lDays(percwt)",
+		"SITPickup/Delivery≤50Miles(percwt)",
+		"SITPickup/Delivery>50Miles(percwtpermile)",
+	}
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		nonPriceHeaderRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-3 : feeRowIndexStart-2][0]
-		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart-2 : feeRowIndexStart-1][0]
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 
-		if err := verifyHeader(nonPriceHeaderRow, priceAreaCodeColumn, "PriceAreaCode/ID"); err != nil {
+	nonPriceHeaderIndex := feeRowIndexStart - 3
+	headerRowIndex := feeRowIndexStart - 2
+
+	if err := verifyHeader(sheet, nonPriceHeaderIndex, priceAreaCodeColumn, "PriceAreaCode/ID"); err != nil {
+		return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+
+	}
+
+	priceAreaNameHeader := "InternationalPriceArea(PPIRA)/DomesticPriceArea(PPDRA)/Non-StandardRateArea"
+	if err := verifyHeader(sheet, nonPriceHeaderIndex, priceAreaNameColumn, priceAreaNameHeader); err != nil {
+		return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
+	}
+
+	// NonPeak season headers
+	colIndex := feeColIndexStart
+	for _, repeatingHeader := range repeatingHeaders {
+		if err := verifyHeader(sheet, headerRowIndex, colIndex, repeatingHeader); err != nil {
 			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-
-		}
-
-		priceAreaNameHeader := "InternationalPriceArea(PPIRA)/DomesticPriceArea(PPDRA)/Non-StandardRateArea"
-		if err := verifyHeader(nonPriceHeaderRow, priceAreaNameColumn, priceAreaNameHeader); err != nil {
-			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-		}
-
-		// NonPeak season headers
-		colIndex := feeColIndexStart
-		for _, repeatingHeader := range repeatingHeaders {
-			if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
-				return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-			}
-			colIndex++
 		}
 		colIndex++
+	}
+	colIndex++
 
-		// Peak season headers
-		for _, repeatingHeader := range repeatingHeaders {
-			if err := verifyHeader(headerRow, colIndex, repeatingHeader); err != nil {
-				return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
-			}
-			colIndex++
+	// Peak season headers
+	for _, repeatingHeader := range repeatingHeaders {
+		if err := verifyHeader(sheet, headerRowIndex, colIndex, repeatingHeader); err != nil {
+			return fmt.Errorf("verifyOtherIntlPrices verification failure: %w", err)
 		}
+		colIndex++
+	}
 
-		return nil
-	*/
+	return nil
 }

--- a/pkg/parser/pricing/parse_other_intl_prices.go
+++ b/pkg/parser/pricing/parse_other_intl_prices.go
@@ -28,31 +28,31 @@ var parseOtherIntlPrices processXlsxSheet = func(params ParamConfig, sheetIndex 
 	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// All the rows are consecutive, if we get to a blank one we're done
-		if getCell(sheet, rowIndex, colIndex) == "" {
+		if mustGetCell(sheet, rowIndex, colIndex) == "" {
 			break
 		}
 
 		for _, s := range rateSeasons {
 			otherIntlPrice := models.StageOtherIntlPrice{
-				RateAreaCode: getCell(sheet, rowIndex, priceAreaCodeColumn),
-				RateAreaName: getCell(sheet, rowIndex, priceAreaNameColumn),
+				RateAreaCode: mustGetCell(sheet, rowIndex, priceAreaCodeColumn),
+				RateAreaName: mustGetCell(sheet, rowIndex, priceAreaNameColumn),
 				Season:       s,
 			}
-			otherIntlPrice.HHGOriginPackPrice = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.HHGOriginPackPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.HHGDestinationUnPackPrice = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.HHGDestinationUnPackPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.UBOriginPackPrice = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.UBOriginPackPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.UBDestinationUnPackPrice = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.UBDestinationUnPackPrice = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.OriginDestinationSITAddlDays = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.SITLte50Miles = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.SITLte50Miles = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.SITGt50Miles = getCell(sheet, rowIndex, colIndex)
+			otherIntlPrice.SITGt50Miles = mustGetCell(sheet, rowIndex, colIndex)
 			colIndex += 2
 
 			if params.ShowOutput {

--- a/pkg/parser/pricing/parse_other_intl_prices.go
+++ b/pkg/parser/pricing/parse_other_intl_prices.go
@@ -24,37 +24,35 @@ var parseOtherIntlPrices processXlsxSheet = func(params ParamConfig, sheetIndex 
 	logger.Info("Parsing other international prices")
 
 	var otherIntlPrices []models.StageOtherIntlPrice
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-
-	for rowIdx := feeRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := feeRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		colIndex := feeColIndexStart
 		// All the rows are consecutive, if we get to a blank one we're done
-		if getCell(sheet, rowIdx, colIndex) == "" {
+		if getCell(sheet, rowIndex, colIndex) == "" {
 			break
 		}
 
 		for _, s := range rateSeasons {
 			otherIntlPrice := models.StageOtherIntlPrice{
-				RateAreaCode: getCell(sheet, rowIdx, priceAreaCodeColumn),
-				RateAreaName: getCell(sheet, rowIdx, priceAreaNameColumn),
+				RateAreaCode: getCell(sheet, rowIndex, priceAreaCodeColumn),
+				RateAreaName: getCell(sheet, rowIndex, priceAreaNameColumn),
 				Season:       s,
 			}
-			otherIntlPrice.HHGOriginPackPrice = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.HHGOriginPackPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.HHGDestinationUnPackPrice = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.HHGDestinationUnPackPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.UBOriginPackPrice = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.UBOriginPackPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.UBDestinationUnPackPrice = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.UBDestinationUnPackPrice = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.OriginDestinationSITFirstDayWarehouse = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.OriginDestinationSITAddlDays = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.SITLte50Miles = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.SITLte50Miles = getCell(sheet, rowIndex, colIndex)
 			colIndex++
-			otherIntlPrice.SITGt50Miles = getCell(sheet, rowIdx, colIndex)
+			otherIntlPrice.SITGt50Miles = getCell(sheet, rowIndex, colIndex)
 			colIndex += 2
 
 			if params.ShowOutput {

--- a/pkg/parser/pricing/parse_price_escalation_discount.go
+++ b/pkg/parser/pricing/parse_price_escalation_discount.go
@@ -1,76 +1,78 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 var parsePriceEscalationDiscount processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		const xlsxDataSheetNum int = 18
-		const discountsRowIndexStart int = 9
-		const contractYearColumn int = 7
-		const forecastingAdjustmentColumn int = 8
-		const discountColumn int = 9
-		const priceEscalationColumn int = 10
+	const xlsxDataSheetNum int = 18
+	const discountsRowIndexStart int = 9
+	const contractYearColumn int = 7
+	const forecastingAdjustmentColumn int = 8
+	const discountColumn int = 9
+	const priceEscalationColumn int = 10
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parsePriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parsePriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing price escalation discount")
+	var priceEscalationDiscounts []models.StagePriceEscalationDiscount
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := discountsRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		priceEscalationDiscount := models.StagePriceEscalationDiscount{
+			ContractYear:          getCell(sheet, rowIdx, contractYearColumn),
+			ForecastingAdjustment: getCell(sheet, rowIdx, forecastingAdjustmentColumn),
+			Discount:              getCell(sheet, rowIdx, discountColumn),
+			PriceEscalation:       getCell(sheet, rowIdx, priceEscalationColumn),
 		}
 
-		logger.Info("Parsing price escalation discount")
-		var priceEscalationDiscounts []models.StagePriceEscalationDiscount
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart:]
-		for _, row := range dataRows {
-			priceEscalationDiscount := models.StagePriceEscalationDiscount{
-				ContractYear:          getCell(row.Cells, contractYearColumn),
-				ForecastingAdjustment: getCell(row.Cells, forecastingAdjustmentColumn),
-				Discount:              getCell(row.Cells, discountColumn),
-				PriceEscalation:       getCell(row.Cells, priceEscalationColumn),
-			}
-
-			if priceEscalationDiscount.ContractYear == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StagePriceEscalationDiscount", priceEscalationDiscount))
-			}
-			priceEscalationDiscounts = append(priceEscalationDiscounts, priceEscalationDiscount)
+		if priceEscalationDiscount.ContractYear == "" {
+			break
 		}
 
-		return priceEscalationDiscounts, nil
-	*/
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StagePriceEscalationDiscount", priceEscalationDiscount))
+		}
+		priceEscalationDiscounts = append(priceEscalationDiscounts, priceEscalationDiscount)
+	}
+
+	return priceEscalationDiscounts, nil
 }
 
 var verifyPriceEscalationDiscount verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
-	return nil
-	/*
-		const xlsxDataSheetNum int = 18
-		const discountsRowIndexStart int = 9
-		const contractYearColumn int = 7
-		const forecastingAdjustmentColumn int = 8
-		const discountColumn int = 9
-		const priceEscalationColumn int = 10
+	const xlsxDataSheetNum int = 18
+	const discountsRowIndexStart int = 9
+	const contractYearColumn int = 7
+	const forecastingAdjustmentColumn int = 8
+	const discountColumn int = 9
+	const priceEscalationColumn int = 10
 
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyPriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyPriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
 
-		// Check names on header row
-		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-2] // header 2 rows above data
-		headers := []headerInfo{
-			{"Contract Year", contractYearColumn},
-			{"Government-set IHS Markit Pricing and Purchasing Industry Forecasting Adjustment", forecastingAdjustmentColumn},
-			{"Discount", discountColumn},
-			{"Resulting Price Escalation", priceEscalationColumn},
+	// Check names on header row
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	headerRowIdx := discountsRowIndexStart - 2
+	headers := []headerInfo{
+		{"Contract Year", contractYearColumn},
+		{"Government-set IHS Markit Pricing and Purchasing Industry Forecasting Adjustment", forecastingAdjustmentColumn},
+		{"Discount", discountColumn},
+		{"Resulting Price Escalation", priceEscalationColumn},
+	}
+	for _, header := range headers {
+		if err := verifyHeader(sheet, headerRowIdx, header.column, header.headerName); err != nil {
+			return err
 		}
-		for _, header := range headers {
-			if err := verifyHeader(headerRow, header.column, header.headerName); err != nil {
-				return err
-			}
-		}
+	}
 
-		// Check name on example row
-		exampleRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-1] // example 1 row above data
-		return verifyHeader(exampleRow, contractYearColumn, "EXAMPLE")
-	*/
+	// Check name on example row
+	exampleRowIdx := discountsRowIndexStart - 1 // example 1 row above data
+	return verifyHeader(sheet, exampleRowIdx, contractYearColumn, "EXAMPLE")
 }

--- a/pkg/parser/pricing/parse_price_escalation_discount.go
+++ b/pkg/parser/pricing/parse_price_escalation_discount.go
@@ -1,76 +1,76 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 var parsePriceEscalationDiscount processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	const xlsxDataSheetNum int = 18
-	const discountsRowIndexStart int = 9
-	const contractYearColumn int = 7
-	const forecastingAdjustmentColumn int = 8
-	const discountColumn int = 9
-	const priceEscalationColumn int = 10
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		const xlsxDataSheetNum int = 18
+		const discountsRowIndexStart int = 9
+		const contractYearColumn int = 7
+		const forecastingAdjustmentColumn int = 8
+		const discountColumn int = 9
+		const priceEscalationColumn int = 10
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parsePriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing price escalation discount")
-	var priceEscalationDiscounts []models.StagePriceEscalationDiscount
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart:]
-	for _, row := range dataRows {
-		priceEscalationDiscount := models.StagePriceEscalationDiscount{
-			ContractYear:          getCell(row.Cells, contractYearColumn),
-			ForecastingAdjustment: getCell(row.Cells, forecastingAdjustmentColumn),
-			Discount:              getCell(row.Cells, discountColumn),
-			PriceEscalation:       getCell(row.Cells, priceEscalationColumn),
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parsePriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		if priceEscalationDiscount.ContractYear == "" {
-			break
+		logger.Info("Parsing price escalation discount")
+		var priceEscalationDiscounts []models.StagePriceEscalationDiscount
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart:]
+		for _, row := range dataRows {
+			priceEscalationDiscount := models.StagePriceEscalationDiscount{
+				ContractYear:          getCell(row.Cells, contractYearColumn),
+				ForecastingAdjustment: getCell(row.Cells, forecastingAdjustmentColumn),
+				Discount:              getCell(row.Cells, discountColumn),
+				PriceEscalation:       getCell(row.Cells, priceEscalationColumn),
+			}
+
+			if priceEscalationDiscount.ContractYear == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StagePriceEscalationDiscount", priceEscalationDiscount))
+			}
+			priceEscalationDiscounts = append(priceEscalationDiscounts, priceEscalationDiscount)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StagePriceEscalationDiscount", priceEscalationDiscount))
-		}
-		priceEscalationDiscounts = append(priceEscalationDiscounts, priceEscalationDiscount)
-	}
-
-	return priceEscalationDiscounts, nil
+		return priceEscalationDiscounts, nil
+	*/
 }
 
 var verifyPriceEscalationDiscount verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	const xlsxDataSheetNum int = 18
-	const discountsRowIndexStart int = 9
-	const contractYearColumn int = 7
-	const forecastingAdjustmentColumn int = 8
-	const discountColumn int = 9
-	const priceEscalationColumn int = 10
+	// TODO: Fix to work with xlsx 3.x
+	return nil
+	/*
+		const xlsxDataSheetNum int = 18
+		const discountsRowIndexStart int = 9
+		const contractYearColumn int = 7
+		const forecastingAdjustmentColumn int = 8
+		const discountColumn int = 9
+		const priceEscalationColumn int = 10
 
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyPriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	// Check names on header row
-	headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-2] // header 2 rows above data
-	headers := []headerInfo{
-		{"Contract Year", contractYearColumn},
-		{"Government-set IHS Markit Pricing and Purchasing Industry Forecasting Adjustment", forecastingAdjustmentColumn},
-		{"Discount", discountColumn},
-		{"Resulting Price Escalation", priceEscalationColumn},
-	}
-	for _, header := range headers {
-		if err := verifyHeader(headerRow, header.column, header.headerName); err != nil {
-			return err
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyPriceEscalationDiscount expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
-	}
 
-	// Check name on example row
-	exampleRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-1] // example 1 row above data
-	return verifyHeader(exampleRow, contractYearColumn, "EXAMPLE")
+		// Check names on header row
+		headerRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-2] // header 2 rows above data
+		headers := []headerInfo{
+			{"Contract Year", contractYearColumn},
+			{"Government-set IHS Markit Pricing and Purchasing Industry Forecasting Adjustment", forecastingAdjustmentColumn},
+			{"Discount", discountColumn},
+			{"Resulting Price Escalation", priceEscalationColumn},
+		}
+		for _, header := range headers {
+			if err := verifyHeader(headerRow, header.column, header.headerName); err != nil {
+				return err
+			}
+		}
+
+		// Check name on example row
+		exampleRow := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[discountsRowIndexStart-1] // example 1 row above data
+		return verifyHeader(exampleRow, contractYearColumn, "EXAMPLE")
+	*/
 }

--- a/pkg/parser/pricing/parse_price_escalation_discount.go
+++ b/pkg/parser/pricing/parse_price_escalation_discount.go
@@ -25,10 +25,10 @@ var parsePriceEscalationDiscount processXlsxSheet = func(params ParamConfig, she
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := discountsRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		priceEscalationDiscount := models.StagePriceEscalationDiscount{
-			ContractYear:          getCell(sheet, rowIndex, contractYearColumn),
-			ForecastingAdjustment: getCell(sheet, rowIndex, forecastingAdjustmentColumn),
-			Discount:              getCell(sheet, rowIndex, discountColumn),
-			PriceEscalation:       getCell(sheet, rowIndex, priceEscalationColumn),
+			ContractYear:          mustGetCell(sheet, rowIndex, contractYearColumn),
+			ForecastingAdjustment: mustGetCell(sheet, rowIndex, forecastingAdjustmentColumn),
+			Discount:              mustGetCell(sheet, rowIndex, discountColumn),
+			PriceEscalation:       mustGetCell(sheet, rowIndex, priceEscalationColumn),
 		}
 
 		if priceEscalationDiscount.ContractYear == "" {

--- a/pkg/parser/pricing/parse_price_escalation_discount.go
+++ b/pkg/parser/pricing/parse_price_escalation_discount.go
@@ -22,14 +22,13 @@ var parsePriceEscalationDiscount processXlsxSheet = func(params ParamConfig, she
 
 	logger.Info("Parsing price escalation discount")
 	var priceEscalationDiscounts []models.StagePriceEscalationDiscount
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := discountsRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := discountsRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		priceEscalationDiscount := models.StagePriceEscalationDiscount{
-			ContractYear:          getCell(sheet, rowIdx, contractYearColumn),
-			ForecastingAdjustment: getCell(sheet, rowIdx, forecastingAdjustmentColumn),
-			Discount:              getCell(sheet, rowIdx, discountColumn),
-			PriceEscalation:       getCell(sheet, rowIdx, priceEscalationColumn),
+			ContractYear:          getCell(sheet, rowIndex, contractYearColumn),
+			ForecastingAdjustment: getCell(sheet, rowIndex, forecastingAdjustmentColumn),
+			Discount:              getCell(sheet, rowIndex, discountColumn),
+			PriceEscalation:       getCell(sheet, rowIndex, priceEscalationColumn),
 		}
 
 		if priceEscalationDiscount.ContractYear == "" {
@@ -59,7 +58,7 @@ var verifyPriceEscalationDiscount verifyXlsxSheet = func(params ParamConfig, she
 
 	// Check names on header row
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	headerRowIdx := discountsRowIndexStart - 2
+	headerRowIndex := discountsRowIndexStart - 2
 	headers := []headerInfo{
 		{"Contract Year", contractYearColumn},
 		{"Government-set IHS Markit Pricing and Purchasing Industry Forecasting Adjustment", forecastingAdjustmentColumn},
@@ -67,12 +66,12 @@ var verifyPriceEscalationDiscount verifyXlsxSheet = func(params ParamConfig, she
 		{"Resulting Price Escalation", priceEscalationColumn},
 	}
 	for _, header := range headers {
-		if err := verifyHeader(sheet, headerRowIdx, header.column, header.headerName); err != nil {
+		if err := verifyHeader(sheet, headerRowIndex, header.column, header.headerName); err != nil {
 			return err
 		}
 	}
 
 	// Check name on example row
-	exampleRowIdx := discountsRowIndexStart - 1 // example 1 row above data
-	return verifyHeader(sheet, exampleRowIdx, contractYearColumn, "EXAMPLE")
+	exampleRowIndex := discountsRowIndexStart - 1 // example 1 row above data
+	return verifyHeader(sheet, exampleRowIndex, contractYearColumn, "EXAMPLE")
 }

--- a/pkg/parser/pricing/parse_service_areas.go
+++ b/pkg/parser/pricing/parse_service_areas.go
@@ -27,10 +27,10 @@ var parseDomesticServiceAreas processXlsxSheet = func(params ParamConfig, sheetI
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := serviceAreaRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		domServArea := models.StageDomesticServiceArea{
-			BasePointCity:     getCell(sheet, rowIndex, basePointCityColumn),
-			State:             getCell(sheet, rowIndex, stateColumn),
-			ServiceAreaNumber: getCell(sheet, rowIndex, serviceAreaNumberColumn),
-			Zip3s:             getCell(sheet, rowIndex, zip3sColumn),
+			BasePointCity:     mustGetCell(sheet, rowIndex, basePointCityColumn),
+			State:             mustGetCell(sheet, rowIndex, stateColumn),
+			ServiceAreaNumber: mustGetCell(sheet, rowIndex, serviceAreaNumberColumn),
+			Zip3s:             mustGetCell(sheet, rowIndex, zip3sColumn),
 		}
 		// All the rows are consecutive, if we get to a blank one we're done
 		if domServArea.BasePointCity == "" {
@@ -62,8 +62,8 @@ var parseInternationalServiceAreas processXlsxSheet = func(params ParamConfig, s
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	for rowIndex := serviceAreaRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		intlServArea := models.StageInternationalServiceArea{
-			RateArea:   getCell(sheet, rowIndex, internationalRateAreaColumn),
-			RateAreaID: getCell(sheet, rowIndex, rateAreaIDColumn),
+			RateArea:   mustGetCell(sheet, rowIndex, internationalRateAreaColumn),
+			RateAreaID: mustGetCell(sheet, rowIndex, rateAreaIDColumn),
 		}
 		// All the rows are consecutive, if we get to a blank one we're done
 		if intlServArea.RateArea == "" {
@@ -98,22 +98,22 @@ var verifyServiceAreas verifyXlsxSheet = func(params ParamConfig, sheetIndex int
 	// Only check header of domestic and international service areas
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
 	dataRowsIndex := serviceAreaRowIndexStart - 1
-	if header := getCell(sheet, dataRowsIndex, basePointCityColumn); header != "Base Point City" {
+	if header := mustGetCell(sheet, dataRowsIndex, basePointCityColumn); header != "Base Point City" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIndex, stateColumn); header != "State" {
+	if header := mustGetCell(sheet, dataRowsIndex, stateColumn); header != "State" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
 	}
-	if header := removeWhiteSpace(getCell(sheet, dataRowsIndex, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
+	if header := removeWhiteSpace(mustGetCell(sheet, dataRowsIndex, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
 	}
-	if header := removeWhiteSpace(getCell(sheet, dataRowsIndex, zip3sColumn)); header != "IncludedZip3's" {
+	if header := removeWhiteSpace(mustGetCell(sheet, dataRowsIndex, zip3sColumn)); header != "IncludedZip3's" {
 		return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIndex, internationalRateAreaColumn); header != "International Rate Area" {
+	if header := mustGetCell(sheet, dataRowsIndex, internationalRateAreaColumn); header != "International Rate Area" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIndex, rateAreaIDColumn); header != "Rate Area ID" {
+	if header := mustGetCell(sheet, dataRowsIndex, rateAreaIDColumn); header != "Rate Area ID" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
 	}
 

--- a/pkg/parser/pricing/parse_service_areas.go
+++ b/pkg/parser/pricing/parse_service_areas.go
@@ -1,126 +1,125 @@
 package pricing
 
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
 // parseServiceAreas: parser for: 1b) Service Areas
 var parseDomesticServiceAreas processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 4         // 1b) Service Areas
-		const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
-		const basePointCityColumn int = 2
-		const stateColumn int = 3
-		const serviceAreaNumberColumn int = 4
-		const zip3sColumn int = 5
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 4         // 1b) Service Areas
+	const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
+	const basePointCityColumn int = 2
+	const stateColumn int = 3
+	const serviceAreaNumberColumn int = 4
+	const zip3sColumn int = 5
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseDomesticServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing domestic service areas")
+	var domServAreas []models.StageDomesticServiceArea
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := serviceAreaRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		domServArea := models.StageDomesticServiceArea{
+			BasePointCity:     getCell(sheet, rowIdx, basePointCityColumn),
+			State:             getCell(sheet, rowIdx, stateColumn),
+			ServiceAreaNumber: getCell(sheet, rowIdx, serviceAreaNumberColumn),
+			Zip3s:             getCell(sheet, rowIdx, zip3sColumn),
+		}
+		// All the rows are consecutive, if we get to a blank one we're done
+		if domServArea.BasePointCity == "" {
+			break
 		}
 
-		logger.Info("Parsing domestic service areas")
-		var domServAreas []models.StageDomesticServiceArea
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
-		for _, row := range dataRows {
-			domServArea := models.StageDomesticServiceArea{
-				BasePointCity:     getCell(row.Cells, basePointCityColumn),
-				State:             getCell(row.Cells, stateColumn),
-				ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
-				Zip3s:             getCell(row.Cells, zip3sColumn),
-			}
-			// All the rows are consecutive, if we get to a blank one we're done
-			if domServArea.BasePointCity == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageDomesticServiceArea", domServArea))
-			}
-			domServAreas = append(domServAreas, domServArea)
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageDomesticServiceArea", domServArea))
 		}
+		domServAreas = append(domServAreas, domServArea)
+	}
 
-		return domServAreas, nil
-	*/
+	return domServAreas, nil
 }
 
 var parseInternationalServiceAreas processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// TODO: Fix to work with xlsx 3.x
-	return nil, nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 4         // 1b) Service Areas
-		const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
-		const internationalRateAreaColumn int = 9
-		const rateAreaIDColumn int = 10
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 4         // 1b) Service Areas
+	const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
+	const internationalRateAreaColumn int = 9
+	const rateAreaIDColumn int = 10
 
-		if xlsxDataSheetNum != sheetIndex {
-			return nil, fmt.Errorf("parseInternationalServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseInternationalServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	logger.Info("Parsing international service areas")
+
+	var intlServAreas []models.StageInternationalServiceArea
+
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	for rowIdx := serviceAreaRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+		intlServArea := models.StageInternationalServiceArea{
+			RateArea:   getCell(sheet, rowIdx, internationalRateAreaColumn),
+			RateAreaID: getCell(sheet, rowIdx, rateAreaIDColumn),
+		}
+		// All the rows are consecutive, if we get to a blank one we're done
+		if intlServArea.RateArea == "" {
+			break
 		}
 
-		logger.Info("Parsing international service areas")
-
-		var intlServAreas []models.StageInternationalServiceArea
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
-		for _, row := range dataRows {
-			intlServArea := models.StageInternationalServiceArea{
-				RateArea:   getCell(row.Cells, internationalRateAreaColumn),
-				RateAreaID: getCell(row.Cells, rateAreaIDColumn),
-			}
-			// All the rows are consecutive, if we get to a blank one we're done
-			if intlServArea.RateArea == "" {
-				break
-			}
-
-			if params.ShowOutput {
-				logger.Info("", zap.Any("StageInternationalServiceArea", intlServArea))
-			}
-			intlServAreas = append(intlServAreas, intlServArea)
+		if params.ShowOutput {
+			logger.Info("", zap.Any("StageInternationalServiceArea", intlServArea))
 		}
+		intlServAreas = append(intlServAreas, intlServArea)
+	}
 
-		return intlServAreas, nil
-	*/
+	return intlServAreas, nil
 }
 
 // verifyServiceAreas: verification for: 1b) Service Areas
 var verifyServiceAreas verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// TODO: Fix to work with xlsx 3.x
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 4         // 1b) Service Areas
+	const serviceAreaRowIndexStart int = 9 // start at row 6 to get the headings
+	const basePointCityColumn int = 2
+	const stateColumn int = 3
+	const serviceAreaNumberColumn int = 4
+	const zip3sColumn int = 5
+	const internationalRateAreaColumn int = 9
+	const rateAreaIDColumn int = 10
+
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	// Only check header of domestic and international service areas
+	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
+	dataRowsIdx := serviceAreaRowIndexStart - 1
+
+	if header := getCell(sheet, dataRowsIdx, basePointCityColumn); header != "Base Point City" {
+		return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
+	}
+	if header := getCell(sheet, dataRowsIdx, stateColumn); header != "State" {
+		return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
+	}
+	if header := removeWhiteSpace(getCell(sheet, dataRowsIdx, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
+		return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
+	}
+	if header := removeWhiteSpace(getCell(sheet, dataRowsIdx, zip3sColumn)); header != "IncludedZip3's" {
+		return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
+	}
+	if header := getCell(sheet, dataRowsIdx, internationalRateAreaColumn); header != "International Rate Area" {
+		return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
+	}
+	if header := getCell(sheet, dataRowsIdx, rateAreaIDColumn); header != "Rate Area ID" {
+		return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
+	}
+
 	return nil
-	/*
-		// XLSX Sheet consts
-		const xlsxDataSheetNum int = 4         // 1b) Service Areas
-		const serviceAreaRowIndexStart int = 9 // start at row 6 to get the headings
-		const basePointCityColumn int = 2
-		const stateColumn int = 3
-		const serviceAreaNumberColumn int = 4
-		const zip3sColumn int = 5
-		const internationalRateAreaColumn int = 9
-		const rateAreaIDColumn int = 10
-
-		if xlsxDataSheetNum != sheetIndex {
-			return fmt.Errorf("verifyServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-		}
-
-		// Only check header of domestic and international service areas
-		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart-1 : serviceAreaRowIndexStart]
-		for _, dataRow := range dataRows {
-			if header := getCell(dataRow.Cells, basePointCityColumn); header != "Base Point City" {
-				return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
-			}
-			if header := getCell(dataRow.Cells, stateColumn); header != "State" {
-				return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(dataRow.Cells, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
-				return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
-			}
-			if header := removeWhiteSpace(getCell(dataRow.Cells, zip3sColumn)); header != "IncludedZip3's" {
-				return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
-			}
-			if header := getCell(dataRow.Cells, internationalRateAreaColumn); header != "International Rate Area" {
-				return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
-			}
-			if header := getCell(dataRow.Cells, rateAreaIDColumn); header != "Rate Area ID" {
-				return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
-			}
-		}
-		return nil
-	*/
 }

--- a/pkg/parser/pricing/parse_service_areas.go
+++ b/pkg/parser/pricing/parse_service_areas.go
@@ -24,14 +24,13 @@ var parseDomesticServiceAreas processXlsxSheet = func(params ParamConfig, sheetI
 
 	logger.Info("Parsing domestic service areas")
 	var domServAreas []models.StageDomesticServiceArea
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := serviceAreaRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := serviceAreaRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		domServArea := models.StageDomesticServiceArea{
-			BasePointCity:     getCell(sheet, rowIdx, basePointCityColumn),
-			State:             getCell(sheet, rowIdx, stateColumn),
-			ServiceAreaNumber: getCell(sheet, rowIdx, serviceAreaNumberColumn),
-			Zip3s:             getCell(sheet, rowIdx, zip3sColumn),
+			BasePointCity:     getCell(sheet, rowIndex, basePointCityColumn),
+			State:             getCell(sheet, rowIndex, stateColumn),
+			ServiceAreaNumber: getCell(sheet, rowIndex, serviceAreaNumberColumn),
+			Zip3s:             getCell(sheet, rowIndex, zip3sColumn),
 		}
 		// All the rows are consecutive, if we get to a blank one we're done
 		if domServArea.BasePointCity == "" {
@@ -59,14 +58,12 @@ var parseInternationalServiceAreas processXlsxSheet = func(params ParamConfig, s
 	}
 
 	logger.Info("Parsing international service areas")
-
 	var intlServAreas []models.StageInternationalServiceArea
-
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	for rowIdx := serviceAreaRowIndexStart; rowIdx < sheet.MaxRow; rowIdx++ {
+	for rowIndex := serviceAreaRowIndexStart; rowIndex < sheet.MaxRow; rowIndex++ {
 		intlServArea := models.StageInternationalServiceArea{
-			RateArea:   getCell(sheet, rowIdx, internationalRateAreaColumn),
-			RateAreaID: getCell(sheet, rowIdx, rateAreaIDColumn),
+			RateArea:   getCell(sheet, rowIndex, internationalRateAreaColumn),
+			RateAreaID: getCell(sheet, rowIndex, rateAreaIDColumn),
 		}
 		// All the rows are consecutive, if we get to a blank one we're done
 		if intlServArea.RateArea == "" {
@@ -100,24 +97,23 @@ var verifyServiceAreas verifyXlsxSheet = func(params ParamConfig, sheetIndex int
 
 	// Only check header of domestic and international service areas
 	sheet := params.XlsxFile.Sheets[xlsxDataSheetNum]
-	dataRowsIdx := serviceAreaRowIndexStart - 1
-
-	if header := getCell(sheet, dataRowsIdx, basePointCityColumn); header != "Base Point City" {
+	dataRowsIndex := serviceAreaRowIndexStart - 1
+	if header := getCell(sheet, dataRowsIndex, basePointCityColumn); header != "Base Point City" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIdx, stateColumn); header != "State" {
+	if header := getCell(sheet, dataRowsIndex, stateColumn); header != "State" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
 	}
-	if header := removeWhiteSpace(getCell(sheet, dataRowsIdx, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
+	if header := removeWhiteSpace(getCell(sheet, dataRowsIndex, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
 	}
-	if header := removeWhiteSpace(getCell(sheet, dataRowsIdx, zip3sColumn)); header != "IncludedZip3's" {
+	if header := removeWhiteSpace(getCell(sheet, dataRowsIndex, zip3sColumn)); header != "IncludedZip3's" {
 		return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIdx, internationalRateAreaColumn); header != "International Rate Area" {
+	if header := getCell(sheet, dataRowsIndex, internationalRateAreaColumn); header != "International Rate Area" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
 	}
-	if header := getCell(sheet, dataRowsIdx, rateAreaIDColumn); header != "Rate Area ID" {
+	if header := getCell(sheet, dataRowsIndex, rateAreaIDColumn); header != "Rate Area ID" {
 		return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
 	}
 

--- a/pkg/parser/pricing/parse_service_areas.go
+++ b/pkg/parser/pricing/parse_service_areas.go
@@ -1,122 +1,126 @@
 package pricing
 
-import (
-	"fmt"
-
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models"
-)
-
 // parseServiceAreas: parser for: 1b) Service Areas
 var parseDomesticServiceAreas processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 4         // 1b) Service Areas
-	const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
-	const basePointCityColumn int = 2
-	const stateColumn int = 3
-	const serviceAreaNumberColumn int = 4
-	const zip3sColumn int = 5
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 4         // 1b) Service Areas
+		const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
+		const basePointCityColumn int = 2
+		const stateColumn int = 3
+		const serviceAreaNumberColumn int = 4
+		const zip3sColumn int = 5
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseDomesticServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing domestic service areas")
-	var domServAreas []models.StageDomesticServiceArea
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
-	for _, row := range dataRows {
-		domServArea := models.StageDomesticServiceArea{
-			BasePointCity:     getCell(row.Cells, basePointCityColumn),
-			State:             getCell(row.Cells, stateColumn),
-			ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
-			Zip3s:             getCell(row.Cells, zip3sColumn),
-		}
-		// All the rows are consecutive, if we get to a blank one we're done
-		if domServArea.BasePointCity == "" {
-			break
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseDomesticServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageDomesticServiceArea", domServArea))
-		}
-		domServAreas = append(domServAreas, domServArea)
-	}
+		logger.Info("Parsing domestic service areas")
+		var domServAreas []models.StageDomesticServiceArea
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
+		for _, row := range dataRows {
+			domServArea := models.StageDomesticServiceArea{
+				BasePointCity:     getCell(row.Cells, basePointCityColumn),
+				State:             getCell(row.Cells, stateColumn),
+				ServiceAreaNumber: getCell(row.Cells, serviceAreaNumberColumn),
+				Zip3s:             getCell(row.Cells, zip3sColumn),
+			}
+			// All the rows are consecutive, if we get to a blank one we're done
+			if domServArea.BasePointCity == "" {
+				break
+			}
 
-	return domServAreas, nil
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageDomesticServiceArea", domServArea))
+			}
+			domServAreas = append(domServAreas, domServArea)
+		}
+
+		return domServAreas, nil
+	*/
 }
 
 var parseInternationalServiceAreas processXlsxSheet = func(params ParamConfig, sheetIndex int, logger Logger) (interface{}, error) {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 4         // 1b) Service Areas
-	const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
-	const internationalRateAreaColumn int = 9
-	const rateAreaIDColumn int = 10
+	// TODO: Fix to work with xlsx 3.x
+	return nil, nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 4         // 1b) Service Areas
+		const serviceAreaRowIndexStart int = 9 // start at row 9 to get the service areas
+		const internationalRateAreaColumn int = 9
+		const rateAreaIDColumn int = 10
 
-	if xlsxDataSheetNum != sheetIndex {
-		return nil, fmt.Errorf("parseInternationalServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	logger.Info("Parsing international service areas")
-
-	var intlServAreas []models.StageInternationalServiceArea
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
-	for _, row := range dataRows {
-		intlServArea := models.StageInternationalServiceArea{
-			RateArea:   getCell(row.Cells, internationalRateAreaColumn),
-			RateAreaID: getCell(row.Cells, rateAreaIDColumn),
-		}
-		// All the rows are consecutive, if we get to a blank one we're done
-		if intlServArea.RateArea == "" {
-			break
+		if xlsxDataSheetNum != sheetIndex {
+			return nil, fmt.Errorf("parseInternationalServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 		}
 
-		if params.ShowOutput {
-			logger.Info("", zap.Any("StageInternationalServiceArea", intlServArea))
-		}
-		intlServAreas = append(intlServAreas, intlServArea)
-	}
+		logger.Info("Parsing international service areas")
 
-	return intlServAreas, nil
+		var intlServAreas []models.StageInternationalServiceArea
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart:]
+		for _, row := range dataRows {
+			intlServArea := models.StageInternationalServiceArea{
+				RateArea:   getCell(row.Cells, internationalRateAreaColumn),
+				RateAreaID: getCell(row.Cells, rateAreaIDColumn),
+			}
+			// All the rows are consecutive, if we get to a blank one we're done
+			if intlServArea.RateArea == "" {
+				break
+			}
+
+			if params.ShowOutput {
+				logger.Info("", zap.Any("StageInternationalServiceArea", intlServArea))
+			}
+			intlServAreas = append(intlServAreas, intlServArea)
+		}
+
+		return intlServAreas, nil
+	*/
 }
 
 // verifyServiceAreas: verification for: 1b) Service Areas
 var verifyServiceAreas verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
-	// XLSX Sheet consts
-	const xlsxDataSheetNum int = 4         // 1b) Service Areas
-	const serviceAreaRowIndexStart int = 9 // start at row 6 to get the headings
-	const basePointCityColumn int = 2
-	const stateColumn int = 3
-	const serviceAreaNumberColumn int = 4
-	const zip3sColumn int = 5
-	const internationalRateAreaColumn int = 9
-	const rateAreaIDColumn int = 10
-
-	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
-	}
-
-	// Only check header of domestic and international service areas
-	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart-1 : serviceAreaRowIndexStart]
-	for _, dataRow := range dataRows {
-		if header := getCell(dataRow.Cells, basePointCityColumn); header != "Base Point City" {
-			return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
-		}
-		if header := getCell(dataRow.Cells, stateColumn); header != "State" {
-			return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(dataRow.Cells, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
-			return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
-		}
-		if header := removeWhiteSpace(getCell(dataRow.Cells, zip3sColumn)); header != "IncludedZip3's" {
-			return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
-		}
-		if header := getCell(dataRow.Cells, internationalRateAreaColumn); header != "International Rate Area" {
-			return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
-		}
-		if header := getCell(dataRow.Cells, rateAreaIDColumn); header != "Rate Area ID" {
-			return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
-		}
-	}
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		// XLSX Sheet consts
+		const xlsxDataSheetNum int = 4         // 1b) Service Areas
+		const serviceAreaRowIndexStart int = 9 // start at row 6 to get the headings
+		const basePointCityColumn int = 2
+		const stateColumn int = 3
+		const serviceAreaNumberColumn int = 4
+		const zip3sColumn int = 5
+		const internationalRateAreaColumn int = 9
+		const rateAreaIDColumn int = 10
+
+		if xlsxDataSheetNum != sheetIndex {
+			return fmt.Errorf("verifyServiceAreas expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		}
+
+		// Only check header of domestic and international service areas
+		dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[serviceAreaRowIndexStart-1 : serviceAreaRowIndexStart]
+		for _, dataRow := range dataRows {
+			if header := getCell(dataRow.Cells, basePointCityColumn); header != "Base Point City" {
+				return fmt.Errorf("verifyServiceAreas expected to find header 'Base Point City', but received header '%s'", header)
+			}
+			if header := getCell(dataRow.Cells, stateColumn); header != "State" {
+				return fmt.Errorf("verifyServiceAreas expected to find header 'State', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(dataRow.Cells, serviceAreaNumberColumn)); header != "ServiceAreaNumber" {
+				return fmt.Errorf("verifyServiceAreas expected to find header 'ServiceAreaNumber', but received header '%s'", header)
+			}
+			if header := removeWhiteSpace(getCell(dataRow.Cells, zip3sColumn)); header != "IncludedZip3's" {
+				return fmt.Errorf("verifyServiceAreas expected to find header \"IncludedZip3's\", but received header '%s'", header)
+			}
+			if header := getCell(dataRow.Cells, internationalRateAreaColumn); header != "International Rate Area" {
+				return fmt.Errorf("verifyServiceAreas expected to find header 'International Rate Area', but received header '%s'", header)
+			}
+			if header := getCell(dataRow.Cells, rateAreaIDColumn); header != "Rate Area ID" {
+				return fmt.Errorf("verifyServiceAreas expected to find header 'Rate Area ID', but received header '%s'", header)
+			}
+		}
+		return nil
+	*/
 }

--- a/pkg/parser/pricing/parse_test.go
+++ b/pkg/parser/pricing/parse_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/suite"
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/parser/pricing/shared.go
+++ b/pkg/parser/pricing/shared.go
@@ -29,12 +29,12 @@ type headerInfo struct {
 
 // A safe way to get a cell's value (as a string) from a sheet
 func getCell(sheet *xlsx.Sheet, rowIndex, colIndex int) (string, error) {
-	if rowIndex < 0 || rowIndex >= sheet.MaxRow || colIndex < 0 || colIndex >= sheet.MaxCol {
-		return "", fmt.Errorf("cell coordinates are out of bounds")
-	}
-
 	if sheet == nil {
 		return "", fmt.Errorf("sheet is nil")
+	}
+
+	if rowIndex < 0 || rowIndex >= sheet.MaxRow || colIndex < 0 || colIndex >= sheet.MaxCol {
+		return "", fmt.Errorf("cell coordinates are out of bounds")
 	}
 
 	cell, err := sheet.Cell(rowIndex, colIndex)

--- a/pkg/parser/pricing/shared.go
+++ b/pkg/parser/pricing/shared.go
@@ -1,13 +1,13 @@
 package pricing
 
 import (
-	"fmt"
+	// "fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 )
 
 /*************************************************************************************************************/
@@ -67,12 +67,16 @@ func removeWhiteSpace(stripString string) string {
 }
 
 func verifyHeader(row *xlsx.Row, column int, expectedName string) error {
-	actual := getCell(row.Cells, column)
-	if removeWhiteSpace(expectedName) != removeWhiteSpace(actual) {
-		return fmt.Errorf("format error: Header <%s> is missing; got <%s> instead", expectedName, actual)
-	}
-
+	// TODO: Fix to work with xlsx 3.x
 	return nil
+	/*
+		actual := getCell(row.Cells, column)
+		if removeWhiteSpace(expectedName) != removeWhiteSpace(actual) {
+			return fmt.Errorf("format error: Header <%s> is missing; got <%s> instead", expectedName, actual)
+		}
+
+		return nil
+	*/
 }
 
 // generateOutputFilename: generates filename using XlsxDataSheetInfo.outputFilename

--- a/pkg/parser/pricing/shared.go
+++ b/pkg/parser/pricing/shared.go
@@ -28,12 +28,12 @@ type headerInfo struct {
 /*************************************************************************/
 
 // A safe way to get a cell from a slice of cells, returning empty string if not found
-func getCell(sheet *xlsx.Sheet, rowIdx, colIdx int) string {
-	if rowIdx >= sheet.MaxRow || colIdx >= sheet.MaxCol {
+func getCell(sheet *xlsx.Sheet, rowIndex, colIndex int) string {
+	if rowIndex >= sheet.MaxRow || colIndex >= sheet.MaxCol {
 		return ""
 	}
 
-	cell, err := sheet.Cell(rowIdx, colIdx)
+	cell, err := sheet.Cell(rowIndex, colIndex)
 	if err != nil {
 		// TODO: Is this panic OK? For now, just trying to avoid having to add in error-checking on every
 		//   getCell call.  It's a CLI, so what would we do to react to it other than end the process?
@@ -72,8 +72,8 @@ func removeWhiteSpace(stripString string) string {
 	return s
 }
 
-func verifyHeader(sheet *xlsx.Sheet, rowIdx, colIdx int, expectedName string) error {
-	actual := getCell(sheet, rowIdx, colIdx)
+func verifyHeader(sheet *xlsx.Sheet, rowIndex, colIndex int, expectedName string) error {
+	actual := getCell(sheet, rowIndex, colIndex)
 	if removeWhiteSpace(expectedName) != removeWhiteSpace(actual) {
 		return fmt.Errorf("format error: Header <%s> is missing; got <%s> instead", expectedName, actual)
 	}

--- a/pkg/parser/transittime/parse.go
+++ b/pkg/parser/transittime/parse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gocarina/gocsv"
 	"github.com/pkg/errors"
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/dbtools"

--- a/pkg/parser/transittime/parse_test.go
+++ b/pkg/parser/transittime/parse_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/suite"
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/parser/transittime/parse_transit_times.go
+++ b/pkg/parser/transittime/parse_transit_times.go
@@ -33,24 +33,24 @@ var parseDomesticTransitTime processXlsxSheet = func(params ParamConfig, sheetIn
 
 	for curRowIndex := transitTimeRowIndex; curRowIndex < sheet.MaxRow; curRowIndex++ {
 		// should be consecutive headers
-		if !strings.Contains(getValueFromSheet(sheet, curRowIndex, distanceHeaderColIndex), "-") {
+		if !strings.Contains(mustGetValueFromSheet(sheet, curRowIndex, distanceHeaderColIndex), "-") {
 			// colIndex should reset
 			break
 		}
 
 		for curColIndex := transitTimeColIndex; curColIndex < sheet.MaxCol; curColIndex++ {
 			// should be consecutive headers
-			if getValueFromSheet(sheet, weightHeaderRowIndex, curColIndex) == "" {
+			if mustGetValueFromSheet(sheet, weightHeaderRowIndex, curColIndex) == "" {
 				// colIndex should reset
 				break
 			}
 
-			distancesSlice, err := getDomesticHeaderBounds(getValueFromSheet(sheet, curRowIndex, distanceHeaderColIndex))
+			distancesSlice, err := getDomesticHeaderBounds(mustGetValueFromSheet(sheet, curRowIndex, distanceHeaderColIndex))
 			if err != nil {
 				return nil, err
 			}
 
-			weightsSlice, err := getDomesticHeaderBounds(getValueFromSheet(sheet, weightHeaderRowIndex, curColIndex))
+			weightsSlice, err := getDomesticHeaderBounds(mustGetValueFromSheet(sheet, weightHeaderRowIndex, curColIndex))
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +59,7 @@ var parseDomesticTransitTime processXlsxSheet = func(params ParamConfig, sheetIn
 
 			domTransitTime := models.GHCDomesticTransitTime{
 				ID:                 id,
-				MaxDaysTransitTime: getInt(getValueFromSheet(sheet, curRowIndex, curColIndex)),
+				MaxDaysTransitTime: getInt(mustGetValueFromSheet(sheet, curRowIndex, curColIndex)),
 				DistanceMilesLower: getInt(distancesSlice[0]),
 				DistanceMilesUpper: getInt(distancesSlice[1]),
 				WeightLbsLower:     getInt(weightsSlice[0]),

--- a/pkg/parser/transittime/shared.go
+++ b/pkg/parser/transittime/shared.go
@@ -17,12 +17,12 @@ import (
 // A way to get a cell value from a sheet
 // return empty string if not found
 func getValueFromSheet(sheet *xlsx.Sheet, row int, col int) (string, error) {
-	if row < 0 || row >= sheet.MaxRow || col < 0 || col >= sheet.MaxCol {
-		return "", fmt.Errorf("cell coordinates are out of bounds")
-	}
-
 	if sheet == nil {
 		return "", fmt.Errorf("sheet is nil")
+	}
+
+	if row < 0 || row >= sheet.MaxRow || col < 0 || col >= sheet.MaxCol {
+		return "", fmt.Errorf("cell coordinates are out of bounds")
 	}
 
 	cell, err := sheet.Cell(row, col)

--- a/pkg/parser/transittime/shared.go
+++ b/pkg/parser/transittime/shared.go
@@ -16,19 +16,31 @@ import (
 
 // A way to get a cell value from a sheet
 // return empty string if not found
-func getValueFromSheet(sheet *xlsx.Sheet, row int, col int) string {
-	if sheet != nil {
-		cell, err := sheet.Cell(row, col)
-		if err != nil {
-			// TODO: Is this panic OK? For now, just trying to avoid having to add in error-checking on every
-			//   getValueFromSheet call.  It's a CLI, so what would we do to react to it other than end the process?
-			panic(err)
-		}
-
-		return cell.String()
+func getValueFromSheet(sheet *xlsx.Sheet, row int, col int) (string, error) {
+	if row < 0 || row >= sheet.MaxRow || col < 0 || col >= sheet.MaxCol {
+		return "", fmt.Errorf("cell coordinates are out of bounds")
 	}
 
-	return ""
+	if sheet == nil {
+		return "", fmt.Errorf("sheet is nil")
+	}
+
+	cell, err := sheet.Cell(row, col)
+	if err != nil {
+		return "", err
+	}
+
+	return cell.String(), nil
+}
+
+// A version of getValueFromSheet that panics if it can't read the cell's value
+func mustGetValueFromSheet(sheet *xlsx.Sheet, row, col int) string {
+	cellString, err := getValueFromSheet(sheet, row, col)
+	if err != nil {
+		panic(fmt.Sprintf("getValueFromSheet: sheet=\"%s\", row=%d, col=%d: %s", sheet.Name, row, col, err.Error()))
+	}
+
+	return cellString
 }
 
 // A way to parse domestic header bounds.

--- a/pkg/parser/transittime/shared.go
+++ b/pkg/parser/transittime/shared.go
@@ -17,15 +17,18 @@ import (
 // A way to get a cell value from a sheet
 // return empty string if not found
 func getValueFromSheet(sheet *xlsx.Sheet, row int, col int) string {
-	// TODO: Fix to work with xlsx 3.x
-	return ""
-	/*
-		if sheet != nil {
-			return sheet.Cell(row, col).String()
+	if sheet != nil {
+		cell, err := sheet.Cell(row, col)
+		if err != nil {
+			// TODO: Is this panic OK? For now, just trying to avoid having to add in error-checking on every
+			//   getValueFromSheet call.  It's a CLI, so what would we do to react to it other than end the process?
+			panic(err)
 		}
 
-		return ""
-	*/
+		return cell.String()
+	}
+
+	return ""
 }
 
 // A way to parse domestic header bounds.

--- a/pkg/parser/transittime/shared.go
+++ b/pkg/parser/transittime/shared.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tealeg/xlsx/v2"
+	"github.com/tealeg/xlsx/v3"
 )
 
 /*************************************************************************/
@@ -17,11 +17,15 @@ import (
 // A way to get a cell value from a sheet
 // return empty string if not found
 func getValueFromSheet(sheet *xlsx.Sheet, row int, col int) string {
-	if sheet != nil {
-		return sheet.Cell(row, col).String()
-	}
-
+	// TODO: Fix to work with xlsx 3.x
 	return ""
+	/*
+		if sheet != nil {
+			return sheet.Cell(row, col).String()
+		}
+
+		return ""
+	*/
 }
 
 // A way to parse domestic header bounds.


### PR DESCRIPTION
## Description

This PR updates the `xlsx` Go dependency from version 2.x to version 3.x (after doing an intermediate 1.x to 2.x upgrade last week in #6786).  There were breaking changes that impacted us in 3.x, so you will find a lot of code changes along with the dependency upgrade.

Specifically, we were most affected by these changes:

- a `Sheet` struct no longer has a `Rows` slice field.
- a `Row` struct no longer has a `Cells` slice field.

Our usual pattern in all of our parsers/validators used those two fields above.  To adjust, I changed the code to use a `for` loop to iterate over the desired row indices, and adjusted our `getCell` method to take a `Sheet` along with a row/column index rather than the `Cells` slice and a column index.  It then uses a `sheet.Cell` call to get the specific cell at the row/column index.

Another change in the library is that the `sheet.Cell` call can return an error.  Given the way we have set things up, that should be pretty unlikely in normal operation.  But given how often we call `getCell` from the parsers, it could get a little unwieldy to have to always check and handle an error.  Since this code is only used as part of a CLI, I made a `mustGetCell` wrapper that will just panic with some context in the event of an error from `getCell`.  I'm open to other ideas on how to handle this, including checking every error from `getCell` explicitly if that feels better.

## Reviewer Notes

- [What's new in 3.x](https://github.com/tealeg/xlsx/releases/tag/v3.0.0)
- [Code changes between version 2.0.1 and 3.2.3](https://github.com/tealeg/xlsx/compare/v2.0.1...v3.2.3)
- Readme notes for [3.x](https://github.com/tealeg/xlsx#version-3xx).
- We have some pre-existing duplication of helper functions between the `ghc-pricing-parser` code and the `ghc-transit-time-parser` code.  To avoid making this story even more complicated, I will write up another story to consider refactoring/consolidating those into public shared functions with appropriate tests.
- I just noticed as I was writing up this PR that the maintainer of `xlsx` has [just added a note](https://github.com/tealeg/xlsx#not-actively-maintained) to the README in the last couple of days that they are not actively maintaining the library anymore.  There have been quite a few changes merged since the last formal release in Nov 2020, so perhaps someone else will pick up the maintenance.  But I'll create a separate story to capture this so we can evaluate later if we need to move to `excelize` or some other XLSX library (update: [story is here](https://dp3.atlassian.net/browse/MB-8475)).  I think we should still move forward with this upgrade for now.

## Setup

- `make clean server_build bin/ghc-pricing-parser bin/ghc-transit-time-parser`
- `make server_test` to ensure server tests still pass for parsers.
- See [this PR](https://github.com/transcom/mymove/pull/4250) for instructions on running `ghc-pricing-parser` and `pricing-import`.
- See [this PR](https://github.com/transcom/mymove/pull/3571) for instructions on running `ghc-transit-time-parser`.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8385) for this change
