### PR TITLE
MB-5700: Force dashes in customer phone number input

### DIFF
--- a/src/components/Customer/MtoShipmentForm/validationSchemas.js
+++ b/src/components/Customer/MtoShipmentForm/validationSchemas.js
@@ -6,7 +6,7 @@ import { ZIP_CODE_REGEX, requiredAddressSchema } from 'utils/validation';
 export const AgentSchema = Yup.object().shape({
   firstName: Yup.string(),
   lastName: Yup.string(),
-  phone: Yup.string().matches(/^[2-9]\d{2}\d{3}\d{4}$/, 'Must be valid phone number'),
+  phone: Yup.string().matches(/^[2-9]\d{2}-\d{3}-\d{4}$/, 'Must be valid phone number'),
   email: Yup.string().email('Must be valid email'),
 });
 

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
@@ -34,6 +34,7 @@ const defaultProps = {
     },
   },
   moveTaskOrderID: 'mock move id',
+  mtoShipments: [],
 };
 
 const mockMtoShipment = {
@@ -111,13 +112,9 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getByLabelText('Customer remarks')).toBeInstanceOf(HTMLTextAreaElement);
 
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);
-    });
-
-    it('does not render special NTS What to expect section', async () => {
-      render(<ServicesCounselingShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
 
       expect(
-        await screen.queryByText(
+        screen.queryByText(
           'The moving company will find a storage facility approved by the government, and will move your belongings there.',
         ),
       ).not.toBeInTheDocument();
@@ -183,7 +180,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('ZIP')[0]).toHaveValue('78234');
       expect(screen.getAllByLabelText('First name')[0]).toHaveValue('Jason');
       expect(screen.getAllByLabelText('Last name')[0]).toHaveValue('Ash');
-      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('9999999999'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('999-999-9999');
       expect(screen.getAllByLabelText('Email')[0]).toHaveValue('jasn@email.com');
       expect(screen.getByLabelText('Requested delivery date')).toHaveValue('30 Mar 2020');
       expect(screen.getByLabelText('Yes')).toBeChecked();
@@ -194,7 +191,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('ZIP')[1]).toHaveValue('98421');
       expect(screen.getAllByLabelText('First name')[1]).toHaveValue('Riley');
       expect(screen.getAllByLabelText('Last name')[1]).toHaveValue('Baker');
-      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('8635559664'); // formatAgentForDisplay removes '-'
+      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('863-555-9664');
       expect(screen.getAllByLabelText('Email')[1]).toHaveValue('rbaker@email.com');
       expect(screen.getByLabelText('Customer remarks')).toHaveValue('mock customer remarks');
       expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');
@@ -265,13 +262,9 @@ describe('ServicesCounselingShipmentForm component', () => {
 
       expect(screen.getByLabelText('Customer remarks')).toBeInstanceOf(HTMLTextAreaElement);
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);
-    });
-
-    it('does not render special NTS What to expect section', async () => {
-      render(<ServicesCounselingShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.NTSR} />);
 
       expect(
-        await screen.queryByText(
+        screen.queryByText(
           'The moving company will find a storage facility approved by the government, and will move your belongings there.',
         ),
       ).not.toBeInTheDocument();

--- a/src/components/form/ContactInfoFields/ContactInfoFields.jsx
+++ b/src/components/form/ContactInfoFields/ContactInfoFields.jsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Fieldset } from '@trussworks/react-uswds';
 
 import TextField from 'components/form/fields/TextField';
+import MaskedTextField from 'components/form/fields/MaskedTextField';
 
 export const ContactInfoFields = ({ legend, className, name, render }) => {
   const contactInfoFieldsUUID = uuidv4();
@@ -15,13 +16,16 @@ export const ContactInfoFields = ({ legend, className, name, render }) => {
           <TextField label="First name" id={`firstName_${contactInfoFieldsUUID}`} name={`${name}.firstName`} />
           <TextField label="Last name" id={`lastName_${contactInfoFieldsUUID}`} name={`${name}.lastName`} />
 
-          <TextField
+          <MaskedTextField
             label="Phone"
             id={`phone_${contactInfoFieldsUUID}`}
             name={`${name}.phone`}
             type="tel"
-            maxLength="10"
+            minimum="12"
+            mask="000{-}000{-}0000"
+            required
           />
+
           <TextField label="Email" id={`email_${contactInfoFieldsUUID}`} name={`${name}.email`} />
         </>,
       )}

--- a/src/components/form/ContactInfoFields/ContactInfoFields.test.jsx
+++ b/src/components/form/ContactInfoFields/ContactInfoFields.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 
 import { ContactInfoFields } from './ContactInfoFields';
@@ -38,6 +39,20 @@ describe('ContactInfoFields component', () => {
       expect(getByLabelText('Last name')).toHaveValue(initialValues.contact.lastName);
       expect(getByLabelText('Phone')).toHaveValue(initialValues.contact.phone);
       expect(getByLabelText('Email')).toHaveValue(initialValues.contact.email);
+    });
+  });
+
+  describe('with inserted values', () => {
+    it('renders phone numbers formatted with dashes', async () => {
+      render(
+        <Formik initialValues={{}}>
+          <ContactInfoFields legend="Contact Info Form" name="contact" />
+        </Formik>,
+      );
+
+      expect(screen.getByLabelText('Phone')).toBeInTheDocument();
+      userEvent.type(screen.getByLabelText('Phone'), '5555555555');
+      expect(await screen.findByLabelText('Phone')).toHaveValue('555-555-5555');
     });
   });
 });

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -5,14 +5,6 @@ import { formatSwaggerDate, parseSwaggerDate } from 'shared/formatters';
 
 function formatAgentForDisplay(agent) {
   const agentCopy = { ...agent };
-  // handle the diff between expected FE and BE phone format
-  Object.keys(agentCopy).forEach((key) => {
-    if (key === 'phone') {
-      const phoneNum = agentCopy[key];
-      // will be in format xxxxxxxxxx
-      agentCopy[key] = phoneNum.split('-').join('');
-    }
-  });
   return agentCopy;
 }
 
