### PR TITLE
MB-8631 Add estimated and actual weights to mto service items

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -646,3 +646,4 @@
 20210611202542_remove_shimona_cac.up.sql
 20210614144532_ronolibert_cac.up.sql
 20210622184646_add_amended_orders_acknowledgement_timestamp.up.sql
+20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql

--- a/migrations/app/schema/20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql
+++ b/migrations/app/schema/20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql
@@ -1,0 +1,8 @@
+-- Column add
+ALTER TABLE mto_service_items
+    ADD COLUMN estimated_weight integer,
+    ADD COLUMN actual_weight integer;
+
+-- Column comments
+COMMENT ON COLUMN mto_service_items.estimated_weight IS 'The guessed weight for a shuttling service item. Relevant for DOSHUT service items.';
+COMMENT ON COLUMN mto_service_items.actual_weight IS 'The measured weight for a shuttling service item. Relevant for DOSHUT service items.';

--- a/migrations/app/schema/20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql
+++ b/migrations/app/schema/20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql
@@ -4,5 +4,5 @@ ALTER TABLE mto_service_items
     ADD COLUMN actual_weight integer;
 
 -- Column comments
-COMMENT ON COLUMN mto_service_items.estimated_weight IS 'The guessed weight for a shuttling service item. Relevant for DOSHUT service items.';
-COMMENT ON COLUMN mto_service_items.actual_weight IS 'The measured weight for a shuttling service item. Relevant for DOSHUT service items.';
+COMMENT ON COLUMN mto_service_items.estimated_weight IS 'An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.';
+COMMENT ON COLUMN mto_service_items.actual_weight IS 'Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.';

--- a/pkg/models/mto_service_items.go
+++ b/pkg/models/mto_service_items.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MTOServiceItemStatus represents the possible statuses for a mto shipment
@@ -44,6 +46,8 @@ type MTOServiceItem struct {
 	SITDestinationFinalAddress    *Address                       `belongs_to:"addresses" fk_id:"sit_destination_final_address_id"`
 	SITDestinationFinalAddressID  *uuid.UUID                     `db:"sit_destination_final_address_id"`
 	Description                   *string                        `db:"description"`
+	EstimatedWeight               *unit.Pound                    `db:"estimated_weight"`
+	ActualWeight                  *unit.Pound                    `db:"actual_weight"`
 	Dimensions                    MTOServiceItemDimensions       `has_many:"mto_service_item_dimensions" fk_id:"mto_service_item_id"`
 	CustomerContacts              MTOServiceItemCustomerContacts `has_many:"mto_service_item_customer_contacts" fk_id:"mto_service_item_id"`
 	CreatedAt                     time.Time                      `db:"created_at"`


### PR DESCRIPTION
## Description

This PR adds estimated and actual weights to the mto service items table. These will be used for shuttling service items.

## Questions

Should the fields be prefixed with `shut` -> `shut_estimated_weight` and `shut_actual_weight`? Or some other abbreviation for shuttling? 

## Setup

To execute the migrations run `make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [x] Have been communicated to #g-database
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8251) for this change
