### PR TITLE
MB-8923 remove DCRTSA service code from prime and support api

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1716,7 +1716,6 @@ func init() {
               "type": "string",
               "enum": [
                 "DCRT",
-                "DCRTSA",
                 "DUCRT"
               ]
             },
@@ -1732,7 +1731,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
+      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -2385,7 +2384,6 @@ func init() {
         "DBHF",
         "DBTF",
         "DCRT",
-        "DCRTSA",
         "DDASIT",
         "DDDSIT",
         "DDFSIT",
@@ -4819,7 +4817,6 @@ func init() {
               "type": "string",
               "enum": [
                 "DCRT",
-                "DCRTSA",
                 "DUCRT"
               ]
             },
@@ -4835,7 +4832,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
+      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -5488,7 +5485,6 @@ func init() {
         "DBHF",
         "DBTF",
         "DCRT",
-        "DCRTSA",
         "DDASIT",
         "DDDSIT",
         "DDFSIT",

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -53,7 +53,7 @@ type MTOServiceItemDomesticCrating struct {
 
 	// A unique code for the service item. Indicates if the service is for crating (DCRT) or uncrating (DUCRT).
 	// Required: true
-	// Enum: [DCRT DCRTSA DUCRT]
+	// Enum: [DCRT DUCRT]
 	ReServiceCode *string `json:"reServiceCode"`
 
 	// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
@@ -164,7 +164,7 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		// A unique code for the service item. Indicates if the service is for crating (DCRT) or uncrating (DUCRT).
 		// Required: true
-		// Enum: [DCRT DCRTSA DUCRT]
+		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
 
 		// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
@@ -263,7 +263,7 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		// A unique code for the service item. Indicates if the service is for crating (DCRT) or uncrating (DUCRT).
 		// Required: true
-		// Enum: [DCRT DCRTSA DUCRT]
+		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
 
 		// The contractor's explanation for why an item needed to be crated or uncrated. Used by the TOO while deciding to approve or reject the service item.
@@ -446,7 +446,7 @@ var mTOServiceItemDomesticCratingTypeReServiceCodePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["DCRT","DCRTSA","DUCRT"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["DCRT","DUCRT"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/primemessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_model_type.go
@@ -20,7 +20,7 @@ import (
 //   * DOFSIT, DOASIT - MTOServiceItemOriginSIT
 //   * DDFSIT, DDASIT - MTOServiceItemDestSIT
 //   * DOSHUT, DDSHUT - MTOServiceItemShuttle
-//   * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+//   * DCRT, DUCRT - MTOServiceItemDomesticCrating
 //
 // The documentation will then update with the supported fields.
 //

--- a/pkg/gen/primemessages/re_service_code.go
+++ b/pkg/gen/primemessages/re_service_code.go
@@ -42,9 +42,6 @@ const (
 	// ReServiceCodeDCRT captures enum value "DCRT"
 	ReServiceCodeDCRT ReServiceCode = "DCRT"
 
-	// ReServiceCodeDCRTSA captures enum value "DCRTSA"
-	ReServiceCodeDCRTSA ReServiceCode = "DCRTSA"
-
 	// ReServiceCodeDDASIT captures enum value "DDASIT"
 	ReServiceCodeDDASIT ReServiceCode = "DDASIT"
 
@@ -186,7 +183,7 @@ var reServiceCodeEnum []interface{}
 
 func init() {
 	var res []ReServiceCode
-	if err := json.Unmarshal([]byte(`["CS","DBHF","DBTF","DCRT","DCRTSA","DDASIT","DDDSIT","DDFSIT","DDP","DDSHUT","DLH","DMHF","DNPKF","DOASIT","DOFSIT","DOP","DOPSIT","DOSHUT","DPK","DSH","DUCRT","DUPK","FSC","IBHF","IBTF","ICOLH","ICOUB","ICRT","ICRTSA","IDASIT","IDDSIT","IDFSIT","IDSHUT","IHPK","IHUPK","INPKF","IOASIT","IOCLH","IOCUB","IOFSIT","IOOLH","IOOUB","IOPSIT","IOSHUT","IUBPK","IUBUPK","IUCRT","MS","NSTH","NSTUB"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["CS","DBHF","DBTF","DCRT","DDASIT","DDDSIT","DDFSIT","DDP","DDSHUT","DLH","DMHF","DNPKF","DOASIT","DOFSIT","DOP","DOPSIT","DOSHUT","DPK","DSH","DUCRT","DUPK","FSC","IBHF","IBTF","ICOLH","ICOUB","ICRT","ICRTSA","IDASIT","IDDSIT","IDFSIT","IDSHUT","IHPK","IHUPK","INPKF","IOASIT","IOCLH","IOCUB","IOFSIT","IOOLH","IOOUB","IOPSIT","IOSHUT","IUBPK","IUBUPK","IUCRT","MS","NSTH","NSTUB"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1450,7 +1450,6 @@ func init() {
               "type": "string",
               "enum": [
                 "DCRT",
-                "DCRTSA",
                 "DUCRT"
               ]
             }
@@ -1459,7 +1458,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
+      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -2171,7 +2170,6 @@ func init() {
         "DBHF",
         "DBTF",
         "DCRT",
-        "DCRTSA",
         "DDASIT",
         "DDDSIT",
         "DDFSIT",
@@ -4164,7 +4162,6 @@ func init() {
               "type": "string",
               "enum": [
                 "DCRT",
-                "DCRTSA",
                 "DUCRT"
               ]
             }
@@ -4173,7 +4170,7 @@ func init() {
       ]
     },
     "MTOServiceItemModelType": {
-      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
+      "description": "Describes all model sub-types for a MTOServiceItem model.\n\nUsing this list, choose the correct modelType in the dropdown, corresponding to the service item type.\n  * DOFSIT, DOASIT - MTOServiceItemOriginSIT\n  * DDFSIT, DDASIT - MTOServiceItemDestSIT\n  * DOSHUT, DDSHUT - MTOServiceItemShuttle\n  * DCRT, DUCRT - MTOServiceItemDomesticCrating\n\nThe documentation will then update with the supported fields.\n",
       "type": "string",
       "enum": [
         "MTOServiceItemBasic",
@@ -4885,7 +4882,6 @@ func init() {
         "DBHF",
         "DBTF",
         "DCRT",
-        "DCRTSA",
         "DDASIT",
         "DDDSIT",
         "DDFSIT",

--- a/pkg/gen/supportmessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_domestic_crating.go
@@ -49,7 +49,7 @@ type MTOServiceItemDomesticCrating struct {
 
 	// Service codes allowed for this model type.
 	// Required: true
-	// Enum: [DCRT DCRTSA DUCRT]
+	// Enum: [DCRT DUCRT]
 	ReServiceCode *string `json:"reServiceCode"`
 }
 
@@ -151,7 +151,7 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		// Service codes allowed for this model type.
 		// Required: true
-		// Enum: [DCRT DCRTSA DUCRT]
+		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
 	}
 	buf := bytes.NewBuffer(raw)
@@ -240,7 +240,7 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		// Service codes allowed for this model type.
 		// Required: true
-		// Enum: [DCRT DCRTSA DUCRT]
+		// Enum: [DCRT DUCRT]
 		ReServiceCode *string `json:"reServiceCode"`
 	}{
 
@@ -442,7 +442,7 @@ var mTOServiceItemDomesticCratingTypeReServiceCodePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["DCRT","DCRTSA","DUCRT"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["DCRT","DUCRT"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
@@ -20,7 +20,7 @@ import (
 //   * DOFSIT, DOASIT - MTOServiceItemOriginSIT
 //   * DDFSIT, DDASIT - MTOServiceItemDestSIT
 //   * DOSHUT, DDSHUT - MTOServiceItemShuttle
-//   * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+//   * DCRT, DUCRT - MTOServiceItemDomesticCrating
 //
 // The documentation will then update with the supported fields.
 //

--- a/pkg/gen/supportmessages/re_service_code.go
+++ b/pkg/gen/supportmessages/re_service_code.go
@@ -42,9 +42,6 @@ const (
 	// ReServiceCodeDCRT captures enum value "DCRT"
 	ReServiceCodeDCRT ReServiceCode = "DCRT"
 
-	// ReServiceCodeDCRTSA captures enum value "DCRTSA"
-	ReServiceCodeDCRTSA ReServiceCode = "DCRTSA"
-
 	// ReServiceCodeDDASIT captures enum value "DDASIT"
 	ReServiceCodeDDASIT ReServiceCode = "DDASIT"
 
@@ -186,7 +183,7 @@ var reServiceCodeEnum []interface{}
 
 func init() {
 	var res []ReServiceCode
-	if err := json.Unmarshal([]byte(`["CS","DBHF","DBTF","DCRT","DCRTSA","DDASIT","DDDSIT","DDFSIT","DDP","DDSHUT","DLH","DMHF","DNPKF","DOASIT","DOFSIT","DOP","DOPSIT","DOSHUT","DPK","DSH","DUCRT","DUPK","FSC","IBHF","IBTF","ICOLH","ICOUB","ICRT","ICRTSA","IDASIT","IDDSIT","IDFSIT","IDSHUT","IHPK","IHUPK","INPKF","IOASIT","IOCLH","IOCUB","IOFSIT","IOOLH","IOOUB","IOPSIT","IOSHUT","IUBPK","IUBUPK","IUCRT","MS","NSTH","NSTUB"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["CS","DBHF","DBTF","DCRT","DDASIT","DDDSIT","DDFSIT","DDP","DDSHUT","DLH","DMHF","DNPKF","DOASIT","DOFSIT","DOP","DOPSIT","DOSHUT","DPK","DSH","DUCRT","DUPK","FSC","IBHF","IBTF","ICOLH","ICOUB","ICRT","ICRTSA","IDASIT","IDDSIT","IDFSIT","IDSHUT","IHPK","IHUPK","INPKF","IOASIT","IOCLH","IOCUB","IOFSIT","IOOLH","IOOUB","IOPSIT","IOSHUT","IUBPK","IUBUPK","IUCRT","MS","NSTH","NSTUB"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -279,11 +279,6 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 			Code: "DUCRT",
 		},
 	})
-	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: "DCRTSA",
-		},
-	})
 	builder := query.NewQueryBuilder(suite.DB())
 	mtoChecker := movetaskorder.NewMoveTaskOrderChecker(suite.DB())
 
@@ -358,29 +353,6 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		suite.NotZero(okResponse.Payload[0].ID())
 	})
 
-	suite.T().Run("Successful POST - Integration Test - Domestic Crating Standalone", func(t *testing.T) {
-		moveRouter := moverouter.NewMoveRouter(suite.DB(), suite.TestLogger())
-		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
-		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-			creator,
-			mtoChecker,
-		}
-
-		mtoServiceItem.ReService.Code = models.ReServiceCodeDCRTSA
-		params := mtoserviceitemops.CreateMTOServiceItemParams{
-			HTTPRequest: req,
-			Body:        payloads.MTOServiceItem(&mtoServiceItem),
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
-		suite.IsType(&mtoserviceitemops.CreateMTOServiceItemOK{}, response)
-
-		okResponse := response.(*mtoserviceitemops.CreateMTOServiceItemOK)
-		suite.NotZero(okResponse.Payload[0].ID())
-	})
-
 	suite.T().Run("POST failure - 422", func(t *testing.T) {
 		mockCreator := mocks.MTOServiceItemCreator{}
 		handler := CreateMTOServiceItemHandler{
@@ -394,7 +366,7 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 			mock.Anything,
 		).Return(nil, nil, err)
 
-		mtoServiceItem.ReService.Code = models.ReServiceCodeDCRTSA
+		mtoServiceItem.ReService.Code = models.ReServiceCodeDUCRT
 		params := mtoserviceitemops.CreateMTOServiceItemParams{
 			HTTPRequest: req,
 			Body:        payloads.MTOServiceItem(&mtoServiceItem),

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -482,7 +482,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			SitDestinationFinalAddress:  Address(mtoServiceItem.SITDestinationFinalAddress),
 		}
 
-	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
+	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT:
 		item := GetDimension(mtoServiceItem.Dimensions, models.DimensionTypeItem)
 		crate := GetDimension(mtoServiceItem.Dimensions, models.DimensionTypeCrate)
 		cratingSI := primemessages.MTOServiceItemDomesticCrating{

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -327,7 +327,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) supportmessages.MTOSe
 			SitEntryDate:                handlers.FmtDatePtr(mtoServiceItem.SITEntryDate),
 		}
 
-	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT, models.ReServiceCodeDCRTSA:
+	case models.ReServiceCodeDCRT, models.ReServiceCodeDUCRT:
 		item := primepayloads.GetDimension(mtoServiceItem.Dimensions, models.DimensionTypeItem)
 		crate := primepayloads.GetDimension(mtoServiceItem.Dimensions, models.DimensionTypeCrate)
 		payload = &supportmessages.MTOServiceItemDomesticCrating{

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1508,7 +1508,6 @@ definitions:
             description: A unique code for the service item. Indicates if the service is for crating (DCRT) or uncrating (DUCRT).
             enum:
               - DCRT # Domestic Crating
-              - DCRTSA # Domestic Crating - Standalone
               - DUCRT # Domestic Uncrating
           item:
             description: The dimensions of the item being crated.
@@ -1543,7 +1542,7 @@ definitions:
         * DOFSIT, DOASIT - MTOServiceItemOriginSIT
         * DDFSIT, DDASIT - MTOServiceItemDestSIT
         * DOSHUT, DDSHUT - MTOServiceItemShuttle
-        * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+        * DCRT, DUCRT - MTOServiceItemDomesticCrating
 
       The documentation will then update with the supported fields.
 
@@ -2027,7 +2026,6 @@ definitions:
       - DBHF
       - DBTF
       - DCRT
-      - DCRTSA
       - DDASIT
       - DDDSIT
       - DDFSIT

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1218,7 +1218,6 @@ definitions:
             description: Service codes allowed for this model type.
             enum:
               - DCRT # Domestic Crating
-              - DCRTSA # Domestic Crating - Standalone
               - DUCRT # Domestic Uncrating
           item:
             $ref: '#/definitions/MTOServiceItemDimension'
@@ -1240,7 +1239,7 @@ definitions:
         * DOFSIT, DOASIT - MTOServiceItemOriginSIT
         * DDFSIT, DDASIT - MTOServiceItemDestSIT
         * DOSHUT, DDSHUT - MTOServiceItemShuttle
-        * DCRT, DCRTSA, DUCRT - MTOServiceItemDomesticCrating
+        * DCRT, DUCRT - MTOServiceItemDomesticCrating
 
       The documentation will then update with the supported fields.
 
@@ -1721,7 +1720,6 @@ definitions:
       - DBHF
       - DBTF
       - DCRT
-      - DCRTSA
       - DDASIT
       - DDDSIT
       - DDFSIT


### PR DESCRIPTION
## Description

This PR removes the `DCRSTA` service code from the prime and support apis. This service code is not valid for MVP, so we are removing it.

## Setup

To verify all tests still run, execute `make server_run`

To verify the prime cannot create a `DCRSTA` service item, use the createMTOServiceItems endpoint and set the reServiceCode to `DCRSTA`. An example payload is below:

```
{
  "moveTaskOrderID": "5e7fce45-ada0-4e7d-b362-9c4337af35aa",
  "modelType": "MTOServiceItemDomesticCrating",
  "reServiceCode": "DCRTSA",
  "item": {
    "type": "ITEM",
    "length": 1000,
    "width": 1000,
    "height": 1000
  },
  "crate": {
    "type": "ITEM",
    "length": 1000,
    "width": 1000,
    "height": 1000
  },
  "description": "Decorated horse head to be crated.",
  "reason": "Storage items need to be picked up"
}
```

You will get the error: 
```
{
    "title": "Validation Error",
    "instance": "5bb1e77d-9419-492d-898e-571802527a06",
    "detail": "reServiceCode in body should be one of [DCRT DUCRT]"
}
```

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8923) for this change
