### PR TITLE
Update hash for circleci-docker updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239
 
   postgres: &postgres postgres:12.7
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -3,7 +3,7 @@
 ###########
 
 # Base builder so the ci build image hash is referenced once
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 ENV CIRCLECI=docker
 ENV REACT_APP_NODE_ENV=development
 # hadolint ignore=DL3002

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d as builder
+FROM milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Makefile
+++ b/Makefile
@@ -1078,7 +1078,7 @@ pretty: gofmt ## Run code through JS and Golang formatters
 
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
-	docker pull milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d
+	docker pull milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239
 	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app bash
 
 .PHONY: prune_images

--- a/cypress/Dockerfile.cypress
+++ b/cypress/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM milmove/circleci-docker:milmove-cypress-c9e92c29cf82553e613fee278bdbfeff612d63ac
+FROM milmove/circleci-docker:milmove-cypress-012fdffe4833f88f67607cd6801f166d0014c239
 
 # use the WORKDIR from the CI image
 # hadolint ignore=DL3045

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d
+  image=milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -8,7 +8,7 @@ if [ -n "${CIRCLECI+x}" ]; then
   echo "CircleCI has swagger built in"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d
+  image=milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239
   docker pull -q "${image}"
 fi
 

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -14,7 +14,7 @@ if [ "$UNAME_S" == "Linux" ]; then
   /usr/local/bin/swagger validate "${filename}"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-e879fc520bb7b2d2878a3925bd472e6e154c562d
+  image=milmove/circleci-docker:milmove-app-012fdffe4833f88f67607cd6801f166d0014c239
   docker pull -q "${image}"
   docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"
 fi


### PR DESCRIPTION
## Description

This updates the docker images for the repo. Here is a link to docker hub: https://hub.docker.com/r/milmove/circleci-docker/tags?page=1&ordering=last_updated and here is the link to the repo: https://github.com/transcom/circleci-docker


## Reviewer Notes

Did I replace all the correct tags?
