### PR TITLE
MB-8843: First pass at fixing the tooFlows test

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -176,9 +176,9 @@ describe('TOO user', () => {
     cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
 
     // Toggle between Edit Allowances and Edit Orders page
-    cy.get('[data-testid="view-allowances"]').click();
+    cy.get('[data-testid="view-allowances"]').should('be.visible').click();
     cy.url().should('include', `/moves/${moveLocator}/allowances`);
-    cy.get('[data-testid="view-orders"]').click();
+    cy.get('[data-testid="view-orders"]').should('be.visible').click();
     cy.url().should('include', `/moves/${moveLocator}/orders`);
 
     // Edit orders fields


### PR DESCRIPTION
**Description**

One of the epics for August 2021 is fix the flakiness of our integration tests, which CircleCI is reporting fail on 13% of builds of the `master` branch. Since any update to the `master` branch is from a peer-reviewed pull request, which independently is running those same integration tests and passing them, we can reasonably infer a 13% sporadic failure rate which can be fixed by a simple re-run (or two, if you're unlucky). That sucks, let's fix it.

This pull request fixes one of the sporadic failures in the `tooFlows` tests. I ran these integration tests 32 times on CircleCI and they never came back with _this_ failure, which gives a reasonable level of confidence in my solution having addressed the underlying race condition. (It can be assumed that these were independent runs since _other_ integration and client-side flaky tests failed on some of those runs. Yes, we're fixing those as well this slice.)

**Setup**

You can run the integration tests (locally: `make e2e test docker`) as many times as you like, and make sure they pass. Alternatively, go into the [integration test step of CircleCI for this branch](https://app.circleci.com/pipelines/github/transcom/mymove?branch=kh-MB-8843-fix-tooFlows-tests) and just hit "restart pipeline" a whole bunch of times and then come back 23 minutes later and check on them because that's what I did.

**Code Review Verification Steps**

- [ ]  This works in Supported Browsers and their phone views (Chrome, Firefox, IE, Edge).
- [ ]  Request review from a member of a different team.
- [ ]  Have the Jira acceptance criteria been met for this change?

**References**

* Closes [MB-8843](https://dp3.atlassian.net/browse/MB-8843).