### PR TITLE
[MB-8656] Convert GHC api shipment scheduled pickup date to be nullable to avoid zero date values on MTO page

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3332,7 +3332,8 @@ func init() {
         },
         "scheduledPickupDate": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true
         },
         "secondaryDeliveryAddress": {
           "x-nullable": true,
@@ -8448,7 +8449,8 @@ func init() {
         },
         "scheduledPickupDate": {
           "type": "string",
-          "format": "date"
+          "format": "date",
+          "x-nullable": true
         },
         "secondaryDeliveryAddress": {
           "x-nullable": true,

--- a/pkg/gen/ghcmessages/m_t_o_shipment.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment.go
@@ -91,7 +91,7 @@ type MTOShipment struct {
 
 	// scheduled pickup date
 	// Format: date
-	ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
+	ScheduledPickupDate *strfmt.Date `json:"scheduledPickupDate,omitempty"`
 
 	// secondary delivery address
 	SecondaryDeliveryAddress *Address `json:"secondaryDeliveryAddress,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -315,7 +315,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 	}
 
 	if mtoShipment.ScheduledPickupDate != nil {
-		payload.ScheduledPickupDate = strfmt.Date(*mtoShipment.ScheduledPickupDate)
+		payload.ScheduledPickupDate = handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate)
 	}
 
 	return payload

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -18,11 +18,12 @@ const ShipmentDetailsMain = ({ className, shipment, dutyStationAddresses, handle
     primeActualWeight,
   } = shipment;
   const { originDutyStationAddress, destinationDutyStationAddress } = dutyStationAddresses;
+
   return (
     <div className={className}>
       <ImportantShipmentDates
         requestedPickupDate={formatDate(requestedPickupDate)}
-        scheduledPickupDate={formatDate(scheduledPickupDate)}
+        scheduledPickupDate={scheduledPickupDate ? formatDate(scheduledPickupDate) : null}
       />
       <ShipmentAddresses
         pickupAddress={pickupAddress}

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -31,6 +31,9 @@ import { setFlashMessage } from 'store/flash/actions';
 import { MatchShape } from 'types/router';
 
 function formatShipmentDate(shipmentDateString) {
+  if (shipmentDateString == null) {
+    return '';
+  }
   const dateObj = new Date(shipmentDateString);
   const weekday = new Intl.DateTimeFormat('en', { weekday: 'long' }).format(dateObj);
   const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(dateObj);

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2717,6 +2717,7 @@ definitions:
       scheduledPickupDate:
         format: date
         type: string
+        x-nullable: true
       requestedPickupDate:
         format: date
         type: string


### PR DESCRIPTION
## Description

On the MTO page when a move and shipment have been approved we were seeing the zero value date of January 1st 0001 for the Scheduled pickup date before the Prime sets the value.  This is a nullable field on the shipment model but in the GHC Api we were treating it as required so in the payload it would get set to Jan 1st 0001 .

Here we make it nullable in the swagger definition and payload function to return a nil pointer before it gets a value from the Prime.  I've also edited the date display component to not try to format a null date value and display an empty string.

## Reviewer Notes

I could not find any Zeplin mocks for where we add the `Pickup Address to Destination Address on [Scheduled Pickup Date]` under the shipment header after the addresses.  Is it okay to leave this date off the end or should we remove the On clause until there is a scheduled pickup date value?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. There should be a move in the devseed with the locator `PayRej` that does not have the scheduled pickup date set http://officelocal:3000/moves/PayRej/mto

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8656) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/52669884/124188165-e0febe80-da8c-11eb-870e-e60a151e41f3.png)
![Screen Shot 2021-07-01 at 4 59 06 PM](https://user-images.githubusercontent.com/52669884/124188762-b3fedb80-da8d-11eb-9a13-0fc55b82e07f.png)
