### PR TITLE
[MB-8787] Auto reweigh request check when prime updates shipment actual weight

### DIFF
--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -205,7 +205,7 @@ func NewGhcAPIHandler(ctx handlers.HandlerContext) *ghcops.MymoveAPI {
 			fetch.NewFetcher(queryBuilder),
 			ctx.Planner(),
 			moveRouter,
-			move.NewMoveWeights(),
+			move.NewMoveWeights(mtoshipment.NewShipmentReweighRequester()),
 		),
 	}
 

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -668,7 +668,7 @@ func (h RequestShipmentReweighHandler) Handle(params shipmentops.RequestShipment
 	}
 
 	shipmentID := uuid.FromStringOrNil(params.ShipmentID.String())
-	reweigh, err := h.RequestShipmentReweigh(appCtx, shipmentID)
+	reweigh, err := h.RequestShipmentReweigh(appCtx, shipmentID, models.ReweighRequesterTOO)
 
 	if err != nil {
 		logger.Error("ghcapi.RequestShipmentReweighHandler", zap.Error(err))

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -1403,7 +1403,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			HTTPRequest: req,
 			ShipmentID:  *handlers.FmtUUID(shipment.ID),
 		}
-		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(nil, services.NotFoundError{})
+		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID, models.ReweighRequesterTOO).Return(nil, services.NotFoundError{})
 
 		response := handler.Handle(params)
 		suite.IsType(&shipmentops.RequestShipmentReweighNotFound{}, response)
@@ -1427,7 +1427,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			ShipmentID:  *handlers.FmtUUID(shipment.ID),
 		}
 
-		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(nil, services.ConflictError{})
+		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID, models.ReweighRequesterTOO).Return(nil, services.ConflictError{})
 
 		response := handler.Handle(params)
 		suite.IsType(&shipmentops.RequestShipmentReweighConflict{}, response)
@@ -1450,7 +1450,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			HTTPRequest: req,
 			ShipmentID:  *handlers.FmtUUID(shipment.ID),
 		}
-		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(nil, services.InvalidInputError{ValidationErrors: &validate.Errors{}})
+		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID, models.ReweighRequesterTOO).Return(nil, services.InvalidInputError{ValidationErrors: &validate.Errors{}})
 
 		response := handler.Handle(params)
 		suite.IsType(&shipmentops.RequestShipmentReweighUnprocessableEntity{}, response)
@@ -1474,7 +1474,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			ShipmentID:  *handlers.FmtUUID(shipment.ID),
 		}
 
