### PR TITLE
MB-8665 Move order validations to order_updater

### DIFF
--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -202,24 +202,14 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusPreconditionFailed{}, response)
 }
 
-// TODO Some validation rules for orders have been disabled for now.
-// TODO with the implementation of amended orders, the customer can upload an amended order which
-// TODO will need to update/save the order. The order is failing because the customer
-// TODO does not update these fields. There is a thread going about this
-// https://ustcdp3.slack.com/archives/CP6F568DC/p1625237648094700
-// https://dp3.atlassian.net/browse/MB-8665
-/*
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncompleteOrder() {
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	order := move.Orders
-	order.TAC = nil
-	suite.MustSave(&order)
-	moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.TestLogger())
-	err := moveRouter.Submit(&move)
-	if err != nil {
-		suite.T().Fatal("Should transition.")
-	}
-	suite.MustSave(&move)
+	orderWithoutDefaults := testdatagen.MakeOrderWithoutDefaults(suite.DB(), testdatagen.Assertions{})
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusServiceCounselingCompleted,
+		},
+		Order: orderWithoutDefaults,
+	})
 
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
@@ -231,6 +221,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 	queryBuilder := query.NewQueryBuilder(suite.DB())
+	moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.TestLogger())
 	siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
 
 	// make the request
@@ -244,8 +235,10 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 	errorDetail := invalidResponse.Detail
 
 	suite.Contains(*errorDetail, "TransportationAccountingCode cannot be blank.")
+	suite.Contains(*errorDetail, "OrdersNumber cannot be blank.")
+	suite.Contains(*errorDetail, "DepartmentIndicator cannot be blank.")
+	suite.Contains(*errorDetail, "OrdersTypeDetail cannot be blank.")
 }
-*/
 
 func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler() {
 	order := testdatagen.MakeDefaultOrder(suite.DB())

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -144,7 +144,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 
 		suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
-		suite.Equal(movePayload.ID, strfmt.UUID(move.ID.String()))
+		suite.Equal(strfmt.UUID(move.ID.String()), movePayload.ID)
 		suite.NotNil(movePayload.AvailableToPrimeAt)
 		suite.HasWebhookNotification(move.ID, traceID) // this action always creates a notification for the Prime
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -564,13 +564,7 @@ func SaveMoveDependencies(db *pop.Connection, move *Move) (*validate.Errors, err
 			}
 		}
 
-		order := &move.Orders
-		err := db.Load(order, "Moves")
-		if err != nil {
-			responseError = errors.Wrap(err, "Error Loading Order")
-			return transactionError
-		}
-		if verrs, err := db.ValidateAndSave(order); verrs.HasAny() || err != nil {
+		if verrs, err := db.ValidateAndSave(&move.Orders); verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error Saving Orders")
 			return transactionError

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -43,20 +43,10 @@ func (suite *ModelSuite) TestMiscValidationsAfterSubmission() {
 		suite.verifyValidationErrors(&order, expErrors)
 	})
 
