### PR TITLE
[MB-8344] Show alert on home screen after saving amending orders

### DIFF
--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -139,7 +139,7 @@ export class Home extends Component {
             The transportation office will review your new documents and update your move info. Contact your movers to
             coordinate any changes to your move.
           </p>
-          You don&apos;t need to do anything else in MilMove.
+          <p>You don&apos;t need to do anything else in MilMove.</p>
         </Alert>
       );
     }

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -46,6 +46,7 @@ import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import { HistoryShape, MoveShape, MtoShipmentShape, OrdersShape, UploadShape } from 'types/customerShapes';
 import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
 import { profileStates } from 'constants/customerStates';
+import Alert from 'shared/Alert';
 
 const Description = ({ className, children, dataTestId }) => (
   <p className={`${styles.description} ${className}`} data-testid={dataTestId}>
@@ -129,6 +130,21 @@ export class Home extends Component {
     }
     return 'Set up your shipments';
   }
+
+  renderAlert = () => {
+    if (this.hasUnapprovedAmendedOrders) {
+      return (
+        <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
+          <p>
+            The transportation office will review your new documents and update your move info. Contact your movers to
+            coordinate any changes to your move.
+          </p>
+          You don&apos;t need to do anything else in MilMove.
+        </Alert>
+      );
+    }
+    return null;
+  };
 
   renderHelper = () => {
     if (!this.hasOrders) return <HelperNeedsOrders />;
@@ -278,6 +294,7 @@ export class Home extends Component {
 
             {isProfileComplete && (
               <>
+                {this.renderAlert()}
                 {this.renderHelper()}
                 <SectionWrapper>
                   <Step

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -134,10 +134,8 @@ export class Home extends Component {
     if (this.hasUnapprovedAmendedOrders) {
       return (
         <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
-          <p>
-            The transportation office will review your new documents and update your move info. Contact your movers to
-            coordinate any changes to your move.
-          </p>
+          The transportation office will review your new documents and update your move info. Contact your movers to
+          coordinate any changes to your move.
           <p>You don&apos;t need to do anything else in MilMove.</p>
         </Alert>
       );

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { arrayOf, bool, func, node, shape, string } from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import { Button } from '@trussworks/react-uswds';
+import { Alert, Button } from '@trussworks/react-uswds';
 import { generatePath } from 'react-router';
 import { withRouter } from 'react-router-dom';
 
@@ -46,7 +46,6 @@ import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';
 import { HistoryShape, MoveShape, MtoShipmentShape, OrdersShape, UploadShape } from 'types/customerShapes';
 import requireCustomerState from 'containers/requireCustomerState/requireCustomerState';
 import { profileStates } from 'constants/customerStates';
-import Alert from 'shared/Alert';
 
 const Description = ({ className, children, dataTestId }) => (
   <p className={`${styles.description} ${className}`} data-testid={dataTestId}>

--- a/src/pages/MyMove/Home/index.test.jsx
+++ b/src/pages/MyMove/Home/index.test.jsx
@@ -335,6 +335,9 @@ describe('Home component', () => {
       it('renders the HelperAmendedOrders helper', () => {
         expect(wrapper.find('HelperAmendedOrders').exists()).toBe(true);
       });
+      it('renders the amended orders alert', () => {
+        expect(wrapper.find('[data-testid="unapproved-amended-orders-alert"]').exists()).toBe(true);
+      });
     });
 
     describe('for approved amended orders', () => {
@@ -364,6 +367,10 @@ describe('Home component', () => {
 
       it('does not render the HelperAmendedOrders helper', () => {
         expect(wrapper.find('HelperAmendedOrders').exists()).toBe(false);
+      });
+
+      it('does not render the amended orders alert', () => {
+        expect(wrapper.find('[data-testid="unapproved-amended-orders-alert"]').exists()).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Description

After a service member uploads files for amended orders, and until the TOO approves the new orders, the service member should see an alert on the home screen to reassure them that they've successfully submitted the new documents.

## Reviewer Notes

I'm piggybacking on @kylehilltruss's [branch](https://github.com/transcom/mymove/pull/6906) , in which he creates some help text that displays in the same scenario that this alert is displayed in.

The formatting doesn't quite match the designs; there's a bigger gap between the text and the top of the alert box than there should be. I'm guessing this is something to do with my use of `<p>` tags. I'm still fiddling with this, but any suggestions are welcome.

Should I move the alert into its own little component in a separate file, like the Helpers are?

Are the tests adequate?

I used a `data-testid` to select the alert because I don't think I have anything else to query on that would distinguish it from other `<Alert>`s we may put on the page in the future. If this is not the best way to do this, let me know.

## Setup

We can't see this in the app yet (devseed data and the ability to upload amended orders are both in progress right now). However, you can see it in storybook:
http://localhost:6006/?path=/story/customer-components-pages-home--amended-orders

and compare against the designs:
- [mobile](https://zpl.io/V4NRGqy)
- [desktop](https://zpl.io/VKd7B5A)

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8344) for this change

## Screenshots

### mobile
![image](https://user-images.githubusercontent.com/2627844/124185127-683d3980-da6f-11eb-952c-5a4ed125fd43.png)

### tablet
![image](https://user-images.githubusercontent.com/2627844/124185106-607d9500-da6f-11eb-8921-2787bf1b7a06.png)
