### PR TITLE
MB-8945: Clean up MtoShipmentForm log pollution

### DIFF
--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -1,7 +1,17 @@
 import { isEmpty } from 'lodash';
+import moment from 'moment';
 
 import { MTOAgentType } from 'shared/constants';
-import { formatSwaggerDate, parseSwaggerDate } from 'shared/formatters';
+import { parseDate } from 'shared/dates';
+import { parseSwaggerDate } from 'shared/formatters';
+
+const formatDateForSwagger = (date) => {
+  const parsedDate = parseDate(date);
+  if (parsedDate) {
+    return moment(parsedDate).format('YYYY-MM-DD');
+  }
+  return '';
+};
 
 function formatAgentForDisplay(agent) {
   const agentCopy = { ...agent };
@@ -167,7 +177,7 @@ export function formatMtoShipmentForAPI({
   };
 
   if (pickup?.requestedDate && pickup.requestedDate !== '') {
-    formattedMtoShipment.requestedPickupDate = formatSwaggerDate(pickup.requestedDate);
+    formattedMtoShipment.requestedPickupDate = formatDateForSwagger(pickup.requestedDate);
     formattedMtoShipment.pickupAddress = formatAddressForAPI(pickup.address);
 
     if (pickup.agent) {
@@ -179,7 +189,7 @@ export function formatMtoShipmentForAPI({
   }
 
   if (delivery?.requestedDate && delivery.requestedDate !== '') {
-    formattedMtoShipment.requestedDeliveryDate = formatSwaggerDate(delivery.requestedDate);
+    formattedMtoShipment.requestedDeliveryDate = formatDateForSwagger(delivery.requestedDate);
 
     if (delivery.address) {
       formattedMtoShipment.destinationAddress = formatAddressForAPI(delivery.address);


### PR DESCRIPTION
## Description

As part of the [TRA epic](https://dp3.atlassian.net/browse/MB-8944) to clear out console warnings/errors during front-end test runs, this pull request fulfills a ticket to resolve emitted messages from the test fixtures for `MtoShipmentForm`. 

In this case, the emitting warnings indicated an inconsistency with how the `formatSwaggerDate` function was using the `moment` library to parse date strings in multiple possible formats (from both user input and database stored values). The easiest way to solve this issue was to adapt it to utilize a `parseDate` function that's in use elsewhere in our code base, which has `moment` check the input date string for multiple valid date formats.

## Reviewer Notes

Ensure that _all_ client and integration tests pass, and that the `MtoShipmentForm.test.jsx` file does not emit any console messages during testing. There should be no perceptible UI change to the user.

## Setup

```sh
yarn test MtoShipmentForm
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Part of epic [MB-8944](https://dp3.atlassian.net/browse/MB-8944).
* Closes [MB-8945](https://dp3.atlassian.net/browse/MB-8945).