### PR TITLE
MB-8839 Next button link from shipment review page to agreement page

### DIFF
--- a/src/pages/MyMove/Review/Review.test.jsx
+++ b/src/pages/MyMove/Review/Review.test.jsx
@@ -15,6 +15,14 @@ describe('Review page', () => {
   const testProps = {
     canMoveNext: true,
     push: jest.fn(),
+    match: {
+      path: '/moves/:moveId/review',
+      url: '/moves/3a8c9f4f-7344-4f18-9ab5-0de3ef57b901/review',
+      isExact: true,
+      params: {
+        moveId: '3a8c9f4f-7344-4f18-9ab5-0de3ef57b901',
+      },
+    },
   };
 
   it('renders the Review Page', async () => {
@@ -56,7 +64,7 @@ describe('Review page', () => {
 
     userEvent.click(submitButton);
 
-    expect(testProps.push).toHaveBeenCalledWith('/moves/:moveId/agreement');
+    expect(testProps.push).toHaveBeenCalledWith(`/moves/${testProps.match.params.moveId}/agreement`);
   });
 
   afterEach(jest.resetAllMocks);

--- a/src/pages/MyMove/Review/index.jsx
+++ b/src/pages/MyMove/Review/index.jsx
@@ -4,10 +4,9 @@ import { connect } from 'react-redux';
 import { GridContainer, Grid } from '@trussworks/react-uswds';
 import { generatePath } from 'react-router';
 
-import { MatchShape } from '../../../types/router';
-
 import styles from './Review.module.scss';
 
+import { MatchShape } from 'types/router';
 import ScrollToTop from 'components/ScrollToTop';
 import { hasShortHaulError } from 'utils/incentives';
 import ConnectedFlashMessage from 'containers/FlashMessage/FlashMessage';

--- a/src/pages/MyMove/Review/index.jsx
+++ b/src/pages/MyMove/Review/index.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
 import { GridContainer, Grid } from '@trussworks/react-uswds';
+import { generatePath } from 'react-router';
+
+import { MatchShape } from '../../../types/router';
 
 import styles from './Review.module.scss';
 
@@ -16,13 +19,16 @@ import { selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import { selectPPMEstimateError } from 'store/onboarding/selectors';
 import { customerRoutes, generalRoutes } from 'constants/routes';
 
-const Review = ({ push, canMoveNext }) => {
+const Review = ({ push, canMoveNext, match }) => {
   const handleCancel = () => {
     push(generalRoutes.HOME_PATH);
   };
 
   const handleNext = () => {
-    push(customerRoutes.MOVE_AGREEMENT_PATH);
+    const nextPath = generatePath(customerRoutes.MOVE_AGREEMENT_PATH, {
+      moveId: match.params.moveId,
+    });
+    push(nextPath);
   };
 
   return (
@@ -59,6 +65,7 @@ const Review = ({ push, canMoveNext }) => {
 Review.propTypes = {
   canMoveNext: bool.isRequired,
   push: func.isRequired,
+  match: MatchShape.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -230,10 +230,9 @@ const pages = {
   [customerRoutes.MOVE_REVIEW_PATH]: {
     isInFlow: always,
     isComplete: ({ sm, orders, move, ppm, mtoShipment }) => isCurrentMoveSubmitted(move),
-    render:
-      () =>
-      ({ history }) =>
-        <Review push={history.push} />,
+    render: () => (props) => {
+      return <Review {...props} push={props.history.push} />;
+    },
   },
   [customerRoutes.MOVE_AGREEMENT_PATH]: {
     isInFlow: always,


### PR DESCRIPTION
## Description

The "Next" button on the Customer shipment review page directs the user to the agreement page, but currently links to `/moves/:moveId/agreement`. This PR fixes the link so that `:moveId` is replaced with the actual uuid of the move (e.g. `/moves/cef88530-60a0-41df-88a3-7c0a7fe1860c/agreement`). 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
Create a user and progress through the flow to adding an HHG shipment. Add the shipment as normal, click through to the review page, and then click "Next" to proceed to the agreement page.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8839) for this change
