### PR TITLE
MB-9317: Updates MyMove homepage amended orders helper to fix DOM validation

### DIFF
--- a/src/pages/MyMove/Home/Home.module.scss
+++ b/src/pages/MyMove/Home/Home.module.scss
@@ -143,6 +143,11 @@
   }
 }
 
-.alertMessage {
+.alertMessageSecondLine {
+  display: block;
   @include u-margin-y(1em);
+}
+
+.alertMessageFirstLine {
+  display: block;
 }

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -134,11 +134,11 @@ export class Home extends Component {
     if (this.hasUnapprovedAmendedOrders) {
       return (
         <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
-          <div>
+          <span className={styles.alertMessageFirstLine}>
             The transportation office will review your new documents and update your move info. Contact your movers to
             coordinate any changes to your move.
-          </div>
-          <div className={styles.alertMessage}>You don&apos;t need to do anything else in MilMove.</div>
+          </span>
+          <span className={styles.alertMessageSecondLine}>You don&apos;t need to do anything else in MilMove.</span>
         </Alert>
       );
     }


### PR DESCRIPTION
## Description

When picking up work on [PR #7277](https://github.com/transcom/mymove/pull/7277), I made a fix to an issue with the CSS of a partially refactored component. That fix re-introduced what React considers a DOM validation error, which is emitted to the console during client tests. As the whole point of the partial refactor was to remove a very similar warning... whoops.

This pull request maintains the CSS fix, and resolves the emitted DOM validation warning.

## Reviewer Notes

Ensure that the component looks identical to the reference in storybook (using Happo and/or comparisons with Storybook). Ensure that the component's tests don't emit any errors.

No visible UI changes should be made.

## Setup

```sh
yarn test MyMove/Home/index
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-9317](https://dp3.atlassian.net/browse/MB-9317).
* Fixes an issue introduced by [PR #7277](https://github.com/transcom/mymove/pull/7277)
