### PR TITLE
[Discovery] Add general error display to customer app

### DIFF
--- a/src/containers/FlashMessage/FlashMessage.jsx
+++ b/src/containers/FlashMessage/FlashMessage.jsx
@@ -6,13 +6,14 @@ import { Alert } from '@trussworks/react-uswds';
 import { clearFlashMessage as clearFlashMessageAction } from 'store/flash/actions';
 import { FlashMessageShape } from 'types/flash';
 
+// Can be used for universal error. Takes values from redux store that are set by
+// certain sagas but values can also be set inside individual promise calls
 export const FlashMessage = ({ flash, clearFlashMessage }) => {
   useEffect(() => () => {
     // Clear this flash message on unmount (this will happen on navigation or if flash state changes)
     clearFlashMessage(flash?.key);
   });
   const { message, title, type, slim } = flash;
-
   return (
     // We use {title || undefined} here because an empty string as the title will render a blank header in Firefox,
     // so we must pass in undefined if we want to see no header at all.

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -266,6 +266,7 @@ export class Home extends Component {
             </div>
           </header>
           <div className={`usa-prose grid-container ${styles['grid-container']}`}>
+            {/* already being used */}
             <ConnectedFlashMessage />
 
             {isProfileComplete && (

--- a/src/sagas/onboarding.js
+++ b/src/sagas/onboarding.js
@@ -41,6 +41,9 @@ export function* createServiceMember() {
     yield call(createServiceMemberApi);
     yield call(fetchCustomerData);
   } catch (e) {
+    // This is what renders <ConnectedFlashMessage /> component.
+    // This is used in multiple sagas but for the api calls that are not using sagas
+    // and are instead promise calls we can still use setFlashMessage
     yield put(
       setFlashMessage(
         'SERVICE_MEMBER_CREATE_ERROR',
@@ -55,7 +58,7 @@ export function* createServiceMember() {
 export function* initializeOnboarding() {
   try {
     const user = yield call(fetchCustomerData);
-    if (!user.serviceMembers) {
+    if (true) {
       yield call(createServiceMember);
     }
 

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -114,8 +114,13 @@ export class CustomerApp extends Component {
 
             <main role="main" className="site__content my-move-container" id="main">
               <ConnectedLogoutOnInactivity />
-
+              {/*
+                We could place general error message here.
+                This component covers the workflow routes and the non authorized pages.
+                Need to handle the case of flash message on Home page from clashing with this
+              */}
               <div className="usa-grid">
+                {/* swaggerError never changes and is therefore never used */}
                 {props.swaggerError && (
                   <div className="grid-container">
                     <div className="grid-row">


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
