### PR TITLE
[MB-8689] Upgrade to go 1.16.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
 
   postgres: &postgres postgres:12.4
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.16.4
+golang 1.16.5

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -3,7 +3,7 @@
 ###########
 
 # Base builder so the ci build image hash is referenced once
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 ENV CIRCLECI=docker
 ENV REACT_APP_NODE_ENV=development
 # hadolint ignore=DL3002

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1 as builder
+FROM milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Makefile
+++ b/Makefile
@@ -1061,7 +1061,7 @@ pretty: gofmt ## Run code through JS and Golang formatters
 
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
-	docker pull milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
+	docker pull milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
 	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app bash
 
 .PHONY: prune_images

--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-1eeafe33e20f4fe38666922196871d73230927f1
+FROM milmove/circleci-docker:milmove-cypress-75d11654ab683e5d8b7889aa02bfdcff25e1269f
 
 # use the WORKDIR from the CI image
 # hadolint ignore=DL3045

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -39,10 +39,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "go-1.16.4";
+      name = "go-1.16.5";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "438b60f3f72725aceecf0e1a3eab0b02d56101c6";
+      rev = "494833dccb956b3da2b77a617ed2165233d19766";
     }) {}).go
 
     (import (builtins.fetchGit {

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
+  image=milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -8,7 +8,7 @@ if [ -n "${CIRCLECI+x}" ]; then
   echo "CircleCI has swagger built in"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
+  image=milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
   docker pull -q "${image}"
 fi
 

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -14,7 +14,7 @@ if [ "$UNAME_S" == "Linux" ]; then
   /usr/local/bin/swagger validate "${filename}"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-1eeafe33e20f4fe38666922196871d73230927f1
+  image=milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
   docker pull -q "${image}"
   docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"
 fi

--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -5,7 +5,7 @@ set -eu -o pipefail
 RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
-GOVERSION='1.16.4'
+GOVERSION='1.16.5'
 
 prereqs_found=true
 


### PR DESCRIPTION
## Description

This PR updates the project from Go 1.16.4 to Go 1.16.5 (which includes security fixes).

Go 1.16.x version history:
https://golang.org/doc/devel/release.html#go1.16

## Reviewer Notes

Here's the [corresponding PR from circleci-docker](https://github.com/transcom/circleci-docker/pull/135) for the docker image hash referenced in this PR.  Please verify that it seems correct and that all relevant references have been updated.


## Setup

To move your local dev environment to 1.16.5 (assuming you're using `asdf`):
```
asdf install
asdf global golang 1.16.5
```
You may want to restart your terminal window after this if you run into issues.

If you're using `nix` instead, you should be prompted to run `./nix/update.sh` .

After moving to go 1.16.5, just try out your normal day-to-day workflow and see if anything falls out.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8689) for this change
* [Wiki page](https://github.com/transcom/mymove/wiki/upgrade-go-version) for updating golang.
