### PR TITLE
[MB-8505] Add Cypress test to cover the amended orders flow

### DIFF
--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -3,6 +3,10 @@ describe('orders entry', function () {
     cy.prepareCustomerApp();
   });
 
+  beforeEach(() => {
+    cy.logout();
+  });
+
   it('will accept orders information', function () {
     // needs@orde.rs
     cy.apiSignInAsPpmUser('feac0e92-66ec-4cab-ad29-538129bf918e');
@@ -48,6 +52,28 @@ describe('orders entry', function () {
     cy.contains('Continue Move Setup').click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.eq('/orders/upload');
+    });
+  });
+
+  it('will allow amended orders upload', function () {
+    const userId = '6016e423-f8d5-44ca-98a8-af03c8445c94';
+    cy.apiSignInAsUser(userId);
+    cy.contains('Upload documents').click();
+
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/orders/amend');
+    });
+
+    // cy.get('.filepond--label-action').click();
+    cy.upload_file('.filepond--root', 'top-secret.png');
+    // cy.get('button').contains('Save').click();
+    cy.nextPage();
+
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq('/');
+    });
+    cy.get('.usa-alert--success').within(() => {
+      cy.contains('The transportation office will review your new documents');
     });
   });
 });

--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -1,3 +1,5 @@
+import { fileUploadTimeout } from '../../support/constants';
+
 describe('orders entry', function () {
   before(() => {
     cy.prepareCustomerApp();
@@ -64,9 +66,9 @@ describe('orders entry', function () {
       expect(loc.pathname).to.eq('/orders/amend');
     });
 
-    // cy.get('.filepond--label-action').click();
     cy.upload_file('.filepond--root', 'top-secret.png');
-    // cy.get('button').contains('Save').click();
+    cy.get('[data-filepond-item-state="processing-complete"]', { timeout: fileUploadTimeout }).should('have.length', 1);
+
     cy.nextPage();
 
     cy.location().should((loc) => {

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1345,38 +1345,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 
-	email = "profile2@complete.hhg"
-	uuidStr = "72f5faa3-6ea7-42f8-8270-6af3aad3b0dd"
-	loginGovID = uuid.Must(uuid.NewV4())
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovUUID:  &loginGovID,
-			LoginGovEmail: email,
-			Active:        true,
-		},
-	})
-
-	testdatagen.MakeMove(db, testdatagen.Assertions{
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("1d72f572-a790-405e-81aa-cc595416edbd"),
-			UserID:        uuid.FromStringOrNil(uuidStr),
-			FirstName:     models.StringPointer("Move"),
-			LastName:      models.StringPointer("Complete"),
-			Edipi:         models.StringPointer("8893308161"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Order: models.Order{
-			HasDependents:    true,
-			SpouseHasProGear: true,
-		},
-		Move: models.Move{
-			ID:      uuid.FromStringOrNil("864e17d0-cd7e-4f5d-a0a2-576eb7a158b1"),
-			Locator: "DFTMFD",
-		},
-		UserUploader: userUploader,
-	})
-
 	email = "profile2@complete.draft"
 	uuidStr = "3b9360a3-3304-4c60-90f4-83d687884077"
 	loginGovID = uuid.Must(uuid.NewV4())

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1345,6 +1345,38 @@ func (e e2eBasicScenario) Run(db *pop.Connection, userUploader *uploader.UserUpl
 		UserUploader: userUploader,
 	})
 
+	email = "profile2@complete.hhg"
+	uuidStr = "72f5faa3-6ea7-42f8-8270-6af3aad3b0dd"
+	loginGovID = uuid.Must(uuid.NewV4())
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovUUID:  &loginGovID,
+			LoginGovEmail: email,
+			Active:        true,
+		},
+	})
+
+	testdatagen.MakeMove(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("1d72f572-a790-405e-81aa-cc595416edbd"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("Move"),
+			LastName:      models.StringPointer("Complete"),
+			Edipi:         models.StringPointer("8893308161"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
+		Move: models.Move{
+			ID:      uuid.FromStringOrNil("864e17d0-cd7e-4f5d-a0a2-576eb7a158b1"),
+			Locator: "DFTMFD",
+		},
+		UserUploader: userUploader,
+	})
+
 	email = "profile2@complete.draft"
 	uuidStr = "3b9360a3-3304-4c60-90f4-83d687884077"
 	loginGovID = uuid.Must(uuid.NewV4())


### PR DESCRIPTION
## Description

This PR adds a cypress test to Orders.js to test the amended orders flow. It starts with a customer that has a previously submitted move and ensures the the upload documents link is visible to them and that they upload amended orders and return to the starting page with a success message

## Reviewer Notes

Is there anything missing from the amended orders flow that I should be testing for?

Also, looking into if I need to use cy.intercept for the api call to /amendOrders

## Setup

```sh
make e2e_test
```
Once cypress spins up you should navigate to the test under mymove/orders

If you have issues running the cypress test you can also try running 

```sh
make e2e_test_fresh
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8505) for this change
* [docs for running cypress test](https://github.com/transcom/mymove/wiki/run-e2e-tests) 
* [Cypress Testing Strategy](https://docs.cypress.io/guides/guides/network-requests#Testing-Strategies) docs