### PR TITLE
[MB-8689] Update alpine from 3.12.3 to 3.12.7

### DIFF
--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3
+FROM alpine:3.12.7
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -19,7 +19,7 @@ RUN rm -f bin/milmove && make bin/milmove
 # FINAL #
 #########
 
-FROM alpine:3.12.3
+FROM alpine:3.12.7
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -57,7 +57,7 @@ RUN set -x \
   && make bin/generate-test-data
 
 # define migrations before client build since it doesn't need client
-FROM alpine:3.12.3 as migrate
+FROM alpine:3.12.7 as migrate
 
 COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=server_builder /build/bin/milmove /bin/milmove

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3
+FROM alpine:3.12.7
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -19,7 +19,7 @@ RUN rm -f bin/prime-api-client && make bin/prime-api-client
 # FINAL #
 #########
 
-FROM alpine:3.12.3
+FROM alpine:3.12.7
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox


### PR DESCRIPTION
## Description

This PR updates Alpine from 3.12.3 to 3.12.7.  There are 3.13.x and 3.14.x versions of Alpine available, but we are blocked on those (#6428, #6814) because of some false positives that are coming out of an AWS ECR scan ([relevant Slack thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1623883007361500)).

I thought it made sense in the meantime to go ahead and update to the latest 3.12.x version since it does include some security fixes [based on the release announcements](https://alpinelinux.org/posts/).

## Reviewer Notes

Just make sure the tests and build seem to be OK.
