### PR TITLE
Fix truncation in db_e2e_up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,6 +661,11 @@ db_test_truncate:
 	@echo "Truncating ${DB_NAME_TEST} database..."
 	DB_PORT=$(DB_PORT_TEST) DB_NAME=$(DB_NAME_TEST) ./scripts/db-truncate
 
+.PHONY: db_e2e_test_truncate
+db_e2e_test_truncate:
+	@echo "Truncating ${DB_NAME_TEST} database for e2e tests..."
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE; TRUNCATE uploads CASCADE; TRUNCATE webhook_subscriptions CASCADE; TRUNCATE traffic_distribution_lists CASCADE'
+
 .PHONY: db_test_migrate_standalone
 db_test_migrate_standalone: bin/milmove ## Migrate Test DB directly
 ifndef CIRCLECI
@@ -730,7 +735,7 @@ e2e_clean: ## Clean e2e (end-to-end) files and docker images
 	docker rm -f cypress || true
 
 .PHONY: db_e2e_up
-db_e2e_up: check_app bin/generate-test-data db_test_truncate ## Truncate Test DB and Generate e2e (end-to-end) data
+db_e2e_up: check_app bin/generate-test-data db_e2e_test_truncate ## Truncate Test DB and Generate e2e (end-to-end) data
 	@echo "Populate the ${DB_NAME_TEST} database..."
 	DB_PORT=$(DB_PORT_TEST) go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="e2e_basic" --db-env="test"
 


### PR DESCRIPTION

In PR #6812, we cleaned up the Makefile by extracting some common setup,
like checking the app and truncating the DB, into separate, reusable
commands. Part of that was extracting the test DB truncation into a
`db_test_truncate` command that only truncated some tables. Earlier,
PR #6650 had also introduced a `db_test_truncate` command that calls
`scripts/db-truncate`, which truncates ALL the tables. For e2e tests,
we only want to truncate a certain set of tables, but for server tests,
we want to truncate everything.

While merging #6650, which happened after #6812 landed, we missed this
distinction between server and e2e tests, and so running
`make e2e_test_fresh` or `make db_e2e_init` or `make db_e2e_up` started
failing because they generate data that depends on certain tables
existing.

To fix this, we are now adding a separate `db_e2e_test_truncate` that
is only used for e2e tests.