### PR TITLE
MB-3728 validator pattern to UpdateMTOShipment

### DIFF
--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -195,77 +195,57 @@ type UpdateMTOShipmentHandler struct {
 func (h UpdateMTOShipmentHandler) Handle(params mtoshipmentops.UpdateMTOShipmentParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
-	mtoShipmentID := uuid.FromStringOrNil(params.MtoShipmentID.String())
+	// Validate payload, remove readOnly fields, convert to model
+	mtoShipment, fieldErrs := UpdateMTOShipmentModel(params.MtoShipmentID, params.Body)
+	if fieldErrs != nil {
+		logger.Error("primeapi.UpdateMTOShipmentHandler error - extra fields in request", zap.Error(fieldErrs))
 
-	// Check that MTO is available to prime
-	mtoAvailableToPrime, err := h.mtoShipmentUpdater.MTOShipmentsMTOAvailableToPrime(mtoShipmentID)
+		errPayload := payloads.ValidationError("Fields that cannot be updated found in input",
+			h.GetTraceID(), fieldErrs)
+
+		return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(errPayload)
+	}
+
+	// Get the associated shipment from the database
+	var dbShipment models.MTOShipment
+	err := h.DB().EagerPreload("PickupAddress",
+		"DestinationAddress",
+		"SecondaryPickupAddress",
+		"SecondaryDeliveryAddress",
+		"MTOAgents").Find(&dbShipment, params.MtoShipmentID)
 	if err != nil {
-		logger.Error("primeapi.UpdateMTOShipmentHandler error - MTO is not available to prime", zap.Error(err))
+		return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
+	}
+
+	// Validate further prime restrictions on model
+	mtoShipment, validationErrs := h.checkPrimeValidationsOnModel(mtoShipment, &dbShipment)
+	if validationErrs != nil && validationErrs.HasAny() {
+		logger.Error("primeapi.UpdateMTOShipmentHandler error - extra fields in request", zap.Error(validationErrs))
+
+		errPayload := payloads.ValidationError("Invalid data found in input",
+			h.GetTraceID(), validationErrs)
+
+		return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(errPayload)
+	}
+
+	logger.Info("primeapi.UpdateMTOShipmentHandler info", zap.String("pointOfContact", params.Body.PointOfContact))
+	mtoShipment, err = h.mtoShipmentUpdater.UpdateMTOShipmentPrime(params.HTTPRequest.Context(), mtoShipment, params.IfMatch)
+	if err != nil {
+		logger.Error("primeapi.UpdateMTOShipmentHandler error", zap.Error(err))
 		switch e := err.(type) {
 		case services.NotFoundError:
-			return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, e.Error(), h.GetTraceID()))
+			return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
+		case services.InvalidInputError:
+			payload := payloads.ValidationError(err.Error(), h.GetTraceID(), e.ValidationErrors)
+			return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(payload)
+		case services.PreconditionFailedError:
+			return mtoshipmentops.NewUpdateMTOShipmentPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
 		default:
 			return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
 		}
 	}