-		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID).Return(nil, errors.New("UnexpectedError"))
+		reweighRequester.On("RequestShipmentReweigh", mock.AnythingOfType("*appcontext.appContext"), shipment.ID, models.ReweighRequesterTOO).Return(nil, errors.New("UnexpectedError"))
 
 		response := handler.Handle(params)
 		suite.IsType(&shipmentops.RequestShipmentReweighInternalServerError{}, response)

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -1780,7 +1780,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mock.Anything,
 	).Return(400, nil)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	suite.Run("Successful PATCH - Integration Test", func() {
 		builder := query.NewQueryBuilder()

--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -145,7 +145,7 @@ func NewInternalAPI(ctx handlers.HandlerContext) *internalops.MymoveAPI {
 
 	internalAPI.MtoShipmentUpdateMTOShipmentHandler = UpdateMTOShipmentHandler{
 		ctx,
-		mtoshipment.NewMTOShipmentUpdater(builder, fetcher, ctx.Planner(), moveRouter, move.NewMoveWeights()),
+		mtoshipment.NewMTOShipmentUpdater(builder, fetcher, ctx.Planner(), moveRouter, move.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())),
 	}
 
 	internalAPI.MtoShipmentListMTOShipmentsHandler = ListMTOShipmentsHandler{

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -402,7 +402,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		mock.Anything,
 	).Return(400, nil)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	suite.Run("Successful PATCH - Integration Test", func() {
 		builder := query.NewQueryBuilder()

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -34,7 +34,7 @@ func NewPrimeAPIHandler(ctx handlers.HandlerContext) http.Handler {
 	primeAPI := primeops.NewMymoveAPI(primeSpec)
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := move.NewMoveRouter()
-	moveWeights := move.NewMoveWeights()
+	moveWeights := move.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	primeAPI.ServeError = handlers.ServeCustomError
 

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -350,7 +350,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 	context.SetPlanner(planner)
@@ -773,7 +773,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressLogic() {
 		mock.Anything,
 	).Return(400, nil)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
@@ -928,7 +928,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 
@@ -1379,7 +1379,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 	context.SetPlanner(planner)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	handler := UpdateMTOShipmentStatusHandler{
 		context,

--- a/pkg/services/mocks/MoveWeights.go
+++ b/pkg/services/mocks/MoveWeights.go
@@ -18,6 +18,20 @@ type MoveWeights struct {
 	mock.Mock
 }
 
+// CheckAutoReweigh provides a mock function with given fields: appCtx, moveID, updatedShipment
+func (_m *MoveWeights) CheckAutoReweigh(appCtx appcontext.AppContext, moveID uuid.UUID, updatedShipment *models.MTOShipment) error {
+	ret := _m.Called(appCtx, moveID, updatedShipment)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, *models.MTOShipment) error); ok {
+		r0 = rf(appCtx, moveID, updatedShipment)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CheckExcessWeight provides a mock function with given fields: appCtx, moveID, updatedShipment
 func (_m *MoveWeights) CheckExcessWeight(appCtx appcontext.AppContext, moveID uuid.UUID, updatedShipment models.MTOShipment) (*models.Move, *validate.Errors, error) {
 	ret := _m.Called(appCtx, moveID, updatedShipment)

--- a/pkg/services/mocks/ShipmentReweighRequester.go
+++ b/pkg/services/mocks/ShipmentReweighRequester.go
@@ -16,13 +16,13 @@ type ShipmentReweighRequester struct {
 	mock.Mock
 }
 
-// RequestShipmentReweigh provides a mock function with given fields: appCtx, shipmentID
-func (_m *ShipmentReweighRequester) RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID) (*models.Reweigh, error) {
-	ret := _m.Called(appCtx, shipmentID)
+// RequestShipmentReweigh provides a mock function with given fields: appCtx, shipmentID, requestor
+func (_m *ShipmentReweighRequester) RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID, requestor models.ReweighRequester) (*models.Reweigh, error) {
+	ret := _m.Called(appCtx, shipmentID, requestor)
 
 	var r0 *models.Reweigh
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID) *models.Reweigh); ok {
-		r0 = rf(appCtx, shipmentID)
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, models.ReweighRequester) *models.Reweigh); ok {
+		r0 = rf(appCtx, shipmentID, requestor)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Reweigh)
@@ -30,8 +30,8 @@ func (_m *ShipmentReweighRequester) RequestShipmentReweigh(appCtx appcontext.App
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext, uuid.UUID) error); ok {
-		r1 = rf(appCtx, shipmentID)
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, uuid.UUID, models.ReweighRequester) error); ok {
+		r1 = rf(appCtx, shipmentID, requestor)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/move.go
+++ b/pkg/services/move.go
@@ -42,4 +42,5 @@ type MoveRouter interface {
 //go:generate mockery --name MoveWeights --disable-version-string
 type MoveWeights interface {
 	CheckExcessWeight(appCtx appcontext.AppContext, moveID uuid.UUID, updatedShipment models.MTOShipment) (*models.Move, *validate.Errors, error)
+	CheckAutoReweigh(appCtx appcontext.AppContext, moveID uuid.UUID, updatedShipment *models.MTOShipment) error
 }

--- a/pkg/services/move/move_weights_test.go
+++ b/pkg/services/move/move_weights_test.go
@@ -437,29 +437,25 @@ func (suite *MoveServiceSuite) TestAutoReweigh() {
 		mockedReweighRequestor.AssertNotCalled(suite.T(), "RequestShipmentReweigh")
 	})
 
-	/*
-		suite.Run("returns error if orders grade is unset to lookup weight allowance", func() {
-			approvedMove := testdatagen.MakeAvailableMove(suite.DB())
-			approvedMove.Orders.Grade = nil
+	suite.Run("returns error if orders grade is unset to lookup weight allowance", func() {
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+		approvedMove.Orders.Grade = nil
 
-			err := suite.DB().Save(&approvedMove.Orders)
-			suite.NoError(err)
+		err := suite.DB().Save(&approvedMove.Orders)
+		suite.NoError(err)
 
-			_, verrs, err := moveWeights.CheckExcessWeight(suite.TestAppContext(), approvedMove.ID, models.MTOShipment{})
-			suite.Nil(verrs)
-			suite.EqualError(err, "could not determine excess weight entitlement without grade")
-		})
+		err = moveWeights.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &models.MTOShipment{})
+		suite.EqualError(err, "could not determine excess weight entitlement without grade")
+	})
 
-		suite.Run("returns error if dependents authorized is unset to lookup weight allowance", func() {
-			approvedMove := testdatagen.MakeAvailableMove(suite.DB())
-			approvedMove.Orders.Entitlement.DependentsAuthorized = nil
+	suite.Run("returns error if dependents authorized is unset to lookup weight allowance", func() {
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+		approvedMove.Orders.Entitlement.DependentsAuthorized = nil
 
-			err := suite.DB().Save(approvedMove.Orders.Entitlement)
-			suite.NoError(err)
+		err := suite.DB().Save(approvedMove.Orders.Entitlement)
+		suite.NoError(err)
 
-			_, verrs, err := moveWeights.CheckExcessWeight(suite.TestAppContext(), approvedMove.ID, models.MTOShipment{})
-			suite.Nil(verrs)
-			suite.EqualError(err, "could not determine excess weight entitlement without dependents authorization value")
-		})
-	*/
+		err = moveWeights.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &models.MTOShipment{})
+		suite.EqualError(err, "could not determine excess weight entitlement without dependents authorization value")
+	})
 }