@@ -29,10 +21,6 @@ function formatAgentForAPI(agent) {
       sanitizedKey === 'mtoShipmentID'
     ) {
       delete agentCopy[sanitizedKey];
-    } else if (sanitizedKey === 'phone') {
-      const phoneNum = agentCopy[sanitizedKey];
-      // will be in format xxx-xxx-xxxx
-      agentCopy[sanitizedKey] = `${phoneNum.slice(0, 3)}-${phoneNum.slice(3, 6)}-${phoneNum.slice(6, 10)}`;
     }
   });
   return agentCopy;

--- a/src/utils/formatMtoShipment.test.js
+++ b/src/utils/formatMtoShipment.test.js
@@ -185,7 +185,7 @@ describe('formatMtoShipmentForAPI', () => {
   };
 
   const pickupInfo = {
-    requestedDate: 'Jan 7, 2026',
+    requestedDate: '2026-01-07',
     address: {
       street_address_1: '123 main',
       city: 'legit human city',
@@ -196,12 +196,12 @@ describe('formatMtoShipmentForAPI', () => {
       firstName: 'mockFirstName',
       lastName: 'mockLastName',
       email: 'mockAgentEmail@example.com',
-      phone: '2225551234',
+      phone: '222-555-1234',
     },
   };
 
   const deliveryInfo = {
-    requestedDate: 'Jan 27, 2026',
+    requestedDate: '2026-01-27',
     address: {
       street_address_1: '0011100010110101',
       city: 'R0B0T T0WN',
@@ -212,7 +212,7 @@ describe('formatMtoShipmentForAPI', () => {
       firstName: 'r0b0tBestFr1end',
       lastName: 'r0b0tBestFr1endLastName',
       email: 'r0b0t-fr1end@example.com',
-      phone: '2225550101',
+      phone: '222-555-0101',
     },
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,7 +1624,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.35", "@fortawesome/fontawesome-common-types@^0.2.36":
+"@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
   integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==


### PR DESCRIPTION
## Description

A standard customer will enter phone numbers in two places when using MyMove.

1. When entering their own contact details (and backup contact details); there, phone numbers are displayed as a `MaskedTextField` component, with dashes automatically inserted between the 3rd/4th and 6th/7th digits (so, `202-555-1234`)
2. When entering contacts details for releasing and/or receiving agents when adding a shipment; there, phone numbers are displayed as a regular `TextField` component. This component was configured so that dashes weren't being automatically inserted (so, `2025551234`) or even possible, as the field was client-side validated to be only ten numbers in length.

This pull request standardizes the formatting of phone numbers as experienced by the customer by changing the releasing and receiving agent fields to use the `MaskedTextField` dashed format as well.

## Reviewer Notes

In concordance with the [TRA epic](https://dp3.atlassian.net/browse/MB-8944) to clean up client-side testing log messages, this pull request also refactors a bunch of test files (which are directly related to the business logic being changed) to clean up those error messages. Ensure that when the changed tests run, there are no `console.error` or `console.warn`s emitted from those test files.

## Setup

You can check the validation in the individual components (or the shipment form itself) with `yarn storybook`; to run the application itself, it's the standard:

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-5700](https://dp3.atlassian.net/browse/MB-5700)

## Screenshots

* [Before](https://user-images.githubusercontent.com/83614364/128888456-7d884711-3de6-4f31-8d0e-83e3c5abc345.png)
* [After](https://user-images.githubusercontent.com/83614364/128888345-101c1016-2f29-4f73-9800-5cbfd8fa4228.png)
