### PR TITLE
MB-9315 clean up ContactInfo.test.jsx console logs

### DIFF
--- a/src/pages/MyMove/Profile/ContactInfo.test.jsx
+++ b/src/pages/MyMove/Profile/ContactInfo.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -34,17 +33,14 @@ describe('ContactInfo page', () => {
 
   it('renders the ContactInfoForm', async () => {
     render(<ContactInfo {...testProps} />);
-    expect(screen.getByRole('heading', { name: 'Your contact info', level: 1 })).toBeInTheDocument();
-    // await waitFor(() => {
-    //   expect(screen.queryByRole('heading', { name: 'Your contact info', level: 1 })).toBeInTheDocument();
-    // });
+    expect(await screen.findByRole('heading', { name: 'Your contact info', level: 1 })).toBeInTheDocument();
   });
 
   it('back button goes to the NAME step', async () => {
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
     render(<ContactInfo {...testProps} serviceMember={testServiceMemberValues} />);
 
-    const backButton = screen.queryByText('Back');
+    const backButton = screen.getByRole('button', { name: 'Back' });
     expect(backButton).toBeInTheDocument();
     userEvent.click(backButton);
 
@@ -59,7 +55,7 @@ describe('ContactInfo page', () => {
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
     render(<ContactInfo {...testProps} serviceMember={testServiceMemberValues} />);
 
-    const submitButton = screen.queryByText('Next');
+    const submitButton = screen.getByRole('button', { name: 'Next' });
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
 
@@ -86,9 +82,9 @@ describe('ContactInfo page', () => {
     );
 
     // Need to provide complete & valid initial values because we aren't testing the form here, and just want to submit immediately
-    const { queryByText } = render(<ContactInfo {...testProps} serviceMember={testServiceMemberValues} />);
+    render(<ContactInfo {...testProps} serviceMember={testServiceMemberValues} />);
 
-    const submitButton = queryByText('Next');
+    const submitButton = screen.getByRole('button', { name: 'Next' });
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
 
@@ -96,7 +92,7 @@ describe('ContactInfo page', () => {
       expect(patchServiceMember).toHaveBeenCalled();
     });
 
-    expect(queryByText('A server error occurred saving the service member')).toBeInTheDocument();
+    expect(screen.queryByText('A server error occurred saving the service member')).toBeInTheDocument();
     expect(testProps.updateServiceMember).not.toHaveBeenCalled();
     expect(testProps.push).not.toHaveBeenCalled();
   });
@@ -153,10 +149,8 @@ describe('requireCustomerState ContactInfo', () => {
     const h1 = screen.getByRole('heading', { name: 'Your contact info', level: 1 });
     expect(h1).toBeInTheDocument();
 
-    // const action = mockDispatch('/service-member/name');
-    // console.log(action);
     await waitFor(async () => {
-      await expect(mockDispatch).toHaveBeenCalledWith('/service-member/name');
+      await expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/name'));
     });
   });
 
@@ -244,7 +238,7 @@ describe('requireCustomerState ContactInfo', () => {
     });
   });
 
-  it('does redirect if the profile is complete', () => {
+  it('does redirect if the profile is complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -293,6 +287,8 @@ describe('requireCustomerState ContactInfo', () => {
     const h1 = screen.getByRole('heading', { name: 'Your contact info', level: 1 });
     expect(h1).toBeInTheDocument();
 
-    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    await waitFor(async () => {
+      await expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    });
   });
 });

--- a/src/pages/MyMove/Profile/ContactInfo.test.jsx
+++ b/src/pages/MyMove/Profile/ContactInfo.test.jsx
@@ -45,7 +45,7 @@ describe('ContactInfo page', () => {
     userEvent.click(backButton);
 
     await waitFor(async () => {
-      await expect(testProps.push).toHaveBeenCalledWith('/service-member/name');
+      expect(testProps.push).toHaveBeenCalledWith('/service-member/name');
     });
   });
 
@@ -150,7 +150,7 @@ describe('requireCustomerState ContactInfo', () => {
     expect(h1).toBeInTheDocument();
 
     await waitFor(async () => {
-      await expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/name'));
+      expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/name'));
     });
   });
 
@@ -186,7 +186,7 @@ describe('requireCustomerState ContactInfo', () => {
     expect(h1).toBeInTheDocument();
 
     await waitFor(async () => {
-      await expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
   it('does not redirect if the current state is after the "NAME COMPLETE" state and profile is not complete', async () => {
@@ -234,7 +234,7 @@ describe('requireCustomerState ContactInfo', () => {
     expect(h1).toBeInTheDocument();
 
     await waitFor(async () => {
-      await expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 
@@ -288,7 +288,7 @@ describe('requireCustomerState ContactInfo', () => {
     expect(h1).toBeInTheDocument();
 
     await waitFor(async () => {
-      await expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+      expect(mockDispatch).toHaveBeenCalledWith(push('/'));
     });
   });
 });


### PR DESCRIPTION
## Description

We're trying to clean up all the warning messages that are logged by the tests so that people can actually know when things are wrong rather than ignoring the flood of messages.

This pr is to fix the messages coming out of src/pages/MyMove/Profile/ContactInfo.test.jsx

## Setup

```sh
yarn test Profile/ContactInfo.test.jsx
```

## Code Review Verification Steps


* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9315) for this change

## Screenshots

<img width="956" alt="Screen Shot 2021-09-02 at 10 31 44 AM" src="https://user-images.githubusercontent.com/14057912/131873085-7fcae366-0300-475f-a826-6dc57d7d9568.png">
