### PR TITLE
MB-8796 Display SITPostalCode in MTO tab

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3016,6 +3016,11 @@ func init() {
         "description"
       ],
       "properties": {
+        "SITPostalCode": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "approvedAt": {
           "type": "string",
           "format": "date-time",
@@ -8075,6 +8080,11 @@ func init() {
         "description"
       ],
       "properties": {
+        "SITPostalCode": {
+          "type": "string",
+          "x-nullable": true,
+          "readOnly": true
+        },
         "approvedAt": {
           "type": "string",
           "format": "date-time",

--- a/pkg/gen/ghcmessages/m_t_o_service_item.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item.go
@@ -19,6 +19,10 @@ import (
 // swagger:model MTOServiceItem
 type MTOServiceItem struct {
 
+	// s i t postal code
+	// Read Only: true
+	SITPostalCode *string `json:"SITPostalCode,omitempty"`
+
 	// approved at
 	// Format: date-time
 	ApprovedAt *strfmt.DateTime `json:"approvedAt,omitempty"`

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -481,6 +481,7 @@ func MTOServiceItemModel(s *models.MTOServiceItem) *ghcmessages.MTOServiceItem {
 		Reason:           handlers.FmtStringPtr(s.Reason),
 		RejectionReason:  handlers.FmtStringPtr(s.RejectionReason),
 		PickupPostalCode: handlers.FmtStringPtr(s.PickupPostalCode),
+		SITPostalCode:    handlers.FmtStringPtr(s.SITPostalCode),
 		Status:           ghcmessages.MTOServiceItemStatus(s.Status),
 		Description:      handlers.FmtStringPtr(s.Description),
 		Dimensions:       MTOServiceItemDimensions(s.Dimensions),

--- a/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
+++ b/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
@@ -115,6 +115,7 @@ RejectServiceItemModal.propTypes = {
     details: PropTypes.shape({
       description: PropTypes.string,
       pickupPostalCode: PropTypes.string,
+      SITPostalCode: PropTypes.string,
       reason: PropTypes.string,
       itemDimensions: PropTypes.shape({ length: PropTypes.number, width: PropTypes.number, height: PropTypes.number }),
       crateDimensions: PropTypes.shape({ length: PropTypes.number, width: PropTypes.number, height: PropTypes.number }),

--- a/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
+++ b/src/components/Office/RejectServiceItemModal/RejectServiceItemModal.jsx
@@ -12,6 +12,7 @@ import { Form } from 'components/form';
 import TextField from 'components/form/fields/TextField';
 import { Modal, ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import ServiceItemDetails from 'components/Office/ServiceItemDetails/ServiceItemDetails';
+import { ServiceItemDetailsShape } from 'types/serviceItems';
 import { formatDateFromIso } from 'shared/formatters';
 import { SERVICE_ITEM_STATUS } from 'shared/constants';
 
@@ -103,28 +104,7 @@ const RejectServiceItemModal = ({ serviceItem, onSubmit, onClose }) => {
 };
 
 RejectServiceItemModal.propTypes = {
-  serviceItem: PropTypes.shape({
-    id: PropTypes.string,
-    mtoShipmentID: PropTypes.string,
-    code: PropTypes.string,
-    status: PropTypes.string,
-    serviceItem: PropTypes.string,
-    createdAt: PropTypes.string,
-    rejectedAt: PropTypes.string,
-    approvedAt: PropTypes.string,
-    details: PropTypes.shape({
-      description: PropTypes.string,
-      pickupPostalCode: PropTypes.string,
-      SITPostalCode: PropTypes.string,
-      reason: PropTypes.string,
-      itemDimensions: PropTypes.shape({ length: PropTypes.number, width: PropTypes.number, height: PropTypes.number }),
-      crateDimensions: PropTypes.shape({ length: PropTypes.number, width: PropTypes.number, height: PropTypes.number }),
-      firstCustomerContact: PropTypes.shape({
-        timeMilitary: PropTypes.string,
-        firstAvailableDeliveryDate: PropTypes.string,
-      }),
-    }),
-  }).isRequired,
+  serviceItem: ServiceItemDetailsShape.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.stories.jsx
@@ -20,6 +20,7 @@ const serviceItems = [
     status: 'SUBMITTED',
     details: {
       pickupPostalCode: '60612',
+      SITPostalCode: '22030',
       reason: "here's the reason",
     },
   },

--- a/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
+++ b/src/components/Office/RequestedServiceItemsTable/RequestedServiceItemsTable.test.jsx
@@ -41,6 +41,7 @@ const serviceItemWithDetails = {
   code: 'DOFSIT',
   details: {
     pickupPostalCode: '20050',
+    SITPostalCode: '12345',
     reason: 'Took a detour',
   },
 };
@@ -61,7 +62,7 @@ const testDetails = (wrapper) => {
   expect(wrapper.find('.detail dd').at(5).text().includes('21 Sep 2020')).toBe(true);
 
   expect(wrapper.find('.detailType').at(7).text()).toBe('ZIP:');
-  expect(wrapper.find('.detail dd').at(7).text().includes('20050')).toBe(true);
+  expect(wrapper.find('.detail dd').at(7).text().includes('12345')).toBe(true);
   expect(wrapper.find('.detailType').at(6).text()).toBe('Reason:');
   expect(wrapper.find('.detail dd').at(6).text().includes('Took a detour')).toBe(true);
 };

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.jsx
@@ -28,7 +28,7 @@ const ServiceItemDetails = ({ id, code, details }) => {
           <dl>
             {generateDetailText(
               {
-                ZIP: details.pickupPostalCode ? details.pickupPostalCode : '-',
+                ZIP: details.SITPostalCode ? details.SITPostalCode : '-',
                 Reason: details.reason ? details.reason : '-',
               },
               id,

--- a/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
+++ b/src/components/Office/ServiceItemDetails/ServiceItemDetails.test.jsx
@@ -6,6 +6,7 @@ import ServiceItemDetails from './ServiceItemDetails';
 const details = {
   description: 'some description',
   pickupPostalCode: '90210',
+  SITPostalCode: '12345',
   reason: 'some reason',
   itemDimensions: { length: 1000, width: 2500, height: 3000 },
   crateDimensions: { length: 2000, width: 3500, height: 4000 },
@@ -25,7 +26,7 @@ describe('ServiceItemDetails Domestic Origin SIT', () => {
     render(<ServiceItemDetails id="1" code={code} details={details} />);
 
     expect(screen.getByText('ZIP:')).toBeInTheDocument();
-    expect(screen.getByText('90210')).toBeInTheDocument();
+    expect(screen.getByText('12345')).toBeInTheDocument();
     expect(screen.getByText('Reason:')).toBeInTheDocument();
     expect(screen.getByText('some reason')).toBeInTheDocument();
   });

--- a/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
+++ b/src/components/Office/ServiceItemsTable/ServiceItemsTable.test.jsx
@@ -95,7 +95,7 @@ describe('ServiceItemsTable', () => {
     expect(wrapper.find('dd').at(3).text()).toBe('01 Jan 2021');
   });
 
-  it('should render a zip and reason for DOFSIT service item', () => {
+  it('should render the SITPostalCode ZIP, and reason for DOFSIT service item', () => {
     const serviceItems = [
       {
         id: 'abc123',
@@ -104,6 +104,7 @@ describe('ServiceItemsTable', () => {
         code: 'DOFSIT',
         details: {
           pickupPostalCode: '11111',
+          SITPostalCode: '12345',
           reason: 'This is the reason',
         },
       },
@@ -117,7 +118,7 @@ describe('ServiceItemsTable', () => {
       />,
     );
     expect(wrapper.find('dt').at(0).contains('ZIP')).toBe(true);
-    expect(wrapper.find('dd').at(0).contains('11111')).toBe(true);
+    expect(wrapper.find('dd').at(0).contains('12345')).toBe(true);
     expect(wrapper.find('dt').at(1).contains('Reason')).toBe(true);
     expect(wrapper.find('dd').at(1).contains('This is the reason')).toBe(true);
   });

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -79,6 +79,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
       newItem.serviceItem = item.reServiceName;
       newItem.details = {
         pickupPostalCode: item.pickupPostalCode,
+        SITPostalCode: item.SITPostalCode,
         reason: item.reason,
         description: item.description,
         itemDimensions: item.dimensions?.find((dimension) => dimension?.type === dimensionTypes.ITEM),

--- a/src/types/order.js
+++ b/src/types/order.js
@@ -124,6 +124,7 @@ export const MTOServiceItemShape = PropTypes.shape({
   moveTaskOrderID: PropTypes.string,
   mtoShipmentID: PropTypes.string,
   pickupPostalCode: PropTypes.string,
+  SITPostalCode: PropTypes.string,
   reServiceCode: PropTypes.string,
   reServiceID: PropTypes.string,
   reServiceName: PropTypes.string,

--- a/src/types/serviceItems.js
+++ b/src/types/serviceItems.js
@@ -32,6 +32,7 @@ export const ServiceItemDetailsShape = PropTypes.shape({
     rejectionReason: PropTypes.string,
     description: PropTypes.string,
     pickupPostalCode: PropTypes.string,
+    SITPostalCode: PropTypes.string,
     itemDimensions: MTOServiceItemDimensionShape,
     crateDimensions: MTOServiceItemDimensionShape,
     firstCustomerContact: MTOServiceItemCustomerContactShape,

--- a/src/types/serviceItems.js
+++ b/src/types/serviceItems.js
@@ -27,6 +27,7 @@ export const ServiceItemDetailsShape = PropTypes.shape({
   rejectedAt: PropTypes.string,
   serviceItem: PropTypes.string,
   code: PropTypes.string,
+  status: PropTypes.string,
   details: PropTypes.shape({
     reason: PropTypes.string,
     rejectionReason: PropTypes.string,

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2930,6 +2930,10 @@ definitions:
         x-nullable: true
       pickupPostalCode:
         type: string
+      SITPostalCode:
+        type: string
+        readOnly: true
+        x-nullable: true
       feeType:
         enum:
           - COUNSELING


### PR DESCRIPTION
## Description

For domestic origin SIT service items, the ZIP displayed to the TOO in
the Move Task Order details should represent the `SITPostalCode` as
supplied by the Prime. This is the location of the SIT facility.
Previously, we were displaying the `pickupPostalCode`, which is where
the shipment was picked up.

## Reviewer Notes

1. Sign in as a TOO
2. Look for the Move with the Move Code `PARAMS`
3. Click on the Move task order tab
4. Scroll down until you see the 3 Domestic Origin service items
5. The ZIP should show 94535
6. Click on "Reject"
7. The ZIP in the modal should show 94535

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8796) for this change

## Screenshots

<img width="1669" alt="Screen Shot 2021-07-20 at 10 14 50" src="https://user-images.githubusercontent.com/811150/126342118-5398b353-c071-4231-b7c1-8f4e5c82e602.png">


<img width="857" alt="Screen Shot 2021-07-20 at 10 18 09" src="https://user-images.githubusercontent.com/811150/126342104-74a0fda7-78a7-4667-8b15-7ccd49122384.png">

