### PR TITLE
MB-8107: Adds helper text to Customer home screen when user has unapproved amended orders

### DIFF
--- a/src/components/Customer/Home/Helper/Helper.stories.jsx
+++ b/src/components/Customer/Home/Helper/Helper.stories.jsx
@@ -10,6 +10,7 @@ import {
   HelperNeedsSubmitMove,
   HelperSubmittedMove,
   HelperSubmittedPPM,
+  HelperAmendedOrders,
 } from 'pages/MyMove/Home/HomeHelpers';
 import { MockProviders } from 'testUtils';
 
@@ -56,3 +57,4 @@ export const SubmittedPPM = () => (
     <HelperSubmittedPPM />
   </MockProviders>
 );
+export const AmendedOrders = () => <HelperAmendedOrders />;

--- a/src/pages/MyMove/Home/HomeHelpers.jsx
+++ b/src/pages/MyMove/Home/HomeHelpers.jsx
@@ -82,3 +82,12 @@ export const HelperSubmittedPPM = () => (
     </ul>
   </Helper>
 );
+
+export const HelperAmendedOrders = () => (
+  <Helper title="Next step: Contact your movers (if you have them)">
+    <p>
+      If your destination changed or your move was canceled, contact your movers ASAP to let them know. They&apos;ll
+      work with you to coordinate any changes.
+    </p>
+  </Helper>
+);

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -13,6 +13,7 @@ import {
   HelperNeedsSubmitMove,
   HelperSubmittedMove,
   HelperSubmittedPPM,
+  HelperAmendedOrders,
 } from './HomeHelpers';
 
 import ScrollToTop from 'components/ScrollToTop';
