### PR TITLE
[MB-8664] log usage indicator for ISA 15 in 997, 824, and 858

### DIFF
--- a/pkg/services/invoice/process_edi824.go
+++ b/pkg/services/invoice/process_edi824.go
@@ -200,6 +200,7 @@ func (e *edi824Processor) logEDI(edi ediResponse824.EDI) {
 		zap.Int64("824 ICN", icn),
 		zap.String("BGN.ReferenceIdentification", bgn.ReferenceIdentification),
 		zap.Int64("858 GCN", otiGCN),
+		zap.String("UsageIndicator (ISA-15)", edi.InterchangeControlEnvelope.ISA.UsageIndicator),
 	)
 }
 
@@ -228,5 +229,6 @@ func (e *edi824Processor) logEDIWithPaymentRequest(edi ediResponse824.EDI, payme
 		zap.Int64("858 GCN", otiGCN),
 		zap.String("PaymentRequestNumber", paymentRequest.PaymentRequestNumber),
 		zap.String("PaymentRequest.Status", string(paymentRequest.Status)),
+		zap.String("UsageIndicator (ISA-15)", edi.InterchangeControlEnvelope.ISA.UsageIndicator),
 	)
 }

--- a/pkg/services/invoice/process_edi997.go
+++ b/pkg/services/invoice/process_edi997.go
@@ -148,6 +148,7 @@ func (e *edi997Processor) logEDI(edi ediResponse997.EDI) {
 	e.logger.Info("EDI 997 log",
 		zap.Int64("997 ICN", edi.InterchangeControlEnvelope.ISA.InterchangeControlNumber),
 		zap.Int64("858 GCN/ICN", ak1.GroupControlNumber),
+		zap.String("UsageIndicator (ISA-15)", edi.InterchangeControlEnvelope.ISA.UsageIndicator),
 	)
 }
 
@@ -165,5 +166,6 @@ func (e *edi997Processor) logEDIWithPaymentRequest(edi ediResponse997.EDI, payme
 		zap.Int64("858 GCN/ICN", ak1.GroupControlNumber),
 		zap.String("PaymentRequestNumber", paymentRequest.PaymentRequestNumber),
 		zap.String("PaymentRequest.Status", string(paymentRequest.Status)),
+		zap.String("UsageIndicator (ISA-15)", edi.InterchangeControlEnvelope.ISA.UsageIndicator),
 	)
 }

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -119,6 +119,7 @@ func (p *paymentRequestReviewedProcessor) ProcessAndLockReviewedPR(pr models.Pay
 			zap.String("ReferenceIdentification/PaymentRequestNumber", edi858c.Header.PaymentRequestNumber.ReferenceIdentification),
 			zap.String("Date", edi858c.ISA.InterchangeDate),
 			zap.String("Time", edi858c.ISA.InterchangeTime),
+			zap.String("UsageIndicator (ISA-15)", edi858c.ISA.UsageIndicator),
 		)
 		// Send EDI string to Syncada
 		// If sent successfully to GEX, update payment request status to SENT_TO_GEX.


### PR DESCRIPTION
## Description

ISA-15 is the usage indicator that says whether the EDI is a `P` or `T` (production or test) invoice.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Below are steps to run locally. I don't think this is really needed, as long as UT is passing, this PR should be good to go.  Small changes to what is being logged.

**Including steps for informational purposes.**

Populate the database and rebuild the bins needed for this run
```sh
make db_dev_e2e_populate && rm bin/prime-api-client ; make bin/prime-api-client  && rm bin/generate-payment-request-edi ; make bin/generate-payment-request-edi
```

Run the server
```sh
make server_run
```

Run the office app
```sh
make office_client_run
```

Run the PRIME API demo script to create a payment request
```sh
prime-api-demo RDY4PY
```
You can cancel after payment request is created

Sample output of what you'll need from demo script
```sh
Payment Request ID: "d29662fc-4fcb-4170-bd2e-1a6da1e16cf8"
Payment Request Number: "8596-7546-1"
Payment Request Status: "PENDING"
```

Login into office app with TIO local creds
Approve service items for RDY4PY
`too_tio_role@office.mil (PPM office)`

Generate EDI to see fields mentioned
```sh
bin/generate-payment-request-edi --payment-request-number "8596-7546-1"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
