### PR TITLE
[MB-9025] Create ReviewBillableWeight page

### DIFF
--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ReviewBillableWeight() {
+  return <div>Review Billable Weight page</div>;
+}

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ReviewBillableWeight from './ReviewBillableWeight';
+
+describe('ReviewBillableWeight', () => {
+  it('renders the component', () => {
+    render(<ReviewBillableWeight />);
+    expect(screen.getByText('Review Billable Weight page')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.jsx
@@ -15,6 +15,7 @@ const MoveDetails = lazy(() => import('pages/Office/MoveDetails/MoveDetails'));
 const MoveDocumentWrapper = lazy(() => import('pages/Office/MoveDocumentWrapper/MoveDocumentWrapper'));
 const MoveTaskOrder = lazy(() => import('pages/Office/MoveTaskOrder/MoveTaskOrder'));
 const PaymentRequestReview = lazy(() => import('pages/Office/PaymentRequestReview/PaymentRequestReview'));
+const ReviewBillableWeight = lazy(() => import('pages/Office/ReviewBillableWeight/ReviewBillableWeight'));
 const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
 const MovePaymentRequests = lazy(() => import('pages/Office/MovePaymentRequests/MovePaymentRequests'));
 
@@ -37,6 +38,10 @@ const TXOMoveInfo = () => {
     }) ||
     matchPath(pathname, {
       path: '/moves/:moveCode/allowances',
+      exact: true,
+    }) ||
+    matchPath(pathname, {
+      path: '/moves/:moveCode/billable-weight',
       exact: true,
     });
 
@@ -131,6 +136,10 @@ const TXOMoveInfo = () => {
               setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
               setPendingPaymentRequestCount={setPendingPaymentRequestCount}
             />
+          </Route>
+
+          <Route path="/moves/:moveCode/billable-weight" exact>
+            <ReviewBillableWeight />
           </Route>
 
           <Route path="/moves/:moveCode/history" exact>

--- a/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
+++ b/src/pages/Office/TXOMoveInfo/TXOMoveInfo.test.jsx
@@ -258,6 +258,18 @@ describe('TXO Move Info Container', () => {
       expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/payment-requests');
     });
 
+    it('should handle the Billable Weight route', () => {
+      const wrapper = mount(
+        <MockProviders initialEntries={[`/moves/${testMoveCode}/billable-weight`]}>
+          <TXOMoveInfo />
+        </MockProviders>,
+      );
+
+      const renderedRoute = wrapper.find('Route');
+      expect(renderedRoute).toHaveLength(1);
+      expect(renderedRoute.prop('path')).toEqual('/moves/:moveCode/billable-weight');
+    });
+
     it('should handle the Move History route', () => {
       const wrapper = mount(
         <MockProviders initialEntries={[`/moves/${testMoveCode}/history`]}>


### PR DESCRIPTION
## Description

Adds the route for the ReviewBillabeWeight page for future use

## Reviewer Notes
- James is on vacation so I just made a route of `/billable-weight`, will have to revisit when he gets back

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make client_run`
Log in as a TIO
Visit a move
Change URL from `/moves/:moveCode/payment-requests` to `/moves/:moveCode/billable-weight`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9025) for this change

## Screenshots
<img width="1680" alt="Screen Shot 2021-08-13 at 10 41 58 AM" src="https://user-images.githubusercontent.com/13622298/129398602-6747d88a-6259-4110-ac71-7282129cd4b6.png">