@@ -32,6 +33,7 @@ import {
   selectIsProfileComplete,
   selectMTOShipmentsForCurrentMove,
   selectServiceMemberFromLoggedInUser,
+  selectUploadsForCurrentAmendedOrders,
   selectUploadsForCurrentOrders,
 } from 'store/entities/selectors';
 import {
@@ -83,6 +85,11 @@ export class Home extends Component {
     return !!Object.keys(orders).length && !!uploadedOrderDocuments.length;
   }
 
+  get hasAmendedOrders() {
+    const { orders, uploadedAmendedOrderDocuments } = this.props;
+    return !!Object.keys(orders).length && !!uploadedAmendedOrderDocuments?.length;
+  }
+
   get hasOrdersNoUpload() {
     const { orders, uploadedOrderDocuments } = this.props;
     return !!Object.keys(orders).length && !uploadedOrderDocuments.length;
@@ -127,6 +134,7 @@ export class Home extends Component {
     if (!this.hasOrders) return <HelperNeedsOrders />;
     if (!this.hasAnyShipments) return <HelperNeedsShipment />;
     if (!this.hasSubmittedMove) return <HelperNeedsSubmitMove />;
+    if (this.hasAmendedOrders) return <HelperAmendedOrders />;
     if (this.hasPPMShipment)
       return (
         <>
@@ -406,6 +414,7 @@ Home.propTypes = {
     shipmentType: string,
   }).isRequired,
   uploadedOrderDocuments: arrayOf(UploadShape).isRequired,
+  uploadedAmendedOrderDocuments: arrayOf(UploadShape).isRequired,
   history: HistoryShape.isRequired,
   move: MoveShape.isRequired,
   isProfileComplete: bool.isRequired,
@@ -431,6 +440,7 @@ const mapStateToProps = (state) => {
     isProfileComplete: selectIsProfileComplete(state),
     orders: selectCurrentOrders(state) || {},
     uploadedOrderDocuments: selectUploadsForCurrentOrders(state),
+    uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
     signedCertification: selectSignedCertification(state),

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -85,9 +85,9 @@ export class Home extends Component {
     return !!Object.keys(orders).length && !!uploadedOrderDocuments.length;
   }
 
-  get hasAmendedOrders() {
-    const { orders, uploadedAmendedOrderDocuments } = this.props;
-    return !!Object.keys(orders).length && !!uploadedAmendedOrderDocuments?.length;
+  get hasUnapprovedAmendedOrders() {
+    const { move, uploadedAmendedOrderDocuments } = this.props;
+    return !!uploadedAmendedOrderDocuments?.length && move.status !== 'APPROVED';
   }
 
   get hasOrdersNoUpload() {
@@ -134,7 +134,7 @@ export class Home extends Component {
     if (!this.hasOrders) return <HelperNeedsOrders />;
     if (!this.hasAnyShipments) return <HelperNeedsShipment />;
     if (!this.hasSubmittedMove) return <HelperNeedsSubmitMove />;
-    if (this.hasAmendedOrders) return <HelperAmendedOrders />;
+    if (this.hasUnapprovedAmendedOrders) return <HelperAmendedOrders />;
     if (this.hasPPMShipment)
       return (
         <>

--- a/src/pages/MyMove/Home/index.stories.jsx
+++ b/src/pages/MyMove/Home/index.stories.jsx
@@ -41,6 +41,7 @@ const uploadOrdersProps = {
     status: 'DRAFT',
   },
   uploadedOrderDocuments: [],
+  uploadedAmendedOrderDocuments: [],
 };
 
 const shipmentSelectionProps = {
@@ -96,6 +97,20 @@ const submittedProps = {
   },
 };
 
+const amendedOrderProps = {
+  ...submittedProps,
+  move: {
+    ...submittedProps.move,
+    status: 'APPROVALS REQUESTED',
+  },
+  uploadedAmendedOrderDocuments: [
+    {
+      id: 'file3',
+      filename: 'Amended_Orders.pdf',
+    },
+  ],
+};
+
 export const Step2 = () => {
   return (
     <MockProviders>
@@ -131,6 +146,16 @@ export const SubmittedMove = () => {
     <MockProviders>
       <div className="grid-container usa-prose">
         <Home {...submittedProps} />
+      </div>
+    </MockProviders>
+  );
+};
+
+export const AmendedOrders = () => {
+  return (
+    <MockProviders>
+      <div className="grid-container usa-prose">
+        <Home {...amendedOrderProps} />
       </div>
     </MockProviders>
   );

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -307,7 +307,7 @@ describe('Home component', () => {
       });
     });
 
-    describe('for amended orders', () => {
+    describe('for unapproved amended orders', () => {
       const submittedAt = new Date();
       const orders = {
         id: 'testOrder123',
@@ -334,6 +334,36 @@ describe('Home component', () => {
 
       it('renders the HelperAmendedOrders helper', () => {
         expect(wrapper.find('HelperAmendedOrders').exists()).toBe(true);
+      });
+    });
+
+    describe('for approved amended orders', () => {
+      const submittedAt = new Date();
+      const orders = {
+        id: 'testOrder123',
+        new_duty_station: {
+          name: 'Test Duty Station',
+        },
+      };
+      const uploadedOrderDocuments = [{ id: 'testDocument354', filename: 'testOrder1.pdf' }];
+      const uploadedAmendedOrderDocuments = [{ id: 'testDocument987', filename: 'testOrder2.pdf' }];
+      const move = { id: 'testMoveId', status: 'APPROVED', submitted_at: submittedAt };
+      const currentPpm = { id: 'mockCombo' };
+      const wrapper = mount(
+        <MockProviders initialEntries={['/']}>
+          <Home
+            {...defaultProps}
+            orders={orders}
+            uploadedOrderDocuments={uploadedOrderDocuments}
+            uploadedAmendedOrderDocuments={uploadedAmendedOrderDocuments}
+            move={move}
+            currentPpm={currentPpm}
+          />
+        </MockProviders>,
+      );
+
+      it('does not render the HelperAmendedOrders helper', () => {
+        expect(wrapper.find('HelperAmendedOrders').exists()).toBe(false);
       });
     });
   });

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -48,6 +48,7 @@ const defaultProps = {
     status: 'DRAFT',
   },
   uploadedOrderDocuments: [],
+  uploadedAmendedOrderDocuments: [],
 };
 
 const mountHomeWithProviders = (props = {}) => {
@@ -303,6 +304,36 @@ describe('Home component', () => {
 
       it('renders the SubmittedPPM helper', () => {
         expect(wrapper.find('HelperSubmittedPPM').exists()).toBe(true);
+      });
+    });
+
+    describe('for amended orders', () => {
+      const submittedAt = new Date();
+      const orders = {
+        id: 'testOrder123',
+        new_duty_station: {
+          name: 'Test Duty Station',
+        },
+      };
+      const uploadedOrderDocuments = [{ id: 'testDocument354', filename: 'testOrder1.pdf' }];
+      const uploadedAmendedOrderDocuments = [{ id: 'testDocument987', filename: 'testOrder2.pdf' }];
+      const move = { id: 'testMoveId', status: 'APPROVALS REQUESTED', submitted_at: submittedAt };
+      const currentPpm = { id: 'mockCombo' };
+      const wrapper = mount(
+        <MockProviders initialEntries={['/']}>
+          <Home
+            {...defaultProps}
+            orders={orders}
+            uploadedOrderDocuments={uploadedOrderDocuments}
+            uploadedAmendedOrderDocuments={uploadedAmendedOrderDocuments}
+            move={move}
+            currentPpm={currentPpm}
+          />
+        </MockProviders>,
+      );
+
+      it('renders the HelperAmendedOrders helper', () => {
+        expect(wrapper.find('HelperAmendedOrders').exists()).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## Description

Design requested that a helper be added to the Customer home page, which displays once a user has uploaded amended orders documents until the TOO has approved the amendments. This PR adds that helper and the conditional logic to display it.

There is a storybook entry added for the helper, and also the state within in the Customer home page that would display this helper.

## Reviewer Notes

Ensure that the added test cases are useful -- the Home page component's tests are written with enzyme, which I haven't used in quite a while. (It didn't seem worth the effort to convert it to RTL at this time.)

## Setup

Right now, this change can only be seen in the story added to storybook (`Customer Components` / `Pages` / `Home`). 

Once the backend-focused branch *mb-8476-customer-has-a-save-button-for-uploading-amended-orders* is merged into master, you'll be able to upload and save amended orders as a Customer with a submitted move and see the helper message display on the home page. 

```sh
make db_dev_e2e_populate
make client_run
make server_run
```

(For the sake of clarity, this PR can be merged safely as-is; it will just have no practical effect until the complementary branch is merged.)

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8107](https://dp3.atlassian.net/browse/MB-8107).
* Requires [MB-8476](https://dp3.atlassian.net/browse/MB-8476) to be completed before this will practically work.

## Screenshots

There's not really a "before"; [here's the after](https://user-images.githubusercontent.com/83614364/124020251-08378c00-d9b8-11eb-9dfc-1a6ba28435e7.png).
