### PR TITLE
MB-9408: add ability to exclude cves

### DIFF
--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -62,6 +62,6 @@ fi
 if [[ "${numberOfValidFindings}" -gt 0 ]]; then
   echo "Scan found ${numberOfValidFindings} findings!"
   exit 1
-elif [[ "${numberOfValidFindings}" -ne  "${totalNumberOfFindings}" ]]; then
+elif [[ "${numberOfValidFindings}" -ne "${totalNumberOfFindings}" ]]; then
   echo "Scan found findings, but excluded one or more them."
 fi

--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -15,11 +15,36 @@ repoName=$1
 gitCommit=$2
 
 get_findings() {
+  # Get the findings reported by ECR.
   findings=$(aws ecr describe-image-scan-findings --repository-name "${repoName}" --image-id "imageTag=\"git-${gitCommit}\"")
   echo "${findings}" | jq .
   echo
+
+  # Save the status of the scan.
   status=$(echo "${findings}" | jq -r ".imageScanStatus.status")
-  numberOfFindings=$(echo "${findings}" | jq -r ".imageScanFindings.findings | length")
+
+  # Extract the findings array. If it is null, set it to an empty array.
+  findingsArray=$(echo "${findings}" | jq .imageScanFindings.findings)
+  if [[ "${findingsArray}" == "null" ]]; then
+    findingsArray='[]'
+  fi
+
+  # Exclude certain findings.
+  #
+  # ID: CVE-2020-28928
+  # Ticket to remove this exclusion: https://dp3.atlassian.net/browse/MB-9408
+  # Description:
+  # https://github.com/aws/containers-roadmap/issues/1388
+  # ECR reports falso positives for this vulnerability. This is a
+  # non-actionableb finding outside of our control, so we are excluding it from
+  # our scans.
+  validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-2020-28928"))')
+
+  # Save the total number of findings.
+  totalNumberOfFindings=$(echo "${findings}" | jq -r ". | length")
+
+  # Save the number of valid scan findings.
+  numberOfValidFindings=$(echo "${validFindings}" | jq -r ". | length")
 }
 
 # Get the results of the scan or wait until they are ready
@@ -34,7 +59,9 @@ if [[ "${status}" != *COMPLETE* ]]; then
   exit 1
 fi
 
-if [[ "${numberOfFindings}" -gt 0 ]]; then
-  echo "Scan found ${numberOfFindings} findings!"
+if [[ "${numberOfValidFindings}" -gt 0 ]]; then
+  echo "Scan found ${numberOfValidFindings} findings!"
   exit 1
+elif [[ "${numberOfValidFindings}" -ne  "${totalNumberOfFindings}" ]]; then
+  echo "Scan found findings, but excluded one or more them."
 fi

--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -36,7 +36,7 @@ get_findings() {
   # Description:
   # https://github.com/aws/containers-roadmap/issues/1388
   # ECR reports falso positives for this vulnerability. This is a
-  # non-actionableb finding outside of our control, so we are excluding it from
+  # non-actionable finding outside of our control, so we are excluding it from
   # our scans.
   validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-2020-28928"))')
 

--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -41,7 +41,7 @@ get_findings() {
   validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-2020-28928"))')
 
   # Save the total number of findings.
-  totalNumberOfFindings=$(echo "${findings}" | jq -r ". | length")
+  totalNumberOfFindings=$(echo "${findingsArray}" | jq -r ". | length")
 
   # Save the number of valid scan findings.
   numberOfValidFindings=$(echo "${validFindings}" | jq -r ". | length")


### PR DESCRIPTION
## Description

ECR is flagging a false positive on CVE-2020-28928. Here is an example failure: https://app.circleci.com/pipelines/github/transcom/mymove/34074/workflows/75d4259a-d08f-44f0-80b3-0dab30f8eb69/jobs/524116

Because these types of issues are outside of our control, it can block our CI pipelines entirely with no way to move forward. This PR grants us the ability to filter out these types of CVEs from the scan results.

This also defines a pattern for including a link to a ticket to remove the exclusion, so that we do not keep these exclusions in forever.

## Setup

Watch CI.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9408) for this change
* https://forums.aws.amazon.com/thread.jspa?threadID=337518
* https://forums.aws.amazon.com/thread.jspa?threadID=336286
* https://github.com/aws/containers-roadmap/issues/798
* https://github.com/aws/containers-roadmap/issues/1388