### PR TITLE
MB-9361 Refactor service item updater

### DIFF
--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -79,7 +79,7 @@ func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemop.Update
 		return mtoserviceitemop.NewUpdateMTOServiceItemStatusInternalServerError()
 	}
 
-	updatedMTOServiceItem, err := h.MTOServiceItemUpdater.UpdateMTOServiceItemStatus(appCtx, mtoServiceItemID, models.MTOServiceItemStatus(params.Body.Status), params.Body.RejectionReason, params.IfMatch)
+	updatedMTOServiceItem, err := h.MTOServiceItemUpdater.ApproveOrRejectServiceItem(appCtx, mtoServiceItemID, models.MTOServiceItemStatus(params.Body.Status), params.Body.RejectionReason, params.IfMatch)
 
 	if err != nil {
 		switch err.(type) {

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -182,7 +182,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil).Once()
 
-		serviceItemStatusUpdater.On("UpdateMTOServiceItemStatus",
+		serviceItemStatusUpdater.On("ApproveOrRejectServiceItem",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.Anything,
 			mock.Anything,
@@ -208,7 +208,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil).Once()
 
-		serviceItemStatusUpdater.On("UpdateMTOServiceItemStatus",
+		serviceItemStatusUpdater.On("ApproveOrRejectServiceItem",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.Anything,
 			mock.Anything,
@@ -234,7 +234,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil).Once()
 
-		serviceItemStatusUpdater.On("UpdateMTOServiceItemStatus",
+		serviceItemStatusUpdater.On("ApproveOrRejectServiceItem",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.Anything,
 			mock.Anything,

--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -32,10 +32,10 @@ func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemops.Updat
 	eTag := params.IfMatch
 	reason := params.Body.RejectionReason
 
-	mtoServiceItem, err := h.UpdateMTOServiceItemStatus(appCtx, mtoServiceItemID, status, reason, eTag)
+	mtoServiceItem, err := h.ApproveOrRejectServiceItem(appCtx, mtoServiceItemID, status, reason, eTag)
 
 	if err != nil {
-		logger.Error("UpdateMTOServiceItemStatus error: ", zap.Error(err))
+		logger.Error("ApproveOrRejectServiceItem error: ", zap.Error(err))
 
 		switch e := err.(type) {
 		case services.NotFoundError:

--- a/pkg/services/mocks/MTOServiceItemUpdater.go
+++ b/pkg/services/mocks/MTOServiceItemUpdater.go
@@ -16,6 +16,29 @@ type MTOServiceItemUpdater struct {
 	mock.Mock
 }
 
+// ApproveOrRejectServiceItem provides a mock function with given fields: appCtx, mtoServiceItemID, status, rejectionReason, eTag
+func (_m *MTOServiceItemUpdater) ApproveOrRejectServiceItem(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error) {
+	ret := _m.Called(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
+
+	var r0 *models.MTOServiceItem
+	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, models.MTOServiceItemStatus, *string, string) *models.MTOServiceItem); ok {
+		r0 = rf(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.MTOServiceItem)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(appcontext.AppContext, uuid.UUID, models.MTOServiceItemStatus, *string, string) error); ok {
+		r1 = rf(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateMTOServiceItem provides a mock function with given fields: appCtx, serviceItem, eTag, validator
 func (_m *MTOServiceItemUpdater) UpdateMTOServiceItem(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string, validator string) (*models.MTOServiceItem, error) {
 	ret := _m.Called(appCtx, serviceItem, eTag, validator)
@@ -78,29 +101,6 @@ func (_m *MTOServiceItemUpdater) UpdateMTOServiceItemPrime(appCtx appcontext.App
 	var r1 error
 	if rf, ok := ret.Get(1).(func(appcontext.AppContext, *models.MTOServiceItem, string) error); ok {
 		r1 = rf(appCtx, serviceItem, eTag)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateMTOServiceItemStatus provides a mock function with given fields: appCtx, mtoServiceItemID, status, rejectionReason, eTag
-func (_m *MTOServiceItemUpdater) UpdateMTOServiceItemStatus(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error) {
-	ret := _m.Called(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
-
-	var r0 *models.MTOServiceItem
-	if rf, ok := ret.Get(0).(func(appcontext.AppContext, uuid.UUID, models.MTOServiceItemStatus, *string, string) *models.MTOServiceItem); ok {
-		r0 = rf(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.MTOServiceItem)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(appcontext.AppContext, uuid.UUID, models.MTOServiceItemStatus, *string, string) error); ok {
-		r1 = rf(appCtx, mtoServiceItemID, status, rejectionReason, eTag)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/mto_service_item.go
+++ b/pkg/services/mto_service_item.go
@@ -17,7 +17,7 @@ type MTOServiceItemCreator interface {
 // MTOServiceItemUpdater is the exported interface for updating an mto service item
 //go:generate mockery --name MTOServiceItemUpdater --disable-version-string
 type MTOServiceItemUpdater interface {
-	UpdateMTOServiceItemStatus(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error)
+	ApproveOrRejectServiceItem(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error)
 	UpdateMTOServiceItem(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string, validator string) (*models.MTOServiceItem, error)
 	UpdateMTOServiceItemBasic(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string) (*models.MTOServiceItem, error)
 	UpdateMTOServiceItemPrime(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string) (*models.MTOServiceItem, error)

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -199,13 +199,13 @@ func (suite *MTOServiceItemServiceSuite) TestCreateMTOServiceItem() {
 	// Happy path: If the service item is created successfully it should be returned
 	suite.T().Run("200 Success - SIT Service Item Creation", func(t *testing.T) {
 		createdServiceItems, verrs, err := creator.CreateMTOServiceItem(suite.TestAppContext(), &serviceItem)
-
-		var foundMove models.Move
-		suite.DB().Find(&foundMove, move.ID)
-
 		suite.NoError(err)
 		suite.Nil(verrs)
 		suite.NotNil(createdServiceItems)
+
+		var foundMove models.Move
+		err = suite.DB().Find(&foundMove, move.ID)
+		suite.NoError(err)
 
 		createdServiceItemList := *createdServiceItems
 		suite.Equal(len(createdServiceItemList), 3)

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	orderservice "github.com/transcom/mymove/pkg/services/order"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
@@ -41,139 +42,114 @@ func NewMTOServiceItemUpdater(builder mtoServiceItemQueryBuilder, moveRouter ser
 }
 
 func (p *mtoServiceItemUpdater) UpdateMTOServiceItemStatus(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error) {
-	var mtoServiceItem models.MTOServiceItem
-
-	queryFilters := []services.QueryFilter{
-		query.NewQueryFilter("id", "=", mtoServiceItemID),
-	}
-	err := p.builder.FetchOne(appCtx, &mtoServiceItem, queryFilters)
-
+	mtoServiceItem, err := p.findServiceItem(appCtx, mtoServiceItemID)
 	if err != nil {
-		return nil, services.NewNotFoundError(mtoServiceItemID, "MTOServiceItemID")
+		return &models.MTOServiceItem{}, err
 	}
 
-	var move models.Move
-	moveFilter := []services.QueryFilter{
-		query.NewQueryFilter("id", "=", mtoServiceItem.MoveTaskOrderID),
-	}
-	err = p.builder.FetchOne(appCtx, &move, moveFilter)
-	moveID := mtoServiceItem.MoveTaskOrderID
+	return p.approveOrRejectServiceItem(appCtx, *mtoServiceItem, status, rejectionReason, eTag, checkMoveStatus(), checkETag())
+}
+
+func (p *mtoServiceItemUpdater) findServiceItem(appCtx appcontext.AppContext, serviceItemID uuid.UUID) (*models.MTOServiceItem, error) {
+	var serviceItem models.MTOServiceItem
+	err := appCtx.DB().Q().EagerPreload("MoveTaskOrder").Find(&serviceItem, serviceItemID)
 	if err != nil {
-		return nil, services.NewNotFoundError(moveID, "MoveID")
+		if errors.Cause(err).Error() == models.RecordNotFoundErrorString {
+			return nil, services.NewNotFoundError(serviceItemID, "while looking for service item")
+		}
 	}
 
-	// Service item status can only be updated if a Move's status is either Approved
-	// or Approvals Requested, so check and fail early.
-	if move.Status != models.MoveStatusAPPROVED && move.Status != models.MoveStatusAPPROVALSREQUESTED {
-		return nil, services.NewConflictError(
-			move.ID,
-			fmt.Sprintf("Cannot update a service item on a move that is not currently approved. The current status for the move with ID %s is %s", move.ID, move.Status),
-		)
+	return &serviceItem, nil
+}
+
+func (p *mtoServiceItemUpdater) approveOrRejectServiceItem(appCtx appcontext.AppContext, serviceItem models.MTOServiceItem, status models.MTOServiceItemStatus, rejectionReason *string, eTag string, checks ...validator) (*models.MTOServiceItem, error) {
+	if verr := validateServiceItem(appCtx, &serviceItem, eTag, checks...); verr != nil {
+		return nil, verr
 	}
 
-	mtoServiceItem.Status = status
+	transactionError := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
+		if err := p.updateServiceItem(txnAppCtx, serviceItem, status, rejectionReason); err != nil {
+			return err
+		}
+		move := serviceItem.MoveTaskOrder
+		err := txnAppCtx.DB().Q().EagerPreload("MTOServiceItems", "Orders").Find(&move, move.ID)
+		if err != nil {
+			return err
+		}
+
+		if err = p.approveMoveOrRequestApproval(txnAppCtx, move.Orders, move); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if transactionError != nil {
+		return nil, transactionError
+	}
+
+	return &serviceItem, nil
+}
+
+func (p *mtoServiceItemUpdater) updateServiceItem(appCtx appcontext.AppContext, serviceItem models.MTOServiceItem, status models.MTOServiceItemStatus, rejectionReason *string) error {
+	serviceItem.Status = status
 	updatedAt := time.Now()
-	mtoServiceItem.UpdatedAt = updatedAt
+	serviceItem.UpdatedAt = updatedAt
 
 	if status == models.MTOServiceItemStatusRejected {
 		if rejectionReason == nil {
 			verrs := validate.NewErrors()
 			verrs.Add("rejectionReason", "field must be provided when status is set to REJECTED")
-			err := services.NewInvalidInputError(mtoServiceItemID, nil, verrs, "Invalid input found in the request.")
-			return nil, err
+			err := services.NewInvalidInputError(serviceItem.ID, nil, verrs, "Invalid input found in the request.")
+			return err
 		}
-		mtoServiceItem.RejectionReason = rejectionReason
-		mtoServiceItem.RejectedAt = &updatedAt
+		serviceItem.RejectionReason = rejectionReason
+		serviceItem.RejectedAt = &updatedAt
 		// clear field if previously accepted
-		mtoServiceItem.ApprovedAt = nil
+		serviceItem.ApprovedAt = nil
 	} else if status == models.MTOServiceItemStatusApproved {
 		// clear fields if previously rejected
-		mtoServiceItem.RejectionReason = nil
-		mtoServiceItem.RejectedAt = nil
-		mtoServiceItem.ApprovedAt = &updatedAt
+		serviceItem.RejectionReason = nil
+		serviceItem.RejectedAt = nil
+		serviceItem.ApprovedAt = &updatedAt
 	}
 
-	verrs, err := p.builder.UpdateOne(appCtx, &mtoServiceItem, &eTag)
+	verrs, err := appCtx.DB().ValidateAndUpdate(&serviceItem)
 
-	if verrs != nil && verrs.HasAny() {
-		return nil, services.NewInvalidInputError(mtoServiceItemID, err, verrs, "")
+	return p.handleError(serviceItem.ID, verrs, err)
+}
+
+func (p *mtoServiceItemUpdater) approveMoveOrRequestApproval(appCtx appcontext.AppContext, order models.Order, move models.Move) error {
+	var err error
+
+	if p.moveShouldBeApproved(order, move) {
+		err = p.moveRouter.Approve(appCtx, &move)
+	} else {
+		err = p.moveRouter.SendToOfficeUser(appCtx, &move)
 	}
 
 	if err != nil {
-		if errors.Cause(err).Error() == models.RecordNotFoundErrorString {
-			return nil, services.NewNotFoundError(mtoServiceItemID, "")
-		}
-
-		switch err.(type) {
-		case query.StaleIdentifierError:
-			return &models.MTOServiceItem{}, services.NewPreconditionFailedError(mtoServiceItemID, err)
-		}
+		return err
 	}
 
-	// If there are no service items that are SUBMITTED then we need to change
-	// the move status to APPROVED
-	moveShouldBeMoveApproved := true
+	verrs, err := appCtx.DB().ValidateAndUpdate(&move)
 
-	if status == models.MTOServiceItemStatusSubmitted {
-		moveShouldBeMoveApproved = false
-	} else {
-		// Fetch move again since other service items could have been updated
-		err = p.builder.FetchOne(appCtx, &move, moveFilter)
-		if err != nil {
-			return nil, services.NewNotFoundError(mtoServiceItemID, "MTOServiceItemID")
-		}
+	return p.handleError(move.ID, verrs, err)
+}
 
-		for _, mtoServiceItem := range move.MTOServiceItems {
-			if mtoServiceItem.Status == models.MTOServiceItemStatusSubmitted {
-				moveShouldBeMoveApproved = false
-				break
-			}
-		}
+func (p *mtoServiceItemUpdater) moveShouldBeApproved(order models.Order, move models.Move) bool {
+	return orderservice.MoveHasReviewedServiceItems(move) && orderservice.MoveHasAcknowledgedOrdersAmendment(order)
+}
 
-		// All service items may be reviewed but amended orders should keep the move in
-		// APPROVALS REQUESTED status
-		if move.Orders.UploadedAmendedOrdersID != nil && move.Orders.AmendedOrdersAcknowledgedAt == nil {
-			moveShouldBeMoveApproved = false
-		}
+func (p *mtoServiceItemUpdater) handleError(modelID uuid.UUID, verrs *validate.Errors, err error) error {
+	if verrs != nil && verrs.HasAny() {
+		return services.NewInvalidInputError(modelID, nil, verrs, "")
+	}
+	if err != nil {
+		return err
 	}
 
-	if moveShouldBeMoveApproved {
-		err = p.moveRouter.Approve(appCtx, &move)
-		if err != nil {
-			return nil, err
-		}
-		verrs, err = p.builder.UpdateOne(appCtx, &move, nil)
-		if verrs != nil && verrs.HasAny() {
-			return nil, services.NewInvalidInputError(move.ID, err, verrs, "")
-		}
-
-		if err != nil {
-			if errors.Cause(err).Error() == models.RecordNotFoundErrorString {
-				return nil, services.NewNotFoundError(move.ID, "")
-			}
-		}
-	}
-	// If the move should not be APPROVED (due to one or more service items
-	// being in SUBMITTED status) then it needs to be set to APPROVALS REQUESTED
-	// so the TOO can review it.
-	if !moveShouldBeMoveApproved {
-		err = p.moveRouter.SendToOfficeUser(appCtx, &move)
-		if err != nil {
-			return nil, err
-		}
-		verrs, err = p.builder.UpdateOne(appCtx, &move, nil)
-		if verrs != nil && verrs.HasAny() {
-			return nil, services.NewInvalidInputError(move.ID, err, verrs, "")
-		}
-
-		if err != nil {
-			if errors.Cause(err).Error() == models.RecordNotFoundErrorString {
-				return nil, services.NewNotFoundError(move.ID, "")
-			}
-		}
-	}
-
-	return &mtoServiceItem, err
+	return nil
 }
 
 // UpdateMTOServiceItemBasic updates the MTO Service Item using base validators

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -40,7 +40,7 @@ func NewMTOServiceItemUpdater(builder mtoServiceItemQueryBuilder, moveRouter ser
 	return &mtoServiceItemUpdater{builder, createNewBuilder, moveRouter}
 }
 
-func (p *mtoServiceItemUpdater) UpdateMTOServiceItemStatus(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error) {
+func (p *mtoServiceItemUpdater) ApproveOrRejectServiceItem(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error) {
 	mtoServiceItem, err := p.findServiceItem(appCtx, mtoServiceItemID)
 	if err != nil {
 		return &models.MTOServiceItem{}, err

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -93,8 +93,7 @@ func (p *mtoServiceItemUpdater) approveOrRejectServiceItem(appCtx appcontext.App
 
 func (p *mtoServiceItemUpdater) updateServiceItem(appCtx appcontext.AppContext, serviceItem models.MTOServiceItem, status models.MTOServiceItemStatus, rejectionReason *string) error {
 	serviceItem.Status = status
-	updatedAt := time.Now()
-	serviceItem.UpdatedAt = updatedAt
+	now := time.Now()
 
 	if status == models.MTOServiceItemStatusRejected {
 		if rejectionReason == nil {
@@ -104,14 +103,14 @@ func (p *mtoServiceItemUpdater) updateServiceItem(appCtx appcontext.AppContext, 
 			return err
 		}
 		serviceItem.RejectionReason = rejectionReason
-		serviceItem.RejectedAt = &updatedAt
+		serviceItem.RejectedAt = &now
 		// clear field if previously accepted
 		serviceItem.ApprovedAt = nil
 	} else if status == models.MTOServiceItemStatusApproved {
 		// clear fields if previously rejected
 		serviceItem.RejectionReason = nil
 		serviceItem.RejectedAt = nil
-		serviceItem.ApprovedAt = &updatedAt
+		serviceItem.ApprovedAt = &now
 	}
 
 	verrs, err := appCtx.DB().ValidateAndUpdate(&serviceItem)

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -363,6 +363,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.NoError(err)
 
 		suite.Equal(models.MoveStatusAPPROVED, move.Status)
+		suite.Equal(models.MTOServiceItemStatusApproved, updatedServiceItem.Status)
 		suite.Equal(models.MTOServiceItemStatusApproved, serviceItem.Status)
 		suite.NotNil(serviceItem.ApprovedAt)
 		suite.Nil(serviceItem.RejectionReason)

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -353,7 +353,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItem()
 
-		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
+		updatedServiceItem, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusApproved, rejectionReason, eTag)
 		suite.NoError(err)
 
@@ -379,7 +379,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		move.Status = models.MoveStatusAPPROVED
 		suite.MustSave(&move)
 
-		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
+		updatedServiceItem, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusSubmitted, rejectionReason, eTag)
 		suite.NoError(err)
 
@@ -403,7 +403,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		eTag, serviceItem, move := suite.createServiceItem()
 		rejectionReason = swag.String("incomplete")
 
-		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
+		updatedServiceItem, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusRejected, rejectionReason, eTag)
 		suite.NoError(err)
 
@@ -427,7 +427,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.SetupTest()
 		eTag, serviceItem, move := suite.createServiceItemForUnapprovedMove()
 
-		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
+		updatedServiceItem, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusApproved, rejectionReason, eTag)
 
 		suite.Error(err)
@@ -447,7 +447,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		suite.SetupTest()
 
 		eTag, serviceItem, move := suite.createServiceItemForMoveWithUnacknowledgedAmendedOrders()
-		updatedServiceItem, err := updater.UpdateMTOServiceItemStatus(
+		updatedServiceItem, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusApproved, rejectionReason, eTag)
 		suite.NoError(err)
 
@@ -469,7 +469,7 @@ func (suite *MTOServiceItemServiceSuite) TestUpdateMTOServiceItemStatus() {
 		_, serviceItem, _ := suite.createServiceItem()
 		rejectionReason = swag.String("incomplete")
 
-		_, err := updater.UpdateMTOServiceItemStatus(
+		_, err := updater.ApproveOrRejectServiceItem(
 			suite.TestAppContext(), serviceItem.ID, models.MTOServiceItemStatusRejected, rejectionReason, "")
 
 		suite.Error(err)

--- a/pkg/services/mto_service_item/validation.go
+++ b/pkg/services/mto_service_item/validation.go
@@ -1,0 +1,70 @@
+package mtoserviceitem
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/validate/v3"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
+)
+
+// Validator is the interface for the various validations we might want to
+// define.
+type validator interface {
+	Validate(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string) error
+}
+
+type validatorFunc func(appcontext.AppContext, *models.MTOServiceItem, string) error
+
+func (fn validatorFunc) Validate(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string) error {
+	return fn(appCtx, serviceItem, eTag)
+}
+
+func validateServiceItem(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string, checks ...validator) (result error) {
+	verrs := validate.NewErrors()
+	for _, checker := range checks {
+		if err := checker.Validate(appCtx, serviceItem, eTag); err != nil {
+			switch e := err.(type) {
+			case *validate.Errors:
+				// accumulate validation errors
+				verrs.Append(e)
+			default:
+				// non-validation errors have priority,
+				// and short-circuit doing any further checks
+				return err
+			}
+		}
+	}
+	if verrs.HasAny() {
+		result = services.NewInvalidInputError(serviceItem.ID, nil, verrs, "")
+	}
+	return result
+}
+
+func checkMoveStatus() validator {
+	return validatorFunc(func(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, _ string) error {
+		verrs := validate.NewErrors()
+		move := serviceItem.MoveTaskOrder
+
+		if move.Status != models.MoveStatusAPPROVED && move.Status != models.MoveStatusAPPROVALSREQUESTED {
+			message := fmt.Sprintf("Cannot approve or reject a service item if the move's status is neither Approved nor Approvals Requested. The current status for the move with ID %s is %s", move.ID, move.Status)
+			verrs.Add("status", message)
+		}
+
+		return verrs
+	})
+}
+
+func checkETag() validator {
+	return validatorFunc(func(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem, eTag string) error {
+		existingETag := etag.GenerateEtag(serviceItem.UpdatedAt)
+		if existingETag != eTag {
+			return services.NewPreconditionFailedError(serviceItem.ID, query.StaleIdentifierError{StaleIdentifier: eTag})
+		}
+		return nil
+	})
+}

--- a/pkg/services/order/excess_weight_risk_manager.go
+++ b/pkg/services/order/excess_weight_risk_manager.go
@@ -174,8 +174,8 @@ func (f *excessWeightRiskManager) moveShouldBeApproved(order models.Order) bool 
 	move := order.Moves[0]
 
 	return excessWeightRiskShouldBeAcknowledged(move) &&
-		moveHasAcknowledgedOrdersAmendment(order) &&
-		moveHasReviewedServiceItems(move)
+		MoveHasAcknowledgedOrdersAmendment(order) &&
+		MoveHasReviewedServiceItems(move)
 }
 
 func (f *excessWeightRiskManager) handleError(modelID uuid.UUID, verrs *validate.Errors, err error) error {
@@ -189,14 +189,17 @@ func (f *excessWeightRiskManager) handleError(modelID uuid.UUID, verrs *validate
 	return nil
 }
 
-func moveHasAcknowledgedOrdersAmendment(order models.Order) bool {
+// MoveHasAcknowledgedOrdersAmendment checks if the TOO has acknowledged amended orders
+func MoveHasAcknowledgedOrdersAmendment(order models.Order) bool {
 	if order.UploadedAmendedOrdersID != nil && order.AmendedOrdersAcknowledgedAt == nil {
 		return false
 	}
 	return true
 }
 
-func moveHasReviewedServiceItems(move models.Move) bool {
+// MoveHasReviewedServiceItems checks if the TOO still needs to accept or reject
+// service items
+func MoveHasReviewedServiceItems(move models.Move) bool {
 	for _, mtoServiceItem := range move.MTOServiceItems {
 		if mtoServiceItem.Status == models.MTOServiceItemStatusSubmitted {
 			return false

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1303,7 +1303,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 	originPickupSIT = *updatedDOPSIT
 
 	for _, createdServiceItem := range []models.MTOServiceItem{originFirstDaySIT, originAdditionalDaySIT, originPickupSIT} {
-		_, updateErr := serviceItemUpdator.UpdateMTOServiceItemStatus(appCtx, createdServiceItem.ID, models.MTOServiceItemStatusApproved, nil, etag.GenerateEtag(createdServiceItem.UpdatedAt))
+		_, updateErr := serviceItemUpdator.ApproveOrRejectServiceItem(appCtx, createdServiceItem.ID, models.MTOServiceItemStatusApproved, nil, etag.GenerateEtag(createdServiceItem.UpdatedAt))
 		if updateErr != nil {
 			logger.Fatal("Error approving SIT service item", zap.Error(updateErr))
 		}
@@ -1337,7 +1337,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 	serviceItemDDDSIT = *updatedDDDSIT
 
 	for _, createdServiceItem := range []models.MTOServiceItem{serviceItemDDFSIT, serviceItemDDASIT, serviceItemDDDSIT} {
-		_, updateErr := serviceItemUpdator.UpdateMTOServiceItemStatus(appCtx, createdServiceItem.ID, models.MTOServiceItemStatusApproved, nil, etag.GenerateEtag(createdServiceItem.UpdatedAt))
+		_, updateErr := serviceItemUpdator.ApproveOrRejectServiceItem(appCtx, createdServiceItem.ID, models.MTOServiceItemStatusApproved, nil, etag.GenerateEtag(createdServiceItem.UpdatedAt))
 		if updateErr != nil {
 			logger.Fatal("Error approving SIT service item", zap.Error(updateErr))
 		}


### PR DESCRIPTION
## Description

The original motivation for this refactor was to reuse the logic for
determining whether or not a move's status should go to Approved or
Approvals Requested, based on whether or not it has unreviewed service
items and/or unacknowledged amended orders.

While I was in the `mto_service_item_updater file`, I took the
opportunity to refactor the `UpdateMTOServiceItemStatus` function to
follow the patterns I've used in other services:

- Make the main function as short as possible
- Break the various steps into well-named, separate functions
- Perform multiple DB updates inside a transaction
- Use the validator pattern for any checks that need to happen

## Reviewer Notes

More things we can refactor:

- Move the logic in `updateServiceItem` for preventing a nil rejection reason into a validation
- Rename `UpdateMTOServiceItemStatus` to `ApproveOrRejectServiceItem`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9361) for this change
