### PR TITLE
MB-5700 Make phone validation more consistent 

### DIFF
--- a/src/components/Customer/MtoShipmentForm/validationSchemas.js
+++ b/src/components/Customer/MtoShipmentForm/validationSchemas.js
@@ -1,13 +1,13 @@
 /* eslint-disable camelcase */
 import * as Yup from 'yup';
 
-import { ZIP_CODE_REGEX, requiredAddressSchema } from 'utils/validation';
+import { ZIP_CODE_REGEX, requiredAddressSchema, phoneSchema, emailSchema } from 'utils/validation';
 
 export const AgentSchema = Yup.object().shape({
   firstName: Yup.string(),
   lastName: Yup.string(),
-  phone: Yup.string().matches(/^[2-9]\d{2}\d{3}\d{4}$/, 'Must be valid phone number'),
-  email: Yup.string().email('Must be valid email'),
+  phone: phoneSchema,
+  email: emailSchema,
 });
 
 export const OptionalAddressSchema = Yup.object().shape(

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
@@ -61,14 +61,14 @@ const mockMtoShipment = {
       email: 'jasn@email.com',
       firstName: 'Jason',
       lastName: 'Ash',
-      phone: '999-999-9999',
+      phone: '9999999999',
     },
     {
       agentType: 'RECEIVING_AGENT',
       email: 'rbaker@email.com',
       firstName: 'Riley',
       lastName: 'Baker',
-      phone: '863-555-9664',
+      phone: '8635559664',
     },
   ],
 };
@@ -183,7 +183,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('ZIP')[0]).toHaveValue('78234');
       expect(screen.getAllByLabelText('First name')[0]).toHaveValue('Jason');
       expect(screen.getAllByLabelText('Last name')[0]).toHaveValue('Ash');
-      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('9999999999'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('999-999-9999'); // formatAgentForDisplay removes '-'
       expect(screen.getAllByLabelText('Email')[0]).toHaveValue('jasn@email.com');
       expect(screen.getByLabelText('Requested delivery date')).toHaveValue('30 Mar 2020');
       expect(screen.getByLabelText('Yes')).toBeChecked();
@@ -194,7 +194,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('ZIP')[1]).toHaveValue('98421');
       expect(screen.getAllByLabelText('First name')[1]).toHaveValue('Riley');
       expect(screen.getAllByLabelText('Last name')[1]).toHaveValue('Baker');
-      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('8635559664'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('863-555-9664'); // formatAgentForDisplay removes '-'
       expect(screen.getAllByLabelText('Email')[1]).toHaveValue('rbaker@email.com');
       expect(screen.getByLabelText('Customer remarks')).toHaveValue('mock customer remarks');
       expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');

--- a/src/components/form/ContactInfoFields/ContactInfoFields.jsx
+++ b/src/components/form/ContactInfoFields/ContactInfoFields.jsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Fieldset } from '@trussworks/react-uswds';
 
 import TextField from 'components/form/fields/TextField';
+import MaskedTextField from 'components/form/fields/MaskedTextField';
 
 export const ContactInfoFields = ({ legend, className, name, render }) => {
   const contactInfoFieldsUUID = uuidv4();
@@ -15,12 +16,13 @@ export const ContactInfoFields = ({ legend, className, name, render }) => {
           <TextField label="First name" id={`firstName_${contactInfoFieldsUUID}`} name={`${name}.firstName`} />
           <TextField label="Last name" id={`lastName_${contactInfoFieldsUUID}`} name={`${name}.lastName`} />
 
-          <TextField
+          <MaskedTextField
             label="Phone"
             id={`phone_${contactInfoFieldsUUID}`}
             name={`${name}.phone`}
             type="tel"
-            maxLength="10"
+            minimum="12"
+            mask="000{-}000{-}0000"
           />
           <TextField label="Email" id={`email_${contactInfoFieldsUUID}`} name={`${name}.email`} />
         </>,

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -29,10 +29,6 @@ function formatAgentForAPI(agent) {
       sanitizedKey === 'mtoShipmentID'
     ) {
       delete agentCopy[sanitizedKey];
-    } else if (sanitizedKey === 'phone') {
-      const phoneNum = agentCopy[sanitizedKey];
-      // will be in format xxx-xxx-xxxx
-      agentCopy[sanitizedKey] = `${phoneNum.slice(0, 3)}-${phoneNum.slice(3, 6)}-${phoneNum.slice(6, 10)}`;
     }
   });
   return agentCopy;

--- a/src/utils/formatMtoShipment.test.js
+++ b/src/utils/formatMtoShipment.test.js
@@ -196,7 +196,7 @@ describe('formatMtoShipmentForAPI', () => {
       firstName: 'mockFirstName',
       lastName: 'mockLastName',
       email: 'mockAgentEmail@example.com',
-      phone: '2225551234',
+      phone: '222-555-1234',
     },
   };
 
@@ -212,7 +212,7 @@ describe('formatMtoShipmentForAPI', () => {
       firstName: 'r0b0tBestFr1end',
       lastName: 'r0b0tBestFr1endLastName',
       email: 'r0b0t-fr1end@example.com',
-      phone: '2225550101',
+      phone: '222-555-0101',
     },
   };
 


### PR DESCRIPTION
## Description

When entering phone numbers in the customer on boarding flow, phone number validation was inconsistent. The Backup Contact phone number input does not allow the user to type dashes, and automatically adds them in. The Receiving Agent phone number input allowed dashes and didn't automatically add them, but if you use dashes you encounter a field length validation error. This PR makes Agent phone number validation match Customer/Backup Contact validation.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
1. Go through customer onboarding flow and enter phone numbers (dashes should automatically be added and only numerical inputs will be recognized)
2. Create a shipment and enter a receiving agent phone number (dashes are now automatically added and only numerical inputs will be recognized)


## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-5700) for this change
