### PR TITLE
MB-8841: Adds tests for existing deprecated component, fixes flaky client tests

### DIFF
--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
 
 import OrdersInfoForm from './OrdersInfoForm';
 
@@ -132,26 +131,26 @@ const testProps = {
 
 describe('OrdersInfoForm component', () => {
   it('renders the form inputs', async () => {
-    const { getByLabelText } = render(<OrdersInfoForm {...testProps} />);
+    render(<OrdersInfoForm {...testProps} />);
 
     await waitFor(() => {
-      expect(getByLabelText('Orders type')).toBeInstanceOf(HTMLSelectElement);
-      expect(getByLabelText('Orders type')).toBeRequired();
-      expect(getByLabelText('Orders date')).toBeInstanceOf(HTMLInputElement);
-      expect(getByLabelText('Orders date')).toBeRequired();
-      expect(getByLabelText('Report-by date')).toBeInstanceOf(HTMLInputElement);
-      expect(getByLabelText('Report-by date')).toBeRequired();
-      expect(getByLabelText('Yes')).toBeInstanceOf(HTMLInputElement);
-      expect(getByLabelText('No')).toBeInstanceOf(HTMLInputElement);
-      expect(getByLabelText('New duty station')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Orders type')).toBeInstanceOf(HTMLSelectElement);
+      expect(screen.getByLabelText('Orders type')).toBeRequired();
+      expect(screen.getByLabelText('Orders date')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Orders date')).toBeRequired();
+      expect(screen.getByLabelText('Report-by date')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('Report-by date')).toBeRequired();
+      expect(screen.getByLabelText('Yes')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('No')).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByLabelText('New duty station')).toBeInstanceOf(HTMLInputElement);
     });
   });
 
   it('renders each option for orders type', async () => {
-    const { getByLabelText } = render(<OrdersInfoForm {...testProps} />);
+    render(<OrdersInfoForm {...testProps} />);
 
     await waitFor(() => {
-      const ordersTypeDropdown = getByLabelText('Orders type');
+      const ordersTypeDropdown = screen.getByLabelText('Orders type');
       expect(ordersTypeDropdown).toBeInstanceOf(HTMLSelectElement);
 
       userEvent.selectOptions(ordersTypeDropdown, 'PERMANENT_CHANGE_OF_STATION');
@@ -166,59 +165,58 @@ describe('OrdersInfoForm component', () => {
   });
 
   it('validates the new duty station against the current duty station', async () => {
-    const { queryByText, getByRole, getByLabelText } = render(
-      <OrdersInfoForm {...testProps} currentStation={{ name: 'Luke AFB' }} />,
-    );
+    render(<OrdersInfoForm {...testProps} currentStation={{ name: 'Luke AFB' }} />);
 
-    userEvent.selectOptions(getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
-    userEvent.type(getByLabelText('Orders date'), '08 Nov 2020');
-    userEvent.type(getByLabelText('Report-by date'), '26 Nov 2020');
-    userEvent.click(getByLabelText('No'));
+    userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+    userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+    userEvent.type(screen.getByLabelText('Report-by date'), '26 Nov 2020');
+    userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    fireEvent.change(getByLabelText('New duty station'), { target: { value: 'AFB' } });
-
-    await selectEvent.select(getByLabelText('New duty station'), /Luke/);
+    userEvent.type(screen.getByLabelText('New duty station'), 'AFB');
+    userEvent.click(await screen.findByText('Luke'));
 
     await waitFor(() => {
-      expect(getByRole('form')).toHaveFormValues({
+      expect(screen.getByRole('form')).toHaveFormValues({
         new_duty_station: 'Luke AFB',
       });
-      expect(getByRole('button', { name: 'Next' })).toHaveAttribute('disabled');
+      expect(screen.getByRole('button', { name: 'Next' })).toHaveAttribute('disabled');
       expect(
-        queryByText('You entered the same duty station for your origin and destination. Please change one of them.'),
+        screen.queryByText(
+          'You entered the same duty station for your origin and destination. Please change one of them.',
+        ),
       ).toBeInTheDocument();
     });
   });
 
   it('shows an error message if trying to submit an invalid form', async () => {
-    const { getByRole, getAllByText } = render(<OrdersInfoForm {...testProps} />);
-    const submitBtn = getByRole('button', { name: 'Next' });
+    render(<OrdersInfoForm {...testProps} />);
+    const submitBtn = screen.getByRole('button', { name: 'Next' });
 
     userEvent.click(submitBtn);
 
     await waitFor(() => {
-      expect(getAllByText('Required').length).toBe(3);
+      expect(screen.getAllByText('Required').length).toBe(3);
     });
     expect(testProps.onSubmit).not.toHaveBeenCalled();
   });
 
   it('submits the form when its valid', async () => {
-    const { getByRole, getByLabelText } = render(<OrdersInfoForm {...testProps} />);
+    render(<OrdersInfoForm {...testProps} />);
 
-    userEvent.selectOptions(getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
-    userEvent.type(getByLabelText('Orders date'), '08 Nov 2020');
-    userEvent.type(getByLabelText('Report-by date'), '26 Nov 2020');
-    userEvent.click(getByLabelText('No'));
+    userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+    userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+    userEvent.type(screen.getByLabelText('Report-by date'), '26 Nov 2020');
+    userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    fireEvent.change(getByLabelText('New duty station'), { target: { value: 'AFB' } });
-    await selectEvent.select(getByLabelText('New duty station'), /Luke/);
-    expect(getByRole('form')).toHaveFormValues({
+    userEvent.type(screen.getByLabelText('New duty station'), 'AFB');
+    userEvent.click(await screen.findByText('Luke'));
+    expect(await screen.findByRole('form')).toHaveFormValues({
       new_duty_station: 'Luke AFB',
     });
 
-    const submitBtn = getByRole('button', { name: 'Next' });
+    const submitBtn = screen.getByRole('button', { name: 'Next' });
     userEvent.click(submitBtn);
 
     await waitFor(() => {
@@ -244,8 +242,8 @@ describe('OrdersInfoForm component', () => {
   });
 
   it('implements the onBack handler when the Back button is clicked', async () => {
-    const { getByRole } = render(<OrdersInfoForm {...testProps} />);
-    const backBtn = getByRole('button', { name: 'Back' });
+    render(<OrdersInfoForm {...testProps} />);
+    const backBtn = screen.getByRole('button', { name: 'Back' });
 
     userEvent.click(backBtn);
 
@@ -281,21 +279,19 @@ describe('OrdersInfoForm component', () => {
     };
 
     it('pre-fills the inputs', async () => {
-      const { getByRole, queryByText, getByLabelText } = render(
-        <OrdersInfoForm {...testProps} initialValues={testInitialValues} />,
-      );
+      render(<OrdersInfoForm {...testProps} initialValues={testInitialValues} />);
 
       await waitFor(() => {
-        expect(getByRole('form')).toHaveFormValues({
+        expect(screen.getByRole('form')).toHaveFormValues({
           new_duty_station: 'Yuma AFB',
         });
 
-        expect(getByLabelText('Orders type')).toHaveValue(testInitialValues.orders_type);
-        expect(getByLabelText('Orders date')).toHaveValue('08 Nov 2020');
-        expect(getByLabelText('Report-by date')).toHaveValue('26 Nov 2020');
-        expect(getByLabelText('Yes')).not.toBeChecked();
-        expect(getByLabelText('No')).toBeChecked();
-        expect(queryByText('Yuma AFB')).toBeInTheDocument();
+        expect(screen.getByLabelText('Orders type')).toHaveValue(testInitialValues.orders_type);
+        expect(screen.getByLabelText('Orders date')).toHaveValue('08 Nov 2020');
+        expect(screen.getByLabelText('Report-by date')).toHaveValue('26 Nov 2020');
+        expect(screen.getByLabelText('Yes')).not.toBeChecked();
+        expect(screen.getByLabelText('No')).toBeChecked();
+        expect(screen.queryByText('Yuma AFB')).toBeInTheDocument();
       });
     });
   });

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.test.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.test.jsx
@@ -1,0 +1,234 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DutyStationSearchBox from './DutyStationSearchBox';
+
+const testAddress = {
+  city: 'Glendale Luke AFB',
+  country: 'United States',
+  id: 'fa51dab0-4553-4732-b843-1f33407f77bc',
+  postal_code: '85309',
+  state: 'AZ',
+  street_address_1: 'n/a',
+};
+
+const testStations = [
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '46c4640b-c35e-4293-a2f1-36c7b629f903',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:04.117Z',
+    id: '93f0755f-6f35-478b-9a75-35a69211da1c',
+    name: 'Altus AFB',
+    updated_at: '2021-02-11T16:48:04.117Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '2d7e17f6-1b8a-4727-8949-007c80961a62',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:04.117Z',
+    id: '7d123884-7c1b-4611-92ae-e8d43ca03ad9',
+    name: 'Hill AFB',
+    updated_at: '2021-02-11T16:48:04.117Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '25be4d12-fe93-47f1-bbec-1db386dfa67f',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:04.117Z',
+    id: 'a8d6b33c-8370-4e92-8df2-356b8c9d0c1a',
+    name: 'Luke AFB',
+    updated_at: '2021-02-11T16:48:04.117Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '3dbf1fc7-3289-4c6e-90aa-01b530a7c3c3',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:20.225Z',
+    id: 'd01bd2a4-6695-4d69-8f2f-69e88dff58f8',
+    name: 'Shaw AFB',
+    updated_at: '2021-02-11T16:48:20.225Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '1af8f0f3-f75f-46d3-8dc8-c67c2feeb9f0',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:49:14.322Z',
+    id: 'b1f9a535-96d4-4cc3-adf1-b76505ce0765',
+    name: 'Yuma AFB',
+    updated_at: '2021-02-11T16:49:14.322Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: 'f2adfebc-7703-4d06-9b49-c6ca8f7968f1',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:20.225Z',
+    id: 'a268b48f-0ad1-4a58-b9d6-6de10fd63d96',
+    name: 'Los Angeles AFB',
+    updated_at: '2021-02-11T16:48:20.225Z',
+  },
+  {
+    address: {
+      city: '',
+      id: '00000000-0000-0000-0000-000000000000',
+      postal_code: '',
+      state: '',
+      street_address_1: '',
+    },
+    address_id: '13eb2cab-cd68-4f43-9532-7a71996d3296',
+    affiliation: 'AIR_FORCE',
+    created_at: '2021-02-11T16:48:20.225Z',
+    id: 'a48fda70-8124-4e90-be0d-bf8119a98717',
+    name: 'Wright-Patterson AFB',
+    updated_at: '2021-02-11T16:48:20.225Z',
+  },
+];
+
+jest.mock('scenes/ServiceMembers/api.js', () => ({
+  SearchDutyStations: async (search) => {
+    if (search === 'empty') {
+      return [];
+    }
+
+    if (search === 'broken') {
+      throw new Error('Server returned an error');
+    }
+
+    return testStations;
+  },
+  ShowAddress: async (addressId) => {
+    return testAddress;
+  },
+}));
+
+describe('scenes/ServiceMembers/DutyStationSearchBox', () => {
+  describe('basic rendering', () => {
+    it('renders with minimal props', () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} />);
+      expect(screen.getByLabelText('Name of Duty Station:')).toBeInTheDocument();
+    });
+
+    it('renders the title', () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} title="Test Component" />);
+      expect(screen.getByLabelText('Test Component')).toBeInTheDocument();
+    });
+
+    it('renders an error message', () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} errorMsg="Test Error Message" />);
+      expect(screen.getByText('Test Error Message')).toBeInTheDocument();
+    });
+
+    it('renders a value passed in via prop', () => {
+      render(
+        <DutyStationSearchBox
+          input={{
+            name: 'test_component',
+            value: {
+              ...testStations[2],
+              address: testAddress,
+            },
+          }}
+        />,
+      );
+      expect(screen.getByText('Luke AFB')).toBeInTheDocument();
+      expect(screen.getByText('Glendale Luke AFB, AZ 85309')).toBeInTheDocument();
+    });
+
+    it('can render without the address', () => {
+      render(
+        <DutyStationSearchBox
+          displayAddress={false}
+          input={{
+            name: 'test_component',
+            value: {
+              ...testStations[2],
+              address: testAddress,
+            },
+          }}
+        />,
+      );
+      expect(screen.getByText('Luke AFB')).toBeInTheDocument();
+      expect(screen.queryByText('Glendale Luke AFB, AZ 85309')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('updating options based on text', () => {
+    it('searches user input and renders options', async () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} title="Test Component" name="test-component" />);
+      userEvent.type(screen.getByLabelText('Test Component'), 'AFB');
+
+      const option = await screen.findByText('Luke');
+      expect(option).toBeInTheDocument();
+
+      const optionsContainer = option.closest('div').parentElement.parentElement;
+      expect(optionsContainer.children.length).toEqual(7);
+    });
+
+    it('searches user input and renders a message if empty', async () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} title="Test Component" />);
+      userEvent.type(screen.getByLabelText('Test Component'), 'empty');
+
+      expect(await screen.findByText('No Options')).toBeInTheDocument();
+    });
+
+    it('searches user input and renders an alert if server error', async () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} title="Test Component" />);
+      userEvent.type(screen.getByLabelText('Test Component'), 'broken');
+
+      expect(await screen.findByText('Server returned an error')).toBeInTheDocument();
+    });
+
+    it("doesnt search if user input isn't 2+ characters in length", async () => {
+      render(<DutyStationSearchBox input={{ name: 'test_component' }} title="Test Component" />);
+      userEvent.type(screen.getByLabelText('Test Component'), '1');
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+
+  describe('selecting options', () => {
+    it('selects an option, calls the onChange callback prop', async () => {
+      const onChange = jest.fn();
+      render(<DutyStationSearchBox input={{ name: 'test_component', onChange }} title="Test Component" />);
+      userEvent.type(screen.getByLabelText('Test Component'), 'AFB');
+      userEvent.click(await screen.findByText('Luke'));
+
+      await waitFor(() => expect(onChange).toHaveBeenCalledWith(testStations[2]));
+    });
+  });
+});

--- a/src/scenes/ServiceMembers/api.test.js
+++ b/src/scenes/ServiceMembers/api.test.js
@@ -1,0 +1,57 @@
+import { SearchDutyStations, ShowAddress } from './api';
+
+jest.mock('shared/Swagger/api.js', () => ({
+  ...jest.requireActual('shared/Swagger/api.js'),
+  getClient: async () => {
+    return {
+      apis: {
+        addresses: {
+          showAddress: ({ addressId }) => {
+            if (addressId === 'broken') {
+              return { ok: false };
+            }
+
+            return { ok: true, body: `address ${addressId}` };
+          },
+        },
+        duty_stations: {
+          searchDutyStations: ({ search }) => {
+            if (search === 'broken') {
+              return { ok: false };
+            }
+
+            return { ok: true, body: `queried ${search}` };
+          },
+        },
+      },
+    };
+  },
+}));
+
+describe('scenes ServiceMembers api', () => {
+  describe('SearchDutyStations', () => {
+    it('retrieves a response from the server', async () => {
+      const response = await SearchDutyStations('ok');
+      expect(response).toEqual('queried ok');
+    });
+
+    it('throws an error when appropriate', async () => {
+      await expect(async () => {
+        await SearchDutyStations('broken');
+      }).rejects.toThrow('failed to query duty stations due to server error');
+    });
+  });
+
+  describe('ShowAddress', () => {
+    it('retrieves a response from the server', async () => {
+      const response = await ShowAddress('ok');
+      expect(response).toEqual('address ok');
+    });
+
+    it('throws an error when appropriate', async () => {
+      await expect(async () => {
+        await ShowAddress('broken');
+      }).rejects.toThrow('failed to query address for duty station');
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pull request refactors two front-end test suites to be more in line with current front-end testing best practices (using `screen` instead of methods returned from `render`, using RTL instead of enzyme, appropriately using `await findByWhatever` instead of `waitFor`); this should greatly reduce the incidence of these tests sporadically failing during our CircleCI `client_test` build jobs, of which these two were probably the worst offenders in our front-end code base.

Since comments attached to the expectations that frequently failed were trying to test the functionality of a complicated, deprecated component that didn't have tests, this pull request also adds test coverage to that deprecated component, ahead of a potential refactor.

## Reviewer Notes

There should be no visible changes to the UI (quite literally, all we're changing/adding are test files). Ensure that the newly-created and modified tests aren't emitting any messages to the console during test runs.

## Setup

```sh
yarn test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8841](https://dp3.atlassian.net/browse/MB-8841) and [MB-8842](https://dp3.atlassian.net/browse/MB-8842).
* [Common mistakes with React Testing Library](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library/)