### PR TITLE
Prime API Documentation Updates: mtoShipment and createMTOShipment

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -38,7 +38,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrimeAt` + "`" + ` timestamp has\nbeen set, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],
@@ -344,7 +344,7 @@ func init() {
     },
     "/mto-shipments": {
       "post": {
-        "description": "Creates a MTO shipment for the specified Move Task Order.\nRequired fields include:\n* Shipment Type\n* Customer requested pick-up date\n* Pick-up Address\n* Delivery Address\n* Releasing / Receiving agents\n\nOptional fields include:\n* Customer Remarks\n* Releasing / Receiving agents\n* An array of optional accessorial service item codes\n",
+        "description": "Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a\nneed for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must\napprove it before the contractor can proceed with billing.\n\n**WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to\none of their moves. Otherwise, the Prime can fetch the related move using the\n[getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status ` + "`" + `\"APPROVED\"` + "`" + `.\n",
         "consumes": [
           "application/json"
         ],
@@ -2590,10 +2590,11 @@ func init() {
   },
   "tags": [
     {
-      "description": "The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
+      "description": "The **moveTaskOrder** represents a military move that has been sent to a contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
       "name": "moveTaskOrder"
     },
     {
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\n",
       "name": "mtoShipment"
     },
     {
@@ -2636,7 +2637,7 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrime` + "`" + ` timestamp has been\nset, that move will always appear in this list.\n",
+        "description": "Gets all moves that have been reviewed and approved by the TOO. The ` + "`" + `since` + "`" + ` parameter can be used to filter this\nlist down to only the moves that have been updated since the provided timestamp. A move will be considered\nupdated if the ` + "`" + `updatedAt` + "`" + ` timestamp on the move is later than the provided date and time.\n\n**WIP**: The original goal was to also look at the ` + "`" + `updateAt` + "`" + ` timestamps of the nested objects - such as the\nshipments, service items, etc. This has not been implemented.\n\n**WIP**: Include what causes moves to leave this list. Currently, once the ` + "`" + `availableToPrimeAt` + "`" + ` timestamp has\nbeen set, that move will always appear in this list.\n",
         "produces": [
           "application/json"
         ],
@@ -3032,7 +3033,7 @@ func init() {
     },
     "/mto-shipments": {
       "post": {
-        "description": "Creates a MTO shipment for the specified Move Task Order.\nRequired fields include:\n* Shipment Type\n* Customer requested pick-up date\n* Pick-up Address\n* Delivery Address\n* Releasing / Receiving agents\n\nOptional fields include:\n* Customer Remarks\n* Releasing / Receiving agents\n* An array of optional accessorial service item codes\n",
+        "description": "Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a\nneed for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must\napprove it before the contractor can proceed with billing.\n\n**WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to\none of their moves. Otherwise, the Prime can fetch the related move using the\n[getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status ` + "`" + `\"APPROVED\"` + "`" + `.\n",
         "consumes": [
           "application/json"
         ],
@@ -5440,10 +5441,11 @@ func init() {
   },
   "tags": [
     {
-      "description": "The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
+      "description": "The **moveTaskOrder** represents a military move that has been sent to a contractor. It contains all the information about shipments, including service items, estimated weights, actual weights, requested and scheduled move dates, etc.\n",
       "name": "moveTaskOrder"
     },
     {
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\n",
       "name": "mtoShipment"
     },
     {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2594,7 +2594,7 @@ func init() {
       "name": "moveTaskOrder"
     },
     {
-      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\n",
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. All of the items in a shipment are weighed and transported as a discrete unit. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\nAll of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and the contractor should keep this in mind when planning a move and the shipments within it. \n",
       "name": "mtoShipment"
     },
     {
@@ -5445,7 +5445,7 @@ func init() {
       "name": "moveTaskOrder"
     },
     {
-      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\n",
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. All of the items in a shipment are weighed and transported as a discrete unit. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\nAll of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and the contractor should keep this in mind when planning a move and the shipments within it. \n",
       "name": "mtoShipment"
     },
     {

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -2594,7 +2594,7 @@ func init() {
       "name": "moveTaskOrder"
     },
     {
-      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. All of the items in a shipment are weighed and transported as a discrete unit. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\nAll of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and the contractor should keep this in mind when planning a move and the shipments within it. \n",
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another\nlocation. All of the items in a shipment are weighed and transported as a discrete unit. One move may include\nmultiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a\n[moveTaskOrder](#tag/moveTaskOrder).\n\nThe weights for all of the shipments in a move are combined and compared to the customer's weight allowance. If\nthe sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and\nthe contractor should keep this potential cost in mind when planning a move and the shipments within it.\n",
       "name": "mtoShipment"
     },
     {
@@ -5445,7 +5445,7 @@ func init() {
       "name": "moveTaskOrder"
     },
     {
-      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another location. All of the items in a shipment are weighed and transported as a discrete unit. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a [moveTaskOrder](#tag/moveTaskOrder).\nAll of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and the contractor should keep this in mind when planning a move and the shipments within it. \n",
+      "description": "A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another\nlocation. All of the items in a shipment are weighed and transported as a discrete unit. One move may include\nmultiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a\n[moveTaskOrder](#tag/moveTaskOrder).\n\nThe weights for all of the shipments in a move are combined and compared to the customer's weight allowance. If\nthe sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and\nthe contractor should keep this potential cost in mind when planning a move and the shipments within it.\n",
       "name": "mtoShipment"
     },
     {

--- a/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
@@ -40,8 +40,8 @@ updated if the `updatedAt` timestamp on the move is later than the provided date
 **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
 shipments, service items, etc. This has not been implemented.
 
-**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
-set, that move will always appear in this list.
+**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrimeAt` timestamp has
+been set, that move will always appear in this list.
 
 
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/create_m_t_o_shipment.go
@@ -33,18 +33,13 @@ func NewCreateMTOShipment(ctx *middleware.Context, handler CreateMTOShipmentHand
 
 createMTOShipment
 
-Creates a MTO shipment for the specified Move Task Order.
-Required fields include:
-* Shipment Type
-* Customer requested pick-up date
-* Pick-up Address
-* Delivery Address
-* Releasing / Receiving agents
+Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a
+need for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must
+approve it before the contractor can proceed with billing.
 
-Optional fields include:
-* Customer Remarks
-* Releasing / Receiving agents
-* An array of optional accessorial service item codes
+**WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to
+one of their moves. Otherwise, the Prime can fetch the related move using the
+[getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status `"APPROVED"`.
 
 
 */

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -46,8 +46,8 @@ updated if the `updatedAt` timestamp on the move is later than the provided date
 **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
 shipments, service items, etc. This has not been implemented.
 
-**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
-set, that move will always appear in this list.
+**WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrimeAt` timestamp has
+been set, that move will always appear in this list.
 
 */
 func (a *Client) FetchMTOUpdates(params *FetchMTOUpdatesParams) (*FetchMTOUpdatesOK, error) {

--- a/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
@@ -91,18 +91,13 @@ func (a *Client) CreateMTOAgent(params *CreateMTOAgentParams) (*CreateMTOAgentOK
 /*
   CreateMTOShipment creates m t o shipment
 
-  Creates a MTO shipment for the specified Move Task Order.
-Required fields include:
-* Shipment Type
-* Customer requested pick-up date
-* Pick-up Address
-* Delivery Address
-* Releasing / Receiving agents
+  Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a
+need for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must
+approve it before the contractor can proceed with billing.
 
-Optional fields include:
-* Customer Remarks
-* Releasing / Receiving agents
-* An array of optional accessorial service item codes
+**WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to
+one of their moves. Otherwise, the Prime can fetch the related move using the
+[getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status `"APPROVED"`.
 
 */
 func (a *Client) CreateMTOShipment(params *CreateMTOShipmentParams) (*CreateMTOShipmentOK, error) {

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -22,10 +22,15 @@ tags:
       information about shipments, including service items, estimated weights, actual weights, requested and scheduled
       move dates, etc.
   - name: mtoShipment
-    description: >
+    description: |
       A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another
-      location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs
-      to a [moveTaskOrder](#tag/moveTaskOrder).
+      location. All of the items in a shipment are weighed and transported as a discrete unit. One move may include
+      multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a
+      [moveTaskOrder](#tag/moveTaskOrder).
+
+      All of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight
+      allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the
+      customer and the contractor should keep this in mind when planning a move and the shipments within it.
   - name: paymentRequest
   - name: mtoServiceItem
 x-tagGroups:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -28,9 +28,9 @@ tags:
       multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs to a
       [moveTaskOrder](#tag/moveTaskOrder).
 
-      All of the shipments in a move, or **moveTaskOrder**, are combined and compared to the customer's weight
-      allowance. If the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the
-      customer and the contractor should keep this in mind when planning a move and the shipments within it.
+      The weights for all of the shipments in a move are combined and compared to the customer's weight allowance. If
+      the sum of the shipments is greater, the customer is liable for paying excess weight cost. Both the customer and
+      the contractor should keep this potential cost in mind when planning a move and the shipments within it.
   - name: paymentRequest
   - name: mtoServiceItem
 x-tagGroups:

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -18,10 +18,14 @@ schemes:
 tags:
   - name: moveTaskOrder
     description: >
-      The **moveTaskOrder** represents a military move that has been sent to the GHC contractor. It contains all the
+      The **moveTaskOrder** represents a military move that has been sent to a contractor. It contains all the
       information about shipments, including service items, estimated weights, actual weights, requested and scheduled
       move dates, etc.
   - name: mtoShipment
+    description: >
+      A shipment is some (or all) of a customer's belongings picked up in one location and delivered to another
+      location. One move may include multiple shipments. An **mtoShipment**, in particular, is a shipment that belongs
+      to a [moveTaskOrder](#tag/moveTaskOrder).
   - name: paymentRequest
   - name: mtoServiceItem
 x-tagGroups:
@@ -43,8 +47,8 @@ paths:
         **WIP**: The original goal was to also look at the `updateAt` timestamps of the nested objects - such as the
         shipments, service items, etc. This has not been implemented.
 
-        **WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrime` timestamp has been
-        set, that move will always appear in this list.
+        **WIP**: Include what causes moves to leave this list. Currently, once the `availableToPrimeAt` timestamp has
+        been set, that move will always appear in this list.
       operationId: fetchMTOUpdates
       tags:
         - moveTaskOrder
@@ -175,18 +179,13 @@ paths:
     post:
       summary: createMTOShipment
       description: |
-        Creates a MTO shipment for the specified Move Task Order.
-        Required fields include:
-        * Shipment Type
-        * Customer requested pick-up date
-        * Pick-up Address
-        * Delivery Address
-        * Releasing / Receiving agents
+        Creates a new shipment within the specified move. This endpoint should be used whenever the movers identify a
+        need for an additional shipment. The new shipment will be submitted to the TOO for review, and the TOO must
+        approve it before the contractor can proceed with billing.
 
-        Optional fields include:
-        * Customer Remarks
-        * Releasing / Receiving agents
-        * An array of optional accessorial service item codes
+        **WIP**: The Prime should be notified by a push notification whenever the TOO approves a shipment connected to
+        one of their moves. Otherwise, the Prime can fetch the related move using the
+        [getMoveTaskOrder](#operation/getMoveTaskOrder) endpoint and see if this shipment has the status `"APPROVED"`.
       consumes:
         - application/json
       produces:


### PR DESCRIPTION
## Description

The PR updates the Prime API definitions for a `mtoShipment` and the `createMTOShipment` endpoint based on what we wrote during the Prime API Docs Review meeting. Additionally, I made some edits to the past updates (`moveTaskOrder` and `fetchMTOUpdates`) based on discussion we had for the new descriptions.

## Reviewer Notes

I added a section about weights to the `mtoShipment` description that we didn't talk about during the meeting because I had found [this document](https://docs.google.com/document/d/1FkDVsm4V8EowRmQrpsEPbpnYU6oEvy5K0Y8FQIxMlfM/edit#heading=h.ewqsjmd3t6bp) with more GHC definitions. Just let me know if we should cut that out 👍 

## Setup

To build and view the documentation in your local environment, run:

```sh
yarn preview-redoc
```

Otherwise, you can view the updated documentation here: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/transcom/mymove/sw-prime-api-docs-shipment/swagger/prime.yaml#tag/mtoShipment

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change.
* [Meeting notes](https://docs.google.com/document/d/1M-FFyv5e_3Ky7jwuFUwIkC0bZXsqGQR159EbrEovbB8/edit#) (with style/content resources linked at the top)
