### PR TITLE
[MB-7253] Add invoice support for domestic crating/uncrating

### DIFF
--- a/pkg/edi/segment/l0.go
+++ b/pkg/edi/segment/l0.go
@@ -7,17 +7,20 @@ import (
 
 // L0 represents the L0 EDI segment
 type L0 struct {
-	LadingLineItemNumber   int     `validate:"min=1,max=999"`
-	BilledRatedAsQuantity  float64 `validate:"required_with=BilledRatedAsQualifier"`
-	BilledRatedAsQualifier string  `validate:"required_with=BilledRatedAsQuantity,omitempty,len=2"`
-	Weight                 float64 `validate:"required_with=WeightQualifier WeightUnitCode"`
-	WeightQualifier        string  `validate:"required_with=Weight WeightUnitCode,omitempty,eq=B"`
-	WeightUnitCode         string  `validate:"required_with=Weight WeightQualifier,omitempty,eq=L"`
+	LadingLineItemNumber   int     `validate:"min=1,max=999"`                                               // L001
+	BilledRatedAsQuantity  float64 `validate:"required_with=BilledRatedAsQualifier"`                        // L002
+	BilledRatedAsQualifier string  `validate:"required_with=BilledRatedAsQuantity,omitempty,len=2"`         // L003
+	Weight                 float64 `validate:"required_with=WeightQualifier WeightUnitCode"`                // L004
+	WeightQualifier        string  `validate:"required_with=Weight WeightUnitCode,omitempty,eq=B"`          // L005
+	Volume                 float64 `validate:"required_with=VolumeUnitQualifier"`                           // L006
+	VolumeUnitQualifier    string  `validate:"required_with=Volume,omitempty,eq=E"`                         // L007
+	LadingQuantity         int     `validate:"required_with=PackagingFormCode,omitempty,min=1,max=9999999"` // L008
+	PackagingFormCode      string  `validate:"required_with=LadingQuantity,omitempty,len=3"`                // L009
+	WeightUnitCode         string  `validate:"required_with=Weight WeightQualifier,omitempty,eq=L"`         // L011
 }
 
 // StringArray converts L0 to an array of strings
 func (s *L0) StringArray() []string {
-
 	var weight string
 	if s.Weight == 0 {
 		weight = ""
@@ -32,6 +35,20 @@ func (s *L0) StringArray() []string {
 		billedRatedAsQuantity = strconv.FormatFloat(s.BilledRatedAsQuantity, 'f', 3, 64)
 	}
 
+	var volume string
+	if s.Volume == 0 {
+		volume = ""
+	} else {
+		volume = strconv.FormatFloat(s.Volume, 'f', 3, 64)
+	}
+
+	var ladingQuantity string
+	if s.LadingQuantity == 0 {
+		ladingQuantity = ""
+	} else {
+		ladingQuantity = strconv.Itoa(s.LadingQuantity)
+	}
+
 	return []string{
 		"L0",
 		strconv.Itoa(s.LadingLineItemNumber),
@@ -39,12 +56,11 @@ func (s *L0) StringArray() []string {
 		s.BilledRatedAsQualifier,
 		weight,
 		s.WeightQualifier,
-		// TODO: will need to fill in the blank fields for crating
-		"",
-		"",
-		"",
-		"",
-		"",
+		volume,
+		s.VolumeUnitQualifier,
+		ladingQuantity,
+		s.PackagingFormCode,
+		"", // Dunnage Description (not used)
 		s.WeightUnitCode,
 	}
 }
@@ -52,8 +68,8 @@ func (s *L0) StringArray() []string {
 // Parse parses an X12 string that's split into an array into the L0 struct
 func (s *L0) Parse(parts []string) error {
 	numElements := len(parts)
-	if numElements != 3 && numElements != 11 {
-		return fmt.Errorf("L0: Wrong number of elements, expected 3 or 11, got %d", numElements)
+	if numElements != 3 && numElements != 9 && numElements != 11 {
+		return fmt.Errorf("L0: Wrong number of elements, expected 3, 9 or 11, got %d", numElements)
 	}
 
 	var err error
@@ -67,12 +83,25 @@ func (s *L0) Parse(parts []string) error {
 	}
 	s.BilledRatedAsQualifier = parts[2]
 
-	if numElements == 11 {
+	if numElements == 9 {
 		s.Weight, err = strconv.ParseFloat(parts[3], 64)
 		if err != nil {
 			return err
 		}
 		s.WeightQualifier = parts[4]
+		s.Volume, err = strconv.ParseFloat(parts[5], 64)
+		if err != nil {
+			return err
+		}
+		s.VolumeUnitQualifier = parts[6]
+		s.LadingQuantity, err = strconv.Atoi(parts[7])
+		if err != nil {
+			return err
+		}
+		s.PackagingFormCode = parts[8]
+	}
+
+	if numElements == 11 {
 		s.WeightUnitCode = parts[10]
 	}
 

--- a/pkg/edi/segment/l0_test.go
+++ b/pkg/edi/segment/l0_test.go
@@ -72,4 +72,45 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateError(err, "WeightUnitCode", "eq")
 		suite.ValidateErrorLen(err, 2)
 	})
+
+	suite.T().Run("validate failure 5", func(t *testing.T) {
+		l0 := L0{
+			LadingLineItemNumber: 1,
+			Volume:               144.0, // required_with
+			LadingQuantity:       1,     // required_with
+		}
+
+		err := suite.validator.Struct(l0)
+		suite.ValidateError(err, "VolumeUnitQualifier", "required_with")
+		suite.ValidateError(err, "PackagingFormCode", "required_with")
+		suite.ValidateErrorLen(err, 2)
+	})
+
+	suite.T().Run("validate failure 6", func(t *testing.T) {
+		l0 := L0{
+			LadingLineItemNumber: 1,
+			Volume:               144.0,
+			VolumeUnitQualifier:  "X",    // eq
+			LadingQuantity:       -1,     // min
+			PackagingFormCode:    "XXXX", // len
+		}
+
+		err := suite.validator.Struct(l0)
+		suite.ValidateError(err, "VolumeUnitQualifier", "eq")
+		suite.ValidateError(err, "LadingQuantity", "min")
+		suite.ValidateError(err, "PackagingFormCode", "len")
+		suite.ValidateErrorLen(err, 3)
+	})
+
+	suite.T().Run("validate failure 7", func(t *testing.T) {
+		l0 := L0{
+			LadingLineItemNumber: 1,
+			LadingQuantity:       10000000, // max
+			PackagingFormCode:    "CRT",
+		}
+
+		err := suite.validator.Struct(l0)
+		suite.ValidateError(err, "LadingQuantity", "max")
+		suite.ValidateErrorLen(err, 1)
+	})
 }

--- a/pkg/edi/segment/l1.go
+++ b/pkg/edi/segment/l1.go
@@ -7,17 +7,17 @@ import (
 
 // L1 represents the L1 EDI segment
 type L1 struct {
-	LadingLineItemNumber int    `validate:"required,min=1,max=999"`
-	FreightRate          *int   `validate:"omitempty,min=0"`
-	RateValueQualifier   string `validate:"required_with=FreightRate,omitempty,eq=LB"`
-	Charge               int64  `validate:"required,min=-999999999999,max=999999999999"` // Supports negative values
+	LadingLineItemNumber int      `validate:"required,min=1,max=999"`
+	FreightRate          *float64 `validate:"omitempty,min=0"`
+	RateValueQualifier   string   `validate:"required_with=FreightRate,omitempty,eq=LB"`
+	Charge               int64    `validate:"required,min=-999999999999,max=999999999999"` // Supports negative values
 }
 
 // StringArray converts L1 to an array of strings
 func (s *L1) StringArray() []string {
 	freightRate := ""
 	if s.FreightRate != nil {
-		freightRate = strconv.Itoa(*s.FreightRate)
+		freightRate = strconv.FormatFloat(*s.FreightRate, 'f', 2, 64)
 	}
 	return []string{
 		"L1",
@@ -40,7 +40,7 @@ func (s *L1) Parse(elements []string) error {
 	if err != nil {
 		return err
 	}
-	freightRate, err := strconv.Atoi(elements[1])
+	freightRate, err := strconv.ParseFloat(elements[1], 64)
 	if err != nil {
 		return err
 	}

--- a/pkg/edi/segment/l1.go
+++ b/pkg/edi/segment/l1.go
@@ -9,7 +9,7 @@ import (
 type L1 struct {
 	LadingLineItemNumber int      `validate:"required,min=1,max=999"`
 	FreightRate          *float64 `validate:"omitempty,min=0"`
-	RateValueQualifier   string   `validate:"required_with=FreightRate,omitempty,eq=LB"`
+	RateValueQualifier   string   `validate:"required_with=FreightRate,omitempty,oneof=LB PF"`
 	Charge               int64    `validate:"required,min=-999999999999,max=999999999999"` // Supports negative values
 }
 

--- a/pkg/edi/segment/l1_test.go
+++ b/pkg/edi/segment/l1_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (suite *SegmentSuite) TestValidateL1() {
-	freightRate := 0
+	freightRate := float64(0)
 	validL1 := L1{
 		LadingLineItemNumber: 1,
 		FreightRate:          &freightRate,
@@ -21,7 +21,7 @@ func (suite *SegmentSuite) TestValidateL1() {
 	suite.T().Run("validate success", func(t *testing.T) {
 		err := suite.validator.Struct(validL1)
 		suite.NoError(err)
-		suite.Equal([]string{"L1", "1", "0", "LB", "10000"}, validL1.StringArray())
+		suite.Equal([]string{"L1", "1", "0.00", "LB", "10000"}, validL1.StringArray())
 	})
 
 	suite.T().Run("validate alt success", func(t *testing.T) {
@@ -31,7 +31,7 @@ func (suite *SegmentSuite) TestValidateL1() {
 	})
 
 	suite.T().Run("validate failure 1", func(t *testing.T) {
-		freightRate := -1
+		freightRate := float64(-1)
 		l1 := L1{
 			// LadingLineItemNumber:          // required
 			FreightRate:        &freightRate, // min

--- a/pkg/edi/segment/l1_test.go
+++ b/pkg/edi/segment/l1_test.go
@@ -35,14 +35,14 @@ func (suite *SegmentSuite) TestValidateL1() {
 		l1 := L1{
 			// LadingLineItemNumber:          // required
 			FreightRate:        &freightRate, // min
-			RateValueQualifier: "XX",         // eq
+			RateValueQualifier: "XX",         // oneof
 			// Charge:                        // required
 		}
 
 		err := suite.validator.Struct(l1)
 		suite.ValidateError(err, "LadingLineItemNumber", "required")
 		suite.ValidateError(err, "FreightRate", "min")
-		suite.ValidateError(err, "RateValueQualifier", "eq")
+		suite.ValidateError(err, "RateValueQualifier", "oneof")
 		suite.ValidateError(err, "Charge", "required")
 		suite.ValidateErrorLen(err, 4)
 	})
@@ -61,7 +61,7 @@ func (suite *SegmentSuite) TestValidateL1() {
 	suite.T().Run("validate failure 3", func(t *testing.T) {
 		l1 := validL1
 		l1.LadingLineItemNumber = -3 // min
-		l1.RateValueQualifier = ""   // required
+		l1.RateValueQualifier = ""   // required_with
 		l1.Charge = -1000000000000   // min
 
 		err := suite.validator.Struct(l1)

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -719,9 +719,10 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				WeightUnitCode:       "L",
 			}
 
+			weightFloat := float64(weight)
 			newSegment.L1 = edisegment.L1{
 				LadingLineItemNumber: hierarchicalIDNumber,
-				FreightRate:          &weight,
+				FreightRate:          &weightFloat,
 				RateValueQualifier:   "LB",
 				Charge:               serviceItem.PriceCents.Int64(),
 			}
@@ -749,9 +750,10 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				WeightUnitCode:         "L",
 			}
 
+			weightFloat := float64(weight)
 			newSegment.L1 = edisegment.L1{
 				LadingLineItemNumber: hierarchicalIDNumber,
-				FreightRate:          &weight,
+				FreightRate:          &weightFloat,
 				RateValueQualifier:   "LB",
 				Charge:               serviceItem.PriceCents.Int64(),
 			}

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -617,6 +617,29 @@ func (g ghcPaymentRequestInvoiceGenerator) getWeightParams(serviceItem models.Pa
 	return weightInt, nil
 }
 
+func (g ghcPaymentRequestInvoiceGenerator) getServiceItemDimensionRateParams(serviceItem models.PaymentServiceItem) (float64, float64, error) {
+	cubicFeet, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNameCubicFeetBilled)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	cubicFeetFloat, err := strconv.ParseFloat(cubicFeet.Value, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("Could not parse cubic feet as a float for PaymentServiceItem %s: %w", serviceItem.ID, err)
+	}
+
+	rate, err := g.fetchPaymentServiceItemParam(serviceItem.ID, models.ServiceItemParamNamePriceRateOrFactor)
+	if err != nil {
+		return 0, 0, err
+	}
+	rateFloat, err := strconv.ParseFloat(rate.Value, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("Could not parse rate as a float for PaymentServiceItem %s: %w", serviceItem.ID, err)
+	}
+
+	return cubicFeetFloat, rateFloat, nil
+}
+
 func (g ghcPaymentRequestInvoiceGenerator) getWeightAndDistanceParams(serviceItem models.PaymentServiceItem) (int, float64, error) {
 	weight, err := g.getWeightParams(serviceItem)
 	if err != nil {
@@ -724,6 +747,36 @@ func (g ghcPaymentRequestInvoiceGenerator) generatePaymentServiceItemSegments(pa
 				LadingLineItemNumber: hierarchicalIDNumber,
 				FreightRate:          &weightFloat,
 				RateValueQualifier:   "LB",
+				Charge:               serviceItem.PriceCents.Int64(),
+			}
+
+		// following service items have service item dimensions and rate but no distance
+		case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT:
+			var err error
+			dimensions, rate, err := g.getServiceItemDimensionRateParams(serviceItem)
+			if err != nil {
+				return segments, l3, err
+			}
+
+			newSegment.L5 = edisegment.L5{
+				LadingLineItemNumber:   hierarchicalIDNumber,
+				LadingDescription:      string(serviceCode),
+				CommodityCode:          "TBD",
+				CommodityCodeQualifier: "D",
+			}
+
+			newSegment.L0 = edisegment.L0{
+				LadingLineItemNumber: hierarchicalIDNumber,
+				Volume:               dimensions,
+				VolumeUnitQualifier:  "E",
+				LadingQuantity:       1,
+				PackagingFormCode:    "CRT",
+			}
+
+			newSegment.L1 = edisegment.L1{
+				LadingLineItemNumber: hierarchicalIDNumber,
+				FreightRate:          &rate,
+				RateValueQualifier:   "PF", // Per Cubic Foot
 				Charge:               serviceItem.PriceCents.Int64(),
 			}
 

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -563,7 +563,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 			suite.T().Run("adds l1 service item segment", func(t *testing.T) {
 				l1 := result.ServiceItems[segmentOffset].L1
 				suite.Equal(hierarchicalNumberInt, l1.LadingLineItemNumber)
-				suite.Equal(4242, *l1.FreightRate)
+				suite.Equal(float64(4242), *l1.FreightRate)
 				suite.Equal("LB", l1.RateValueQualifier)
 				suite.Equal(serviceItemPrice, l1.Charge)
 			})
@@ -598,7 +598,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 			suite.T().Run("adds l1 service item segment", func(t *testing.T) {
 				l1 := result.ServiceItems[segmentOffset].L1
 				suite.Equal(hierarchicalNumberInt, l1.LadingLineItemNumber)
-				suite.Equal(4242, *l1.FreightRate)
+				suite.Equal(float64(4242), *l1.FreightRate)
 				suite.Equal("LB", l1.RateValueQualifier)
 				suite.Equal(serviceItemPrice, l1.Charge)
 			})

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -215,6 +215,32 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		assertions,
 	)
 
+	additionalParamsForCrating := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameCubicFeetBilled,
+			KeyType: models.ServiceItemParamTypeDecimal,
+			Value:   "144.5",
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeDecimal,
+			Value:   "23.69",
+		},
+	}
+	cratingParams := append(basicPaymentServiceItemParams, additionalParamsForCrating...)
+	dcrt := testdatagen.MakePaymentServiceItemWithParams(
+		suite.DB(),
+		models.ReServiceCodeDCRT,
+		cratingParams,
+		assertions,
+	)
+	ducrt := testdatagen.MakePaymentServiceItemWithParams(
+		suite.DB(),
+		models.ReServiceCodeDUCRT,
+		cratingParams,
+		assertions,
+	)
+
 	distanceZipSITDestParam := testdatagen.CreatePaymentServiceItemParams{
 		Key:     models.ServiceItemParamNameDistanceZipSITDest,
 		KeyType: models.ServiceItemParamTypeInteger,
@@ -241,7 +267,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		assertions,
 	)
 
-	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk, ddfsit, ddasit, dofsit, doasit, doshut, ddshut, dddsit, dopsit)
+	paymentServiceItems = append(paymentServiceItems, dlh, fsc, ms, cs, dsh, dop, ddp, dpk, dupk, ddfsit, ddasit, dofsit, doasit, doshut, ddshut, dcrt, ducrt, dddsit, dopsit)
 
 	serviceMember := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -308,7 +334,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 
 	suite.T().Run("se segment has correct value", func(t *testing.T) {
 		// Will need to be updated as more service items are supported
-		suite.Equal(142, result.SE.NumberOfIncludedSegments)
+		suite.Equal(156, result.SE.NumberOfIncludedSegments)
 		suite.Equal("0001", result.SE.TransactionSetControlNumber)
 	})
 
@@ -530,6 +556,15 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 			suite.T().Run("adds l0 service item segment", func(t *testing.T) {
 				l0 := result.ServiceItems[segmentOffset].L0
 				suite.Equal(hierarchicalNumberInt, l0.LadingLineItemNumber)
+				suite.Equal(float64(0), l0.BilledRatedAsQuantity)
+				suite.Equal("", l0.BilledRatedAsQualifier)
+				suite.Equal(float64(0), l0.Weight)
+				suite.Equal("", l0.WeightQualifier)
+				suite.Equal(float64(0), l0.Volume)
+				suite.Equal("", l0.VolumeUnitQualifier)
+				suite.Equal(0, l0.LadingQuantity)
+				suite.Equal("", l0.PackagingFormCode)
+				suite.Equal("", l0.WeightUnitCode)
 			})
 
 			suite.T().Run("adds l1 service item segment", func(t *testing.T) {
@@ -557,6 +592,10 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				suite.Equal("", l0.BilledRatedAsQualifier)
 				suite.Equal(float64(4242), l0.Weight)
 				suite.Equal("B", l0.WeightQualifier)
+				suite.Equal(float64(0), l0.Volume)
+				suite.Equal("", l0.VolumeUnitQualifier)
+				suite.Equal(0, l0.LadingQuantity)
+				suite.Equal("", l0.PackagingFormCode)
 				suite.Equal("L", l0.WeightUnitCode)
 			})
 
@@ -565,6 +604,36 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				suite.Equal(hierarchicalNumberInt, l1.LadingLineItemNumber)
 				suite.Equal(float64(4242), *l1.FreightRate)
 				suite.Equal("LB", l1.RateValueQualifier)
+				suite.Equal(serviceItemPrice, l1.Charge)
+			})
+		case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT:
+			suite.T().Run("adds l5 service item segment", func(t *testing.T) {
+				l5 := result.ServiceItems[segmentOffset].L5
+				suite.Equal(hierarchicalNumberInt, l5.LadingLineItemNumber)
+				suite.Equal(string(serviceCode), l5.LadingDescription)
+				suite.Equal("TBD", l5.CommodityCode)
+				suite.Equal("D", l5.CommodityCodeQualifier)
+			})
+
+			suite.T().Run("adds l0 service item segment", func(t *testing.T) {
+				l0 := result.ServiceItems[segmentOffset].L0
+				suite.Equal(hierarchicalNumberInt, l0.LadingLineItemNumber)
+				suite.Equal(float64(0), l0.BilledRatedAsQuantity)
+				suite.Equal("", l0.BilledRatedAsQualifier)
+				suite.Equal(float64(0), l0.Weight)
+				suite.Equal("", l0.WeightQualifier)
+				suite.Equal(144.5, l0.Volume)
+				suite.Equal("E", l0.VolumeUnitQualifier)
+				suite.Equal(1, l0.LadingQuantity)
+				suite.Equal("CRT", l0.PackagingFormCode)
+				suite.Equal("", l0.WeightUnitCode)
+			})
+
+			suite.T().Run("adds l1 service item segment", func(t *testing.T) {
+				l1 := result.ServiceItems[segmentOffset].L1
+				suite.Equal(hierarchicalNumberInt, l1.LadingLineItemNumber)
+				suite.Equal(23.69, *l1.FreightRate)
+				suite.Equal("PF", l1.RateValueQualifier)
 				suite.Equal(serviceItemPrice, l1.Charge)
 			})
 		default:
@@ -593,6 +662,10 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 				suite.Equal("DM", l0.BilledRatedAsQualifier)
 				suite.Equal(float64(4242), l0.Weight)
 				suite.Equal("B", l0.WeightQualifier)
+				suite.Equal(float64(0), l0.Volume)
+				suite.Equal("", l0.VolumeUnitQualifier)
+				suite.Equal(0, l0.LadingQuantity)
+				suite.Equal("", l0.PackagingFormCode)
 				suite.Equal("L", l0.WeightUnitCode)
 			})
 			suite.T().Run("adds l1 service item segment", func(t *testing.T) {
@@ -619,7 +692,7 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 	suite.T().Run("adds l3 service item segment", func(t *testing.T) {
 		l3 := result.L3
 		// Will need to be updated as more service items are supported
-		suite.Equal(int64(15096), l3.PriceCents)
+		suite.Equal(int64(16872), l3.PriceCents)
 	})
 }
 


### PR DESCRIPTION
## Description

This PR adds support for domestic crating and uncrating service (`DCRT` and `DUCRT`) to invoicing.

## Reviewer Notes

- I used [this PR](https://github.com/transcom/mymove/pull/7001) as a guide as to what fields needed to change.  Note that it deals with both shuttle service and crating.  Shuttle service didn't require changes to our EDI segments, although crating did.
- I did make some tweaks from what was in the PR as I worked through some validations.  See this [Slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1627652234003200) for context.
- Note that I changed `L1.FreightRate` from an int to a float32 to match the EDI spec.  We had previously been able to get away with it being only an int because the weights we were storing in `FreightWeight` were already integers, but with this PR we need to store a rate that goes to two decimal places.

## Setup

I don't believe you can test this with a real move until we have a [lookup for `CubicFeetBilled`](https://dp3.atlassian.net/browse/MB-1572) and the [pricer PR](https://github.com/transcom/mymove/pull/7093) has been merged.

For now, you can exercise this by running server tests: `make server_test`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7253) for this change
