### PR TITLE
MB-8225: Copy changes for the home page, add shipment step

### DIFF
--- a/cypress/integration/mymove/nts.js
+++ b/cypress/integration/mymove/nts.js
@@ -93,7 +93,7 @@ function customerVisitsReviewPage() {
 }
 
 function customerCreatesAnNTSShipment() {
-  cy.get('[data-testid="shipment-selection-btn"]').contains('Plan your shipments').click();
+  cy.get('[data-testid="shipment-selection-btn"]').contains('Set up your shipments').click();
   cy.nextPage();
   cy.get('input[type="radio"]').eq(2).check({ force: true });
   cy.nextPage();

--- a/cypress/integration/mymove/utilities/customer.js
+++ b/cypress/integration/mymove/utilities/customer.js
@@ -125,5 +125,5 @@ export function customerFillsOutOrdersInformation() {
 
   cy.visit('/');
   cy.get('[data-testid="doc-list-container"]').contains('top-secret.png');
-  cy.get('button').contains('Plan your shipments').click();
+  cy.get('button').contains('Set up your shipments').click();
 }

--- a/src/pages/MyMove/Home/HomeHelpers.jsx
+++ b/src/pages/MyMove/Home/HomeHelpers.jsx
@@ -14,12 +14,8 @@ export const HelperNeedsOrders = () => (
 );
 
 export const HelperNeedsShipment = () => (
-  <Helper title="Gather this info, then plan your shipments">
-    <ul>
-      <li>Preferred moving details</li>
-      <li>Destination address (your new place, your duty station ZIP, or somewhere else)</li>
-      <li>Names and contact info for anyone you authorize to act on your behalf</li>
-    </ul>
+  <Helper title="Time for step 3: set up your shipments">
+    <p>Share where and when you&apos;re moving, and how you want your things to be shipped.</p>
   </Helper>
 );
 

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -120,7 +120,7 @@ export class Home extends Component {
     if (this.hasAnyShipments) {
       return 'Add another shipment';
     }
-    return 'Plan your shipments';
+    return 'Set up your shipments';
   }
 
   renderHelper = () => {
@@ -325,7 +325,7 @@ export class Home extends Component {
                     onActionBtnClick={() => this.handleNewPathClick(shipmentSelectionPath)}
                     complete={this.hasAnyShipments}
                     completedHeaderText="Shipments"
-                    headerText="Shipment selection"
+                    headerText="Set up shipments"
                     secondaryBtn={this.hasAnyShipments}
                     secondaryClassName="margin-top-2"
                     step="3"
@@ -343,8 +343,9 @@ export class Home extends Component {
                       </div>
                     ) : (
                       <Description>
-                        Tell us where you&apos;re going and when you want to get there. We&apos;ll help you set up
-                        shipments to make it work.
+                        We&apos;ll collect addresses, dates, and how you want to move your things.
+                        <br />
+                        Note: You can change these details later by talking to a move counselor or your movers.
                       </Description>
                     )}
                   </Step>

--- a/src/pages/MyMove/Home/index.stories.jsx
+++ b/src/pages/MyMove/Home/index.stories.jsx
@@ -9,7 +9,7 @@ export default {
   title: 'Customer Components / Pages / Home',
 };
 
-const defaultProps = {
+const uploadOrdersProps = {
   serviceMember: {
     id: 'testServiceMemberId',
     first_name: 'John',
@@ -20,8 +20,8 @@ const defaultProps = {
         name: 'Test Transportation Office Name',
         phone_lines: ['555-555-5555'],
       },
-      weight_allotment: {},
     },
+    weight_allotment: {},
   },
   showLoggedInUser() {},
   loadMTOShipments() {},
@@ -36,14 +36,102 @@ const defaultProps = {
   currentPpm: {},
   orders: {},
   location: {},
-  move: {},
+  move: {
+    locator: 'XYZ890',
+    status: 'DRAFT',
+  },
   uploadedOrderDocuments: [],
 };
 
-export const Basic = () => (
-  <MockProviders>
-    <div className="grid-container usa-prose">
-      <Home {...defaultProps} />
-    </div>
-  </MockProviders>
-);
+const shipmentSelectionProps = {
+  ...uploadOrdersProps,
+  serviceMember: {
+    ...uploadOrdersProps.serviceMember,
+    weight_allotment: {
+      total_weight_self: 10000,
+    },
+  },
+  orders: {
+    ...uploadOrdersProps.orders,
+    new_duty_station: {
+      name: 'NAS Jacksonville',
+    },
+    origin_duty_station: {
+      name: 'NAS Norfolk',
+    },
+    report_by_date: '25 December 2020',
+  },
+  uploadedOrderDocuments: [
+    {
+      id: 'file1',
+      filename: 'Uploaded_Orders.pdf',
+    },
+    {
+      id: 'file2',
+      filename: 'Supporting_Documentation_Screenshot.png',
+    },
+  ],
+};
+
+const withShipmentProps = {
+  ...shipmentSelectionProps,
+  mtoShipments: [
+    {
+      id: 'testShipment1',
+      shipmentType: 'HHG',
+      createdAt: '24 December 2020',
+    },
+  ],
+  currentPpm: {
+    id: 'testMove',
+  },
+};
+
+const submittedProps = {
+  ...withShipmentProps,
+  move: {
+    ...withShipmentProps.move,
+    status: 'SUBMITTED',
+    submitted_at: '24 December 2020',
+  },
+};
+
+export const Step2 = () => {
+  return (
+    <MockProviders>
+      <div className="grid-container usa-prose">
+        <Home {...uploadOrdersProps} />
+      </div>
+    </MockProviders>
+  );
+};
+
+export const Step3 = () => {
+  return (
+    <MockProviders>
+      <div className="grid-container usa-prose">
+        <Home {...shipmentSelectionProps} />
+      </div>
+    </MockProviders>
+  );
+};
+
+export const Step4 = () => {
+  return (
+    <MockProviders>
+      <div className="grid-container usa-prose">
+        <Home {...withShipmentProps} />
+      </div>
+    </MockProviders>
+  );
+};
+
+export const SubmittedMove = () => {
+  return (
+    <MockProviders>
+      <div className="grid-container usa-prose">
+        <Home {...submittedProps} />
+      </div>
+    </MockProviders>
+  );
+};


### PR DESCRIPTION
## Description

Design requested copy changes to the third step of the Customer home page, the "Set up shipments" section, and changes to the Helper copy that displays beneath the header when the user has added orders but not yet set up a shipment. This pull request implements those changes.

This pull request also expands the stories available for the Customer home page in Storybook (`Customer Components` / `Pages` / `Home`) , adding three additional stories and renaming the existing story to fit the new naming scheme, to highlight the major progression states that the user can view this page in.

## Reviewer Notes

It's pretty straightforward, although it's worth ensuring that the additional stories seem like logical states that the user can be in, and match the expectations of what content should display.

## Setup

View this updated component in Storybook, or launch the application:

```sh
yarn server_run
yarn client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8225](https://dp3.atlassian.net/browse/MB-8225).

## Screenshots

Before: 

* https://user-images.githubusercontent.com/83614364/122961708-a68d7700-d352-11eb-9774-411f03bdf671.png
* https://user-images.githubusercontent.com/83614364/122961711-a7260d80-d352-11eb-8761-0edc0a8e9983.png

After:

* https://user-images.githubusercontent.com/83614364/122961740-b016df00-d352-11eb-848c-4ffd56612c45.png
* https://user-images.githubusercontent.com/83614364/122961742-b016df00-d352-11eb-9b2a-ac4fa216b151.png
