### PR TITLE
 FIx AV CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,8 +695,7 @@ jobs:
     steps:
       - checkout
       - run: clamscan --version
-      - run: mkdir -p /store && chown clamav /store
-      - run: cp -v ~/transcom/mymove/anti-virus/whitelist-*.{fp,ign2} /store
+      - run: cp -v ~/transcom/mymove/anti-virus/whitelist-*.{fp,ign2} /var/lib/clamav/
       - run: >
           clamscan \
             --recursive \
@@ -708,10 +707,7 @@ jobs:
             --max-filesize=100M \
             --max-recursion=30 \
             --max-files=50000 \
-            --tempdir=/tmp \
-            --database=/store \
-            /root/project \
-            /store
+            --tempdir=/tmp
       - announce_failure
 
   # `pre_test` runs pre-commit against all files.
@@ -1671,8 +1667,8 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              # only: master
               only: fix-av-ci
+              # only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     resource_class: medium
     working_directory: /root/project
     docker:
-      - image: mk0x/docker-clamav:latest
+      - image: milmove/clamav-ci
         # Authenticate with Docker Hub to avoid rate limit problems beginning on Nov 1st, 2020.
         # See https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/ for details
         # We'll need this until CircleCI and Docker Hub work out a deal to prevent rate limiting errors from CircleCI
@@ -693,14 +693,7 @@ jobs:
   anti_virus:
     executor: av_medium
     steps:
-      - run: apt-get update && apt-get install -y clamav curl git ssh
       - checkout
-      - run: clamscan --version
-      - run: mkdir -p /store && chown clamav /store
-      - run: cp -v /root/project/anti-virus/whitelist-*.{fp,ign2} /store
-      - run:
-          name: freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store
-          command: for i in $(seq 1 5); do freshclam --config-file /etc/clamav/freshclam.conf --datadir=/store && s=0 && break || s=$? && sleep 5; done; (exit $s)
       - run: >
           clamscan \
             --recursive \
@@ -1675,7 +1668,8 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: master
+              only: fix-av-ci
+              # only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1671,7 +1671,8 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: master
+              # only: master
+              only: fix-av-ci
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,7 +707,8 @@ jobs:
             --max-filesize=100M \
             --max-recursion=30 \
             --max-files=50000 \
-            --tempdir=/tmp
+            --tempdir=/tmp \
+            ~/transcom/mymove
       - announce_failure
 
   # `pre_test` runs pre-commit against all files.
@@ -1667,7 +1668,7 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: master
+              only: fix-av-ci
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1667,8 +1667,7 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: fix-av-ci
-              # only: master
+              only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,6 +694,9 @@ jobs:
     executor: av_medium
     steps:
       - checkout
+      - run: clamscan --version
+      - run: mkdir -p /store && chown clamav /store
+      - run: cp -v ~/transcom/mymove/anti-virus/whitelist-*.{fp,ign2} /store
       - run: >
           clamscan \
             --recursive \
@@ -1668,8 +1671,7 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: fix-av-ci
-              # only: master
+              only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1668,7 +1668,7 @@ workflows:
       - anti_virus:
           filters:
             branches:
-              only: fix-av-ci
+              only: master
 
       - pre_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
 executors:
   av_medium:
     resource_class: medium
-    working_directory: /root/project
+    working_directory: ~/transcom/mymove
     docker:
       - image: milmove/clamav-ci
         # Authenticate with Docker Hub to avoid rate limit problems beginning on Nov 1st, 2020.


### PR DESCRIPTION
## Description

Fixes the anti-virus CI/CD step to not pull the database each time this CI/CD step is run. Going forward, this will use an image that will pull the ClamAV DB 2x per day. 

## Reviewer Notes

none

## Setup
change L1670 to point to your branch

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.
