### PR TITLE
MB-8142 858 fixes

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -42,6 +42,7 @@ type InvoiceHeader struct {
 	ServiceMemberName        edisegment.N9
 	ServiceMemberRank        edisegment.N9
 	ServiceMemberBranch      edisegment.N9
+	Currency                 edisegment.C3
 	RequestedPickupDate      *edisegment.G62
 	ScheduledPickupDate      *edisegment.G62
 	ActualPickupDate         *edisegment.G62

--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -92,6 +92,7 @@ func (ih *InvoiceHeader) NonEmptySegments() []edisegment.Segment {
 		&ih.ServiceMemberName,
 		&ih.ServiceMemberRank,
 		&ih.ServiceMemberBranch,
+		&ih.Currency,
 		ih.RequestedPickupDate,
 		ih.ScheduledPickupDate,
 		ih.ActualPickupDate,

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -135,6 +135,10 @@ func MakeValidEdi() Invoice858C {
 			ReferenceIdentification:          "ARMY",
 		},
 
+		Currency: edisegment.C3{
+			CurrencyCodeC301: "USD",
+		},
+
 		RequestedPickupDate: &date,
 
 		BuyerOrganizationName: edisegment.N1{

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -68,6 +68,7 @@ N9*CT*TRUSS_TEST**
 N9*1W*Leo, Spacemen**
 N9*ML*E_1**
 N9*3L*ARMY**
+C3*USD***
 G62*10*20200909**
 N1*BY*BuyerOrganizationName*92*LKNQ
 N1*SE*SellerOrganizationName*2*BLKW
@@ -87,7 +88,6 @@ SE*12345*ABCDE
 GE*1*9999
 IEA*1*000009999
 `, ediString)
-		fmt.Println(ediString)
 	})
 
 }

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -87,7 +87,9 @@ SE*12345*ABCDE
 GE*1*9999
 IEA*1*000009999
 `, ediString)
+		fmt.Println(ediString)
 	})
