### PR TITLE
Fix non-deterministic Happo diffs in Customer Components, Review Shipment story

### DIFF
--- a/src/components/Customer/Review/Review.stories.jsx
+++ b/src/components/Customer/Review/Review.stories.jsx
@@ -95,6 +95,7 @@ const HHGShipment = {
   requestedPickupDate: '2020-08-31',
   shipmentType: 'HHG',
   status: MOVE_STATUSES.SUBMITTED,
+  createdAt: '2020-09-01T21:00:00.000Z',
   updatedAt: '2020-09-02T21:08:38.392Z',
 };
 
@@ -103,6 +104,7 @@ const PPMShipment = {
   pickup_postal_code: '13643',
   destination_postal_code: '91945',
   original_move_date: '2021-06-23',
+  created_at: '2020-09-01T22:00:00.000Z',
 };
 
 export const WithNoShipments = () => {


### PR DESCRIPTION
## Description

Similar to [this pull request](https://github.com/transcom/mymove/pull/6861) from earlier this week, this pull request fixes a Happo diff issue introduced by adding stories to Review Shipments component. In this case, the "As Approved" and "As Submitted" stories (which both have HHG and PPM shipments) did not have `created_at` (or `createdAt`) values defined for the props outlining the shipments to display. Since:

* the underlying component sorts by that value, 
* and Moment.js interprets an undefined value as "right now", 
* and JavaScript does not sort two equal values into a consistent arrangement

this is causing the two shipment cards to display in an indeterminate way, causing Happo diffs to fire for unrelated changes.

This pull request sets applicable date values for these fields.

## Reviewer Notes

This is a straightforward PR; you can ensure that it works by changing the `createdAt` or `created_at` values in `/src/components/Customer/Review/Review.stories.jsx` and verifying that order of shipments as displayed in the "As Approved" and "As Submitted" stories change accordingly.

@transcom/truss-design is only added as a reviewer since this pull request affects a story, and so they're currently configured as Code Owners.

## Setup

```sh
yarn storybook
```

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Fixes issue introduced by PR [#6820](https://github.com/transcom/mymove/pull/6820).
