### PR TITLE
[MB-8999] Include reweigh in move weight total on MTO page if lower than shipment actual weight 

### DIFF
--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -880,6 +880,218 @@ const approvedMTOWithCancelledShipmentQuery = {
   isSuccess: true,
 };
 
+const lowerReweighsMTOQuery = {
+  orders: {
+    1: {
+      id: '1',
+      originDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Knox',
+          state: 'KY',
+          postal_code: '40121',
+        },
+      },
+      destinationDutyStation: {
+        address: {
+          street_address_1: '',
+          city: 'Fort Irwin',
+          state: 'CA',
+          postal_code: '92310',
+        },
+      },
+      entitlement: {
+        authorizedWeight: 8000,
+        totalWeight: 8500,
+      },
+    },
+  },
+  move: {
+    id: '2',
+    status: MOVE_STATUSES.APPROVALS_REQUESTED,
+    availableToPrimeAt: '2020-03-01T00:00:00.000Z',
+  },
+  mtoShipments: [
+    {
+      id: '3',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      reweigh: {
+        weight: 99,
+      },
+    },
+    {
+      id: '4',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.NTS,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: shipmentStatuses.APPROVED,
+      eTag: '1234',
+      primeEstimatedWeight: null,
+      primeActualWeight: null,
+      reweigh: {
+        id: '00000000-0000-0000-0000-000000000000',
+      },
+    },
+    {
+      id: '5',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.NTSR,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: shipmentStatuses.DIVERSION_REQUESTED,
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      reweigh: {
+        weight: 99,
+      },
+    },
+    {
+      id: '6',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: shipmentStatuses.CANCELLATION_REQUESTED,
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 50,
+      reweigh: {
+        weight: 49,
+      },
+    },
+    {
+      id: '7',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: shipmentStatuses.SUBMITTED,
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      diversion: true,
+      reweigh: {
+        weight: 99,
+      },
+    },
+    {
+      id: '7',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        street_address_1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postal_code: '60601',
+      },
+      destinationAddress: {
+        street_address_1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postal_code: '08401',
+      },
+      status: shipmentStatuses.CANCELED,
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      diversion: true,
+      reweigh: {
+        weight: 99,
+      },
+    },
+  ],
+  mtoServiceItems: [
+    {
+      id: '8',
+      mtoShipmentID: '3',
+      reServiceName: 'Domestic origin 1st day SIT',
+      status: SERVICE_ITEM_STATUS.SUBMITTED,
+      reServiceCode: 'DOFSIT',
+    },
+    {
+      id: '9',
+      mtoShipmentID: '4',
+      reServiceName: "Domestic origin add'l SIT",
+      status: SERVICE_ITEM_STATUS.SUBMITTED,
+      reServiceCode: 'DOASIT',
+    },
+  ],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
 const setUnapprovedShipmentCount = jest.fn();
 const setUnapprovedServiceItemCount = jest.fn();
 const setExcessWeightRiskCount = jest.fn();
@@ -1158,6 +1370,24 @@ describe('MoveTaskOrder', () => {
       );
 
       const moveWeightTotal = await screen.getByText(/350 lbs/);
+      expect(moveWeightTotal).toBeInTheDocument();
+    });
+
+    it('displays the move weight total using lower reweighs', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(lowerReweighsMTOQuery);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+            setExcessWeightRiskCount={setExcessWeightRiskCount}
+          />
+        </MockProviders>,
+      );
+
+      const moveWeightTotal = await screen.getByText(/247 lbs/);
       expect(moveWeightTotal).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Description

Now that shipment's can have reweigh weights, we want to take that into account when showing the total move weight of all shipments on the MTO page.  The reweigh weight will be used instead of the actual weight when it is lower than the actual weight of that shipment.  We also want to ignore any shipments that aren't on the MTO page so we want to ignore shipments in the status of DRAFT, SUBMITTED, and CANCELLED.  While CANCELLED will still appear on the MTO page because it was previously approved, it's weights won't contribute to the total move weight.

## Reviewer Notes

We had a discussion during sprint planning and came to the conclusion we didn't have clarity on what to do with diversions that result in 2 shipments in the system.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8999) for this change

## Screenshots


