### PR TITLE
MB-9009 Show diversion requested on Move Details

### DIFF
--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -39,6 +39,7 @@ const ShipmentDisplay = ({ shipmentType, displayInfo, onChange, shipmentId, isSu
             </h3>
             {displayInfo.isDiversion && <Tag>diversion</Tag>}
             {displayInfo.shipmentStatus === shipmentStatuses.CANCELED && <Tag className="usa-tag--red">cancelled</Tag>}
+            {displayInfo.shipmentStatus === shipmentStatuses.DIVERSION_REQUESTED && <Tag>diversion requested</Tag>}
           </div>
 
           <FontAwesomeIcon icon="chevron-down" />

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -89,7 +89,10 @@ const MoveDetails = ({ setUnapprovedShipmentCount, setUnapprovedServiceItemCount
     (shipment) => shipment.status === shipmentStatuses.SUBMITTED && !shipment.deletedAt,
   );
   const approvedOrCanceledShipments = mtoShipments?.filter(
-    (shipment) => shipment.status === shipmentStatuses.APPROVED || shipment.status === shipmentStatuses.CANCELED,
+    (shipment) =>
+      shipment.status === shipmentStatuses.APPROVED ||
+      shipment.status === shipmentStatuses.CANCELED ||
+      shipment.status === shipmentStatuses.DIVERSION_REQUESTED,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Previously, when a TOO requested a diversion on a shipment from the
MTO tab, the shipment would disappear from the Move details page.

This PR updates the logic to include shipments with the "Diversion
Requested" status, and also labels them as such to make it easier for
the TOO to tell the shipments apart.

## Reviewer Notes

1. Sign in to the office app as a TOO
2. Click on the move with code PARAMS
3. Go to the "Move task order" tab
4. Click on the "Request diversion" link under the first shipment
5. Go back to the Mode details tab
6. Verify that you still see 2 shipments and that the "DIVERSION REQUESTED" label shows up on the first one.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9009) for this change

## Screenshots

<img width="1680" alt="Screen Shot 2021-08-10 at 10 44 45" src="https://user-images.githubusercontent.com/811150/128891957-ea7186b6-7ab7-4f45-8c7a-027bc5a1e933.png">
