### PR TITLE
[MB-2612] Add dimensions for crating to lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,7 @@ The test DB commands all talk to the DB over localhost.  But in a docker-only en
 
 #### Migrations
 
-To add new regular and/or secure migrations, see the [database development guide](https://github.com/transcom/mymove/wiki/migrate-the-database)
+To add new regular and/or secure migrations, see the [database development guide](https://github.com/transcom/mymove/wiki/Database-Migrations)
 
 Running migrations in local development:
 

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -654,3 +654,4 @@
 20210714221936_change_cubic_feet_crating_to_decimal.up.sql
 20210720183133_create_rds_pgaudit_role.up.sql
 20210721192603_remove_erin_cac_certs.up.sql
+20210726214608_add_dimension_param_keys.up.sql

--- a/migrations/app/schema/20210726214608_add_dimension_param_keys.up.sql
+++ b/migrations/app/schema/20210726214608_add_dimension_param_keys.up.sql
@@ -1,0 +1,26 @@
+------ Add new service item param keys ------
+INSERT INTO service_item_param_keys
+(id, key,description,type,origin,created_at,updated_at)
+VALUES
+('9df726f8-5ae7-4749-8446-28815ff16271', 'DimensionLength', 'Compounded escalation factor applied to final price', 'INTEGER', 'PRIME', now(), now()),
+('79bdb87e-776b-43fe-a54b-40e519a9a76f', 'DimensionWidth', 'Price, rate, or factor used in calculation', 'INTEGER', 'PRIME', now(), now()),
+('33d99169-b36c-42f8-ad81-99cb54c9a723', 'DimensionHeight', 'True if this is a peak season move', 'INTEGER', 'PRIME', now(), now());
+
+
+------ Map new service item param keys to corresponding service items ------
+INSERT INTO service_params
+(id,service_id,service_item_param_key_id,created_at,updated_at)
+VALUES
+('ee7e92b9-68aa-474e-b62d-bd1362808d2e', (SELECT id FROM re_services WHERE code='DCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionLength'), now(), now()),
+('8457ab1c-5fee-40bb-9fa7-da54e915ecbc', (SELECT id FROM re_services WHERE code='DCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionWidth'), now(), now()),
+('6936e9d6-d01a-4230-a36d-e9e75144d747', (SELECT id FROM re_services WHERE code='DCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionHeight'), now(), now()),
+('f9229c7c-e367-4ea8-862a-92b39a78e304', (SELECT id FROM re_services WHERE code='DUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionLength'), now(), now()),
+('21aa5c4f-6058-4aee-ab36-76bacd8c12a6', (SELECT id FROM re_services WHERE code='DUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionWidth'), now(), now()),
+('d293a4ad-4b82-4a4c-b8a2-12f212f9237e', (SELECT id FROM re_services WHERE code='DUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionHeight'), now(), now()),
+('fb6a629c-a566-450c-96e7-329005d8ccdb', (SELECT id FROM re_services WHERE code='ICRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionLength'), now(), now()),
+('6405feb4-366b-44a3-8877-59e39c1d2182', (SELECT id FROM re_services WHERE code='ICRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionWidth'), now(), now()),
+('c6c69b88-1fbb-4a3f-8a63-4db468b22b58', (SELECT id FROM re_services WHERE code='ICRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionHeight'), now(), now()),
+('a5cf6d2b-b903-4cb6-9d85-1c79a0034e94', (SELECT id FROM re_services WHERE code='IUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionLength'), now(), now()),
+('883bb58b-ec0e-44cd-b8dd-24eab0effdb9', (SELECT id FROM re_services WHERE code='IUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionWidth'), now(), now()),
+('719893a7-cc10-4bef-b192-77b03364bbe2', (SELECT id FROM re_services WHERE code='IUCRT'), (SELECT id FROM service_item_param_keys WHERE key='DimensionHeight'), now(), now());
+

--- a/migrations/app/schema/20210726214608_add_dimension_param_keys.up.sql
+++ b/migrations/app/schema/20210726214608_add_dimension_param_keys.up.sql
@@ -2,9 +2,9 @@
 INSERT INTO service_item_param_keys
 (id, key,description,type,origin,created_at,updated_at)
 VALUES
-('9df726f8-5ae7-4749-8446-28815ff16271', 'DimensionLength', 'Compounded escalation factor applied to final price', 'INTEGER', 'PRIME', now(), now()),
-('79bdb87e-776b-43fe-a54b-40e519a9a76f', 'DimensionWidth', 'Price, rate, or factor used in calculation', 'INTEGER', 'PRIME', now(), now()),
-('33d99169-b36c-42f8-ad81-99cb54c9a723', 'DimensionHeight', 'True if this is a peak season move', 'INTEGER', 'PRIME', now(), now());
+('9df726f8-5ae7-4749-8446-28815ff16271', 'DimensionLength', 'Dimension length describing the length of a service item', 'INTEGER', 'PRIME', now(), now()),
+('79bdb87e-776b-43fe-a54b-40e519a9a76f', 'DimensionWidth', 'Dimension width describing the width of a service item', 'INTEGER', 'PRIME', now(), now()),
+('33d99169-b36c-42f8-ad81-99cb54c9a723', 'DimensionHeight', 'Dimension height describing the height of a service item', 'INTEGER', 'PRIME', now(), now());
 
 
 ------ Map new service item param keys to corresponding service items ------

--- a/pkg/models/service_item_param_key.go
+++ b/pkg/models/service_item_param_key.go
@@ -28,6 +28,12 @@ const (
 	ServiceItemParamNameCubicFeetBilled ServiceItemParamName = "CubicFeetBilled"
 	// ServiceItemParamNameCubicFeetCrating is the param key name CubicFeetCrating
 	ServiceItemParamNameCubicFeetCrating ServiceItemParamName = "CubicFeetCrating"
+	// ServiceItemParamNameDimensionHeight is the param key name DimensionHeight
+	ServiceItemParamNameDimensionHeight ServiceItemParamName = "DimensionHeight"
+	// ServiceItemParamNameDimensionLength is the param key name DimensionLength
+	ServiceItemParamNameDimensionLength ServiceItemParamName = "DimensionLength"
+	// ServiceItemParamNameDimensionWidth is the param key name DimensionWidth
+	ServiceItemParamNameDimensionWidth ServiceItemParamName = "DimensionWidth"
 	// ServiceItemParamNameDistanceZip3 is the param key name DistanceZip3
 	ServiceItemParamNameDistanceZip3 ServiceItemParamName = "DistanceZip3"
 	// ServiceItemParamNameDistanceZip5 is the param key name DistanceZip5

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup.go
@@ -7,10 +7,6 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-const (
-	thousandthInchesPerFoot = 12000
-)
-
 // CubicFeetCratingLookup does lookup for CubicFeetCrating
 type CubicFeetCratingLookup struct {
 	Dimensions models.MTOServiceItemDimensions
@@ -22,9 +18,9 @@ func (c CubicFeetCratingLookup) lookup(keyData *ServiceItemParamKeyData) (string
 	// look for the first crating dimension.
 	for _, dimension := range c.Dimensions {
 		if dimension.Type == models.DimensionTypeCrate {
-			lengthFeet := float64(dimension.Length) / thousandthInchesPerFoot
-			heightFeet := float64(dimension.Height) / thousandthInchesPerFoot
-			widthFeet := float64(dimension.Width) / thousandthInchesPerFoot
+			lengthFeet := dimension.Length.ToFeet()
+			heightFeet := dimension.Height.ToFeet()
+			widthFeet := dimension.Width.ToFeet()
 
 			volume := lengthFeet * heightFeet * widthFeet
 			return fmt.Sprintf("%.2f", volume), nil

--- a/pkg/payment_request/service_param_value_lookups/dimension_height_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_height_lookup.go
@@ -1,0 +1,28 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// DimensionHeightLookup does lookup for DimensionHeightLookup
+type DimensionHeightLookup struct {
+	Dimensions models.MTOServiceItemDimensions
+}
+
+func (d DimensionHeightLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	// Each service item has an array of dimensions. There is a DB constraint preventing
+	// more than one dimension of each type for a given service item, so we just have to
+	// look for the first crating dimension.
+	for _, dimension := range d.Dimensions {
+		if dimension.Type == models.DimensionTypeCrate {
+			heightInches := int(dimension.Height.ToInches())
+
+			return strconv.Itoa(heightInches), nil
+		}
+	}
+
+	return "", services.NewConflictError(keyData.MTOServiceItemID, "unable to find height crate dimension")
+}

--- a/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
@@ -1,0 +1,69 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
+	key := models.ServiceItemParamNameDimensionHeight
+
+	suite.T().Run("successful DimensionHeight lookup", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDCRT,
+			},
+		})
+		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeCrate,
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    16*12*1000 + 1000,
+				Height:    8 * 12 * 1000,
+				Width:     9 * 12 * 1000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
+		})
+		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           12000,
+				Height:           12000,
+				Width:            12000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
+		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
+		suite.MustSave(&mtoServiceItem)
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		stringValue, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+
+		suite.Equal("96", stringValue)
+		suite.Equal("96", strconv.Itoa(int(cratingDimension.Height.ToInches())))
+	})
+
+	suite.T().Run("missing dimension should error", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		_, err = paramLookup.ServiceParamValue(key)
+
+		suite.Error(err)
+		suite.Contains(err.Error(), "unable to find height crate dimension")
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/dimension_length_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_length_lookup.go
@@ -1,0 +1,28 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// DimensionLengthLookup does lookup for DimensionLengthLookup
+type DimensionLengthLookup struct {
+	Dimensions models.MTOServiceItemDimensions
+}
+
+func (d DimensionLengthLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	// Each service item has an array of dimensions. There is a DB constraint preventing
+	// more than one dimension of each type for a given service item, so we just have to
+	// look for the first crating dimension.
+	for _, dimension := range d.Dimensions {
+		if dimension.Type == models.DimensionTypeCrate {
+			lengthInches := int(dimension.Length.ToInches())
+
+			return strconv.Itoa(lengthInches), nil
+		}
+	}
+
+	return "", services.NewConflictError(keyData.MTOServiceItemID, "unable to find length crate dimension")
+}

--- a/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
@@ -1,0 +1,69 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
+	key := models.ServiceItemParamNameDimensionLength
+
+	suite.T().Run("successful DimensionLength lookup", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDCRT,
+			},
+		})
+		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeCrate,
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    16*12*1000 + 1000,
+				Height:    8 * 12 * 1000,
+				Width:     9 * 12 * 1000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
+		})
+		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           12000,
+				Height:           12000,
+				Width:            12000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
+		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
+		suite.MustSave(&mtoServiceItem)
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		stringValue, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+
+		suite.Equal("193", stringValue)
+		suite.Equal("193", strconv.Itoa(int(cratingDimension.Length.ToInches())))
+	})
+
+	suite.T().Run("missing dimension should error", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		_, err = paramLookup.ServiceParamValue(key)
+
+		suite.Error(err)
+		suite.Contains(err.Error(), "unable to find length crate dimension")
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup.go
@@ -1,0 +1,28 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// DimensionWidthLookup does lookup for DimensionWidthLookup
+type DimensionWidthLookup struct {
+	Dimensions models.MTOServiceItemDimensions
+}
+
+func (d DimensionWidthLookup) lookup(keyData *ServiceItemParamKeyData) (string, error) {
+	// Each service item has an array of dimensions. There is a DB constraint preventing
+	// more than one dimension of each type for a given service item, so we just have to
+	// look for the first crating dimension.
+	for _, dimension := range d.Dimensions {
+		if dimension.Type == models.DimensionTypeCrate {
+			lengthWidths := int(dimension.Width.ToInches())
+
+			return strconv.Itoa(lengthWidths), nil
+		}
+	}
+
+	return "", services.NewConflictError(keyData.MTOServiceItemID, "unable to find width crate dimension")
+}

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup.go
@@ -18,9 +18,9 @@ func (d DimensionWidthLookup) lookup(keyData *ServiceItemParamKeyData) (string, 
 	// look for the first crating dimension.
 	for _, dimension := range d.Dimensions {
 		if dimension.Type == models.DimensionTypeCrate {
-			lengthWidths := int(dimension.Width.ToInches())
+			widthInches := int(dimension.Width.ToInches())
 
-			return strconv.Itoa(lengthWidths), nil
+			return strconv.Itoa(widthInches), nil
 		}
 	}
 

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
@@ -1,0 +1,70 @@
+package serviceparamvaluelookups
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
+	key := models.ServiceItemParamNameDimensionWidth
+
+	suite.T().Run("successful DimensionWidth lookup", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDCRT,
+			},
+		})
+		cratingDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeCrate,
+				// These dimensions are chosen to overflow 32bit ints if multiplied, and give a fractional result
+				// when converted to cubic feet.
+				Length:    16*12*1000 + 1000,
+				Height:    8 * 12 * 1000,
+				Width:     9 * 12 * 1000,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
+		})
+		itemDimension := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItem.ID,
+				Type:             models.DimensionTypeItem,
+				Length:           12000,
+				Height:           12000,
+				Width:            12000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
+		mtoServiceItem.Dimensions = []models.MTOServiceItemDimension{itemDimension, cratingDimension}
+		suite.MustSave(&mtoServiceItem)
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		stringValue, err := paramLookup.ServiceParamValue(key)
+		suite.FatalNoError(err)
+
+		suite.Equal("108", stringValue)
+		suite.Equal("108", strconv.Itoa(int(cratingDimension.Width.ToInches())))
+
+	})
+
+	suite.T().Run("missing dimension should error", func(t *testing.T) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+		paramLookup, err := ServiceParamLookupInitialize(suite.DB(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
+		suite.FatalNoError(err)
+
+		_, err = paramLookup.ServiceParamValue(key)
+
+		suite.Error(err)
+		suite.Contains(err.Error(), "unable to find width crate dimension")
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -377,6 +377,31 @@ func ServiceParamLookupInitialize(
 	if err != nil {
 		return nil, err
 	}
+
+	paramKey = models.ServiceItemParamNameDimensionHeight
+	err = s.setLookup(serviceItemCode, paramKey, DimensionHeightLookup{
+		Dimensions: serviceItemDimensions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	paramKey = models.ServiceItemParamNameDimensionLength
+	err = s.setLookup(serviceItemCode, paramKey, DimensionLengthLookup{
+		Dimensions: serviceItemDimensions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	paramKey = models.ServiceItemParamNameDimensionWidth
+	err = s.setLookup(serviceItemCode, paramKey, DimensionWidthLookup{
+		Dimensions: serviceItemDimensions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &s, nil
 }
 

--- a/pkg/unit/thousandth_inches.go
+++ b/pkg/unit/thousandth_inches.go
@@ -1,5 +1,10 @@
 package unit
 
+const (
+	thousandthInchPerFoot = 12000
+	thousandthInchPerInch = 1000
+)
+
 // ThousandthInches Inches represents a value in thousandth of an inch Eg. 1.00 inch = 1000 ThousandthInches
 type ThousandthInches int
 
@@ -7,4 +12,18 @@ type ThousandthInches int
 func (t ThousandthInches) Int32Ptr() *int32 {
 	val := int32(t)
 	return &val
+}
+
+// ToFeet returns feet for this value
+func (t ThousandthInches) ToFeet() float64 {
+	feet := float64(t) / thousandthInchPerFoot
+
+	return feet
+}
+
+// ToInches returns inches for this value
+func (t ThousandthInches) ToInches() float64 {
+	inches := float64(t) / thousandthInchPerInch
+
+	return inches
 }

--- a/pkg/unit/thousandth_inches_test.go
+++ b/pkg/unit/thousandth_inches_test.go
@@ -16,7 +16,7 @@ func Test_ThousandthInches(t *testing.T) {
 
 func TestToFeet(t *testing.T) {
 	thous := ThousandthInches(5 * 12000)
-	expected := float64((5 * thousandthInchPerFoot) / thousandthInchPerFoot)
+	expected := float64((5 * 12000) / 12000)
 	result := thous.ToFeet()
 	if result != expected {
 		t.Errorf("ThousandthInches did not convert properly to feet: expected %f, got %f", expected, result)
@@ -25,7 +25,7 @@ func TestToFeet(t *testing.T) {
 
 func TestToInches(t *testing.T) {
 	thous := ThousandthInches(12 * 1000)
-	expected := float64((12 * thousandthInchPerInch) / thousandthInchPerInch)
+	expected := float64((12 * 1000) / 1000)
 	result := thous.ToInches()
 	if result != expected {
 		t.Errorf("ThousandthInches did not convert properly to inches: expected %f, got %f", expected, result)

--- a/pkg/unit/thousandth_inches_test.go
+++ b/pkg/unit/thousandth_inches_test.go
@@ -15,7 +15,6 @@ func Test_ThousandthInches(t *testing.T) {
 }
 
 func TestToFeet(t *testing.T) {
-	// Test int -> int32
 	thous := ThousandthInches(5 * 12000)
 	expected := float64((5 * thousandthInchPerFoot) / thousandthInchPerFoot)
 	result := thous.ToFeet()
@@ -25,7 +24,6 @@ func TestToFeet(t *testing.T) {
 }
 
 func TestToInches(t *testing.T) {
-	// Test int -> int32
 	thous := ThousandthInches(12 * 1000)
 	expected := float64((12 * thousandthInchPerInch) / thousandthInchPerInch)
 	result := thous.ToInches()

--- a/pkg/unit/thousandth_inches_test.go
+++ b/pkg/unit/thousandth_inches_test.go
@@ -13,3 +13,23 @@ func Test_ThousandthInches(t *testing.T) {
 		t.Errorf("ThousandthInches did not convert properly: expected %d, got %d", expected, result)
 	}
 }
+
+func TestToFeet(t *testing.T) {
+	// Test int -> int32
+	thous := ThousandthInches(5 * 12000)
+	expected := float64((5 * thousandthInchPerFoot) / thousandthInchPerFoot)
+	result := thous.ToFeet()
+	if result != expected {
+		t.Errorf("ThousandthInches did not convert properly to feet: expected %f, got %f", expected, result)
+	}
+}
+
+func TestToInches(t *testing.T) {
+	// Test int -> int32
+	thous := ThousandthInches(12 * 1000)
+	expected := float64((12 * thousandthInchPerInch) / thousandthInchPerInch)
+	result := thous.ToInches()
+	if result != expected {
+		t.Errorf("ThousandthInches did not convert properly to inches: expected %f, got %f", expected, result)
+	}
+}


### PR DESCRIPTION
## Description

This adds length, width, and height dimensions for lookups and to the database to crating/uncrating service items.

## Reviewer Notes

n/a

## Setup

Just runs normal `make server_test`

## Code Review Verification Steps

* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2612) for this change

## Screenshots
n/a
