### PR TITLE
MB-8648 TOO can see Reason and Rejection reason fields for MTO Service Items

### DIFF
--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
@@ -79,10 +79,17 @@ const serviceItems = [
 ];
 
 const approvedServiceItems = serviceItems.map((serviceItem) => {
-  return { ...serviceItem, status: 'APPROVED' };
+  return {
+    ...serviceItem,
+    status: 'APPROVED',
+  };
 });
 const rejectedServiceItems = serviceItems.map((serviceItem) => {
-  return { ...serviceItem, status: 'REJECTED' };
+  return {
+    ...serviceItem,
+    status: 'REJECTED',
+    details: { ...serviceItem.details, rejectionReason: 'Here is a reason for rejection' },
+  };
 });
 
 export const Default = () => (

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
@@ -30,6 +30,7 @@ const serviceItemWithContact = {
   details: {
     firstCustomerContact: { timeMilitary: '1200Z', firstAvailableDeliveryDate: '2020-09-15' },
     secondCustomerContact: { timeMilitary: '2300Z', firstAvailableDeliveryDate: '2020-09-21' },
+    reason: 'Took a detour',
   },
 };
 
@@ -59,10 +60,10 @@ const testDetails = (wrapper) => {
   expect(wrapper.find('.detailType').at(4).text()).toBe('Second Available Delivery Date:');
   expect(wrapper.find('.detail dd').at(4).text().includes('21 Sep 2020')).toBe(true);
 
-  expect(wrapper.find('.detailType').at(5).text()).toBe('ZIP:');
-  expect(wrapper.find('.detail dd').at(5).text().includes('20050')).toBe(true);
-  expect(wrapper.find('.detailType').at(6).text()).toBe('Reason:');
-  expect(wrapper.find('.detail dd').at(6).text().includes('Took a detour')).toBe(true);
+  expect(wrapper.find('.detailType').at(6).text()).toBe('ZIP:');
+  expect(wrapper.find('.detail dd').at(6).text().includes('20050')).toBe(true);
+  expect(wrapper.find('.detailType').at(5).text()).toBe('Reason:');
+  expect(wrapper.find('.detail dd').at(5).text().includes('Took a detour')).toBe(true);
 };
 
 describe('RequestedServiceItemsTable', () => {

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
@@ -50,20 +50,20 @@ const testDetails = (wrapper) => {
   expect(wrapper.find('.detailType').at(0).text()).toBe('Item Dimensions:');
   expect(wrapper.find('.detail dd').at(0).text()).toBe('7"x2"x3.5"');
 
-  expect(wrapper.find('.detailType').at(1).text()).toBe('First Customer Contact:');
-  expect(wrapper.find('.detail dd').at(1).text().includes('1200Z')).toBe(true);
-  expect(wrapper.find('.detailType').at(2).text()).toBe('First Available Delivery Date:');
-  expect(wrapper.find('.detail dd').at(2).text().includes('15 Sep 2020')).toBe(true);
+  expect(wrapper.find('.detailType').at(2).text()).toBe('First Customer Contact:');
+  expect(wrapper.find('.detail dd').at(2).text().includes('1200Z')).toBe(true);
+  expect(wrapper.find('.detailType').at(3).text()).toBe('First Available Delivery Date:');
+  expect(wrapper.find('.detail dd').at(3).text().includes('15 Sep 2020')).toBe(true);
 
-  expect(wrapper.find('.detailType').at(3).text()).toBe('Second Customer Contact:');
-  expect(wrapper.find('.detail dd').at(3).text().includes('2300Z')).toBe(true);
-  expect(wrapper.find('.detailType').at(4).text()).toBe('Second Available Delivery Date:');
-  expect(wrapper.find('.detail dd').at(4).text().includes('21 Sep 2020')).toBe(true);
+  expect(wrapper.find('.detailType').at(4).text()).toBe('Second Customer Contact:');
+  expect(wrapper.find('.detail dd').at(4).text().includes('2300Z')).toBe(true);
+  expect(wrapper.find('.detailType').at(5).text()).toBe('Second Available Delivery Date:');
+  expect(wrapper.find('.detail dd').at(5).text().includes('21 Sep 2020')).toBe(true);
 
-  expect(wrapper.find('.detailType').at(6).text()).toBe('ZIP:');
-  expect(wrapper.find('.detail dd').at(6).text().includes('20050')).toBe(true);
-  expect(wrapper.find('.detailType').at(5).text()).toBe('Reason:');
-  expect(wrapper.find('.detail dd').at(5).text().includes('Took a detour')).toBe(true);
+  expect(wrapper.find('.detailType').at(7).text()).toBe('ZIP:');
+  expect(wrapper.find('.detail dd').at(7).text().includes('20050')).toBe(true);
+  expect(wrapper.find('.detailType').at(6).text()).toBe('Reason:');
+  expect(wrapper.find('.detail dd').at(6).text().includes('Took a detour')).toBe(true);
 };
 
 describe('RequestedServiceItemsTable', () => {

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -25,7 +25,16 @@ const ServiceItemDetails = ({ id, code, details }) => {
     case 'DOPSIT': {
       detailSection = (
         <div>
-          <dl>{generateDetailText({ ZIP: details.pickupPostalCode, Reason: details.reason }, id)}</dl>
+          <dl>
+            {generateDetailText(
+              {
+                ZIP: details.pickupPostalCode ? details.pickupPostalCode : '-',
+                Reason: details.reason ? details.reason : '-',
+              },
+              id,
+            )}
+            {details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}
+          </dl>
         </div>
       );
       break;
@@ -48,6 +57,8 @@ const ServiceItemDetails = ({ id, code, details }) => {
                 },
                 id,
               )}
+            {!firstCustomerContact &&
+              generateDetailText({ 'First Customer Contact': '-', 'First Available Delivery Date': '-' })}
             <div className={styles.customerContact}>
               {secondCustomerContact &&
                 generateDetailText(
@@ -60,7 +71,11 @@ const ServiceItemDetails = ({ id, code, details }) => {
                   },
                   id,
                 )}
+              {!secondCustomerContact &&
+                generateDetailText({ 'Second Customer Contact': '-', 'Second Available Delivery Date': '-' })}
             </div>
+            {generateDetailText({ Reason: details.reason ? details.reason : '-' })}
+            {details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}
           </dl>
         </div>
       );
@@ -84,6 +99,7 @@ const ServiceItemDetails = ({ id, code, details }) => {
             <p className={styles.detailLine}>{description}</p>
             {itemDimensions && generateDetailText({ 'Item Dimensions': itemDimensionFormat }, id)}
             {crateDimensions && generateDetailText({ 'Crate Dimensions': crateDimensionFormat }, id)}
+            {details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}
           </dl>
         </div>
       );
@@ -99,13 +115,19 @@ const ServiceItemDetails = ({ id, code, details }) => {
               <dd className={styles.detailType}>{estimatedWeight}</dd> <dt>estimated weight</dt>
             </div>
             {generateDetailText({ Reason: details.reason })}
+            {details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}
           </dl>
         </div>
       );
       break;
     }
     default:
-      detailSection = <div>—</div>;
+      detailSection = (
+        <div>
+          <div>—</div>
+          <dl>{details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}</dl>
+        </div>
+      );
   }
   return <div>{detailSection}</div>;
 };

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -99,6 +99,7 @@ const ServiceItemDetails = ({ id, code, details }) => {
             <p className={styles.detailLine}>{description}</p>
             {itemDimensions && generateDetailText({ 'Item Dimensions': itemDimensionFormat }, id)}
             {crateDimensions && generateDetailText({ 'Crate Dimensions': crateDimensionFormat }, id)}
+            {generateDetailText({ Reason: details.reason ? details.reason : '-' })}
             {details.rejectionReason && generateDetailText({ 'Rejection reason': details.rejectionReason }, id)}
           </dl>
         </div>

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
@@ -14,6 +14,8 @@ const details = {
   estimatedWeight: 2500,
 };
 
+const detailsRejectedServiceItem = { ...details, rejectionReason: 'some rejection reason' };
+
 const nilDetails = {
   estimatedWeight: null,
 };
@@ -72,5 +74,18 @@ describe('ServiceItemDetails Domestic Shuttling', () => {
 
     expect(screen.getByText('— lbs')).toBeInTheDocument();
     expect(screen.getByText('estimated weight')).toBeInTheDocument();
+  });
+});
+
+describe('ServiceItemDetails Crating Rejected', () => {
+  it('renders the rejection reason field when it is populated with information', () => {
+    render(<ServiceItemDetails id="1" code="DCRT" details={detailsRejectedServiceItem} />);
+
+    expect(screen.getByText('some description')).toBeInTheDocument();
+    expect(screen.getByText('Item Dimensions:')).toBeInTheDocument();
+    expect(screen.getByText('1"x2.5"x3"')).toBeInTheDocument();
+    expect(screen.getByText('Crate Dimensions:')).toBeInTheDocument();
+    expect(screen.getByText('2"x3.5"x4"')).toBeInTheDocument();
+    expect(screen.getByText('some rejection reason')).toBeInTheDocument();
   });
 });

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -86,6 +86,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
         firstCustomerContact: item.customerContacts?.find((contact) => contact?.type === customerContactTypes.FIRST),
         secondCustomerContact: item.customerContacts?.find((contact) => contact?.type === customerContactTypes.SECOND),
         estimatedWeight: item.estimatedWeight,
