### PR TITLE
Add demo cert migration

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -665,3 +665,4 @@
 20210824181514_change_weight_params.up.sql
 20210826153944_add_tio_remarks_to_moves_table.up.sql
 20210903211741_recalculation_payment_request.up.sql
+20210909171753_add_demo_tls_cert.up.sql

--- a/migrations/app/secure/20210909171753_add_demo_tls_cert.up.sql
+++ b/migrations/app/secure/20210909171753_add_demo_tls_cert.up.sql
@@ -1,0 +1,41 @@
+-- This migration adds a cert that can access the MilMove Demo environment with mTLS.
+-- The Orders API and the Prime API use client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed which includes CACs.
+INSERT INTO public.client_certs (
+	id,
+	sha256_digest,
+	subject,
+	allow_dps_auth_api,
+	allow_orders_api,
+	created_at,
+	updated_at,
+	allow_air_force_orders_read,
+	allow_air_force_orders_write,
+	allow_army_orders_read,
+	allow_army_orders_write,
+	allow_coast_guard_orders_read,
+	allow_coast_guard_orders_write,
+	allow_marine_corps_orders_read,
+	allow_marine_corps_orders_write,
+	allow_navy_orders_read,
+	allow_navy_orders_write,
+	allow_prime)
+VALUES (
+   '2fbfb740-cc36-4eeb-a6c6-1e800c74b348',
+   '27250e2fbbf5c27931bb38b750a0722b64bf737d9be26b60b78ac34ade7a1f95',
+   'CN=api.demo.dp3.us',
+   false,
+   true,
+   now(),
+   now(),
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true);


### PR DESCRIPTION
## Description

This PR adds the secure migration to add the demo cert to the `client_certs` table. All secure migrations have already been uploaded to their respective environments (exp, stg, and prd have empty placeholder files). It is ready to be deployed and tested!
