### PR TITLE
MB-8899: Changes the error message text returned for a SqlErrMessage

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -26,7 +26,7 @@ import (
 // The following are strings to be used in the title field of errors sent to the client
 
 // SQLErrMessage represents string value to represent generic sql error to avoid leaking implementation details
-const SQLErrMessage string = "Unhandled SQL error encountered"
+const SQLErrMessage string = "Unhandled data error encountered"
 
 // NotFoundMessage indicates a resource was not found
 const NotFoundMessage string = "Not Found Error"


### PR DESCRIPTION
## Description

As part of the [POAM](https://dp3.atlassian.net/browse/MB-4864) to restrict information about specific technologies in use, this pull request changes the text the error message returned by some responses when an unspecified Postgres error occurs to scrub the word "SQL" from that response.

As multiple error responses which use the `ResponseForError` handler do not actually return *any* response body, just the HTTP status code and headers, I actually can't find a place to test whether or not this change will have any effect, but if any do, this is the error message text that would be returned in case of an unspecified `pq` error.

## Reviewer Notes

This change should be imperceptible to the UI of the application, and only changes text that is possibly returned in an error message.

## Setup

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8899](https://dp3.atlassian.net/browse/MB-8899).
