### PR TITLE
[MB-4742] Add risk of excess weight tag to MTO page

### DIFF
--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -165,6 +165,34 @@ func makeMoveForOrders(orders models.Order, db *pop.Connection, moveCode string,
 	return move
 }
 
+func makeRiskOfExcessShipmentForMove(move models.Move, shipmentStatus models.MTOShipmentStatus, db *pop.Connection) models.MTOShipment {
+	estimatedWeight := unit.Pound(7200)
+	actualWeight := unit.Pound(7400)
+	MTOShipment := testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
+			ApprovedDate:         swag.Time(time.Now()),
+			Status:               shipmentStatus,
+		},
+		Move: move,
+	})
+
+	testdatagen.MakeMTOAgent(db, testdatagen.Assertions{
+		MTOAgent: models.MTOAgent{
+			MTOShipment:   MTOShipment,
+			MTOShipmentID: MTOShipment.ID,
+			FirstName:     swag.String("Test"),
+			LastName:      swag.String("Agent"),
+			Email:         swag.String("test@test.email.com"),
+			MTOAgentType:  models.MTOAgentReleasing,
+		},
+	})
+
+	return MTOShipment
+}
+
 func makeShipmentForMove(move models.Move, shipmentStatus models.MTOShipmentStatus, db *pop.Connection) models.MTOShipment {
 	estimatedWeight := unit.Pound(1400)
 	actualWeight := unit.Pound(2000)

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -4103,6 +4103,16 @@ func createHHGMoveWithAmendedOrders(db *pop.Connection, userUploader *uploader.U
 	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
 }
 
+func createHHGMoveWithRiskOfExcess(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
+	filterFile := &[]string{"2mb.png", "150Kb.png"}
+	serviceMember := makeServiceMember(db)
+	orders := makeOrdersForServiceMember(serviceMember, db, userUploader, filterFile)
+	move := makeMoveForOrders(orders, db, "RISKEX", models.MoveStatusAPPROVALSREQUESTED)
+	shipment := makeRiskOfExcessShipmentForMove(move, models.MTOShipmentStatusApproved, db)
+	paymentRequestID := uuid.Must(uuid.FromString("50b35add-705a-468b-8bad-056f5d9ef7e1"))
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
+}
+
 func createMoveWithDivertedShipments(db *pop.Connection, userUploader *uploader.UserUploader) {
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -227,5 +227,6 @@ func subScenarioMisc(db *pop.Connection, userUploader *uploader.UserUploader, pr
 		// Creates a move that has multiple orders uploaded
 		createHHGMoveWithMultipleOrdersFiles(db, userUploader, primeUploader)
 		createHHGMoveWithAmendedOrders(db, userUploader, primeUploader)
+		createHHGMoveWithRiskOfExcess(db, userUploader, primeUploader)
 	}
 }

--- a/src/components/Office/WeightDisplay/WeightDisplay.module.scss
+++ b/src/components/Office/WeightDisplay/WeightDisplay.module.scss
@@ -31,7 +31,7 @@
   }
 
   .details span {
-    background-color: $base-lightest;
+    background-color: $info-light;
   }
 
   .details {

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -10,6 +10,7 @@ import styles from '../TXOMoveInfo/TXOTab.module.scss';
 
 import moveTaskOrderStyles from './MoveTaskOrder.module.scss';
 
+import hasRiskOfExcess from 'utils/hasRiskOfExcess';
 import customerContactTypes from 'constants/customerContactTypes';
 import dimensionTypes from 'constants/dimensionTypes';
 import { MTO_SERVICE_ITEMS, MTO_SHIPMENTS } from 'constants/queryKeys';
@@ -346,7 +347,9 @@ export const MoveTaskOrder = ({ match, ...props }) => {
           </div>
           <div className={moveTaskOrderStyles.weightHeader}>
             <WeightDisplay heading="Weight allowance" weightValue={order.entitlement.totalWeight} />
-            <WeightDisplay heading="Estimated weight (total)" weightValue={estimatedWeightTotal} />
+            <WeightDisplay heading="Estimated weight (total)" weightValue={estimatedWeightTotal}>
+              {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && <Tag>Risk of excess</Tag>}
+            </WeightDisplay>
             <WeightDisplay
               heading="Max billable weight"
               weightValue={order.entitlement.authorizedWeight}

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -525,7 +525,7 @@ const missingSomeWeightQuery = {
   ],
 };
 
-// no weight is not returned in payload at all
+// weight is not returned in payload at all
 const noWeightQuery = {
   ...allApprovedMTOQuery,
   mtoShipments: [
@@ -665,6 +665,83 @@ const someWeightNotReturned = {
       eTag: '1234',
       primeActualWeight: 1,
       primeEstimatedWeight: 1,
+    },
+  ],
+};
+
+const riskOfExcessWeightQuery = {
+  ...allApprovedMTOQuery,
+  orders: {
+    1: {
+      id: '1',
+      originDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Knox',
+          state: 'KY',
+          postal_code: '40121',
+        },
+      },
+      destinationDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Irwin',
+          state: 'CA',
+          postal_code: '92310',
+        },
+      },
+      entitlement: {
+        authorizedWeight: 100,
+        totalWeight: 100,
+      },
+    },
+  },
+  mtoShipments: [
+    {
+      id: '3',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 50,
+      primeActualWeight: 50,
+    },
+    {
+      id: '5',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.NTSR,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 40,
+      primeActualWeight: 40,
     },
   ],
 };
