### PR TITLE
[MB-8756] Update remaining pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,11 @@ repos:
         types: [go]
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-json
       - id: check-merge-conflict
       - id: check-yaml
-        exclude: config/database.yml # database.yml is not a valid yaml file, it contains go templating
       - id: detect-private-key
         #RA Summary: detect-private-key - Private key found
         #RA: detect-private-key detected a private key in source control

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         entry: bash -c 'exec golangci-lint run -v ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,12 +10,7 @@ import '../src/icons';
 export const parameters = {
   options: {
     storySort: {
-      order: [
-        'Global',
-        'Components',
-        'Office Components',
-        'Customer Components',
-      ],
+      order: ['Global', 'Components', 'Office Components', 'Customer Components'],
     },
   },
 };

--- a/cypress/integration/mymove/serviceMemberProfile.js
+++ b/cypress/integration/mymove/serviceMemberProfile.js
@@ -34,7 +34,6 @@ function serviceMemberChoosesConusOrOconus() {
   });
   cy.get('[for="input_CONUS"]').click();
   cy.get('button[data-testid="wizardNextButton"]').click();
-
 }
 
 function serviceMemberProfile(reloadAfterEveryPage) {
@@ -64,9 +63,12 @@ function serviceMemberProfile(reloadAfterEveryPage) {
   //contact info
   cy.get('button[data-testid="wizardNextButton"]').should('be.disabled');
   cy.get('input[name="telephone"]').type('6784567890');
-  cy.get('[type="checkbox"]').not('[disabled]').check({
-    force: true
-  }).should('be.checked');
+  cy.get('[type="checkbox"]')
+    .not('[disabled]')
+    .check({
+      force: true,
+    })
+    .should('be.checked');
   cy.nextPage();
   cy.location().should((loc) => {
     expect(loc.pathname).to.match(/^\/service-member\/current-duty/);

--- a/eslint-plugin-ato/.eslintrc
+++ b/eslint-plugin-ato/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": "off"
+  }
+}

--- a/eslint-plugin-ato/tests/no-unapproved-annotation.test.js
+++ b/eslint-plugin-ato/tests/no-unapproved-annotation.test.js
@@ -66,8 +66,7 @@ ruleTester.run('no-unapproved-annotation', rule, {
 
   invalid: [
     {
-      code:
-        '// RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}\n// eslint-disable no-console',
+      code: '// RA Validator Status: {RA Accepted, Return to Developer, Known Issue, Mitigated, False Positive, Bad Practice}\n// eslint-disable no-console',
       errors: [{ message: ERRORS.REQUIRES_APPROVAL_MSG }],
     },
     {

--- a/scripts/generate-secure-migration
+++ b/scripts/generate-secure-migration
@@ -6,7 +6,8 @@
 
 set -eu -o pipefail
 
-readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly dir
 
 readonly local_secure_migrations_dir="${dir}/../migrations/app/secure"
 readonly prod_migrations_temp_dir="${dir}/../tmp"
@@ -34,7 +35,8 @@ readonly migration_name="$1"
 # - remove ".up.fizz" from filename
 # - remove "migrations/" from filename
 # - append ".sql"
-readonly version=$(date +"%Y%m%d%H%M%S")
+version=$(date +"%Y%m%d%H%M%S")
+readonly version
 readonly secure_migration_name="${version}_${migration_name}.up.sql"
 
 readonly local_test_migration_name="${local_secure_migrations_dir}/${secure_migration_name}"

--- a/scripts/pricing-import
+++ b/scripts/pricing-import
@@ -8,7 +8,8 @@ readonly db_user=${DB_USER:-postgres}
 readonly db_host=${DB_HOST:-localhost}
 
 # find current directory
-readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly dir
 readonly local_secure_migrations_dir="${dir}/../migrations/app/secure"
 readonly prod_migrations_temp_dir="${dir}/../tmp"
 readonly path="${dir}/../tmp/pricing_import_dump.sql"
@@ -80,7 +81,8 @@ readonly migration_name="import_pricing_data_${unique_contract_code}"
 # - remove ".up.fizz" from filename
 # - remove "migrations/" from filename
 # - append ".sql"
-readonly version=$(date +"%Y%m%d%H%M%S")
+version=$(date +"%Y%m%d%H%M%S")
+readonly version
 readonly secure_migration_name="${version}_${migration_name}.up.sql"
 
 readonly local_test_migration_name="${local_secure_migrations_dir}/${secure_migration_name}"

--- a/scripts/rds-snapshot-app-db
+++ b/scripts/rds-snapshot-app-db
@@ -15,7 +15,8 @@ set -u
 readonly environment=$1
 
 readonly db_instance_identifier=app-$environment
-readonly db_snapshot_identifier=$db_instance_identifier-$(date +%s)
+db_snapshot_identifier=$db_instance_identifier-$(date +%s)
+readonly db_snapshot_identifier
 readonly tags=("Key=Environment,Value=$environment" "Key=Tool,Value=$(basename "$0")")
 
 echo

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -50,7 +50,8 @@ fi
 readonly production_migration_file="$1"
 
 # Migration files need to have the suffix ".up.sql"
-readonly basename_production_migration_file=$(basename "${production_migration_file}")
+basename_production_migration_file=$(basename "${production_migration_file}")
+readonly basename_production_migration_file
 if [[ "${basename_production_migration_file#*.}" != "up.sql" ]]; then
   echo "error: migration filename extensions must be '.up.sql'"
   exit 1


### PR DESCRIPTION
## Description

In #6987, I updated the pre-commit hook for `golangci-lint` to the latest version.  Since it required some fixes and annotations, I kept it separate from other pre-commit updates to make that PR more focused.

In this PR, I am updating the remaining versioned hooks.  This includes:

- `pre-commit-hooks` updated from v3.4.0 to v4.0.1
- `markdownlint-ci` updated from v0.26.0 to v0.27.1.

In addition, while running all files through all pre-commit hooks, I found that a few JavaScript files were being flagged by prettier.  Those have been fixed in this PR.  There was also an eslint issue around a dependency in our custom `eslint-plugin-ato` linter.  After talking with @Ronolibert , we decided it was safe to turn that check off because the dependency is in the parent node modules, but it's not being recognized properly by the linter.

Similarly, there were also some issues flagged by `shell-lint` that required some slight adjustments.  Those are also fixed here. 

## Reviewer Notes

I've added additional context inline where needed.

## Setup

1. `make clean server_build client_build build_tools`
1. `pre-commit run -a`

Verify that all pre-commit checks run successfully.

Also, you can run `pre-commit autoupdate` and verify that there are no additional hooks that need updating.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8756) for this change
