### PR TITLE
[MB-8312] New orders are included in the Move Details visual cue count

### DIFF
--- a/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.test.jsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import ServicesCounselingEditShipmentDetails from './ServicesCounselingEditShipmentDetails';
 
 import { updateMTOShipment } from 'services/ghcApi';
+import { useEditShipmentQueries } from 'hooks/queries';
 
 const mockPush = jest.fn();
 
@@ -26,132 +27,131 @@ jest.mock('services/ghcApi', () => ({
 }));
 
 jest.mock('hooks/queries', () => ({
-  useEditShipmentQueries: jest
-    .fn(() => {
-      return {
-        move: {
-          id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
-          ordersId: '1',
-          status: 'NEEDS SERVICE COUNSELING',
-        },
-        order: {
-          id: '1',
-          originDutyStation: {
-            address: {
-              street_address_1: '',
-              city: 'Fort Knox',
-              state: 'KY',
-              postal_code: '40121',
-            },
-          },
-          destinationDutyStation: {
-            address: {
-              street_address_1: '',
-              city: 'Fort Irwin',
-              state: 'CA',
-              postal_code: '92310',
-            },
-          },
-          customer: {
-            agency: 'ARMY',
-            backup_contact: {
-              email: 'email@example.com',
-              name: 'name',
-              phone: '555-555-5555',
-            },
-            current_address: {
-              city: 'Beverly Hills',
-              country: 'US',
-              eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41Mzg0Njha',
-              id: '3a5f7cf2-6193-4eb3-a244-14d21ca05d7b',
-              postal_code: '90210',
-              state: 'CA',
-              street_address_1: '123 Any Street',
-              street_address_2: 'P.O. Box 12345',
-              street_address_3: 'c/o Some Person',
-            },
-            dodID: '6833908165',
-            eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NjAzNTJa',
-            email: 'combo@ppm.hhg',
-            first_name: 'Submitted',
-            id: 'f6bd793f-7042-4523-aa30-34946e7339c9',
-            last_name: 'Ppmhhg',
-            phone: '555-555-5555',
-          },
-          entitlement: {
-            authorizedWeight: 8000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NzgwMzda',
-            id: 'e0fefe58-0710-40db-917b-5b96567bc2a8',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 8000,
-          },
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          tac: '9999',
-        },
-        mtoShipments: [
-          {
-            customerRemarks: 'please treat gently',
-            destinationAddress: {
-              city: 'Fairfield',
-              country: 'US',
-              id: '672ff379-f6e3-48b4-a87d-796713f8f997',
-              postal_code: '94535',
-              state: 'CA',
-              street_address_1: '987 Any Avenue',
-              street_address_2: 'P.O. Box 9876',
-              street_address_3: 'c/o Some Person',
-            },
-            eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
-            id: 'shipment123',
-            moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
-            pickupAddress: {
-              city: 'Beverly Hills',
-              country: 'US',
-              eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
-              id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
-              postal_code: '90210',
-              state: 'CA',
-              street_address_1: '123 Any Street',
-              street_address_2: 'P.O. Box 12345',
-              street_address_3: 'c/o Some Person',
-            },
-            requestedPickupDate: '2018-03-15',
-            scheduledPickupDate: '2018-03-16',
-            requestedDeliveryDate: '2018-04-15',
-            scheduledDeliveryDate: '2014-04-16',
-            shipmentType: 'HHG',
-            status: 'SUBMITTED',
-            updatedAt: '2020-06-10T15:58:02.404031Z',
-          },
-        ],
-        isLoading: false,
-        isError: false,
-        isSuccess: true,
-      };
-    })
-    .mockImplementationOnce(() => {
-      return {
-        isLoading: true,
-        isError: false,
-        isSuccess: false,
-      };
-    })
-    .mockImplementationOnce(() => {
-      return {
-        isLoading: false,
-        isError: true,
-        isSuccess: false,
-      };
-    }),
+  useEditShipmentQueries: jest.fn(),
 }));
