### PR TITLE
[MB-7692] CAT II: consistent-return finding

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -2,6 +2,7 @@
   "plugins": ["prettier", "security", "no-only-tests"],
   "extends": ["react-app", "plugin:prettier/recommended", "plugin:security/recommended"],
   "rules": {
+    "consistent-return": "error",
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
     "no-debugger": "warn",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
+    "@material-ui/core": "^4.12.3",
     "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
     "@trussworks/react-uswds": "^2.0.0",
     "bytes": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
     "@material-ui/core": "^4.12.3",
+    "@material-ui/icons": "^4.11.2",
     "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
     "@trussworks/react-uswds": "^2.0.0",
     "bytes": "^3.0.0",

--- a/src/scenes/.eslintrc
+++ b/src/scenes/.eslintrc
@@ -2,6 +2,7 @@
   "plugins": ["prettier", "security", "no-only-tests"],
   "extends": ["react-app", "plugin:prettier/recommended", "plugin:security/recommended"],
   "rules": {
+    "consistent-return": "error",
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
     "no-debugger": "warn",

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -65,6 +65,7 @@ const validateDifferentZip = (value, formValues) => {
   if (value && value === formValues.pickup_postal_code) {
     return 'You entered the same zip code for your origin and destination. Please change one of them.';
   }
+  return undefined;
 };
 
 export class DateAndLocation extends Component {
@@ -121,6 +122,7 @@ export class DateAndLocation extends Component {
           .catch((err) => err);
       }
     }
+    return undefined;
   };
 
   render() {

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -19,6 +19,7 @@ class PPMPaymentRequestActionBtns extends Component {
     }
 
     this.setState({ displayConfirmation: true });
+    return undefined;
   };
 
   cancelConfirmationHandler = () => {

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -141,9 +141,7 @@ export class PpmWeight extends Component {
     if (currentEstimate >= 500 && currentEstimate < 1500) {
       return <img className="icon" src={trailerGray} alt="trailer-gray" data-testid="vehicleIcon" />;
     }
-    if (currentEstimate >= 1500) {
-      return <img className="icon" src={truckGray} alt="truck-gray" data-testid="vehicleIcon" />;
-    }
+    return <img className="icon" src={truckGray} alt="truck-gray" data-testid="vehicleIcon" />;
   }
 
   chooseEstimateText(currentEstimate) {
@@ -195,14 +193,13 @@ export class PpmWeight extends Component {
         </p>
       );
     }
-    if (currentEstimate >= 7000) {
-      return (
-        <p data-testid="estimateText">
-          A large house or small palace, many heavy or bulky items. Multiple trips using large vehicles, or hire
-          professional movers.
-        </p>
-      );
-    }
+
+    return (
+      <p data-testid="estimateText">
+        A large house or small palace, many heavy or bulky items. Multiple trips using large vehicles, or hire
+        professional movers.
+      </p>
+    );
   }
 
   chooseIncentiveRangeText(hasEstimateError) {
@@ -255,6 +252,9 @@ export class PpmWeight extends Component {
         </Fragment>
       );
     }
+
+    // if there is no error to show
+    return undefined;
   }
 
   render() {

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -110,6 +110,8 @@ class WeightTicket extends Component {
         </div>
       );
     }
+    // if there is no trailer, don't show text
+    return undefined;
   };
 
   uploaderWithInvalidState = () => {

--- a/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
@@ -16,6 +16,7 @@ const validateWeight = (value, formValues, props, fieldName) => {
   if (value && props.entitlement && value > props.entitlement.sum) {
     return `Cannot be more than full entitlement weight (${props.entitlement.sum} lbs)`;
   }
+  return undefined;
 };
 
 const EstimatesDisplay = (props) => {

--- a/src/scenes/PpmLanding/PPMStatusTimeline.js
+++ b/src/scenes/PpmLanding/PPMStatusTimeline.js
@@ -40,7 +40,7 @@ export class PPMStatusTimeline extends React.Component {
     // if there's no approve date, then the PPM hasn't been approved yet
     // and the in progress date should not be shown
     if (!approveDate) {
-      return;
+      return undefined;
     }
     // if there's an actual move date that is known and passed, show it
     // else show original move date if it has passed
@@ -50,6 +50,7 @@ export class PPMStatusTimeline extends React.Component {
     if (moment(originalMoveDate, 'YYYY-MM-DD').isSameOrBefore()) {
       return originalMoveDate;
     }
+    return undefined;
   }
 
   isCompleted(statusCode) {
@@ -75,6 +76,7 @@ export class PPMStatusTimeline extends React.Component {
       default:
         console.log('Unknown status');
     }
+    return undefined;
   }
 
   getStatuses() {

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -135,6 +135,7 @@ class EditDateAndLocation extends Component {
           return err;
         });
     }
+    return undefined;
   };
 
   getSitEstimate = (ppmId, moveDate, sitDays, pickupZip, ordersID, weight) => {

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -57,6 +57,7 @@ const validateWeight = (value, formValues, props, fieldName) => {
   if (value && props.entitlement && value > props.entitlement.sum) {
     return 'Cannot be more than your full entitlement';
   }
+  return undefined;
 };
 
 let EditWeightForm = (props) => {
@@ -291,6 +292,8 @@ class EditWeight extends Component {
         </div>
       );
     }
+    // don't show any text if there is no error
+    return undefined;
   }
 
   render() {

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -50,6 +50,7 @@ export class DutyStationSearchBox extends Component {
         });
     } else {
       callback([]);
+      return undefined;
     }
   }
 
