### PR TITLE
MB-8771 Display Reweigh tags in MTO tab

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -3552,7 +3552,20 @@ func createTXOServicesUSMCCounselor(db *pop.Connection) {
 }
 
 func createHHGMoveWithReweigh(db *pop.Connection, userUploader *uploader.UserUploader) {
-	testdatagen.MakeReweigh(db, testdatagen.Assertions{UserUploader: userUploader})
+	move := testdatagen.MakeAvailableMove(db)
+	move.Locator = "REWAYD"
+	mustSave(db, &move)
+	reweighedWeight := unit.Pound(1000)
+	testdatagen.MakeReweigh(db, testdatagen.Assertions{
+		UserUploader: userUploader,
+		MTOShipment: models.MTOShipment{
+			MoveTaskOrderID: move.ID,
+			MoveTaskOrder:   move,
+		},
+		Reweigh: models.Reweigh{
+			Weight: &reweighedWeight,
+		},
+	})
 }
 
 func createHHGMoveWithTaskOrderServices(db *pop.Connection, userUploader *uploader.UserUploader) {

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -49,6 +49,7 @@ const ShipmentDetailsMain = ({
           shipmentID: shipment.id,
           ifMatchEtag: shipment.eTag,
           reweighID: shipment.reweigh?.id,
+          reweighWeight: shipment.reweigh?.weight,
         }}
         handleRequestReweighModal={handleRequestReweighModal}
       />

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Tag } from '@trussworks/react-uswds';
 
 import DataPointGroup from '../../DataPointGroup/index';
 import DataPoint from '../../DataPoint/index';
@@ -21,6 +21,8 @@ const ShipmentWeightDetails = ({ estimatedWeight, actualWeight, shipmentInfo, ha
           </Button>
         </div>
       )}
+      {shipmentInfo.reweighID && !shipmentInfo.reweighWeight && <Tag>reweigh requested</Tag>}
+      {shipmentInfo.reweighWeight && <Tag>reweighed</Tag>}
     </div>
   );
   return (
@@ -45,6 +47,7 @@ ShipmentWeightDetails.propTypes = {
     shipmentID: PropTypes.string,
     ifMatchEtag: PropTypes.string,
     reweighID: PropTypes.string,
+    reweighWeight: PropTypes.number,
   }).isRequired,
   handleRequestReweighModal: PropTypes.func.isRequired,
 };

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.module.scss
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.module.scss
@@ -18,4 +18,11 @@
   .shipmentWeight {
     display: flex;
   }
+
+  :global(.usa-tag) {
+    @include u-font-size('body', 3xs);
+    @include u-margin-left(1);
+    @include u-margin-right(0);
+    background-color: $info-light;
+  }
 }

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
@@ -14,6 +14,13 @@ const shipmentInfoNoReweigh = {
   ifMatchEtag: 'etag1',
 };
 
+const shipmentInfoReweigh = {
+  shipmentID: 'shipment1',
+  ifMatchEtag: 'etag1',
+  reweighID: 'reweighRequestID',
+  reweighWeight: 1000,
+};
+
 const handleRequestReweighModal = jest.fn();
 
 describe('ShipmentWeightDetails', () => {
@@ -90,6 +97,28 @@ describe('ShipmentWeightDetails', () => {
     );
 
     const reweighButton = await screen.queryByText('Request reweigh');
+    const reweighRequestedLabel = await screen.queryByText('reweigh requested');
+    const reweighedLabel = await screen.queryByText('reweighed');
+
     expect(reweighButton).toBeFalsy();
+    expect(reweighRequestedLabel).toBeTruthy();
+    expect(reweighedLabel).toBeFalsy();
+  });
+
+  it('only renders the reweighed label if a shipment has been reweighed', async () => {
+    render(
+      <ShipmentWeightDetails
+        estimatedWeight={11000}
+        actualWeight={12000}
+        shipmentInfo={shipmentInfoReweigh}
+        handleRequestReweighModal={handleRequestReweighModal}
+      />,
+    );
+
+    const reweighRequestedLabel = await screen.queryByText('reweigh requested');
+    const reweighedLabel = await screen.queryByText('reweighed');
+
+    expect(reweighRequestedLabel).toBeFalsy();
+    expect(reweighedLabel).toBeTruthy();
   });
 });

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -1368,7 +1368,7 @@ describe('MoveTaskOrder', () => {
     it('renders the ShipmentHeading', () => {
       expect(wrapper.find('ShipmentHeading').exists()).toBe(true);
       expect(wrapper.find('h2').at(0).text()).toEqual('Household goods');
-      expect(wrapper.find('span[data-testid="tag"]').text()).toEqual('cancelled');
+      expect(wrapper.find('span[data-testid="tag"]').at(0).text()).toEqual('cancelled');
     });
 
     it('renders the ImportantShipmentDates', () => {
@@ -1381,6 +1381,7 @@ describe('MoveTaskOrder', () => {
 
     it('renders the ShipmentWeightDetails', () => {
       expect(wrapper.find('ShipmentWeightDetails').exists()).toBe(true);
+      expect(wrapper.find('span[data-testid="tag"]').at(1).text()).toEqual('reweigh requested');
     });
 
     it('renders the RequestedServiceItemsTable for SUBMITTED service item', () => {


### PR DESCRIPTION
## Description

As a TOO, when I am viewing shipments in the Move Task Order tab, I want
to easily identify shipments that have been reweighed, and those that I
have requested to be reweighed.

## Reviewer Notes

### Testing Reweighed shipment
1. Sign in as a TOO and search for the move with Locator REWAYD.
2. Click on the move
3. Go to the Move task order tab
4. Look for the "Shipment weight" box 
5. Verify that it has a `REWEIGHED` tag

### Testing Reweigh Requested shipment
1. Sign in as a TOO and search for the move with Locator AMDORD (or any move with approved shipments).
2. Click on the move
3. Go to the Move task order tab
4. Look for the "Shipment weight" box
5. Click on the "Request reweigh" link
6. Click on "Submit request" when the modal appears
7. When the page refreshes, verify that it has a `REWEIGH REQUESTED` tag

## Setup

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8771) for this change

## Screenshots

<img width="1680" alt="Screen Shot 2021-08-17 at 11 45 14" src="https://user-images.githubusercontent.com/811150/129758157-8b08a799-ac39-4be5-91c4-5a214cd60a2b.png">
<img width="1676" alt="Screen Shot 2021-08-17 at 11 45 57" src="https://user-images.githubusercontent.com/811150/129758159-c42e1d00-93c3-4725-8081-6607f5db32ce.png">
