### PR TITLE
Updated alpine from 3.12.3 to 3.13.5

### DIFF
--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3
+FROM alpine:3.13.5
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -19,7 +19,7 @@ RUN rm -f bin/milmove && make bin/milmove
 # FINAL #
 #########
 
-FROM alpine:3.12.3
+FROM alpine:3.13.5
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -57,7 +57,7 @@ RUN set -x \
   && make bin/generate-test-data
 
 # define migrations before client build since it doesn't need client
-FROM alpine:3.12.3 as migrate
+FROM alpine:3.13.5 as migrate
 
 COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=server_builder /build/bin/milmove /bin/milmove

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3
+FROM alpine:3.13.5
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -19,7 +19,7 @@ RUN rm -f bin/prime-api-client && make bin/prime-api-client
 # FINAL #
 #########
 
-FROM alpine:3.12.3
+FROM alpine:3.13.5
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox


### PR DESCRIPTION
## Description

Draft PR to see if an upgrade to alpine 3.13.5 will pass checks.  It has previously failed an ECR scan, but I saw some indications online that it may pass now.  This may be a good intermediate step until we can get to 3.14.0 (ECR fails for it too).
