### PR TITLE
Enables Milmove system to handle repeated orders amendment cycles

### DIFF
--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -71,7 +71,7 @@ func (router moveRouter) Submit(move *models.Move) error {
 				ordersForMove.AmendedOrdersAcknowledgedAt = nil
 				_, err = tx.ValidateAndSave(&ordersForMove)
 				if err != nil {
-					router.logger.Error("failure resetting orders AmendedOrdersAcknowledgeAt field when routing move with amended orders to office user / TOO queue", zap.Error(err))
+					router.logger.Error("failure resetting orders AmendedOrdersAcknowledgeAt field when routing move submission with amended orders ", zap.Error(err))
 					return err
 				}
 				router.logger.Info("Successfully reset orders acknowledgement")

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -48,10 +48,38 @@ func (router moveRouter) Submit(move *models.Move) error {
 		}
 		router.logger.Info("SUCCESS: Move sent to services counseling")
 	} else if move.Orders.UploadedAmendedOrders != nil {
-		err = router.SendToOfficeUser(move)
-		if err != nil {
-			router.logger.Error("failure routing move with amended orders to office user / TOO queue", zap.Error(err))
-			return err
+		router.logger.Info("Move has amended orders")
+		transactionError := router.db.Transaction(func(tx *pop.Connection) error {
+			err = router.SendToOfficeUser(move)
+			if err != nil {
+				router.logger.Error("failure routing move with amended orders to office user / TOO queue", zap.Error(err))
+				return err
+			}
+			// Let's get the orders for this move so we can wipe out the acknowledgement if it exists already (from a prior orders amendment process)
+			var ordersForMove models.Order
+			err = router.db.Find(&ordersForMove, move.OrdersID)
+			if err != nil {
+				return err
+			}
+			// Here we'll nil out the value (if it's set already) so that on the client-side we'll see view this change
+			// in status as 'new orders' that need acknowledging by the TOO.
+			// We shouldn't need more complicated logic here since we only hit this point from calling Submit().
+			// Other circumstances like new MTOServiceItems will be calling SendToOfficeUser() directly.
+			router.logger.Info("Determining whether there is a preexisting orders acknowledgement")
+			if ordersForMove.AmendedOrdersAcknowledgedAt != nil {
+				router.logger.Info("Move has a preexisting acknowledgement")
+				ordersForMove.AmendedOrdersAcknowledgedAt = nil
+				_, err = router.db.ValidateAndSave(&ordersForMove)
+				if err != nil {
+					router.logger.Error("failure resetting orders AmendedOrdersAcknowledgeAt field when routing move with amended orders to office user / TOO queue", zap.Error(err))
+					return err
+				}
+				router.logger.Info("Successfully reset orders acknowledgement")
+			}
+			return nil
+		})
+		if transactionError != nil {
+			return transactionError
 		}
 		router.logger.Info("SUCCESS: Move with amended orders sent to office user / TOO queue")
 	} else {

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -52,7 +52,7 @@ func (router moveRouter) Submit(move *models.Move) error {
 		transactionError := router.db.Transaction(func(tx *pop.Connection) error {
 			err = router.SendToOfficeUser(move)
 			if err != nil {
-				router.logger.Error("failure routing move with amended orders to office user / TOO queue", zap.Error(err))
+				router.logger.Error("failure routing move submission with amended orders", zap.Error(err))
 				return err
 			}
 			// Let's get the orders for this move so we can wipe out the acknowledgement if it exists already (from a prior orders amendment process)

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -57,7 +57,7 @@ func (router moveRouter) Submit(move *models.Move) error {
 			}
 			// Let's get the orders for this move so we can wipe out the acknowledgement if it exists already (from a prior orders amendment process)
 			var ordersForMove models.Order
-			err = router.db.Find(&ordersForMove, move.OrdersID)
+			err = tx.Find(&ordersForMove, move.OrdersID)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ func (router moveRouter) Submit(move *models.Move) error {
 			if ordersForMove.AmendedOrdersAcknowledgedAt != nil {
 				router.logger.Info("Move has a preexisting acknowledgement")
 				ordersForMove.AmendedOrdersAcknowledgedAt = nil
-				_, err = router.db.ValidateAndSave(&ordersForMove)
+				_, err = tx.ValidateAndSave(&ordersForMove)
 				if err != nil {
 					router.logger.Error("failure resetting orders AmendedOrdersAcknowledgeAt field when routing move with amended orders to office user / TOO queue", zap.Error(err))
 					return err


### PR DESCRIPTION

## Description

These changes should make it so that when the customer uploads an additional orders amendment after the first one, that the TOO app will be able to notice and flag the new set of orders in the same way that occurs when this happens for the first time. The way this is handled is by ensuring that when we go through the `MoveRouter.Submit()` path that we clear out the orders acknowledgement data field for their `Orders` if it already exists. This then allows the flags to reset on the client side on the office app and effectively puts things in the expected situation when an orders amendment process starts.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
# get some data
make db_dev_e2e_populate

# start your server and client up
make server_run
make client_run
```

Once you're up and running you can navigate over to the `AMENDO` move in the office app and make sure that things are all approved. After that, log in as the customer for this move: `hhg@multiple.pickup.amendedOrders.submitted` and go ahead and upload a new orders document. When you hit save after uploading you should then be able to go look at the same move as a TOO and see the flag along with the status change to `Approvals Requested`.

By flag, I mean this visual:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/4325613/126547390-514cc6fa-85b6-42d8-b14f-d17cc1fbde6a.png">


## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

