### PR TITLE
Override location of opensc when using nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -297,6 +297,9 @@ if [ ! -r .nix-disable  ] && has nix-env; then
   export NIX_SSL_CERT_FILE_ORIG=$NIX_SSL_CERT_FILE
   unset NIX_SSL_CERT_FILE
 
+  # Nix installs opensc which the prime-api-client needs
+  export PKCS11MODULE=/nix/var/nix/profiles/mymove/lib/opensc-pkcs11.so
+
   nix_dir="nix"
   # add the nix files so that if they change, direnv needs to be reloaded
   watch_file "${nix_dir}"/*.nix

--- a/scripts/cac-prereqs
+++ b/scripts/cac-prereqs
@@ -39,10 +39,3 @@ if [[ -z "${MODULE}" ]]; then
   echo "Could not find the opensc-pkcs11 module. You are either missing it or the CAC scripts need to be updated."
   exit 1
 fi
-
-readonly OLD_MODULE=/usr/local/lib/pkcs11/cackey.dylib
-
-if [[ -f "${OLD_MODULE}" ]]; then
-  echo "${OLD_MODULE} must be removed for MacOS versions 10.15 or later"
-  exit 1
-fi

--- a/scripts/cac-prereqs
+++ b/scripts/cac-prereqs
@@ -8,18 +8,28 @@ set -eu -o pipefail
 # Note: This script has no output other than Exit 0 on success  so it can be used in other scripts.
 #
 
-PKCS11=/usr/local/bin/pkcs11-tool
-PKCS15=/usr/local/bin/pkcs15-tool
+INSTALL_MSG=
+PKCS11=
+PKCS15=
+if [ ! -r .nix-disable ] && [ -f ~/.nix-profile/bin/nix-env ]; then
+  INSTALL_MSG="./nix/update.sh"
+  PKCS11=/nix/var/nix/profiles/mymove/bin/pkcs11-tool
+  PKCS15=/nix/var/nix/profiles/mymove/bin/pkcs15-tool
+else
+  INSTALL_MSG="brew install --cask opensc"
+  PKCS11=/usr/local/bin/pkcs11-tool
+  PKCS15=/usr/local/bin/pkcs15-tool
+fi
 
 if [[ ! -x "${PKCS11}" ]]; then
   echo "${PKCS11} has not been installed"
-  echo "Please install with 'brew install --cask opensc'"
+  echo "Please install with '${INSTALL_MSG}'"
   exit 1
 fi
 
 if [[ ! -x "${PKCS15}" ]]; then
   echo "${PKCS15} has not been installed"
-  echo "Please install with 'brew install --cask opensc'"
+  echo "Please install with '${INSTALL_MSG}'"
   exit 1
 fi
 
@@ -31,6 +41,8 @@ if [[ -f /usr/local/lib/opensc-pkcs11.so ]]; then
   MODULE=/usr/local/lib/opensc-pkcs11.so
 elif [[ -f /usr/local/lib/pkcs11/opensc-pkcs11.so ]]; then
   MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [ ! -r .nix-disable ] && [[ -f /nix/var/nix/profiles/mymove/lib/opensc-pkcs11.so ]]; then
+  MODULE=/nix/var/nix/profiles/mymove/lib/opensc-pkcs11.so
 fi
 
 readonly MODULE


### PR DESCRIPTION
## Description

Nix installs opensc which we depend on in `prime-api-client`. However, the default location that `prime-api-client` looks for the library where homebrew installs it. This PR sets an override when nix is enabled.

## Reviewer Notes

You will need nix, a CAC, and access to staging.

## Setup

The following should output nothing and exit with 0 error code

```sh
scripts/cac-prereqs
```

The following should run successfully
```
rm -rf bin/prime-api-client
make bin/prime-api-client
bin/prime-api-client --cac --hostname api.stg.move.mil --port 443 list-moves
```

## Code Review Verification Steps

* [X] Request review from a member of a different team.