### PR TITLE
Fix bug that nullifies shipment ApprovedDate

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -78,10 +78,6 @@ func setNewShipmentFields(dbShipment *models.MTOShipment, requestedUpdatedShipme
 		dbShipment.ScheduledPickupDate = requestedUpdatedShipment.ScheduledPickupDate
 	}
 
-	if requestedUpdatedShipment.ScheduledPickupDate != nil {
-		dbShipment.ApprovedDate = requestedUpdatedShipment.ApprovedDate
-	}
-
 	if requestedUpdatedShipment.PrimeEstimatedWeight != nil {
 		now := time.Now()
 		dbShipment.PrimeEstimatedWeight = requestedUpdatedShipment.PrimeEstimatedWeight


### PR DESCRIPTION
In PR #4686, we introduced a bug that nullified a shipment's
`ApprovedDate` if a `ScheduledPickupDate` was included in the payload.
This affects approving diverted shipments because we determine which
endpoint to hit based on the presence of the `ApprovedDate`.

When a shipment is diverted, the original shipment that was created by
the customer gets updated by the Prime to set its `Diversion` field to
`true`. In addition, the Prime creates a new shipment. Both of these
shipments have the `SUBMITTED` status, but only the new shipment should
have service items automatically created for it.

To distinguish between these two scenarios, we created separate
endpoints in the GHC API: `shipments/{shipmentID}/approve` for new
shipments, and `shipments/{shipmentID}/approve-diversion` for existing
shipments that had previously been approved by the TOO. The way the
front end determines which endpoint to call is by looking at the
shipment's `ApprovedDate` because only the previously-existing shipment
would have that set. The new shipment hasn't been approved yet by the
TOO.

But because of this bug, both shipments end up with a nil
`ApprovedDate`, and the frontend sends both to the `approve` endpoint,
which creates service items, and so the existing shipment ends up with
duplicate service items.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
