### PR TITLE
[MB-9257] Create EditBillableWeight storybook component"

### DIFF
--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { number } from 'prop-types';
+import { Button, TextInput, Fieldset, Label, Textarea } from '@trussworks/react-uswds';
+
+import styles from './EditBillableWeight.module.scss';
+
+import { formatWeight } from 'shared/formatters';
+
+export default function EditBillableWeight({ weightAllowance, estimatedWeight }) {
+  const [showEditBtn, setShowEditBtn] = useState(true);
+
+  function toggleEdit() {
+    setShowEditBtn(!showEditBtn);
+  }
+
+  return showEditBtn ? (
+    <Button className={styles.editBtn} onClick={toggleEdit}>
+      Edit
+    </Button>
+  ) : (
+    <div className={styles.container}>
+      <h5>Max billable weight</h5>
+      <div>
+        <strong>{formatWeight(weightAllowance)}</strong> <span>| weight allowance</span>
+      </div>
+      <div className={styles.estimatedWeight}>
+        <strong>{formatWeight(estimatedWeight)}</strong> <span>| 110% of total estimated weight</span>
+      </div>
+
+      <Fieldset className={styles.fieldset}>
+        <TextInput className={styles.maxBillableWeight} type="number" /> lbs
+        <Label htmlFor="remarks">Remarks</Label>
+        <Textarea data-testid="remarks" name="remarks" placeholder="" id="remarks" maxLength={500} />
+      </Fieldset>
+      <div className={styles.btnContainer}>
+        <Button onClick={toggleEdit}>Save changes</Button>
+        <Button onClick={toggleEdit} unstyled>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+EditBillableWeight.propTypes = {
+  weightAllowance: number.isRequired,
+  estimatedWeight: number.isRequired,
+};

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -73,6 +73,7 @@ MaxBillableWeightHintText.defaultProps = {
 
 export default function EditBillableWeight({
   billableWeight,
+  billableWeightJustification,
   estimatedWeight,
   maxBillableWeight,
   originalWeight,
@@ -86,42 +87,56 @@ export default function EditBillableWeight({
     setShowEditBtn(!showEditBtn);
   }
 
-  return showEditBtn ? (
-    <Button className={styles.editBtn} onClick={toggleEdit}>
-      Edit
-    </Button>
-  ) : (
-    <div className={styles.container}>
-      <h5>{title}</h5>
-      {billableWeight ? (
-        <BillableWeightHintText
-          billableWeight={billableWeight}
-          estimatedWeight={estimatedWeight}
-          maxBillableWeight={maxBillableWeight}
-          originalWeight={originalWeight}
-          totalBillableWeight={totalBillableWeight}
-        />
+  return (
+    <>
+      <h4 className={styles.header}>{title}</h4>
+      {showEditBtn ? (
+        <>
+          <span>{billableWeight ? formatWeight(billableWeight) : formatWeight(maxBillableWeight)}</span>
+          {billableWeightJustification && (
+            <>
+              <h5 className={styles.remarksHeader}>Remarks</h5>
+              <p className={styles.remarks}>{billableWeightJustification}</p>
+            </>
+          )}
+          <Button className={styles.editBtn} onClick={toggleEdit}>
+            Edit
+          </Button>
+        </>
       ) : (
-        <MaxBillableWeightHintText weightAllowance={weightAllowance} estimatedWeight={estimatedWeight} />
-      )}
+        <div className={styles.container}>
+          {billableWeight ? (
+            <BillableWeightHintText
+              billableWeight={billableWeight}
+              estimatedWeight={estimatedWeight}
+              maxBillableWeight={maxBillableWeight}
+              originalWeight={originalWeight}
+              totalBillableWeight={totalBillableWeight}
+            />
+          ) : (
+            <MaxBillableWeightHintText weightAllowance={weightAllowance} estimatedWeight={estimatedWeight} />
+          )}
 
-      <Fieldset className={styles.fieldset}>
-        <TextInput className={styles.maxBillableWeight} type="number" /> lbs
-        <Label htmlFor="remarks">Remarks</Label>
-        <Textarea data-testid="remarks" name="remarks" placeholder="" id="remarks" maxLength={500} />
-      </Fieldset>
-      <div className={styles.btnContainer}>
-        <Button onClick={toggleEdit}>Save changes</Button>
-        <Button onClick={toggleEdit} unstyled>
-          Cancel
-        </Button>
-      </div>
-    </div>
+          <Fieldset className={styles.fieldset}>
+            <TextInput className={styles.maxBillableWeight} type="number" /> lbs
+            <Label htmlFor="remarks">Remarks</Label>
+            <Textarea data-testid="remarks" name="remarks" placeholder="" id="remarks" maxLength={500} />
+          </Fieldset>
+          <div className={styles.btnContainer}>
+            <Button onClick={toggleEdit}>Save changes</Button>
+            <Button onClick={toggleEdit} unstyled>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 
 EditBillableWeight.propTypes = {
   billableWeight: number,
+  billableWeightJustification: string,
   estimatedWeight: number,
   maxBillableWeight: number.isRequired,
   originalWeight: number,
@@ -136,4 +151,5 @@ EditBillableWeight.defaultProps = {
   originalWeight: null,
   totalBillableWeight: null,
   weightAllowance: null,
+  billableWeightJustification: '',
 };

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -80,7 +80,7 @@ export default function EditBillableWeight({
   totalBillableWeight,
   weightAllowance,
 }) {
-  const [showEditBtn, setShowEditBtn] = useState(false);
+  const [showEditBtn, setShowEditBtn] = useState(true);
 
   function toggleEdit() {
     setShowEditBtn(!showEditBtn);

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -1,13 +1,86 @@
 import React, { useState } from 'react';
-import { number } from 'prop-types';
+import { number, string } from 'prop-types';
 import { Button, TextInput, Fieldset, Label, Textarea } from '@trussworks/react-uswds';
 
 import styles from './EditBillableWeight.module.scss';
 
 import { formatWeight } from 'shared/formatters';
 
-export default function EditBillableWeight({ weightAllowance, estimatedWeight }) {
-  const [showEditBtn, setShowEditBtn] = useState(true);
+function BillableWeightHintText({
+  billableWeight,
+  estimatedWeight,
+  maxBillableWeight,
+  originalWeight,
+  totalBillableWeight,
+}) {
+  const showToFit = billableWeight > maxBillableWeight && billableWeight < estimatedWeight * 1.1;
+
+  return (
+    <>
+      <div>
+        <strong>{formatWeight(originalWeight)}</strong> <span>| original weight</span>
+      </div>
+      <div className={styles.hintText}>
+        <strong>{formatWeight(estimatedWeight * 1.1)}</strong> <span>| 110% of total estimated weight</span>
+      </div>
+      {showToFit && (
+        <div className={styles.hintText}>
+          <strong>{formatWeight(totalBillableWeight - billableWeight)}</strong>{' '}
+          <span>| to fit within max billable weight</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+BillableWeightHintText.propTypes = {
+  billableWeight: number,
+  estimatedWeight: number,
+  maxBillableWeight: number.isRequired,
+  originalWeight: number,
+  totalBillableWeight: number,
+};
+
+BillableWeightHintText.defaultProps = {
+  billableWeight: null,
+  estimatedWeight: null,
+  originalWeight: null,
+  totalBillableWeight: null,
+};
+
+function MaxBillableWeightHintText({ weightAllowance, estimatedWeight }) {
+  return (
+    <>
+      <div>
+        <strong>{formatWeight(weightAllowance)}</strong> <span>| weight allowance</span>
+      </div>
+      <div className={styles.hintText}>
+        <strong>{formatWeight(estimatedWeight * 1.1)}</strong> <span>| 110% of total estimated weight</span>
+      </div>
+    </>
+  );
+}
+
+MaxBillableWeightHintText.propTypes = {
+  estimatedWeight: number,
+  weightAllowance: number,
+};
+
+MaxBillableWeightHintText.defaultProps = {
+  estimatedWeight: null,
+  weightAllowance: null,
+};
+
+export default function EditBillableWeight({
+  billableWeight,
+  estimatedWeight,
+  maxBillableWeight,
+  originalWeight,
+  title,
+  totalBillableWeight,
+  weightAllowance,
+}) {
+  const [showEditBtn, setShowEditBtn] = useState(false);
 
   function toggleEdit() {
     setShowEditBtn(!showEditBtn);
@@ -19,13 +92,18 @@ export default function EditBillableWeight({ weightAllowance, estimatedWeight })
     </Button>
   ) : (
     <div className={styles.container}>
-      <h5>Max billable weight</h5>
-      <div>
-        <strong>{formatWeight(weightAllowance)}</strong> <span>| weight allowance</span>
-      </div>
-      <div className={styles.estimatedWeight}>
-        <strong>{formatWeight(estimatedWeight)}</strong> <span>| 110% of total estimated weight</span>
-      </div>
+      <h5>{title}</h5>
+      {billableWeight ? (
+        <BillableWeightHintText
+          billableWeight={billableWeight}
+          estimatedWeight={estimatedWeight}
+          maxBillableWeight={maxBillableWeight}
+          originalWeight={originalWeight}
+          totalBillableWeight={totalBillableWeight}
+        />
+      ) : (
+        <MaxBillableWeightHintText weightAllowance={weightAllowance} estimatedWeight={estimatedWeight} />
+      )}
 
       <Fieldset className={styles.fieldset}>
         <TextInput className={styles.maxBillableWeight} type="number" /> lbs
@@ -43,6 +121,19 @@ export default function EditBillableWeight({ weightAllowance, estimatedWeight })
 }
 
 EditBillableWeight.propTypes = {
-  weightAllowance: number.isRequired,
-  estimatedWeight: number.isRequired,
+  billableWeight: number,
+  estimatedWeight: number,
+  maxBillableWeight: number.isRequired,
+  originalWeight: number,
+  title: string.isRequired,
+  totalBillableWeight: number,
+  weightAllowance: number,
+};
+
+EditBillableWeight.defaultProps = {
+  billableWeight: null,
+  estimatedWeight: null,
+  originalWeight: null,
+  totalBillableWeight: null,
+  weightAllowance: null,
 };

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -13,7 +13,7 @@
     color: $base-darker;
   }
 
-  .estimatedWeight {
+  .hintText {
     line-height: 18px;
   }
 

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -2,11 +2,11 @@
 @import 'shared/styles/_mixins';
 @import 'shared/styles/colors';
 
-.container {
-  .editBtn {
-    width: fit-content;
-  }
+.editBtn {
+  width: fit-content;
+}
 
+.container {
   h5 {
     @include u-margin-bottom(0.5);
     font-size: 13px;

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -4,15 +4,27 @@
 
 .editBtn {
   width: fit-content;
+  @include u-margin-top(2);
+}
+
+.header {
+  @include u-margin-bottom(0.5);
+  font-size: 17px;
+  color: $base-darker;
+  font-weight: bold;
+}
+
+.remarksHeader {
+  margin: 0;
+  @include u-margin-top(2);
+}
+
+.remarks {
+  margin: 0;
+  @include u-margin-bottom(3);
 }
 
 .container {
-  h5 {
-    @include u-margin-bottom(0.5);
-    font-size: 13px;
-    color: $base-darker;
-  }
-
   .hintText {
     line-height: 18px;
   }

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -1,0 +1,53 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.container {
+  .editBtn {
+    width: fit-content;
+  }
+
+  h5 {
+    @include u-margin-bottom(0.5);
+    font-size: 13px;
+    color: $base-darker;
+  }
+
+  .estimatedWeight {
+    line-height: 18px;
+  }
+
+  strong,
+  span {
+    font-size: 13px;
+    color: $base;
+  }
+
+  .maxBillableWeight {
+    display: inline-block;
+    width: 96px;
+    appearance: none; // removes up and down arrow for number inputs on firefox
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      appearance: none; // removes up and down arrow for number inputs on all other browsers
+    }
+  }
+
+  .fieldset {
+    padding: 0;
+
+    :global(.usa-label) {
+      color: $base-darker;
+      @include u-margin-top(3);
+    }
+
+    :global(.usa-textarea) {
+      height: 96px;
+    }
+  }
+  .btnContainer {
+    display: flex;
+    @include u-margin-top(2);
+  }
+}

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import EditBillableWeight from './EditBillableWeight';
+
+export default {
+  title: 'Office Components/EditBillableWeight',
+  component: EditBillableWeight,
+};
+
+export const Basic = () => (
+  <div style={{ width: 336, margin: '0 auto' }}>
+    <EditBillableWeight weightAllowance={8000} estimatedWeight={13750} />
+  </div>
+);

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { node } from 'prop-types';
+import { number } from '@storybook/addon-knobs';
 
 import EditBillableWeight from './EditBillableWeight';
 
@@ -7,8 +9,31 @@ export default {
   component: EditBillableWeight,
 };
 
-export const Basic = () => (
-  <div style={{ width: 336, margin: '0 auto' }}>
-    <EditBillableWeight weightAllowance={8000} estimatedWeight={13750} />
-  </div>
+const Container = ({ children }) => <div style={{ width: 336, margin: '0 auto' }}>{children}</div>;
+
+Container.propTypes = {
+  children: node.isRequired,
+};
+
+export const MaxbillableWeight = () => (
+  <Container>
+    <EditBillableWeight
+      title="Max billable weight"
+      weightAllowance={number('WeightAllowance', 8000)}
+      estimatedWeight={number('EstimatedWeight', 13750)}
+    />
+  </Container>
+);
+
+export const BillableWeight = () => (
+  <Container>
+    <EditBillableWeight
+      title="Billable weight"
+      originalWeight={number('OriginalWeight', 10000)}
+      estimatedWeight={number('EstimatedWeight', 13000)}
+      maxBillableWeight={number('MaxBillableWeight', 6000)}
+      billableWeight={number('BillableWeight', 7000)}
+      totalBillableWeight={number('TotalBillableWeight', 11000)}
+    />
+  </Container>
 );

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { node } from 'prop-types';
-import { number } from '@storybook/addon-knobs';
 
 import EditBillableWeight from './EditBillableWeight';
 

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -14,26 +14,30 @@ const Container = ({ children }) => <div style={{ width: 336, margin: '0 auto' }
 Container.propTypes = {
   children: node.isRequired,
 };
-
-export const MaxbillableWeight = () => (
+const Template = (args) => (
   <Container>
-    <EditBillableWeight
-      title="Max billable weight"
-      weightAllowance={number('WeightAllowance', 8000)}
-      estimatedWeight={number('EstimatedWeight', 13750)}
-    />
+    <EditBillableWeight {...args} />
   </Container>
 );
 
-export const BillableWeight = () => (
-  <Container>
-    <EditBillableWeight
-      title="Billable weight"
-      originalWeight={number('OriginalWeight', 10000)}
-      estimatedWeight={number('EstimatedWeight', 13000)}
-      maxBillableWeight={number('MaxBillableWeight', 6000)}
-      billableWeight={number('BillableWeight', 7000)}
-      totalBillableWeight={number('TotalBillableWeight', 11000)}
-    />
-  </Container>
-);
+export const MaxBillableWeight = Template.bind({});
+
+MaxBillableWeight.args = {
+  billableWeightJustification: 'Reduced billable weight to cap at 110% of estimated.',
+  estimatedWeight: 13750,
+  maxBillableWeight: 13000,
+  title: 'Max billable weight',
+  weightAllowance: 8000,
+};
+
+export const BillableWeight = Template.bind({});
+
+BillableWeight.args = {
+  billableWeight: 7000,
+  billableWeightJustification: 'Reduced billable weight to cap at 110% of estimated.',
+  estimatedWeight: 13000,
+  maxBillableWeight: 6000,
+  originalWeight: 10000,
+  title: 'Billable weight',
+  totalBillableWeight: 11000,
+};

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -6,7 +6,7 @@ import EditBillableWeight from './EditBillableWeight';
 import { formatWeight } from 'shared/formatters';
 
 describe('EditBillableWeight', () => {
-  it('renders edit button intially', () => {
+  it('renders weight and edit button intially', () => {
     const defaultProps = {
       title: 'Max billable weight',
       weightAllowance: 8000,
@@ -17,6 +17,22 @@ describe('EditBillableWeight', () => {
     render(<EditBillableWeight {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+    expect(screen.queryByText('Remarks')).toBeNull();
+    expect(screen.getByText(formatWeight(defaultProps.maxBillableWeight))).toBeInTheDocument();
+  });
+
+  it('renders billable weight justification', () => {
+    const defaultProps = {
+      title: 'Max billable weight',
+      weightAllowance: 8000,
+      estimatedWeight: 13750,
+      maxBillableWeight: 10000,
+      billableWeightJustification: 'Reduced billable weight to cap at 110% of estimated.',
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+    expect(screen.getByText(defaultProps.billableWeightJustification)).toBeInTheDocument();
   });
 
   it('renders max billable weight view', () => {

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -7,12 +7,11 @@ import { formatWeight } from 'shared/formatters';
 
 describe('EditBillableWeight', () => {
   it('renders edit button intially', () => {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
     const defaultProps = {
       title: 'Max billable weight',
       weightAllowance: 8000,
       estimatedWeight: 13750,
+      maxBillableWeight: 10000,
     };
 
     render(<EditBillableWeight {...defaultProps} />);
@@ -20,11 +19,50 @@ describe('EditBillableWeight', () => {
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
   });
 
+  it('renders max billable weight view', () => {
+    const defaultProps = {
+      title: 'Max billable weight',
+      weightAllowance: 8000,
+      estimatedWeight: 13750,
+      maxBillableWeight: 10000,
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByText(formatWeight(defaultProps.weightAllowance))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(defaultProps.estimatedWeight * 1.1))).toBeInTheDocument();
+    expect(screen.getByText('| weight allowance')).toBeInTheDocument();
+    expect(screen.getByText('| 110% of total estimated weight')).toBeInTheDocument();
+  });
+
+  it('renders edit billable weight view', () => {
+    const defaultProps = {
+      title: 'Billable weight',
+      originalWeight: 10000,
+      estimatedWeight: 13000,
+      maxBillableWeight: 6000,
+      billableWeight: 7000,
+      totalBillableWeight: 11000,
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByText(formatWeight(defaultProps.originalWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(defaultProps.estimatedWeight * 1.1))).toBeInTheDocument();
+    expect(
+      screen.getByText(formatWeight(defaultProps.totalBillableWeight - defaultProps.billableWeight)),
+    ).toBeInTheDocument();
+    expect(screen.getByText('| original weight')).toBeInTheDocument();
+    expect(screen.getByText('| 110% of total estimated weight')).toBeInTheDocument();
+    expect(screen.getByText('| to fit within max billable weight')).toBeInTheDocument();
+  });
+
   it('clicking edit button shows different view', () => {
     const defaultProps = {
       title: 'Max billable weight',
       weightAllowance: 8000,
       estimatedWeight: 13750,
+      maxBillableWeight: 10000,
     };
 
     render(<EditBillableWeight {...defaultProps} />);
@@ -41,8 +79,10 @@ describe('EditBillableWeight', () => {
 
   it('should be able to toggle between views', () => {
     const defaultProps = {
+      title: 'Max billable weight',
       weightAllowance: 8000,
       estimatedWeight: 13750,
+      maxBillableWeight: 10000,
     };
 
     render(<EditBillableWeight {...defaultProps} />);

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import EditBillableWeight from './EditBillableWeight';
+
+import { formatWeight } from 'shared/formatters';
+
+describe('EditBillableWeight', () => {
+  it('renders edit button intially', () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const defaultProps = {
+      weightAllowance: 8000,
+      estimatedWeight: 13750,
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+  });
+
+  it('clicking edit button shows different view', () => {
+    const defaultProps = {
+      weightAllowance: 8000,
+      estimatedWeight: 13750,
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.queryByText('Edit')).toBeNull();
+    // weights
+    expect(screen.getByText(formatWeight(defaultProps.weightAllowance))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(defaultProps.estimatedWeight))).toBeInTheDocument();
+    // buttons
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('should be able to toggle between views', () => {
+    const defaultProps = {
+      weightAllowance: 8000,
+      estimatedWeight: 13750,
+    };
+
+    render(<EditBillableWeight {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.queryByText('Edit')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Edit')).toBeInTheDocument();
+    expect(screen.queryByText('Save changes')).toBeNull();
+    expect(screen.queryByText('Cancel')).toBeNull();
+  });
+});

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -10,6 +10,7 @@ describe('EditBillableWeight', () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     const defaultProps = {
+      title: 'Max billable weight',
       weightAllowance: 8000,
       estimatedWeight: 13750,
     };
@@ -21,6 +22,7 @@ describe('EditBillableWeight', () => {
 
   it('clicking edit button shows different view', () => {
     const defaultProps = {
+      title: 'Max billable weight',
       weightAllowance: 8000,
       estimatedWeight: 13750,
     };
@@ -31,7 +33,7 @@ describe('EditBillableWeight', () => {
     expect(screen.queryByText('Edit')).toBeNull();
     // weights
     expect(screen.getByText(formatWeight(defaultProps.weightAllowance))).toBeInTheDocument();
-    expect(screen.getByText(formatWeight(defaultProps.estimatedWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(defaultProps.estimatedWeight * 1.1))).toBeInTheDocument();
     // buttons
     expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { string, number, shape } from 'prop-types';
 import classnames from 'classnames';
-import { Button } from '@trussworks/react-uswds';
+
+import EditBillableWeight from '../EditBillableWeight/EditBillableWeight';
 
 import styles from './ShipmentCard.module.scss';
 
@@ -65,7 +66,7 @@ export default function ShipmentCard({
       <footer>
         <h3>Billable weight</h3>
         <span>{formatWeight(billableWeight)}</span>
-        <Button className={styles.editBtn}>Edit</Button>
+        <EditBillableWeight />
       </footer>
     </ShipmentContainer>
   );

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -64,9 +64,12 @@ export default function ShipmentCard({
         </div>
       </div>
       <footer>
-        <h3>Billable weight</h3>
-        <span>{formatWeight(billableWeight)}</span>
-        <EditBillableWeight />
+        <EditBillableWeight
+          title="Billable weight"
+          billableWeight={billableWeight}
+          originalWeight={originalWeight}
+          estimatedWeight={estimatedWeight}
+        />
       </footer>
     </ShipmentContainer>
   );

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
@@ -5,6 +5,10 @@
 .container {
   @include u-padding-x(0);
 
+  :global(.usa-button) {
+    width: fit-content;
+  }
+
   header {
     @include u-padding-x(2);
     @include u-padding-bottom(2);

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
@@ -71,9 +71,5 @@
       @include u-margin-bottom(1);
       font-size: 17px;
     }
-
-    .editBtn {
-      width: fit-content;
-    }
   }
 }


### PR DESCRIPTION
## Description

Creates `EditBillableWeight` storybook component

## Setup
`make storybook`
Search for `EditBillableWeight` component
Click `Edit` button
Should show alternate edit view
Click `Cancel` button
Should go back to Edit button view

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9257) for this change

## Screenshots

<img width="449" alt="Screen Shot 2021-08-27 at 11 06 17 AM" src="https://user-images.githubusercontent.com/13622298/131170407-e40a063e-cced-4e99-9b8f-ee2e35ea5172.png">
<img width="449" alt="Screen Shot 2021-08-27 at 11 06 34 AM" src="https://user-images.githubusercontent.com/13622298/131170452-b240b76c-d4a3-44d3-9280-1af58bf670a6.png">
<img width="420" alt="Screen Shot 2021-09-01 at 12 02 57 PM" src="https://user-images.githubusercontent.com/13622298/131728874-fca7ab22-9719-414e-af4f-840f1b2872ac.png">