-
-	if mtoAvailableToPrime {
-
-		// Validate payload, remove readOnly fields, convert to model
-		mtoShipment, fieldErrs := UpdateMTOShipmentModel(params.MtoShipmentID, params.Body)
-		if fieldErrs != nil {
-			logger.Error("primeapi.UpdateMTOShipmentHandler error - extra fields in request", zap.Error(fieldErrs))
-
-			errPayload := payloads.ValidationError("Fields that cannot be updated found in input",
-				h.GetTraceID(), fieldErrs)
-
-			return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(errPayload)
-		}
-
-		// Get the associated shipment from the database
-		var dbShipment models.MTOShipment
-		err := h.DB().EagerPreload("PickupAddress",
-			"DestinationAddress",
-			"SecondaryPickupAddress",
-			"SecondaryDeliveryAddress",
-			"MTOAgents").Find(&dbShipment, params.MtoShipmentID)
-		if err != nil {
-			return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
-		}
-
-		// Validate further prime restrictions on model
-		mtoShipment, validationErrs := h.checkPrimeValidationsOnModel(mtoShipment, &dbShipment)
-		if validationErrs != nil && validationErrs.HasAny() {
-			logger.Error("primeapi.UpdateMTOShipmentHandler error - extra fields in request", zap.Error(validationErrs))
-
-			errPayload := payloads.ValidationError("Invalid data found in input",
-				h.GetTraceID(), validationErrs)
-
-			return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(errPayload)
-		}
-
-		eTag := params.IfMatch
-
-		logger.Info("primeapi.UpdateMTOShipmentHandler info", zap.String("pointOfContact", params.Body.PointOfContact))
-		mtoShipment, err = h.mtoShipmentUpdater.UpdateMTOShipmentPrime(params.HTTPRequest.Context(), mtoShipment, eTag)
-		if err != nil {
-			logger.Error("primeapi.UpdateMTOShipmentHandler error", zap.Error(err))
-			switch e := err.(type) {
-			case services.NotFoundError:
-				return mtoshipmentops.NewUpdateMTOShipmentNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceID()))
-			case services.InvalidInputError:
-				payload := payloads.ValidationError(err.Error(), h.GetTraceID(), e.ValidationErrors)
-				return mtoshipmentops.NewUpdateMTOShipmentUnprocessableEntity().WithPayload(payload)
-			case services.PreconditionFailedError:
-				return mtoshipmentops.NewUpdateMTOShipmentPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceID()))
-			default:
-				return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
-			}
-		}
-		mtoShipmentPayload := payloads.MTOShipment(mtoShipment)
-		return mtoshipmentops.NewUpdateMTOShipmentOK().WithPayload(mtoShipmentPayload)
-	}
-	return mtoshipmentops.NewUpdateMTOShipmentInternalServerError().WithPayload(payloads.InternalServerError(nil, h.GetTraceID()))
+	mtoShipmentPayload := payloads.MTOShipment(mtoShipment)
+	return mtoshipmentops.NewUpdateMTOShipmentOK().WithPayload(mtoShipmentPayload)
 }
 
 // This function checks Prime specific validations on the model

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -49,10 +49,7 @@ func NewMTOShipmentUpdater(db *pop.Connection, builder UpdateMTOShipmentQueryBui
 }
 
 // setNewShipmentFields validates the updated shipment
