### PR TITLE
[MB-9245] make service item calculations better fit on page

### DIFF
--- a/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.module.scss
+++ b/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.module.scss
@@ -70,6 +70,6 @@
   }
 
   &.expandedDetail td {
-    @include u-padding(3);
+    padding: 0;
   }
 }

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.module.scss
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.module.scss
@@ -149,8 +149,8 @@
 
 .drawer {
   border-top: 1px solid #dcdee0;
-  padding-left: 7.2rem;
-  padding-right: 7.2rem;
+  padding-left: 0;
+  padding-right: 0;
   @include u-margin-top(2);
 
   > div {

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.module.scss
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.module.scss
@@ -31,7 +31,7 @@
 
   :global .table--stacked {
     width: 100%;
-
+    table-layout: fixed;
     th {
       @include u-font-weight(bold);
       @include u-font-size('body', '3xs');

--- a/src/pages/Office/TXOMoveInfo/TXOTab.module.scss
+++ b/src/pages/Office/TXOMoveInfo/TXOTab.module.scss
@@ -99,3 +99,12 @@
   align-items: center;
   margin: auto 0;
 }
+
+.movePaymentRequests {
+  table-layout: fixed;
+  border: 5px solid red;
+}
+.PaymentRequestDetails_PaymentRequestDetails .table--stacked {
+  table-layout: fixed;
+
+}


### PR DESCRIPTION
## Description

This PR resolves an issue where the service item calculations component was overflowing its container. Note, service items that have many pricing param columns will have horizontal scrolling. The slack this was brought up in here:

https://ustcdp3.slack.com/archives/C0292K7MY31/p1629240575022300 

## Reviewer Notes

This branch is deployed here: https://office-milmove-pr-7221.mymove.sandbox.truss.coffee/ 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run client_run
```
In the office app sign in as a TIO and view a reviewed payment request. When you click the more details you should see the service item calculations are back to being contained in its outer container 


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9245) for this change

## Screenshots

<img width="1306" alt="Screen Shot 2021-08-20 at 3 32 57 PM" src="https://user-images.githubusercontent.com/67110378/130284726-876eb3e9-6849-436b-8c3f-862db0c83742.png">
