### PR TITLE
MB-9049 Add a wait time for the SC login test

### DIFF
--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -1,4 +1,4 @@
-import { officeBaseURL } from '../../support/constants';
+import { longPageLoadTimeout, officeBaseURL } from '../../support/constants';
 
 describe('Office Home Page', function () {
   before(() => {
@@ -55,6 +55,7 @@ describe('Office authorization', () => {
     cy.signInAsNewServicesCounselorUser();
     cy.waitFor('@getCounselingSortedOrders');
 
+    cy.wait(longPageLoadTimeout);
     cy.contains('Moves');
     cy.contains('Needs counseling');
     cy.url().should('eq', officeBaseURL + '/');


### PR DESCRIPTION
## Description

This PR is to fix a flaky test we have: Office authorization redirects Services Counselor to Services Counselor homepage

This integration test has failed 20 times in the master branch within the past 90 days (in 487 runs of the integration_tests step, a single-test failure rate of 4.1%). 

## Reviewer Notes

I just re-used a constant time for long-loading pages. I mainly used it because when I did the steps the test does locally, it took a bit to load. Though I'm surprised it fails on the second thing it checks on the page. I'm wondering if we fixed this issue via devseed data and that's why we haven't seen it since around June: [CircleCI test failure](https://app.circleci.com/pipelines/github/transcom/mymove/31795/workflows/bf2d5351-90cb-4f22-a84b-59d6e3df95e0/jobs/485481/tests)

## Setup

1. If you haven't run migrations recently:

    ```sh
    make db_dev_fresh
    ```

    otherwise, run

    ```sh
    make db_dev_e2e_populate
    ```

1. Run e2e tests

    ```sh
    make run-e2e-test-docker
    ```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9049) for this change