### PR TITLE
MB-8414 Prime API: Update moveTaskOrder and fetchMTOUpdates descriptions

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -38,7 +38,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move task orders where ` + "`" + `availableToPrimeAt` + "`" + ` has been set. This prevents viewing any move task orders that have not been made available to the Prime.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],
@@ -2590,6 +2590,7 @@ func init() {
   },
   "tags": [
     {
+      "description": "The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
       "name": "moveTaskOrder"
     },
     {
@@ -2635,7 +2636,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move task orders where ` + "`" + `availableToPrimeAt` + "`" + ` has been set. This prevents viewing any move task orders that have not been made available to the Prime.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],
@@ -5439,6 +5440,7 @@ func init() {
   },
   "tags": [
     {
+      "description": "The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
       "name": "moveTaskOrder"
     },
     {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -38,7 +38,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],
@@ -2636,7 +2636,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],

--- a/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
@@ -33,7 +33,15 @@ func NewFetchMTOUpdates(ctx *middleware.Context, handler FetchMTOUpdatesHandler)
 
 fetchMTOUpdates
 
-Gets all move task orders where `availableToPrimeAt` has been set. This prevents viewing any move task orders that have not been made available to the Prime.
+Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
+list down to only the moves that have been updated since the provided timestamp. A move will be considered
+updated if the `updatedAt` timestamp on the move is later than the provided date.
+
+**WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
+shipments, service items, etc. This has not been implemented.
+
+**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
+set, that move will always appear in this list.
 
 
 */

--- a/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
@@ -35,7 +35,7 @@ fetchMTOUpdates
 
 Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
 list down to only the moves that have been updated since the provided timestamp. A move will be considered
-updated if the `updatedAt` timestamp on the move is later than the provided date.
+updated if the `updatedAt` timestamp on the move is later than the provided date and time.
 
 **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
 shipments, service items, etc. This has not been implemented.

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -41,7 +41,7 @@ type ClientService interface {
 
   Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
 list down to only the moves that have been updated since the provided timestamp. A move will be considered
-updated if the `updatedAt` timestamp on the move is later than the provided date.
+updated if the `updatedAt` timestamp on the move is later than the provided date and time.
 
 **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
 shipments, service items, etc. This has not been implemented.

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -39,7 +39,15 @@ type ClientService interface {
 /*
   FetchMTOUpdates fetches m t o updates
 
-  Gets all move task orders where `availableToPrimeAt` has been set. This prevents viewing any move task orders that have not been made available to the Prime.
+  Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
+list down to only the moves that have been updated since the provided timestamp. A move will be considered
+updated if the `updatedAt` timestamp on the move is later than the provided date.
+
+**WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
+shipments, service items, etc. This has not been implemented.
+
+**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
+set, that move will always appear in this list.
 
 */
 func (a *Client) FetchMTOUpdates(params *FetchMTOUpdatesParams) (*FetchMTOUpdatesOK, error) {

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -38,7 +38,7 @@ paths:
       description: |
         Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
         list down to only the moves that have been updated since the provided timestamp. A move will be considered
-        updated if the `updatedAt` timestamp on the move is later than the provided date.
+        updated if the `updatedAt` timestamp on the move is later than the provided date and time.
 
         **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
         shipments, service items, etc. This has not been implemented.

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -35,9 +35,16 @@ paths:
   /move-task-orders:
     get:
       summary: fetchMTOUpdates
-      description: >
-        Gets all move task orders where `availableToPrimeAt` has been set.
-        This prevents viewing any move task orders that have not been made available to the Prime.
+      description: |
+        Gets all moves that have been reviewed and approved by the TOO. The `since` parameter can be used to filter this
+        list down to only the moves that have been updated since the provided timestamp. A move will be considered
+        updated if the `updatedAt` timestamp on the move is later than the provided date.
+
+        **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
+        shipments, service items, etc. This has not been implemented.
+
+        **WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
+        set, that move will always appear in this list.
       operationId: fetchMTOUpdates
       tags:
         - moveTaskOrder

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -17,6 +17,10 @@ schemes:
   - http
 tags:
   - name: moveTaskOrder
+    description: >
+      The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the
+      information about shipments, including service items, estimated weights, actual weights, requested and scheduled
+      move dates, etc.
   - name: mtoShipment
   - name: paymentRequest
   - name: mtoServiceItem


### PR DESCRIPTION
## Description

This PR adds a description for the "moveTaskOrder" tag and updates the description for the "fetchMTOUpdates" endpoint. Note that we decided to include some WIP notes about topics that we thought _should_ be covered by these descriptions but were not possible to add for some reason.

## Setup

To preview the generated documentation, run:

```sh
yarn preview-redoc
```

And then navigate to http://127.0.0.1:8080/redoc/prime.html#tag/moveTaskOrder.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8414) for this change.