--- a/pkg/services/move/move_weights_test.go
+++ b/pkg/services/move/move_weights_test.go
@@ -3,13 +3,18 @@ package move
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/services/mocks"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *MoveServiceSuite) TestExcessWeight() {
-	moveWeights := NewMoveWeights()
+	moveWeights := NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	suite.Run("qualifies move for excess weight when an approved shipment estimated weight is updated within threshold", func() {
 		// The default weight allotment for this move is 8000 and the threshold is 90% of that
@@ -235,4 +240,226 @@ func (suite *MoveServiceSuite) TestExcessWeight() {
 		suite.Nil(verrs)
 		suite.EqualError(err, "could not determine excess weight entitlement without dependents authorization value")
 	})
+}
+
+func (suite *MoveServiceSuite) TestAutoReweigh() {
+	moveWeights := NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
+
+	suite.Run("requests reweigh on shipment if the acutal weight is 90% of the weight allowance", func() {
+		// The default weight allotment for this move is 8000 and the threshold is 90% of that
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+		now := time.Now()
+		pickupDate := now.AddDate(0, 0, 10)
+		approvedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+			},
+			Move: approvedMove,
+		})
+
+		actualWeight := unit.Pound(7200)
+		approvedShipment.PrimeActualWeight = &actualWeight
+		err := moveWeights.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &approvedShipment)
+
+		suite.NoError(err)
+
+		suite.NotNil(approvedShipment.Reweigh)
+		suite.Equal(approvedShipment.ID.String(), approvedShipment.Reweigh.ShipmentID.String())
+		suite.Equal(models.ReweighRequesterSystem, approvedShipment.Reweigh.RequestedBy)
+		suite.NotNil(approvedShipment.Reweigh.RequestedAt)
+	})
+
+	suite.Run("does not request reweigh on shipments when below 90% of weight allowance threshold", func() {
+		mockedReweighRequestor := mocks.ShipmentReweighRequester{}
+		mockedWeightService := NewMoveWeights(&mockedReweighRequestor)
+
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+
+		now := time.Now()
+		pickupDate := now.AddDate(0, 0, 10)
+		approvedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+			},
+			Move: approvedMove,
+		})
+
+		actualWeight := unit.Pound(7199)
+		approvedShipment.PrimeEstimatedWeight = &actualWeight
+		err := mockedWeightService.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &approvedShipment)
+
+		suite.NoError(err)
+		suite.Equal(uuid.Nil, approvedShipment.Reweigh.ID)
+		mockedReweighRequestor.AssertNotCalled(suite.T(), "RequestShipmentReweigh")
+	})
+
+	suite.Run("requests reweigh on existing shipments in addition to the one being updated", func() {
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+
+		now := time.Now()
+		pickupDate := now.AddDate(0, 0, 10)
+		actualWeight := unit.Pound(3600)
+
+		existingShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+				PrimeActualWeight:   &actualWeight,
+			},
+			Move: approvedMove,
+		})
+
+		approvedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+			},
+			Move: approvedMove,
+		})
+
+		approvedShipment.PrimeActualWeight = &actualWeight
+		err := moveWeights.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &approvedShipment)
+
+		suite.NoError(err)
+
+		suite.NotNil(approvedShipment.Reweigh)
+		suite.NotEqual(uuid.Nil, approvedShipment.Reweigh.ID)
+		suite.Equal(approvedShipment.ID, approvedShipment.Reweigh.ShipmentID)
+		suite.Equal(models.ReweighRequesterSystem, approvedShipment.Reweigh.RequestedBy)
+
+		err = suite.DB().Eager("Reweigh").Reload(&existingShipment)
+		suite.NoError(err)
+
+		suite.NotNil(existingShipment.Reweigh)
+		suite.NotEqual(uuid.Nil, existingShipment.Reweigh.ID)
+		suite.Equal(existingShipment.ID, existingShipment.Reweigh.ShipmentID)
+		suite.Equal(models.ReweighRequesterSystem, existingShipment.Reweigh.RequestedBy)
+	})
+
+	suite.Run("does not request reweigh when shipments aren't in approved statuses", func() {
+		mockedReweighRequestor := mocks.ShipmentReweighRequester{}
+		mockedWeightService := NewMoveWeights(&mockedReweighRequestor)
+
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+		now := time.Now()
+		pickupDate := now.AddDate(0, 0, 10)
+		actualWeight := unit.Pound(3600)
+
+		existingShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusCanceled,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+				PrimeActualWeight:   &actualWeight,
+			},
+			Move: approvedMove,
+		})
+		approvedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+			},
+			Move: approvedMove,
+		})
+
+		approvedShipment.PrimeActualWeight = &actualWeight
+		err := mockedWeightService.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &approvedShipment)
+
+		suite.NoError(err)
+
+		err = suite.DB().Eager("Reweigh").Reload(&existingShipment)
+		suite.NoError(err)
+		suite.Equal(uuid.Nil, existingShipment.Reweigh.ID)
+		suite.Equal(uuid.Nil, approvedShipment.Reweigh.ID)
+		mockedReweighRequestor.AssertNotCalled(suite.T(), "RequestShipmentReweigh")
+	})
+
+	suite.Run("uses lower reweigh weight on shipments that already have reweighs", func() {
+		mockedReweighRequestor := mocks.ShipmentReweighRequester{}
+		mockedWeightService := NewMoveWeights(&mockedReweighRequestor)
+		approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+
+		now := time.Now()
+		pickupDate := now.AddDate(0, 0, 10)
+		actualWeight := unit.Pound(2400)
+		existingShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+				PrimeActualWeight:   &actualWeight,
+			},
+			Move: approvedMove,
+		})
+
+		reweighedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+				PrimeActualWeight:   &actualWeight,
+			},
+			Move: approvedMove,
+		})
+		reweighWeight := unit.Pound(2399)
+		testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{
+			Reweigh: models.Reweigh{
+				Weight: &reweighWeight,
+			},
+			MTOShipment: reweighedShipment,
+		})
+
+		approvedShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				Status:              models.MTOShipmentStatusApproved,
+				ApprovedDate:        &now,
+				ScheduledPickupDate: &pickupDate,
+			},
+			Move: approvedMove,
+		})
+
+		approvedShipment.PrimeActualWeight = &actualWeight
+		err := mockedWeightService.CheckAutoReweigh(suite.TestAppContext(), approvedMove.ID, &approvedShipment)
+
+		suite.NoError(err)
+
+		err = suite.DB().Eager("Reweigh").Reload(&existingShipment)
+		suite.NoError(err)
+		suite.Equal(uuid.Nil, existingShipment.Reweigh.ID)
+		suite.Equal(uuid.Nil, approvedShipment.Reweigh.ID)
+		mockedReweighRequestor.AssertNotCalled(suite.T(), "RequestShipmentReweigh")
+	})
+
+	/*
+		suite.Run("returns error if orders grade is unset to lookup weight allowance", func() {
+			approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+			approvedMove.Orders.Grade = nil
+
+			err := suite.DB().Save(&approvedMove.Orders)
+			suite.NoError(err)
+
+			_, verrs, err := moveWeights.CheckExcessWeight(suite.TestAppContext(), approvedMove.ID, models.MTOShipment{})
+			suite.Nil(verrs)
+			suite.EqualError(err, "could not determine excess weight entitlement without grade")
+		})
+
+		suite.Run("returns error if dependents authorized is unset to lookup weight allowance", func() {
+			approvedMove := testdatagen.MakeAvailableMove(suite.DB())
+			approvedMove.Orders.Entitlement.DependentsAuthorized = nil
+
+			err := suite.DB().Save(approvedMove.Orders.Entitlement)
+			suite.NoError(err)
+
+			_, verrs, err := moveWeights.CheckExcessWeight(suite.TestAppContext(), approvedMove.ID, models.MTOShipment{})
+			suite.Nil(verrs)
+			suite.EqualError(err, "could not determine excess weight entitlement without dependents authorization value")
+		})
+	*/
 }

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -58,7 +58,7 @@ type ShipmentCancellationRequester interface {
 //ShipmentReweighRequester is the service object interface for approving a shipment diversion
 //go:generate mockery --name ShipmentReweighRequester --disable-version-string
 type ShipmentReweighRequester interface {
-	RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID) (*models.Reweigh, error)
+	RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID, requestor models.ReweighRequester) (*models.Reweigh, error)
 }
 
 // MTOShipmentStatusUpdater is the exported interface for updating an MTO shipment status

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -421,6 +421,15 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 			}
 		}
 
