### PR TITLE
[MB-9309] reweigh lookup implemented for pricing

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -220,6 +220,14 @@ func ServiceParamLookupInitialize(
 		return nil, err
 	}
 
+	paramKey = models.ServiceItemParamNameWeightReweigh
+	err = s.setLookup(appCtx, serviceItemCode, paramKey, WeightReweighLookup{
+		MTOShipment: mtoShipment,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	paramKey = models.ServiceItemParamNameZipPickupAddress
 	err = s.setLookup(appCtx, serviceItemCode, paramKey, ZipAddressLookup{
 		Address: pickupAddress,

--- a/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup.go
@@ -3,6 +3,8 @@ package serviceparamvaluelookups
 import (
 	"fmt"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
@@ -22,7 +24,7 @@ func (r WeightReweighLookup) lookup(appCtx appcontext.AppContext, keyData *Servi
 
 	var reweighWeight *unit.Pound
 	// Make sure there's a reweigh weight since that's nullable
-	if r.MTOShipment.Reweigh != nil {
+	if r.MTOShipment.Reweigh != nil && r.MTOShipment.Reweigh.ID != uuid.Nil {
 		reweighWeight = r.MTOShipment.Reweigh.Weight
 	}
 

--- a/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup.go
@@ -1,0 +1,35 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+// WeightReweighLookup does lookup on estimated weight billed
+type WeightReweighLookup struct {
+	MTOShipment models.MTOShipment
+}
+
+func (r WeightReweighLookup) lookup(appCtx appcontext.AppContext, keyData *ServiceItemParamKeyData) (string, error) {
+
+	err := appCtx.DB().Load(&r.MTOShipment, "Reweigh")
+	if err != nil {
+		return "", err
+	}
+
+	var reweighWeight *unit.Pound
+	// Make sure there's a reweigh weight since that's nullable
+	if r.MTOShipment.Reweigh != nil {
+		reweighWeight = r.MTOShipment.Reweigh.Weight
+	}
+
+	if reweighWeight == nil {
+		return "", nil
+	}
+
+	value := fmt.Sprintf("%d", int(*reweighWeight))
+	return value, nil
+}

--- a/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_reweigh_lookup_test.go
@@ -1,0 +1,29 @@
+package serviceparamvaluelookups
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestWeightReweighLookup() {
+	key := models.ServiceItemParamNameWeightReweigh
+
+	suite.Run("reweigh weight is present on MTO Shipment", func() {
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithReweigh(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
+		suite.FatalNoError(err)
+		suite.Equal("1234", valueStr)
+	})
+
+	suite.Run("nil Shipment Reweigh", func() {
+		// Set the reweigh weight to nil
+		mtoServiceItem, paymentRequest, _ := suite.setupTestMTOServiceItemWithWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+
+		paramLookup, err := ServiceParamLookupInitialize(suite.TestAppContext(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+
+		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
+		suite.NoError(err)
+		suite.Equal("", valueStr)
+	})
+}

--- a/pkg/testdatagen/make_service_param.go
+++ b/pkg/testdatagen/make_service_param.go
@@ -38,27 +38,25 @@ func MakeServiceParam(db *pop.Connection, assertions Assertions) models.ServiceP
 
 	serviceParam.IsOptional = false
 	switch assertions.ServiceParam.ServiceItemParamKey.Key {
-	case models.ServiceItemParamNameWeightEstimated, models.ServiceItemParamNameWeightReweigh, models.ServiceItemParamNameWeightAdjusted:
+	case models.ServiceItemParamNameWeightEstimated,
+		models.ServiceItemParamNameWeightReweigh,
+		models.ServiceItemParamNameWeightAdjusted:
 		serviceParam.IsOptional = true
 		assertions.ServiceParam.IsOptional = true
 	}
 
 	switch serviceParam.ServiceItemParamKey.Key {
-	case models.ServiceItemParamNameWeightEstimated:
-		fallthrough
-	case models.ServiceItemParamNameWeightReweigh:
-		fallthrough
-	case models.ServiceItemParamNameWeightAdjusted:
+	case models.ServiceItemParamNameWeightEstimated,
+		models.ServiceItemParamNameWeightReweigh,
+		models.ServiceItemParamNameWeightAdjusted:
 		serviceParam.IsOptional = true
 		assertions.ServiceParam.IsOptional = true
 	}
 
 	switch assertions.ServiceItemParamKey.Key {
-	case models.ServiceItemParamNameWeightEstimated:
-		fallthrough
-	case models.ServiceItemParamNameWeightReweigh:
-		fallthrough
-	case models.ServiceItemParamNameWeightAdjusted:
+	case models.ServiceItemParamNameWeightEstimated,
+		models.ServiceItemParamNameWeightReweigh,
+		models.ServiceItemParamNameWeightAdjusted:
 		serviceParam.IsOptional = true
 		assertions.ServiceParam.IsOptional = true
 	}

--- a/pkg/testdatagen/make_service_param.go
+++ b/pkg/testdatagen/make_service_param.go
@@ -38,11 +38,7 @@ func MakeServiceParam(db *pop.Connection, assertions Assertions) models.ServiceP
 
 	serviceParam.IsOptional = false
 	switch assertions.ServiceParam.ServiceItemParamKey.Key {
-	case models.ServiceItemParamNameWeightEstimated:
-		fallthrough
-	case models.ServiceItemParamNameWeightReweigh:
-		fallthrough
-	case models.ServiceItemParamNameWeightAdjusted:
+	case models.ServiceItemParamNameWeightEstimated, models.ServiceItemParamNameWeightReweigh, models.ServiceItemParamNameWeightAdjusted:
 		serviceParam.IsOptional = true
 		assertions.ServiceParam.IsOptional = true
 	}

--- a/pkg/testdatagen/make_service_param.go
+++ b/pkg/testdatagen/make_service_param.go
@@ -37,6 +37,35 @@ func MakeServiceParam(db *pop.Connection, assertions Assertions) models.ServiceP
 	}
 
 	serviceParam.IsOptional = false
+	switch assertions.ServiceParam.ServiceItemParamKey.Key {
+	case models.ServiceItemParamNameWeightEstimated:
+		fallthrough
+	case models.ServiceItemParamNameWeightReweigh:
+		fallthrough
+	case models.ServiceItemParamNameWeightAdjusted:
+		serviceParam.IsOptional = true
+		assertions.ServiceParam.IsOptional = true
+	}
+
+	switch serviceParam.ServiceItemParamKey.Key {
+	case models.ServiceItemParamNameWeightEstimated:
+		fallthrough
+	case models.ServiceItemParamNameWeightReweigh:
+		fallthrough
+	case models.ServiceItemParamNameWeightAdjusted:
+		serviceParam.IsOptional = true
+		assertions.ServiceParam.IsOptional = true
+	}
+
+	switch assertions.ServiceItemParamKey.Key {
+	case models.ServiceItemParamNameWeightEstimated:
+		fallthrough
+	case models.ServiceItemParamNameWeightReweigh:
+		fallthrough
+	case models.ServiceItemParamNameWeightAdjusted:
+		serviceParam.IsOptional = true
+		assertions.ServiceParam.IsOptional = true
+	}
 
 	// Overwrite values with those from assertions
 	mergeModels(&serviceParam, assertions.ServiceParam)


### PR DESCRIPTION
## Description

Add lookup for reweigh. This is subtle change in invoicing/pricing. The pricing will not be changed, but if there is a reweigh weight present it will now be visible in the TIO "show your work" pane.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add reweigh to a shipment. 
Create payment request.
Review in TIO calculations window.

Follow the setup from https://github.com/transcom/mymove/pull/7248 which points to https://github.com/transcom/mymove/pull/7171.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9309) for this change


## Screenshots

n/a