### PR TITLE
MB-8141 increase jest coverage threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,10 +173,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 40,
-        "functions": 35,
-        "lines": 40,
-        "statements": 40
+        "branches": 60,
+        "functions": 55,
+        "lines": 65,
+        "statements": 65
       }
     },
     "transformIgnorePatterns": [

--- a/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
+++ b/src/pages/Office/CustomerInfo/CustomerInfo.test.jsx
@@ -45,45 +45,94 @@ const mockCustomer = {
   phone: '123-444-3434',
 };
 
+const mockUpdate = jest.fn();
+
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 describe('CustomerInfo', () => {
-  it('populates initial field values', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      updateCustomerInfo.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={[customerInfoEditURL]}>
+          <CustomerInfo customer={mockCustomer} onUpdate={mockUpdate} ordersId="abc123" isLoading isError={false} />{' '}
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      updateCustomerInfo.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={[customerInfoEditURL]}>
+          <CustomerInfo customer={mockCustomer} onUpdate={mockUpdate} ordersId="abc123" isLoading={false} isError />{' '}
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
+  it('populates initial field values', async () => {
     render(
       <MockProviders initialEntries={[customerInfoEditURL]}>
-        <CustomerInfo customer={mockCustomer} ordersId="abc123" isLoading={false} isError={false} />{' '}
+        <CustomerInfo
+          customer={mockCustomer}
+          onUpdate={mockUpdate}
+          ordersId="abc123"
+          isLoading={false}
+          isError={false}
+        />
       </MockProviders>,
     );
-    expect(screen.getByLabelText('First name').value).toEqual(mockCustomer.first_name);
-    expect(screen.getByLabelText(/Middle name/i).value).toEqual(mockCustomer.middle_name);
-    expect(screen.getByLabelText('Last name').value).toEqual(mockCustomer.last_name);
-    expect(screen.getByLabelText(/Suffix/i).value).toEqual(mockCustomer.suffix);
-    // to get around the two inputs labeled "Phone" on the screen
-    expect(screen.getByDisplayValue(mockCustomer.phone).value).toEqual(mockCustomer.phone);
-    expect(screen.getByDisplayValue(mockCustomer.backup_contact.phone).value).toEqual(
-      mockCustomer.backup_contact.phone,
-    );
-    // to get around the two inputs labeled "Email" on the screen
-    expect(screen.getByDisplayValue(mockCustomer.email).value).toEqual(mockCustomer.email);
-    expect(screen.getByDisplayValue(mockCustomer.backup_contact.email).value).toEqual(
-      mockCustomer.backup_contact.email,
-    );
-    expect(screen.getByLabelText('Address 1').value).toEqual(mockCustomer.current_address.street_address_1);
-    expect(screen.getByLabelText('City').value).toEqual(mockCustomer.current_address.city);
-    expect(screen.getByLabelText('State').value).toEqual(mockCustomer.current_address.state);
-    expect(screen.getByLabelText('ZIP').value).toEqual(mockCustomer.current_address.postal_code);
-    expect(screen.getByLabelText('Name').value).toEqual(mockCustomer.backup_contact.name);
+    await waitFor(() => {
+      expect(screen.getByLabelText('First name').value).toEqual(mockCustomer.first_name);
+      expect(screen.getByLabelText(/Middle name/i).value).toEqual(mockCustomer.middle_name);
+      expect(screen.getByLabelText('Last name').value).toEqual(mockCustomer.last_name);
+      expect(screen.getByLabelText(/Suffix/i).value).toEqual(mockCustomer.suffix);
+      // to get around the two inputs labeled "Phone" on the screen
+      expect(screen.getByDisplayValue(mockCustomer.phone).value).toEqual(mockCustomer.phone);
+      expect(screen.getByDisplayValue(mockCustomer.backup_contact.phone).value).toEqual(
+        mockCustomer.backup_contact.phone,
+      );
+      // to get around the two inputs labeled "Email" on the screen
+      expect(screen.getByDisplayValue(mockCustomer.email).value).toEqual(mockCustomer.email);
+      expect(screen.getByDisplayValue(mockCustomer.backup_contact.email).value).toEqual(
+        mockCustomer.backup_contact.email,
+      );
+      expect(screen.getByLabelText('Address 1').value).toEqual(mockCustomer.current_address.street_address_1);
+      expect(screen.getByLabelText('City').value).toEqual(mockCustomer.current_address.city);
+      expect(screen.getByLabelText('State').value).toEqual(mockCustomer.current_address.state);
+      expect(screen.getByLabelText('ZIP').value).toEqual(mockCustomer.current_address.postal_code);
+      expect(screen.getByLabelText('Name').value).toEqual(mockCustomer.backup_contact.name);
+    });
   });
 
   it('calls onUpdate prop with success on successful form submission', async () => {
-    const mockUpdate = jest.fn();
     updateCustomerInfo.mockImplementation(() => Promise.resolve({ customer: { customerId: '123' } }));
     render(
       <MockProviders initialEntries={[customerInfoEditURL]}>
         <CustomerInfo
           customer={mockCustomer}
+          onUpdate={mockUpdate}
           ordersId="abc123"
           isLoading={false}
           isError={false}
-          onUpdate={mockUpdate}
         />
       </MockProviders>,
     );
@@ -96,7 +145,6 @@ describe('CustomerInfo', () => {
   });
 
   it('calls onUpdate prop with error on unsuccessful form submission', async () => {
-    const mockUpdate = jest.fn();
     updateCustomerInfo.mockImplementation(() => Promise.reject());
     render(
       <MockProviders initialEntries={[customerInfoEditURL]}>

--- a/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
@@ -1,10 +1,12 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import MoveAllowances from './MoveAllowances';
 
 import { MockProviders } from 'testUtils';
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -41,89 +43,132 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            requiredMedicalEquipmentWeight: 1000,
-            organizationalClothingAndIndividualEquipment: true,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
-describe('MoveAllowances page', () => {
-  const wrapper = mount(
-    <MockProviders initialEntries={['moves/1000/allowances']}>
-      <MoveAllowances />
-    </MockProviders>,
-  );
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        requiredMedicalEquipmentWeight: 1000,
+        organizationalClothingAndIndividualEquipment: true,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+};
 
-  it('renders the sidebar elements', () => {
-    expect(wrapper.find({ 'data-testid': 'allowances-header' }).text()).toBe('View Allowances');
-    // There is only 1 button, but mount-rendering react-uswds Button component has inner buttons
-    expect(wrapper.find({ 'data-testid': 'view-orders' }).at(0).text()).toBe('View Orders');
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+describe('MoveAllowances page', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useOrdersDocumentQueries.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveAllowances />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useOrdersDocumentQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveAllowances />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('renders displays the allowances in the sidebar form', () => {
-    // Pro-gear
-    expect(wrapper.find(`input[data-testid="proGearWeightInput"]`).getDOMNode().value).toBe('2,000');
+  describe('Basic rendering', () => {
+    useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
 
-    // Pro-gear spouse
-    expect(wrapper.find(`input[data-testid="proGearWeightSpouseInput"]`).getDOMNode().value).toBe('500');
+    const wrapper = mount(
+      <MockProviders initialEntries={['moves/1000/allowances']}>
+        <MoveAllowances />
+      </MockProviders>,
+    );
+    it('renders the sidebar elements', () => {
+      expect(wrapper.find({ 'data-testid': 'allowances-header' }).text()).toBe('View Allowances');
+      // There is only 1 button, but mount-rendering react-uswds Button component has inner buttons
+      expect(wrapper.find({ 'data-testid': 'view-orders' }).at(0).text()).toBe('View Orders');
+    });
 
-    // RME
-    expect(wrapper.find(`input[data-testid="rmeInput"]`).getDOMNode().value).toBe('1,000');
+    it('renders displays the allowances in the sidebar form', () => {
+      // Pro-gear
+      expect(wrapper.find(`input[data-testid="proGearWeightInput"]`).getDOMNode().value).toBe('2,000');
 
-    // Branch
-    expect(wrapper.find(`select[data-testid="branchInput"]`).getDOMNode().value).toBe('ARMY');
+      // Pro-gear spouse
+      expect(wrapper.find(`input[data-testid="proGearWeightSpouseInput"]`).getDOMNode().value).toBe('500');
 
-    // Rank
-    expect(wrapper.find(`select[data-testid="rankInput"]`).getDOMNode().value).toBe('E_1');
+      // RME
+      expect(wrapper.find(`input[data-testid="rmeInput"]`).getDOMNode().value).toBe('1,000');
 
-    // OCIE
-    expect(
-      wrapper.find(`input[name="organizationalClothingAndIndividualEquipment"]`).getDOMNode().checked,
-    ).toBeTruthy();
+      // Branch
+      expect(wrapper.find(`select[data-testid="branchInput"]`).getDOMNode().value).toBe('ARMY');
 
-    // Weight allowance
-    expect(wrapper.find('dd').at(0).text()).toBe('5,000 lbs');
+      // Rank
+      expect(wrapper.find(`select[data-testid="rankInput"]`).getDOMNode().value).toBe('E_1');
 
-    // Storage in-transit
-    expect(wrapper.find('dd').at(1).text()).toBe('2 days');
+      // OCIE
+      expect(
+        wrapper.find(`input[name="organizationalClothingAndIndividualEquipment"]`).getDOMNode().checked,
+      ).toBeTruthy();
 
-    // Dependents authorized
-    expect(wrapper.find(`input[name="dependentsAuthorized"]`).getDOMNode().checked).toBeTruthy();
+      // Weight allowance
+      expect(wrapper.find('dd').at(0).text()).toBe('5,000 lbs');
+
+      // Storage in-transit
+      expect(wrapper.find('dd').at(1).text()).toBe('2 days');
+
+      // Dependents authorized
+      expect(wrapper.find(`input[name="dependentsAuthorized"]`).getDOMNode().checked).toBeTruthy();
+    });
   });
 });

--- a/src/pages/Office/MoveDetails/MoveDetails.test.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.test.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import { ORDERS_TYPE, ORDERS_TYPE_DETAILS } from '../../../constants/orders';
 
@@ -515,9 +516,54 @@ const approvedMoveDetailsQuery = {
   ],
 };
 
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 describe('MoveDetails page', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useMoveDetailsQueries.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
+          <MoveDetails
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+          />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useMoveDetailsQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
+          <MoveDetails
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+          />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
   describe('requested shipment', () => {
-    useMoveDetailsQueries.mockImplementation(() => requestedMoveDetailsQuery);
+    useMoveDetailsQueries.mockReturnValue(requestedMoveDetailsQuery);
 
     const wrapper = mount(
       <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
@@ -579,7 +625,7 @@ describe('MoveDetails page', () => {
   });
 
   describe('requested shipment with amended orders', () => {
-    useMoveDetailsQueries.mockImplementation(() => requestedMoveDetailsAmendedOrdersQuery);
+    useMoveDetailsQueries.mockReturnValue(requestedMoveDetailsAmendedOrdersQuery);
 
     const wrapper = mount(
       <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
@@ -600,7 +646,7 @@ describe('MoveDetails page', () => {
   });
 
   describe('requested and approved shipment', () => {
-    useMoveDetailsQueries.mockImplementation(() => requestedAndApprovedMoveDetailsQuery);
+    useMoveDetailsQueries.mockReturnValue(requestedAndApprovedMoveDetailsQuery);
 
     const wrapper = mount(
       <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
@@ -635,7 +681,7 @@ describe('MoveDetails page', () => {
   });
 
   describe('approved shipment', () => {
-    useMoveDetailsQueries.mockImplementation(() => approvedMoveDetailsQuery);
+    useMoveDetailsQueries.mockReturnValue(approvedMoveDetailsQuery);
 
     const wrapper = mount(
       <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
@@ -655,7 +701,7 @@ describe('MoveDetails page', () => {
   });
 
   describe('When required Orders information (like TAC) is missing', () => {
-    useMoveDetailsQueries.mockImplementation(() => requestedMoveDetailsMissingInfoQuery);
+    useMoveDetailsQueries.mockReturnValue(requestedMoveDetailsMissingInfoQuery);
 
     const wrapper = mount(
       <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>

--- a/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/MoveDocumentWrapper/MoveDocumentWrapper.test.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
 
 import MoveDocumentWrapper from './MoveDocumentWrapper';
+
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -39,75 +42,89 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-      documents: {
-        2: {
-          id: '2',
-          uploads: ['z'],
-        },
-      },
-      upload: {
-        z: {
-          id: 'z',
-          filename: 'test.pdf',
-          contentType: 'application/pdf',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-      },
-      amendedDocuments: {
-        3: {
-          id: '3',
-          uploads: ['x'],
-        },
-      },
-      amendedUpload: {
-        x: {
-          id: 'z',
-          filename: 'amended_test.pdf',
-          contentType: 'application/pdf',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
 const testMoveId = '10000';
+
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+  documents: {
+    2: {
+      id: '2',
+      uploads: ['z'],
+    },
+  },
+  upload: {
+    z: {
+      id: 'z',
+      filename: 'test.pdf',
+      contentType: 'application/pdf',
+      url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+    },
+  },
+  amendedDocuments: {
+    3: {
+      id: '3',
+      uploads: ['x'],
+    },
+  },
+  amendedUpload: {
+    x: {
+      id: 'z',
+      filename: 'amended_test.pdf',
+      contentType: 'application/pdf',
+      url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+    },
+  },
+};
+
+const loadingReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -116,42 +133,72 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('MoveDocumentWrapper', () => {
-  it('renders the document viewer', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/moves/${testMoveId}/orders` }));
-    const wrapper = shallow(<MoveDocumentWrapper />);
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(loadingReturnValue);
 
-    expect(wrapper.find('DocumentViewer').exists()).toBe(true);
+      render(<MoveDocumentWrapper />);
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(errorReturnValue);
+
+      render(<MoveDocumentWrapper />);
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('renders the sidebar Orders component', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/moves/${testMoveId}/orders` }));
-    const wrapper = shallow(<MoveDocumentWrapper />);
-    expect(wrapper.find('Orders').exists()).toBe(true);
-  });
+  describe('Basic rendering', () => {
+    it('renders the document viewer', () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<MoveDocumentWrapper />);
 
-  it('renders the sidebar MoveAllowances component', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/moves/${testMoveId}/allowances` }));
-    const wrapper = shallow(<MoveDocumentWrapper />);
-    expect(wrapper.find('MoveAllowances').exists()).toBe(true);
-  });
+      expect(wrapper.find('DocumentViewer').exists()).toBe(true);
+    });
 
-  it('combines orders and amended orders', () => {
-    const wrapper = shallow(<MoveDocumentWrapper />);
-    expect(wrapper.find('DocumentViewer').props('files')).toEqual({
-      files: [
-        {
-          contentType: 'application/pdf',
-          filename: 'test.pdf',
-          id: 'z',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-        {
-          contentType: 'application/pdf',
-          filename: 'amended_test.pdf',
-          id: 'z',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-      ],
+    it('renders the sidebar Orders component', () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<MoveDocumentWrapper />);
+      expect(wrapper.find('Orders').exists()).toBe(true);
+    });
+
+    it('renders the sidebar MoveAllowances component', () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/allowances` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<MoveDocumentWrapper />);
+      expect(wrapper.find('MoveAllowances').exists()).toBe(true);
+    });
+
+    it('combines orders and amended orders', () => {
+      useLocation.mockReturnValue({ pathname: `/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      const wrapper = shallow(<MoveDocumentWrapper />);
+      expect(wrapper.find('DocumentViewer').props('files')).toEqual({
+        files: [
+          {
+            contentType: 'application/pdf',
+            filename: 'test.pdf',
+            id: 'z',
+            url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+          },
+          {
+            contentType: 'application/pdf',
+            filename: 'amended_test.pdf',
+            id: 'z',
+            url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+          },
+        ],
+      });
     });
   });
 });

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -44,7 +44,7 @@ const MovePaymentRequests = ({
   }, [mtoShipments, setUnapprovedServiceItemCount]);
 
   useEffect(() => {
-    const pendingCount = paymentRequests.filter((pr) => pr.status === paymentRequestStatus.PENDING).length;
+    const pendingCount = paymentRequests?.filter((pr) => pr.status === paymentRequestStatus.PENDING).length;
     setPendingPaymentRequestCount(pendingCount);
   }, [paymentRequests, setPendingPaymentRequestCount]);
 

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -215,6 +215,18 @@ const emptyPaymentRequests = {
   mtoShipments: [],
 };
 
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 function renderMovePaymentRequests(props) {
   return render(
     <MockProviders initialEntries={[`/moves/L2BKD6/payment-requests`]}>
@@ -224,9 +236,29 @@ function renderMovePaymentRequests(props) {
 }
 
 describe('MovePaymentRequests', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useMovePaymentRequestsQueries.mockReturnValue(loadingReturnValue);
+
+      renderMovePaymentRequests(testProps);
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useMovePaymentRequestsQueries.mockReturnValue(errorReturnValue);
+
+      renderMovePaymentRequests(testProps);
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
   describe('with multiple payment requests', () => {
     beforeEach(() => {
-      useMovePaymentRequestsQueries.mockImplementation(() => multiplePaymentRequests);
+      useMovePaymentRequestsQueries.mockReturnValue(multiplePaymentRequests);
     });
 
     it('renders without errors', () => {
@@ -267,7 +299,7 @@ describe('MovePaymentRequests', () => {
 
   describe('with one reviewed payment request', () => {
     beforeEach(() => {
-      useMovePaymentRequestsQueries.mockImplementation(() => singleReviewedPaymentRequest);
+      useMovePaymentRequestsQueries.mockReturnValue(singleReviewedPaymentRequest);
     });
 
     it('updates the pending payment request count callback', async () => {
@@ -294,7 +326,7 @@ describe('MovePaymentRequests', () => {
 
   describe('with no payment requests for move', () => {
     beforeEach(() => {
-      useMovePaymentRequestsQueries.mockImplementation(() => emptyPaymentRequests);
+      useMovePaymentRequestsQueries.mockReturnValue(emptyPaymentRequests);
     });
 
     it('renders with empty message when no payment requests exist', async () => {

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import { MoveTaskOrder } from 'pages/Office/MoveTaskOrder/MoveTaskOrder';
 import MOVE_STATUSES from 'constants/moves';
@@ -417,16 +418,64 @@ const approvedMTOWithCancelledShipmentQuery = {
 const setUnapprovedShipmentCount = jest.fn();
 const setUnapprovedServiceItemCount = jest.fn();
 
+const moveCode = 'WE31AZ';
+const requiredProps = {
+  match: { params: { moveCode } },
+  history: { push: jest.fn() },
+  setMessage: jest.fn(),
+};
+
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 describe('MoveTaskOrder', () => {
-  const moveCode = 'WE31AZ';
-  const requiredProps = {
-    match: { params: { moveCode } },
-    history: { push: jest.fn() },
-    setMessage: jest.fn(),
-  };
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+          />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+          />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
 
   describe('move is not available to prime', () => {
-    useMoveTaskOrderQueries.mockImplementation(() => unapprovedMTOQuery);
+    useMoveTaskOrderQueries.mockReturnValue(unapprovedMTOQuery);
     const wrapper = mount(
       <MockProviders>
         <MoveTaskOrder
@@ -460,7 +509,7 @@ describe('MoveTaskOrder', () => {
   });
 
   describe('approved mto with both submitted and approved shipments', () => {
-    useMoveTaskOrderQueries.mockImplementation(() => someShipmentsApprovedMTOQuery);
+    useMoveTaskOrderQueries.mockReturnValue(someShipmentsApprovedMTOQuery);
     const wrapper = mount(
       <MockProviders>
         <MoveTaskOrder
@@ -526,7 +575,7 @@ describe('MoveTaskOrder', () => {
   });
 
   describe('approved mto with approved shipments', () => {
-    useMoveTaskOrderQueries.mockImplementation(() => allApprovedMTOQuery);
+    useMoveTaskOrderQueries.mockReturnValue(allApprovedMTOQuery);
     const wrapper = mount(
       <MockProviders>
         <MoveTaskOrder
@@ -604,7 +653,7 @@ describe('MoveTaskOrder', () => {
   });
 
   describe('approved mto with cancelled shipment', () => {
-    useMoveTaskOrderQueries.mockImplementation(() => approvedMTOWithCancelledShipmentQuery);
+    useMoveTaskOrderQueries.mockReturnValue(approvedMTOWithCancelledShipmentQuery);
     const wrapper = mount(
       <MockProviders>
         <MoveTaskOrder

--- a/src/pages/Office/Orders/Orders.test.jsx
+++ b/src/pages/Office/Orders/Orders.test.jsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { IMaskInput } from 'react-imask';
 
 import Orders from './Orders';
 
 import { MockProviders } from 'testUtils';
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -42,67 +44,113 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
-describe('Orders page', () => {
-  const wrapper = mount(
-    <MockProviders initialEntries={['moves/FP24I2/orders']}>
-      <Orders />
-    </MockProviders>,
-  );
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+};
 
-  it('renders the sidebar orders detail form', () => {
-    expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+const loadingReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+describe('Orders page', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useOrdersDocumentQueries.mockReturnValueOnce(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <Orders />
+        </MockProviders>,
+      );
+
+      const h2 = screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useOrdersDocumentQueries.mockReturnValueOnce(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <Orders />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('populates initial field values', () => {
-    expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
-    expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
-    expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
-    expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
-    expect(wrapper.find('select[name="departmentIndicator"]').prop('value')).toBe('AIR_FORCE');
-    expect(wrapper.find('input[name="ordersNumber"]').prop('value')).toBe('ORDER3');
-    expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
-    expect(wrapper.find('select[name="ordersTypeDetail"]').prop('value')).toBe('HHG_PERMITTED');
-    expect(wrapper.find(IMaskInput).getDOMNode().value).toBe('F8E1');
-    expect(wrapper.find('input[name="sac"]').prop('value')).toBe('E2P3');
+  describe('Basic rendering', () => {
+    useOrdersDocumentQueries.mockReturnValueOnce(useOrdersDocumentQueriesReturnValue);
+
+    const wrapper = mount(
+      <MockProviders initialEntries={['moves/FP24I2/orders']}>
+        <Orders />
+      </MockProviders>,
+    );
+
+    it('renders the sidebar orders detail form', () => {
+      expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+    });
+
+    it('populates initial field values', () => {
+      expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
+      expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
+      expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
+      expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
+      expect(wrapper.find('select[name="departmentIndicator"]').prop('value')).toBe('AIR_FORCE');
+      expect(wrapper.find('input[name="ordersNumber"]').prop('value')).toBe('ORDER3');
+      expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
+      expect(wrapper.find('select[name="ordersTypeDetail"]').prop('value')).toBe('HHG_PERMITTED');
+      expect(wrapper.find(IMaskInput).getDOMNode().value).toBe('F8E1');
+      expect(wrapper.find('input[name="sac"]').prop('value')).toBe('E2P3');
+    });
   });
 });

--- a/src/pages/Office/PaymentRequestReview/PaymentRequestReview.test.jsx
+++ b/src/pages/Office/PaymentRequestReview/PaymentRequestReview.test.jsx
@@ -1,10 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import { SHIPMENT_OPTIONS } from '../../../shared/constants';
 
 import { PaymentRequestReview } from './PaymentRequestReview';
+
+import { usePaymentRequestQueries } from 'hooks/queries';
 
 const mockPDFUpload = {
   contentType: 'application/pdf',
@@ -30,139 +33,171 @@ const mockPNGUpload = {
   contentType: 'image/png',
   createdAt: '2020-09-17T16:00:48.099137Z',
   filename: 'test.png',
-  id: '11',
+  id: '12',
   status: 'PROCESSING',
-  updatedAt: '11',
+  updatedAt: '12',
   url: '/storage/prime/99/uploads/10?contentType=image%2Fpng',
 };
 
 const mockShipmentOptions = SHIPMENT_OPTIONS;
 
+const testPaymentRequestId = 'test-payment-id-123';
+
 jest.mock('hooks/queries', () => ({
-  usePaymentRequestQueries: () => {
-    const testPaymentRequestId = 'test-payment-id-123';
-    return {
-      paymentRequest: {
-        id: testPaymentRequestId,
-        moveTaskOrderID: '123',
-        proofOfServiceDocs: [
-          {
-            uploads: [mockPDFUpload],
-          },
-          {
-            uploads: [mockJPGUpload, mockPNGUpload],
-          },
-        ],
-      },
-      paymentRequests: {
-        [testPaymentRequestId]: {
-          id: testPaymentRequestId,
-          moveTaskOrderID: '123',
-        },
-      },
-      mtoShipments: [
-        {
-          actualPickupDate: '2021-05-04',
-          destinationAddress: {
-            city: 'Fairfield',
-            id: '1f0054d2-6cf9-41aa-8b9c-27b9fc6667b5',
-            postal_code: '94535',
-            state: 'CA',
-            street_address_1: '987 Any Avenue',
-            street_address_2: 'P.O. Box 9876',
-            street_address_3: 'c/o Some Person',
-          },
-          id: 'a1',
-          status: 'CANCELED',
-          moveTaskOrderID: '123',
-          pickupAddress: {
-            city: 'Beverly Hills',
-            id: '0cf43b1f-04e8-4c56-a6a1-06aec192ca07',
-            postal_code: '90210',
-            state: 'CA',
-            street_address_1: '123 Any Street',
-            street_address_2: 'P.O. Box 12345',
-            street_address_3: 'c/o Some Person',
-          },
-        },
-        {
-          actualPickupDate: '2021-05-04',
-          destinationAddress: {
-            city: 'Fairfield',
-            id: '1f0054d2-6cf9-41aa-8b9c-27b9fc6667b5',
-            postal_code: '94535',
-            state: 'CA',
-            street_address_1: '987 Any Avenue',
-            street_address_2: 'P.O. Box 9876',
-            street_address_3: 'c/o Some Person',
-          },
-          id: 'b2',
-          moveTaskOrderID: '123',
-          pickupAddress: {
-            city: 'Beverly Hills',
-            id: '0cf43b1f-04e8-4c56-a6a1-06aec192ca07',
-            postal_code: '90210',
-            state: 'CA',
-            street_address_1: '123 Any Street',
-            street_address_2: 'P.O. Box 12345',
-            street_address_3: 'c/o Some Person',
-          },
-        },
-      ],
-      paymentServiceItems: {
-        1: {
-          id: '1',
-          mtoServiceItemID: 'a',
-          mtoShipmentID: 'a1',
-          mtoShipmentType: mockShipmentOptions.HHG,
-          mtoServiceItemName: 'Test Service Item',
-          priceCents: 12399,
-          createdAt: '2020-01-01T00:09:00.999Z',
-          status: 'APPROVED',
-        },
-        2: {
-          id: '2',
-          mtoServiceItemID: 'b',
-          mtoShipmentID: 'b2',
-          mtoShipmentType: mockShipmentOptions.NTSR,
-          mtoServiceItemName: 'Test Service Item 2',
-          priceCents: 45600,
-          createdAt: '2020-01-01T00:09:00.999Z',
-        },
-        3: {
-          id: '3',
-          mtoServiceItemID: 'c',
-          mtoShipmentID: 'a1',
-          mtoShipmentType: mockShipmentOptions.HHG,
-          mtoServiceItemName: 'Test Service Item 3',
-          priceCents: 12312,
-          createdAt: '2020-01-01T00:09:00.999Z',
-          status: 'DENIED',
-        },
-        4: {
-          id: '4',
-          mtoServiceItemID: 'd',
-          priceCents: 99999,
-          mtoServiceItemName: 'Test Service Item 4',
-          createdAt: '2020-01-01T00:09:00.999Z',
-        },
-      },
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-    };
-  },
+  usePaymentRequestQueries: jest.fn(),
 }));
 
-describe('PaymentRequestReview', () => {
-  const testPaymentRequestId = 'test-payment-id-123';
+const usePaymentRequestQueriesReturnValue = {
+  paymentRequest: {
+    id: testPaymentRequestId,
+    moveTaskOrderID: '123',
+    proofOfServiceDocs: [
+      {
+        uploads: [mockPDFUpload],
+      },
+      {
+        uploads: [mockJPGUpload, mockPNGUpload],
+      },
+    ],
+  },
+  paymentRequests: {
+    [testPaymentRequestId]: {
+      id: testPaymentRequestId,
+      moveTaskOrderID: '123',
+    },
+  },
+  mtoShipments: [
+    {
+      actualPickupDate: '2021-05-04',
+      destinationAddress: {
+        city: 'Fairfield',
+        id: '1f0054d2-6cf9-41aa-8b9c-27b9fc6667b5',
+        postal_code: '94535',
+        state: 'CA',
+        street_address_1: '987 Any Avenue',
+        street_address_2: 'P.O. Box 9876',
+        street_address_3: 'c/o Some Person',
+      },
+      id: 'a1',
+      status: 'CANCELED',
+      moveTaskOrderID: '123',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        id: '0cf43b1f-04e8-4c56-a6a1-06aec192ca07',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+    },
+    {
+      actualPickupDate: '2021-05-04',
+      destinationAddress: {
+        city: 'Fairfield',
+        id: '1f0054d2-6cf9-41aa-8b9c-27b9fc6667b5',
+        postal_code: '94535',
+        state: 'CA',
+        street_address_1: '987 Any Avenue',
+        street_address_2: 'P.O. Box 9876',
+        street_address_3: 'c/o Some Person',
+      },
+      id: 'b2',
+      moveTaskOrderID: '123',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        id: '0cf43b1f-04e8-4c56-a6a1-06aec192ca07',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+    },
+  ],
+  paymentServiceItems: {
+    1: {
+      id: '1',
+      mtoServiceItemID: 'a',
+      mtoShipmentID: 'a1',
+      mtoShipmentType: mockShipmentOptions.HHG,
+      mtoServiceItemName: 'Test Service Item',
+      priceCents: 12399,
+      createdAt: '2020-01-01T00:09:00.999Z',
+      status: 'APPROVED',
+    },
+    2: {
+      id: '2',
+      mtoServiceItemID: 'b',
+      mtoShipmentID: 'b2',
+      mtoShipmentType: mockShipmentOptions.NTSR,
+      mtoServiceItemName: 'Test Service Item 2',
+      priceCents: 45600,
+      createdAt: '2020-01-01T00:09:00.999Z',
+    },
+    3: {
+      id: '3',
+      mtoServiceItemID: 'c',
+      mtoShipmentID: 'a1',
+      mtoShipmentType: mockShipmentOptions.HHG,
+      mtoServiceItemName: 'Test Service Item 3',
+      priceCents: 12312,
+      createdAt: '2020-01-01T00:09:00.999Z',
+      status: 'DENIED',
+    },
+    4: {
+      id: '4',
+      mtoServiceItemID: 'd',
+      priceCents: 99999,
+      mtoServiceItemName: 'Test Service Item 4',
+      createdAt: '2020-01-01T00:09:00.999Z',
+    },
+  },
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
 
-  const requiredProps = {
-    match: { params: { paymentRequestId: testPaymentRequestId } },
-    history: { push: jest.fn() },
-  };
+const requiredProps = {
+  match: { params: { paymentRequestId: testPaymentRequestId } },
+  history: { push: jest.fn() },
+};
+
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+describe('PaymentRequestReview', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      usePaymentRequestQueries.mockReturnValue(loadingReturnValue);
+
+      render(<PaymentRequestReview {...requiredProps} />);
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      usePaymentRequestQueries.mockReturnValue(errorReturnValue);
+
+      render(<PaymentRequestReview {...requiredProps} />);
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
 
   describe('with data loaded', () => {
+    usePaymentRequestQueries.mockReturnValue(usePaymentRequestQueriesReturnValue);
     const wrapper = mount(<PaymentRequestReview {...requiredProps} />);
 
     it('renders without errors', () => {

--- a/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.test.jsx
+++ b/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.test.jsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import ServicesCounselingAddShipment from './ServicesCounselingAddShipment';
 
 import { createMTOShipment } from 'services/ghcApi';
+import { useEditShipmentQueries } from 'hooks/queries';
 
 const mockPush = jest.fn();
 
@@ -26,132 +27,131 @@ jest.mock('services/ghcApi', () => ({
 }));
 
 jest.mock('hooks/queries', () => ({
-  useEditShipmentQueries: jest
-    .fn(() => {
-      return {
-        move: {
-          id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
-          ordersId: '1',
-          status: 'NEEDS SERVICE COUNSELING',
-        },
-        order: {
-          id: '1',
-          originDutyStation: {
-            address: {
-              street_address_1: '',
-              city: 'Fort Knox',
-              state: 'KY',
-              postal_code: '40121',
-            },
-          },
-          destinationDutyStation: {
-            address: {
-              street_address_1: '',
-              city: 'Fort Irwin',
-              state: 'CA',
-              postal_code: '92310',
-            },
-          },
-          customer: {
-            agency: 'ARMY',
-            backup_contact: {
-              email: 'email@example.com',
-              name: 'name',
-              phone: '555-555-5555',
-            },
-            current_address: {
-              city: 'Beverly Hills',
-              country: 'US',
-              eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41Mzg0Njha',
-              id: '3a5f7cf2-6193-4eb3-a244-14d21ca05d7b',
-              postal_code: '90210',
-              state: 'CA',
-              street_address_1: '123 Any Street',
-              street_address_2: 'P.O. Box 12345',
-              street_address_3: 'c/o Some Person',
-            },
-            dodID: '6833908165',
-            eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NjAzNTJa',
-            email: 'combo@ppm.hhg',
-            first_name: 'Submitted',
-            id: 'f6bd793f-7042-4523-aa30-34946e7339c9',
-            last_name: 'Ppmhhg',
-            phone: '555-555-5555',
-          },
-          entitlement: {
-            authorizedWeight: 8000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NzgwMzda',
-            id: 'e0fefe58-0710-40db-917b-5b96567bc2a8',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 8000,
-          },
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          tac: '9999',
-        },
-        mtoShipments: [
-          {
-            customerRemarks: 'please treat gently',
-            destinationAddress: {
-              city: 'Fairfield',
-              country: 'US',
-              id: '672ff379-f6e3-48b4-a87d-796713f8f997',
-              postal_code: '94535',
-              state: 'CA',
-              street_address_1: '987 Any Avenue',
-              street_address_2: 'P.O. Box 9876',
-              street_address_3: 'c/o Some Person',
-            },
-            eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
-            id: 'shipment123',
-            moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
-            pickupAddress: {
-              city: 'Beverly Hills',
-              country: 'US',
-              eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
-              id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
-              postal_code: '90210',
-              state: 'CA',
-              street_address_1: '123 Any Street',
-              street_address_2: 'P.O. Box 12345',
-              street_address_3: 'c/o Some Person',
-            },
-            requestedPickupDate: '2018-03-15',
-            scheduledPickupDate: '2018-03-16',
-            requestedDeliveryDate: '2018-04-15',
-            scheduledDeliveryDate: '2014-04-16',
-            shipmentType: 'HHG',
-            status: 'SUBMITTED',
-            updatedAt: '2020-06-10T15:58:02.404031Z',
-          },
-        ],
-        isLoading: false,
-        isError: false,
-        isSuccess: true,
-      };
-    })
-    .mockImplementationOnce(() => {
-      return {
-        isLoading: true,
-        isError: false,
-        isSuccess: false,
-      };
-    })
-    .mockImplementationOnce(() => {
-      return {
-        isLoading: false,
-        isError: true,
-        isSuccess: false,
-      };
-    }),
+  useEditShipmentQueries: jest.fn(),
 }));
+
+const useEditShipmentQueriesReturnValue = {
+  move: {
+    id: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+    ordersId: '1',
+    status: 'NEEDS SERVICE COUNSELING',
+  },
+  order: {
+    id: '1',
+    originDutyStation: {
+      address: {
+        street_address_1: '',
+        city: 'Fort Knox',
+        state: 'KY',
+        postal_code: '40121',
+      },
+    },
+    destinationDutyStation: {
+      address: {
+        street_address_1: '',
+        city: 'Fort Irwin',
+        state: 'CA',
+        postal_code: '92310',
+      },
+    },
+    customer: {
+      agency: 'ARMY',
+      backup_contact: {
+        email: 'email@example.com',
+        name: 'name',
+        phone: '555-555-5555',
+      },
+      current_address: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41Mzg0Njha',
+        id: '3a5f7cf2-6193-4eb3-a244-14d21ca05d7b',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+      dodID: '6833908165',
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NjAzNTJa',
+      email: 'combo@ppm.hhg',
+      first_name: 'Submitted',
+      id: 'f6bd793f-7042-4523-aa30-34946e7339c9',
+      last_name: 'Ppmhhg',
+      phone: '555-555-5555',
+    },
+    entitlement: {
+      authorizedWeight: 8000,
+      dependentsAuthorized: true,
+      eTag: 'MjAyMS0wMS0yMVQxNTo0MTozNS41NzgwMzda',
+      id: 'e0fefe58-0710-40db-917b-5b96567bc2a8',
+      nonTemporaryStorage: true,
+      privatelyOwnedVehicle: true,
+      proGearWeight: 2000,
+      proGearWeightSpouse: 500,
+      storageInTransit: 2,
+      totalDependents: 1,
+      totalWeight: 8000,
+    },
+    order_number: 'ORDER3',
+    order_type: 'PERMANENT_CHANGE_OF_STATION',
+    order_type_detail: 'HHG_PERMITTED',
+    tac: '9999',
+  },
+  mtoShipments: [
+    {
+      customerRemarks: 'please treat gently',
+      destinationAddress: {
+        city: 'Fairfield',
+        country: 'US',
+        id: '672ff379-f6e3-48b4-a87d-796713f8f997',
+        postal_code: '94535',
+        state: 'CA',
+        street_address_1: '987 Any Avenue',
+        street_address_2: 'P.O. Box 9876',
+        street_address_3: 'c/o Some Person',
+      },
+      eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi40MDQwMzFa',
+      id: 'shipment123',
+      moveTaskOrderID: '9c7b255c-2981-4bf8-839f-61c7458e2b4d',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMC0wNi0xMFQxNTo1ODowMi4zODQ3Njla',
+        id: '1686751b-ab36-43cf-b3c9-c0f467d13c19',
+        postal_code: '90210',
+        state: 'CA',
+        street_address_1: '123 Any Street',
+        street_address_2: 'P.O. Box 12345',
+        street_address_3: 'c/o Some Person',
+      },
+      requestedPickupDate: '2018-03-15',
+      scheduledPickupDate: '2018-03-16',
+      requestedDeliveryDate: '2018-04-15',
+      scheduledDeliveryDate: '2014-04-16',
+      shipmentType: 'HHG',
+      status: 'SUBMITTED',
+      updatedAt: '2020-06-10T15:58:02.404031Z',
+    },
+  ],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
+const loadingReturnValue = {
+  ...useEditShipmentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useEditShipmentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
 
 const props = {
   match: {
@@ -163,15 +163,9 @@ const props = {
 };
 
 describe('ServicesCounselingAddShipment component', () => {
-  /*
-  The order in which these mockImplementationOnce is directly correlated to the
-  order in which the tests are run. This is because different data should be
-  returned from the call each time in order to tests the different states that
-  the component can be in. The default will be to return all the data needed for
-  the full tests.
-  */
-  describe('check different component states - ORDER MATTERS see comment in tests', () => {
+  describe('check different component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
+      useEditShipmentQueries.mockReturnValue(loadingReturnValue);
       render(<ServicesCounselingAddShipment {...props} />);
 
       const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
@@ -179,6 +173,8 @@ describe('ServicesCounselingAddShipment component', () => {
     });
 
     it('renders the Something Went Wrong component when the query errors', async () => {
+      useEditShipmentQueries.mockReturnValue(errorReturnValue);
+
       render(<ServicesCounselingAddShipment {...props} />);
 
       const errorMessage = await screen.getByText(/Something went wrong./);
@@ -186,57 +182,64 @@ describe('ServicesCounselingAddShipment component', () => {
     });
   });
 
-  it('renders the Services Counseling Shipment Form', async () => {
-    render(<ServicesCounselingAddShipment {...props} />);
+  describe('Basic rendering', () => {
+    it('renders the Services Counseling Shipment Form', async () => {
+      useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
+      render(<ServicesCounselingAddShipment {...props} />);
 
-    const h1 = await screen.getByRole('heading', { name: 'Add shipment details', level: 1 });
-    expect(h1).toBeInTheDocument();
-  });
-
-  it('routes to the move details page when the save button is clicked', async () => {
-    createMTOShipment.mockImplementation(() => Promise.resolve());
-
-    render(<ServicesCounselingAddShipment {...props} />);
-
-    const saveButton = screen.getByRole('button', { name: 'Save' });
-
-    expect(saveButton).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(saveButton).toBeDisabled();
+      const h1 = await screen.getByRole('heading', { name: 'Add shipment details', level: 1 });
+      await waitFor(() => {
+        expect(h1).toBeInTheDocument();
+      });
     });
 
-    expect(screen.getByLabelText('Use current address')).not.toBeChecked();
+    it('routes to the move details page when the save button is clicked', async () => {
+      useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
+      createMTOShipment.mockImplementation(() => Promise.resolve());
 
-    userEvent.type(screen.getAllByLabelText('Address 1')[0], '812 S 129th St');
-    userEvent.type(screen.getAllByLabelText('City')[0], 'San Antonio');
-    userEvent.selectOptions(screen.getAllByLabelText('State')[0], ['TX']);
-    userEvent.type(screen.getAllByLabelText('ZIP')[0], '78234');
-    userEvent.type(screen.getByLabelText('Requested pickup date'), '01 Nov 2020');
-    userEvent.type(screen.getByLabelText('Requested delivery date'), '08 Nov 2020');
+      render(<ServicesCounselingAddShipment {...props} />);
 
-    await waitFor(() => {
-      expect(saveButton).not.toBeDisabled();
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+
+      expect(saveButton).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(saveButton).toBeDisabled();
+      });
+
+      expect(screen.getByLabelText('Use current address')).not.toBeChecked();
+
+      userEvent.type(screen.getAllByLabelText('Address 1')[0], '812 S 129th St');
+      userEvent.type(screen.getAllByLabelText('City')[0], 'San Antonio');
+      userEvent.selectOptions(screen.getAllByLabelText('State')[0], ['TX']);
+      userEvent.type(screen.getAllByLabelText('ZIP')[0], '78234');
+      userEvent.type(screen.getByLabelText('Requested pickup date'), '01 Nov 2020');
+      userEvent.type(screen.getByLabelText('Requested delivery date'), '08 Nov 2020');
+
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+
+      userEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/counseling/moves/move123/details');
+      });
     });
 
-    userEvent.click(saveButton);
+    it('routes to the move details page when the cancel button is clicked', async () => {
+      useEditShipmentQueries.mockReturnValue(useEditShipmentQueriesReturnValue);
+      render(<ServicesCounselingAddShipment {...props} />);
 
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/counseling/moves/move123/details');
-    });
-  });
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
 
-  it('routes to the move details page when the cancel button is clicked', async () => {
-    render(<ServicesCounselingAddShipment {...props} />);
+      expect(cancelButton).not.toBeDisabled();
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      userEvent.click(cancelButton);
 
-    expect(cancelButton).not.toBeDisabled();
-
-    userEvent.click(cancelButton);
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/counseling/moves/move123/details');
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/counseling/moves/move123/details');
+      });
     });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
@@ -1,9 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import ServicesCounselingMoveAllowances from 'pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances';
 import { MockProviders } from 'testUtils';
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -40,92 +42,136 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            requiredMedicalEquipmentWeight: 1000,
-            organizationalClothingAndIndividualEquipment: true,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
-describe('MoveAllowances page', () => {
-  const wrapper = mount(
-    <MockProviders initialEntries={['/counseling/moves/1000/allowances']}>
-      <ServicesCounselingMoveAllowances />
-    </MockProviders>,
-  );
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        requiredMedicalEquipmentWeight: 1000,
+        organizationalClothingAndIndividualEquipment: true,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+};
 
-  it('renders the sidebar elements', () => {
-    expect(wrapper.find({ 'data-testid': 'allowances-header' }).text()).toBe('View allowances');
-    expect(wrapper.find({ 'data-testid': 'view-orders' }).at(0).text()).toBe('View orders');
-    expect(wrapper.find({ 'data-testid': 'header' }).text()).toBe('Counseling');
+const loadingReturnValue = {
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+describe('MoveAllowances page', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useOrdersDocumentQueries.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={['/counseling/moves/1000/allowances']}>
+          <ServicesCounselingMoveAllowances />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useOrdersDocumentQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={['/counseling/moves/1000/allowances']}>
+          <ServicesCounselingMoveAllowances />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('renders displays the allowances in the sidebar form', () => {
-    // Pro-gear
-    expect(wrapper.find(`input[data-testid="proGearWeightInput"]`).getDOMNode().value).toBe('2,000');
+  describe('Basic rendering', () => {
+    useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
 
-    // Pro-gear spouse
-    expect(wrapper.find(`input[data-testid="proGearWeightSpouseInput"]`).getDOMNode().value).toBe('500');
+    const wrapper = mount(
+      <MockProviders initialEntries={['/counseling/moves/1000/allowances']}>
+        <ServicesCounselingMoveAllowances />
+      </MockProviders>,
+    );
 
-    // RME
-    expect(wrapper.find(`input[data-testid="rmeInput"]`).getDOMNode().value).toBe('1,000');
+    it('renders the sidebar elements', () => {
+      expect(wrapper.find({ 'data-testid': 'allowances-header' }).text()).toBe('View allowances');
+      expect(wrapper.find({ 'data-testid': 'view-orders' }).at(0).text()).toBe('View orders');
+      expect(wrapper.find({ 'data-testid': 'header' }).text()).toBe('Counseling');
+    });
 
-    // Branch
-    expect(wrapper.find(`select[data-testid="branchInput"]`).getDOMNode().value).toBe('ARMY');
+    it('renders displays the allowances in the sidebar form', () => {
+      // Pro-gear
+      expect(wrapper.find(`input[data-testid="proGearWeightInput"]`).getDOMNode().value).toBe('2,000');
 
-    // Rank
-    expect(wrapper.find(`select[data-testid="rankInput"]`).getDOMNode().value).toBe('E_1');
+      // Pro-gear spouse
+      expect(wrapper.find(`input[data-testid="proGearWeightSpouseInput"]`).getDOMNode().value).toBe('500');
 
-    // OCIE
-    expect(
-      wrapper.find(`input[name="organizationalClothingAndIndividualEquipment"]`).getDOMNode().checked,
-    ).toBeTruthy();
+      // RME
+      expect(wrapper.find(`input[data-testid="rmeInput"]`).getDOMNode().value).toBe('1,000');
 
-    // Authorized weight
-    expect(wrapper.find('dd').at(0).text()).toBe('5,000 lbs');
+      // Branch
+      expect(wrapper.find(`select[data-testid="branchInput"]`).getDOMNode().value).toBe('ARMY');
 
-    // Weight allowance
-    expect(wrapper.find('dd').at(1).text()).toBe('5,000 lbs');
+      // Rank
+      expect(wrapper.find(`select[data-testid="rankInput"]`).getDOMNode().value).toBe('E_1');
 
-    // Storage in-transit
-    expect(wrapper.find('dd').at(2).text()).toBe('2 days');
+      // OCIE
+      expect(
+        wrapper.find(`input[name="organizationalClothingAndIndividualEquipment"]`).getDOMNode().checked,
+      ).toBeTruthy();
 
-    // Dependents authorized
-    expect(wrapper.find(`input[name="dependentsAuthorized"]`).getDOMNode().checked).toBeTruthy();
+      // Authorized weight
+      expect(wrapper.find('dd').at(0).text()).toBe('5,000 lbs');
+
+      // Weight allowance
+      expect(wrapper.find('dd').at(1).text()).toBe('5,000 lbs');
+
+      // Storage in-transit
+      expect(wrapper.find('dd').at(2).text()).toBe('2 days');
+
+      // Dependents authorized
+      expect(wrapper.find(`input[name="dependentsAuthorized"]`).getDOMNode().checked).toBeTruthy();
+    });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -216,311 +216,349 @@ const mockedComponent = (
   </MockProviders>
 );
 
+const loadingReturnValue = {
+  ...newMoveDetailsQuery,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...newMoveDetailsQuery,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 describe('MoveDetails page', () => {
-  it('renders the h1', async () => {
-    useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useMoveDetailsQueries.mockReturnValue(loadingReturnValue);
 
-    render(mockedComponent);
+      render(mockedComponent);
 
-    expect(await screen.findByRole('heading', { name: 'Move details', level: 1 })).toBeInTheDocument();
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useMoveDetailsQueries.mockReturnValue(errorReturnValue);
+
+      render(mockedComponent);
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  /* eslint-disable camelcase */
-  it('renders shipments info', async () => {
-    useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
+  describe('Basic rendering', () => {
+    it('renders the h1', async () => {
+      useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
 
-    render(mockedComponent);
+      render(mockedComponent);
 
-    expect(await screen.findByRole('heading', { name: 'Shipments', level: 2 })).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: 'Move details', level: 1 })).toBeInTheDocument();
+    });
 
-    expect(screen.getAllByRole('heading', { name: 'HHG', level: 3 }).length).toBe(2);
+    /* eslint-disable camelcase */
+    it('renders shipments info', async () => {
+      useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
 
-    const moveDateTerms = screen.getAllByText('Requested move date');
+      render(mockedComponent);
 
-    expect(moveDateTerms.length).toBe(2);
+      expect(await screen.findByRole('heading', { name: 'Shipments', level: 2 })).toBeInTheDocument();
 
-    for (let i = 0; i < moveDateTerms.length; i += 1) {
-      expect(moveDateTerms[i].nextElementSibling.textContent).toBe(
-        formatDate(newMoveDetailsQuery.mtoShipments[i].requestedPickupDate, 'DD MMM YYYY'),
-      );
-    }
+      expect(screen.getAllByRole('heading', { name: 'HHG', level: 3 }).length).toBe(2);
 
-    const originAddressTerms = screen.getAllByText('Origin address');
+      const moveDateTerms = screen.getAllByText('Requested move date');
 
-    expect(originAddressTerms.length).toBe(2);
+      expect(moveDateTerms.length).toBe(2);
 
-    for (let i = 0; i < 2; i += 1) {
-      const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].pickupAddress;
+      for (let i = 0; i < moveDateTerms.length; i += 1) {
+        expect(moveDateTerms[i].nextElementSibling.textContent).toBe(
+          formatDate(newMoveDetailsQuery.mtoShipments[i].requestedPickupDate, 'DD MMM YYYY'),
+        );
+      }
 
-      const addressText = originAddressTerms[i].nextElementSibling.textContent;
+      const originAddressTerms = screen.getAllByText('Origin address');
+
+      expect(originAddressTerms.length).toBe(2);
+
+      for (let i = 0; i < 2; i += 1) {
+        const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].pickupAddress;
+
+        const addressText = originAddressTerms[i].nextElementSibling.textContent;
+
+        expect(addressText).toContain(street_address_1);
+        expect(addressText).toContain(city);
+        expect(addressText).toContain(state);
+        expect(addressText).toContain(postal_code);
+      }
+
+      const secondAddressTerms = screen.getAllByText('Second pickup address');
+
+      expect(secondAddressTerms.length).toBe(1);
+
+      for (let i = 0; i < 1; i += 1) {
+        const { street_address_1, city, state, postal_code } =
+          newMoveDetailsQuery.mtoShipments[i].secondaryPickupAddress;
+
+        const addressText = secondAddressTerms[0].nextElementSibling.textContent;
+
+        expect(addressText).toContain(street_address_1);
+        expect(addressText).toContain(city);
+        expect(addressText).toContain(state);
+        expect(addressText).toContain(postal_code);
+      }
+
+      const destinationAddressTerms = screen.getAllByText('Destination address');
+
+      expect(destinationAddressTerms.length).toBe(2);
+
+      for (let i = 0; i < destinationAddressTerms.length; i += 1) {
+        const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].destinationAddress;
+
+        const addressText = destinationAddressTerms[i].nextElementSibling.textContent;
+
+        expect(addressText).toContain(street_address_1);
+        expect(addressText).toContain(city);
+        expect(addressText).toContain(state);
+        expect(addressText).toContain(postal_code);
+      }
+
+      const secondDestinationAddressTerms = screen.getAllByText('Second destination address');
+
+      // This is not a required field, and only one of our shipments has it filled out:
+      expect(secondDestinationAddressTerms.length).toBe(1);
+
+      const { street_address_1, city, state, postal_code } =
+        newMoveDetailsQuery.mtoShipments[0].secondaryDeliveryAddress;
+      const addressText = secondDestinationAddressTerms[0].nextElementSibling.textContent;
 
       expect(addressText).toContain(street_address_1);
       expect(addressText).toContain(city);
       expect(addressText).toContain(state);
       expect(addressText).toContain(postal_code);
-    }
 
-    const secondAddressTerms = screen.getAllByText('Second pickup address');
+      const counselorRemarksTerms = screen.getAllByText('Counselor remarks');
 
-    expect(secondAddressTerms.length).toBe(1);
+      expect(counselorRemarksTerms.length).toBe(2);
 
-    for (let i = 0; i < 1; i += 1) {
-      const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].secondaryPickupAddress;
-
-      const addressText = secondAddressTerms[0].nextElementSibling.textContent;
-
-      expect(addressText).toContain(street_address_1);
-      expect(addressText).toContain(city);
-      expect(addressText).toContain(state);
-      expect(addressText).toContain(postal_code);
-    }
-
-    const destinationAddressTerms = screen.getAllByText('Destination address');
-
-    expect(destinationAddressTerms.length).toBe(2);
-
-    for (let i = 0; i < destinationAddressTerms.length; i += 1) {
-      const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[i].destinationAddress;
-
-      const addressText = destinationAddressTerms[i].nextElementSibling.textContent;
-
-      expect(addressText).toContain(street_address_1);
-      expect(addressText).toContain(city);
-      expect(addressText).toContain(state);
-      expect(addressText).toContain(postal_code);
-    }
-
-    const secondDestinationAddressTerms = screen.getAllByText('Second destination address');
-
-    // This is not a required field, and only one of our shipments has it filled out:
-    expect(secondDestinationAddressTerms.length).toBe(1);
-
-    const { street_address_1, city, state, postal_code } = newMoveDetailsQuery.mtoShipments[0].secondaryDeliveryAddress;
-    const addressText = secondDestinationAddressTerms[0].nextElementSibling.textContent;
-
-    expect(addressText).toContain(street_address_1);
-    expect(addressText).toContain(city);
-    expect(addressText).toContain(state);
-    expect(addressText).toContain(postal_code);
-
-    const counselorRemarksTerms = screen.getAllByText('Counselor remarks');
-
-    expect(counselorRemarksTerms.length).toBe(2);
-
-    for (let i = 0; i < counselorRemarksTerms.length; i += 1) {
-      expect(counselorRemarksTerms[i].nextElementSibling.textContent).toBe(
-        newMoveDetailsQuery.mtoShipments[i].counselorRemarks || '—',
-      );
-    }
-  });
-
-  it('renders shipments info even if destination address is missing', async () => {
-    const moveDetailsQuery = {
-      ...newMoveDetailsQuery,
-      mtoShipments: [
-        // Want to create a "new" mtoShipment to be able to delete things without messing up existing tests
-        { ...newMoveDetailsQuery.mtoShipments[0] },
-        newMoveDetailsQuery.mtoShipments[1],
-      ],
-    };
-
-    delete moveDetailsQuery.mtoShipments[0].destinationAddress;
-
-    useMoveDetailsQueries.mockImplementation(() => moveDetailsQuery);
-
-    render(mockedComponent);
-
-    const destinationAddressTerms = screen.getAllByText('Destination address');
-
-    expect(destinationAddressTerms.length).toBe(2);
-
-    expect(destinationAddressTerms[0].nextElementSibling.textContent).toBe(
-      moveDetailsQuery.order.destinationDutyStation.address.postal_code,
-    );
-
-    const { street_address_1, city, state, postal_code } = moveDetailsQuery.mtoShipments[1].destinationAddress;
-
-    const addressText = destinationAddressTerms[1].nextElementSibling.textContent;
-
-    expect(addressText).toContain(street_address_1);
-    expect(addressText).toContain(city);
-    expect(addressText).toContain(state);
-    expect(addressText).toContain(postal_code);
-  });
-  /* eslint-enable camelcase */
-
-  it('renders customer info', async () => {
-    useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-    render(mockedComponent);
-
-    expect(await screen.findByRole('heading', { name: 'Customer info', level: 2 })).toBeInTheDocument();
-  });
-
-  it('renders customer edit alert', () => {
-    renderMockedComponent({ customerEditAlert: { alertType: 'success', message: 'great success!' } });
-    expect(screen.getByText('great success!')).toBeInTheDocument();
-  });
-
-  describe('new move - needs service counseling', () => {
-    it('submit move details button is on page', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
-    });
-
-    it('submit move details button is disabled when there are no shipments', async () => {
-      useMoveDetailsQueries.mockImplementation(() => ({ ...newMoveDetailsQuery, mtoShipments: [] }));
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeDisabled();
-    });
-
-    it('submit move details button is disabled when all shipments are deleted', async () => {
-      const deletedMtoShipments = mtoShipments.map((shipment) => ({ ...shipment, deletedAt: new Date() }));
-      useMoveDetailsQueries.mockImplementation(() => ({
-        ...newMoveDetailsQuery,
-        mtoShipments: deletedMtoShipments,
-      }));
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeDisabled();
-    });
-
-    it('submit move details button is not disabled when some shipments are deleted', async () => {
-      const deletedMtoShipments = mtoShipments.map((shipment, index) => {
-        if (index > 0) {
-          return { ...shipment, deletedAt: new Date() };
-        }
-        return shipment;
-      });
-      useMoveDetailsQueries.mockImplementation(() => ({
-        ...newMoveDetailsQuery,
-        mtoShipments: deletedMtoShipments,
-      }));
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
-      expect(await screen.findByRole('button', { name: 'Submit move details' })).not.toBeDisabled();
-    });
-
-    it('renders the Orders Definition List', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('heading', { name: 'Orders', level: 2 })).toBeInTheDocument();
-      expect(screen.getByText('Current duty station')).toBeInTheDocument();
-    });
-
-    it('renders the Allowances Table', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      render(mockedComponent);
-
-      expect(await screen.findByRole('heading', { name: 'Allowances', level: 2 })).toBeInTheDocument();
-      expect(screen.getByText('Branch, rank')).toBeInTheDocument();
-    });
-
-    it('allows the service counselor to use the modal as expected', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      render(mockedComponent);
-
-      const submitButton = await screen.findByRole('button', { name: 'Submit move details' });
-
-      userEvent.click(submitButton);
-
-      expect(await screen.findByRole('heading', { name: 'Are you sure?', level: 2 }));
-
-      const modalSubmitButton = screen.getByRole('button', { name: 'Yes, submit' });
-
-      userEvent.click(modalSubmitButton);
-
-      expect(screen.queryByRole('heading', { name: 'Are you sure?', level: 2 }));
-    });
-
-    it.each([
-      ['Add a new shipment', servicesCounselingRoutes.SHIPMENT_ADD_PATH],
-      ['View and edit orders', servicesCounselingRoutes.ORDERS_EDIT_PATH],
-      ['Edit allowances', servicesCounselingRoutes.ALLOWANCES_EDIT_PATH],
-      ['Edit customer info', servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH],
-    ])('shows the "%s" link as expected: %s', async (linkText, route) => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      const { history } = renderWithRouter(<ServicesCounselingMoveDetails />, { route: detailsURL });
-
-      const link = await screen.findByRole('link', { name: linkText });
-
-      expect(link).toBeInTheDocument();
-
-      userEvent.click(link);
-
-      const path = generatePath(route, {
-        moveCode: mockRequestedMoveCode,
-      });
-
-      await waitFor(() => {
-        expect(history.location.pathname).toEqual(path);
-      });
-    });
-
-    it('shows the edit shipment buttons', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-
-      render(mockedComponent);
-
-      const shipmentEditButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
-
-      expect(shipmentEditButtons.length).toBe(2);
-
-      for (let i = 0; i < shipmentEditButtons.length; i += 1) {
-        expect(shipmentEditButtons[i].getAttribute('data-testid')).toBe(
-          generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
-            moveCode: mockRequestedMoveCode,
-            shipmentId: newMoveDetailsQuery.mtoShipments[i].id,
-          }),
+      for (let i = 0; i < counselorRemarksTerms.length; i += 1) {
+        expect(counselorRemarksTerms[i].nextElementSibling.textContent).toBe(
+          newMoveDetailsQuery.mtoShipments[i].counselorRemarks || '—',
         );
       }
     });
 
-    it('shows the customer and counselor remarks', async () => {
-      useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
+    it('renders shipments info even if destination address is missing', async () => {
+      const moveDetailsQuery = {
+        ...newMoveDetailsQuery,
+        mtoShipments: [
+          // Want to create a "new" mtoShipment to be able to delete things without messing up existing tests
+          { ...newMoveDetailsQuery.mtoShipments[0] },
+          newMoveDetailsQuery.mtoShipments[1],
+        ],
+      };
+
+      delete moveDetailsQuery.mtoShipments[0].destinationAddress;
+
+      useMoveDetailsQueries.mockReturnValue(moveDetailsQuery);
 
       render(mockedComponent);
 
-      const customerRemarks1 = await screen.findByText('please treat gently');
-      const customerRemarks2 = await screen.findByText('do not drop!');
+      const destinationAddressTerms = screen.getAllByText('Destination address');
 
-      const counselorRemarks1 = await screen.findByText('all good');
-      const counselorRemarks2 = await screen.findByText('looks good');
+      expect(destinationAddressTerms.length).toBe(2);
 
-      expect(customerRemarks1).toBeInTheDocument();
-      expect(customerRemarks2).toBeInTheDocument();
-      expect(counselorRemarks1).toBeInTheDocument();
-      expect(counselorRemarks2).toBeInTheDocument();
+      expect(destinationAddressTerms[0].nextElementSibling.textContent).toBe(
+        moveDetailsQuery.order.destinationDutyStation.address.postal_code,
+      );
+
+      const { street_address_1, city, state, postal_code } = moveDetailsQuery.mtoShipments[1].destinationAddress;
+
+      const addressText = destinationAddressTerms[1].nextElementSibling.textContent;
+
+      expect(addressText).toContain(street_address_1);
+      expect(addressText).toContain(city);
+      expect(addressText).toContain(state);
+      expect(addressText).toContain(postal_code);
     });
-  });
+    /* eslint-enable camelcase */
 
-  describe('service counseling completed', () => {
-    it('hides submit and view/edit buttons/links', async () => {
-      useMoveDetailsQueries.mockImplementation(() => counselingCompletedMoveDetailsQuery);
+    it('renders customer info', async () => {
+      useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
 
       render(mockedComponent);
 
-      expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Add a new shipment' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'View and edit orders' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Edit customer info' })).not.toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: 'Customer info', level: 2 })).toBeInTheDocument();
+    });
+
+    it('renders customer edit alert', () => {
+      renderMockedComponent({ customerEditAlert: { alertType: 'success', message: 'great success!' } });
+      expect(screen.getByText('great success!')).toBeInTheDocument();
+    });
+
+    describe('new move - needs service counseling', () => {
+      it('submit move details button is on page', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+      });
+
+      it('submit move details button is disabled when there are no shipments', async () => {
+        useMoveDetailsQueries.mockReturnValue({ ...newMoveDetailsQuery, mtoShipments: [] });
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeDisabled();
+      });
+
+      it('submit move details button is disabled when all shipments are deleted', async () => {
+        const deletedMtoShipments = mtoShipments.map((shipment) => ({ ...shipment, deletedAt: new Date() }));
+        useMoveDetailsQueries.mockReturnValue({
+          ...newMoveDetailsQuery,
+          mtoShipments: deletedMtoShipments,
+        });
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeDisabled();
+      });
+
+      it('submit move details button is not disabled when some shipments are deleted', async () => {
+        const deletedMtoShipments = mtoShipments.map((shipment, index) => {
+          if (index > 0) {
+            return { ...shipment, deletedAt: new Date() };
+          }
+          return shipment;
+        });
+        useMoveDetailsQueries.mockReturnValue({
+          ...newMoveDetailsQuery,
+          mtoShipments: deletedMtoShipments,
+        });
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).toBeInTheDocument();
+        expect(await screen.findByRole('button', { name: 'Submit move details' })).not.toBeDisabled();
+      });
+
+      it('renders the Orders Definition List', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('heading', { name: 'Orders', level: 2 })).toBeInTheDocument();
+        expect(screen.getByText('Current duty station')).toBeInTheDocument();
+      });
+
+      it('renders the Allowances Table', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        expect(await screen.findByRole('heading', { name: 'Allowances', level: 2 })).toBeInTheDocument();
+        expect(screen.getByText('Branch, rank')).toBeInTheDocument();
+      });
+
+      it('allows the service counselor to use the modal as expected', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        const submitButton = await screen.findByRole('button', { name: 'Submit move details' });
+
+        userEvent.click(submitButton);
+
+        expect(await screen.findByRole('heading', { name: 'Are you sure?', level: 2 }));
+
+        const modalSubmitButton = screen.getByRole('button', { name: 'Yes, submit' });
+
+        userEvent.click(modalSubmitButton);
+
+        expect(screen.queryByRole('heading', { name: 'Are you sure?', level: 2 }));
+      });
+
+      it.each([
+        ['Add a new shipment', servicesCounselingRoutes.SHIPMENT_ADD_PATH],
+        ['View and edit orders', servicesCounselingRoutes.ORDERS_EDIT_PATH],
+        ['Edit allowances', servicesCounselingRoutes.ALLOWANCES_EDIT_PATH],
+        ['Edit customer info', servicesCounselingRoutes.CUSTOMER_INFO_EDIT_PATH],
+      ])('shows the "%s" link as expected: %s', async (linkText, route) => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        const { history } = renderWithRouter(<ServicesCounselingMoveDetails />, { route: detailsURL });
+
+        const link = await screen.findByRole('link', { name: linkText });
+
+        expect(link).toBeInTheDocument();
+
+        userEvent.click(link);
+
+        const path = generatePath(route, {
+          moveCode: mockRequestedMoveCode,
+        });
+
+        await waitFor(() => {
+          expect(history.location.pathname).toEqual(path);
+        });
+      });
+
+      it('shows the edit shipment buttons', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        const shipmentEditButtons = await screen.findAllByRole('button', { name: 'Edit shipment' });
+
+        expect(shipmentEditButtons.length).toBe(2);
+
+        for (let i = 0; i < shipmentEditButtons.length; i += 1) {
+          expect(shipmentEditButtons[i].getAttribute('data-testid')).toBe(
+            generatePath(servicesCounselingRoutes.SHIPMENT_EDIT_PATH, {
+              moveCode: mockRequestedMoveCode,
+              shipmentId: newMoveDetailsQuery.mtoShipments[i].id,
+            }),
+          );
+        }
+      });
+
+      it('shows the customer and counselor remarks', async () => {
+        useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        const customerRemarks1 = await screen.findByText('please treat gently');
+        const customerRemarks2 = await screen.findByText('do not drop!');
+
+        const counselorRemarks1 = await screen.findByText('all good');
+        const counselorRemarks2 = await screen.findByText('looks good');
+
+        expect(customerRemarks1).toBeInTheDocument();
+        expect(customerRemarks2).toBeInTheDocument();
+        expect(counselorRemarks1).toBeInTheDocument();
+        expect(counselorRemarks2).toBeInTheDocument();
+      });
+    });
+
+    describe('service counseling completed', () => {
+      it('hides submit and view/edit buttons/links', async () => {
+        useMoveDetailsQueries.mockReturnValue(counselingCompletedMoveDetailsQuery);
+
+        render(mockedComponent);
+
+        expect(screen.queryByRole('button', { name: 'Submit move details' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Add a new shipment' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Edit shipment' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'View and edit orders' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Edit allowances' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Edit customer info' })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDocumentWrapper/ServicesCounselingMoveDocumentWrapper.test.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
 
 import ServicesCounselingMoveDocumentWrapper from './ServicesCounselingMoveDocumentWrapper';
+
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -39,70 +42,71 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            requiredMedicalEquipmentWeight: 1000,
-            organizationalClothingAndIndividualEquipment: true,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-      documents: {
-        2: {
-          id: '2',
-          uploads: [
-            {
-              id: 'z',
-              filename: 'test.pdf',
-              contentType: 'application/pdf',
-              url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-            },
-          ],
-        },
-      },
-      upload: {
-        z: {
-          id: 'z',
-          filename: 'test.pdf',
-          contentType: 'application/pdf',
-          url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
 const testMoveId = '10000';
+
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        requiredMedicalEquipmentWeight: 1000,
+        organizationalClothingAndIndividualEquipment: true,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+  upload: {
+    z: {
+      id: 'z',
+      filename: 'test.pdf',
+      contentType: 'application/pdf',
+      url: '/storage/user/1/uploads/2?contentType=application%2Fpdf',
+    },
+  },
+};
+
+const loadingReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -111,22 +115,49 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('ServicesCounselingMoveDocumentWrapper', () => {
-  it('renders the document viewer', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/counseling/moves/${testMoveId}/orders` }));
-    const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useLocation.mockReturnValue({ pathname: `/counseling/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(loadingReturnValue);
 
-    expect(wrapper.find('DocumentViewer').exists()).toBe(true);
+      render(<ServicesCounselingMoveDocumentWrapper />);
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useLocation.mockReturnValue({ pathname: `/counseling/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(errorReturnValue);
+
+      render(<ServicesCounselingMoveDocumentWrapper />);
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('renders the sidebar ServicesCounselingOrders component', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/counseling/moves/${testMoveId}/orders` }));
-    const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
-    expect(wrapper.find('ServicesCounselingOrders').exists()).toBe(true);
-  });
+  describe('Basic rendering', () => {
+    it('renders the document viewer', () => {
+      useLocation.mockReturnValue({ pathname: `/counseling/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
 
-  it('renders the sidebar ServicesCounselingMoveAllowances component', () => {
-    useLocation.mockImplementation(() => ({ pathname: `/counseling/moves/${testMoveId}/allowances` }));
-    const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
-    expect(wrapper.find('ServicesCounselingMoveAllowances').exists()).toBe(true);
+      expect(wrapper.find('DocumentViewer').exists()).toBe(true);
+    });
+
+    it('renders the sidebar ServicesCounselingOrders component', () => {
+      useLocation.mockReturnValue({ pathname: `/counseling/moves/${testMoveId}/orders` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
+      expect(wrapper.find('ServicesCounselingOrders').exists()).toBe(true);
+    });
+
+    it('renders the sidebar ServicesCounselingMoveAllowances component', () => {
+      useLocation.mockReturnValue({ pathname: `/counseling/moves/${testMoveId}/allowances` });
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+      const wrapper = shallow(<ServicesCounselingMoveDocumentWrapper />);
+      expect(wrapper.find('ServicesCounselingMoveAllowances').exists()).toBe(true);
+    });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import ServicesCounselingMoveInfo from './ServicesCounselingMoveInfo';
 
@@ -151,19 +152,63 @@ const newMoveDetailsQuery = {
   isSuccess: true,
 };
 
-describe('Services Counseling Move Info Container', () => {
-  useMoveDetailsQueries.mockImplementation(() => newMoveDetailsQuery);
-  it('should render the move tab container', () => {
-    const wrapper = mount(
-      <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
-        <ServicesCounselingMoveInfo />
-      </MockProviders>,
-    );
+const loadingReturnValue = {
+  ...newMoveDetailsQuery,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
 
-    expect(wrapper.find('CustomerHeader').exists()).toBe(true);
+const errorReturnValue = {
+  ...newMoveDetailsQuery,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
+describe('Services Counseling Move Info Container', () => {
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useMoveDetailsQueries.mockReturnValue(loadingReturnValue);
+
+      render(
+        <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useMoveDetailsQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
+  describe('Basic rendering', () => {
+    useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+    it('should render the move tab container', () => {
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(wrapper.find('CustomerHeader').exists()).toBe(true);
+    });
+  });
   describe('routing', () => {
+    useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
     it('should handle the Services Counseling Move Details route', () => {
       const wrapper = mount(
         <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
@@ -1,9 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import ServicesCounselingOrders from 'pages/Office/ServicesCounselingOrders/ServicesCounselingOrders';
 import { MockProviders } from 'testUtils';
+import { useOrdersDocumentQueries } from 'hooks/queries';
 
 const mockOriginDutyStation = {
   address: {
@@ -40,68 +42,114 @@ const mockDestinationDutyStation = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useOrdersDocumentQueries: () => {
-    return {
-      orders: {
-        1: {
-          agency: 'ARMY',
-          customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
-          date_issued: '2018-03-15',
-          department_indicator: 'AIR_FORCE',
-          destinationDutyStation: mockDestinationDutyStation,
-          eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
-          entitlement: {
-            authorizedWeight: 5000,
-            dependentsAuthorized: true,
-            eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
-            id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
-            nonTemporaryStorage: true,
-            privatelyOwnedVehicle: true,
-            proGearWeight: 2000,
-            proGearWeightSpouse: 500,
-            storageInTransit: 2,
-            totalDependents: 1,
-            totalWeight: 5000,
-          },
-          first_name: 'Leo',
-          grade: 'E_1',
-          id: '1',
-          last_name: 'Spacemen',
-          order_number: 'ORDER3',
-          order_type: 'PERMANENT_CHANGE_OF_STATION',
-          order_type_detail: 'HHG_PERMITTED',
-          originDutyStation: mockOriginDutyStation,
-          report_by_date: '2018-08-01',
-          tac: 'F8E1',
-          sac: 'E2P3',
-        },
-      },
-    };
-  },
+  useOrdersDocumentQueries: jest.fn(),
 }));
 
+const useOrdersDocumentQueriesReturnValue = {
+  orders: {
+    1: {
+      agency: 'ARMY',
+      customerID: '6ac40a00-e762-4f5f-b08d-3ea72a8e4b63',
+      date_issued: '2018-03-15',
+      department_indicator: 'AIR_FORCE',
+      destinationDutyStation: mockDestinationDutyStation,
+      eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC43MTE0Nlo=',
+      entitlement: {
+        authorizedWeight: 5000,
+        dependentsAuthorized: true,
+        eTag: 'MjAyMC0wOS0xNFQxNzo0MTozOC42ODAwOVo=',
+        id: '0dbc9029-dfc5-4368-bc6b-dfc95f5fe317',
+        nonTemporaryStorage: true,
+        privatelyOwnedVehicle: true,
+        proGearWeight: 2000,
+        proGearWeightSpouse: 500,
+        storageInTransit: 2,
+        totalDependents: 1,
+        totalWeight: 5000,
+      },
+      first_name: 'Leo',
+      grade: 'E_1',
+      id: '1',
+      last_name: 'Spacemen',
+      order_number: 'ORDER3',
+      order_type: 'PERMANENT_CHANGE_OF_STATION',
+      order_type_detail: 'HHG_PERMITTED',
+      originDutyStation: mockOriginDutyStation,
+      report_by_date: '2018-08-01',
+      tac: 'F8E1',
+      sac: 'E2P3',
+    },
+  },
+};
+
+const loadingReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: true,
+  isError: false,
+  isSuccess: false,
+};
+
+const errorReturnValue = {
+  ...useOrdersDocumentQueriesReturnValue,
+  isLoading: false,
+  isError: true,
+  isSuccess: false,
+};
+
 describe('Orders page', () => {
-  const wrapper = mount(
-    <MockProviders initialEntries={['moves/FP24I2/orders']}>
-      <ServicesCounselingOrders />
-    </MockProviders>,
-  );
+  describe('check loading and error component states', () => {
+    it('renders the Loading Placeholder when the query is still loading', async () => {
+      useOrdersDocumentQueries.mockReturnValue(loadingReturnValue);
 
-  it('renders the sidebar orders detail form', () => {
-    expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <ServicesCounselingOrders />
+        </MockProviders>,
+      );
+
+      const h2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      expect(h2).toBeInTheDocument();
+    });
+
+    it('renders the Something Went Wrong component when the query errors', async () => {
+      useOrdersDocumentQueries.mockReturnValue(errorReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <ServicesCounselingOrders />
+        </MockProviders>,
+      );
+
+      const errorMessage = await screen.getByText(/Something went wrong./);
+      expect(errorMessage).toBeInTheDocument();
+    });
   });
 
-  it('renders the sidebar elements', () => {
-    expect(wrapper.find({ 'data-testid': 'view-orders-header' }).text()).toBe('View orders');
-    // There is only 1 button, but mount-rendering react-uswds Button component has inner buttons
-    expect(wrapper.find({ 'data-testid': 'view-allowances' }).at(0).text()).toBe('View allowances');
-  });
+  describe('Basic rendering', () => {
+    useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
 
-  it('populates initial field values', () => {
-    expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
-    expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
-    expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
-    expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
-    expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
+    const wrapper = mount(
+      <MockProviders initialEntries={['moves/FP24I2/orders']}>
+        <ServicesCounselingOrders />
+      </MockProviders>,
+    );
+
+    it('renders the sidebar orders detail form', () => {
+      expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+    });
+
+    it('renders the sidebar elements', () => {
+      expect(wrapper.find({ 'data-testid': 'view-orders-header' }).text()).toBe('View orders');
+      // There is only 1 button, but mount-rendering react-uswds Button component has inner buttons
+      expect(wrapper.find({ 'data-testid': 'view-allowances' }).at(0).text()).toBe('View allowances');
+    });
+
+    it('populates initial field values', () => {
+      expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
+      expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
+      expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
+      expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
+      expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
+    });
   });
 });

--- a/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
+++ b/src/pages/Office/ServicesCounselingQueue/ServicesCounselingQueue.test.jsx
@@ -172,8 +172,8 @@ const serviceCounselingCompletedMoves = {
 
 describe('ServicesCounselingQueue', () => {
   describe('no moves in service counseling statuses', () => {
-    useUserQueries.mockImplementation(() => serviceCounselorUser);
-    useServicesCounselingQueueQueries.mockImplementation(() => emptyServiceCounselingMoves);
+    useUserQueries.mockReturnValue(serviceCounselorUser);
+    useServicesCounselingQueueQueries.mockReturnValue(emptyServiceCounselingMoves);
     const wrapper = mount(
       <MockProviders initialEntries={['counseling/queue']}>
         <ServicesCounselingQueue />
@@ -194,8 +194,8 @@ describe('ServicesCounselingQueue', () => {
   });
 
   describe('non-USMC Service Counselor', () => {
-    useUserQueries.mockImplementation(() => serviceCounselorUser);
-    useServicesCounselingQueueQueries.mockImplementation(() => needsCounselingMoves);
+    useUserQueries.mockReturnValue(serviceCounselorUser);
+    useServicesCounselingQueueQueries.mockReturnValue(needsCounselingMoves);
     const wrapper = mount(
       <MockProviders initialEntries={['counseling/queue']}>
         <ServicesCounselingQueue />
@@ -268,8 +268,8 @@ describe('ServicesCounselingQueue', () => {
   });
 
   describe('USMC Service Counselor', () => {
-    useUserQueries.mockImplementation(() => marineCorpsUser);
-    useServicesCounselingQueueQueries.mockImplementation(() => marineCorpsNeedsCounselingMoves);
+    useUserQueries.mockReturnValue(marineCorpsUser);
+    useServicesCounselingQueueQueries.mockReturnValue(marineCorpsNeedsCounselingMoves);
     const wrapper = mount(
       <MockProviders initialEntries={['counseling/queue']}>
         <ServicesCounselingQueue />
@@ -336,8 +336,8 @@ describe('ServicesCounselingQueue', () => {
   });
 
   describe('service counseling completed moves', () => {
-    useUserQueries.mockImplementation(() => serviceCounselorUser);
-    useServicesCounselingQueueQueries.mockImplementation(() => serviceCounselingCompletedMoves);
+    useUserQueries.mockReturnValue(serviceCounselorUser);
+    useServicesCounselingQueueQueries.mockReturnValue(serviceCounselingCompletedMoves);
     const wrapper = mount(
       <MockProviders initialEntries={['counseling/queue']}>
         <ServicesCounselingQueue />

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -42,14 +42,12 @@ const basicUseTXOMoveInfoQueriesValue = {
 };
 
 const loadingReturnValue = {
-  ...basicUseTXOMoveInfoQueriesValue,
   isLoading: true,
   isError: false,
   isSuccess: false,
 };
 
 const errorReturnValue = {
-  ...basicUseTXOMoveInfoQueriesValue,
   isLoading: false,
   isError: true,
   isSuccess: false,
@@ -60,12 +58,8 @@ const updatedOrdersUseTXOMoveInfoQueriesValue = {
   order: { ...basicUseTXOMoveInfoQueriesValue.order, uploadedAmendedOrderID: '123' },
 };
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
 describe('TXO Move Info Container', () => {
-  describe('check different component states', () => {
+  describe('check loading and error component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
       useTXOMoveInfoQueries.mockReturnValue(loadingReturnValue);
 


### PR DESCRIPTION
## Description

I added a number of loading and error component tests, fixed a small bug, and bumped up our Jest minimum coverage numbers.

## Reviewer Notes

There are definitely ways we can streamline these tests further. I considered putting the loading/error component tests at the bottom for legibility and to keep focus on the rest of the tests. I also considered not creating `const` for the loading and error data since it's streamlined but opted not to for the moment. Style-wise, this means keeping all the return data at the top of the tests and I cleaned up a few other similar instances as well.

I would have loved to take time to clean these up further. Many of the loading/error return values had to include the success return data as well or there were `undefined` failures. This is a smell for both how our code is handling data and also how and what our tests are testing.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run

yarn test
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8141) for this change
