### PR TITLE
[MB-2504] SystemError on error office queue page

### DIFF
--- a/src/components/SystemError/SystemError.module.scss
+++ b/src/components/SystemError/SystemError.module.scss
@@ -7,4 +7,10 @@
   padding-top: 0.8rem;
   padding-left: 1.6rem;
   padding-right: 1.6rem;
+  line-height: 20px;
+  & > a,
+  a:visited {
+    color: black;
+    text-decoration: underline;
+  }
 }

--- a/src/components/SystemError/SystemError.module.scss
+++ b/src/components/SystemError/SystemError.module.scss
@@ -1,3 +1,10 @@
+@import 'shared/styles/colors';
+
 .systemError {
   font-size: 1rem;
+  background-color: $warning;
+  padding-bottom: 0.8rem;
+  padding-top: 0.8rem;
+  padding-left: 1.6rem;
+  padding-right: 1.6rem;
 }

--- a/src/components/SystemError/index.jsx
+++ b/src/components/SystemError/index.jsx
@@ -3,7 +3,7 @@ import { node } from 'prop-types';
 
 import styles from './SystemError.module.scss';
 
-const SystemError = ({ children }) => <div className={`usa-alert--system-error ${styles.systemError}`}>{children}</div>;
+const SystemError = ({ children }) => <div className={styles.systemError}>{children}</div>;
 
 SystemError.propTypes = {
   children: node.isRequired,

--- a/src/components/SystemError/index.jsx
+++ b/src/components/SystemError/index.jsx
@@ -3,7 +3,11 @@ import { node } from 'prop-types';
 
 import styles from './SystemError.module.scss';
 
-const SystemError = ({ children }) => <div className={styles.systemError}>{children}</div>;
+const SystemError = ({ children }) => (
+  <div className={styles.systemError} data-testid="system-error">
+    {children}
+  </div>
+);
 
 SystemError.propTypes = {
   children: node.isRequired,

--- a/src/pages/Office/Office.module.scss
+++ b/src/pages/Office/Office.module.scss
@@ -1,0 +1,4 @@
+.link,
+.link:visited {
+  color: black;
+}

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -1,8 +1,10 @@
 import React, { Suspense, lazy, useState, useEffect } from 'react';
 import { Switch, useParams, Redirect, Route, useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 import 'styles/office.scss';
 import CustomerHeader from 'components/CustomerHeader';
+import SystemError from 'components/SystemError';
 import { servicesCounselingRoutes } from 'constants/routes';
 import { useTXOMoveInfoQueries } from 'hooks/queries';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -18,7 +20,7 @@ const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo')
 
 const ServicesCounselingMoveInfo = () => {
   const [customerEditAlert, setCustomerEditAlert] = useState(null);
-
+  const { hasRecentError, traceId } = useSelector((state) => state.interceptor);
   const onCustomerInfoUpdate = (alertType) => {
     if (alertType === 'error') {
       setCustomerEditAlert({
@@ -55,7 +57,15 @@ const ServicesCounselingMoveInfo = () => {
   return (
     <>
       <CustomerHeader order={order} customer={customerData} moveCode={moveCode} />
-
+      {hasRecentError && (
+        <SystemError>
+          Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
+          <br />
+          If that doesn&apos;t fix it, contact the{' '}
+          <a href="https://move.mil/customer-service#technical-help-desk">Technical Help Desk</a> and give them this
+          code: <strong>{traceId}</strong>
+        </SystemError>
+      )}
       <Suspense fallback={<LoadingPlaceholder />}>
         <Switch>
           {/* TODO - Routes not finalized, revisit */}

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, queryByTestId } from '@testing-library/react';
 
 import ServicesCounselingMoveInfo from './ServicesCounselingMoveInfo';
 
@@ -205,6 +205,34 @@ describe('Services Counseling Move Info Container', () => {
       );
 
       expect(wrapper.find('CustomerHeader').exists()).toBe(true);
+    });
+    it('should render the system error when there is an error', () => {
+      render(
+        <MockProviders
+          initialState={{ interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
+          initialEntries={[`/counseling/moves/${testMoveCode}/details`]}
+        >
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+      expect(screen.getByText('Technical Help Desk').closest('a')).toHaveAttribute(
+        'href',
+        'https://move.mil/customer-service#technical-help-desk',
+      );
+      expect(screen.getByTestId('system-error').textContent).toEqual(
+        "Something isn't working, but we're not sure what. Wait a minute and try again.If that doesn't fix it, contact the Technical Help Desk and give them this code: some-trace-id",
+      );
+    });
+    it('should not render system error when there is not an error', () => {
+      render(
+        <MockProviders
+          initialState={{ interceptor: { hasRecentError: false, traceId: '' } }}
+          initialEntries={[`/counseling/moves/${testMoveCode}/details`]}
+        >
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+      expect(queryByTestId(document.documentElement, 'system-error')).not.toBeInTheDocument();
     });
   });
   describe('routing', () => {

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -1,11 +1,13 @@
 import React, { Suspense, lazy } from 'react';
 import { NavLink, Switch, useParams, Redirect, Route, useLocation, matchPath } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { Tag } from '@trussworks/react-uswds';
 
 import 'styles/office.scss';
 import TabNav from 'components/TabNav';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import CustomerHeader from 'components/CustomerHeader';
+import SystemError from 'components/SystemError';
 import { useTXOMoveInfoQueries } from 'hooks/queries';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 
@@ -20,7 +22,7 @@ const TXOMoveInfo = () => {
   const [unapprovedShipmentCount, setUnapprovedShipmentCount] = React.useState(0);
   const [unapprovedServiceItemCount, setUnapprovedServiceItemCount] = React.useState(0);
   const [pendingPaymentRequestCount, setPendingPaymentRequestCount] = React.useState(0);
-
+  const { hasRecentError, traceId } = useSelector((state) => state.interceptor);
   const { moveCode } = useParams();
   const { pathname } = useLocation();
   const { order, customerData, isLoading, isError } = useTXOMoveInfoQueries(moveCode);
@@ -52,6 +54,15 @@ const TXOMoveInfo = () => {
   return (
     <>
       <CustomerHeader order={order} customer={customerData} moveCode={moveCode} />
+      {hasRecentError && (
+        <SystemError>
+          Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
+          <br />
+          If that doesn&apos;t fix it, contact the{' '}
+          <a href="https://move.mil/customer-service#technical-help-desk">Technical Help Desk</a> and give them this
+          code: <strong>{traceId}</strong>
+        </SystemError>
+      )}
       {!hideNav && (
         <header className="nav-header">
           <div className="grid-container-desktop-lg">
@@ -89,6 +100,7 @@ const TXOMoveInfo = () => {
           </div>
         </header>
       )}
+
       <Suspense fallback={<LoadingPlaceholder />}>
         <Switch>
           <Route path="/moves/:moveCode/details" exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, queryByTestId } from '@testing-library/react';
 
 import TXOMoveInfo from './TXOMoveInfo';
 
@@ -111,6 +111,37 @@ describe('TXO Move Info Container', () => {
       expect(wrapper.find('li.tabItem a').at(1).prop('href')).toEqual(`/moves/${testMoveCode}/mto`);
       expect(wrapper.find('li.tabItem a').at(2).prop('href')).toEqual(`/moves/${testMoveCode}/payment-requests`);
       expect(wrapper.find('li.tabItem a').at(3).prop('href')).toEqual(`/moves/${testMoveCode}/history`);
+    });
+    it('should render the system error when there is an error', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(basicUseTXOMoveInfoQueriesValue);
+
+      render(
+        <MockProviders
+          initialState={{ interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
+          initialEntries={[`/moves/${testMoveCode}/details`]}
+        >
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+      expect(screen.getByText('Technical Help Desk').closest('a')).toHaveAttribute(
+        'href',
+        'https://move.mil/customer-service#technical-help-desk',
+      );
+      expect(screen.getByTestId('system-error').textContent).toEqual(
+        "Something isn't working, but we're not sure what. Wait a minute and try again.If that doesn't fix it, contact the Technical Help Desk and give them this code: some-trace-id",
+      );
+    });
+    it('should not render system error when there is not an error', () => {
+      useTXOMoveInfoQueries.mockReturnValueOnce(basicUseTXOMoveInfoQueriesValue);
+      render(
+        <MockProviders
+          initialState={{ interceptor: { hasRecentError: false, traceId: '' } }}
+          initialEntries={[`/moves/${testMoveCode}/details`]}
+        >
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+      expect(queryByTestId(document.documentElement, 'system-error')).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -22,6 +22,7 @@ import PrivateRoute from 'containers/PrivateRoute';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import FOUOHeader from 'components/FOUOHeader';
 import BypassBlock from 'components/BypassBlock';
+import SystemError from 'components/SystemError';
 import OfficeLoggedInHeader from 'containers/Headers/OfficeLoggedInHeader';
 import LoggedOutHeader from 'containers/Headers/LoggedOutHeader';
 import { ConnectedSelectApplication } from 'pages/SelectApplication/SelectApplication';
@@ -91,6 +92,7 @@ export class OfficeApp extends Component {
       userIsLoggedIn,
       userRoles,
       location: { pathname },
+      hasRecentError,
     } = this.props;
     const selectedRole = userIsLoggedIn && activeRole;
 
@@ -160,7 +162,15 @@ export class OfficeApp extends Component {
             {!hideHeaderPPM && <>{userIsLoggedIn ? <OfficeLoggedInHeader /> : <LoggedOutHeader />}</>}
             <main id="main" role="main" className="site__content site-office__content">
               <ConnectedLogoutOnInactivity />
-
+              {hasRecentError && (
+                <SystemError>
+                  Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
+                  <br />
+                  If that doesn&apos;t fix it, contact the{' '}
+                  <a href="https://move.mil/customer-service#technical-help-desk">Technical Help Desk</a> and give them
+                  this code: [trace ID]
+                </SystemError>
+              )}
               {hasError && <SomethingWentWrong error={error} info={info} />}
 
               <Suspense fallback={<LoadingPlaceholder />}>
@@ -258,6 +268,7 @@ OfficeApp.propTypes = {
   userIsLoggedIn: PropTypes.bool,
   userRoles: UserRolesShape,
   activeRole: PropTypes.string,
+  hasRecentError: PropTypes.bool.isRequired,
 };
 
 OfficeApp.defaultProps = {
@@ -275,6 +286,7 @@ const mapStateToProps = (state) => {
     userIsLoggedIn: selectIsLoggedIn(state),
     userRoles: user?.roles || [],
     activeRole: state.auth.activeRole,
+    hasRecentError: state.interceptor.hasRecentError,
   };
 };
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -95,7 +95,7 @@ export class OfficeApp extends Component {
       location: { pathname },
       hasRecentError,
       traceId,
-      match,
+      history,
     } = this.props;
     const selectedRole = userIsLoggedIn && activeRole;
 
@@ -164,7 +164,7 @@ export class OfficeApp extends Component {
             {!hideHeaderPPM && <>{userIsLoggedIn ? <OfficeLoggedInHeader /> : <LoggedOutHeader />}</>}
             <main id="main" role="main" className="site__content site-office__content">
               <ConnectedLogoutOnInactivity />
-              {hasRecentError && match.path === '/' && (
+              {hasRecentError && history.location.pathname === '/' && (
                 <SystemError>
                   Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
                   <br />
@@ -274,8 +274,10 @@ OfficeApp.propTypes = {
   activeRole: PropTypes.string,
   hasRecentError: PropTypes.bool.isRequired,
   traceId: PropTypes.string.isRequired,
-  match: PropTypes.shape({
-    path: PropTypes.string,
+  history: PropTypes.shape({
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
   }),
 };
 
@@ -284,8 +286,8 @@ OfficeApp.defaultProps = {
   userIsLoggedIn: false,
   userRoles: [],
   activeRole: null,
-  match: {
-    path: '',
+  history: {
+    location: { pathname: '' },
   },
 };
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -5,6 +5,7 @@ import { Route, Switch, withRouter, matchPath, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
+import styles from './Office.module.scss';
 import '../../../node_modules/uswds/dist/css/uswds.css';
 import 'scenes/Office/office.scss';
 
@@ -93,6 +94,7 @@ export class OfficeApp extends Component {
       userRoles,
       location: { pathname },
       hasRecentError,
+      traceId,
     } = this.props;
     const selectedRole = userIsLoggedIn && activeRole;
 
@@ -167,8 +169,10 @@ export class OfficeApp extends Component {
                   Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
                   <br />
                   If that doesn&apos;t fix it, contact the{' '}
-                  <a href="https://move.mil/customer-service#technical-help-desk">Technical Help Desk</a> and give them
-                  this code: [trace ID]
+                  <a className={styles.link} href="https://move.mil/customer-service#technical-help-desk">
+                    Technical Help Desk
+                  </a>{' '}
+                  and give them this code: <strong>{traceId}</strong>
                 </SystemError>
               )}
               {hasError && <SomethingWentWrong error={error} info={info} />}
@@ -269,6 +273,7 @@ OfficeApp.propTypes = {
   userRoles: UserRolesShape,
   activeRole: PropTypes.string,
   hasRecentError: PropTypes.bool.isRequired,
+  traceId: PropTypes.string.isRequired,
 };
 
 OfficeApp.defaultProps = {
@@ -287,6 +292,7 @@ const mapStateToProps = (state) => {
     userRoles: user?.roles || [],
     activeRole: state.auth.activeRole,
     hasRecentError: state.interceptor.hasRecentError,
+    traceId: state.interceptor.traceId,
   };
 };
 

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -95,6 +95,7 @@ export class OfficeApp extends Component {
       location: { pathname },
       hasRecentError,
       traceId,
+      match,
     } = this.props;
     const selectedRole = userIsLoggedIn && activeRole;
 
@@ -164,17 +165,19 @@ export class OfficeApp extends Component {
             {!hideHeaderPPM && <>{userIsLoggedIn ? <OfficeLoggedInHeader /> : <LoggedOutHeader />}</>}
             <main id="main" role="main" className="site__content site-office__content">
               <ConnectedLogoutOnInactivity />
-              {hasRecentError && (
-                <SystemError>
-                  Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
-                  <br />
-                  If that doesn&apos;t fix it, contact the{' '}
-                  <a className={styles.link} href="https://move.mil/customer-service#technical-help-desk">
-                    Technical Help Desk
-                  </a>{' '}
-                  and give them this code: <strong>{traceId}</strong>
-                </SystemError>
-              )}
+              {hasRecentError &&
+                match.path ===
+                  '/'(
+                    <SystemError>
+                      Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
+                      <br />
+                      If that doesn&apos;t fix it, contact the{' '}
+                      <a className={styles.link} href="https://move.mil/customer-service#technical-help-desk">
+                        Technical Help Desk
+                      </a>{' '}
+                      and give them this code: <strong>{traceId}</strong>
+                    </SystemError>,
+                  )}
               {hasError && <SomethingWentWrong error={error} info={info} />}
 
               <Suspense fallback={<LoadingPlaceholder />}>
@@ -274,6 +277,9 @@ OfficeApp.propTypes = {
   activeRole: PropTypes.string,
   hasRecentError: PropTypes.bool.isRequired,
   traceId: PropTypes.string.isRequired,
+  match: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 OfficeApp.defaultProps = {

--- a/src/pages/Office/index.jsx
+++ b/src/pages/Office/index.jsx
@@ -154,7 +154,6 @@ export class OfficeApp extends Component {
     const siteClasses = classnames('site', {
       [`site--fullscreen`]: isFullscreenPage,
     });
-
     return (
       <>
         <div id="app-root">
@@ -165,19 +164,17 @@ export class OfficeApp extends Component {
             {!hideHeaderPPM && <>{userIsLoggedIn ? <OfficeLoggedInHeader /> : <LoggedOutHeader />}</>}
             <main id="main" role="main" className="site__content site-office__content">
               <ConnectedLogoutOnInactivity />
-              {hasRecentError &&
-                match.path ===
-                  '/'(
-                    <SystemError>
-                      Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
-                      <br />
-                      If that doesn&apos;t fix it, contact the{' '}
-                      <a className={styles.link} href="https://move.mil/customer-service#technical-help-desk">
-                        Technical Help Desk
-                      </a>{' '}
-                      and give them this code: <strong>{traceId}</strong>
-                    </SystemError>,
-                  )}
+              {hasRecentError && match.path === '/' && (
+                <SystemError>
+                  Something isn&apos;t working, but we&apos;re not sure what. Wait a minute and try again.
+                  <br />
+                  If that doesn&apos;t fix it, contact the{' '}
+                  <a className={styles.link} href="https://move.mil/customer-service#technical-help-desk">
+                    Technical Help Desk
+                  </a>{' '}
+                  and give them this code: <strong>{traceId}</strong>
+                </SystemError>
+              )}
               {hasError && <SomethingWentWrong error={error} info={info} />}
 
               <Suspense fallback={<LoadingPlaceholder />}>
@@ -278,8 +275,8 @@ OfficeApp.propTypes = {
   hasRecentError: PropTypes.bool.isRequired,
   traceId: PropTypes.string.isRequired,
   match: PropTypes.shape({
-    path: PropTypes.string.isRequired,
-  }).isRequired,
+    path: PropTypes.string,
+  }),
 };
 
 OfficeApp.defaultProps = {
@@ -287,6 +284,9 @@ OfficeApp.defaultProps = {
   userIsLoggedIn: false,
   userRoles: [],
   activeRole: null,
+  match: {
+    path: '',
+  },
 };
 
 const mapStateToProps = (state) => {

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { queryByTestId, render, screen } from '@testing-library/react';
 
 import ConnectedOffice, { OfficeApp } from './index';
 
@@ -87,7 +87,7 @@ describe('Office App', () => {
         render(
           <MockProviders
             initialState={{ ...officeUserState, interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
-            initialEntries={['/moves/queue']}
+            initialEntries={['/']}
           >
             <ConnectedOffice />
           </MockProviders>,
@@ -99,6 +99,17 @@ describe('Office App', () => {
         expect(screen.getByTestId('system-error').textContent).toEqual(
           "Something isn't working, but we're not sure what. Wait a minute and try again.If that doesn't fix it, contact the Technical Help Desk and give them this code: some-trace-id",
         );
+      });
+      it('does not render system error if it is not on the queue page', () => {
+        render(
+          <MockProviders
+            initialState={{ ...officeUserState, interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
+            initialEntries={['/sign-in']}
+          >
+            <ConnectedOffice />
+          </MockProviders>,
+        );
+        expect(queryByTestId(document.documentElement, 'system-error')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import ConnectedOffice, { OfficeApp } from './index';
 
@@ -77,9 +78,25 @@ describe('Office App', () => {
             <ConnectedOffice />
           </MockProviders>,
         );
-
         expect(app.containsMatchingElement(<a href="/">ABCD moves</a>)).toEqual(true);
         expect(app.containsMatchingElement(<span>Gorman, Amanda</span>)).toEqual(true);
+      });
+      it('renders the system error component if there is an unexpected error', () => {
+        render(
+          <MockProviders
+            initialState={{ ...officeUserState, interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
+            initialEntries={['/moves/queue']}
+          >
+            <ConnectedOffice />
+          </MockProviders>,
+        );
+        expect(screen.getByText('Technical Help Desk').closest('a')).toHaveAttribute(
+          'href',
+          'https://move.mil/customer-service#technical-help-desk',
+        );
+        expect(screen.getByTestId('system-error').textContent).toEqual(
+          "Something isn't working, but we're not sure what. Wait a minute and try again.If that doesn't fix it, contact the Technical Help Desk and give them this code: some-trace-id",
+        );
       });
     });
   });

--- a/src/pages/Office/index.test.jsx
+++ b/src/pages/Office/index.test.jsx
@@ -14,6 +14,8 @@ describe('Office App', () => {
     loadInternalSchema: jest.fn(),
     loadPublicSchema: jest.fn(),
     logOut: jest.fn(),
+    hasRecentError: false,
+    traceId: '',
   };
 
   describe('component', () => {
@@ -81,7 +83,7 @@ describe('Office App', () => {
         expect(app.containsMatchingElement(<a href="/">ABCD moves</a>)).toEqual(true);
         expect(app.containsMatchingElement(<span>Gorman, Amanda</span>)).toEqual(true);
       });
-      it('renders the system error component if there is an unexpected error', () => {
+      it('renders the system error component if there is an unexpected error and on the queue page', () => {
         render(
           <MockProviders
             initialState={{ ...officeUserState, interceptor: { hasRecentError: true, traceId: 'some-trace-id' } }}
@@ -122,6 +124,11 @@ describe('Office App', () => {
             },
           },
         },
+      },
+      interceptor: {
+        hasRecentError: false,
+        timestamp: 0,
+        traceId: '',
       },
     };
 

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -1,6 +1,6 @@
 import Swagger from 'swagger-client';
 
-import { makeSwaggerRequest, requestInterceptor } from './swaggerRequest';
+import { makeSwaggerRequest, requestInterceptor, responseInterceptor } from './swaggerRequest';
 
 let ghcClient = null;
 
@@ -10,6 +10,7 @@ export async function getGHCClient() {
     ghcClient = await Swagger({
       url: '/ghc/v1/swagger.yaml',
       requestInterceptor,
+      responseInterceptor,
     });
   }
   return ghcClient;

--- a/src/services/swaggerRequest.js
+++ b/src/services/swaggerRequest.js
@@ -34,7 +34,7 @@ export const requestInterceptor = (req) => {
 export const responseInterceptor = (res) => {
   switch (res.status) {
     case 500: {
-      interceptInjection(interceptResponse(true));
+      interceptInjection(interceptResponse(true, res.headers['x-milmove-trace-id']));
       break;
     }
 

--- a/src/store/interceptor/actions.js
+++ b/src/store/interceptor/actions.js
@@ -1,6 +1,7 @@
 export const INTERCEPT_RESPONSE = 'INTERCEPT_RESPONSE';
 
-export const interceptResponse = (hasError) => ({
+export const interceptResponse = (hasError, traceId = '') => ({
   type: INTERCEPT_RESPONSE,
   hasError,
+  traceId,
 });

--- a/src/store/interceptor/actions.test.js
+++ b/src/store/interceptor/actions.test.js
@@ -5,6 +5,12 @@ describe('interceptor actions', () => {
     expect(interceptResponse(true)).toEqual({
       type: INTERCEPT_RESPONSE,
       hasError: true,
+      traceId: '',
+    });
+    expect(interceptResponse(true, 'some-id')).toEqual({
+      type: INTERCEPT_RESPONSE,
+      hasError: true,
+      traceId: 'some-id',
     });
   });
 });

--- a/src/store/interceptor/reducer.js
+++ b/src/store/interceptor/reducer.js
@@ -5,6 +5,7 @@ const ACTION_RESPONSE_INTERVAL_MS = 3000;
 export const initialState = {
   hasRecentError: false,
   timestamp: 0,
+  traceId: '',
 };
 
 const interceptorReducer = (state = initialState, action) => {
@@ -17,6 +18,7 @@ const interceptorReducer = (state = initialState, action) => {
           ...state,
           hasRecentError: true,
           timestamp,
+          traceId: action.traceId,
         };
       }
 
@@ -25,6 +27,7 @@ const interceptorReducer = (state = initialState, action) => {
           ...state,
           hasRecentError: false,
           timestamp,
+          traceId: '',
         };
       }
 

--- a/src/store/interceptor/reducer.test.js
+++ b/src/store/interceptor/reducer.test.js
@@ -14,11 +14,13 @@ describe('interceptorReducer', () => {
       const oldState = {
         hasRecentError: false,
         timestamp: Date.now() - SHORT_RESPONSE_GAP_MS,
+        traceId: '',
       };
-
-      const newState = interceptorReducer(oldState, interceptResponse(true));
+      const traceId = 'some-trace-id';
+      const newState = interceptorReducer(oldState, interceptResponse(true, traceId));
       expect(newState.hasRecentError).toEqual(true);
       expect(newState.timestamp - oldState.timestamp).toBeGreaterThanOrEqual(SHORT_RESPONSE_GAP_MS);
+      expect(newState.traceId).toBe(traceId);
     });
 
     it('maintains hasRecentError value if a recent response was intercepted', () => {
@@ -32,15 +34,17 @@ describe('interceptorReducer', () => {
       expect(newState.timestamp - oldState.timestamp).toBeGreaterThanOrEqual(SHORT_RESPONSE_GAP_MS);
     });
 
-    it('updates hasRecentError value if timestamp is stale', () => {
+    it('updates hasRecentError value if timestamp is stale and clears traceId', () => {
       const oldState = {
         hasRecentError: true,
         timestamp: Date.now() - LONG_RESPONSE_GAP_MS,
+        traceId: 'some-trace-id',
       };
 
       const newState = interceptorReducer(oldState, interceptResponse(false));
       expect(newState.hasRecentError).toEqual(false);
       expect(newState.timestamp - oldState.timestamp).toBeGreaterThanOrEqual(LONG_RESPONSE_GAP_MS);
+      expect(newState.traceId).toBe('');
     });
 
     it('maintains hasRecentError value if action value is false and state timestamp is stale', () => {


### PR DESCRIPTION
## Description

Show `SystemError` component when there is an error on any office page

## Setup
Locally, change `GetMovesQueueHandler` function located [here](https://github.com/transcom/mymove/blob/e1a30ff02bbdb771977b15c9ecad25ae9acbee9d/pkg/handlers/ghcapi/queues.go#L31) to this so it will always error:
```
func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middleware.Responder {
	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)

	if !session.IsOfficeUser() || !session.Roles.HasRole(roles.RoleTypeTOO) {
		logger.Error("user is not authenticated with TOO office role")
		return queues.NewGetMovesQueueForbidden()
	}

	return queues.NewGetMovesQueueInternalServerError()
}

```
Log in to a TOO
You should see the error
`make server_run`
`make office_client_run`

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2504) for this change

## Screenshots

Queue pages (TOO/TIO/TXO/Services Counselor)
![image](https://user-images.githubusercontent.com/13622298/127395205-33c551eb-21d2-49b8-b543-9639f4739e90.png)

TIO/TOO/TXO Move details
![image](https://user-images.githubusercontent.com/13622298/127611838-b85b8802-184d-4864-86da-2b21524b225f.png)

Services Counselor Move Details
![image](https://user-images.githubusercontent.com/13622298/127611908-1e2e35bb-c64c-4648-8548-333cabd3a16c.png)