+		if newShipment.PrimeActualWeight != nil {
+			if dbShipment.PrimeActualWeight == nil || *newShipment.PrimeActualWeight != *dbShipment.PrimeActualWeight {
+				err := f.moveWeights.CheckAutoReweigh(txnAppCtx, dbShipment.MoveTaskOrderID, newShipment)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// A diverted shipment gets set to the SUBMITTED status automatically:
 		if !dbShipment.Diversion && newShipment.Diversion {
 			newShipment.Status = models.MTOShipmentStatusSubmitted

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -1108,6 +1108,8 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 		actualWeight := unit.Pound(7200)
 		primeShipment.PrimeActualWeight = &actualWeight
 
+		moveWeights.On("CheckAutoReweigh", mock.AnythingOfType("*appcontext.appContext"), primeShipment.MoveTaskOrderID, mock.AnythingOfType("*models.MTOShipment")).Return(nil)
+
 		suite.Nil(primeShipment.MoveTaskOrder.ExcessWeightQualifiedAt)
 
 		_, err := mockedUpdater.UpdateMTOShipmentPrime(suite.TestAppContext(), &primeShipment, etag.GenerateEtag(primeShipment.UpdatedAt))

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -49,7 +49,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		mock.Anything,
 	).Return(500, nil)
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(NewShipmentReweighRequester())
 	mtoShipmentUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 
 	requestedPickupDate := *oldMTOShipment.RequestedPickupDate
@@ -1011,7 +1011,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 	fetcher := fetch.NewFetcher(builder)
 	planner := &mocks.Planner{}
 	moveRouter := moverouter.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(NewShipmentReweighRequester())
 	updater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 
 	suite.T().Run("Shipment exists and is available to Prime - success", func(t *testing.T) {
@@ -1051,7 +1051,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 	fetcher := fetch.NewFetcher(builder)
 	planner := &mocks.Planner{}
 	moveRouter := moveservices.NewMoveRouter()
-	moveWeights := moveservices.NewMoveWeights()
+	moveWeights := moveservices.NewMoveWeights(NewShipmentReweighRequester())
 	updater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights)
 
 	suite.T().Run("Updating the shipment estimated weight will flag excess weight on the move and transitions move status", func(t *testing.T) {

--- a/pkg/services/mto_shipment/shipment_reweigh_requester.go
+++ b/pkg/services/mto_shipment/shipment_reweigh_requester.go
@@ -20,13 +20,13 @@ func NewShipmentReweighRequester() services.ShipmentReweighRequester {
 }
 
 // RequestShipmentReweigh Requests the shipment reweigh
-func (f *shipmentReweighRequester) RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID) (*models.Reweigh, error) {
+func (f *shipmentReweighRequester) RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID, requester models.ReweighRequester) (*models.Reweigh, error) {
 	shipment, err := f.findShipment(appCtx, shipmentID)
 	if err != nil {
 		return nil, err
 	}
 
-	reweigh, err := f.createReweigh(appCtx, shipment, checkReweighAllowed())
+	reweigh, err := f.createReweigh(appCtx, shipment, requester, checkReweighAllowed())
 
 	return reweigh, err
 }
@@ -47,14 +47,14 @@ func (f *shipmentReweighRequester) findShipment(appCtx appcontext.AppContext, sh
 	return &shipment, nil
 }
 
-func (f *shipmentReweighRequester) createReweigh(appCtx appcontext.AppContext, shipment *models.MTOShipment, checks ...validator) (*models.Reweigh, error) {
+func (f *shipmentReweighRequester) createReweigh(appCtx appcontext.AppContext, shipment *models.MTOShipment, requester models.ReweighRequester, checks ...validator) (*models.Reweigh, error) {
 	if verr := validateShipment(appCtx, shipment, shipment, checks...); verr != nil {
 		return nil, verr
 	}
 
 	now := time.Now()
 	reweigh := models.Reweigh{
-		RequestedBy: models.ReweighRequesterTOO,
+		RequestedBy: requester,
 		RequestedAt: now,
 		ShipmentID:  shipment.ID,
 	}

--- a/pkg/services/mto_shipment/shipment_reweigh_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_reweigh_requester_test.go
@@ -23,7 +23,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentReweigh() {
 		})
 		fetchedShipment := models.MTOShipment{}
 
-		reweigh, err := requester.RequestShipmentReweigh(suite.TestAppContext(), shipment.ID)
+		reweigh, err := requester.RequestShipmentReweigh(suite.TestAppContext(), shipment.ID, models.ReweighRequesterTOO)
 
 		suite.NoError(err)
 		suite.Equal(shipment.MoveTaskOrderID, reweigh.Shipment.MoveTaskOrderID)
@@ -46,7 +46,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentReweigh() {
 			},
 		})
 
-		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), rejectedShipment.ID)
+		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), rejectedShipment.ID, models.ReweighRequesterTOO)
 
 		suite.Error(err)
 		suite.IsType(services.ConflictError{}, err)
