### PR TITLE
[MB-7543] CAT II: eslint no-case-declarations

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -4,11 +4,12 @@
   "rules": {
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
+    "no-case-declarations": "error",
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",
     "react/jsx-curly-brace-presence": "error",
-    "security/detect-object-injection": "off",
+    "security/detect-object-injection": "off"
   },
   "globals": {
     "cy": "readonly",

--- a/src/scenes/.eslintrc
+++ b/src/scenes/.eslintrc
@@ -4,6 +4,7 @@
   "rules": {
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
+    "no-case-declarations": "error",
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",

--- a/src/scenes/SystemAdmin/shared/rest_provider.js
+++ b/src/scenes/SystemAdmin/shared/rest_provider.js
@@ -92,7 +92,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
         url = `${apiUrl}/${resource}?${stringify(query)}`;
         break;
       }
-      case UPDATE:
+      case UPDATE: {
         url = `${apiUrl}/${resource}/${params.id}`;
         options.method = 'PATCH';
         options.headers.set('If-Match', params.data?.eTag); // for optimistic locking / concurrency control
@@ -102,6 +102,7 @@ const restProvider = (apiUrl, httpClient = fetchUtils.fetchJson) => {
         }
         options.body = JSON.stringify(paramsDiff);
         break;
+      }
       case CREATE:
         url = `${apiUrl}/${resource}`;
         options.method = 'POST';

--- a/src/shared/.eslintrc
+++ b/src/shared/.eslintrc
@@ -4,6 +4,7 @@
   "rules": {
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",
+    "no-case-declarations": "error",
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "error",


### PR DESCRIPTION
## Description

This PR turns on the [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations) rule for eslint in three directories where we had explicit `.eslintrc` files, then fixes anything flagged from it.

There was only one case (pun intended) I could find that exhibited this problem.

## Reviewer Notes

I did not have any problems running the linter, but I know that others have experienced a crash.  PR #7166 adds another library that may fix a crash if you run into it.  More info can be found in [this Slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1628280575183800).

## Setup

Make sure that there are no linter errors when running:

`yarn run lint`

I believe this will also do the same thing:

`pre-commit run -a eslint`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7543) for this change
* [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations) info
