### PR TITLE
[MB-8757] Update golangci-lint to latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         exclude: ^public/swagger-ui/
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.38.0
+    rev: v1.41.1
     hooks:
       - id: golangci-lint
         entry: bash -c 'exec golangci-lint run -v ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -32,7 +32,7 @@ func Recovery(logger Logger) func(inner http.Handler) http.Handler {
 						fields = append(fields, zap.Error(err))
 					} else {
 						fields = append(fields, zap.Any("object", obj))
-						fields = append(fields, zap.String("stacktrace", fmt.Sprintf("%s", debug.Stack())))
+						fields = append(fields, zap.String("stacktrace", string(debug.Stack())))
 					}
 					logger.Error("http request panic", fields...)
 

--- a/pkg/paperwork/generator.go
+++ b/pkg/paperwork/generator.go
@@ -50,13 +50,7 @@ type pdfCPUWrapper struct {
 // Merge merges files
 func (pcw pdfCPUWrapper) Merge(files []io.ReadSeeker, w io.Writer) error {
 	var rscs []io.ReadSeeker
-	for _, f := range files {
-		frsc, ok := f.(io.ReadSeeker)
-		if !ok {
-			return errors.Errorf("file %T does not implement io.ReadSeeker", f)
-		}
-		rscs = append(rscs, frsc)
-	}
+	rscs = append(rscs, files...)
 	return api.Merge(rscs, w, pcw.Configuration)
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,7 +4,8 @@
 //RA: Given the functions causing the lint errors are used to close a local server connection for testing purposes, it is not deemed a risk
 //RA Developer Status: Mitigated
 //RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+//RA Validator: leodis.f.scott.civ@mail.mil
+//RA Modified Severity: CAT III
 // nolint:errcheck
 package server
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -247,6 +247,16 @@ func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 	srv.WaitUntilReady()
 
 	// Send a request
+
+	//RA Summary: gosec - G402 - TLS MinVersion too low
+	//RA: The linter flagged this line of code because we are passing in a tlsVersion which could be deemed too low.
+	//RA: The code is part of a test function that tests TLS configuration with multiple TLS levels (currently 1.2 and 1.3).
+	//RA: It is executed as part of our test suite and is not included in the production system.
+	//RA Developer Status: Mitigated
+	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
+	//RA Validator:
+	//RA Modified Severity:
+	// #nosec G402
 	clientTLSConfig := tls.Config{
 		RootCAs:      caCertPool,
 		Certificates: certificates,
@@ -340,7 +350,9 @@ func (suite *serverSuite) TestTLSConfigWithRequestNoClientAuth() {
 
 	// Check the TLS connection directly
 	// This should fail and conn should be nil
-	config := tls.Config{}
+	config := tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
 	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", host, port), &config)
 	suite.Nil(conn)
 	suite.Error(err)
@@ -401,6 +413,7 @@ func (suite *serverSuite) TestTLSConfigWithInvalidAuth() {
 	config := tls.Config{
 		RootCAs:      invalidCaCertPool,
 		Certificates: invalidCertificates,
+		MinVersion:   tls.VersionTLS13,
 	}
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,8 +4,7 @@
 //RA: Given the functions causing the lint errors are used to close a local server connection for testing purposes, it is not deemed a risk
 //RA Developer Status: Mitigated
 //RA Validator Status: Mitigated
-//RA Validator: leodis.f.scott.civ@mail.mil
-//RA Modified Severity: CAT III
+//RA Modified Severity: N/A
 // nolint:errcheck
 package server
 
@@ -254,9 +253,9 @@ func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 	//RA: The code is part of a test function that tests TLS configuration with multiple TLS levels (currently 1.2 and 1.3).
 	//RA: It is executed as part of our test suite and is not included in the production system.
 	//RA Developer Status: Mitigated
-	//RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}
-	//RA Validator:
-	//RA Modified Severity:
+	//RA Validator Status: Mitigated
+	//RA Validator: leodis.f.scott.civ@mail.mil
+     //RA Modified Severity: CAT III
 	// #nosec G402
 	clientTLSConfig := tls.Config{
 		RootCAs:      caCertPool,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -255,7 +255,7 @@ func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 	//RA Developer Status: Mitigated
 	//RA Validator Status: Mitigated
 	//RA Validator: leodis.f.scott.civ@mail.mil
-     //RA Modified Severity: CAT III
+	//RA Modified Severity: CAT III
 	// #nosec G402
 	clientTLSConfig := tls.Config{
 		RootCAs:      caCertPool,


### PR DESCRIPTION
## Description

This PR updates our `golangci-lint` pre-commit hook to the latest version (1.41.1).  The updated linter end up flagging some new potential issues.  I have attempted to address those in this PR.  There is one linter suppression that needs review and approval.

## Reviewer Notes

I have put inline comments on each of the issues describing the linter feedback and how I addressed it.

## Setup

Execute `pre-commit run -a golangci-lint` to run all files through the updated linter.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8757) for this change
