### PR TITLE
MB-8733 Fix Console Warning on Home Page

### DIFF
--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -136,9 +136,7 @@ export class Home extends Component {
         <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
           The transportation office will review your new documents and update your move info. Contact your movers to
           coordinate any changes to your move.
-          <br />
-          <br />
-          You don&apos;t need to do anything else in MilMove.
+          <p>You don&apos;t need to do anything else in MilMove.</p>
         </Alert>
       );
     }

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -454,7 +454,7 @@ const mapStateToProps = (state) => {
     isProfileComplete: selectIsProfileComplete(state),
     orders: selectCurrentOrders(state) || {},
     uploadedOrderDocuments: selectUploadsForCurrentOrders(state),
-    uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state),
+    uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state) || [],
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
     signedCertification: selectSignedCertification(state),

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -453,7 +453,7 @@ const mapStateToProps = (state) => {
   return {
     currentPpm: selectCurrentPPM(state) || {},
     isProfileComplete: selectIsProfileComplete(state),
-    orders: selectCurrentOrders(state),
+    orders: selectCurrentOrders(state) || {},
     uploadedOrderDocuments: selectUploadsForCurrentOrders(state),
     uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state),
     serviceMember,

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -442,7 +442,7 @@ Home.propTypes = {
 };
 
 Home.defaultProps = {
-  orders: null,
+  orders: {},
   serviceMember: null,
   signedCertification: {},
   uploadedAmendedOrderDocuments: [],

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -428,7 +428,7 @@ Home.propTypes = {
     shipmentType: string,
   }).isRequired,
   uploadedOrderDocuments: arrayOf(UploadShape).isRequired,
-  uploadedAmendedOrderDocuments: arrayOf(UploadShape).isRequired,
+  uploadedAmendedOrderDocuments: arrayOf(UploadShape),
   history: HistoryShape.isRequired,
   move: MoveShape.isRequired,
   isProfileComplete: bool.isRequired,
@@ -443,6 +443,7 @@ Home.defaultProps = {
   orders: null,
   serviceMember: null,
   signedCertification: {},
+  uploadedAmendedOrderDocuments: [],
 };
 
 const mapStateToProps = (state) => {
@@ -452,9 +453,9 @@ const mapStateToProps = (state) => {
   return {
     currentPpm: selectCurrentPPM(state) || {},
     isProfileComplete: selectIsProfileComplete(state),
-    orders: selectCurrentOrders(state) || {},
+    orders: selectCurrentOrders(state),
     uploadedOrderDocuments: selectUploadsForCurrentOrders(state),
-    uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state) || [],
+    uploadedAmendedOrderDocuments: selectUploadsForCurrentAmendedOrders(state),
     serviceMember,
     backupContacts: serviceMember?.backup_contacts || [],
     signedCertification: selectSignedCertification(state),

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -136,7 +136,9 @@ export class Home extends Component {
         <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
           The transportation office will review your new documents and update your move info. Contact your movers to
           coordinate any changes to your move.
-          <p>You don&apos;t need to do anything else in MilMove.</p>
+          <br />
+          <br />
+          You don&apos;t need to do anything else in MilMove.
         </Alert>
       );
     }


### PR DESCRIPTION
Give a fallback value for uploaded amended order documents

## Description

There won't always be a value for the uploaded amended orders. It's marked as required for the props, but give it a default value to fall back to if there aren't uploaded amended orders.

## Reviewer Notes

Took off the required for `orders` and `uploadedAmendedOrderDocuments` since they technically aren't required for the home component (it can be in different states that don't have `orders` or `uploadedAmendedOrderDocuments`). 
Used default prop value for `uploadedAmendedOrderDocuments` rather than having it get defaulted in the `mapStateToProps`.
Left the default for orders inside of `mapStateToProps` since the `selectCurrentOrders` returns null instead of an empty object, which causes the site to crash.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make client_run
make server_run
```

Go through the workflow up to the home page screen and verify that there are no console warnings. 

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8733) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