@@ -925,6 +1002,23 @@ describe('MoveTaskOrder', () => {
 
       const weightSummaries = await screen.findAllByTestId('weight-display');
       expect(weightSummaries[3]).toHaveTextContent('101');
+    });
+
+    it('displays risk of excess tag', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(riskOfExcessWeightQuery);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+          />
+        </MockProviders>,
+      );
+
+      const riskOfExcessTag = await screen.getByText(/Risk of excess/);
+      expect(riskOfExcessTag).toBeInTheDocument();
     });
 
     it('displays the estimated total weight', async () => {

--- a/src/utils/hasRiskOfExcess.js
+++ b/src/utils/hasRiskOfExcess.js
@@ -1,0 +1,5 @@
+// If the estimated weight is 90% or more of the weight allowance,
+// then there is a risk of excess
+export default function hasRiskOfExcess(estimatedWeight, weightAllowance) {
+  return 0.9 * weightAllowance <= estimatedWeight;
+}

--- a/src/utils/hasRiskOfExcess.test.js
+++ b/src/utils/hasRiskOfExcess.test.js
@@ -1,0 +1,15 @@
+import hasRiskOfExcess from './hasRiskOfExcess';
+
+describe('hasRiskOfExcess', () => {
+  it('returns true when estimated weight is 90% of weight allowancew', () => {
+    expect(hasRiskOfExcess(90, 100)).toEqual(true);
+  });
+
+  it('returns true when estimated weight is more than 90% of weight allowancew', () => {
+    expect(hasRiskOfExcess(91, 100)).toEqual(true);
+  });
+
+  it('returns false when estimated weight is less than 90% of weight allowancew', () => {
+    expect(hasRiskOfExcess(89, 100)).toEqual(false);
+  });
+});

--- a/src/utils/hasRiskOfExcess.test.js
+++ b/src/utils/hasRiskOfExcess.test.js
@@ -12,4 +12,12 @@ describe('hasRiskOfExcess', () => {
   it('returns false when estimated weight is less than 90% of weight allowancew', () => {
     expect(hasRiskOfExcess(89, 100)).toEqual(false);
   });
+
+  it('returns false when estimated weight is undefined', () => {
+    expect(hasRiskOfExcess(undefined, 100)).toEqual(false);
+  });
+
+  it('returns false when estimated weight is zero', () => {
+    expect(hasRiskOfExcess(0, 100)).toEqual(false);
+  });
 });


### PR DESCRIPTION
## Description

Add risk of excess tag to estimated weight total display if the estimated weight is 90% or more of the weight allowance.

## Setup


```sh
make db_dev_e2e_populate
make server_run
make client_run
```

Use `RISKEX` move code to view the tag, and other moves shouldn't have the tag.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-4742) for this change

## Screenshots

<img width="880" alt="Screen Shot 2021-08-10 at 1 26 12 PM" src="https://user-images.githubusercontent.com/3903208/128906350-f528dec0-9e05-47c1-9c32-870e95f126ea.png">
