### PR TITLE
[MB-7250] Add invoice support for origin/destination shuttle service

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -697,7 +697,8 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
 			models.ReServiceCodeDPK, models.ReServiceCodeDDP,
 			models.ReServiceCodeDDFSIT, models.ReServiceCodeDDASIT,
-			models.ReServiceCodeDOFSIT, models.ReServiceCodeDOASIT:
+			models.ReServiceCodeDOFSIT, models.ReServiceCodeDOASIT,
+			models.ReServiceCodeDOSHUT, models.ReServiceCodeDDSHUT:
 			var err error
 			weight, err := g.getWeightParams(serviceItem)
 			if err != nil {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
+	"github.com/transcom/mymove/pkg/unit"
 
 	"go.uber.org/zap"
 )
@@ -119,12 +120,14 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		},
 	})
 
+	priceCents := unit.Cents(888)
 	assertions := testdatagen.Assertions{
 		Move:           mto,
 		MTOShipment:    mtoShipment,
 		PaymentRequest: paymentRequest,
 		PaymentServiceItem: models.PaymentServiceItem{
-			Status: models.PaymentServiceItemStatusApproved,
+			Status:     models.PaymentServiceItemStatusApproved,
+			PriceCents: &priceCents,
 		},
 	}
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -207,6 +207,18 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		basicPaymentServiceItemParams,
 		assertions,
 	)
+	doshut := testdatagen.MakePaymentServiceItemWithParams(
+		suite.DB(),
+		models.ReServiceCodeDOSHUT,
+		basicPaymentServiceItemParams,
+		assertions,
+	)
+	ddshut := testdatagen.MakePaymentServiceItemWithParams(
+		suite.DB(),
+		models.ReServiceCodeDDSHUT,
+		basicPaymentServiceItemParams,
+		assertions,
+	)
 
 	distanceZipSITDestParam := testdatagen.CreatePaymentServiceItemParams{
 		Key:     models.ServiceItemParamNameDistanceZipSITDest,
@@ -234,7 +246,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		assertions,
 	)
 
-	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk, ddfsit, ddasit, dofsit, doasit, dddsit, dopsit)
+	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk, ddfsit, ddasit, dofsit, doasit, doshut, ddshut, dddsit, dopsit)
 
 	serviceMember := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -300,7 +312,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("se segment has correct value", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(128, result.SE.NumberOfIncludedSegments)
+		suite.Equal(142, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -532,7 +544,8 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		case models.ReServiceCodeDOP, models.ReServiceCodeDUPK,
 			models.ReServiceCodeDPK, models.ReServiceCodeDDP,
 			models.ReServiceCodeDDFSIT, models.ReServiceCodeDDASIT,
-			models.ReServiceCodeDOFSIT, models.ReServiceCodeDOASIT:
+			models.ReServiceCodeDOFSIT, models.ReServiceCodeDOASIT,
+			models.ReServiceCodeDOSHUT, models.ReServiceCodeDDSHUT:
 			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
 				l5 := result.ServiceItems[segmentOffset].L5
 				suite.Equal(hierarchicalNumberInt, l5.LadingLineItemNumber)
@@ -609,7 +622,8 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("adds l3 service item segment", func(t *testing.T) {
 		l3 := result.L3
-		suite.Equal(int64(13320), l3.PriceCents)
+		// Will need to be updated as more service items are supported
+		suite.Equal(int64(15096), l3.PriceCents)
 	})
 }
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -1,11 +1,3 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used set up environment variables
-//RA: Given the functions causing the lint errors are used to set environment variables for testing purposes, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
-// nolint:errcheck
 package invoice
 
 import (
@@ -258,7 +250,8 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	})
 
 	// setup known next value
-	suite.icnSequencer.SetVal(122)
+	icnErr := suite.icnSequencer.SetVal(122)
+	suite.NoError(icnErr)
 
 	// Proceed with full EDI Generation tests
 	result, err := generator.Generate(paymentRequest, false)
@@ -674,6 +667,7 @@ func (suite *GHCInvoiceSuite) TestOnlyMsandCsGenerateEdi() {
 	_, err := generator.Generate(paymentRequest, false)
 	suite.NoError(err)
 }
+
 func (suite *GHCInvoiceSuite) TestNilValues() {
 	mockClock := clock.NewMock()
 	currentTime := mockClock.Now()


### PR DESCRIPTION
## Description

This PR adds support for origin and destination shuttle service (`DOSHUT` and `DDSHUT`) to invoicing.

## Reviewer Notes

- I used [this PR](https://github.com/transcom/mymove/pull/7001) as a guide as to what fields needed to change.  Note that it dealt with both shuttle service and crating.  Shuttle service didn't seem to require changes to our EDI segments, although crating looks like it will.  Since this PR only covered shuttling, I left the EDI changes for the crating invoice story.
- I noticed a couple other small things to fix in the invoice code as I was working on the PR; I'll add comments inline for those.

## Setup

### On local development ###

First, do a clean build on this branch, reset the database with E2E data, and start the server and client:
- `make clean server_build client_build build_tools`
- `make db_dev_reset db_dev_e2e_populate`
- `make server_run`
- `make client_run`

Now, referencing IDs in the E2E data, let's create a payment request on a move (locator `HMMPDV`) with domestic origin (`DOSHUT`) and domestic destination (`DDSHUT`) service items.  Put the JSON below into a `create_payment_request.json` file:

```json
{
  "body": {
    "isFinal": false,
    "moveTaskOrderID": "d4d95b22-2d9d-428b-9a11-284455aa87ba",
    "serviceItems": [
      {
        "id": "801c8cdb-1573-40cc-be5f-d0a24034894b"
      },
      {
        "id": "2b0ce635-d71b-4000-a22a-7c098a3b6ae9"
      }
    ]
  }
}
```

Then, let's create the payment request using that file:

`prime-api-client --insecure create-payment-request --filename create_payment_request.json | jq`

Now that we have a payment request for this move ID, login to the office UI using the `tio_role@office.mil` local sign in and go to it (you may want to first find the locator for the move in your local DB).  Go to the Payment Requests tab and find the payment request that you created above with the shuttling service items.  Review the service items and approve each one and authorize the payment request.  Once you've done this, you should be able to see the detailed calculations for those service items in the UI.

Next, let's generate EDI for that payment request.  Create a file called `generate_edi.json` with these contents:

```json
{
  "paymentRequestID": "<payment request ID>"
}
```

You'll need the payment request ID from the JSON returned when creating the payment request earlier.  Alternatively, you can find it in your local database.  Once you've got your file ready, let's generate some EDI:

`prime-api-client --insecure support-get-payment-request-edi --filename generate_edi.json | jq -r .edi`

If successful, you should see the EDI returned.  There should be two sections that start with `HL` and go through `FA2`.  Those are the `DOSHUT` and `DDSHUT` service items.  Verify that the values there seem to be in sync with the payment request.

### Acceptance ###

TBD

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7250) for this change
