### PR TITLE
[MB-9035] Remove readOnly from PaymentRequestID

### DIFF
--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -2096,7 +2096,6 @@ func init() {
         "paymentRequestID": {
           "type": "string",
           "format": "uuid",
-          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "readFromSyncada": {
@@ -4811,7 +4810,6 @@ func init() {
         "paymentRequestID": {
           "type": "string",
           "format": "uuid",
-          "readOnly": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "readFromSyncada": {

--- a/pkg/gen/supportmessages/process_reviewed_payment_requests.go
+++ b/pkg/gen/supportmessages/process_reviewed_payment_requests.go
@@ -26,7 +26,6 @@ type ProcessReviewedPaymentRequests struct {
 
 	// payment request ID
 	// Example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-	// Read Only: true
 	// Format: uuid
 	PaymentRequestID strfmt.UUID `json:"paymentRequestID,omitempty"`
 
@@ -132,10 +131,6 @@ func (m *ProcessReviewedPaymentRequests) validateStatus(formats strfmt.Registry)
 func (m *ProcessReviewedPaymentRequests) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidatePaymentRequestID(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateStatus(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -143,15 +138,6 @@ func (m *ProcessReviewedPaymentRequests) ContextValidate(ctx context.Context, fo
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *ProcessReviewedPaymentRequests) contextValidatePaymentRequestID(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "paymentRequestID", "body", strfmt.UUID(m.PaymentRequestID)); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1648,7 +1648,6 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
-        readOnly: true
       status:
         $ref: '#/definitions/PaymentRequestStatus'
       sendToSyncada:


### PR DESCRIPTION
## Description

The latest version of go-swagger prevents us from sending `readOnly` parameters in the body of a request.
Since we need to send `paymentRequestID` in the body of requests to `/payment-requests/process-reviewed`, it can no longer be `readOnly`.
## Reviewer Notes


## Setup
Make a request to this endpoint:
`PATCH https://primelocal:9443/support/v1/payment-requests/process-reviewed`
with this body:
```json
{
    "sendToSyncada": false,
    "readFromSyncada": false,
    "deleteFromSyncada": false,
    "paymentRequestID": "46ffbf9c-153b-48b5-b2b1-b7c99853f4bd",
    "status": "REVIEWED"
}
```
The actual `paymentRequestID value doesn't matter. If you like, you can send the ID of a real payment request, and then you should get a success and not an error, but that's not technically necessary because the swagger validation happens earlier.

You should see:
```json
{
    "detail": "Error finding Payment Request with ID: 46ffbf9c-153b-48b5-b2b1-b7c99853f4bd",
    "instance": "11f1f76b-f6c9-49fc-acc8-5d61ee9fabdb",
    "title": "Not Found Error"
}
```
If you see instead:
```json
{
    "title": "Validation Error",
    "instance": "4e901c86-b5cd-4d18-bd88-0f7050906668",
    "detail": "paymentRequestID in body is readOnly"
}
```
Then this fix did not work.


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9035) for this change
