### PR TITLE
MB-8252 TIO can see pricing details for Domestic Crating

### DIFF
--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -74,6 +74,7 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 		query.NewQueryAssociation("DestinationAddress"),
 		query.NewQueryAssociation("SecondaryPickupAddress"),
 		query.NewQueryAssociation("SecondaryDeliveryAddress"),
+		query.NewQueryAssociation("MTOServiceItems.Dimensions"),
 	})
 
 	queryOrder := query.NewQueryOrder(swag.String("created_at"), swag.Bool(true))

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1317,28 +1317,7 @@ func createHHGWithPaymentServiceItems(db *pop.Connection, primeUploader *uploade
 		Stub:        true,
 	})
 
-	standaloneDesc := "baby grand piano"
-	standaloneReason := "in a Billy Joel cover band"
-	cratingStandalone := testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDCRTSA,
-		},
-		MTOServiceItem: models.MTOServiceItem{
-			Description: &standaloneDesc,
-			Reason:      &standaloneReason,
-			Dimensions: models.MTOServiceItemDimensions{
-				itemDimension,
-				crateDimension,
-			},
-			Status:     models.MTOServiceItemStatusApproved,
-			ApprovedAt: &approvedAt,
-		},
-		Move:        move,
-		MTOShipment: longhaulShipment,
-		Stub:        true,
-	})
-
-	cratingServiceItems := []models.MTOServiceItem{crating, uncrating, cratingStandalone}
+	cratingServiceItems := []models.MTOServiceItem{crating, uncrating}
 	for index := range cratingServiceItems {
 		_, _, cratingErr := serviceItemCreator.CreateMTOServiceItem(&cratingServiceItems[index])
 		if cratingErr != nil {

--- a/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
+++ b/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
@@ -8,10 +8,11 @@ import styles from './ExpandableServiceItemRow.module.scss';
 import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
 import { allowedServiceItemCalculations } from 'constants/serviceItems';
 import { PaymentServiceItemShape } from 'types';
+import { MTOServiceItemShape } from 'types/order';
 import { formatCents, toDollarString } from 'shared/formatters';
 import ServiceItemCalculations from 'components/Office/ServiceItemCalculations/ServiceItemCalculations';
 
-const ExpandableServiceItemRow = ({ serviceItem, index, disableExpansion }) => {
+const ExpandableServiceItemRow = ({ serviceItem, additionalServiceItemData, index, disableExpansion }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const canClickToExpandContent = (canShowExpandableContent, item) => {
     return canShowExpandableContent && item.status !== PAYMENT_SERVICE_ITEM_STATUS.REQUESTED;
@@ -78,6 +79,7 @@ const ExpandableServiceItemRow = ({ serviceItem, index, disableExpansion }) => {
               itemCode={serviceItem.mtoServiceItemCode}
               totalAmountRequested={serviceItem.priceCents}
               serviceItemParams={serviceItem.paymentServiceItemParams}
+              additionalServiceItemData={additionalServiceItemData}
             />
           </td>
         </tr>
@@ -90,10 +92,12 @@ ExpandableServiceItemRow.propTypes = {
   serviceItem: PaymentServiceItemShape.isRequired,
   index: PropTypes.number.isRequired,
   disableExpansion: PropTypes.bool,
+  additionalServiceItemData: MTOServiceItemShape,
 };
 
 ExpandableServiceItemRow.defaultProps = {
   disableExpansion: false,
+  additionalServiceItemData: {},
 };
 
 export default ExpandableServiceItemRow;

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -51,7 +51,7 @@ const PaymentRequestCard = ({ paymentRequest, shipmentsInfo, history }) => {
 
   if (paymentRequest.serviceItems) {
     paymentRequest.serviceItems.forEach((item) => {
-      if (item.priceCents !== undefined) {
+      if (item.priceCents != null) {
         requestedAmount += item.priceCents;
 
         if (item.status === 'APPROVED') {

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -51,12 +51,14 @@ const PaymentRequestCard = ({ paymentRequest, shipmentsInfo, history }) => {
 
   if (paymentRequest.serviceItems) {
     paymentRequest.serviceItems.forEach((item) => {
-      requestedAmount += item.priceCents;
+      if (item.priceCents !== undefined) {
+        requestedAmount += item.priceCents;
 
-      if (item.status === 'APPROVED') {
-        approvedAmount += item.priceCents;
-      } else if (item.status === 'DENIED') {
-        rejectedAmount += item.priceCents;
+        if (item.status === 'APPROVED') {
+          approvedAmount += item.priceCents;
+        } else if (item.status === 'DENIED') {
+          rejectedAmount += item.priceCents;
+        }
       }
     });
 

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -8,6 +8,7 @@ import styles from './PaymentRequestDetails.module.scss';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { PaymentServiceItemShape } from 'types';
+import { MTOServiceItemShape } from 'types/order';
 import { formatDateFromIso } from 'shared/formatters';
 import PAYMENT_REQUEST_STATUSES from 'constants/paymentRequestStatus';
 import { shipmentModificationTypes } from 'constants/shipments';
@@ -30,10 +31,14 @@ const shipmentHeadingAndStyle = (mtoShipmentType) => {
   }
 };
 
+const findAdditionalServiceItemData = (mtoServiceItemsList, mtoServiceItemCode) => {
+  return mtoServiceItemsList?.find((mtoServiceItem) => mtoServiceItem.reServiceCode === mtoServiceItemCode);
+};
+
 const PaymentRequestDetails = ({ serviceItems, shipment, paymentRequestStatus }) => {
   const mtoShipmentType = serviceItems?.[0]?.mtoShipmentType;
   const [headingType, shipmentStyle] = shipmentHeadingAndStyle(mtoShipmentType);
-  const { modificationType, departureDate, address } = shipment;
+  const { modificationType, departureDate, address, mtoServiceItems } = shipment;
   return (
     serviceItems.length > 0 && (
       <div className={styles.PaymentRequestDetails}>
@@ -78,6 +83,7 @@ const PaymentRequestDetails = ({ serviceItems, shipment, paymentRequestStatus })
               return (
                 <ExpandableServiceItemRow
                   serviceItem={item}
+                  additionalServiceItemData={findAdditionalServiceItemData(mtoServiceItems, item.mtoServiceItemCode)}
                   key={item.id}
                   index={index}
                   disableExpansion={paymentRequestStatus === PAYMENT_REQUEST_STATUSES.PENDING}
@@ -100,6 +106,7 @@ PaymentRequestDetails.propTypes = {
       PropTypes.oneOf(Object.values(shipmentModificationTypes)),
     ]),
     departureDate: PropTypes.string,
+    mtoServiceItems: PropTypes.arrayOf(MTOServiceItemShape),
   }),
   paymentRequestStatus: PropTypes.oneOf(Object.values(PAYMENT_REQUEST_STATUSES)).isRequired,
 };
@@ -109,6 +116,7 @@ PaymentRequestDetails.defaultProps = {
     departureDate: '',
     address: '',
     modificationType: '',
+    mtoServiceItems: [],
   },
 };
 

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -31,14 +31,15 @@ const shipmentHeadingAndStyle = (mtoShipmentType) => {
   }
 };
 
-const findAdditionalServiceItemData = (mtoServiceItemsList, mtoServiceItemCode) => {
-  return mtoServiceItemsList?.find((mtoServiceItem) => mtoServiceItem.reServiceCode === mtoServiceItemCode);
-};
-
 const PaymentRequestDetails = ({ serviceItems, shipment, paymentRequestStatus }) => {
   const mtoShipmentType = serviceItems?.[0]?.mtoShipmentType;
   const [headingType, shipmentStyle] = shipmentHeadingAndStyle(mtoShipmentType);
   const { modificationType, departureDate, address, mtoServiceItems } = shipment;
+
+  const findAdditionalServiceItemData = (mtoServiceItemCode) => {
+    return mtoServiceItems?.find((mtoServiceItem) => mtoServiceItem.reServiceCode === mtoServiceItemCode);
+  };
+
   return (
     serviceItems.length > 0 && (
       <div className={styles.PaymentRequestDetails}>
@@ -83,7 +84,7 @@ const PaymentRequestDetails = ({ serviceItems, shipment, paymentRequestStatus })
               return (
                 <ExpandableServiceItemRow
                   serviceItem={item}
-                  additionalServiceItemData={findAdditionalServiceItemData(mtoServiceItems, item.mtoServiceItemCode)}
+                  additionalServiceItemData={findAdditionalServiceItemData(item.mtoServiceItemCode)}
                   key={item.id}
                   index={index}
                   disableExpansion={paymentRequestStatus === PAYMENT_REQUEST_STATUSES.PENDING}

--- a/src/components/Office/ReviewServiceItems/ReviewServiceItems.jsx
+++ b/src/components/Office/ReviewServiceItems/ReviewServiceItems.jsx
@@ -15,6 +15,7 @@ import PaymentReviewed from './PaymentReviewed';
 
 import Alert from 'shared/Alert';
 import { ServiceItemCardsShape } from 'types/serviceItems';
+import { MTOServiceItemShape } from 'types/order';
 import { PAYMENT_SERVICE_ITEM_STATUS, PAYMENT_REQUEST_STATUS } from 'shared/constants';
 import { toDollarString } from 'shared/formatters';
 import { PaymentRequestShape } from 'types/index';
@@ -45,6 +46,16 @@ const ReviewServiceItems = ({
 
   const handleAuthorizePaymentClick = (allServiceItemsRejected = false) => {
     onCompleteReview(allServiceItemsRejected);
+  };
+
+  const findAdditionalServiceItemData = (mtoServiceItemCode) => {
+    const serviceItemCard = serviceItemCards?.find((item) => item.mtoServiceItemCode === mtoServiceItemCode);
+
+    const additionalServiceItems = serviceItemCard
+      ? serviceItemCard.mtoServiceItems?.find((mtoItem) => mtoItem.reServiceCode === mtoServiceItemCode)
+      : [];
+
+    return additionalServiceItems;
   };
 
   // calculating the sums
@@ -188,6 +199,7 @@ const ReviewServiceItems = ({
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...curCard}
                 requestComplete={requestReviewed}
+                additionalServiceItemData={findAdditionalServiceItemData(currentCard.mtoServiceItemCode)}
               />
             ))
           ) : (
@@ -197,6 +209,7 @@ const ReviewServiceItems = ({
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...currentCard}
               requestComplete={requestReviewed}
+              additionalServiceItemData={findAdditionalServiceItemData(currentCard.mtoServiceItemCode)}
             />
           ))}
       </div>
@@ -243,6 +256,7 @@ ReviewServiceItems.propTypes = {
     detail: PropTypes.string,
     title: PropTypes.string,
   }),
+  mtoServiceItems: PropTypes.arrayOf(MTOServiceItemShape),
 };
 
 ReviewServiceItems.defaultProps = {
@@ -251,6 +265,7 @@ ReviewServiceItems.defaultProps = {
   serviceItemCards: [],
   disableScrollIntoView: false,
   completeReviewError: undefined,
+  mtoServiceItems: [],
 };
 
 export default ReviewServiceItems;

--- a/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
+++ b/src/components/Office/ReviewServiceItems/ServiceItemCard.jsx
@@ -14,7 +14,7 @@ import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentConta
 import { toDollarString, formatDateFromIso } from 'shared/formatters';
 import { ShipmentOptionsOneOf } from 'types/shipment';
 import { PAYMENT_SERVICE_ITEM_STATUS } from 'shared/constants';
-import { PaymentServiceItemParam } from 'types/order';
+import { PaymentServiceItemParam, MTOServiceItemShape } from 'types/order';
 import { allowedServiceItemCalculations } from 'constants/serviceItems';
 
 /** This component represents a Payment Request Service Item */
@@ -33,6 +33,7 @@ const ServiceItemCard = ({
   patchPaymentServiceItem,
   requestComplete,
   paymentServiceItemParams,
+  additionalServiceItemData,
 }) => {
   const [calculationsVisible, setCalulationsVisible] = useState(false);
   const [canEditRejection, setCanEditRejection] = useState(!rejectionReason);
@@ -63,6 +64,7 @@ const ServiceItemCard = ({
             <ServiceItemCalculations
               totalAmountRequested={amount * 100}
               serviceItemParams={paymentServiceItemParams}
+              additionalServiceItemData={additionalServiceItemData}
               itemCode={mtoServiceItemCode}
               tableSize="small"
             />
@@ -337,6 +339,7 @@ ServiceItemCard.propTypes = {
   patchPaymentServiceItem: PropTypes.func.isRequired,
   requestComplete: PropTypes.bool,
   paymentServiceItemParams: PropTypes.arrayOf(PaymentServiceItemParam),
+  additionalServiceItemData: MTOServiceItemShape,
 };
 
 ServiceItemCard.defaultProps = {
@@ -351,6 +354,7 @@ ServiceItemCard.defaultProps = {
   rejectionReason: '',
   requestComplete: false,
   paymentServiceItemParams: [],
+  additionalServiceItemData: {},
 };
 
 export default ServiceItemCard;

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.jsx
@@ -6,13 +6,19 @@ import classnames from 'classnames';
 import { makeCalculations } from './helpers';
 import styles from './ServiceItemCalculations.module.scss';
 
-import { PaymentServiceItemParam } from 'types/order';
+import { PaymentServiceItemParam, MTOServiceItemShape } from 'types/order';
 import { allowedServiceItemCalculations } from 'constants/serviceItems';
 
 const times = <FontAwesomeIcon className={styles.icon} icon="times" />;
 const equals = <FontAwesomeIcon className={styles.icon} icon="equals" />;
 
-const ServiceItemCalculations = ({ itemCode, totalAmountRequested, serviceItemParams, tableSize }) => {
+const ServiceItemCalculations = ({
+  itemCode,
+  totalAmountRequested,
+  serviceItemParams,
+  additionalServiceItemData,
+  tableSize,
+}) => {
   if (!allowedServiceItemCalculations.includes(itemCode) || serviceItemParams.length === 0) {
     return <></>;
   }
@@ -33,7 +39,7 @@ const ServiceItemCalculations = ({ itemCode, totalAmountRequested, serviceItemPa
     return <></>;
   };
 
-  const calculations = makeCalculations(itemCode, totalAmountRequested, serviceItemParams);
+  const calculations = makeCalculations(itemCode, totalAmountRequested, serviceItemParams, additionalServiceItemData);
 
   return (
     <div
@@ -89,6 +95,7 @@ ServiceItemCalculations.propTypes = {
   // in cents
   totalAmountRequested: PropTypes.number.isRequired,
   serviceItemParams: PropTypes.arrayOf(PaymentServiceItemParam),
+  additionalServiceItemData: MTOServiceItemShape,
   // apply small or large styling
   tableSize: PropTypes.oneOf(['small', 'large']),
 };
@@ -96,6 +103,7 @@ ServiceItemCalculations.propTypes = {
 ServiceItemCalculations.defaultProps = {
   tableSize: 'large',
   serviceItemParams: [],
+  additionalServiceItemData: {},
 };
 
 export default ServiceItemCalculations;

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.stories.jsx
@@ -159,3 +159,13 @@ export const DDSHUT = (data) => (
     tableSize={data.tableSize}
   />
 );
+
+export const DCRT = (data) => (
+  <ServiceItemCalculations
+    serviceItemParams={testParams.DomesticCrating}
+    additionalServiceItemData={testParams.additionalCratingDataDCRT}
+    totalAmountRequested={642}
+    itemCode="DCRT"
+    tableSize={data.tableSize}
+  />
+);

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
@@ -7,12 +7,23 @@ import testParams from './serviceItemTestParams';
 import { SERVICE_ITEM_CODES } from 'constants/serviceItems';
 
 // helper test function that helps test service item calculations based on code
-const testServiceItemCalculation = (serviceItemCodeToTest, data, expectedOutput) => {
+const testServiceItemCalculation = (testData) => {
+  const [serviceItemCodeToTest, data, additionalData, expectedOutput] = testData;
   const totalAmount = 1000;
 
   const mountedComponent = mount(
     <ServiceItemCalculations
       serviceItemParams={data}
+      additionalServiceItemData={additionalData}
+      totalAmountRequested={totalAmount}
+      itemCode={serviceItemCodeToTest}
+    />,
+  );
+
+  const mountedComponentAdditionalData = mount(
+    <ServiceItemCalculations
+      serviceItemParams={data}
+      additionalServiceItemData={additionalData}
       totalAmountRequested={totalAmount}
       itemCode={serviceItemCodeToTest}
     />,
@@ -20,7 +31,10 @@ const testServiceItemCalculation = (serviceItemCodeToTest, data, expectedOutput)
 
   describe(`item code ${serviceItemCodeToTest}`, () => {
     it('renders correct data', () => {
-      const wrapper = mountedComponent.find('[data-testid="column"]');
+      const wrapper = additionalData
+        ? mountedComponentAdditionalData.find('[data-testid="column"]')
+        : mountedComponent.find('[data-testid="column"]');
+
       expectedOutput.forEach((obj, index) => {
         expect(wrapper.at(index).find('[data-testid="value"]').text()).toBe(obj.value);
         expect(wrapper.at(index).find('[data-testid="label"]').text()).toBe(obj.label);
@@ -30,7 +44,7 @@ const testServiceItemCalculation = (serviceItemCodeToTest, data, expectedOutput)
   });
 };
 
-describe('ServiceItemCalculations', () => {
+describe('ServiceItemCalculations DLH', () => {
   const itemCode = 'DLH';
   const totalAmount = 1000;
   const serviceItemCalculationsLarge = mount(
@@ -115,5 +129,95 @@ describe('ServiceItemCalculations', () => {
       details: [],
     },
   ];
-  testServiceItemCalculation(SERVICE_ITEM_CODES.DLH, testParams.DomesticLongHaul, expectedOutput);
+  testServiceItemCalculation([SERVICE_ITEM_CODES.DLH, testParams.DomesticLongHaul, {}, expectedOutput]);
+});
+
+describe('ServiceItemCalculations DCRT', () => {
+  const itemCode = 'DCRT';
+  const totalAmount = 1000;
+  const serviceItemCalculationsLarge = mount(
+    <ServiceItemCalculations
+      itemCode={itemCode}
+      totalAmountRequested={totalAmount}
+      serviceItemParams={testParams.DomesticCrating}
+      additionalServiceItemData={testParams.additionalCratingDataDCRT}
+    />,
+  );
+  const serviceItemCalculationsSmall = mount(
+    <ServiceItemCalculations
+      itemCode={itemCode}
+      totalAmountRequested={totalAmount}
+      serviceItemParams={testParams.DomesticCrating}
+      additionalServiceItemData={testParams.additionalCratingDataDCRT}
+      tableSize="small"
+    />,
+  );
+
+  it('renders without crashing', () => {
+    expect(serviceItemCalculationsLarge.length).toBe(1);
+  });
+
+  describe('large table', () => {
+    it('renders correct classnames by default', () => {
+      const wrapper = serviceItemCalculationsLarge.find('[data-testid="ServiceItemCalculations"]');
+      expect(wrapper.hasClass('ServiceItemCalculationsSmall')).toBe(false);
+    });
+
+    it('renders icons', () => {
+      const wrapper = serviceItemCalculationsLarge;
+      const timesIcons = wrapper.find('[icon="times"]');
+      const equalsIcons = wrapper.find('[icon="equals"]');
+
+      expect(timesIcons.length).toBe(2);
+      expect(equalsIcons.length).toBe(1);
+    });
+  });
+
+  describe('small table', () => {
+    it('renders correct classnames', () => {
+      expect(
+        serviceItemCalculationsSmall
+          .find('[data-testid="ServiceItemCalculations"]')
+          .hasClass('ServiceItemCalculationsSmall'),
+      ).toBe(true);
+    });
+
+    it('renders no icons', () => {
+      const wrapper = serviceItemCalculationsSmall;
+      const timesIcons = wrapper.find('[icon="times"]');
+      const equalsIcons = wrapper.find('[icon="equals"]');
+
+      expect(timesIcons.length).toBe(0);
+      expect(equalsIcons.length).toBe(0);
+    });
+  });
+
+  const expectedOutput = [
+    {
+      value: '2',
+      label: 'Crating size (cu ft)',
+      details: ['Description: Grand piano', 'Dimensions: 50x100x80 in'],
+    },
+    {
+      value: '1.71',
+      label: 'Crating price (per cu ft)',
+      details: ['Service schedule: 3', 'Crating date: 09 Mar 2020', 'Domestic'],
+    },
+    {
+      value: '1.033',
+      label: 'Price escalation factor',
+      details: [],
+    },
+    {
+      value: '$10.00',
+      label: 'Total amount requested',
+      details: [''],
+    },
+  ];
+  testServiceItemCalculation([
+    SERVICE_ITEM_CODES.DCRT,
+    testParams.DomesticCrating,
+    testParams.additionalCratingDataDCRT,
+    expectedOutput,
+  ]);
 });

--- a/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
+++ b/src/components/Office/ServiceItemCalculations/ServiceItemCalculations.test.jsx
@@ -196,7 +196,7 @@ describe('ServiceItemCalculations DCRT', () => {
     {
       value: '2',
       label: 'Crating size (cu ft)',
-      details: ['Description: Grand piano', 'Dimensions: 50x100x80 in'],
+      details: ['Description: Grand piano', 'Dimensions: 0.05x0.1x0.08 in'],
     },
     {
       value: '1.71',

--- a/src/components/Office/ServiceItemCalculations/helpers.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.js
@@ -1,6 +1,6 @@
 import { SERVICE_ITEM_CALCULATION_LABELS, SERVICE_ITEM_CODES, SERVICE_ITEM_PARAM_KEYS } from 'constants/serviceItems';
 import { LONGHAUL_MIN_DISTANCE } from 'constants/shipments';
-import { formatWeight, formatCents, toDollarString } from 'shared/formatters';
+import { convertFromThousandthInchToInch, formatWeight, formatCents, toDollarString } from 'shared/formatters';
 import { formatDate } from 'shared/dates';
 import { formatWeightCWTFromLbs, formatDollarFromMillicents } from 'utils/formatters';
 
@@ -349,11 +349,13 @@ const cratingSize = (params, mtoParams) => {
 
   const description = `${SERVICE_ITEM_CALCULATION_LABELS.Description}: ${mtoParams.description}`;
 
-  const dimension = mtoParams.dimensions.find((dim) => dim.type === 'CRATE');
+  const dimensions = mtoParams.dimensions.find((dim) => dim.type === 'CRATE');
 
-  const dimensions = `${SERVICE_ITEM_CALCULATION_LABELS.Dimensions}: ${dimension.length}x${dimension.width}x${dimension.height} in`;
+  const formattedDimensions = `${SERVICE_ITEM_CALCULATION_LABELS.Dimensions}: ${convertFromThousandthInchToInch(
+    dimensions.length,
+  )}x${convertFromThousandthInchToInch(dimensions.width)}x${convertFromThousandthInchToInch(dimensions.height)} in`;
 
-  return calculation(value, label, description, dimensions);
+  return calculation(value, label, description, formattedDimensions);
 };
 
 // totalAmountRequested is not a service item param

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -409,7 +409,7 @@ describe('makeCalculations', () => {
       {
         value: '2',
         label: 'Crating size (cu ft)',
-        details: ['Description: Grand piano', 'Dimensions: 50x100x80 in'],
+        details: ['Description: Grand piano', 'Dimensions: 0.05x0.1x0.08 in'],
       },
       {
         value: '1.71',

--- a/src/components/Office/ServiceItemCalculations/helpers.test.js
+++ b/src/components/Office/ServiceItemCalculations/helpers.test.js
@@ -3,7 +3,7 @@ import testParams from './serviceItemTestParams';
 
 describe('makeCalculations', () => {
   it('returns correct data for DomesticLongHaul', () => {
-    const result = makeCalculations('DLH', 99999, testParams.DomesticLongHaul);
+    const result = makeCalculations('DLH', 99999, testParams.DomesticLongHaul, testParams.additionalCratingDataDCRT);
     expect(result).toEqual([
       {
         value: '85 cwt',
@@ -404,13 +404,29 @@ describe('makeCalculations', () => {
   });
 
   it('returns correct data for DomesticCrating', () => {
-    const result = makeCalculations('?', 99999, testParams.DomesticCrating);
-    expect(result).toEqual([]);
-  });
-
-  it('returns correct data for DomesticCratingStandalone', () => {
-    const result = makeCalculations('?', 99999, testParams.DomesticCratingStandalone);
-    expect(result).toEqual([]);
+    const result = makeCalculations('DCRT', 99999, testParams.DomesticCrating, testParams.additionalCratingDataDCRT);
+    expect(result).toEqual([
+      {
+        value: '2',
+        label: 'Crating size (cu ft)',
+        details: ['Description: Grand piano', 'Dimensions: 50x100x80 in'],
+      },
+      {
+        value: '1.71',
+        label: 'Crating price (per cu ft)',
+        details: ['Service schedule: 3', 'Crating date: 09 Mar 2020', 'Domestic'],
+      },
+      {
+        value: '1.033',
+        label: 'Price escalation factor',
+        details: [],
+      },
+      {
+        value: '$999.99',
+        label: 'Total amount requested',
+        details: [''],
+      },
+    ]);
   });
 
   it('returns correct data for DomesticUncrating', () => {

--- a/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
+++ b/src/components/Office/ServiceItemCalculations/serviceItemTestParams.js
@@ -151,7 +151,7 @@ const CubicFeetBilled = {
   origin: 'SYSTEM',
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'INTEGER',
-  value: '',
+  value: '1.71',
 };
 const CubicFeetCrating = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
@@ -160,7 +160,7 @@ const CubicFeetCrating = {
   origin: 'PRIME',
   paymentServiceItemID: '28039a62-387d-479f-b50f-e0041b7e6e22',
   type: 'INTEGER',
-  value: '',
+  value: '2',
 };
 const DistanceZipSITOrigin = {
   eTag: 'MjAyMS0wMy0xOFQwMTozMTo1MS4yNjY4M1o=',
@@ -602,14 +602,9 @@ const testParams = {
     ZipDestAddress,
   ],
   DomesticCrating: [
-    RequestedPickupDate,
-    CubicFeetBilled,
-    CubicFeetCrating,
-    ServicesScheduleOrigin,
-    ServiceAreaOrigin,
-    ZipPickupAddress,
-  ],
-  DomesticCratingStandalone: [
+    ContractYearName,
+    EscalationCompounded,
+    PriceRateOrFactor,
     RequestedPickupDate,
     CubicFeetBilled,
     CubicFeetCrating,
@@ -695,6 +690,18 @@ const testParams = {
     PSIPriceDomDestPrice,
   ],
   DomesticNTSPackingFactor: [PSIPackingDom, PSIPackingDomPrice],
+  additionalCratingDataDCRT: {
+    reServiceCode: 'DCRT',
+    description: 'Grand piano',
+    dimensions: [
+      {
+        type: 'CRATE',
+        width: 100,
+        height: 80,
+        length: 50,
+      },
+    ],
+  },
 };
 
 export default testParams;

--- a/src/constants/serviceItems.js
+++ b/src/constants/serviceItems.js
@@ -7,6 +7,8 @@ const SERVICE_ITEM_STATUSES = {
 const SERVICE_ITEM_PARAM_KEYS = {
   ActualPickupDate: 'ActualPickupDate',
   ContractYearName: 'ContractYearName',
+  CubicFeetCrating: 'CubicFeetCrating',
+  CubicFeetBilled: 'CubicFeetBilled',
   DestinationPrice: 'DestinationPrice',
   DistanceZip3: 'DistanceZip3',
   DistanceZip5: 'DistanceZip5',
@@ -64,9 +66,14 @@ const SERVICE_ITEM_CALCULATION_LABELS = {
   BaselineLinehaulPrice: 'Baseline linehaul price',
   BaselineShorthaulPrice: 'Baseline shorthaul price',
   BillableWeight: 'Billable weight (cwt)',
+  CratingDate: 'Crating date',
+  CubicFeetBilled: 'Crating price (per cu ft)',
+  CubicFeetCrating: 'Crating size (cu ft)',
   DaysInSIT: 'Days in SIT',
   DeliveryDate: 'Delivery date',
+  Description: 'Description',
   DestinationSchedule: 'Destination schedule',
+  Dimensions: 'Dimensions',
   Domestic: 'Domestic',
   FuelSurchargePrice: 'Fuel surcharge price (per mi)',
   Mileage: 'Mileage',
@@ -97,6 +104,7 @@ const SERVICE_ITEM_CODES = {
   DUPK: 'DUPK',
   FSC: 'FSC',
   DDSHUT: 'DDSHUT',
+  DCRT: 'DCRT',
 };
 
 // TODO - temporary, will remove once all service item calculations are implemented
@@ -116,6 +124,7 @@ const allowedServiceItemCalculations = [
   SERVICE_ITEM_CODES.DUPK,
   SERVICE_ITEM_CODES.FSC,
   SERVICE_ITEM_CODES.DDSHUT,
+  SERVICE_ITEM_CODES.DCRT,
 ];
 
 export {

--- a/src/content/serviceItems.js
+++ b/src/content/serviceItems.js
@@ -3,7 +3,6 @@ const serviceItemCodes = {
   DBHF: 'Domestic haul away boat factor',
   DBTF: 'Domestic tow away boat factor',
   DCRT: 'Domestic crating',
-  DCRTSA: 'Domestic crating - standalone',
   DDASIT: "Domestic destination add'l SIT",
   DDDSIT: 'Domestic destination SIT delivery',
   DDFSIT: 'Domestic destination 1st day SIT',

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -60,6 +60,7 @@ const MovePaymentRequests = ({
         address: formatPaymentRequestAddressString(shipment.pickupAddress, shipment.destinationAddress),
         departureDate: shipment.actualPickupDate,
         modificationType: getShipmentModificationType(shipment),
+        mtoServiceItems: shipment.mtoServiceItems,
       });
     });
   }

--- a/src/pages/Office/PaymentRequestReview/PaymentRequestReview.jsx
+++ b/src/pages/Office/PaymentRequestReview/PaymentRequestReview.jsx
@@ -116,6 +116,7 @@ export const PaymentRequestReview = ({ history, match }) => {
       mtoShipmentModificationType: selectedShipment ? getShipmentModificationType(selectedShipment) : undefined,
       mtoServiceItemCode: item.mtoServiceItemCode,
       mtoServiceItemName: item.mtoServiceItemName,
+      mtoServiceItems: selectedShipment?.mtoServiceItems,
       amount: item.priceCents ? item.priceCents / 100 : 0,
       createdAt: item.createdAt,
       status: item.status,


### PR DESCRIPTION
## Description

TIO can see calculations for Domestic crating, on both payment requests and the service item review flow.

## Reviewer Notes

There are quite a few files being touched so I am concerned I missed something. I didn't like passing the mtoServiceItems params around like a hot potato to get them where they need to be, but it's not too awful. 

I removed the Domestic Crating Standalone test data and seed data because that functionality will not be implemented. I'm going to be adding further tests and doing some test cleanup as well.

## Setup

Make sure data is up to date:

```
make db_dev_e2e_populate
```

Build and run the office app:

```
make server_run
make office_client_run
```

To check storybook changes locally:

```
make storybook
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8252) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._

![Screen Shot 2021-07-21 at 6 06 23 PM](https://user-images.githubusercontent.com/1587316/126672045-f0e0a8ba-2ec3-4188-a409-eb64bd4635de.png)