-	suite.T().Run("test blank fields", func(t *testing.T) {
-		order.TAC = nil
-		order.DepartmentIndicator = nil
+	suite.T().Run("test UploadedAmendedOrdersID is not nil UUID", func(t *testing.T) {
 		order.UploadedAmendedOrdersID = &uuid.Nil
 
 		expErrors := map[string][]string{
-			// TODO We are disabling validation for these fields for now.
-			// TODO With the implementation of amended orders, the customer can upload an amended order which
-			// TODO will need to update/save the order. The order is failing because the customer
-			// TODO does not update these fields. There is a thread going about this
-			// https://ustcdp3.slack.com/archives/CP6F568DC/p1625237648094700
-			// https://dp3.atlassian.net/browse/MB-8665
-			//"transportation_accounting_code": {"TransportationAccountingCode cannot be blank."},
-			//"department_indicator":           {"DepartmentIndicator cannot be blank."},
 			"uploaded_amended_orders_id": {"UploadedAmendedOrdersID can not be blank."},
 		}
 
@@ -108,60 +98,6 @@ func (suite *ModelSuite) TestTacFormat() {
 		suite.verifyValidationErrors(&order, expErrors)
 	}
 }
-
-// TODO Some validation rules for orders have been disabled for now.
-// TODO with the implementation of amended orders, the customer can upload an amended order which
-// TODO will need to update/save the order. The order is failing because the customer
-// TODO does not update these fields. There is a thread going about this
-// https://ustcdp3.slack.com/archives/CP6F568DC/p1625237648094700
-// https://dp3.atlassian.net/browse/MB-8665
-/*
-func (suite *ModelSuite) TestOrdersNumberPresenceAfterSubmission() {
-	invalidCases := []struct {
-		desc  string
-		value *string
-	}{
-		{"EmptyString", swag.String("")},
-		{"Nil", nil},
-	}
-	for _, invalidCase := range invalidCases {
-		move := testdatagen.MakeStubbedMoveWithStatus(suite.DB(), MoveStatusSUBMITTED)
-		order := move.Orders
-		order.OrdersNumber = invalidCase.value
-		order.Moves = append(order.Moves, move)
-
-		expErrors := map[string][]string{
-			"orders_number": {"OrdersNumber cannot be blank."},
-		}
-
-		suite.verifyValidationErrors(&order, expErrors)
-	}
-}
-
-func (suite *ModelSuite) TestOrdersTypeDetailPresenceAfterSubmission() {
-	emptyString := internalmessages.OrdersTypeDetail("")
-
-	invalidCases := []struct {
-		desc  string
-		value *internalmessages.OrdersTypeDetail
-	}{
-		{"EmptyString", &emptyString},
-		{"Nil", nil},
-	}
-	for _, invalidCase := range invalidCases {
-		move := testdatagen.MakeStubbedMoveWithStatus(suite.DB(), MoveStatusSUBMITTED)
-		order := move.Orders
-		order.OrdersTypeDetail = invalidCase.value
-		order.Moves = append(order.Moves, move)
-
-		expErrors := map[string][]string{
-			"orders_type_detail": {"OrdersTypeDetail cannot be blank."},
-		}
-
-		suite.verifyValidationErrors(&order, expErrors)
-	}
-}
-*/
 
 func (suite *ModelSuite) TestFetchOrderForUser() {
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())

--- a/pkg/services/mocks/MTOServiceItemCreator.go
+++ b/pkg/services/mocks/MTOServiceItemCreator.go
@@ -6,6 +6,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	models "github.com/transcom/mymove/pkg/models"
 
+	pop "github.com/gobuffalo/pop/v5"
+
 	validate "github.com/gobuffalo/validate/v3"
 )
 
@@ -44,4 +46,9 @@ func (_m *MTOServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOSer
 	}
 
 	return r0, r1, r2
+}
+
+// SetConnection provides a mock function with given fields: db
+func (_m *MTOServiceItemCreator) SetConnection(db *pop.Connection) {
+	_m.Called(db)
 }

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -14,6 +14,7 @@ import (
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/order"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/unit"
 
@@ -84,10 +85,8 @@ func (o moveTaskOrderUpdater) UpdateStatusServiceCounselingCompleted(moveTaskOrd
 }
 
 //MakeAvailableToPrime updates the status of a MoveTaskOrder for a given UUID to make it available to prime
-func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eTag string,
+func (o *moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eTag string,
 	includeServiceCodeMS bool, includeServiceCodeCS bool) (*models.Move, error) {
-	var err error
-	var verrs *validate.Errors
 
 	searchParams := services.MoveTaskOrderFetcherParams{
 		IncludeHidden: false,
@@ -97,18 +96,12 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 		return &models.Move{}, err
 	}
 
-	// Fail early if the Order is invalid due to missing required fields
-	order := move.Orders
-	err = o.db.Load(&order, "Moves")
-	if err != nil {
-		return &models.Move{}, err
-	}
-	if verrs, err = o.db.ValidateAndUpdate(&order); verrs.HasAny() || err != nil {
-		return &models.Move{}, services.NewInvalidInputError(move.ID, nil, verrs, "")
+	existingETag := etag.GenerateEtag(move.UpdatedAt)
+	if existingETag != eTag {
+		return &models.Move{}, services.NewPreconditionFailedError(move.ID, query.StaleIdentifierError{StaleIdentifier: eTag})
 	}
 
 	if move.AvailableToPrimeAt == nil {
-		// update field for move
 		now := time.Now()
 		move.AvailableToPrimeAt = &now
 
@@ -117,73 +110,81 @@ func (o moveTaskOrderUpdater) MakeAvailableToPrime(moveTaskOrderID uuid.UUID, eT
 			return &models.Move{}, services.NewConflictError(move.ID, err.Error())
 		}
 
-		verrs, err = o.builder.UpdateOne(move, &eTag)
-		if verrs != nil && verrs.HasAny() {
-			return &models.Move{}, services.NewInvalidInputError(move.ID, nil, verrs, "")
-		}
-		if err != nil {
-			switch err.(type) {
-			case query.StaleIdentifierError:
-				return nil, services.NewPreconditionFailedError(move.ID, err)
-			default:
-				return &models.Move{}, err
+		transactionError := o.db.Transaction(func(tx *pop.Connection) error {
+			err = o.updateMove(tx, *move, order.CheckRequiredFields())
+			if err != nil {
+				return err
 			}
-		}
 
-		// When provided, this will auto create and approve MTO level service items. This is going to typically happen
-		// from the ghc api via the office app. The handler in question is this one: UpdateMoveTaskOrderStatusHandlerFunc
-		// in ghcapi/move_task_order.go
-		if includeServiceCodeMS {
-			// create if doesn't exist
-			_, verrs, err = o.serviceItemCreator.CreateMTOServiceItem(&models.MTOServiceItem{
-				MoveTaskOrderID: moveTaskOrderID,
-				MTOShipmentID:   nil,
-				ReService:       models.ReService{Code: models.ReServiceCodeMS},
-				Status:          models.MTOServiceItemStatusApproved,
-				ApprovedAt:      &now,
-			})
-		}
-
-		if err != nil {
-			if errors.Is(err, models.ErrInvalidTransition) {
-				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
+			// When provided, this will auto create and approve MTO level service items. This is going to typically happen
+			// from the ghc api via the office app. The handler in question is this one: UpdateMoveTaskOrderStatusHandlerFunc
+			// in ghcapi/move_task_order.go
+			if includeServiceCodeMS {
+				err = o.createServiceItem(tx, *move, models.ReServiceCodeMS)
 			}
-			return &models.Move{}, err
-		}
-		if verrs != nil {
-			return &models.Move{}, verrs
-		}
 
-		if includeServiceCodeCS {
-			// create if doesn't exist
-			_, verrs, err = o.serviceItemCreator.CreateMTOServiceItem(&models.MTOServiceItem{
-				MoveTaskOrderID: moveTaskOrderID,
-				MTOShipmentID:   nil,
-				ReService:       models.ReService{Code: models.ReServiceCodeCS},
-				Status:          models.MTOServiceItemStatusApproved,
-				ApprovedAt:      &now,
-			})
-		}
-
-		if err != nil {
-			if errors.Is(err, models.ErrInvalidTransition) {
-				return &models.Move{}, services.NewConflictError(move.ID, err.Error())
+			if err != nil {
+				return err
 			}
-			return &models.Move{}, err
-		}
-		if verrs != nil {
-			return &models.Move{}, verrs
-		}
 
-		// CreateMTOServiceItem may have updated the move status so refetch as to not return incorrect status
-		// TODO: Modify CreateMTOServiceItem to return the updated move or refactor to operate on the passed in reference
-		move, err = o.FetchMoveTaskOrder(moveTaskOrderID, nil)
-		if err != nil {
-			return &models.Move{}, err
+			if includeServiceCodeCS {
+				err = o.createServiceItem(tx, *move, models.ReServiceCodeCS)
+			}
+
+			return err
+		})
+
+		if transactionError != nil {
+			return &models.Move{}, transactionError
 		}
 	}
 
 	return move, nil
+}
+
+func (o *moveTaskOrderUpdater) updateMove(tx *pop.Connection, move models.Move, checks ...order.Validator) error {
+	if verr := order.ValidateOrder(&move.Orders, checks...); verr != nil {
+		return verr
+	}
+
+	verrs, err := tx.ValidateAndUpdate(&move)
+
+	if verrs != nil && verrs.HasAny() {
+		return services.NewInvalidInputError(move.ID, nil, verrs, "")
+	}
+
+	return err
+}
+
+func (o *moveTaskOrderUpdater) createServiceItem(tx *pop.Connection, move models.Move, code models.ReServiceCode) error {
+	now := time.Now()
+
+	_, verrs, err := o.serviceItemCreator.CreateMTOServiceItem(&models.MTOServiceItem{
+		MoveTaskOrderID: move.ID,
+		MTOShipmentID:   nil,
+		ReService:       models.ReService{Code: code},
+		Status:          models.MTOServiceItemStatusApproved,
+		ApprovedAt:      &now,
+	})
+
+	if err != nil {
+		if errors.Is(err, models.ErrInvalidTransition) {
+			return services.NewConflictError(move.ID, err.Error())
+		}
+		return err
+	}
+
+	if verrs != nil {
+		return verrs
+	}
+
+	verrs, err = tx.ValidateAndUpdate(&move)
+
+	if verrs != nil && verrs.HasAny() {
+		return services.NewInvalidInputError(move.ID, nil, verrs, "")
+	}
+
+	return err
 }
 
 // UpdateMoveTaskOrderQueryBuilder is the query builder for updating MTO

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -159,7 +159,10 @@ func (o *moveTaskOrderUpdater) updateMove(tx *pop.Connection, move models.Move, 
 func (o *moveTaskOrderUpdater) createServiceItem(tx *pop.Connection, move models.Move, code models.ReServiceCode) error {
 	now := time.Now()
 
-	_, verrs, err := o.serviceItemCreator.CreateMTOServiceItem(&models.MTOServiceItem{
+	siCreator := o.serviceItemCreator
+	siCreator.SetConnection(tx)
+
+	_, verrs, err := siCreator.CreateMTOServiceItem(&models.MTOServiceItem{
 		MoveTaskOrderID: move.ID,
 		MTOShipmentID:   nil,
 		ReService:       models.ReService{Code: code},
@@ -174,17 +177,11 @@ func (o *moveTaskOrderUpdater) createServiceItem(tx *pop.Connection, move models
 		return err
 	}
 
-	if verrs != nil {
-		return verrs
-	}
-
-	verrs, err = tx.ValidateAndUpdate(&move)
-
 	if verrs != nil && verrs.HasAny() {
 		return services.NewInvalidInputError(move.ID, nil, verrs, "")
 	}
 
-	return err
+	return nil
 }
 
 // UpdateMoveTaskOrderQueryBuilder is the query builder for updating MTO

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -224,22 +224,31 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_MakeAvailableToPrime() {
-	mockserviceItemCreator := &mocks.MTOServiceItemCreator{}
-	queryBuilder := query.NewQueryBuilder(suite.DB())
-	moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
-	mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mockserviceItemCreator, moveRouter)
-
-	suite.RunWithRollback("Service item creator is not called if move fails to get approved", func() {
+	suite.Run("Service item creator is not called if move fails to get approved", func() {
+		mockserviceItemCreator := &mocks.MTOServiceItemCreator{}
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mockserviceItemCreator, moveRouter)
 		// Create move in DRAFT status, which should fail to get approved
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+
 		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, true)
 
 		mockserviceItemCreator.AssertNumberOfCalls(suite.T(), "CreateMTOServiceItem", 0)
 		suite.Error(err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.Nil(fetchedMove.AvailableToPrimeAt)
 	})
 
-	suite.RunWithRollback("When ETag is stale", func() {
+	suite.Run("When ETag is stale", func() {
+		mockserviceItemCreator := &mocks.MTOServiceItemCreator{}
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mockserviceItemCreator, moveRouter)
+
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusSUBMITTED,
@@ -247,9 +256,170 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_MakeAvailableTo
 		})
 
 		eTag := etag.GenerateEtag(time.Now())
-		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, false, false)
+		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, true)
 
+		mockserviceItemCreator.AssertNumberOfCalls(suite.T(), "CreateMTOServiceItem", 0)
 		suite.Error(err)
 		suite.IsType(services.PreconditionFailedError{}, err)
+	})
+
+	suite.Run("Makes move available to Prime and creates Move management and Service counseling service items when both are specified", func() {
+		suite.createMSAndCSReServices()
+
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		serviceItemCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, serviceItemCreator, moveRouter)
+
+		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+		var serviceItems models.MTOServiceItems
+
+		suite.Nil(move.AvailableToPrimeAt)
+
+		updatedMove, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, true)
+
+		suite.NoError(err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.NotNil(fetchedMove.AvailableToPrimeAt)
+		suite.NotNil(updatedMove.AvailableToPrimeAt)
+		suite.Equal(models.MoveStatusAPPROVED, fetchedMove.Status)
+		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
+		err = suite.DB().Eager("ReService").Where("move_id = ?", move.ID).All(&serviceItems)
+		suite.NoError(err)
+		suite.Len(serviceItems, 2, "Expected to find at most 2 service items")
+		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeMS), "Expected to find reServiceCode, MS, in array.")
+		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeCS), "Expected to find reServiceCode, CS, in array.")
+	})
+
+	suite.Run("Makes move available to Prime and only creates Move management when it's the only one specified", func() {
+		suite.createMSAndCSReServices()
+
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		serviceItemCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, serviceItemCreator, moveRouter)
+
+		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+		var serviceItems models.MTOServiceItems
+
+		suite.Nil(move.AvailableToPrimeAt)
+
+		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, false)
+
+		suite.NoError(err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.NotNil(fetchedMove.AvailableToPrimeAt)
+		err = suite.DB().Eager("ReService").Where("move_id = ?", move.ID).All(&serviceItems)
+		suite.NoError(err)
+		suite.Len(serviceItems, 1, "Expected to find at most 1 service item")
+		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeMS), "Expected to find reServiceCode, MS, in array.")
+		suite.False(suite.containsServiceCode(serviceItems, models.ReServiceCodeCS), "Expected to find reServiceCode, CS, in array.")
+	})
+
+	suite.Run("Makes move available to Prime and only creates CS service item when it's the only one specified", func() {
+		suite.createMSAndCSReServices()
+
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		serviceItemCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, serviceItemCreator, moveRouter)
+
+		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+		var serviceItems models.MTOServiceItems
+
+		suite.Nil(move.AvailableToPrimeAt)
+
+		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, false, true)
+
+		suite.NoError(err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.NotNil(fetchedMove.AvailableToPrimeAt)
+		err = suite.DB().Eager("ReService").Where("move_id = ?", move.ID).All(&serviceItems)
+		suite.NoError(err)
+		suite.Len(serviceItems, 1, "Expected to find at most 1 service item")
+		suite.False(suite.containsServiceCode(serviceItems, models.ReServiceCodeMS), "Expected to find reServiceCode, MS, in array.")
+		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeCS), "Expected to find reServiceCode, CS, in array.")
+	})
+
+	suite.Run("Does not create service items if neither CS nor MS are requested", func() {
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		mockserviceItemCreator := &mocks.MTOServiceItemCreator{}
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mockserviceItemCreator, moveRouter)
+
+		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+
+		suite.Nil(move.AvailableToPrimeAt)
+
+		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, false, false)
+
+		mockserviceItemCreator.AssertNumberOfCalls(suite.T(), "CreateMTOServiceItem", 0)
+		suite.NoError(err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.NotNil(fetchedMove.AvailableToPrimeAt)
+	})
+
+	suite.Run("Does not make move available to prime if Order is missing required fields", func() {
+		mockserviceItemCreator := &mocks.MTOServiceItemCreator{}
+		queryBuilder := query.NewQueryBuilder(suite.DB())
+		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.logger)
+		mtoUpdater := NewMoveTaskOrderUpdater(suite.DB(), queryBuilder, mockserviceItemCreator, moveRouter)
+
+		orderWithoutDefaults := testdatagen.MakeOrderWithoutDefaults(suite.DB(), testdatagen.Assertions{})
+		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				Status: models.MoveStatusServiceCounselingCompleted,
+			},
+			Order: orderWithoutDefaults,
+		})
+		eTag := etag.GenerateEtag(move.UpdatedAt)
+		fetchedMove := models.Move{}
+
+		_, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, true)
+
+		mockserviceItemCreator.AssertNumberOfCalls(suite.T(), "CreateMTOServiceItem", 0)
+		suite.Error(err)
+		suite.IsType(services.InvalidInputError{}, err)
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.Nil(fetchedMove.AvailableToPrimeAt)
+	})
+}
+
+func (suite *MoveTaskOrderServiceSuite) containsServiceCode(items models.MTOServiceItems, target models.ReServiceCode) bool {
+	for _, si := range items {
+		if si.ReService.Code == target {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (suite *MoveTaskOrderServiceSuite) createMSAndCSReServices() {
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			ID:   uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"),
+			Code: "MS",
+		},
+	})
+
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			ID:   uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"),
+			Code: "CS",
+		},
 	})
 }

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -281,17 +281,17 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_MakeAvailableTo
 		updatedMove, err := mtoUpdater.MakeAvailableToPrime(move.ID, eTag, true, true)
 
 		suite.NoError(err)
