### PR TITLE
MB-8767 Selectable Card Selected State - color contrast

### DIFF
--- a/src/components/Customer/SelectableCard.module.scss
+++ b/src/components/Customer/SelectableCard.module.scss
@@ -3,11 +3,11 @@
 @import '../../shared/styles/colors';
 @import '../../shared/styles/_variables';
 
-p + .cardContainer {
+p+.cardContainer {
   margin-top: 0px;
 }
 
-.cardContainer + .cardContainer {
+.cardContainer+.cardContainer {
   @include u-margin-top('105');
 }
 
@@ -80,6 +80,10 @@ p + .cardContainer {
     background-color: $info-light;
     border: 2px solid $base-lighter;
     @include u-padding-bottom('205');
+
+    & :global(.usa-checkbox__label-description) {
+      color: $base-dark;
+    }
   }
 
   :global(.usa-radio__input--tile + .usa-radio__label) {


### PR DESCRIPTION
## Description

This branch darkens the description text on the selectable card only in the selected state to account for the darkened background to meet color contrast standards, and provide further visual difference between the selected and unselected sate without relying on color.

## Reviewer Notes

nope!

## Setup

```sh
yarn storybook
```
http://localhost:6006/?path=/story/customer-components-selectablecard--selected

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8767?atlOrigin=eyJpIjoiZmU1NDk4ZWZhOWI3NDE1ZTk2ZjJiNGRkNzZjNzliYzEiLCJwIjoiaiJ9) for this change

## Screenshots
<img width="935" alt="image" src="https://user-images.githubusercontent.com/59394696/131400340-0019df3f-eccb-4653-8b02-f6fd5aaebef5.png">
