### PR TITLE
MB-8493-add-search-to-offices-page

### DIFF
--- a/cypress/integration/admin/offices.js
+++ b/cypress/integration/admin/offices.js
@@ -10,6 +10,7 @@ describe('Offices Page', function () {
     cy.get('a[href*="system/offices"]').click();
     cy.url().should('eq', adminBaseURL + '/system/offices');
     cy.get('header').contains('Offices');
+    cy.get('[data-source=q]').should('be.visible');
 
     const columnLabels = ['Id', 'Name', 'Latitude', 'Longitude', 'Gbloc'];
     columnLabels.forEach((label) => {

--- a/cypress/integration/admin/offices.js
+++ b/cypress/integration/admin/offices.js
@@ -1,0 +1,19 @@
+import { adminBaseURL } from '../../support/constants';
+
+describe('Offices Page', function () {
+  before(() => {
+    cy.prepareAdminApp();
+  });
+
+  it('successfully navigates to offices page', function () {
+    cy.signInAsNewAdminUser();
+    cy.get('a[href*="system/users"]').click();
+    cy.url().should('eq', adminBaseURL + '/system/offices');
+    cy.get('header').contains('Offices');
+
+    const columnLabels = ['Id', 'Name', 'Latitude', 'Longitude', 'Gbloc'];
+    columnLabels.forEach((label) => {
+      cy.get('table').contains(label);
+    });
+  });
+});

--- a/cypress/integration/admin/offices.js
+++ b/cypress/integration/admin/offices.js
@@ -7,7 +7,7 @@ describe('Offices Page', function () {
 
   it('successfully navigates to offices page', function () {
     cy.signInAsNewAdminUser();
-    cy.get('a[href*="system/users"]').click();
+    cy.get('a[href*="system/offices"]').click();
     cy.url().should('eq', adminBaseURL + '/system/offices');
     cy.get('header').contains('Offices');
 

--- a/src/pages/Admin/Offices/OfficeList.jsx
+++ b/src/pages/Admin/Offices/OfficeList.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { List, Datagrid, TextField, Filter, TextInput } from 'react-admin';
+
 import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 
 const defaultSort = { field: 'name', order: 'ASC' };

--- a/src/pages/Admin/Offices/OfficeList.jsx
+++ b/src/pages/Admin/Offices/OfficeList.jsx
@@ -20,6 +20,7 @@ const OfficeList = (props) => (
     pagination={<AdminPagination />}
     perPage={25}
     sort={defaultSort}
+    bulkActionButtons={false}
   >
     <Datagrid>
       <TextField source="id" />

--- a/src/pages/Admin/Offices/OfficeList.jsx
+++ b/src/pages/Admin/Offices/OfficeList.jsx
@@ -6,7 +6,6 @@ import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 const defaultSort = { field: 'name', order: 'ASC' };
 
 const OfficeFilter = (props) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
   <Filter {...props}>
     <TextInput label="Search by Office Name" source="q" resettable alwaysOn />
   </Filter>
@@ -14,7 +13,6 @@ const OfficeFilter = (props) => (
 
 const OfficeList = (props) => (
   <List
-    /* eslint-disable-next-line react/jsx-props-no-spreading */
     {...props}
     filters={<OfficeFilter />}
     pagination={<AdminPagination />}

--- a/src/pages/Admin/Offices/OfficeList.jsx
+++ b/src/pages/Admin/Offices/OfficeList.jsx
@@ -8,7 +8,7 @@ const defaultSort = { field: 'name', order: 'ASC' };
 const OfficeFilter = (props) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <Filter {...props}>
-    <TextInput label="Search by Office Id" source="search" resettable alwaysOn />
+    <TextInput label="Search by Office Name" source="q" resettable alwaysOn />
   </Filter>
 );
 

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -14,7 +14,7 @@ import AdminUserList from 'pages/Admin/AdminUsers/AdminUserList';
 import AdminUserShow from 'pages/Admin/AdminUsers/AdminUserShow';
 import AdminUserCreate from 'pages/Admin/AdminUsers/AdminUserCreate';
 import AdminUserEdit from 'pages/Admin/AdminUsers/AdminUserEdit';
-import OfficeList from '../../pages/Admin/Offices/OfficeList';
+import OfficeList from 'pages/Admin/Offices/OfficeList';
 import TSPPList from './TSPPs/TSPPList';
 import TSPPShow from './TSPPs/TSPPShow';
 import ElectronicOrderList from './ElectronicOrders/ElectronicOrderList';

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -14,7 +14,7 @@ import AdminUserList from 'pages/Admin/AdminUsers/AdminUserList';
 import AdminUserShow from 'pages/Admin/AdminUsers/AdminUserShow';
 import AdminUserCreate from 'pages/Admin/AdminUsers/AdminUserCreate';
 import AdminUserEdit from 'pages/Admin/AdminUsers/AdminUserEdit';
-import OfficeList from './Offices/OfficeList';
+import OfficeList from '../../pages/Admin/Offices/OfficeList';
 import TSPPList from './TSPPs/TSPPList';
 import TSPPShow from './TSPPs/TSPPShow';
 import ElectronicOrderList from './ElectronicOrders/ElectronicOrderList';

--- a/src/scenes/SystemAdmin/Offices/OfficeList.jsx
+++ b/src/scenes/SystemAdmin/Offices/OfficeList.jsx
@@ -1,11 +1,25 @@
 import React from 'react';
-import { List, Datagrid, TextField } from 'react-admin';
+import { List, Datagrid, TextField, Filter, TextInput } from 'react-admin';
 import AdminPagination from 'scenes/SystemAdmin/shared/AdminPagination';
 
 const defaultSort = { field: 'name', order: 'ASC' };
 
+const OfficeFilter = (props) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <Filter {...props}>
+    <TextInput label="Search by Office Id" source="search" resettable alwaysOn />
+  </Filter>
+);
+
 const OfficeList = (props) => (
-  <List {...props} pagination={<AdminPagination />} perPage={25} sort={defaultSort}>
+  <List
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    {...props}
+    filters={<OfficeFilter />}
+    pagination={<AdminPagination />}
+    perPage={25}
+    sort={defaultSort}
+  >
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />


### PR DESCRIPTION
## Description

Added a search feature to the offices page in the Admin console. An admin user can now log into the console and search for offices by name in the admin page. 

Additionally an integration test was created to test the page.

Finally, offficeList.jsx was moved into the pages folder in the codebase to as was the convention for the other pages in the Admin console.

## Setup

To run the cypress test

```sh
make e2e_test
```

1. Select the `Offices` folder in the popup window and watch the test run.T

To test the feature locally, run the server `make server_run` and the client `make admin_client_run`. Then login using the Local Login, and navigate to the Offices page.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8493) for this change

## Screenshots
![Screen Shot 2021-06-24 at 10 03 39 AM](https://user-images.githubusercontent.com/17951554/123304317-a9fc3c00-d4d3-11eb-8278-df49099797b0.png)

