### PR TITLE
MB-7237-update-validation-display-for-crating

### DIFF
--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -239,8 +239,11 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 				createDimension := &requestedServiceItem.Dimensions[index]
 				createDimension.MTOServiceItemID = requestedServiceItem.ID
 				verrs, err = txBuilder.CreateOne(createDimension)
-				if verrs != nil || err != nil {
-					return fmt.Errorf("%#v %e", verrs, err)
+				if verrs != nil && verrs.HasAny() {
+					return services.NewInvalidInputError(uuid.Nil, nil, verrs, "Failed to create dimensions")
+				}
+				if err != nil {
+					return fmt.Errorf("%e", err)
 				}
 			}
 


### PR DESCRIPTION
## Description

Validation errors were created and passing for crating dimensions, however a small bug in the create_mto_service_item service object caused the validation error to not be displayed if an item dimension was a negative number and would return a 500 Internal Server error instead of a 422 Unprocessable Entity. This change fixes that.

The original PR that added validation for item and crating is:
https://github.com/transcom/mymove/pull/3869/files 

## Reviewer Notes

First remain in the Master branch, then try creating a service item in Postman using the following body to see the 500 error:
```
{
    "modelType": "MTOServiceItemDomesticCrating",
    "moveTaskOrderID": "a416b6c5-c8c2-44b7-8130-d793452ba3b6",
    "mtoShipmentID": "fc1f85b6-63d6-45b9-99fb-fa290da22c20",
    "status": "SUBMITTED",
    "reServiceCode": "DCRT",
    "item": {
        "type": "ITEM",
        "length": -2000,
        "width": 3000,
        "height": 4000
    },
    "crate": {
        "type": "CRATE",
        "length": 3000,
        "width": 4000,
        "height": 5000
    },
    "description": "some description information"
}
```

## Setup

Add any steps or code to run in this section to help others prepare to run your code:
1. switch to this branch
2. Try creating the service item again with the above body 
3. Verify that the response is now:
```
{
    "detail": "Failed to create dimensions",
    "instance": "b3fd935a-bef1-42cb-853d-50fe32a1c788",
    "title": "Validation Error",
    "invalidFields": {
        "length": [
            "-2000 is not greater than -1."
        ]
    }
}
```


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7237) for this change

