### PR TITLE
MB-8671: Intercept XHR responses and dispatch actions

### DIFF
--- a/src/services/internalApi.js
+++ b/src/services/internalApi.js
@@ -1,6 +1,6 @@
 import Swagger from 'swagger-client';
 
-import { makeSwaggerRequest, requestInterceptor } from './swaggerRequest';
+import { makeSwaggerRequest, requestInterceptor, responseInterceptor } from './swaggerRequest';
 
 let internalClient = null;
 
@@ -10,6 +10,7 @@ export async function getInternalClient() {
     internalClient = await Swagger({
       url: '/internal/swagger.yaml',
       requestInterceptor,
+      responseInterceptor,
     });
   }
 

--- a/src/services/swaggerRequest.js
+++ b/src/services/swaggerRequest.js
@@ -4,6 +4,8 @@ import { normalize } from 'normalizr';
 import * as Cookies from 'js-cookie';
 
 import * as schema from 'shared/Entities/schema';
+import { interceptInjection } from 'store/interceptor/injectionMiddleware';
+import { interceptResponse } from 'store/interceptor/actions';
 
 // setting up the same config from Swagger/api.js
 export const requestInterceptor = (req) => {
@@ -27,6 +29,21 @@ export const requestInterceptor = (req) => {
     }
   }
   return req;
+};
+
+export const responseInterceptor = (res) => {
+  switch (res.status) {
+    case 500: {
+      interceptInjection(interceptResponse(true));
+      break;
+    }
+
+    default: {
+      interceptInjection(interceptResponse(false));
+    }
+  }
+
+  return res;
 };
 
 /**

--- a/src/shared/Swagger/api.js
+++ b/src/shared/Swagger/api.js
@@ -1,7 +1,7 @@
 import Swagger from 'swagger-client';
 import * as Cookies from 'js-cookie';
+import { getInternalClient } from 'services/internalApi';
 
-let client = null;
 let publicClient = null;
 let ghcClient = null;
 
@@ -18,13 +18,7 @@ export const requestInterceptor = (req) => {
 };
 
 export async function getClient() {
-  if (!client) {
-    client = await Swagger({
-      url: '/internal/swagger.yaml',
-      requestInterceptor: requestInterceptor,
-    });
-  }
-  return client;
+  return await getInternalClient();
 }
 
 export async function getPublicClient() {

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -14,6 +14,7 @@ import logger from './reduxLogger';
 import * as schema from 'shared/Entities/schema';
 
 import rootSaga, { rootCustomerSaga } from 'sagas/index';
+import { interceptorInjectionMiddleware } from 'store/interceptor/injectionMiddleware';
 
 export const history = createBrowserHistory();
 
@@ -27,7 +28,12 @@ function appSelector() {
 
 export const configureStore = (history, initialState = {}) => {
   const sagaMiddleware = createSagaMiddleware();
-  const middlewares = [thunk.withExtraArgument({ schema }), routerMiddleware(history), sagaMiddleware];
+  const middlewares = [
+    thunk.withExtraArgument({ schema }),
+    routerMiddleware(history),
+    sagaMiddleware,
+    interceptorInjectionMiddleware,
+  ];
 
   if (isDevelopment && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
     middlewares.push(logger);

--- a/src/store/interceptor/actions.js
+++ b/src/store/interceptor/actions.js
@@ -1,0 +1,6 @@
+export const INTERCEPT_RESPONSE = 'INTERCEPT_RESPONSE';
+
+export const interceptResponse = (hasError) => ({
+  type: INTERCEPT_RESPONSE,
+  hasError,
+});

--- a/src/store/interceptor/actions.test.js
+++ b/src/store/interceptor/actions.test.js
@@ -1,0 +1,10 @@
+import { INTERCEPT_RESPONSE, interceptResponse } from './actions';
+
+describe('interceptor actions', () => {
+  it('interceptResponse returns an action object', () => {
+    expect(interceptResponse(true)).toEqual({
+      type: INTERCEPT_RESPONSE,
+      hasError: true,
+    });
+  });
+});

--- a/src/store/interceptor/injectionMiddleware.js
+++ b/src/store/interceptor/injectionMiddleware.js
@@ -1,0 +1,49 @@
+/*
+ * This code exists to allow a requestInterceptor to arbitrarily dispatch events to the
+ * active redux store. Redux, by design, doesn't want to do this! But:
+ *
+ * 1. The most sensible place to put universal response interception for analysis was
+ *    attaching it to the SwaggerClient, which by its nature is going to be disconnected
+ *    from the redux store scope and the actions that caused it to fire in the first place
+ *
+ * 2. All of the common methods for redux side effects (sagas and thunks, which we use elsewhere)
+ *    need to be connected logically to redux actions that caused them to fire; this isn't
+ *    a useful pattern for us unfortunately, as there's a ton of user actions that result in
+ *    swagger requests being made. To set up a saga watcher we'd need to exhaustively track them
+ *    all, and somehow incorporate adding any future actions which result in XHRs into the array
+ *    of events being watched.
+ *
+ * The conclusion I came to was just closing over a reference to the redux store's dispatch, and
+ * then exporting a function that has access to that closure, for use in the requestInterceptor.
+ */
+
+/*
+ * Start out a closed over reference as a no-op function.
+ * There shouldn't be a logical way for this not be defined when a user makes a request,
+ * as several actions get fired through the application before the user will have a chance
+ * to make any XHR request, but let's just be on the safe side and prevent
+ * "cannot execute undefined" errors as a class.
+ */
+let dispatchReference = () => {};
+
+/*
+ * Create some middleware, which is a double curried function. The outermost function gets a
+ * reference to the active redux store (in the shape of { getState(), dispatch() }) and we
+ * only need the dispatch half of it. This does nothing practical to the application
+ * besides getting and closing over a reference to the store's dispatch method.
+ */
+export const interceptorInjectionMiddleware =
+  ({ dispatch }) =>
+  (next) =>
+  (action) => {
+    dispatchReference = dispatch;
+    return next(action);
+  };
+
+/*
+ * Export a function that has access to the closed over dispatch, which can get used by
+ * the responseInterceptor attached to the SwaggerClient instance.
+ */
+export const interceptInjection = (action) => {
+  dispatchReference(action);
+};

