### PR TITLE
MB-8801 add system error component

### DIFF
--- a/src/components/SystemError/SystemError.stories.jsx
+++ b/src/components/SystemError/SystemError.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import SystemError from './index';
+
+export default {
+  title: 'Components/System Error',
+  parameters: {
+    abstract: {
+      url: 'https://share.goabstract.com/d9ad20e6-944c-48a2-bbd2-1c7ed8bc1315?mode=design',
+    },
+  },
+};
+
+export const SystemErrorComponent = () => <SystemError />;

--- a/src/components/SystemError/SystemError.test.jsx
+++ b/src/components/SystemError/SystemError.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import SystemError from './index';
+
+describe('SystemError component', () => {
+  it('renders without crashing', () => {
+    render(<SystemError />);
+    expect(screen.getByText(/contact the Technical Help Desk and give them this code:/)).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemError/index.jsx
+++ b/src/components/SystemError/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const SystemError = () => (
+  <div className="usa-alert--system-error">
+    Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again. If that doesn&apos;t fix
+    it, contact the Technical Help Desk and give them this code: <strong>[trace ID]</strong>.
+  </div>
+);
+
+export default SystemError;


### PR DESCRIPTION
## Description

We want a general error that we can display on the Office and Customer apps when there are errors outside of the user’s control. This PR creates a SystemError component and adds it to storybook.

## Setup

```sh
make storybook
```
http://localhost:6006/?path=/story/components-system-error--system-error-component

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8801) for this change
