### PR TITLE
[MB-8689] Update milmove-app hash to point to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
 
   postgres: &postgres postgres:12.4
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -3,7 +3,7 @@
 ###########
 
 # Base builder so the ci build image hash is referenced once
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 ENV CIRCLECI=docker
 ENV REACT_APP_NODE_ENV=development
 # hadolint ignore=DL3002

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c as builder
+FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Makefile
+++ b/Makefile
@@ -1061,7 +1061,7 @@ pretty: gofmt ## Run code through JS and Golang formatters
 
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
-	docker pull milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c
+	docker pull milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
 	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app bash
 
 .PHONY: prune_images

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c
+  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -8,7 +8,7 @@ if [ -n "${CIRCLECI+x}" ]; then
   echo "CircleCI has swagger built in"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c
+  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
   docker pull -q "${image}"
 fi
 

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -14,7 +14,7 @@ if [ "$UNAME_S" == "Linux" ]; then
   /usr/local/bin/swagger validate "${filename}"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-55d6d1fc05e24d833c7b6ddc8f43ca901a40f22c
+  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
   docker pull -q "${image}"
   docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"
 fi


### PR DESCRIPTION
## Description

This PR updates the hash for the `milmove-app` docker image so that it refers to the latest version [with its recent updates to the baseline image](https://github.com/transcom/circleci-docker/commits/master).

## Reviewer Notes

The `milmove-cypress` hash was already updated in #6947 (the cypress 7.7.0 dependabot PR).

## Setup

Just verify that the hash is referring to the latest one and that all instances of it have been fixed in the code.  Also verify that all tests are passing.
