### PR TITLE
[MB-1573] Implement lookup for CubicFeetCrating

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -649,3 +649,4 @@
 20210628223755_add_actual_and_estimated_weight_to_mto_service_items.up.sql
 20210629133827_remove_char_limit_payment_service_item_rejection_reason.up.sql
 20210706214857_felipe_cac.up.sql
+20210714221936_change_cubic_feet_crating_to_decimal.up.sql

--- a/migrations/app/schema/20210714221936_change_cubic_feet_crating_to_decimal.up.sql
+++ b/migrations/app/schema/20210714221936_change_cubic_feet_crating_to_decimal.up.sql
@@ -1,0 +1,3 @@
+UPDATE service_item_param_keys
+    SET type = 'DECIMAL'
+    WHERE key IN ('CubicFeetCrating', 'CubicFeetBilled');

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
@@ -16,11 +16,11 @@ type CubicFeetCratingLookup struct {
 }
 
 func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
-	// Each service item has an array of dimensions. We expect there to be at most one
-	// dimension for the crate size.
+	// Each service item has an array of dimensions. There is a DB constraint preventing
+	// more than one dimension of each type for a given service item, so we just have to
+	// look for the first crating dimension.
 	for _, dimension := range keyData.MTOServiceItem.Dimensions {
 		if dimension.Type == models.DimensionTypeCrate {
-			// is there a classier way to work with unit.ThousandthInches?
 			lengthFeet := dimension.Length / thousandthInchesPerFoot
 			heightFeet := dimension.Height / thousandthInchesPerFoot
 			widthFeet := dimension.Width / thousandthInchesPerFoot
@@ -29,7 +29,6 @@ func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string
 			return fmt.Sprint(*volume.Int32Ptr()), nil
 		}
 	}
