### PR TITLE
MB-8769 Fix a11y test failures on FileUplaod component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,4 +13,10 @@ export const parameters = {
       order: ['Global', 'Components', 'Office Components', 'Customer Components'],
     },
   },
+  a11y: {
+    // axe-core configurationOptions (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#parameters-1)
+    config: {},
+    // axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
+    options: {},
+  },
 };


### PR DESCRIPTION
## Description

We were seeing color contrast failures on the FileUpload component, which was a bit confusing because it was designed with AA contrast standards in mind. Turns, out our storybook a11y addon was checking contrast at the AAA level, which we are not required to adhere to. So this branch sets to back to AA in our add-on configuration.

## Reviewer Notes

A remaining issue is there about being unable to focus content. This is related to the markup of the `FileUpload` component, the markup of which comes from [FilePond]( https://github.com/pqina/react-filepond/). I think the next step here would be to submit the failure as an issue to FilePond, since it cannot be easily remediated on our end.

## Setup


```sh
yarn storybook
```
http://localhost:6006/?path=/story/components-fileupload--file-upload-success 

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story]((https://dp3.atlassian.net/browse/MB-8769?atlOrigin=eyJpIjoiNTBlYjNhNDgwN2JhNDJiY2EwYzMzYmRkMjZiNjY0MDkiLCJwIjoiaiJ9) for this change

## Screenshots

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/59394696/126238239-ee2c9a2a-5a83-4794-b81b-e2489a91aebf.png">

