### PR TITLE
[MB-9062] add contract code to FSC for the purposes of displaying on the EDI

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -657,3 +657,4 @@
 20210726214608_add_dimension_param_keys.up.sql
 20210729204423_install_pgaudit_extension.up.sql
 20210802205220_create_reweighs_table_excess_weights_columns.up.sql
+20210812163307_add_contract_code_FSC.up.sql

--- a/migrations/app/schema/20210812163307_add_contract_code_FSC.up.sql
+++ b/migrations/app/schema/20210812163307_add_contract_code_FSC.up.sql
@@ -1,0 +1,2 @@
+INSERT INTO service_params(id, service_id, service_item_param_key_id, created_at, updated_at)
+VALUES ('9e70a393-aa8c-4ad2-a432-9b9bae71e7b8', (SELECT id FROM re_services WHERE code = 'FSC'), (SELECT id FROM service_item_param_keys where key = 'ContractCode'), now(), now())

--- a/scripts/pricing-acceptance
+++ b/scripts/pricing-acceptance
@@ -15,7 +15,7 @@ function usage() {
   echo "  hostname   Target host of api calls, defaults to 'local' which is primelocal:9443"
   echo "  proofs     Paths to proof of service docs. Defaults to (${proofs[0]})"
   echo "             You can specify as many proofs as you want"
-  echo
+  echo20210812163307_add_contract_code_FSC.up.sql
   echo "EXAMPLES:"
   echo "$0 --help # prints this help"
   echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d"

--- a/scripts/pricing-acceptance
+++ b/scripts/pricing-acceptance
@@ -15,7 +15,7 @@ function usage() {
   echo "  hostname   Target host of api calls, defaults to 'local' which is primelocal:9443"
   echo "  proofs     Paths to proof of service docs. Defaults to (${proofs[0]})"
   echo "             You can specify as many proofs as you want"
-  echo20210812163307_add_contract_code_FSC.up.sql
+  echo
   echo "EXAMPLES:"
   echo "$0 --help # prints this help"
   echo "$0 9c7b255c-2981-4bf8-839f-61c7458e2b4d"


### PR DESCRIPTION
## Description

This fixes the issue where generating an EDI for a payment request that has only 1 service item and it is an FSC it won't error out due to a missing a missing `ContractCode`.


## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?


## Setup

You will need to:
1.) create a payment request with only 1 service item. That service item is an FSC.
2.) then you will need to generate an EDI to see that there is no error

### Get your move code
a.) Either run through customer onboarding and have the TOO approve the move or
b.) Login as the TOO and find an "approved move"
either way you will be generating a new shipment so any visible shipments from the TXO aren't important

### Run the pricing-acceptence script to create a new
#### Local DEV

pricing-acceptance RDY4PY local

#### Acceptance STG

pricing-acceptance <moveCode> api.stg.move.mil

Follow the instructions and exit when asked to provide the path to a payload. Use the MTO ID and Shipment ID provided by the script.
```sh
MTO ID: <moveID>
Shipment ID: <mtoShipmentID>
```

### Create a payment request and generate EDI

#### Local DEV

**payload**
```sh
prime-api-client --insecure  fetch-mto-updates | jq \
'map(select(.id == <moveID>)) | .[0] | \
.mtoServiceItems | map(select((.mtoShipmentID == <mtoShipmentID>) \
and .reServiceCode == "FSC") ) | \
{ body: \
{ isFinal: false, moveTaskOrderID: <moveID>, \
serviceItems: map({ id: .id }) } }' > payload_payment_request.json
```
**request to create**
```sh
prime-api-client --insecure create-payment-request --filename payload_payment_request.json | \
jq '{ paymentRequestID: .id}' > generate_edi.json
```

**generate EDI for payment request**
```shell
prime-api-client --insecure support-get-payment-request-edi --filename generate_edi.json | \
jq -r .edi
```

#### Acceptance STG

**payload**
```sh
prime-api-client --cac --hostname api.stg.move.mil --port 443  fetch-mto-updates | jq \
'map(select(.id == <moveID>)) | .[0] | \
.mtoServiceItems | map(select((.mtoShipmentID == <mtoShipmentID>) \
and .reServiceCode == "FSC") ) | \
{ body: \
{ isFinal: false, moveTaskOrderID: <moveID>, \
serviceItems: map({ id: .id }) } }' > payload_payment_request.json
```
**request to create**
```sh
prime-api-client --cac --hostname api.stg.move.mil --port 443 create-payment-request --filename payload_payment_request.json | \
jq '{ paymentRequestID: .id}' > generate_edi.json
```

**generate EDI for payment request**
```shell
prime-api-client --cac --hostname api.stg.move.mil --port 443 support-get-payment-request-edi --filename generate_edi.json | \
jq -r .edi
```


## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9062) for this change


## Screenshots

n/a