+
 }
 
 func (suite *InvoiceSuite) TestValidate() {

--- a/pkg/edi/segment/c3.go
+++ b/pkg/edi/segment/c3.go
@@ -1,0 +1,48 @@
+package edisegment
+
+import "fmt"
+
+// C3 represents the C3 EDI segment (Currency)
+type C3 struct {
+	// http://www.iso.org/iso/en/prods-services/popstds/currencycodeslist.html is the URL
+	// referenced in the 858 standard, but that URL is not valid
+	// https://en.wikipedia.org/wiki/ISO_4217 seems to be a good list to reference
+	CurrencyCodeC301 string `validate:"omitempty,max=3"`
+	ExchangeRate     string `validate:"omitempty"`
+	CurrencyCodeC303 string `validate:"omitempty,max=3"`
+	CurrencyCodeC304 string `validate:"omitempty,max=3"`
+}
+
+// StringArray converts C3 to an array of strings
+func (s *C3) StringArray() []string {
+	return []string{
+		"C3",
+		s.CurrencyCodeC301,
+		s.ExchangeRate,
+		s.CurrencyCodeC303,
+		s.CurrencyCodeC304,
+	}
+}
+
+// Parse parses an C3 string that's split into an array into the C3 struct
+func (s *C3) Parse(elements []string) error {
+	expectedMinNumElements := 1
+	expectedMaxNumElements := 4
+	numElements := len(elements)
+	if numElements < expectedMinNumElements || numElements > expectedMaxNumElements {
+		return fmt.Errorf("C3: Wrong number of fields, expected min %d and max %d, got %d", expectedMinNumElements, expectedMaxNumElements, len(elements))
+	}
+
+	s.CurrencyCodeC301 = elements[0]
+	if numElements > 1 {
+		s.ExchangeRate = elements[1]
+	}
+	if numElements > 2 {
+		s.CurrencyCodeC303 = elements[2]
+	}
+	if numElements > 3 {
+		s.CurrencyCodeC304 = elements[3]
+	}
+
+	return nil
+}

--- a/pkg/edi/segment/c3_test.go
+++ b/pkg/edi/segment/c3_test.go
@@ -1,0 +1,34 @@
+package edisegment
+
+import (
+	"testing"
+)
+
+func (suite *SegmentSuite) TestValidateC3() {
+	validC3 := C3{
+		CurrencyCodeC301: "USD",
+		ExchangeRate:     "x",
+		CurrencyCodeC303: "USD",
+		CurrencyCodeC304: "EUR",
+	}
+
+	suite.T().Run("validate success", func(t *testing.T) {
+		err := suite.validator.Struct(validC3)
+		suite.NoError(err)
+	})
+
+	suite.T().Run("validate failure 1", func(t *testing.T) {
+		c3 := C3{
+			CurrencyCodeC301: "TTTT", // max
+			ExchangeRate:     "K",    // none
+			CurrencyCodeC303: "QQQQ", // max
+			CurrencyCodeC304: "RRRR", // max
+		}
+
+		err := suite.validator.Struct(c3)
+		suite.ValidateError(err, "CurrencyCodeC301", "max")
+		suite.ValidateError(err, "CurrencyCodeC303", "max")
+		suite.ValidateError(err, "CurrencyCodeC304", "max")
+		suite.ValidateErrorLen(err, 3)
+	})
+}

--- a/pkg/edi/segment/hl.go
+++ b/pkg/edi/segment/hl.go
@@ -8,7 +8,7 @@ import (
 type HL struct {
 	HierarchicalIDNumber       string `validate:"alphanum,min=1,max=12"`
 	HierarchicalParentIDNumber string `validate:"isdefault"` // not used
-	HierarchicalLevelCode      string `validate:"oneof=SS I"`
+	HierarchicalLevelCode      string `validate:"oneof=SS I 9"`
 }
 
 // StringArray converts HL to an array of strings

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -248,9 +248,6 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	// Proceed with full EDI Generation tests
 	result, err := generator.Generate(paymentRequest, false)
 	suite.NoError(err)
-	ediPrint, ediPrintErr := result.EDIString(suite.logger)
-	suite.NoError(ediPrintErr)
-	fmt.Println(ediPrint)
 
 	// Test that the Interchange Control Number (ICN) is being used as the Group Control Number (GCN)
 	suite.T().Run("the GCN is equal to the ICN", func(t *testing.T) {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -303,7 +303,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("se segment has correct value", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(127, result.SE.NumberOfIncludedSegments)
+		suite.Equal(128, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -355,6 +355,12 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 			suite.Equal(data.ExpectedValue, n9.ReferenceIdentification)
 		})
 	}
+
+	suite.T().Run("adds currency to header", func(t *testing.T) {
+		currency := result.Header.Currency
+		suite.IsType(edisegment.C3{}, currency)
+		suite.Equal("USD", currency.CurrencyCodeC301)
+	})
 
 	suite.T().Run("adds actual pickup date to header", func(t *testing.T) {
 		g62Requested := result.Header.RequestedPickupDate


### PR DESCRIPTION
## Description

Fixes to EDI 858 generation

**There was a list of things that needed to be fixed for 858, some of them were fixed in this PR**
6359-1464-1 PER 04 This field must be a number. (destination duty station poc number)   
6359-1464-1 PER 04 This field must be a number. (origin duty station poc number)    
6359-1464-1 HL 03 should be set to 9.   
6359-1464-1 Recommended Field Missing - C3   


```txt
HL*1**I
```
is now 
```txt
HL*1**9
```

```txt
PER*CN**TE*(618) 256-1201
PER*CN**TE*(757) 878-4664
```
now doesn't have any `()-` characters only numbers allowed in field 
```txt
PER*CN**TE*7067914184
PER*CN**TE*5105555555
```

Added in the C3 currency field
```txt
C3*USD***
```


## Reviewer Notes

Make sure the UT is sufficient for the changes made. No acceptance needed for this.

## Setup
Populate the database and rebuild the bins needed for this run
```sh
make db_dev_e2e_populate && rm bin/prime-api-client ; make bin/prime-api-client  && rm bin/generate-payment-request-edi ; make bin/generate-payment-request-edi
```

Run the server
```sh
make server_run
```

Run the office app
```sh
make office_client_run
```



Run the PRIME API demo script to create a payment request
```sh
prime-api-demo RDY4PY
```
You can cancel after payment request is created

Sample output of what you'll need from demo script
```sh
Payment Request ID: "d29662fc-4fcb-4170-bd2e-1a6da1e16cf8"
Payment Request Number: "8596-7546-1"
Payment Request Status: "PENDING"
```


Login into office app with TIO local creds
Approve service items for RDY4PY
`too_tio_role@office.mil (PPM office)`

Generate EDI to see fields mentioned
```sh
bin/generate-payment-request-edi --payment-request-number "8596-7546-1"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8142) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
