### PR TITLE
MB-8857 Remove open in new window link from document viewer

### DIFF
--- a/src/components/DocumentViewer/DocumentViewer.jsx
+++ b/src/components/DocumentViewer/DocumentViewer.jsx
@@ -9,12 +9,10 @@ import Content from './Content/Content';
 import Menu from './Menu/Menu';
 
 import { formatDate } from 'shared/dates';
-import { ReactComponent as ExternalLink } from 'shared/icon/external-link.svg';
 import { filenameFromPath } from 'shared/formatters';
 
 /**
  * TODO
- * - implement open in a new window
  * - implement next/previous pages instead of scroll through pages
  * - implement rotate left/right
  * - handle fetch doc errors
@@ -70,9 +68,6 @@ const DocumentViewer = ({ files }) => {
     selectFile(index);
     closeMenu();
   };
-  const openInNewWindow = () => {
-    // TODO - do we need to stream the file or can we just open the URL?
-  };
 
   const selectedFilename = filenameFromPath(selectedFile.filename);
 
@@ -87,11 +82,6 @@ const DocumentViewer = ({ files }) => {
         <p title={selectedFilename} data-testid="documentTitle">
           <span>{selectedFilename}</span> <span>- Added on {selectedFileDate}</span>
         </p>
-        {/* TODO */}
-        <Button type="button" unstyled onClick={openInNewWindow}>
-          <span>Open in a new window</span>
-          <ExternalLink />
-        </Button>
       </div>
       <Content fileType={fileType} filePath={selectedFile.url} />
       {menuIsOpen && <div className={styles.overlay} />}


### PR DESCRIPTION
## Description

This PR removes the `Open in new window` link from the document viewer.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8857) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/127196398-d607912e-8628-4298-9b02-c431253aa89d.png)
