### PR TITLE
[MB-8680] cleanup for UT and refactor to DRY up calling functions to create use…

### DIFF
--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -156,17 +156,7 @@ func (suite *HandlerSuite) TestUploadAmendedOrder() {
 	suite.Assertions.IsType(&ordersop.UploadAmendedOrdersCreated{}, response)
 	okResponse := response.(*ordersop.UploadAmendedOrdersCreated)
 	suite.Assertions.NotNil(okResponse.Payload.ID.String()) // UploadPayload
-
-	/*
-		suite.Assertions.Equal(order.ServiceMember.ID.String(), okResponse.Payload.ServiceMemberID.String())
-		suite.Assertions.Equal(order.OrdersType, okResponse.Payload.OrdersType)
-		suite.Assertions.Equal(order.OrdersTypeDetail, okResponse.Payload.OrdersTypeDetail)
-		suite.Assertions.Equal(*order.Grade, *okResponse.Payload.Grade)
-		suite.Assertions.Equal(*order.TAC, *okResponse.Payload.Tac)
-		suite.Assertions.Equal(*order.DepartmentIndicator, string(*okResponse.Payload.DepartmentIndicator))
-		suite.Assertions.Equal(order.HasDependents, *okResponse.Payload.HasDependents)
-		suite.Assertions.Equal(order.SpouseHasProGear, *okResponse.Payload.SpouseHasProGear)
-	*/
+	suite.Assertions.Equal("test.pdf", *okResponse.Payload.Filename)
 }
 
 // TODO: Fix now that we capture transaction error. May be a data setup problem

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -54,7 +54,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	logger.Info(
 		"File uploader and size",
-		zap.String("userID", session.ServiceMemberID.String()),
+		zap.String("userID", session.UserID.String()),
 		zap.String("serviceMemberID", session.ServiceMemberID.String()),
 		zap.String("officeUserID", session.OfficeUserID.String()),
 		zap.String("AdminUserID", session.AdminUserID.String()),
@@ -77,32 +77,31 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		docID = &document.ID
 	}
 
-	userUploader, err := uploaderpkg.NewUserUploader(h.DB(), logger, h.FileStorer(), uploaderpkg.MaxCustomerUserUploadFileSizeLimit)
-	if err != nil {
-		logger.Fatal("could not instantiate uploader", zap.Error(err))
-	}
+	newUserUpload, url, verrs, createErr := uploaderpkg.CreateUserUploadForDocument(
+		h.DB(),
+		logger,
+		session.UserID,
+		h.FileStorer(),
+		file,
+		file.Header.Filename,
+		uploaderpkg.MaxCustomerUserUploadFileSizeLimit,
+		docID,
+	)
 
-	aFile, err := userUploader.PrepareFileForUpload(file.Data, file.Header.Filename)
-	if err != nil {
-		logger.Fatal("could not prepare file for uploader", zap.Error(err))
-		return uploadop.NewCreateUploadInternalServerError()
-	}
-
-	newUserUpload, verrs, err := userUploader.CreateUserUploadForDocument(docID, session.UserID, uploaderpkg.File{File: aFile}, uploaderpkg.AllowedTypesServiceMember)
-	if verrs.HasAny() || err != nil {
-		switch err.(type) {
+	if verrs.HasAny() || createErr != nil {
+		logger.Error("failed to create new user upload", zap.Error(createErr), zap.String("verrs", verrs.Error()))
+		switch createErr.(type) {
 		case uploaderpkg.ErrTooLarge:
 			return uploadop.NewCreateUploadRequestEntityTooLarge()
+		case uploaderpkg.ErrFile:
+			return uploadop.NewCreateUploadInternalServerError()
+		case uploaderpkg.ErrFailedToInitUploader:
+			return uploadop.NewCreateUploadInternalServerError()
 		default:
-			return handlers.ResponseForVErrors(logger, verrs, err)
+			return handlers.ResponseForVErrors(logger, verrs, createErr)
 		}
 	}
 
-	url, err := userUploader.PresignedURL(newUserUpload)
-	if err != nil {
-		logger.Error("failed to get presigned url", zap.Error(err))
-		return uploadop.NewCreateUploadInternalServerError()
-	}
 	uploadPayload := payloadForUploadModel(h.FileStorer(), newUserUpload.Upload, url)
 	return uploadop.NewCreateUploadCreated().WithPayload(uploadPayload)
 }

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -77,7 +77,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		docID = &document.ID
 	}
 
-	newUserUpload, url, verrs, createErr := uploaderpkg.CreateUserUploadForDocument(
+	newUserUpload, url, verrs, createErr := uploaderpkg.CreateUserUploadForDocumentWrapper(
 		h.DB(),
 		logger,
 		session.UserID,

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -219,7 +219,7 @@ func (f *orderUpdater) amendedOrder(db *pop.Connection, logger services.Logger, 
 	var userUpload *models.UserUpload
 	var verrs *validate.Errors
 	var url string
-	userUpload, url, verrs, err = uploader.CreateUserUploadForDocument(
+	userUpload, url, verrs, err = uploader.CreateUserUploadForDocumentWrapper(
 		db,
 		logger,
 		userID,

--- a/pkg/uploader/create_user_upload.go
+++ b/pkg/uploader/create_user_upload.go
@@ -12,8 +12,8 @@ import (
 	"github.com/transcom/mymove/pkg/storage"
 )
 
-// CreateUserUploadForDocument wrapper/helper function to create a user upload
-func CreateUserUploadForDocument(db *pop.Connection, logger Logger, userID uuid.UUID, storer storage.FileStorer, file io.ReadCloser, filename string, fileSizeLimit ByteSize, docID *uuid.UUID) (*models.UserUpload, string, *validate.Errors, error) {
+// CreateUserUploadForDocumentWrapper wrapper/helper function to create a user upload
+func CreateUserUploadForDocumentWrapper(db *pop.Connection, logger Logger, userID uuid.UUID, storer storage.FileStorer, file io.ReadCloser, filename string, fileSizeLimit ByteSize, docID *uuid.UUID) (*models.UserUpload, string, *validate.Errors, error) {
 	userUploader, err := NewUserUploader(db, logger, storer, fileSizeLimit)
 	if err != nil {
 		logger.Fatal("could not instantiate uploader", zap.Error(err))


### PR DESCRIPTION
…rupload's for documents

## Description

A little bit of refactor after finishing https://github.com/transcom/mymove/pull/6908. A new function `CreateUserUploadForDocumentWrapper` was created and wanted to replace some redundant code after introducting that function. There was also some UT clean-up needed.

## Reviewer Notes

n/a

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Once you have the client running. You'll need to create a new move and do an upload. Make sure the upload works w/o issues.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8680) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
