### PR TITLE
[MB-8652] Adds estimated weight to the service item payload in the ghc api

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3041,6 +3041,13 @@ func init() {
         "eTag": {
           "type": "string"
         },
+        "estimatedWeight": {
+          "description": "estimated weight of the shuttle service item provided by the prime",
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2500
+        },
         "feeType": {
           "type": "string",
           "enum": [
@@ -8096,6 +8103,13 @@ func init() {
         },
         "eTag": {
           "type": "string"
+        },
+        "estimatedWeight": {
+          "description": "estimated weight of the shuttle service item provided by the prime",
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2500
         },
         "feeType": {
           "type": "string",

--- a/pkg/gen/ghcmessages/m_t_o_service_item.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item.go
@@ -44,6 +44,9 @@ type MTOServiceItem struct {
 	// e tag
 	ETag string `json:"eTag,omitempty"`
 
+	// estimated weight of the shuttle service item provided by the prime
+	EstimatedWeight *int64 `json:"estimatedWeight,omitempty"`
+
 	// fee type
 	// Enum: [COUNSELING CRATING TRUCKING SHUTTLE]
 	FeeType string `json:"feeType,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -485,6 +485,7 @@ func MTOServiceItemModel(s *models.MTOServiceItem) *ghcmessages.MTOServiceItem {
 		Description:      handlers.FmtStringPtr(s.Description),
 		Dimensions:       MTOServiceItemDimensions(s.Dimensions),
 		CustomerContacts: MTOServiceItemCustomerContacts(s.CustomerContacts),
+		EstimatedWeight:  handlers.FmtPoundPtr(s.EstimatedWeight),
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),
 		ApprovedAt:       handlers.FmtDateTimePtr(s.ApprovedAt),
 		RejectedAt:       handlers.FmtDateTimePtr(s.RejectedAt),

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -31,14 +31,14 @@ var CreateableServiceItemMap = map[primemessages.MTOServiceItemModelType]bool{
 	primemessages.MTOServiceItemModelTypeMTOServiceItemDomesticCrating: true,
 }
 
-// CreateMTOServiceItemHandler is the handler to update MTO shipments
+// CreateMTOServiceItemHandler is the handler to create MTO service items
 type CreateMTOServiceItemHandler struct {
 	handlers.HandlerContext
 	mtoServiceItemCreator  services.MTOServiceItemCreator
 	mtoAvailabilityChecker services.MoveTaskOrderChecker
 }
 
-// Handle handler that updates a mto shipment
+// Handle handler that creates a mto service item
 func (h CreateMTOServiceItemHandler) Handle(params mtoserviceitemops.CreateMTOServiceItemParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
@@ -109,7 +109,7 @@ func (h CreateMTOServiceItemHandler) Handle(params mtoserviceitemops.CreateMTOSe
 	return mtoserviceitemops.NewCreateMTOServiceItemOK().WithPayload(mtoServiceItemsPayload)
 }
 
-// UpdateMTOServiceItemHandler is the handler to update MTO shipments
+// UpdateMTOServiceItemHandler is the handler to update MTO service items
 type UpdateMTOServiceItemHandler struct {
 	handlers.HandlerContext
 	services.MTOServiceItemUpdater

--- a/pkg/testdatagen/make_mto_service_item.go
+++ b/pkg/testdatagen/make_mto_service_item.go
@@ -277,11 +277,6 @@ func MakeRealMTOServiceItemWithAllDeps(db *pop.Connection, serviceCode models.Re
 
 // MakeMTOServiceItemDomesticCrating makes a domestic crating service item and its associated item and crate
 func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions) models.MTOServiceItem {
-	// Set service item type
-	assertions.ReService = models.ReService{
-		ID: uuid.FromStringOrNil("68417bd7-4a9d-4472-941e-2ba6aeaf15f4"), // DCRT - Domestic Crating
-	}
-
 	mtoServiceItem := MakeMTOServiceItem(db, assertions)
 
 	// Create item
@@ -290,7 +285,7 @@ func MakeMTOServiceItemDomesticCrating(db *pop.Connection, assertions Assertions
 		MTOServiceItem:          mtoServiceItem,
 	})
 
-	// Creat crate
+	// Create crate
 	assertions.MTOServiceItemDimensionCrate.Type = models.DimensionTypeCrate
 	crateItem := MakeMTOServiceItemDimension(db, Assertions{
 		MTOServiceItemDimension: assertions.MTOServiceItemDimensionCrate,

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1262,6 +1262,134 @@ func createHHGWithPaymentServiceItems(db *pop.Connection, primeUploader *uploade
 		}
 	}
 
+	description := "leg lamp"
+	reason := "family heirloom extremely fragile"
+	approvedAt := time.Now()
+	itemDimension := models.MTOServiceItemDimension{
+		Type:   models.DimensionTypeItem,
+		Length: unit.ThousandthInches(2500),
+		Height: unit.ThousandthInches(5000),
+		Width:  unit.ThousandthInches(7500),
+	}
+	crateDimension := models.MTOServiceItemDimension{
+		Type:   models.DimensionTypeCrate,
+		Length: unit.ThousandthInches(3000),
+		Height: unit.ThousandthInches(6000),
+		Width:  unit.ThousandthInches(10000),
+	}
+	crating := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDCRT,
+		},
+		MTOServiceItem: models.MTOServiceItem{
+			Status:      models.MTOServiceItemStatusApproved,
+			Description: &description,
+			Reason:      &reason,
+			Dimensions: models.MTOServiceItemDimensions{
+				itemDimension,
+				crateDimension,
+			},
+			ApprovedAt: &approvedAt,
+		},
+		Move:        move,
+		MTOShipment: longhaulShipment,
+		Stub:        true,
+	})
+
+	uncrating := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDUCRT,
+		},
+		MTOServiceItem: models.MTOServiceItem{
+			Description: &description,
+			Reason:      &reason,
+			Dimensions: models.MTOServiceItemDimensions{
+				itemDimension,
+				crateDimension,
+			},
+			Status:     models.MTOServiceItemStatusApproved,
+			ApprovedAt: &approvedAt,
+		},
+		Move:        move,
+		MTOShipment: longhaulShipment,
+		Stub:        true,
+	})
+
+	standaloneDesc := "baby grand piano"
+	standaloneReason := "in a Billy Joel cover band"
+	cratingStandalone := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDCRTSA,
+		},
+		MTOServiceItem: models.MTOServiceItem{
+			Description: &standaloneDesc,
+			Reason:      &standaloneReason,
+			Dimensions: models.MTOServiceItemDimensions{
+				itemDimension,
+				crateDimension,
+			},
+			Status:     models.MTOServiceItemStatusApproved,
+			ApprovedAt: &approvedAt,
+		},
+		Move:        move,
+		MTOShipment: longhaulShipment,
+		Stub:        true,
+	})
+
+	cratingServiceItems := []models.MTOServiceItem{crating, uncrating, cratingStandalone}
+	for index := range cratingServiceItems {
+		_, _, cratingErr := serviceItemCreator.CreateMTOServiceItem(&cratingServiceItems[index])
+		if cratingErr != nil {
+			logger.Fatal("Error creating crating service item", zap.Error(cratingErr))
+		}
+	}
+
+	shuttleDesc := "our smallest capacity shuttle vehicle"
+	shuttleReason := "the bridge clearance was too low"
+	estimatedShuttleWeigtht := unit.Pound(1000)
+	actualShuttleWeight := unit.Pound(1500)
+	originShuttle := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDOSHUT,
+		},
+		MTOServiceItem: models.MTOServiceItem{
+			Description:     &shuttleDesc,
+			Reason:          &shuttleReason,
+			EstimatedWeight: &estimatedShuttleWeigtht,
+			ActualWeight:    &actualShuttleWeight,
+			Status:          models.MTOServiceItemStatusApproved,
+			ApprovedAt:      &approvedAt,
+		},
+		Move:        move,
+		MTOShipment: longhaulShipment,
+		Stub:        true,
+	})
+
+	destShuttle := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		ReService: models.ReService{
+			Code: models.ReServiceCodeDDSHUT,
+		},
+		MTOServiceItem: models.MTOServiceItem{
+			Description:     &shuttleDesc,
+			Reason:          &shuttleReason,
+			EstimatedWeight: &estimatedShuttleWeigtht,
+			ActualWeight:    &actualShuttleWeight,
+			Status:          models.MTOServiceItemStatusApproved,
+			ApprovedAt:      &approvedAt,
+		},
+		Move:        move,
+		MTOShipment: longhaulShipment,
+		Stub:        true,
+	})
+
+	shuttleServiceItems := []models.MTOServiceItem{originShuttle, destShuttle}
+	for index := range shuttleServiceItems {
+		_, _, shuttlingErr := serviceItemCreator.CreateMTOServiceItem(&shuttleServiceItems[index])
+		if shuttlingErr != nil {
+			logger.Fatal("Error creating shuttle service item", zap.Error(shuttlingErr))
+		}
+	}
+
 	paymentRequestCreator := paymentrequest.NewPaymentRequestCreator(
 		db,
 		planner,

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2956,6 +2956,12 @@ definitions:
       total:
         format: cents
         type: integer
+      estimatedWeight:
+        type: integer
+        description: estimated weight of the shuttle service item provided by the prime
+        example: 2500
+        x-formatting: weight
+        x-nullable: true
       updatedAt:
         format: date-time
         type: string


### PR DESCRIPTION
## Description

Estimated weight is a new column for shuttling service items created by the Prime.  The TOO needs to be able to see this value if provided on the Move Task Order page when reviewing requested service items.  As this is a new column on the `mto_service_items` table it was not yet returned by the `ghc/v1/move_task_orders/:moveTaskOrderID/mto_service_items` endpoint that returns all service items on the move.  I've updated the swagger definition to make this an optional value that can exist for shuttling service items.

I had some extra time so added the crating and shuttling service items to the move we've used in the past (move locator `PARAMS`) to test payment service item params, but they should all appear as well on the TOO Move Task Order page.  The frontend does not yet incorporate the estimated weight into the shuttle service item display but will in a subsequent story.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

This can be tested with Postman or by authenticating as the TOO user and making a request for a move with a shuttle service item with the estimatedWeight field set.

1. Navigate to the TOO MTO page of the `PARAMS` move or another move where the prime added these service items.
2. Open the developer tools network inspector
3. Find the mto_service_items request `http://officelocal:3000/ghc/v1/move_task_orders/:moveTaskOrderID/mto_service_items` and inspect the response.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8652) for this change

## Screenshots

![Screen Shot 2021-07-07 at 5 40 23 PM](https://user-images.githubusercontent.com/52669884/124947083-8bbb3380-dfdd-11eb-92de-e65ccca9a1a6.png)

