### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,13 @@
 queue_rules:
   - name: default
     conditions:
-      - "#approved-reviews-by>=1"
+      - "label=ready-to-merge"
 
 pull_request_rules:
   - name: merge using the merge queue
     conditions:
       - base=master
+      - "label=ready-to-merge"
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+
+pull_request_rules:
+  - name: merge using the merge queue
+    conditions:
+      - base=master
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
This change has been made by @monfresh from https://mergify.io config editor.

Mergify is a tool that can automate the merging of PRs, while making sure they are up to date with master before merging. This will prevent build failures on the master branch that sometimes happen when master was just updated with a change that conflicts with a PR that is about to be merged but that wasn't updated with master.

I added a new "ready-to-merge" label that people will need to add in order to put the PR in Mergify's queue. That way, if people don't want Mergify to automatically merge the PR, they won't have to do anything. Only by adding the "ready-to-merge" label will they trigger Mergify. Alternatively, if we think most people will want the automation by default, we could modify the config so that it checks for the absence of the "do not merge" label, which people will need to add if they don't want the automation.