-	// TODO maybe add a check for multiple crating dimensions
 
 	return "", services.NewConflictError(keyData.MTOServiceItemID, "unable to calculate crate volume due to missing crate dimensions")
 }

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
@@ -13,13 +13,14 @@ const (
 
 // CubicFeetCratingLookup does lookup for CubicFeetCrating
 type CubicFeetCratingLookup struct {
+	Dimensions models.MTOServiceItemDimensions
 }
 
 func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
 	// Each service item has an array of dimensions. There is a DB constraint preventing
 	// more than one dimension of each type for a given service item, so we just have to
 	// look for the first crating dimension.
-	for _, dimension := range keyData.MTOServiceItem.Dimensions {
+	for _, dimension := range c.Dimensions {
 		if dimension.Type == models.DimensionTypeCrate {
 			lengthFeet := float64(dimension.Length) / thousandthInchesPerFoot
 			heightFeet := float64(dimension.Height) / thousandthInchesPerFoot

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
@@ -1,0 +1,35 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+const (
+	thousandthInchesPerFoot = 12000
+)
+
+// CubicFeetCratingLookup does lookup for CubicFeetCrating
+type CubicFeetCratingLookup struct {
+}
+
+func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	// Each service item has an array of dimensions. We expect there to be at most one
+	// dimension for the crate size.
+	for _, dimension := range keyData.MTOServiceItem.Dimensions {
+		if dimension.Type == models.DimensionTypeCrate {
+			// is there a classier way to work with unit.ThousandthInches?
+			lengthFeet := dimension.Length / thousandthInchesPerFoot
+			heightFeet := dimension.Height / thousandthInchesPerFoot
+			widthFeet := dimension.Width / thousandthInchesPerFoot
+
+			volume := lengthFeet * heightFeet * widthFeet
+			return fmt.Sprint(*volume.Int32Ptr()), nil
+		}
+	}
+	// TODO maybe add a check for multiple crating dimensions
+
+	return "", services.NewConflictError(keyData.MTOServiceItemID, "unable to calculate crate volume due to missing crate dimensions")
+}

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
@@ -21,12 +21,12 @@ func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string
 	// look for the first crating dimension.
 	for _, dimension := range keyData.MTOServiceItem.Dimensions {
 		if dimension.Type == models.DimensionTypeCrate {
-			lengthFeet := dimension.Length / thousandthInchesPerFoot
-			heightFeet := dimension.Height / thousandthInchesPerFoot
-			widthFeet := dimension.Width / thousandthInchesPerFoot
+			lengthFeet := float64(dimension.Length) / thousandthInchesPerFoot
+			heightFeet := float64(dimension.Height) / thousandthInchesPerFoot
+			widthFeet := float64(dimension.Width) / thousandthInchesPerFoot
 
 			volume := lengthFeet * heightFeet * widthFeet
-			return fmt.Sprint(*volume.Int32Ptr()), nil
+			return fmt.Sprintf("%.2f", volume), nil
 		}
 	}
 

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -10,20 +10,18 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-// todo test for multiple crating dimensions?
-
 func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 	key := models.ServiceItemParamNameCubicFeetCrating
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.T().Run("successful CubicFeetCrating lookup", func(t *testing.T) {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
 			MTOServiceItemDimension: models.MTOServiceItemDimension{
 				MTOServiceItemID: mtoServiceItem.ID,
 				Type:             models.DimensionTypeCrate,
 				Length:           24000,
-				Height:           24000,
-				Width:            24000,
+				Height:           12000,
+				Width:            48000,
 				CreatedAt:        time.Time{},
 				UpdatedAt:        time.Time{},
 			},

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -14,7 +14,11 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 	key := models.ServiceItemParamNameCubicFeetCrating
 
 	suite.T().Run("successful CubicFeetCrating lookup", func(t *testing.T) {
-		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDCRT,
+			},
+		})
 		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
 			MTOServiceItemDimension: models.MTOServiceItemDimension{
 				MTOServiceItemID: mtoServiceItem.ID,

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -19,11 +19,13 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 			MTOServiceItemDimension: models.MTOServiceItemDimension{
 				MTOServiceItemID: mtoServiceItem.ID,
 				Type:             models.DimensionTypeCrate,
-				Length:           24000,
-				Height:           12000,
-				Width:            48000,
-				CreatedAt:        time.Time{},
-				UpdatedAt:        time.Time{},
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    16*12*1000 + 1000,
+				Height:    8 * 12 * 1000,
+				Width:     8 * 12 * 1000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
 			},
 		})
 		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
@@ -45,7 +47,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 		stringValue, err := paramLookup.ServiceParamValue(key)
 		suite.FatalNoError(err)
 
-		suite.Equal("8", stringValue)
+		suite.Equal("1029.33", stringValue)
 	})
 
 	suite.T().Run("missing dimension should error", func(t *testing.T) {

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -1,0 +1,63 @@
+package serviceparamvaluelookups
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+// todo test for multiple crating dimensions?
+
+func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
+	key := models.ServiceItemParamNameCubicFeetCrating
+
+	suite.T().Run("golden path", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeCrate,
+				Length:           24000,
+				Height:           24000,
+				Width:            24000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
+		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           12000,
+				Height:           12000,
+				Width:            12000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
+		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
+		suite.MustSave(&mtoServiceItem)
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		stringValue, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+
+		suite.Equal("8", stringValue)
+	})
+
+	suite.T().Run("missing dimension should error", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		_, err = paramLookup.ServiceParamValue(key)
+
+		suite.Error(err)
+		suite.Contains(err.Error(), "missing crate dimensions")
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -44,7 +44,7 @@ func ServiceParamLookupInitialize(
 
 	// Get the MTOServiceItem
 	var mtoServiceItem models.MTOServiceItem
-	err := db.Eager("ReService").Find(&mtoServiceItem, mtoServiceItemID)
+	err := db.Eager("ReService", "Dimensions").Find(&mtoServiceItem, mtoServiceItemID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -359,6 +359,12 @@ func ServiceParamLookupInitialize(
 	err = s.setLookup(serviceItemCode, paramKey, DistanceZipSITOriginLookup{
 		ServiceItem: mtoServiceItem,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	paramKey = models.ServiceItemParamNameCubicFeetCrating
+	err = s.setLookup(serviceItemCode, paramKey, CubicFeetCratingLookup{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -44,7 +44,7 @@ func ServiceParamLookupInitialize(
 
 	// Get the MTOServiceItem
 	var mtoServiceItem models.MTOServiceItem
-	err := db.Eager("ReService", "Dimensions").Find(&mtoServiceItem, mtoServiceItemID)
+	err := db.Eager("ReService").Find(&mtoServiceItem, mtoServiceItemID)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
@@ -88,10 +88,17 @@ func ServiceParamLookupInitialize(
 	var pickupAddress models.Address
 	var destinationAddress models.Address
 	var sitDestinationFinalAddress models.Address
+	var serviceItemDimensions models.MTOServiceItemDimensions
 
 	switch mtoServiceItem.ReService.Code {
 	case models.ReServiceCodeCS, models.ReServiceCodeMS:
 		// Do nothing, these service items don't use the MTOShipment
+	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
+		err = db.Load(&mtoServiceItem, "Dimensions")
+		if err != nil {
+			return nil, err
+		}
+		serviceItemDimensions = mtoServiceItem.Dimensions
 	case models.ReServiceCodeDDASIT, models.ReServiceCodeDDDSIT, models.ReServiceCodeDDFSIT:
 		// load destination address from final address on service item
 		if mtoServiceItem.SITDestinationFinalAddressID != nil && *mtoServiceItem.SITDestinationFinalAddressID != uuid.Nil {
@@ -364,7 +371,9 @@ func ServiceParamLookupInitialize(
 	}
 
 	paramKey = models.ServiceItemParamNameCubicFeetCrating
-	err = s.setLookup(serviceItemCode, paramKey, CubicFeetCratingLookup{})
+	err = s.setLookup(serviceItemCode, paramKey, CubicFeetCratingLookup{
+		Dimensions: serviceItemDimensions,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

The lookup for `CubicFeetCrating` finds the length, width, and height of the crate for a given service item, and multiplies them to get the volume.

I also added a migration to change the types of both the `CubicFeetCrating` and `CubicFeetBilled` service item param keys from `INTEGER` to `DECIMAL`. The designs show 2 decimal places for these, and since we're storing as a string anyway there's not much reason to use an integer to store fractions of a cubic foot.

## Reviewer Notes

- I had to preload `Dimensions` when setting up lookups to make sure that I could access the field in the new lookup. If there's a better way to do this, let me know.
- I've been going back and forth about moving the thousandth of an inch to feet conversion to `unit.ThousandthInch`. I haven't so far because there are a few potential numerical pitfalls here and I wanted everything in one place so those would be easier to spot, but I'm open to refactoring that out.

## Setup
I don't think there's any code that uses this lookup yet, so just make sure migrations run:
```sh
make db_dev_reset
make db_dev_migrate
```
```sql
select key, type from service_item_param_keys where key in ('CubicFeetCrating', 'CubicFeetBilled');
```
you should see:

key                        | type
----------------- | -------------
CubicFeetBilled | DECIMAL
CubicFeetCrating | DECIMAL

and make sure tests pass:
```sh
make server_test
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1573) for this change