### PR TITLE
Add in git-attributes for generated files;

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# README: https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes
+
+# Generated Golang files by `make server_generate`
+pkg/gen/**/* binary
+
+# Generated Swagger files by `yarn build-redoc`
+swagger/*.yaml binary


### PR DESCRIPTION
## Description

It's best practice to treat generated files as if they were binary files
so that they don't show up when you perform a `git diff` on changed
files.

## Reviewer Notes

n/a

## Setup

Make a change to any of the files in `pkg/gen` or any of the Yaml files in `swagger/` and then run `git diff` and you will see that they do not produce a visual diff and Git reports back that they are binary files.

## References

* [See other PR](https://github.com/transcom/mymove/pull/7145) for this change

## Screenshot

![5locd9](https://user-images.githubusercontent.com/706004/132068196-8e258a6b-6725-419c-82c8-64c95dba0d61.jpg)