@@ -60,6 +61,7 @@ export class DutyStationSearchBox extends Component {
       return callback(null);
     }
     this.debouncedLoadOptions(inputValue, callback);
+    return undefined;
   }
 
   localOnChange(value) {

--- a/src/scenes/SystemAdmin/shared/RolesCheckboxes.jsx
+++ b/src/scenes/SystemAdmin/shared/RolesCheckboxes.jsx
@@ -5,7 +5,7 @@ import { adminOfficeRoles } from 'constants/userRoles';
 
 const makeRoleTypeArray = (roles) => {
   if (!roles || roles.length === 0) {
-    return;
+    return undefined;
   }
   return roles.reduce((rolesArray, role) => {
     if (role.roleType) {

--- a/src/shared/.eslintrc
+++ b/src/shared/.eslintrc
@@ -2,6 +2,7 @@
   "plugins": ["prettier", "security", "no-only-tests"],
   "extends": ["react-app", "plugin:prettier/recommended", "plugin:security/recommended"],
   "rules": {
+    "consistent-return": "error",
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
     "no-debugger": "warn",

--- a/src/shared/Alert/index.jsx
+++ b/src/shared/Alert/index.jsx
@@ -33,6 +33,7 @@ const requiredPropsCheck = (props, propName, componentName) => {
   if (!props.heading && !props.children) {
     return new Error(`One of 'heading' or 'children' is required by '${componentName}' component.`);
   }
+  return undefined;
 };
 
 Alert.propTypes = {

--- a/src/shared/AlertWithConfirmation/index.jsx
+++ b/src/shared/AlertWithConfirmation/index.jsx
@@ -41,6 +41,7 @@ const requiredPropsCheck = (props, propName, componentName) => {
   if (!props.heading || !props.message) {
     return new Error(`A heading or message is required by '${componentName}' component.`);
   }
+  return undefined;
 };
 
 AlertWithConfirmation.propTypes = {

--- a/src/shared/AlertWithDeleteConfirmation/index.jsx
+++ b/src/shared/AlertWithDeleteConfirmation/index.jsx
@@ -38,6 +38,7 @@ const requiredPropsCheck = (props, propName, componentName) => {
   if (!props.heading || !props.message) {
     return new Error(`A heading or message is required by '${componentName}' component.`);
   }
+  return undefined;
 };
 
 AlertWithDeleteConfirmation.propTypes = {

--- a/src/shared/ConfirmWithReasonButton/index.jsx
+++ b/src/shared/ConfirmWithReasonButton/index.jsx
@@ -81,6 +81,8 @@ export default class ConfirmWithReasonButton extends Component {
       );
     } else {
       console.error('Unknown State: ', this.state.displayState);
+      // TODO I think we can do better here
+      return undefined;
     }
   }
 }

--- a/src/shared/JsonSchemaForm/index.jsx
+++ b/src/shared/JsonSchemaForm/index.jsx
@@ -41,7 +41,7 @@ const renderGroupOrField = (fieldName, fields, uiSchema, nameSpace) => {
 export const renderField = (fieldName, fields, nameSpace) => {
   const field = fields[fieldName];
   if (!field) {
-    return;
+    return undefined;
   }
   return SchemaField.createSchemaField(fieldName, field, nameSpace);
 };
@@ -149,6 +149,7 @@ export const renderSchema = (schema, uiSchema, nameSpace = '') => {
     const fields = schema.properties || {};
     return uiSchema.order.map((i) => renderGroupOrField(i, fields, uiSchema, nameSpace));
   }
+  return undefined;
 };
 
 export const addUiSchemaRequiredFields = (schema, uiSchema) => {

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -11,22 +11,26 @@ const maxLength = memoize((maxLength) => (value) => {
   if (value && value.length > maxLength) {
     return `Cannot exceed ${maxLength} characters.`;
   }
+  return undefined;
 });
 const minLength = memoize((minLength) => (value) => {
   if (value && value.length < minLength) {
     return `Must be at least ${minLength} characters long.`;
   }
+  return undefined;
 });
 
 const maximum = memoize((maximum) => (value) => {
   if (value && value > maximum) {
     return `Must be ${maximum} or less`;
   }
+  return undefined;
 });
 const minimum = memoize((minimum) => (value) => {
   if (value && value < minimum) {
     return `Must be ${minimum} or more`;
   }
+  return undefined;
 });
 
 const isNumber = (value) => {
@@ -35,6 +39,7 @@ const isNumber = (value) => {
       return 'Must be a number';
     }
   }
+  return undefined;
 };
 
 const isInteger = (value) => {
@@ -43,6 +48,7 @@ const isInteger = (value) => {
       return 'Must be an integer';
     }
   }
+  return undefined;
 };
 
 const isDate = (value) => {
@@ -52,6 +58,7 @@ const isDate = (value) => {
       return 'Must be a valid date';
     }
   }
+  return undefined;
 };
 
 const patternMatches = memoize((pattern, message) => {
@@ -62,6 +69,7 @@ const patternMatches = memoize((pattern, message) => {
         return message;
       }
     }
+    return undefined;
   };
 });
 
@@ -70,6 +78,7 @@ const minDateValidation = memoize((minDate = null, message) => {
     if (minDate && moment(value).isBefore(moment(minDate))) {
       return message;
     }
+    return undefined;
   };
 });
 
@@ -78,6 +87,7 @@ const maxDateValidation = memoize((maxDate = null, message) => {
     if (maxDate && moment(value).isAfter(moment(maxDate))) {
       return message;
     }
+    return undefined;
   };
 });
 

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -35,7 +35,7 @@ function successfulReturnType(routeDefinition, status) {
   const schemaKey = response.schema['$$ref'].split('/').pop();
   if (!response) {
     console.error(`No response found for operation ${routeDefinition.operationId} with status ${status}`);
-    return;
+    return undefined;
   }
   return toCamelCase(schemaKey);
 }

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -75,7 +75,7 @@ export class Uploader extends Component {
     // If this component is unloaded quickly, this function can be called after the ref is deleted,
     // so check that the ref still exists before continuing
     if (!this.pond) {
-      return;
+      return undefined;
     }
     // Returns a boolean: is FilePond done with all uploading?
     const existingFiles = this.pond._pond.getFiles();

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -63,6 +63,7 @@ export class WizardFormPage extends Component {
       return this.props.reduxFormSubmit().then(() => this.beforeTransition(getPreviousPagePath, false));
     }
     this.beforeTransition(getPreviousPagePath, shouldHandleSubmit);
+    return undefined;
   }
 
   submit() {

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -34,6 +34,7 @@ export function formatDateForSwagger(dateString) {
   if (dateString) {
     return formatDate(dateString, swaggerDateFormat);
   }
+  return undefined;
 }
 
 export function formatDateTime(dateString) {
@@ -41,4 +42,5 @@ export function formatDateTime(dateString) {
     const startOfDay = moment(dateString).hour(0);
     return moment.utc(startOfDay).format(utcDateFormat);
   }
+  return undefined;
 }

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -86,7 +86,7 @@ export function convertFromThousandthInchToInch(thousandthInch) {
 // Format a dimensions object length, width and height to inches
 export function formatToDimensionsInches(dimensions) {
   if (!dimensions) {
-    return;
+    return undefined;
   }
 
   dimensions.length = convertFromThousandthInchToInch(dimensions.length);
@@ -105,6 +105,7 @@ export function formatDimensionsToThousandthInches(dimensions) {
   dimensions.length = formatToThousandthInches(dimensions.length);
   dimensions.width = formatToThousandthInches(dimensions.width);
   dimensions.height = formatToThousandthInches(dimensions.height);
+  return;
 }
 
 // Format user-entered dimension into base dimension, e.g. 15.25 -> 15250
@@ -127,6 +128,7 @@ export function formatDateSM(date) {
   if (date) {
     return moment(date).format('MM/DD/YYYY');
   }
+  return undefined;
 }
 
 // Format a date into the format required for submission as a date property in
@@ -143,6 +145,7 @@ export function parseSwaggerDate(dateString) {
   if (dateString) {
     return moment(dateString, 'YYYY-MM-DD').toDate();
   }
+  return undefined;
 }
 
 // Format a weight with lbs following, e.g. 4000 becomes 4,000 lbs
@@ -170,6 +173,7 @@ const formatDateForDateRange = (date, formatType) => {
   if (date) {
     return moment(date).format(format);
   }
+  return undefined;
 };
 
 export const displayDateRange = (dates, formatType = 'long') => {
@@ -191,6 +195,7 @@ export function formatDate(date, inputFormat, outputFormat = 'DD-MMM-YY', locale
   if (date) {
     return moment(date, inputFormat, locale, isStrict).format(outputFormat);
   }
+  return undefined;
 }
 
 export function formatDateFromIso(date, outputFormat) {
@@ -201,12 +206,14 @@ export function formatDate4DigitYear(date) {
   if (date) {
     return moment(date).format('DD-MMM-YYYY');
   }
+  return undefined;
 }
 
 export function formatTime(date) {
   if (date) {
     return moment(date).format('HH:mm');
   }
+  return undefined;
 }
 
 // Format a date and include its time, e.g. 03-Jan-2018 21:23
@@ -214,6 +221,7 @@ export function formatDateTime(date) {
   if (date) {
     return moment(date).format('DD-MMM-YY HH:mm');
   }
+  return undefined;
 }
 
 // Format a date, include its time and timezone, e.g. 03-Jan-2018 21:23 ET

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -73,7 +73,7 @@ export function formatPayload(payload, def) {
 
 export const convertDollarsToCents = (dollars) => {
   if (!dollars && dollars !== 0) {
-    return;
+    return undefined;
   }
 
   return Math.round(parseFloat(String(dollars).replace(',', '')) * 100);
@@ -81,7 +81,7 @@ export const convertDollarsToCents = (dollars) => {
 
 export function renderStatusIcon(status) {
   if (!status) {
-    return;
+    return undefined;
   }
   if (status === 'AWAITING_REVIEW' || status === 'DRAFT' || status === 'SUBMITTED') {
     return <FontAwesomeIcon className="icon approval-waiting" icon="clock" />;
@@ -95,6 +95,7 @@ export function renderStatusIcon(status) {
   if (status === 'HAS_ISSUE') {
     return <FontAwesomeIcon className="icon approval-problem" icon="exclamation-circle" />;
   }
+  return undefined;
 }
 
 export function snakeCaseToCapitals(str) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,7 +1624,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.35", "@fortawesome/fontawesome-common-types@^0.2.36":
+"@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
   integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
@@ -1945,6 +1945,24 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/core@^4.12.3":
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
+  integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.12.1"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
 "@material-ui/icons@^4.11.2":
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
@@ -1978,6 +1996,16 @@
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
   integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"


### PR DESCRIPTION
## Description
In this PR, I turned on the [eslint `consistent-return` rule](https://eslint.org/docs/rules/consistent-return) for the directories `src/shared` and `src/scene`, and fixed all the errors that popped up.

There are a lot of cases where javascript will implicitly return `undefined` from a function, and this rule forces us to handle those cases more explicitly, to prevent bugs from `undefined` values popping up in places where we don't expect them.

In most cases that eslint flagged, our code was clearly written with the knowledge that `undefined` would be returned, so we can fix the errors reported by the linter without changing behavior by explicitly returning `undefined`.

The only cases where I did more than that were `if` statements that I rearranged to get rid of an implicit return.

## Reviewer Notes

- There are a few cases where we hit a problem or end up in an unexpected state, and use `console.error` and return `undefined`. I think for the purposes of this PR, it's OK to leave these as they are, but we're going to have to come back to them soon when we remove `console` statements for MB-7690.
I don't know how we should handle these without a system like Sentry or OpenTelemetry or something to send errors to. I know that stuff is in the works, but I'm not sure what we should do before we have it.

- I ran into some dependency struggles that I don't really understand. Yarn told me to install some things so I did. Please let me know if I've done this wrong.

## Setup

Make sure that the linter runs without displaying any errors:
```sh
yarn run lint
```

## Acceptance
No acceptance for this.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7692) for this change
* [eslint docs for this error](https://eslint.org/docs/rules/consistent-return)
