### PR TITLE
MB-7234 Removing fields from WebhookNotification payload

### DIFF
--- a/cmd/webhook-client/webhook/payloads.go
+++ b/cmd/webhook-client/webhook/payloads.go
@@ -11,11 +11,8 @@ import (
 // GetWebhookNotificationPayload converts Webhook Notification model to Payload using the definition in support API
 func GetWebhookNotificationPayload(model *models.WebhookNotification) *supportmessages.WebhookNotification {
 	payload := supportmessages.WebhookNotification{
-		ID:              *handlers.FmtUUID(model.ID),
 		EventKey:        model.EventKey,
 		Object:          swag.String(model.Payload),
-		CreatedAt:       *handlers.FmtDateTime(model.CreatedAt),
-		UpdatedAt:       *handlers.FmtDateTime(model.UpdatedAt),
 		ObjectID:        handlers.FmtUUIDPtr(model.ObjectID),
 		MoveTaskOrderID: handlers.FmtUUIDPtr(model.MoveTaskOrderID),
 	}


### PR DESCRIPTION
## Description

[There were errors][errors] being produced when these fields were passed for
WebhookNotifications, this was because these fields are considered
`readOnly` and after discussing it in #prac-engineering, it was decided
it's easier to modify the payload being sent than to restructure the
definitions for these fields.

[slack]: https://ustcdp3.slack.com/archives/CP6PTUPQF/p1630088202042000
[errors]: https://dp3.atlassian.net/browse/MB-7234?focusedCommentId=17281

The work here was done in part because of the acceptance testing for
[MB-7234][jira].
There was some updates that needed to be made for [documentation][docs] and to
the `bin/webhook-client` in order to properly perform the manual acceptance tests.

## Reviewer Notes

Follow [the documentation here][docs] to setup a Notification subscription as
the **Prime**. You will need to modify the `event_key` to match what we're
trying to test here. The SQL here has the proper `event_key` for shipment
reweigh requests.

```sql
INSERT INTO public.webhook_subscriptions
(id,subscriber_id,status,event_key,callback_url,created_at,updated_at)
VALUES
('5cd33db4-9441-4d2d-bd7c-f9efd9ce310c','5db13bb4-6d29-4bdb-bc81-262f4513ecf6',
'ACTIVE','Shipment.RequestReweigh','https://primelocal:9443/support/v1/webhook-notify',
'2020-08-24 18:31:29.171','2020-08-24 18:31:29.171');

```

[docs]: https://github.com/transcom/mymove/wiki/Acceptance-Testing-Notifications#1-creating-a-subscription-for-an-event

## Setup

You'll need to have four separate terminals running in order to test this code
properly. The testing of this code also does the acceptance testing for
[MB-7234][jira] which is pretty cool. So once this is reviewed, we can mark this
story as _Accepted_.

[jira]: https://dp3.atlassian.net/browse/MB-7234

### Terminal 1

Start the server:

```sh
make serve_run
```

### Terminal 2

Start the UI:

```sh
make client_run
```

### Terminal 3
Populate the database with data:

```sh
make db_dev_e2e_populate
```

### Terminal 4

Compile the `bin/webhook-client` locally:

```sh
rm -rvf bin/webhook-client && make bin/webhook-client
```

Start the `webhook-client` locally:

```sh
webhook-client webhook-notify --period 20 --insecure
```

### Manual steps in the browser

Once that's all setup, you will have to go into the Office app and login locally as a TOO. Then scroll down to an _Move Approved_ and select _Move Task Order_. After you're on the _Move task order_ screen, you will scroll down and see the text _Request Reweigh_ near the title **Shipment weight**. Click the link _Request reweigh_ and your **Terminal 4** from above will include output showing a successful `200 OK` for the notification request.

## Code Review Verification Steps

* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story][jira] for this change
* [Conversation in Slack][slack] explains more about the approach used.
