### PR TITLE
MB-5446: bump docker postgres to 12.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: '2.1'
 references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-75d11654ab683e5d8b7889aa02bfdcff25e1269f
 
-  postgres: &postgres postgres:12.4
+  postgres: &postgres postgres:12.7
 
 executors:
   av_medium:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/transcom-infrasec-com/blob/c32c45078f29ea6fd58b0c246f994dbea91be372/transcom-com-legacy/app-prod/main.tf#L62
-DB_DOCKER_CONTAINER_IMAGE = postgres:12.4
+DB_DOCKER_CONTAINER_IMAGE = postgres:12.7
 REDIS_DOCKER_CONTAINER_IMAGE = redis:5.0.6
 REDIS_DOCKER_CONTAINER = milmove-redis
 TASKS_DOCKER_CONTAINER = tasks

--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=mysecretpassword

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.mtls_local.yml
+++ b/docker-compose.mtls_local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.prime.yml
+++ b/docker-compose.prime.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.reviewapp.yml
+++ b/docker-compose.reviewapp.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   database_review:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:12.4
+    image: postgres:12.7
     restart: always
     ports:
       - '6432:5432'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -47,10 +47,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "postgresql-12.4";
+      name = "postgresql-12.7";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "db2de55cbe4258f223ca7af0ace34fce9046d731";
+      rev = "860b56be91fb874d48e23a950815969a7b832fbc";
     }) {}).postgresql_12
 
     (import (builtins.fetchGit {


### PR DESCRIPTION
## Description

Our PostgreSQL servers running in RDS are using 12.7. This change makes it so our Docker systems also use 12.7.

## Reviewer Notes

I'm not sure if I did the nix update correctly. I followed the [instructions at the top of the default.nix file](https://github.com/transcom/mymove/blob/0074d7090d579fe0af0067a8fa968fa8082ebb40/nix/default.nix#L4-L7), which took me to [this page](https://lazamar.co.uk/nix-versions/?package=postgresql&version=12.7&fullName=postgresql-12.7&keyName=postgresql_12&revision=860b56be91fb874d48e23a950815969a7b832fbc&channel=nixpkgs-unstable#instructions), which gave me the `860b56be91fb874d48e23a950815969a7b832fbc` hash. If that hash should be something else, please let me know.

## Setup

I ran these commands and loaded the site locally:

```sh
make server_run
make client_build
make client_run
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5446) for this change