### PR TITLE
[MB-8798] Fix deprecation warning for pdf files in the document viewer progress callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
+    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer#ds-pdfjs-getDocument-deprecation",
     "@trussworks/react-uswds": "^2.0.0",
     "bytes": "^3.0.0",
     "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer#ds-pdfjs-getDocument-deprecation",
+    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
     "@trussworks/react-uswds": "^2.0.0",
     "bytes": "^3.0.0",
     "classnames": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,9 +3600,9 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer":
+"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer#ds-pdfjs-getDocument-deprecation":
   version "1.2.1"
-  resolved "https://github.com/trussworks/react-file-viewer#5344ad893ce5b4e0038b4d8956b281154ce49ae3"
+  resolved "https://github.com/trussworks/react-file-viewer#1be484c80160c40f8eec83e833186d90bb63b291"
   dependencies:
     pdfjs-dist "1.8.357"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,9 +3600,9 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer#ds-pdfjs-getDocument-deprecation":
+"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer":
   version "1.2.1"
-  resolved "https://github.com/trussworks/react-file-viewer#6dfbf8a5b6b03c6b52f5ee972681fbf5667f1e96"
+  resolved "https://github.com/trussworks/react-file-viewer#fe70df7fe43d96a4cdc4a5314ed0496d6a84f495"
   dependencies:
     pdfjs-dist "1.8.357"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,7 +3602,7 @@
 
 "@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer#ds-pdfjs-getDocument-deprecation":
   version "1.2.1"
-  resolved "https://github.com/trussworks/react-file-viewer#1be484c80160c40f8eec83e833186d90bb63b291"
+  resolved "https://github.com/trussworks/react-file-viewer#6dfbf8a5b6b03c6b52f5ee972681fbf5667f1e96"
   dependencies:
     pdfjs-dist "1.8.357"
     prop-types "^15.5.10"


### PR DESCRIPTION
## Description

This PR updates our document viewer library `react-file-viewer` fork to use changes to no longer use the deprecated getDocument function with the progress loading callback https://github.com/trussworks/react-file-viewer/pull/5.  This only applies the loading of PDF files in the orders or payment requests document viewer so make sure you are looking at uploads that are not images.

When that PR gets merged into master I will update the package.json to no longer resolve to using the branch name.

It looks like we're still seeing another warning about an undefined function but we will need to upgrade pdf.js to eventually get rid of this https://github.com/mozilla/pdf.js/issues/3768

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as a TOO user
2. Find the move from the queue with locator `AMDORD` http://officelocal:3000/moves/AMDORD/orders
3. Navigate to the Edit Orders page if you have not gone there directly
4. Open the devtools browser console `option + command + i` or from the Tools -> Browser Tools -> Web Developer Tools menu in Firefox.
5. Verify there is no more deprecation warning logged to the console when the small.pdf document is loaded.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8798) for this change

## Screenshots

<img width="1676" alt="Screen Shot 2021-07-13 at 2 16 04 PM" src="https://user-images.githubusercontent.com/52669884/126516400-ffa3713f-1662-461d-b416-407ef3815e92.png">

<img width="1678" alt="Screen Shot 2021-07-21 at 10 30 11 AM" src="https://user-images.githubusercontent.com/52669884/126514035-2815d41f-5c3f-41a4-8280-62eb2c492fdc.png">
