### PR TITLE
MB-8950 Storybook weight display component

### DIFF
--- a/src/components/Office/WeightDisplay/WeightDisplay.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from '@trussworks/react-uswds';
+
+import styles from 'components/Office/WeightDisplay/WeightDisplay.module.scss';
+import { formatWeight } from 'shared/formatters';
+
+const WeightDisplay = ({ heading, value, showEditBtn, onEdit }) => {
+  return (
+    <div className={classnames('maxw-tablet', styles.WeightDisplay)}>
+      <div className={styles.heading}>
+        <div>{heading}</div>
+        {showEditBtn && (
+          <Button unstyled type="button" className={styles.editButton} onClick={onEdit}>
+            <FontAwesomeIcon icon="pen" title="edit" alt="" />
+          </Button>
+        )}
+      </div>
+      <div className={styles.value}>{value ? formatWeight(value) : null}</div>
+    </div>
+  );
+};
+
+WeightDisplay.propTypes = {
+  heading: PropTypes.string.isRequired,
+  value: PropTypes.number,
+  showEditBtn: PropTypes.bool,
+  onEdit: PropTypes.func,
+};
+
+WeightDisplay.defaultProps = {
+  value: null,
+  showEditBtn: false,
+  onEdit: null,
+};
+
+export default WeightDisplay;

--- a/src/components/Office/WeightDisplay/WeightDisplay.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.jsx
@@ -7,7 +7,7 @@ import { Button } from '@trussworks/react-uswds';
 import styles from 'components/Office/WeightDisplay/WeightDisplay.module.scss';
 import { formatWeight } from 'shared/formatters';
 
-const WeightDisplay = ({ heading, weightValue, onEdit }) => {
+const WeightDisplay = ({ heading, weightValue, onEdit, children }) => {
   return (
     <div className={classnames('maxw-tablet', styles.WeightDisplay)}>
       <div className={styles.heading}>
@@ -19,6 +19,7 @@ const WeightDisplay = ({ heading, weightValue, onEdit }) => {
         )}
       </div>
       {weightValue && <div className={styles.value}>{formatWeight(weightValue)}</div>}
+      {children && <div className={styles.details}>{children}</div>}
     </div>
   );
 };