+
+const useEditShipmentQueriesReturnValue = {
+  move: {
+    id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    ordersId: '1',
+    status: 'NEEDS SERVICE COUNSELING',
+  },
+  order: {
+    id: '1',
+    originDutyStation: {
+      address: {
+        street_address_1: '',
+        city: 'Fort Knox',
+        state: 'KY',
+        postal_code: '40121',
+      },
+    },
+    destinationDutyStation: {
+      address: {
+        street_address_1: '',
+        city: 'Fort Irwin',
+        state: 'CA',
+        postal_code: '92310',
+      },
+    },
+    customer: {
+      agency: 'ARMY',
+      backup_contact: {
+        email: 'email@example.com',
+        name: 'name',
+        phone: '555-555-5555',
+      },
+      current_address: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41Mzg0Njha',
+        id: '3a5f7cf2-6193-4eb3-a244-14d21ca05d7b',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+      dodID: '6833908165',
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NjAzNTJa',
+      email: 'combo@ppm.hhg',
+      first_name: 'Submitted',
+      id: 'f6bd793f-7042-4523-aa30-34946e7339c9',
+      last_name: 'Ppmhhg',
+      phone: '555-555-5555',
+    },
+    entitlement: {
+      authorizedWeight: 8000,
+      dependentsAuthorized: true,
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NzgwMzda',
+      id: 'e0fefe58-0710-40db-917b-5b96567bc2a8',
+      nonTemporaryStorage: true,
+      privatelyOwnedVehicle: true,
+      proGearWeight: 2000,
+      proGearWeightSpouse: 500,
+      storageInTransit: 2,
+      totalDependents: 1,
+      totalWeight: 8000,
+    },
+    order_number: 'ORDER3',
+    order_type: 'PERMANENT_CHANGE_OF_STATION',
+    order_type_detail: 'HHG_PERMITTED',
+    tac: '9999',
+  },
+  mtoShipments: [
+    {
+      customerRemarks: 'please treat gently',
+      destinationAddress: {
+        city: 'Fairfield',
+        country: 'US',
+        id: '672ff379-f6e3-48b4-a87d-796713f8f997',
+        postal_code: '94535',
+        state: 'CA',
+        street_address_1: '987 Any Avenue',
+        street_address_2: 'P.O. Box 9876',
+        street_address_3: 'c/o Some Person',
+      },
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
+      id: 'shipment123',
+      moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
+        id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+      requestedPickupDate: '2018-03-15',
+      scheduledPickupDate: '2018-03-16',
+      requestedDeliveryDate: '2018-04-15',
+      scheduledDeliveryDate: '2014-04-16',
+      shipmentType: 'HHG',
+      status: 'SUBMITTED',
+      updatedAt: '2020-06-10T15:58:02.404031Z',
+    },
+  ],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
+const loadingReturnValue = {
+  ...useEditShipmentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useEditShipmentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
 
 const props = {
   match: {
@@ -163,15 +163,10 @@ const props = {
 };
 
 describe('ServicesCounselingEditShipmentDetails component', () => {
-  /*
-  The order in which these mockImplementationOnce is directly correlated to the
-  order in which the tests are run. This is because different data should be
-  returned from the call each time in order to tests the different states that
-  the component can be in. The default will be to return all the data needed for
-  the full tests.
-  */
-  describe('check different component states - ORDER MATTERS see comment in tests', () => {
+  describe('check different component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
+      useEditShipmentQueries.mockReturnValue(loadingReturnValue);
+
       render(<ServicesCounselingEditShipmentDetails {...props} />);
 
       const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
@@ -179,6 +174,8 @@ describe('ServicesCounselingEditShipmentDetails component', () => {
     });
 
     it('renders the Something Went Wrong component when the query errors', async () => {
+      useEditShipmentQueries.mockReturnValue(errorReturnValue);
+
       render(<ServicesCounselingEditShipmentDetails {...props} />);
 
       const errorMessage = await screen.getByText(/Something went wrong./);
@@ -187,6 +184,7 @@ describe('ServicesCounselingEditShipmentDetails component', () => {
   });
 
   it('renders the Services Counseling Shipment Form', async () => {
+    useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
     render(<ServicesCounselingEditShipmentDetails {...props} />);
 
     const h1 = await screen.getByRole('heading', { name: 'Edit shipment details', level: 1 });
@@ -210,6 +208,7 @@ describe('ServicesCounselingEditShipmentDetails component', () => {
   });
 
   it('routes to the move details page when the cancel button is clicked', async () => {
+    useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
     render(<ServicesCounselingEditShipmentDetails {...props} />);
 
     const cancelButton = screen.getByRole('button', { name: 'Cancel' });

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -41,6 +41,14 @@ const TXOMoveInfo = () => {
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
+  let moveDetailsTagCount = 0;
+  if (unapprovedShipmentCount > 0) {
+    moveDetailsTagCount += unapprovedShipmentCount;
+  }
+  if (order.uploadedAmendedOrderID && !order.amendedOrdersAcknowledgedAt) {
+    moveDetailsTagCount += 1;
+  }
+
   return (
     <>
       <CustomerHeader order={order} customer={customerData} moveCode={moveCode} />
@@ -57,7 +65,7 @@ const TXOMoveInfo = () => {
                   data-testid="MoveDetails-Tab"
                 >
                   <span className="tab-title">Move details</span>
-                  {unapprovedShipmentCount > 0 && <Tag>{unapprovedShipmentCount}</Tag>}
+                  {moveDetailsTagCount > 0 && <Tag>{moveDetailsTagCount}</Tag>}
                 </NavLink>,
                 <NavLink
                   data-testid="MoveTaskOrder-Tab"

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import TXOMoveInfo from './TXOMoveInfo';
 
 import { MockProviders } from 'testUtils';
+import { useTXOMoveInfoQueries } from 'hooks/queries';
 
 const testMoveCode = '1A5PM3';
 
@@ -14,56 +16,154 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('hooks/queries', () => ({
   ...jest.requireActual('hooks/queries'),
-  useTXOMoveInfoQueries: () => {
-    return {
-      customerData: { id: '2468', last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
-      order: {
-        id: '4321',
-        customerID: '2468',
-        uploaded_order_id: '2',
-        departmentIndicator: 'Navy',
-        grade: 'E-6',
-        originDutyStation: {
-          name: 'JBSA Lackland',
-        },
-        destinationDutyStation: {
-          name: 'JB Lewis-McChord',
-        },
-        report_by_date: '2018-08-01',
-      },
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-    };
-  },
+  useTXOMoveInfoQueries: jest.fn(),
 }));
 
+const basicUseTXOMoveInfoQueriesValue = {
+  customerData: { id: '2468', last_name: 'Kerry', first_name: 'Smith', dodID: '999999999' },
+  order: {
+    id: '4321',
+    customerID: '2468',
+    uploaded_order_id: '2',
+    departmentIndicator: 'Navy',
+    grade: 'E-6',
+    originDutyStation: {
+      name: 'JBSA Lackland',
+    },
+    destinationDutyStation: {
+      name: 'JB Lewis-McChord',
+    },
+    report_by_date: '2018-08-01',
+  },
+
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
+const loadingReturnValue = {
+  ...basicUseTXOMoveInfoQueriesValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...basicUseTXOMoveInfoQueriesValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+const updatedOrdersUseTXOMoveInfoQueriesValue = {
+  ...basicUseTXOMoveInfoQueriesValue,
+  order: { ...basicUseTXOMoveInfoQueriesValue.order, uploadedAmendedOrderID: '123' },
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('TXO Move Info Container', () => {
-  it('should render the move tab container', () => {
-    const wrapper = mount(
-      <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
-        <TXOMoveInfo />
-      </MockProviders>,
-    );
+  describe('check different component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useTXOMoveInfoQueries.mockReturnValue(loadingReturnValue);
 
-    expect(wrapper.find('CustomerHeader').exists()).toBe(true);
-    expect(wrapper.find('header.nav-header').exists()).toBe(true);
-    expect(wrapper.find('nav.tabNav').exists()).toBe(true);
-    expect(wrapper.find('li.tabItem').length).toEqual(4);
+      render(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
 
-    expect(wrapper.find('span.tab-title').at(0).text()).toContain('Move details');
-    expect(wrapper.find('span.tab-title + span').at(0).exists()).toBe(false);
-    expect(wrapper.find('span.tab-title').at(1).text()).toContain('Move task order');
-    expect(wrapper.find('span.tab-title').at(2).text()).toContain('Payment requests');
-    expect(wrapper.find('span.tab-title').at(3).text()).toContain('History');
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
 
-    expect(wrapper.find('li.tabItem a').at(0).prop('href')).toEqual(`/moves/${testMoveCode}/details`);
-    expect(wrapper.find('li.tabItem a').at(1).prop('href')).toEqual(`/moves/${testMoveCode}/mto`);
-    expect(wrapper.find('li.tabItem a').at(2).prop('href')).toEqual(`/moves/${testMoveCode}/payment-requests`);
-    expect(wrapper.find('li.tabItem a').at(3).prop('href')).toEqual(`/moves/${testMoveCode}/history`);
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useTXOMoveInfoQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
+  describe('Basic rendering', () => {
+    it('should render the move tab container', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(basicUseTXOMoveInfoQueriesValue);
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(wrapper.find('CustomerHeader').exists()).toBe(true);
+      expect(wrapper.find('header.nav-header').exists()).toBe(true);
+      expect(wrapper.find('nav.tabNav').exists()).toBe(true);
+      expect(wrapper.find('li.tabItem').length).toEqual(4);
+
+      expect(wrapper.find('span.tab-title').at(0).text()).toContain('Move details');
+      expect(wrapper.find('span.tab-title + span').at(0).exists()).toBe(false);
+      expect(wrapper.find('span.tab-title').at(1).text()).toContain('Move task order');
+      expect(wrapper.find('span.tab-title').at(2).text()).toContain('Payment requests');
+      expect(wrapper.find('span.tab-title').at(3).text()).toContain('History');
+
+      expect(wrapper.find('li.tabItem a').at(0).prop('href')).toEqual(`/moves/${testMoveCode}/details`);
+      expect(wrapper.find('li.tabItem a').at(1).prop('href')).toEqual(`/moves/${testMoveCode}/mto`);
+      expect(wrapper.find('li.tabItem a').at(2).prop('href')).toEqual(`/moves/${testMoveCode}/payment-requests`);
+      expect(wrapper.find('li.tabItem a').at(3).prop('href')).toEqual(`/moves/${testMoveCode}/history`);
+    });
+  });
+
+  describe('Tag rendering', () => {
+    it('should render the move details tab container with a tag that shows the count of items that need attention when the orders have been amended', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(updatedOrdersUseTXOMoveInfoQueriesValue);
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(wrapper.find('[data-testid="MoveDetails-Tab"] [data-testid="tag"]').text()).toContain('1');
+    });
+
+    it('should render the move details tab container with a tag that shows the count of items that need attention when there are unapproved shipments', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(basicUseTXOMoveInfoQueriesValue);
+      const setUnapprovedShipmentCount = jest.fn();
+      jest.spyOn(React, 'useState').mockReturnValueOnce([2, setUnapprovedShipmentCount]);
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(wrapper.find('[data-testid="MoveDetails-Tab"] [data-testid="tag"]').text()).toContain('2');
+    });
+
+    it('should render the move details tab container with a tag that shows the count of items that need attention when the orders have been amended and there are unapproved shipments', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(updatedOrdersUseTXOMoveInfoQueriesValue);
+      const setUnapprovedShipmentCount = jest.fn();
+      jest.spyOn(React, 'useState').mockReturnValueOnce([2, setUnapprovedShipmentCount]);
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(wrapper.find('[data-testid="MoveDetails-Tab"] [data-testid="tag"]').text()).toContain('3');
+    });
   });
 
   describe('routing', () => {
+    beforeAll(() => {
+      useTXOMoveInfoQueries.mockReturnValue(basicUseTXOMoveInfoQueriesValue);
+    });
+
     it('should handle the Move Details route', () => {
       const wrapper = mount(
         <MockProviders initialEntries={[`/moves/${testMoveCode}/details`]}>


### PR DESCRIPTION
## Description

Added logic to account for both the `unapprovedShipmentCount` and  if there is an `uploadedAmendedOrderID` in order to show the correct count on the Move Details navigation tab.

I also refactored an unrelated test to bring it in line with a new pattern I'm establishing on this PR to test the loading and error states of the query response. This change can be carried over to the rest of the components that use the `onLoading` `onError` `onSuccess` rendering pattern.

I tried covering the Move Task Order and Payment Request nav tab tags as well, but couldn't get it working like I wanted to. I might try again before merging this if time allows.

## Reviewer Notes
I added a lot of tests but am unsure if I covered things as expected. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8312) for this change

## Screenshots
![Screen Shot 2021-06-30 at 1 43 54 PM](https://user-images.githubusercontent.com/1587316/124007270-382b6300-d9a9-11eb-91d3-a5eca947e531.png)