-func setNewShipmentFields(dbShipment *models.MTOShipment, requestedUpdatedShipment *models.MTOShipment) error {
-	verrs := validate.NewErrors()
-	oldShipmentCopy := dbShipment // make a copy to restore values in case there were errors while setting
-
+func setNewShipmentFields(dbShipment *models.MTOShipment, requestedUpdatedShipment *models.MTOShipment) {
 	if requestedUpdatedShipment.RequestedPickupDate != nil {
 		dbShipment.RequestedPickupDate = requestedUpdatedShipment.RequestedPickupDate
 	}
@@ -111,9 +108,6 @@ func setNewShipmentFields(dbShipment *models.MTOShipment, requestedUpdatedShipme
 
 	if requestedUpdatedShipment.Status != "" {
 		dbShipment.Status = requestedUpdatedShipment.Status
-		if dbShipment.Status != models.MTOShipmentStatusDraft && dbShipment.Status != models.MTOShipmentStatusSubmitted {
-			verrs.Add("status", "can only update status to DRAFT or SUBMITTED. use UpdateMTOShipmentStatus for other status updates")
-		}
 	}
 
 	if requestedUpdatedShipment.RequiredDeliveryDate != nil {
@@ -175,13 +169,6 @@ func setNewShipmentFields(dbShipment *models.MTOShipment, requestedUpdatedShipme
 		}
 		dbShipment.MTOAgents = agentsToCreateOrUpdate // don't return unchanged existing agents
 	}
-
-	if verrs.HasAny() {
-		dbShipment = oldShipmentCopy
-		return services.NewInvalidInputError(dbShipment.ID, nil, verrs, "Invalid input found while updating the shipment.")
-	}
-
-	return nil
 }
 
 // StaleIdentifierError is used when optimistic locking determines that the identifier refers to stale data
@@ -226,61 +213,77 @@ func (f *mtoShipmentUpdater) RetrieveMTOShipment(mtoShipmentID uuid.UUID) (*mode
 // TODO: apply the subset of business logic validations
 // that would be appropriate for the OFFICE USER
 func (f *mtoShipmentUpdater) UpdateMTOShipmentOffice(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
-	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+	return f.updateMTOShipment(
+		ctx,
+		mtoShipment,
+		eTag,
+		checkStatus(),
+	)
 }
 
 // UpdateMTOShipmentCustomer updates the mto shipment
 // TODO: apply the subset of business logic validations
 // that would be appropriate for the CUSTOMER
 func (f *mtoShipmentUpdater) UpdateMTOShipmentCustomer(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
-	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+	return f.updateMTOShipment(
+		ctx,
+		mtoShipment,
+		eTag,
+		checkStatus(),
+	)
 }
 
 // UpdateMTOShipmentPrime updates the mto shipment
 // TODO: apply the subset of business logic validations
 // that would be appropriate for the PRIME
 func (f *mtoShipmentUpdater) UpdateMTOShipmentPrime(ctx context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
-	return f.updateMTOShipment(ctx, mtoShipment, eTag)
+	return f.updateMTOShipment(
+		ctx,
+		mtoShipment,
+		eTag,
+		checkStatus(),
+	)
 }
 
 //updateMTOShipment updates the mto shipment
-func (f *mtoShipmentUpdater) updateMTOShipment(_ context.Context, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
+func (f *mtoShipmentUpdater) updateMTOShipment(ctx context.Context, mtoShipment *models.MTOShipment, eTag string, checks ...validator) (*models.MTOShipment, error) {
 	oldShipment, err := f.RetrieveMTOShipment(mtoShipment.ID)
-
 	if err != nil {
 		return nil, services.NewNotFoundError(mtoShipment.ID, "while looking for mtoShipment")
 	}
+
+	// run the (read-only) validations
+	if verr := validateShipment(ctx, mtoShipment, oldShipment, checks...); verr != nil {
+		return nil, verr
+	}
+
 	var dbShipment models.MTOShipment
 	err = deepcopy.Copy(&dbShipment, oldShipment) // save the original db version, oldShipment will be modified
 	if err != nil {
 		return nil, fmt.Errorf("error copying shipment data %w", err)
 	}
-	err = setNewShipmentFields(oldShipment, mtoShipment)
-	if err != nil {
-		return nil, err
-	}
+
+	setNewShipmentFields(oldShipment, mtoShipment)
 	newShipment := oldShipment // old shipment has now been updated with requested changes
 	// db version is used to check if agents need creating or updating
 	err = f.updateShipmentRecord(&dbShipment, newShipment, eTag)
-
 	if err != nil {
 		switch err.(type) {
 		case StaleIdentifierError:
-			return &models.MTOShipment{}, services.NewPreconditionFailedError(mtoShipment.ID, err)
+			return nil, services.NewPreconditionFailedError(mtoShipment.ID, err)
 		default:
-			return &models.MTOShipment{}, err
+			return nil, err
 		}
 	}
 
 	updatedShipment, err := f.RetrieveMTOShipment(mtoShipment.ID)
-
 	if err != nil {
-		return &models.MTOShipment{}, err
+		return nil, err
 	}
 
 	err = f.db.Eager("MTOServiceItems.ReService").Find(updatedShipment, mtoShipment.ID.String())
 	if err != nil {
-		return &models.MTOShipment{}, err
+		return nil, err
 	}
 
 	return updatedShipment, nil
@@ -581,9 +584,7 @@ func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(shipmentID uuid.UUID,
 	}
 
 	if verrs != nil && verrs.HasAny() {
-		invalidInputError := services.NewInvalidInputError(shipment.ID, nil, verrs, "There was an issue with validating the updates")
-
-		return &models.MTOShipment{}, invalidInputError
+		return nil, services.NewInvalidInputError(shipment.ID, nil, verrs, "There was an issue with validating the updates")
 	}
 
 	// after updating shipment

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -167,10 +167,8 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	suite.T().Run("If-Unmodified-Since is equal to the updated_at date", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment, eTag)
-		if !suite.NoError(err) {
-			return
-		}
 
+		suite.Require().NoError(err)
 		suite.Equal(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(updatedMTOShipment.MoveTaskOrder.ID, oldMTOShipment.MoveTaskOrder.ID)
 		suite.Equal(updatedMTOShipment.ShipmentType, models.MTOShipmentTypeInternationalUB)
@@ -191,10 +189,8 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment2.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment2, eTag)
-		if !suite.NoError(err) {
-			return
-		}
 
+		suite.Require().NoError(err)
 		suite.Equal(updatedMTOShipment.ID, oldMTOShipment2.ID)
 		suite.Equal(updatedMTOShipment.MoveTaskOrder.ID, oldMTOShipment2.MoveTaskOrder.ID)
 		suite.Equal(updatedMTOShipment.ShipmentType, models.MTOShipmentTypeInternationalUB)
@@ -220,9 +216,8 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), updatedShipment, eTag)
-		if !suite.NoError(err) {
-			return
-		}
+
+		suite.Require().NoError(err)
 		suite.Equal(newDestinationAddress.ID, *updatedShipment.DestinationAddressID)
 		suite.Equal(newDestinationAddress.StreetAddress1, updatedShipment.DestinationAddress.StreetAddress1)
 		suite.Equal(newPickupAddress.ID, *updatedShipment.PickupAddressID)
@@ -276,9 +271,8 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		newShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
-		if !suite.NoError(err) {
-			return
-		}
+
+		suite.Require().NoError(err)
 		suite.True(requestedPickupDate.Equal(*newShipment.RequestedPickupDate))
 		suite.True(scheduledPickupDate.Equal(*newShipment.ScheduledPickupDate))
 		suite.True(requestedDeliveryDate.Equal(*newShipment.RequestedDeliveryDate))
@@ -342,9 +336,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
-		if !suite.NoError(err) {
-			return
-		}
+		suite.Require().NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(phone, *updatedMTOShipment.MTOAgents[0].Phone)
 		suite.Equal(newFirstName, *updatedMTOShipment.MTOAgents[0].FirstName)
@@ -388,9 +380,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
-		if !suite.NoError(err) {
-			return
-		}
+		suite.Require().NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(phone, *updatedMTOShipment.MTOAgents[0].Phone)
 		suite.Equal(*mtoAgentToCreate.FirstName, *updatedMTOShipment.MTOAgents[1].FirstName)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -167,7 +167,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	suite.T().Run("If-Unmodified-Since is equal to the updated_at date", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment, eTag)
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 
 		suite.Equal(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(updatedMTOShipment.MoveTaskOrder.ID, oldMTOShipment.MoveTaskOrder.ID)
@@ -189,12 +191,13 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
 		eTag := etag.GenerateEtag(oldMTOShipment2.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &mtoShipment2, eTag)
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 
 		suite.Equal(updatedMTOShipment.ID, oldMTOShipment2.ID)
 		suite.Equal(updatedMTOShipment.MoveTaskOrder.ID, oldMTOShipment2.MoveTaskOrder.ID)
 		suite.Equal(updatedMTOShipment.ShipmentType, models.MTOShipmentTypeInternationalUB)
-		suite.Nil(updatedMTOShipment.PrimeEstimatedWeight)
 	})
 
 	suite.T().Run("Successful update to all address fields", func(t *testing.T) {
@@ -217,7 +220,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		updatedShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), updatedShipment, eTag)
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 		suite.Equal(newDestinationAddress.ID, *updatedShipment.DestinationAddressID)
 		suite.Equal(newDestinationAddress.StreetAddress1, updatedShipment.DestinationAddress.StreetAddress1)
 		suite.Equal(newPickupAddress.ID, *updatedShipment.PickupAddressID)
@@ -271,7 +276,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		newShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 		suite.True(requestedPickupDate.Equal(*newShipment.RequestedPickupDate))
 		suite.True(scheduledPickupDate.Equal(*newShipment.ScheduledPickupDate))
 		suite.True(requestedDeliveryDate.Equal(*newShipment.RequestedDeliveryDate))
@@ -335,7 +342,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(phone, *updatedMTOShipment.MTOAgents[0].Phone)
 		suite.Equal(newFirstName, *updatedMTOShipment.MTOAgents[0].FirstName)
@@ -379,7 +388,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(context.Background(), &updatedShipment, eTag)
 
-		suite.NoError(err)
+		if !suite.NoError(err) {
+			return
+		}
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
 		suite.Equal(phone, *updatedMTOShipment.MTOAgents[0].Phone)
 		suite.Equal(*mtoAgentToCreate.FirstName, *updatedMTOShipment.MTOAgents[1].FirstName)

--- a/pkg/services/mto_shipment/validation.go
+++ b/pkg/services/mto_shipment/validation.go
@@ -28,9 +28,6 @@ func validateShipment(ctx context.Context, newer *models.MTOShipment, older *mod
 			case *validate.Errors:
 				// accumulate validation errors
 				verrs.Append(e)
-				// if true {
-				// 	return err
-				// }
 			default:
 				// non-validation errors have priority,
 				// and short-circuit doing any further checks

--- a/pkg/services/mto_shipment/validation.go
+++ b/pkg/services/mto_shipment/validation.go
@@ -1,0 +1,54 @@
+package mtoshipment
+
+import (
+	"context"
+
+	"github.com/gobuffalo/validate/v3"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+type validator interface {
+	Validate(c context.Context, newer *models.MTOShipment, older *models.MTOShipment) error
+}
+
+type validatorFunc func(context.Context, *models.MTOShipment, *models.MTOShipment) error
+
+func (fn validatorFunc) Validate(c context.Context, newer *models.MTOShipment, older *models.MTOShipment) error {
+	return fn(c, newer, older)
+}
+
+func validateShipment(ctx context.Context, newer *models.MTOShipment, older *models.MTOShipment, checks ...validator) (result error) {
+	verrs := validate.NewErrors()
+	for _, checker := range checks {
+		if err := checker.Validate(ctx, newer, older); err != nil {
+			switch e := err.(type) {
+			case *validate.Errors:
+				// accumulate validation errors
+				verrs.Append(e)
+				// if true {
+				// 	return err
+				// }
+			default:
+				// non-validation errors have priority,
+				// and short-circuit doing any further checks
+				return err
+			}
+		}
+	}
+	if verrs.HasAny() {
+		result = services.NewInvalidInputError(newer.ID, nil, verrs, "Invalid input found while updating the shipment.")
+	}
+	return result
+}
+
+func checkStatus() validator {
+	return validatorFunc(func(_ context.Context, newer *models.MTOShipment, _ *models.MTOShipment) error {
+		verrs := validate.NewErrors()
+		if newer.Status != "" && newer.Status != models.MTOShipmentStatusDraft && newer.Status != models.MTOShipmentStatusSubmitted {
+			verrs.Add("status", "can only update status to DRAFT or SUBMITTED. use UpdateMTOShipmentStatus for other status updates")
+		}
+		return verrs
+	})
+}

--- a/pkg/services/mto_shipment/validation.go
+++ b/pkg/services/mto_shipment/validation.go
@@ -53,13 +53,13 @@ func checkStatus() validator {
 
 func checkAvailToPrime(db *pop.Connection) validator {
 	return validatorFunc(func(_ context.Context, newer *models.MTOShipment, _ *models.MTOShipment) error {
-		var mto models.Move
+		var move models.Move
 		err := db.Q().
 			Join("mto_shipments", "moves.id = mto_shipments.move_id").
 			Where("available_to_prime_at IS NOT NULL").
 			Where("mto_shipments.id = ?", newer.ID).
 			Where("show = TRUE").
-			First(&mto)
+			First(&move)
 		if err != nil {
 			if err.Error() == models.RecordNotFoundErrorString {
 				return services.NewNotFoundError(newer.ID, "for mtoShipment")

--- a/pkg/services/mto_shipment/validation_test.go
+++ b/pkg/services/mto_shipment/validation_test.go
@@ -1,0 +1,37 @@
+package mtoshipment
+
+import (
+	"context"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
+	suite.Run("checkStatus", func() {
+		testCases := map[models.MTOShipmentStatus]bool{
+			"":                                            true,
+			models.MTOShipmentStatusDraft:                 true,
+			models.MTOShipmentStatusSubmitted:             true,
+			"random_junk_status":                          false,
+			models.MTOShipmentStatusApproved:              false,
+			models.MTOShipmentStatusRejected:              false,
+			models.MTOShipmentStatusCancellationRequested: false,
+			models.MTOShipmentStatusCanceled:              false,
+			models.MTOShipmentStatusDiversionRequested:    false,
+		}
+		for status, allowed := range testCases {
+			suite.Run("status "+string(status), func() {
+				err := checkStatus().Validate(
+					context.Background(),
+					&models.MTOShipment{Status: status},
+					nil,
+				)
+				if allowed {
+					suite.Empty(err.Error())
+				} else {
+					suite.NotEmpty(err.Error())
+				}
+			})
+		}
+	})
+}

--- a/pkg/services/mto_shipment/validation_test.go
+++ b/pkg/services/mto_shipment/validation_test.go
@@ -2,8 +2,13 @@ package mtoshipment
 
 import (
 	"context"
+	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
@@ -31,6 +36,68 @@ func (suite *MTOShipmentServiceSuite) TestUpdateValidations() {
 				} else {
 					suite.NotEmpty(err.Error())
 				}
+			})
+		}
+	})
+
+	suite.Run("checkAvailToPrime", func() {
+		now := time.Now()
+		hide := false
+		primeShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+		})
+		nonPrimeShipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
+		hiddenPrimeShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+				Show:               &hide,
+			},
+		})
+		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
+
+		testCases := map[string]struct {
+			id   uuid.UUID
+			verf func(error)
+		}{
+			"happy path": {
+				primeShipment.ID,
+				func(err error) {
+					suite.Require().NoError(err)
+				},
+			},
+			"exists unavailable": {
+				nonPrimeShipment.ID,
+				func(err error) {
+					suite.Require().Error(err)
+					suite.IsType(err, services.NotFoundError{})
+					suite.Contains(err.Error(), nonPrimeShipment.ID.String())
+				},
+			},
+			"disabled move": {
+				hiddenPrimeShipment.ID,
+				func(err error) {
+					suite.Require().Error(err)
+					suite.IsType(err, services.NotFoundError{})
+					suite.Contains(err.Error(), hiddenPrimeShipment.ID.String())
+				},
+			},
+			"does not exist": {
+				badUUID,
+				func(err error) {
+					suite.Require().Error(err)
+					suite.IsType(err, services.NotFoundError{})
+					suite.Contains(err.Error(), badUUID.String())
+				},
+			},
+		}
+
+		for name, tc := range testCases {
+			suite.Run(name, func() {
+				checker := checkAvailToPrime(suite.DB())
+				err := checker.Validate(context.Background(), &models.MTOShipment{ID: tc.id}, nil)
+				tc.verf(err)
 			})
 		}
 	})


### PR DESCRIPTION
## Description

Introduce the validator pattern to the `UpdateMTOShipment` service layer. Converts one shared validation (`checkStatus()`), and converts one Prime-specific validation (`checkAvailToPrime(...)`).

## Reviewer Notes

There are _a lot_ of business-logic validations that are occurring in the `handlers` layer, that would be more appropriate in the `services` layer, but I had to control my urge to go an refactor everything... After this PR the validator pattern will be available for any further refactorings.

* [x] Request review from a member of a different team.