-		err = suite.DB().Find(&fetchedMove, move.ID)
-		suite.NoError(err)
-		suite.NotNil(fetchedMove.AvailableToPrimeAt)
 		suite.NotNil(updatedMove.AvailableToPrimeAt)
-		suite.Equal(models.MoveStatusAPPROVED, fetchedMove.Status)
 		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 		err = suite.DB().Eager("ReService").Where("move_id = ?", move.ID).All(&serviceItems)
 		suite.NoError(err)
 		suite.Len(serviceItems, 2, "Expected to find at most 2 service items")
 		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeMS), "Expected to find reServiceCode, MS, in array.")
 		suite.True(suite.containsServiceCode(serviceItems, models.ReServiceCodeCS), "Expected to find reServiceCode, CS, in array.")
+		err = suite.DB().Find(&fetchedMove, move.ID)
+		suite.NoError(err)
+		suite.NotNil(fetchedMove.AvailableToPrimeAt)
+		suite.Equal(models.MoveStatusAPPROVED, fetchedMove.Status)
 	})
 
 	suite.Run("Makes move available to Prime and only creates Move management when it's the only one specified", func() {

--- a/pkg/services/mto_service_item.go
+++ b/pkg/services/mto_service_item.go
@@ -12,6 +12,7 @@ import (
 //go:generate mockery --name MTOServiceItemCreator --disable-version-string
 type MTOServiceItemCreator interface {
 	CreateMTOServiceItem(serviceItem *models.MTOServiceItem) (*models.MTOServiceItems, *validate.Errors, error)
+	SetConnection(db *pop.Connection)
 }
 
 // MTOServiceItemUpdater is the exported interface for updating an mto service item

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -19,12 +19,19 @@ type createMTOServiceItemQueryBuilder interface {
 	CreateOne(model interface{}) (*validate.Errors, error)
 	UpdateOne(model interface{}, eTag *string) (*validate.Errors, error)
 	Transaction(fn func(tx *pop.Connection) error) error
+	SetConnection(db *pop.Connection)
 }
 
 type mtoServiceItemCreator struct {
 	builder          createMTOServiceItemQueryBuilder
 	createNewBuilder func(db *pop.Connection) createMTOServiceItemQueryBuilder
 	moveRouter       services.MoveRouter
+}
+
+// SetConnection allows passing in a transaction connection so the builder
+// can use it.
+func (o *mtoServiceItemCreator) SetConnection(db *pop.Connection) {
+	o.builder = o.createNewBuilder(db)
 }
 
 // CreateMTOServiceItem creates a MTO Service Item

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -54,6 +54,9 @@ func (t *testCreateMTOServiceItemQueryBuilder) Transaction(fn func(tx *pop.Conne
 	return t.fakeTransaction(fn)
 }
 
+func (t *testCreateMTOServiceItemQueryBuilder) SetConnection(db *pop.Connection) {
+}
+
 func (suite *MTOServiceItemServiceSuite) buildValidServiceItemWithInvalidMove() models.MTOServiceItem {
 	// Default move has status DRAFT, which is invalid for this test because
 	// service items can only be created if a Move's status is Approved or

--- a/pkg/services/order/validation.go
+++ b/pkg/services/order/validation.go
@@ -1,0 +1,88 @@
+package order
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// Validator is the interface for the various validations we might want to
+// define.
+type Validator interface {
+	Validate(order *models.Order) error
+}
+
+type validatorFunc func(*models.Order) error
+
+func (fn validatorFunc) Validate(order *models.Order) error {
+	return fn(order)
+}
+
+// ValidateOrder accepts a range of validator functions and runs each one
+func ValidateOrder(order *models.Order, checks ...Validator) (result error) {
+	verrs := validate.NewErrors()
+	for _, checker := range checks {
+		if err := checker.Validate(order); err != nil {
+			switch e := err.(type) {
+			case *validate.Errors:
+				// accumulate validation errors
+				verrs.Append(e)
+			default:
+				// non-validation errors have priority,
+				// and short-circuit doing any further checks
+				return err
+			}
+		}
+	}
+	if verrs.HasAny() {
+		result = services.NewInvalidInputError(order.ID, nil, verrs, "")
+	}
+	return result
+}
+
+// StringIsPresentAfterSubmission checks presence of fields after an order has been submitted
+// This validation only applies when a TOO is updating orders.
+type StringIsPresentAfterSubmission struct {
+	Name  string
+	Field *string
+}
+
+// IsValid adds an error if the field is blank
+func (validate *StringIsPresentAfterSubmission) IsValid(errors *validate.Errors) {
+	if validate.Field == nil || *validate.Field == "" {
+		errors.Add(validators.GenerateKey(validate.Name), fmt.Sprintf("%s cannot be blank.", validate.Name))
+	}
+}
+
+// OrdersTypeDetailIsPresentAfterSubmission validates that orders type field is present
+type OrdersTypeDetailIsPresentAfterSubmission struct {
+	Name  string
+	Field *internalmessages.OrdersTypeDetail
+}
+
+// IsValid adds an error if the string value is blank.
+func (validate *OrdersTypeDetailIsPresentAfterSubmission) IsValid(errors *validate.Errors) {
+	if validate.Field == nil || string(*validate.Field) == "" {
+		errors.Add(validators.GenerateKey(validate.Name), fmt.Sprintf("%s cannot be blank.", validate.Name))
+	}
+}
+
+// CheckRequiredFields ensures the presence of certain order fields before a TOO
+// can approve a move or update an order.
+func CheckRequiredFields() Validator {
+	return validatorFunc(func(order *models.Order) error {
+		verrs := validate.Validate(
+			&StringIsPresentAfterSubmission{Name: "TransportationAccountingCode", Field: order.TAC},
+			&StringIsPresentAfterSubmission{Name: "DepartmentIndicator", Field: order.DepartmentIndicator},
+			&StringIsPresentAfterSubmission{Name: "OrdersNumber", Field: order.OrdersNumber},
+			&OrdersTypeDetailIsPresentAfterSubmission{Name: "OrdersTypeDetail", Field: order.OrdersTypeDetail},
+		)
+
+		return verrs
+	})
+}

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -45,6 +45,12 @@ func NewQueryBuilder(db *pop.Connection) *Builder {
 	return &Builder{db}
 }
 
+// SetConnection allows passing in a transaction connection so the builder
+// can use it.
+func (p *Builder) SetConnection(db *pop.Connection) {
+	p.db = db
+}
+
 // Lookup to check if a specific string is inside the db field tags of the type
 func getDBColumn(t reflect.Type, field string) (string, bool) {
 	for i := 0; i < t.NumField(); i++ {


### PR DESCRIPTION
When we first added validations to prevent a TOO from submitting a move
while certain order fields were missing, we made the mistake of putting
the validations in the Order model as opposed to the service. Back then,
we only had one generic service for updating orders, so it might have
made sense at the time.

Since then, we've added more complexity, such as requiring separate
validations for counselors versus TOOs, and allowing customers to
upload amended orders even if the move has made it past service
counseling but hasn't been updated by the TOO yet.

Instead of trying to fit all of these different scenarios into a
generic validation in the Order model, it now makes more sense to
only add the validation where it applies, which is only when a TOO is
updating an order and when they are approving a move.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
