### PR TITLE
MB-8983 Create Devseed Data for Reweighs

### DIFF
--- a/pkg/testdatagen/make_reweigh.go
+++ b/pkg/testdatagen/make_reweigh.go
@@ -31,14 +31,30 @@ func MakeReweigh(db *pop.Connection, assertions Assertions) models.Reweigh {
 	return reweigh
 }
 
-// MakeReweighForTIO creates a reweigh request for given shipment and a given weight.
-func MakeReweighForTIO(db *pop.Connection, assertions Assertions, shipment models.MTOShipment, pound unit.Pound) models.Reweigh {
+// MakeReweighForShipment creates a reweigh request for given shipment and a given weight.
+func MakeReweighForShipment(db *pop.Connection, assertions Assertions, shipment models.MTOShipment, pound unit.Pound) models.Reweigh {
 	reweigh := models.Reweigh{
 		RequestedAt: time.Now(),
 		RequestedBy: models.ReweighRequesterPrime,
 		Shipment:    shipment,
 		ShipmentID:  shipment.ID,
 		Weight:      &pound,
+	}
+
+	mergeModels(&reweigh, assertions.Reweigh)
+
+	mustCreate(db, &reweigh, assertions.Stub)
+
+	return reweigh
+}
+
+// MakeReweighWithNoWeightForShipment creates a reweigh request for a given shipment. It leaves the weight field empty to simulate that no reweigh was done.
+func MakeReweighWithNoWeightForShipment(db *pop.Connection, assertions Assertions, shipment models.MTOShipment) models.Reweigh {
+	reweigh := models.Reweigh{
+		RequestedAt: time.Now(),
+		RequestedBy: models.ReweighRequesterPrime,
+		Shipment:    shipment,
+		ShipmentID:  shipment.ID,
 	}
 
 	mergeModels(&reweigh, assertions.Reweigh)

--- a/pkg/testdatagen/make_reweigh.go
+++ b/pkg/testdatagen/make_reweigh.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gobuffalo/pop/v5"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MakeReweigh creates a reweigh request for a shipment with required fields
@@ -21,6 +22,23 @@ func MakeReweigh(db *pop.Connection, assertions Assertions) models.Reweigh {
 		RequestedBy: models.ReweighRequesterTOO,
 		Shipment:    shipment,
 		ShipmentID:  shipment.ID,
+	}
+
+	mergeModels(&reweigh, assertions.Reweigh)
+
+	mustCreate(db, &reweigh, assertions.Stub)
+
+	return reweigh
+}
+
+// MakeReweighForTIO creates a reweigh request for given shipment and a given weight.
+func MakeReweighForTIO(db *pop.Connection, assertions Assertions, shipment models.MTOShipment, pound unit.Pound) models.Reweigh {
+	reweigh := models.Reweigh{
+		RequestedAt: time.Now(),
+		RequestedBy: models.ReweighRequesterPrime,
+		Shipment:    shipment,
+		ShipmentID:  shipment.ID,
+		Weight:      &pound,
 	}
 
 	mergeModels(&reweigh, assertions.Reweigh)

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -57,6 +57,7 @@ func (e *devSeedScenario) Setup(db *pop.Connection, userUploader *uploader.UserU
 		"shipment_hhg_cancelled":       subScenarioShipmentHHGCancelled(db, allDutyStations, originDutyStationsInGBLOC),
 		"txo_queues":                   subScenarioTXOQueues(db, userUploader, logger),
 		"misc":                         subScenarioMisc(db, userUploader, primeUploader, moveRouter),
+		"reweighs":                     subScenarioReweighs(db, userUploader, primeUploader, moveRouter),
 	}
 }
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -3564,7 +3564,7 @@ func createHHGMoveWithBillableWeights(db *pop.Connection, userUploader *uploader
 	shipment := makeShipmentForMove(move, models.MTOShipmentStatusApproved, db)
 	paymentRequestID := uuid.Must(uuid.FromString("6cd95b06-fef3-11eb-9a03-0242ac130003"))
 	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
-	testdatagen.MakeReweighForTIO(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(5000))
+	testdatagen.MakeReweighForShipment(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(5000))
 }
 
 func createReweighWithMultipleShipments(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
@@ -3662,7 +3662,7 @@ func createReweighWithMultipleShipments(db *pop.Connection, userUploader *upload
 	filterFile := &[]string{"150Kb.png"}
 	paymentRequestID := uuid.Must(uuid.FromString("78a475d6-ffb8-11eb-9a03-0242ac130003"))
 	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
-	testdatagen.MakeReweighForTIO(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(5000))
+	testdatagen.MakeReweighForShipment(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(5000))
 }
 
 func createReweighWithShipmentMissingReweigh(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
@@ -3734,7 +3734,7 @@ func createReweighWithShipmentMissingReweigh(db *pop.Connection, userUploader *u
 	filterFile := &[]string{"150Kb.png"}
 	paymentRequestID := uuid.Must(uuid.FromString("4a1b0048-ffe7-11eb-9a03-0242ac130003"))
 	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
-	testdatagen.MakeReweighForTIO(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, 0)
+	testdatagen.MakeReweighWithNoWeightForShipment(db, testdatagen.Assertions{UserUploader: userUploader}, shipment)
 }
 
 func createReweighWithShipmentMaxBillableWeightExceeded(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
@@ -3806,7 +3806,7 @@ func createReweighWithShipmentMaxBillableWeightExceeded(db *pop.Connection, user
 	filterFile := &[]string{"150Kb.png"}
 	paymentRequestID := uuid.Must(uuid.FromString("096496b0-ffea-11eb-9a03-0242ac130003"))
 	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
-	testdatagen.MakeReweighForTIO(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(123456))
+	testdatagen.MakeReweighForShipment(db, testdatagen.Assertions{UserUploader: userUploader}, shipment, unit.Pound(123456))
 }
 
 func createHHGMoveWithTaskOrderServices(db *pop.Connection, userUploader *uploader.UserUploader) {

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -3568,9 +3568,6 @@ func createHHGMoveWithBillableWeights(db *pop.Connection, userUploader *uploader
 }
 
 func createReweighWithMultipleShipments(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
-	/*
-	 * A service member with orders and a submitted move with a ppm and hhg
-	 */
 	email := "multShipments@hhg.hhg"
 	uuidStr := "db5d94fe-ffb9-11eb-9a03-0242ac130003"
 	loginGovUUID := uuid.Must(uuid.NewV4())
@@ -3666,9 +3663,6 @@ func createReweighWithMultipleShipments(db *pop.Connection, userUploader *upload
 }
 
 func createReweighWithShipmentMissingReweigh(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
-	/*
-	 * A service member with orders and a submitted move with a ppm and hhg
-	 */
 	email := "missingShipmentReweighWeight@hhg.hhg"
 	uuidStr := "39b0a762-ffe7-11eb-9a03-0242ac130003"
 	loginGovUUID := uuid.Must(uuid.NewV4())
@@ -3738,9 +3732,6 @@ func createReweighWithShipmentMissingReweigh(db *pop.Connection, userUploader *u
 }
 
 func createReweighWithShipmentMaxBillableWeightExceeded(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) {
-	/*
-	 * A service member with orders and a submitted move with a ppm and hhg
-	 */
 	email := "shipmentMaxBillableWeightExceeded@hhg.hhg"
 	uuidStr := "f938fc7c-ffe9-11eb-9a03-0242ac130003"
 	loginGovUUID := uuid.Must(uuid.NewV4())

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -194,6 +194,16 @@ func subScenarioDivertedShipments(db *pop.Connection, userUploader *uploader.Use
 	}
 }
 
+func subScenarioReweighs(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) func() {
+	return func() {
+		createHHGMoveWithReweigh(db, userUploader)
+		createHHGMoveWithBillableWeights(db, userUploader, primeUploader)
+		createReweighWithMultipleShipments(db, userUploader, primeUploader, moveRouter)
+		createReweighWithShipmentMissingReweigh(db, userUploader, primeUploader, moveRouter)
+		createReweighWithShipmentMaxBillableWeightExceeded(db, userUploader, primeUploader, moveRouter)
+	}
+}
+
 func subScenarioMisc(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader,
 	moveRouter services.MoveRouter) func() {
 	return func() {
@@ -207,7 +217,7 @@ func subScenarioMisc(db *pop.Connection, userUploader *uploader.UserUploader, pr
 		createHHGMoveWith2PaymentRequests(db, userUploader)
 		createHHGMoveWith2PaymentRequestsReviewedAllRejectedServiceItems(db, userUploader)
 		createHHGMoveWithTaskOrderServices(db, userUploader)
-		createHHGMoveWithReweigh(db, userUploader)
+
 		// This one doesn't have submitted shipments. Can we get rid of it?
 		// createRecentlyUpdatedHHGMove(db, userUploader)
 		createMoveWithHHGAndNTSRPaymentRequest(db, userUploader)

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -201,6 +201,7 @@ func subScenarioReweighs(db *pop.Connection, userUploader *uploader.UserUploader
 		createReweighWithMultipleShipments(db, userUploader, primeUploader, moveRouter)
 		createReweighWithShipmentMissingReweigh(db, userUploader, primeUploader, moveRouter)
 		createReweighWithShipmentMaxBillableWeightExceeded(db, userUploader, primeUploader, moveRouter)
+		createReweighWithShipmentNoEstimatedWeight(db, userUploader, primeUploader, moveRouter)
 	}
 }
 


### PR DESCRIPTION
## Description

-  extract out related data creation into a new subscenario for reweighs
- create a new function to make reweighs with a given shipment and reweigh weight
- add new devseed data for reweighs with
    - multiple shipments
    - missing reweigh weight
    - max shipment weight exceeded
    - move with billable weights

## Reviewer Notes

Does the setup look ok? 
The UI for the data won't look any different for the TIO because there haven't been any UI elements put in yet. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make office_client_run
make server_run
```
When you access the office site and login as the TIO, there should be new moves with the locators of
- BILWEI 
- MULTRW
- MISHRW 
- MAXCED

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8983) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
