### PR TITLE
MB-8770 Step Component - Edit button focus state

### DIFF
--- a/src/components/Customer/Home/Step/Step.module.scss
+++ b/src/components/Customer/Home/Step/Step.module.scss
@@ -8,11 +8,13 @@
     p {
       margin-bottom: 0;
     }
+
     ul {
       padding: 0 40px;
       margin-top: 0;
       font-size: 1rem;
     }
+
     .edit-btn {
       width: auto;
       margin-right: 0;
@@ -24,11 +26,13 @@
   p {
     margin-bottom: 0;
   }
+
   ul {
     padding: 0 40px;
     margin-top: 0;
     font-size: 1rem;
   }
+
   .edit-btn {
     width: auto;
   }
@@ -78,6 +82,7 @@
 
 .action-btn:disabled {
   pointer-events: auto;
+
   &:disabled:hover {
     cursor: not-allowed;
   }
@@ -92,8 +97,10 @@
   width: 42px;
   text-align: center;
   margin-left: auto;
+
   &:active,
-  &:hover {
+  &:hover,
+  &:focus {
     color: $primary;
     background-color: white;
   }
@@ -104,8 +111,10 @@
   }
 }
 
+
 .edit-btn:disabled {
   pointer-events: auto;
+
   &:disabled:hover {
     cursor: not-allowed;
     background-color: transparent;
@@ -115,10 +124,12 @@
 // TODO: remove when GHC styles are integrated into customer app and migrate to using "secondary" prop on button, you will still need the box-shadow tho since secondary has a different outline
 .action-button--secondary {
   box-shadow: inset 0 0 0 2px $base-lighter;
+
   &:active,
   &:hover {
     box-shadow: inset 0 0 0 2px $base-lighter;
   }
+
   &:focus,
   &:not([disabled]):focus {
     box-shadow: inset 0 0 0 2px $base-lighter;


### PR DESCRIPTION
## Description
This branch adds styling for the edit button in the step component to ensure it remains legible when focused. Before, it was getting a dark blue background, making it too hard to read the blue text of the button. Now, when focused, it gets a blue outline and follows the `:hover` styles.

## Reviewer Notes

This is pretty straightforward, 1 line of code added to a css module.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
yarn storybook
```

- Open [step component](http://localhost:6006/?path=/story/customer-components-step--profile-complete)
- press tab key to focus the edit button

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8770?atlOrigin=eyJpIjoiZThkZGUwNTA2MTljNGQ2ZThlMzgwNDc4MjdlODFlMmMiLCJwIjoiaiJ9) for this change

## Screenshots
Before
----------------
<img width="463" alt="image" src="https://user-images.githubusercontent.com/59394696/126229528-deb09f8f-750d-41df-8cf1-1637f21c6fcc.png">


After
------------
<img width="471" alt="image" src="https://user-images.githubusercontent.com/59394696/126229445-c397f801-5e5c-48c6-90fa-b984cd7ad71a.png">
