### PR TITLE
MB-8901 Return 403 when user is not admin

### DIFF
--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -65,11 +65,11 @@ func UserAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 			// This must be the right type of user for the application
 			if session.IsOfficeApp() && !session.IsOfficeUser() {
 				logger.Error("unauthorized user for office.move.mil", zap.String("email", session.Email))
-				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			} else if session.IsAdminApp() && !session.IsAdminUser() {
 				logger.Error("unauthorized user for admin.move.mil", zap.String("email", session.Email))
-				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			}
 
@@ -526,6 +526,7 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		provider.ClientKey,
 		h.loginGovProvider)
 	if err != nil {
+		h.logger.Error("Reading openIDSession from login.gov", zap.Error(err))
 		http.Error(w, http.StatusText(401), http.StatusUnauthorized)
 		return
 	}
@@ -589,7 +590,7 @@ var authorizeKnownUser = func(userIdentity *models.UserIdentity, h CallbackHandl
 			officeUser, err := models.FetchOfficeUserByEmail(h.db, session.Email)
 			if err == models.ErrFetchNotFound {
 				h.logger.Error("Non-office user authenticated at office site", zap.String("email", session.Email))
-				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			} else if err != nil {
 				h.logger.Error("Checking for office user", zap.String("email", session.Email), zap.Error(err))
@@ -624,8 +625,9 @@ var authorizeKnownUser = func(userIdentity *models.UserIdentity, h CallbackHandl
 				query.NewQueryFilter("email", "=", strings.ToLower(userIdentity.Email)),
 			}
 			err := queryBuilder.FetchOne(&adminUser, filters)
-			if err == models.ErrFetchNotFound {
-				h.logger.Error("Non-admin user authenticated at admin site", zap.String("email", session.Email))
+
+			if err != nil && errors.Cause(err).Error() == models.RecordNotFoundErrorString {
+				h.logger.Error("No admin user found", zap.String("email", session.Email))
 				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			} else if err != nil {
@@ -677,7 +679,7 @@ var authorizeUnknownUser = func(openIDUser goth.User, h CallbackHandler, session
 		officeUser, err = models.FetchOfficeUserByEmail(conn, session.Email)
 		if err == models.ErrFetchNotFound {
 			h.logger.Error("No Office user found", zap.String("email", session.Email))
-			http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		} else if err != nil {
 			h.logger.Error("Checking for office user", zap.String("email", session.Email), zap.Error(err))
@@ -702,7 +704,7 @@ var authorizeUnknownUser = func(openIDUser goth.User, h CallbackHandler, session
 
 		if err != nil && errors.Cause(err).Error() == models.RecordNotFoundErrorString {
 			h.logger.Error("No admin user found", zap.String("email", session.Email))
-			http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		} else if err != nil {
 			h.logger.Error("Checking for admin user", zap.String("email", session.Email), zap.Error(err))


### PR DESCRIPTION
## Description

When checking if an existing user is an admin (in order to grant
access to the admin site), we were comparing with the wrong error
message in the scenario where the admin user was not found, and so the
code went to the next `if` statement and returned a 500 error.

To fix this, we need to check for `RecordNotFoundErrorString`
as opposed to `ErrFetchNotFound`.

While I was in here, I added the missing test for this bug, and I fixed
other places where we were returning a 401 instead of a 403.

## Reviewer Notes

1. Sign in to http://milmovelocal:3000 via login.gov
2. Sign in to http://adminlocal:3000 via login.gov

Expected: you should see a Forbidden error, and not an Internal Server Error

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8901) for this change

## Screenshots

<img width="1680" alt="Screen Shot 2021-08-03 at 09 54 01" src="https://user-images.githubusercontent.com/811150/128027651-12e1981b-a513-4d79-9ded-5d01b7bc3218.png">
