### PR TITLE
MB-8334 Counselors shouldn't be able to update shipment status

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -4346,9 +4346,6 @@ func init() {
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
-        },
-        "status": {
-          "$ref": "#/definitions/MTOShipmentStatus"
         }
       }
     },
@@ -9405,9 +9402,6 @@ func init() {
         },
         "shipmentType": {
           "$ref": "#/definitions/MTOShipmentType"
-        },
-        "status": {
-          "$ref": "#/definitions/MTOShipmentStatus"
         }
       }
     },

--- a/pkg/gen/ghcmessages/update_shipment.go
+++ b/pkg/gen/ghcmessages/update_shipment.go
@@ -46,9 +46,6 @@ type UpdateShipment struct {
 
 	// shipment type
 	ShipmentType MTOShipmentType `json:"shipmentType,omitempty"`
-
-	// status
-	Status MTOShipmentStatus `json:"status,omitempty"`
 }
 
 // Validate validates this update shipment
@@ -76,10 +73,6 @@ func (m *UpdateShipment) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateShipmentType(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -158,22 +151,6 @@ func (m *UpdateShipment) validateShipmentType(formats strfmt.Registry) error {
 	if err := m.ShipmentType.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("shipmentType")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *UpdateShipment) validateStatus(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.Status) { // not required
-		return nil
-	}
-
-	if err := m.Status.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("status")
 		}
 		return err
 	}

--- a/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
@@ -166,7 +166,6 @@ func MTOShipmentModelFromUpdate(mtoShipment *ghcmessages.UpdateShipment) *models
 		RequestedDeliveryDate: &requestedDeliveryDate,
 		CustomerRemarks:       mtoShipment.CustomerRemarks,
 		CounselorRemarks:      mtoShipment.CounselorRemarks,
-		Status:                models.MTOShipmentStatus(mtoShipment.Status),
 	}
 
 	model.PickupAddress = AddressModel(&mtoShipment.PickupAddress.Address)

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2751,8 +2751,6 @@ definitions:
   UpdateShipment:
     type: object
     properties:
-      status:
-        $ref: '#/definitions/MTOShipmentStatus'
       shipmentType:
         $ref: '#/definitions/MTOShipmentType'
       requestedPickupDate:


### PR DESCRIPTION
## Description

The `UpdateMTOShipment` handler is meant for counselors to update shipments. However, counselors should not be able to make any status changes to shipments. This pr removes status changes from the handler.

## Setup

```sh
make server_run
```
Set up [postman](https://github.com/transcom/mymove/wiki/Test-Admin-and-Office-APIs-with-Postman) and hit `http://officelocal:3000/ghc/v1/move_task_orders/e0463784-d5ea-4974-b526-f2a58c79ed07/mto_shipments/3c207b2a-d946-11eb-b8bc-0242ac130003` with a body containing:
```
{
    "counselorRemarks": "New customer remarks",
    "status": "APPROVED"
}
```

Counselor remarks should be updated, while status should be ignored


## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8334) for this change


