### PR TITLE
MB-8853 Fix estimated and actual weights for shuttling service items

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1692,9 +1692,7 @@ func init() {
           "required": [
             "reason",
             "reServiceCode",
-            "description",
-            "estimatedWeight",
-            "actualWeight"
+            "description"
           ],
           "properties": {
             "actualWeight": {
@@ -4674,9 +4672,7 @@ func init() {
           "required": [
             "reason",
             "reServiceCode",
-            "description",
-            "estimatedWeight",
-            "actualWeight"
+            "description"
           ],
           "properties": {
             "actualWeight": {

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -34,7 +34,6 @@ type MTOServiceItemShuttle struct {
 	statusField MTOServiceItemStatus
 
 	// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-	// Required: true
 	ActualWeight *int64 `json:"actualWeight"`
 
 	// Further details about the shuttle service.
@@ -42,7 +41,6 @@ type MTOServiceItemShuttle struct {
 	Description *string `json:"description"`
 
 	// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-	// Required: true
 	EstimatedWeight *int64 `json:"estimatedWeight"`
 
 	// Service codes allowed for this model type.
@@ -139,7 +137,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	var data struct {
 
 		// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-		// Required: true
 		ActualWeight *int64 `json:"actualWeight"`
 
 		// Further details about the shuttle service.
@@ -147,7 +144,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		Description *string `json:"description"`
 
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-		// Required: true
 		EstimatedWeight *int64 `json:"estimatedWeight"`
 
 		// Service codes allowed for this model type.
@@ -232,7 +228,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 	b1, err = json.Marshal(struct {
 
 		// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-		// Required: true
 		ActualWeight *int64 `json:"actualWeight"`
 
 		// Further details about the shuttle service.
@@ -240,7 +235,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		Description *string `json:"description"`
 
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-		// Required: true
 		EstimatedWeight *int64 `json:"estimatedWeight"`
 
 		// Service codes allowed for this model type.
@@ -327,15 +321,7 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateActualWeight(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateEstimatedWeight(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -408,27 +394,9 @@ func (m *MTOServiceItemShuttle) validateStatus(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *MTOServiceItemShuttle) validateActualWeight(formats strfmt.Registry) error {
-
-	if err := validate.Required("actualWeight", "body", m.ActualWeight); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *MTOServiceItemShuttle) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemShuttle) validateEstimatedWeight(formats strfmt.Registry) error {
-
-	if err := validate.Required("estimatedWeight", "body", m.EstimatedWeight); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1529,9 +1529,7 @@ func init() {
           "required": [
             "reason",
             "reServiceCode",
-            "description",
-            "estimatedWeight",
-            "actualWeight"
+            "description"
           ],
           "properties": {
             "actualWeight": {
@@ -4246,9 +4244,7 @@ func init() {
           "required": [
             "reason",
             "reServiceCode",
-            "description",
-            "estimatedWeight",
-            "actualWeight"
+            "description"
           ],
           "properties": {
             "actualWeight": {

--- a/pkg/gen/supportmessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_shuttle.go
@@ -34,7 +34,6 @@ type MTOServiceItemShuttle struct {
 	statusField MTOServiceItemStatus
 
 	// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-	// Required: true
 	ActualWeight *int64 `json:"actualWeight"`
 
 	// Further details about the shuttle service.
@@ -42,7 +41,6 @@ type MTOServiceItemShuttle struct {
 	Description *string `json:"description"`
 
 	// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-	// Required: true
 	EstimatedWeight *int64 `json:"estimatedWeight"`
 
 	// Service codes allowed for this model type.
@@ -139,7 +137,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	var data struct {
 
 		// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-		// Required: true
 		ActualWeight *int64 `json:"actualWeight"`
 
 		// Further details about the shuttle service.
@@ -147,7 +144,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		Description *string `json:"description"`
 
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-		// Required: true
 		EstimatedWeight *int64 `json:"estimatedWeight"`
 
 		// Service codes allowed for this model type.
@@ -232,7 +228,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 	b1, err = json.Marshal(struct {
 
 		// Provided by the movers, based on weight tickets. Relevant for shuttling (DDSHUT & DOSHUT) service items.
-		// Required: true
 		ActualWeight *int64 `json:"actualWeight"`
 
 		// Further details about the shuttle service.
@@ -240,7 +235,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		Description *string `json:"description"`
 
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
-		// Required: true
 		EstimatedWeight *int64 `json:"estimatedWeight"`
 
 		// Service codes allowed for this model type.
@@ -327,15 +321,7 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateActualWeight(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateEstimatedWeight(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -408,27 +394,9 @@ func (m *MTOServiceItemShuttle) validateStatus(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *MTOServiceItemShuttle) validateActualWeight(formats strfmt.Registry) error {
-
-	if err := validate.Required("actualWeight", "body", m.ActualWeight); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *MTOServiceItemShuttle) validateDescription(formats strfmt.Registry) error {
 
 	if err := validate.Required("description", "body", m.Description); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemShuttle) validateEstimatedWeight(formats strfmt.Registry) error {
-
-	if err := validate.Required("estimatedWeight", "body", m.EstimatedWeight); err != nil {
 		return err
 	}
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1527,8 +1527,6 @@ definitions:
           - reason
           - reServiceCode
           - description
-          - estimatedWeight
-          - actualWeight
   MTOServiceItemStatus:
     description: Describes all statuses for a MTOServiceItem.
     type: string

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1322,8 +1322,6 @@ definitions:
           - reason
           - reServiceCode
           - description
-          - estimatedWeight
-          - actualWeight
   MTOServiceItemStatus:
     description: Describes all statuses for a MTOServiceItem.
     type: string


### PR DESCRIPTION
## Description

This PR makes the estimated and actual weights for shuttling service items optional again. For additional context: https://ustcdp3.slack.com/archives/CP6F568DC/p1627338724088900

## Setup

To test, complete the following steps:
To run the tests execute make server_test

To test the createMTOServiceItem endpoint complete the following steps using postman:

- Start your local server
- hit the fetchMTOUpdates endpoint
- Select a move with an existing shipment and grab the shipment and move IDs.
- Hit the createMTOServiceItem endpoint with the following body

```
{
    "modelType": "MTOServiceItemShuttle",
    "moveTaskOrderID": "<YOUR MOVE ID>",
    "mtoShipmentID": "<YOUR SHIPMENT ID>",
    "status": "SUBMITTED",
    "reServiceCode": "DOSHUT",
    "description": "description",
    "reason": "reason",
    "estimatedWeight": 4200
}
```
This will create the DOSHUT service item.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8853) for this change
