### PR TITLE
MB-8946 Clean up profile name test console msgs

### DIFF
--- a/src/pages/MyMove/Profile/Name.test.jsx
+++ b/src/pages/MyMove/Profile/Name.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ConnectedName, { Name } from './Name';
@@ -129,7 +129,7 @@ describe('requireCustomerState Name', () => {
     push: jest.fn(),
   };
 
-  it('dispatches a redirect if the current state is earlier than the "DOD INFO COMPLETE" state', () => {
+  it('dispatches a redirect if the current state is earlier than the "DOD INFO COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -147,17 +147,18 @@ describe('requireCustomerState Name', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedName {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
+    expect(await screen.findByRole('heading', { name: 'Name', level: 1 })).toBeInTheDocument();
+
     expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/conus-oconus'));
   });
 
-  it('does not redirect if the current state equals the "DOD INFO COMPLETE" state', () => {
+  it('does not redirect if the current state equals the "DOD INFO COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -178,16 +179,18 @@ describe('requireCustomerState Name', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedName {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
+    expect(await screen.findByRole('heading', { name: 'Name', level: 1 })).toBeInTheDocument();
+
     expect(mockDispatch).not.toHaveBeenCalled();
   });
-  it('does not redirect if the current state is after the "DOD INFO COMPLETE" state and profile is not complete', () => {
+
+  it('does not redirect if the current state is after the "DOD INFO COMPLETE" state and profile is not complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -216,17 +219,18 @@ describe('requireCustomerState Name', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedName {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
+    expect(await screen.findByRole('heading', { name: 'Name', level: 1 })).toBeInTheDocument();
+
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it('does redirect if the profile is complete', () => {
+  it('does redirect if the profile is complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -266,13 +270,14 @@ describe('requireCustomerState Name', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedName {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
+    expect(await screen.findByRole('heading', { name: 'Name', level: 1 })).toBeInTheDocument();
+
     expect(mockDispatch).toHaveBeenCalledWith(push('/'));
   });
 });

--- a/src/pages/MyMove/Profile/Name.test.jsx
+++ b/src/pages/MyMove/Profile/Name.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -28,20 +27,17 @@ describe('Name page', () => {
   };
 
   it('renders the NameForm', async () => {
-    await waitFor(() => {
-      const wrapper = mount(<Name {...testProps} />);
-      expect(wrapper.find('NameForm').exists()).toBe(true);
-    });
+    render(<Name {...testProps} />);
+
+    expect(await screen.findByRole('heading', { name: 'Name', level: 1 })).toBeInTheDocument();
   });
 
   it('back button goes to the DoD Info step', async () => {
-    const { queryByText } = render(<Name {...testProps} />);
+    render(<Name {...testProps} />);
 
-    const backButton = queryByText('Back');
+    const backButton = await screen.findByRole('button', { name: 'Back' });
 
-    await waitFor(() => {
-      expect(backButton).toBeInTheDocument();
-    });
+    expect(backButton).toBeInTheDocument();
 
     userEvent.click(backButton);
     expect(testProps.push).toHaveBeenCalledWith('/service-member/dod-info');
@@ -59,9 +55,10 @@ describe('Name page', () => {
     patchServiceMember.mockImplementation(() => Promise.resolve(testServiceMemberValues));
 
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
-    const { queryByText } = render(<Name {...testProps} serviceMember={testServiceMemberValues} />);
+    render(<Name {...testProps} serviceMember={testServiceMemberValues} />);
 
-    const submitButton = queryByText('Next');
+    const submitButton = await screen.findByRole('button', { name: 'Next' });
+
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
 
@@ -96,9 +93,10 @@ describe('Name page', () => {
     );
 
     // Need to provide complete & valid initial values because we aren't testing the form here, and just want to submit immediately
-    const { queryByText } = render(<Name {...testProps} serviceMember={testServiceMemberValues} />);
+    render(<Name {...testProps} serviceMember={testServiceMemberValues} />);
 
-    const submitButton = queryByText('Next');
+    const submitButton = await screen.findByRole('button', { name: 'Next' });
+
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
 
@@ -106,7 +104,7 @@ describe('Name page', () => {
       expect(patchServiceMember).toHaveBeenCalled();
     });
 
-    expect(queryByText('A server error occurred saving the service member')).toBeInTheDocument();
+    expect(screen.getByText('A server error occurred saving the service member')).toBeInTheDocument();
     expect(testProps.updateServiceMember).not.toHaveBeenCalled();
     expect(testProps.push).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Description

We're trying to clean up all the warning messages that are logged by the tests so that people can actually know when things are wrong rather than ignoring the flood of messages. This pr is to fix the messages coming out of `src/pages/MyMove/Profile/Name.test.jsx`

## Reviewer Notes

Anything amiss? 

## Setup

1. Run tests:

    ```sh
    react-scripts test Name.test.jsx
    ```

1. Or alternatively use

    ```sh
    yarn test
    ```

    and run either all the tests or filter by file name (Use `Profile/Name` since there's a `Name.test.js` file).

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8946) for this change

## Screenshots

No user facing changes, but here you can see the tests run for the file without any messages being logged:
<img width="1014" alt="Screen Shot 2021-08-16 at 18 40 51" src="https://user-images.githubusercontent.com/35938642/129642290-91d70426-eb3f-4d69-bc2c-d5c60cadbb49.png">
