### PR TITLE
MB-7449: stop deploying to niprnet on ecs in stg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1971,21 +1971,7 @@ workflows:
             branches:
               only: master
 
-      - deploy_stg_app_niprnet:
-          requires:
-            - deploy_stg_migrations
-          filters:
-            branches:
-              only: master
-
       - deploy_stg_app_client_tls:
-          requires:
-            - deploy_stg_migrations
-          filters:
-            branches:
-              only: master
-
-      - deploy_stg_app_client_tls_niprnet:
           requires:
             - deploy_stg_migrations
           filters:
@@ -2004,9 +1990,7 @@ workflows:
           requires:
             - deploy_stg_tasks
             - deploy_stg_app
-            - deploy_stg_app_niprnet
             - deploy_stg_app_client_tls
-            - deploy_stg_app_client_tls_niprnet
             - deploy_stg_webhook_client
 
       - deploy_storybook_dp3:


### PR DESCRIPTION
## Description

Stop deploying the NIPRNet ECS tasks. The underlying infrastructure is in flux, so these deployments will likely become unstable. Therefore, to avoid impacting engineers, I'm removing the deployment when merging to master.

## Setup

Look at CircleCI after merging to master.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7449) for this change