### PR TITLE
Update prereqs script to support nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ install_pre_commit:  ## Installs pre-commit hooks
 	pre-commit install-hooks
 
 .PHONY: prereqs
-prereqs: .prereqs.stamp ## Check that pre-requirements are installed
-.prereqs.stamp: scripts/prereqs
+prereqs: .prereqs.stamp ## Check that pre-requirements are installed, includes dependency scripts
+.prereqs.stamp: scripts/prereqs scripts/check-aws-cli-version scripts/check-aws-vault-version scripts/check-bash-version scripts/check-chamber-version scripts/check-go-version scripts/check-gopath scripts/check-hosts-file scripts/check-node-version scripts/check-opensc-version
 	scripts/prereqs
 	touch .prereqs.stamp
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -127,10 +127,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "chamber-2.9.0";
+      name = "chamber-2.10.2";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "559cf76fa3642106d9f23c9e845baf4d354be682";
+      rev = "08c66abd89d9be404c4decd360746095a4bad0a5";
     }) {}).chamber
 
     (import (builtins.fetchGit {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -103,10 +103,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "aws-vault-6.2.0";
+      name = "aws-vault-6.3.1";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "559cf76fa3642106d9f23c9e845baf4d354be682";
+      rev = "54c1e44240d8a527a8f4892608c4bce5440c3ecb";
     }) {}).aws-vault
 
     (import (builtins.fetchGit {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -127,10 +127,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "chamber-2.10.2";
+      name = "chamber-2.9.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "08c66abd89d9be404c4decd360746095a4bad0a5";
+      rev = "559cf76fa3642106d9f23c9e845baf4d354be682";
     }) {}).chamber
 
     (import (builtins.fetchGit {

--- a/scripts/check-bash-version
+++ b/scripts/check-bash-version
@@ -18,7 +18,12 @@ function check_shell () {
   fi
 }
 
-check_shell /usr/local/bin/bash
+# if nix is in use
+if [ ! -r .nix-disable ] && [ -f ~/.nix-profile/bin/nix-env ]; then
+  check_shell "${NIX_PROFILE}/bin/bash"
+else
+  check_shell /usr/local/bin/bash
+fi
 
 # Knocks off everything after the last decimal
 SHORT_VERSION=${BASH_VERSION%.*}

--- a/scripts/check-chamber-version
+++ b/scripts/check-chamber-version
@@ -13,7 +13,7 @@ if [[ -x "${GOPATH}/bin/chamber" ]]; then
   exit 1
 fi
 
-VERSION="2.10"
+VERSION="2.9"
 
 CHAMBER_VERSION=$(type -p chamber && DISABLE_AWS_VAULT_WRAPPER=1 chamber version)
 

--- a/scripts/check-opensc-version
+++ b/scripts/check-opensc-version
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 VERSION="0.21"
 
-OPENSC_VERSION=$(brew info --cask opensc | head -n1 | cut -d" " -f2 )
+OPENSC_VERSION=$(opensc-tool --info | head -n1 | cut -d" " -f2 )
 
 # Knocks off everything after the last decimal
 SHORT_VERSION=${OPENSC_VERSION%.*}

--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -47,20 +47,37 @@ function has_path() {
   esac
 }
 
+# if nix is in use
+if [ ! -r .nix-disable ] && [ -f ~/.nix-profile/bin/nix-env ]; then
+  nix_dir="nix"
+  # add the nix files so that if they change, direnv needs to be reloaded
+  config_hash=$(nix-hash "${nix_dir}")
+  store_hash=$(nix-store -q --hash "${NIX_PROFILE}")
+
+  # The .nix-hash file is created by nix/update.sh
+  if [ ! -r .nix-hash ] || ! grep -q "${config_hash}-${store_hash}" .nix-hash; then
+    echo -e "${YELLOW}WARNING: nix packages out of date Run ${nix_dir}/update.sh${NC}"
+    prereqs_found=false
+  else
+    echo "nix dependencies installed"
+  fi
+else # things only required without nix
+  has asdf "brew install asdf; # then add 'source /usr/local/opt/asdf/asdf.sh' to your shell rc file"
+  has_path ".asdf/shims" "asdf plugin add golang; asdf install; asdf global golang ${GOVERSION}"
+  has nodenv "brew install nodenv"
+  has_path ".nodenv/shims" "nodenv init"
+fi
+
 has aws "brew install awscli"
 has bash "brew install bash"
 has chamber "brew install chamber"
 has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Docker.dmg"
 has jq "brew install jq"
-has asdf "brew install asdf; # then add 'source /usr/local/opt/asdf/asdf.sh' to your shell rc file"
-has_path ".asdf/shims" "asdf plugin add golang; asdf install; asdf global golang ${GOVERSION}"
 has go "asdf plugin add golang; asdf install; asdf global golang ${GOVERSION}"
 has yarn "brew install yarn"
 has pre-commit "brew install pre-commit"
 has shellcheck "brew install shellcheck"
 has psql "brew install postgresql"
-has nodenv "brew install nodenv"
-has_path ".nodenv/shims" "nodenv init"
 has node "nodenv local 14.17.1"
 
 # not on CircleCI


### PR DESCRIPTION
## Description

Some of us have been using nix to install MilMove development dependencies. This PR updates the various prerequisite check scripts to support a nix install. This PR also updates the versions for `aws-vault` and `chamber` as the nix config was out of date for what brew installed.

## Reviewer Notes

Will be looking for approval from a fellow `nix` user and someone who is still using `brew`, `asdf`, and `nodenv`.

## Setup

Run the prereqs check. You may have to fix somethings if you haven't run these in a while. Note `nix` users will need to run `nix/update.sh` but the script should warn you about it.

```sh
 ❯ rm -f .prereqs.stamp
 ❯ make prereqs
scripts/prereqs
nix dependencies installed
aws installed.
bash installed.
chamber installed.
docker installed.
jq installed.
go installed.
yarn installed.
pre-commit installed.
shellcheck installed.
psql installed.
node installed.
pkcs11-tool installed.
pkcs15-tool installed.
circleci installed.
direnv installed.
entr installed.
aws-vault installed.
watchman installed.
OK: all prereqs found

aws-cli/2.1.7 Python/3.8.6 Darwin/20.6.0 source/x86_64 prompt/off installed
aws-vault /nix/var/nix/profiles/mymove/bin/aws-vault v6.3.1 installed
Bash 5.1.4(1)-release installed
/nix/var/nix/profiles/mymove/bin/chamber
chamber v2.10.2 installed
Golang go version go1.16.6 darwin/amd64 installed
Node v14.17.1 installed
opensc 0.21.0 installed
touch .prereqs.stamp
```

## Code Review Verification Steps

* [ x ] Request review from a member of a different team.