### PR TITLE
Fix createHHGWithPaymentServiceItems in devseed

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -650,5 +650,5 @@
 20210629133827_remove_char_limit_payment_service_item_rejection_reason.up.sql
 20210630143013_add_demo_users.up.sql
 20210706214857_felipe_cac.up.sql
-20210714221936_change_cubic_feet_crating_to_decimal.up.sql
 20210713232711_remove_can_stand_alone_parameter.up.sql
+20210714221936_change_cubic_feet_crating_to_decimal.up.sql

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1134,6 +1134,8 @@ func createHHGWithPaymentServiceItems(db *pop.Connection, primeUploader *uploade
 	// called for domestic destination SIT delivery service item
 	planner.On("Zip3TransitDistance", "94535", "90210").Return(348, nil).Once()
 
+	serviceItemCreator.SetConnection(db)
+
 	for _, shipment := range []models.MTOShipment{longhaulShipment, shorthaulShipment} {
 		shipmentUpdater := mtoshipment.NewMTOShipmentStatusUpdater(db, queryBuilder, serviceItemCreator, planner)
 		_, updateErr := shipmentUpdater.UpdateMTOShipmentStatus(shipment.ID, models.MTOShipmentStatusApproved, nil, etag.GenerateEtag(shipment.UpdatedAt))


### PR DESCRIPTION
In PR #6995, we updated the service item creator to allow setting its
DB connection. This was necessary to allow the service item creator to
use the same transaction as the one in `MakeAvailableToPrime`.

The problem is that anytime `MakeAvailableToPrime` is called, the
service item creator's connection will be set to the transaction that
was created in `MakeAvailableToPrime`, and it will stay that way unless
it gets set again.

In `createHHGWithPaymentServiceItems`, we first call
`MakeAvailableToPrime`, and then later on, we approve the shipments by
calling `UpdateMTOShipmentStatus`, which in turn calls the service item
creator, which is now using the transaction connection. However, the
move that's associated with the shipments was created with the initial
DB connection (not a transaction) that was passed into the devseed, and
so it blows up when looking up the move associated with the
shipment.

To fix this, we need to set the service item creator's connection back
to the initial DB connection so that `UpdateMTOShipmentStatus` can work.

This is by no means ideal, and is a result of us not implementing DB
connections The Go Way, and due to our choice (back when this project
started) of not using more established frameworks. We are planning a
refactor to straighten things out.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