--- a/src/store/interceptor/injectionMiddleware.test.js
+++ b/src/store/interceptor/injectionMiddleware.test.js
@@ -1,0 +1,42 @@
+import { INTERCEPT_RESPONSE } from './actions';
+import { interceptorInjectionMiddleware, interceptInjection } from './injectionMiddleware';
+
+describe('injection middleware', () => {
+  it('safely performs a no-op if called before a dispatch reference is found', () => {
+    expect(() => {
+      interceptInjection({
+        type: INTERCEPT_RESPONSE,
+        hasError: true,
+      });
+    }).not.toThrow();
+  });
+
+  it('acts as true middleware and just forwards the action to the next listener', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
+
+    interceptorInjectionMiddleware({ dispatch })(next)({
+      type: 'test_event',
+    });
+    expect(next).toHaveBeenCalledWith({ type: 'test_event' });
+  });
+
+  it('maintains a closed over reference to the dispatch function', () => {
+    const dispatch = jest.fn();
+    const next = jest.fn();
+
+    interceptorInjectionMiddleware({ dispatch })(next)({
+      type: 'test_event',
+    });
+
+    interceptInjection({
+      type: INTERCEPT_RESPONSE,
+      hasError: false,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: INTERCEPT_RESPONSE,
+      hasError: false,
+    });
+  });
+});


### PR DESCRIPTION
## Description

One of our July slice goals is to display a universal error message to Customer users whenever an action that they take causes an XHR to be responded to with a 500 status code. This pull request implements a `requestInterceptor` function which:

* attaches to the `internal` SwaggerClient, 
* listens to every XHR response that comes back, 
* and dispatches an action to the redux store declaring whether or not that response contained a 500 error code.

The first two parts of that checklist are relatively straightforward, but the third presented a unique challenge, as redux is not designed for arbitrary event dispatch and "side effects." There are several popular options for managing redux side effects ([thunks](https://github.com/reduxjs/redux-thunk) and [sagas](https://redux-saga.js.org/)), which we use elsewhere in our application, but neither is really appropriate for our use case here.

The solution I came up with was to create a middleware function which, upon application startup, receives a reference to the active redux store and maintains it in a closure; another function is exported which allows our `responseInterceptor` to make dispatches using that closed over reference.

## Reviewer Notes

There should be no perceptible change to the application's display of information or performance. (It actually might be a little faster, because we're instantiating one fewer copy of SwaggerClient now.)

Also this is... uh, a bit of a hack; I am very interested if reviewers know of better strategies here!

## Setup

Run the application normally. There should be no perceptible change to the content or display, as this ticket is just setting up scaffolding for future work in this slice.

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8671](https://dp3.atlassian.net/browse/MB-8671).