@@ -26,11 +27,13 @@ const WeightDisplay = ({ heading, weightValue, onEdit }) => {
 WeightDisplay.propTypes = {
   heading: PropTypes.string.isRequired,
   weightValue: PropTypes.number,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onEdit: PropTypes.func,
 };
 
 WeightDisplay.defaultProps = {
   weightValue: null,
+  children: null,
   onEdit: null,
 };
 

--- a/src/components/Office/WeightDisplay/WeightDisplay.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.jsx
@@ -7,12 +7,12 @@ import { Button } from '@trussworks/react-uswds';
 import styles from 'components/Office/WeightDisplay/WeightDisplay.module.scss';
 import { formatWeight } from 'shared/formatters';
 
-const WeightDisplay = ({ heading, weightValue, showEditBtn, onEdit }) => {
+const WeightDisplay = ({ heading, weightValue, onEdit }) => {
   return (
     <div className={classnames('maxw-tablet', styles.WeightDisplay)}>
       <div className={styles.heading}>
         <div>{heading}</div>
-        {showEditBtn && (
+        {onEdit && (
           <Button unstyled type="button" className={styles.editButton} onClick={onEdit}>
             <FontAwesomeIcon icon="pen" title="edit" alt="" />
           </Button>
@@ -26,13 +26,11 @@ const WeightDisplay = ({ heading, weightValue, showEditBtn, onEdit }) => {
 WeightDisplay.propTypes = {
   heading: PropTypes.string.isRequired,
   weightValue: PropTypes.number,
-  showEditBtn: PropTypes.bool,
   onEdit: PropTypes.func,
 };
 
 WeightDisplay.defaultProps = {
   weightValue: null,
-  showEditBtn: false,
   onEdit: null,
 };
 

--- a/src/components/Office/WeightDisplay/WeightDisplay.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.jsx
@@ -7,7 +7,7 @@ import { Button } from '@trussworks/react-uswds';
 import styles from 'components/Office/WeightDisplay/WeightDisplay.module.scss';
 import { formatWeight } from 'shared/formatters';
 
-const WeightDisplay = ({ heading, value, showEditBtn, onEdit }) => {
+const WeightDisplay = ({ heading, weightValue, showEditBtn, onEdit }) => {
   return (
     <div className={classnames('maxw-tablet', styles.WeightDisplay)}>
       <div className={styles.heading}>
@@ -18,20 +18,20 @@ const WeightDisplay = ({ heading, value, showEditBtn, onEdit }) => {
           </Button>
         )}
       </div>
-      <div className={styles.value}>{value ? formatWeight(value) : null}</div>
+      {weightValue && <div className={styles.value}>{formatWeight(weightValue)}</div>}
     </div>
   );
 };
 
 WeightDisplay.propTypes = {
   heading: PropTypes.string.isRequired,
-  value: PropTypes.number,
+  weightValue: PropTypes.number,
   showEditBtn: PropTypes.bool,
   onEdit: PropTypes.func,
 };
 
 WeightDisplay.defaultProps = {
-  value: null,
+  weightValue: null,
   showEditBtn: false,
   onEdit: null,
 };

--- a/src/components/Office/WeightDisplay/WeightDisplay.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.jsx
@@ -18,7 +18,7 @@ const WeightDisplay = ({ heading, weightValue, onEdit, children }) => {
           </Button>
         )}
       </div>
-      {weightValue && <div className={styles.value}>{formatWeight(weightValue)}</div>}
+      {Number.isFinite(weightValue) && <div className={styles.value}>{formatWeight(weightValue)}</div>}
       {children && <div className={styles.details}>{children}</div>}
     </div>
   );

--- a/src/components/Office/WeightDisplay/WeightDisplay.module.scss
+++ b/src/components/Office/WeightDisplay/WeightDisplay.module.scss
@@ -1,12 +1,11 @@
 @import '../../../shared/styles/basics';
-@import '../../../shared/styles/mixins';
 @import '../../../shared/styles/colors';
 
 .WeightDisplay {
   @include u-padding(3);
   @include u-bg('white');
   @include u-radius(3px);
-  border: 1px solid #dcdee0;
+  border: 1px solid $border-color;
 
   .heading {
     @include u-font-size('base', 2);
@@ -25,5 +24,13 @@
     color: $link;
     max-width: 15px;
     min-width: 15px;
+  }
+
+  .details span {
+    background-color: $base-lightest;
+  }
+
+  .details {
+    @include u-font-size('base', 3);
   }
 }

--- a/src/components/Office/WeightDisplay/WeightDisplay.module.scss
+++ b/src/components/Office/WeightDisplay/WeightDisplay.module.scss
@@ -1,0 +1,29 @@
+@import '../../../shared/styles/basics';
+@import '../../../shared/styles/mixins';
+@import '../../../shared/styles/colors';
+
+.WeightDisplay {
+  @include u-padding(3);
+  @include u-bg('white');
+  @include u-radius(3px);
+  border: 1px solid #dcdee0;
+
+  .heading {
+    @include u-font-size('base', 2);
+    @include u-text('uppercase');
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .value {
+    @include u-font-size('base', 11);
+    @include u-text('bold');
+  }
+
+  .editButton {
+    @include u-padding(0);
+    color: $link;
+    max-width: 15px;
+    min-width: 15px;
+  }
+}

--- a/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
@@ -10,8 +10,7 @@ export default {
     weightValue: { defaultValue: 10000 },
     onEdit: { defaultValue: null },
     heading: { defaultValue: 'weight allowance' },
-    tagDetails: { defaultValue: null },
-    textDetails: { defaultValue: null },
+    children: { defaultValue: null },
   },
 };
 

--- a/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tag } from '@trussworks/react-uswds';
 
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
 
@@ -6,23 +7,34 @@ export default {
   title: 'Office Components/WeightDisplay',
   component: WeightDisplay,
   argTypes: {
-    value: { defaultValue: 10000 },
-    onEdit: { action: 'clicked' },
-    showEditBtn: { defaultValue: false },
+    weightValue: { defaultValue: 10000 },
+    onEdit: { defaultValue: null },
     heading: { defaultValue: 'weight allowance' },
+    tagDetails: { defaultValue: null },
+    textDetails: { defaultValue: null },
   },
 };
 
 const Template = (args) => <WeightDisplay {...args} />;
 
-export const WithNoDetails = Template.bind({});
-WithNoDetails.args = {
-  value: null,
+export const WithNoWeight = Template.bind({});
+WithNoWeight.args = {
+  weightValue: null,
 };
 
-export const WithDetails = Template.bind({});
+export const WithWeight = Template.bind({});
 
 export const WithEditButton = Template.bind({});
-WithEditButton.args = {
-  showEditBtn: true,
+WithEditButton.argTypes = {
+  onEdit: { defaultValue: () => {}, action: 'clicked' },
+};
+
+export const WithWeightAndDetailsTag = Template.bind({});
+WithWeightAndDetailsTag.args = {
+  children: <Tag>Risk of excess</Tag>,
+};
+
+export const WithWeightAndDetailsText = Template.bind({});
+WithWeightAndDetailsText.args = {
+  children: '110% of estimated weight',
 };

--- a/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
+
+export default {
+  title: 'Office Components/WeightDisplay',
+  component: WeightDisplay,
+  argTypes: {
+    value: { defaultValue: 10000 },
+    onEdit: { action: 'clicked' },
+    showEditBtn: { defaultValue: false },
+    heading: { defaultValue: 'weight allowance' },
+  },
+};
+
+const Template = (args) => <WeightDisplay {...args} />;
+
+export const WithNoDetails = Template.bind({});
+WithNoDetails.args = {
+  value: null,
+};
+
+export const WithDetails = Template.bind({});
+
+export const WithEditButton = Template.bind({});
+WithEditButton.args = {
+  showEditBtn: true,
+};

--- a/src/components/Office/WeightDisplay/WeightDisplay.test.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
+
+describe('WeightDisplay', () => {
+  it('renders without crashing', () => {
+    render(<WeightDisplay heading="heading test" />);
+
+    expect(screen.getByText('heading test')).toBeInTheDocument();
+  });
+
+  it('renders with weight value', () => {
+    render(<WeightDisplay heading="heading test" value={1234} />);
+
+    expect(screen.getByText('1,234 lbs')).toBeInTheDocument();
+  });
+
+  it('renders with edit button', () => {
+    render(<WeightDisplay heading="heading test" value={1234} showEditBtn />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('edit button is clicked', () => {
+    const mockEditBtn = jest.fn();
+    render(<WeightDisplay heading="heading test" value={1234} showEditBtn onEdit={mockEditBtn} />);
+    screen.getByRole('button').click();
+
+    expect(mockEditBtn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Office/WeightDisplay/WeightDisplay.test.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { Tag } from '@trussworks/react-uswds';
 
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
 
@@ -11,15 +12,41 @@ describe('WeightDisplay', () => {
   });
 
   it('renders with weight value', () => {
-    render(<WeightDisplay heading="heading test" value={1234} />);
+    render(<WeightDisplay heading="heading test" weightValue={1234} />);
 
     expect(screen.getByText('1,234 lbs')).toBeInTheDocument();
   });
 
   it('renders with edit button', () => {
-    render(<WeightDisplay heading="heading test" value={1234} showEditBtn />);
+    render(<WeightDisplay heading="heading test" value={1234} onEdit={jest.fn()} />);
 
     expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders with no edit button', () => {
+    render(<WeightDisplay heading="heading test" value={1234} />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders with react element as a child', () => {
+    render(
+      <WeightDisplay heading="heading test" value={1234}>
+        <Tag>tag passed in</Tag>
+      </WeightDisplay>,
+    );
+
+    expect(screen.getByText('tag passed in')).toBeInTheDocument();
+  });
+
+  it('renders with text as a child', () => {
+    render(
+      <WeightDisplay heading="heading test" value={1234}>
+        text passed in
+      </WeightDisplay>,
+    );
+
+    expect(screen.getByText('text passed in')).toBeInTheDocument();
   });
 
   it('edit button is clicked', () => {

--- a/src/shared/styles/colors.scss
+++ b/src/shared/styles/colors.scss
@@ -58,3 +58,6 @@ $color-gray-light: #b2b2b2;
 $color-red: #cd3504;
 $color-blue: #005ea2;
 $color-blue-focus: #2491ff;
+
+// border color
+$border-color: #dcdee0;


### PR DESCRIPTION
## Description

This PR creates the component to display the PO5 weights to be shown on the MTO page. This small component takes in an heading, weight value, and edit button callback function. The component can shrink or grow up to the `maxw-tablet` value.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
- ~~I omitted the tags that were shown in the screenshots seeing that we didn't have any stories relating to that. We could always add those later when we work on it.~~ Nevermind, I ended up added that third row to support the tags and text.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make storybook
```

Head over to this url: http://localhost:6006/?path=/story/office-components-weightdisplay--with-no-details

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8950) for this change
* [Maxw-tablet](https://designsystem.digital.gov/utilities/height-and-width/)

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/127580931-2fd36da6-7ed9-4d1e-b003-129273e49aa9.png)
