### PR TITLE
[MB-8981] Billable weight card component

### DIFF
--- a/src/components/Office/BillableWeightCard/BillableWeightCard.jsx
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.jsx
@@ -5,6 +5,8 @@ import { Button } from '@trussworks/react-uswds';
 
 import styles from './BillableWeightCard.module.scss';
 
+import { formatWeight } from 'shared/formatters';
+
 export default function BillableWeightCard({
   maxBillableWeight,
   weightRequested,
@@ -20,17 +22,17 @@ export default function BillableWeightCard({
       <div className={styles.spaceBetween}>
         <div>
           <h5>Maximum billable weight</h5>
-          <h4>{maxBillableWeight} lbs</h4>
+          <h4>{formatWeight(maxBillableWeight)}</h4>
           <h6>
-            Weight requested<strong>{weightRequested} lbs</strong>
+            Weight requested<strong>{formatWeight(weightRequested)}</strong>
           </h6>
           <h6>
-            Weight allowance<strong>{weightAllowance} lbs</strong>
+            Weight allowance<strong>{formatWeight(weightAllowance)}</strong>
           </h6>
         </div>
         <div className={styles.shipmentSection}>
           <h5>Total billable weight</h5>
-          <h4>{totalBillableWeight} lbs</h4>
+          <h4>{formatWeight(totalBillableWeight)}</h4>
           <div className={styles.shipmentPlaceholder}>shipment list placeholder</div>
         </div>
       </div>

--- a/src/components/Office/BillableWeightCard/BillableWeightCard.jsx
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { string } from 'prop-types';
+import classnames from 'classnames';
+import { Button } from '@trussworks/react-uswds';
+
+import styles from './BillableWeightCard.module.scss';
+
+export default function BillableWeightCard({
+  maxBillableWeight,
+  weightRequested,
+  weightAllowance,
+  totalBillableWeight,
+}) {
+  return (
+    <div className={classnames(styles.cardContainer, 'container')}>
+      <div className={styles.cardHeader}>
+        <h2>Billable weights</h2>
+        <Button>Review weights</Button>
+      </div>
+      <div className={styles.spaceBetween}>
+        <div>
+          <h5>Maximum billable weight</h5>
+          <h4>{maxBillableWeight} lbs</h4>
+          <h6>
+            Weight requested<strong>{weightRequested} lbs</strong>
+          </h6>
+          <h6>
+            Weight allowance<strong>{weightAllowance} lbs</strong>
+          </h6>
+        </div>
+        <div className={styles.shipmentSection}>
+          <h5>Total billable weight</h5>
+          <h4>{totalBillableWeight} lbs</h4>
+          <div className={styles.shipmentPlaceholder}>shipment list placeholder</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+BillableWeightCard.propTypes = {
+  maxBillableWeight: string.isRequired,
+  weightRequested: string.isRequired,
+  weightAllowance: string.isRequired,
+  totalBillableWeight: string.isRequired,
+};

--- a/src/components/Office/BillableWeightCard/BillableWeightCard.module.scss
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.module.scss
@@ -1,0 +1,95 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.cardContainer {
+  max-width: 1046px;
+  @include u-padding-x(3);
+  @include u-padding-y(4);
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+    text-transform: none;
+  }
+
+  button {
+    margin: 0;
+  }
+
+  h5,
+  h4 {
+    color: $base-darkest;
+  }
+
+  h5 {
+    font-weight: normal;
+
+    &:first-of-type {
+      @include u-margin-bottom('05');
+    }
+
+    &:last-of-type {
+      @include u-margin-bottom(1);
+    }
+  }
+
+  h4 {
+    font-weight: bold;
+    font-size: 22px;
+
+    &:first-of-type {
+      @include u-margin-bottom(3);
+    }
+
+    &:last-of-type {
+      @include u-margin-bottom(2);
+    }
+  }
+
+  h6 {
+    color: $base;
+    font-size: 13px;
+    &:first-of-type {
+      @include u-margin-bottom('05');
+    }
+
+    strong {
+      font-size: 15px;
+      color: $base-darker;
+      @include u-margin-left(1);
+    }
+  }
+
+  .cardHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    @include u-margin-bottom(5);
+  }
+
+  .spaceBetween {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .maxBillableSection {
+    max-width: 222px;
+  }
+
+  .shipmentSection {
+    min-width: 684px;
+  }
+
+  .shipmentPlaceholder {
+    width: 684px;
+    height: 94px;
+    background-color: $bg-gray;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/components/Office/BillableWeightCard/BillableWeightCard.module.scss
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.module.scss
@@ -6,6 +6,7 @@
   max-width: 1046px;
   @include u-padding-x(3);
   @include u-padding-y(4);
+
   h1,
   h2,
   h3,
@@ -20,21 +21,9 @@
     margin: 0;
   }
 
-  h5,
-  h4 {
-    color: $base-darkest;
-  }
-
+  h4,
   h5 {
-    font-weight: normal;
-
-    &:first-of-type {
-      @include u-margin-bottom('05');
-    }
-
-    &:last-of-type {
-      @include u-margin-bottom(1);
-    }
+    color: $base-darkest;
   }
 
   h4 {
@@ -47,6 +36,18 @@
 
     &:last-of-type {
       @include u-margin-bottom(2);
+    }
+  }
+
+  h5 {
+    font-weight: normal;
+
+    &:first-of-type {
+      @include u-margin-bottom('05');
+    }
+
+    &:last-of-type {
+      @include u-margin-bottom(1);
     }
   }
 
@@ -74,10 +75,6 @@
   .spaceBetween {
     display: flex;
     justify-content: space-between;
-  }
-
-  .maxBillableSection {
-    max-width: 222px;
   }
 
   .shipmentSection {

--- a/src/components/Office/BillableWeightCard/BillableWeightCard.stories.jsx
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import BillableWeightCard from './BillableWeightCard';
+
+export default {
+  title: 'Office Components/BillableWeightCard',
+  component: BillableWeightCard,
+};
+
+export const Card = () => (
+  <div style={{ background: '#f9f9f9', width: '100%', height: '100%', paddingTop: 20 }}>
+    <BillableWeightCard
+      maxBillableWeight="13,750"
+      totalBillableWeight="12,460"
+      weightRequested="12,460"
+      weightAllowance="8,000"
+    />
+  </div>
+);

--- a/src/components/Office/BillableWeightCard/BillableWeightCard.test.jsx
+++ b/src/components/Office/BillableWeightCard/BillableWeightCard.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import BillableWeightCard from './BillableWeightCard';
+
+describe('BillableWeightCard', () => {
+  it('renders maximum billable weight, total billable weight, weight requested and weight allowance', () => {
+    const weights = {
+      maxBillableWeight: '13,750',
+      totalBillableWeight: '12,460',
+      weightRequested: '12,260',
+      weightAllowance: '8,000',
+    };
+    const { getByText } = render(<BillableWeightCard {...weights} />);
+
+    // labels
+    expect(getByText('Maximum billable weight')).toBeInTheDocument();
+    expect(getByText('Weight requested')).toBeInTheDocument();
+    expect(getByText('Weight allowance')).toBeInTheDocument();
+    expect(getByText('Total billable weight')).toBeInTheDocument();
+
+    // weights
+    expect(getByText(`${weights.maxBillableWeight} lbs`)).toBeInTheDocument();
+    expect(getByText(`${weights.totalBillableWeight} lbs`)).toBeInTheDocument();
+    expect(getByText(`${weights.weightRequested} lbs`)).toBeInTheDocument();
+    expect(getByText(`${weights.weightAllowance} lbs`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Billable weight card component is added to storybook for future use

## Reviewer Notes
- For some of the padding/margin values in the Zeplin design I rounded/down to be consistent with uswds spacing values being divisible by 8

## Setup
```sh
make storybook
```
Search for component named `BillableWeightCard`

## Code Review Verification Steps
* [x] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8981) for this change

## Screenshots
<img width="1191" alt="Screen Shot 2021-08-12 at 12 00 38 AM" src="https://user-images.githubusercontent.com/13622298/129152259-008fa762-eeb5-4937-b5d7-aed5278fd996.png">
