### PR TITLE
add ability to exclude cves

### DIFF
--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -19,7 +19,18 @@ get_findings() {
   echo "${findings}" | jq .
   echo
   status=$(echo "${findings}" | jq -r ".imageScanStatus.status")
-  numberOfFindings=$(echo "${findings}" | jq -r ".imageScanFindings.findings | length")
+
+  # Exclude certain findings.
+  #
+  # ID: CVE-2021-36159
+  # Ticket to remove this exclusion: https://dp3.atlassian.net/browse/MB-TBD
+  # Description:
+  # As of 2021-07-27, no description of this vulnerability is available and no fix is available.
+  # ECR scanning detects this as a vulnerability, but there is no way to fix it, so our builds are
+  # blocked. To unblock this, we are excluding it from our scans since this is a non-actionable
+  # finding.
+  validFindings=$(echo "${findings}" | jq 'del(.imageScanFindings.findings[] | select(.name == "CVE-2021-36159"))')
+  numberOfValidFindings=$(echo "${validFindings}" | jq -r ".imageScanFindings.findings | length")
 }
 
 # Get the results of the scan or wait until they are ready
@@ -34,7 +45,7 @@ if [[ "${status}" != *COMPLETE* ]]; then
   exit 1
 fi
 
-if [[ "${numberOfFindings}" -gt 0 ]]; then
-  echo "Scan found ${numberOfFindings} findings!"
+if [[ "${numberOfValidFindings}" -gt 0 ]]; then
+  echo "Scan found ${numberOfValidFindings} findings!"
   exit 1
 fi


### PR DESCRIPTION
## Description

ECR periodically produces false positives (flagging CVEs incorrectly due to bugs in its scanning engine) or due to CVEs that have no fix available. Because these issues are outside of our control, it can block our CI pipelines entirely with no way to move forward. This PR grants us the ability to filter out these types of CVEs from the scan results.

This also defines a pattern for including a link to a ticket to remove the exclusion, so that we do not keep these exclusions in forever.

## Code Review Verification Steps
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.

## References

* https://forums.aws.amazon.com/thread.jspa?threadID=337518
* https://github.com/aws/containers-roadmap/issues/798
* https://forums.aws.amazon.com/thread.jspa?threadID=336286