### PR TITLE
Fix broken Happo diffs in Customer Components, Review Shipment stories due to broken date

### DIFF
--- a/src/components/Customer/Review/Review.stories.jsx
+++ b/src/components/Customer/Review/Review.stories.jsx
@@ -102,6 +102,7 @@ const PPMShipment = {
   id: 'ppmShipmentUuid',
   pickup_postal_code: '13643',
   destination_postal_code: '91945',
+  original_move_date: '2020-08-31',
 };
 
 export const WithNoShipments = () => {

--- a/src/components/Customer/Review/Review.stories.jsx
+++ b/src/components/Customer/Review/Review.stories.jsx
@@ -102,7 +102,7 @@ const PPMShipment = {
   id: 'ppmShipmentUuid',
   pickup_postal_code: '13643',
   destination_postal_code: '91945',
-  original_move_date: '2020-08-31',
+  original_move_date: '2021-06-23',
 };
 
 export const WithNoShipments = () => {


### PR DESCRIPTION
## Description

I recently merged a [pull request](https://github.com/transcom/mymove/pull/6820) that added several new stories for an existing component I was modifying. One of the fixture props for these stories was missing a property for an object that moment.js was interpreting as an empty string, which it then interpreted as today's date, and rendered it as such. That's for just for Storybook, but since we use Happo to compare images to previous test runs, the fact that this date would be different from run to run is causing unnecessary diffs to show up during morning Dependabot updates.

This pull request statically sets the missing date property (to today's date, for convenience) so that the component should render correctly.

## Reviewer Notes

Assuming that the most recently accepted Happo reference images for this story were from June 23, 2021, there should be no diffs from the reference image for any of the Review Shipment stories.

## Setup

You can test this locally if you wish by 
* changing your computer's internal date to anything besides June 23, 2021, 
* running Storybook (`yarn storybook`),
* verifying that the "Expected departure" date displayed in the PPM shipment card of the "With PPM" story for `Customer Components` / `Review Shipment` is displaying as June 23, 2021.

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Have the Jira acceptance criteria been met for this change?