+        rejectionReason: item.rejectionReason,
       };
 
       if (serviceItemsForShipment[`${newItem.mtoShipmentID}`]) {

--- a/src/types/serviceItems.js
+++ b/src/types/serviceItems.js
@@ -12,7 +12,6 @@ export const ServiceItemCardShape = PropTypes.shape({
   mtoServiceItemName: PropTypes.string,
   amount: PropTypes.number,
   status: PropTypes.oneOf(Object.values(PAYMENT_SERVICE_ITEM_STATUS)),
-  rejectionReason: PropTypes.string,
   createdAt: PropTypes.string,
   paymentServiceItemParams: PropTypes.arrayOf(PaymentServiceItemParam),
 });
@@ -30,6 +29,7 @@ export const ServiceItemDetailsShape = PropTypes.shape({
   code: PropTypes.string,
   details: PropTypes.shape({
     reason: PropTypes.string,
+    rejectionReason: PropTypes.string,
     description: PropTypes.string,
     pickupPostalCode: PropTypes.string,
     itemDimensions: MTOServiceItemDimensionShape,


### PR DESCRIPTION
## Description

When the TOO navigates to the MTO page they should be able to see the `Reason` and `Rejection reason` fields for the MTO service items where those apply. The `Reason` field should render with a `-` character when the field is nil and the `Rejection reason` field should only render when there is a rejection reason, which allows us to infer that the status of the MTO Service Item is rejected.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

Make sure there's data to mess about with:
```sh
make db_dev_e2e_populate
```
Build and run the office app:
```sh
make server_run
make office_client_run
```
Navigate to the `PARAMS` move and go to its MTO page. There you should see some examples of service items where the fields apply.

To check storybook changes locally:
```sh
make storybook
```



## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots

<img width="823" alt="image" src="https://user-images.githubusercontent.com/4325613/125801406-08ce07dc-0687-49ee-88e8-37ae706693d7.png">