@@ -57,7 +57,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentReweigh() {
 		reweigh := testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{})
 		existingShipment := reweigh.Shipment
 
-		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), existingShipment.ID)
+		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), existingShipment.ID, models.ReweighRequesterTOO)
 
 		suite.Error(err)
 		suite.IsType(services.ConflictError{}, err)
@@ -67,7 +67,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestShipmentReweigh() {
 	suite.T().Run("Passing in a bad shipment id returns a Not Found error", func(t *testing.T) {
 		badShipmentID := uuid.FromStringOrNil("424d930b-cf8d-4c10-8059-be8a25ba952a")
 
-		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), badShipmentID)
+		_, err := requester.RequestShipmentReweigh(suite.TestAppContext(), badShipmentID, models.ReweighRequesterTOO)
 
 		suite.Error(err)
 		suite.IsType(services.NotFoundError{}, err)


### PR DESCRIPTION
## Description

This PR adds functionality that auto requests a reweigh for all shipments of a move if the actual weight is updated and the sum reaches 90% of the weight allowance.

It assumes the shipment has already been approved (not cancelled or a diversion kicked back to submitted) and visible on the MTO page.

The weight sum will take the lower of the actual weight and reweigh weight for a shipment (of the shipment being updated or another shipment on the move) when doing the calculation.

## Reviewer Notes

Should we modify the Prime shipment response payloads to include the reweigh object?  It seems to not be included but maybe that work is being done elsewhere?

There is no hard constraint that the actual weight has to be updated before the reweigh weight to my knowledge but I'm not sure that would happen in practice?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the TOO user
2. Locate the move with locator `INXSWT` and select it from the queue
3. Approve both shipments on the move with a basic service item making it available to the prime.
4. Either from the dev console or from the prime API grab one of the shipment ids from the move.
5. Make a PATCH request using the `updateMTOShipment` prime endpoint, setting the mtoShipmentID var in the path and the If-Match header.  The PATCH request JSON body should set the PrimeActualWeight to 90% of the weight allowance (8,000 lbs)
6. Navigate to the Move Task Order page and observe the shipment with the actual weight of 7200 displayed and tags that both shipments now have reweigh requests

![Screen Shot 2021-09-03 at 11 27 11 AM](https://user-images.githubusercontent.com/52669884/132030176-3cb0ebbb-f9a5-4f58-848c-64dca8f2aca4.png)

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-8787) for this change

## Screenshots

![Screen Shot 2021-09-03 at 10 03 00 AM](https://user-images.githubusercontent.com/52669884/132021489-3c9593ef-cc21-4fe1-ae6d-f2e9bd3b68c4.png)
![Screen Shot 2021-09-03 at 10 03 11 AM](https://user-images.githubusercontent.com/52669884/132021504-4c187e94-e933-44aa-a3d2-518254415c91.png)
