### PR TITLE
MB-9313 hookup billable weight component on payment requests page

### DIFF
--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
@@ -23,7 +23,7 @@ export const Card = (argTypes) => (
         {
           id: '0002',
           shipmentType: 'HHG',
-          billableWeight: 3200,
+          calculatedBillableWeight: 3200,
           estimatedWeight: 5000,
           reweigh: { id: '1234' },
         },

--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
@@ -19,7 +19,7 @@ export const Card = (argTypes) => (
       weightAllowance={8000}
       onReviewWeights={argTypes.onReviewWeights}
       shipments={[
-        { id: '0001', shipmentType: 'HHG', billableWeight: 6161, estimatedWeight: 5600 },
+        { id: '0001', shipmentType: 'HHG', calculatedBillableWeight: 6161, estimatedWeight: 5600 },
         {
           id: '0002',
           shipmentType: 'HHG',
@@ -27,7 +27,7 @@ export const Card = (argTypes) => (
           estimatedWeight: 5000,
           reweigh: { id: '1234' },
         },
-        { id: '0003', shipmentType: 'HHG', billableWeight: 3400, estimatedWeight: 5000 },
+        { id: '0003', shipmentType: 'HHG', calculatedBillableWeight: 3400, estimatedWeight: 5000 },
       ]}
     />
   </div>

--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.test.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.test.jsx
@@ -8,15 +8,15 @@ import { formatWeight } from 'shared/formatters';
 
 describe('BillableWeightCard', () => {
   const shipments = [
-    { id: '0001', shipmentType: 'HHG', billableWeight: 6161, estimatedWeight: 5600 },
+    { id: '0001', shipmentType: 'HHG', calculatedBillableWeight: 6161, estimatedWeight: 5600 },
     {
       id: '0002',
       shipmentType: 'HHG',
-      billableWeight: 3200,
+      calculatedBillableWeight: 3200,
       estimatedWeight: 5000,
       reweigh: { id: '1234' },
     },
-    { id: '0003', shipmentType: 'HHG', billableWeight: 3400, estimatedWeight: 5000 },
+    { id: '0003', shipmentType: 'HHG', calculatedBillableWeight: 3400, estimatedWeight: 5000 },
   ];
 
   const defaultProps = {
@@ -48,9 +48,9 @@ describe('BillableWeightCard', () => {
     expect(screen.getByText('Missing weight')).toBeInTheDocument();
 
     // shipment weights
-    expect(screen.getByText(formatWeight(shipments[0].billableWeight))).toBeInTheDocument();
-    expect(screen.getByText(formatWeight(shipments[1].billableWeight))).toBeInTheDocument();
-    expect(screen.getByText(formatWeight(shipments[2].billableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[0].calculatedBillableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[1].calculatedBillableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[2].calculatedBillableWeight))).toBeInTheDocument();
   });
 
   it('implements the review weights handler when the review weights button is clicked', async () => {

--- a/src/components/ShipmentList/ShipmentList.stories.jsx
+++ b/src/components/ShipmentList/ShipmentList.stories.jsx
@@ -26,16 +26,16 @@ export const ShipmentListWithWeights = () => (
   <div className="grid-container">
     <h3>Single Shipment</h3>
     <ShipmentList
-      shipments={[{ id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG, billableWeight: 4600 }]}
+      shipments={[{ id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG, calculatedBillableWeight: 4600 }]}
       showShipmentWeight
     />
     <br />
     <h3>Multiple shipments</h3>
     <ShipmentList
       shipments={[
-        { id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG, billableWeight: 6161, estimatedWeight: 5600 },
-        { id: '0002', shipmentType: SHIPMENT_OPTIONS.HHG, billableWeight: 3200, reweigh: { id: '1234' } },
-        { id: '0003', shipmentType: SHIPMENT_OPTIONS.HHG, billableWeight: 3400, estimatedWeight: 5000 },
+        { id: '0001', shipmentType: SHIPMENT_OPTIONS.HHG, calculatedBillableWeight: 6161, estimatedWeight: 5600 },
+        { id: '0002', shipmentType: SHIPMENT_OPTIONS.HHG, calculatedBillableWeight: 3200, reweigh: { id: '1234' } },
+        { id: '0003', shipmentType: SHIPMENT_OPTIONS.HHG, calculatedBillableWeight: 3400, estimatedWeight: 5000 },
       ]}
       showShipmentWeight
     />

--- a/src/components/ShipmentList/ShipmentList.test.jsx
+++ b/src/components/ShipmentList/ShipmentList.test.jsx
@@ -56,15 +56,15 @@ describe('ShipmentList component', () => {
 describe('BillableWeightCard', () => {
   it('renders maximum billable weight, total billable weight, weight requested and weight allowance', () => {
     const shipments = [
-      { id: '0001', shipmentType: 'HHG', billableWeight: 6161, estimatedWeight: 5600 },
+      { id: '0001', shipmentType: 'HHG', calculatedBillableWeight: 6161, estimatedWeight: 5600 },
       {
         id: '0002',
         shipmentType: 'HHG',
-        billableWeight: 3200,
+        calculatedBillableWeight: 3200,
         estimatedWeight: 5000,
         reweigh: { id: '1234' },
       },
-      { id: '0003', shipmentType: 'HHG', billableWeight: 3400, estimatedWeight: 5000 },
+      { id: '0003', shipmentType: 'HHG', calculatedBillableWeight: 3400, estimatedWeight: 5000 },
     ];
 
     const defaultProps = {
@@ -80,8 +80,8 @@ describe('BillableWeightCard', () => {
     expect(screen.getByText('Missing weight')).toBeInTheDocument();
 
     // weights
-    expect(screen.getByText(formatWeight(shipments[0].billableWeight))).toBeInTheDocument();
-    expect(screen.getByText(formatWeight(shipments[1].billableWeight))).toBeInTheDocument();
-    expect(screen.getByText(formatWeight(shipments[2].billableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[0].calculatedBillableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[1].calculatedBillableWeight))).toBeInTheDocument();
+    expect(screen.getByText(formatWeight(shipments[2].calculatedBillableWeight))).toBeInTheDocument();
   });
 });

--- a/src/components/ShipmentList/index.jsx
+++ b/src/components/ShipmentList/index.jsx
@@ -51,7 +51,9 @@ export const ShipmentListItem = ({
       {!showShipmentWeight && (
         <span className={styles['shipment-code']}>#{shipment.id.substring(0, 8).toUpperCase()}</span>
       )}{' '}
-      {showShipmentWeight && <div className={styles.shipmentWeight}>{formatWeight(shipment.billableWeight)}</div>}
+      {showShipmentWeight && (
+        <div className={styles.shipmentWeight}>{formatWeight(shipment.calculatedBillableWeight)}</div>
+      )}
       {(isOverweight || isMissingWeight) && (
         <div>
           <FontAwesomeIcon icon="exclamation-triangle" className={styles.warning} />

--- a/src/components/ShipmentList/index.jsx
+++ b/src/components/ShipmentList/index.jsx
@@ -113,7 +113,7 @@ const ShipmentList = ({ shipments, onShipmentClick, moveSubmitted, showShipmentW
         if (showShipmentWeight) {
           canEdit = false;
           showNumber = false;
-          if (shipmentIsOverweight(shipment.estimatedWeight, shipment.billableWeight)) {
+          if (shipmentIsOverweight(shipment.estimatedWeight, shipment.calculatedBillableWeight)) {
             isOverweight = true;
           }
           if (shipment.reweigh?.id && !shipment.reweigh?.weight) {

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { shipmentStatuses } from 'constants/shipments';
 import returnLowestValue from 'utils/returnLowestValue';
 
+// only sum estimated/actual/reweigh weights for shipments in these statuses
 export const includedStatuses = (status) => {
   return (
     status === shipmentStatuses.APPROVED ||

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -4,7 +4,7 @@ import { shipmentStatuses } from 'constants/shipments';
 import returnLowestValue from 'utils/returnLowestValue';
 
 // only sum estimated/actual/reweigh weights for shipments in these statuses
-export const includedStatuses = (status) => {
+export const includedStatusesForCalculatingWeights = (status) => {
   return (
     status === shipmentStatuses.APPROVED ||
     status === shipmentStatuses.DIVERSION_REQUESTED ||
@@ -16,7 +16,7 @@ export const useCalculatedTotalBillableWeight = (mtoShipments) => {
   return useMemo(() => {
     return (
       mtoShipments
-        ?.filter((s) => includedStatuses(s.status) && s.calculatedBillableWeight)
+        ?.filter((s) => includedStatusesForCalculatingWeights(s.status) && s.calculatedBillableWeight)
         .reduce((prev, current) => {
           return prev + current.calculatedBillableWeight;
         }, 0) || null
@@ -28,7 +28,7 @@ export const useCalculatedWeightRequested = (mtoShipments) => {
   return useMemo(() => {
     return (
       mtoShipments
-        ?.filter((s) => includedStatuses(s.status) && (s.primeActualWeight || s.reweigh?.weight))
+        ?.filter((s) => includedStatusesForCalculatingWeights(s.status) && (s.primeActualWeight || s.reweigh?.weight))
         .reduce((prev, current) => {
           return prev + returnLowestValue(current.primeActualWeight, current.reweigh?.weight);
         }, 0) || null

--- a/src/hooks/custom.js
+++ b/src/hooks/custom.js
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+
+import { shipmentStatuses } from 'constants/shipments';
+import returnLowestValue from 'utils/returnLowestValue';
+
+export const includedStatuses = (status) => {
+  return (
+    status === shipmentStatuses.APPROVED ||
+    status === shipmentStatuses.DIVERSION_REQUESTED ||
+    status === shipmentStatuses.CANCELLATION_REQUESTED
+  );
+};
+
+export const useCalculatedTotalBillableWeight = (mtoShipments) => {
+  return useMemo(() => {
+    return (
+      mtoShipments
+        ?.filter((s) => includedStatuses(s.status) && s.calculatedBillableWeight)
+        .reduce((prev, current) => {
+          return prev + current.calculatedBillableWeight;
+        }, 0) || null
+    );
+  }, [mtoShipments]);
+};
+
+export const useCalculatedWeightRequested = (mtoShipments) => {
+  return useMemo(() => {
+    return (
+      mtoShipments
+        ?.filter((s) => includedStatuses(s.status) && (s.primeActualWeight || s.reweigh?.weight))
+        .reduce((prev, current) => {
+          return prev + returnLowestValue(current.primeActualWeight, current.reweigh?.weight);
+        }, 0) || null
+    );
+  }, [mtoShipments]);
+};

--- a/src/hooks/custom.test.js
+++ b/src/hooks/custom.test.js
@@ -1,4 +1,10 @@
-import { includedStatusesForCalculatingWeights } from 'hooks/custom';
+import { renderHook } from '@testing-library/react-hooks';
+
+import {
+  includedStatusesForCalculatingWeights,
+  useCalculatedTotalBillableWeight,
+  useCalculatedWeightRequested,
+} from 'hooks/custom';
 import { shipmentStatuses } from 'constants/shipments';
 
 describe('includedStatusesForCalculatingWeights returns true for approved, diversion requested, or cancellation requested', () => {
@@ -13,5 +19,85 @@ describe('includedStatusesForCalculatingWeights returns true for approved, diver
     ['FAKE_STATUS', false],
   ])('checks if a shipment with status %s should be included: %b', (status, isIncluded) => {
     expect(includedStatusesForCalculatingWeights(status)).toBe(isIncluded);
+  });
+});
+
+describe('for all shipments that are approved, have a cancellation requested, or have a diversion requested', () => {
+  it('useCalculatedTotalBillableWeight returns the calculated billable weight', () => {
+    let mtoShipments = [
+      {
+        calculatedBillableWeight: 10,
+        status: shipmentStatuses.DRAFT,
+      },
+      {
+        calculatedBillableWeight: 500,
+        status: shipmentStatuses.APPROVED,
+      },
+      {
+        calculatedBillableWeight: 200,
+        status: shipmentStatuses.CANCELLATION_REQUESTED,
+      },
+      {
+        calculatedBillableWeight: 300,
+        status: shipmentStatuses.DIVERSION_REQUESTED,
+      },
+    ];
+
+    const { result, rerender } = renderHook(() => useCalculatedTotalBillableWeight(mtoShipments));
+
+    expect(result.current).toBe(1000);
+
+    mtoShipments = mtoShipments.concat([{ calculatedBillableWeight: 100, status: shipmentStatuses.APPROVED }]);
+    rerender();
+
+    expect(result.current).toBe(1100);
+  });
+
+  it('useCalculatedWeightRequested returns the calculated billable weight using the lower value between the prime actual weight and the reweigh weight', () => {
+    let mtoShipments = [
+      {
+        primeActualWeight: 10,
+        status: shipmentStatuses.DRAFT,
+        reweigh: {
+          weight: 5,
+        },
+      },
+      {
+        primeActualWeight: 2000,
+        status: shipmentStatuses.APPROVED,
+        reweigh: {
+          weight: 300,
+        },
+      },
+      {
+        primeActualWeight: 100,
+        status: shipmentStatuses.APPROVED,
+      },
+      {
+        primeActualWeight: 1000,
+        status: shipmentStatuses.CANCELLATION_REQUESTED,
+        reweigh: {
+          weight: 200,
+        },
+      },
+      {
+        primeActualWeight: 400,
+        status: shipmentStatuses.DIVERSION_REQUESTED,
+        reweigh: {
+          weight: 3000,
+        },
+      },
+    ];
+
+    const { result, rerender } = renderHook(() => useCalculatedWeightRequested(mtoShipments));
+
+    expect(result.current).toBe(1000);
+
+    mtoShipments = mtoShipments.concat([
+      { primeActualWeight: 100, status: shipmentStatuses.APPROVED, reweigh: { weight: 3000 } },
+    ]);
+    rerender();
+
+    expect(result.current).toBe(1100);
   });
 });

--- a/src/hooks/custom.test.js
+++ b/src/hooks/custom.test.js
@@ -1,0 +1,17 @@
+import { includedStatusesForCalculatingWeights } from 'hooks/custom';
+import { shipmentStatuses } from 'constants/shipments';
+
+describe('includedStatusesForCalculatingWeights returns true for approved, diversion requested, or cancellation requested', () => {
+  it.each([
+    [shipmentStatuses.DRAFT, false],
+    [shipmentStatuses.SUBMITTED, false],
+    [shipmentStatuses.APPROVED, true],
+    [shipmentStatuses.REJECTED, false],
+    [shipmentStatuses.CANCELLATION_REQUESTED, true],
+    [shipmentStatuses.CANCELED, false],
+    [shipmentStatuses.DIVERSION_REQUESTED, true],
+    ['FAKE_STATUS', false],
+  ])('checks if a shipment with status %s should be included: %b', (status, isIncluded) => {
+    expect(includedStatusesForCalculatingWeights(status)).toBe(isIncluded);
+  });
+});

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -19,6 +19,7 @@ import { useMovePaymentRequestsQueries } from 'hooks/queries';
 import { formatPaymentRequestAddressString, getShipmentModificationType } from 'utils/shipmentDisplay';
 import { shipmentStatuses } from 'constants/shipments';
 import SERVICE_ITEM_STATUSES from 'constants/serviceItems';
+import { useCalculatedTotalBillableWeight, useCalculatedWeightRequested } from 'hooks/custom';
 
 const sectionLabels = {
   'billable-weights': 'Billable weights',
@@ -75,6 +76,9 @@ const MovePaymentRequests = ({
     };
   }, [sections, activeSection]);
 
+  const totalBillableWeight = useCalculatedTotalBillableWeight(mtoShipments);
+  const weightRequested = useCalculatedWeightRequested(mtoShipments);
+
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
@@ -112,14 +116,10 @@ const MovePaymentRequests = ({
         <GridContainer className={txoStyles.gridContainer} data-testid="tio-payment-request-details">
           <h1>Payment requests</h1>
           <div className={txoStyles.section} id="billable-weights">
-            {/* TODO
-                totalBillableWeights needs to be calculated using serviceObject from MB-9278
-                weightRequested needs to be calculated using the serviceObject from MB-9278
-              */}
             <BillableWeightCard
               maxBillableWeight={order?.entitlement?.authorizedWeight}
-              totalBillableWeight={0}
-              weightRequested={0}
+              totalBillableWeight={totalBillableWeight}
+              weightRequested={weightRequested}
               weightAllowance={order?.entitlement?.totalWeight}
               onReviewWeights={handleReviewWeightsClick}
               shipments={mtoShipments}

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -7,13 +7,12 @@ import MovePaymentRequests from './MovePaymentRequests';
 
 import MOVE_STATUSES from 'constants/moves';
 import { MockProviders } from 'testUtils';
-import { useMovePaymentRequestsQueries, useMoveDetailsQueries } from 'hooks/queries';
+import { useMovePaymentRequestsQueries } from 'hooks/queries';
 import { shipmentStatuses } from 'constants/shipments';
 import SERVICE_ITEM_STATUSES from 'constants/serviceItems';
 
 jest.mock('hooks/queries', () => ({
   useMovePaymentRequestsQueries: jest.fn(),
-  useMoveDetailsQueries: jest.fn(),
 }));
 
 const mockPush = jest.fn();
@@ -40,6 +39,48 @@ const move = {
   orders: {
     sac: '1234456',
     tac: '1213',
+  },
+};
+
+const order = {
+  orders_type: 'PERMANENT_CHANGE_OF_STATION',
+  has_dependents: false,
+  issue_date: '2020-08-11',
+  grade: 'RANK',
+  moves: ['123'],
+  origin_duty_station: {
+    name: 'Test Duty Station',
+    address: {
+      postal_code: '123456',
+    },
+  },
+  new_duty_station: {
+    name: 'New Test Duty Station',
+    address: {
+      postal_code: '123456',
+    },
+  },
+  report_by_date: '2020-08-31',
+  service_member_id: '666',
+  spouse_has_pro_gear: false,
+  status: MOVE_STATUSES.SUBMITTED,
+  uploaded_orders: {
+    uploads: [],
+  },
+  entitlement: {
+    authorizedWeight: 8000,
+    dependentsAuthorized: true,
+    eTag: 'MjAyMS0wOC0yNFQxODoyNDo0MC45NzIzMTha',
+    id: '188842d1-cf88-49ec-bd2f-dfa98da44bb2',
+    nonTemporaryStorage: true,
+    organizationalClothingAndIndividualEquipment: true,
+    privatelyOwnedVehicle: true,
+    proGearWeight: 2000,
+    proGearWeightSpouse: 500,
+    requiredMedicalEquipmentWeight: 1000,
+    storageInTransit: 2,
+    totalDependents: 1,
+    totalWeight: 8000,
   },
 };
 
@@ -105,6 +146,12 @@ const multiplePaymentRequests = {
       scheduledPickupDate: '2020-01-09T00:00:00.000Z',
       destinationAddress: { city: 'Princeton', state: 'NJ', postal_code: '08540' },
       pickupAddress: { city: 'Boston', state: 'MA', postal_code: '02101' },
+      calculatedBillableWeight: 9000,
+      primeActualWeight: 500,
+      reweigh: {
+        id: 'reweighID1',
+        weight: 100,
+      },
       mtoServiceItems: [
         {
           id: '5',
@@ -131,6 +178,12 @@ const multiplePaymentRequests = {
       scheduledPickupDate: '2020-01-10T00:00:00.000Z',
       destinationAddress: { city: 'Princeton', state: 'NJ', postal_code: '08540' },
       pickupAddress: { city: 'Boston', state: 'MA', postal_code: '02101' },
+      calculatedBillableWeight: 1000,
+      primeActualWeight: 5000,
+      reweigh: {
+        id: 'reweighID2',
+        weight: 600,
+      },
       mtoServiceItems: [
         {
           id: '9',
@@ -157,6 +210,12 @@ const multiplePaymentRequests = {
       scheduledPickupDate: '2020-01-11T00:00:00.000Z',
       destinationAddress: { city: 'Princeton', state: 'NJ', postal_code: '08540' },
       pickupAddress: { city: 'Boston', state: 'MA', postal_code: '02101' },
+      calculatedBillableWeight: 2000,
+      primeActualWeight: 300,
+      reweigh: {
+        id: 'reweighID3',
+        weight: 900,
+      },
       mtoServiceItems: [
         {
           id: '12',
@@ -176,6 +235,7 @@ const multiplePaymentRequests = {
       ],
     },
   ],
+  order,
 };
 
 const singleReviewedPaymentRequest = {
@@ -216,6 +276,12 @@ const singleReviewedPaymentRequest = {
       scheduledPickupDate: '2020-01-11T00:00:00.000Z',
       destinationAddress: { city: 'Princeton', state: 'NJ', postal_code: '08540' },
       pickupAddress: { city: 'Boston', state: 'MA', postal_code: '02101' },
+      calculatedBillableWeight: 2000,
+      primeActualWeight: 300,
+      reweigh: {
+        id: 'reweighID',
+        weight: 900,
+      },
       mtoServiceItems: [
         {
           id: '3',
@@ -225,55 +291,36 @@ const singleReviewedPaymentRequest = {
       ],
     },
   ],
-};
-
-const orders = {
-  order: {
-    orders_type: 'PERMANENT_CHANGE_OF_STATION',
-    has_dependents: false,
-    issue_date: '2020-08-11',
-    grade: 'RANK',
-    moves: ['123'],
-    origin_duty_station: {
-      name: 'Test Duty Station',
-      address: {
-        postal_code: '123456',
-      },
-    },
-    new_duty_station: {
-      name: 'New Test Duty Station',
-      address: {
-        postal_code: '123456',
-      },
-    },
-    report_by_date: '2020-08-31',
-    service_member_id: '666',
-    spouse_has_pro_gear: false,
-    status: MOVE_STATUSES.SUBMITTED,
-    uploaded_orders: {
-      uploads: [],
-    },
-    entitlement: {
-      authorizedWeight: 8000,
-      dependentsAuthorized: true,
-      eTag: 'MjAyMS0wOC0yNFQxODoyNDo0MC45NzIzMTha',
-      id: '188842d1-cf88-49ec-bd2f-dfa98da44bb2',
-      nonTemporaryStorage: true,
-      organizationalClothingAndIndividualEquipment: true,
-      privatelyOwnedVehicle: true,
-      proGearWeight: 2000,
-      proGearWeightSpouse: 500,
-      requiredMedicalEquipmentWeight: 1000,
-      storageInTransit: 2,
-      totalDependents: 1,
-      totalWeight: 8000,
-    },
-  },
+  order,
 };
 
 const emptyPaymentRequests = {
   paymentRequests: [],
-  mtoShipments: [],
+  mtoShipments: [
+    {
+      shipmentType: 'HHG',
+      id: '2',
+      moveTaskOrderID: '1',
+      status: shipmentStatuses.APPROVED,
+      scheduledPickupDate: '2020-01-11T00:00:00.000Z',
+      destinationAddress: { city: 'Princeton', state: 'NJ', postal_code: '08540' },
+      pickupAddress: { city: 'Boston', state: 'MA', postal_code: '02101' },
+      calculatedBillableWeight: 2000,
+      primeActualWeight: 300,
+      reweigh: {
+        id: 'reweighID',
+        weight: 900,
+      },
+      mtoServiceItems: [
+        {
+          id: '3',
+          mtoShipmentID: '2',
+          status: SERVICE_ITEM_STATUSES.APPROVED,
+        },
+      ],
+    },
+  ],
+  order,
 };
 
 const loadingReturnValue = {
@@ -300,7 +347,6 @@ describe('MovePaymentRequests', () => {
   describe('check loading and error component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
       useMovePaymentRequestsQueries.mockReturnValue(loadingReturnValue);
-      useMoveDetailsQueries.mockReturnValue(loadingReturnValue);
 
       renderMovePaymentRequests(testProps);
 
@@ -310,7 +356,6 @@ describe('MovePaymentRequests', () => {
 
     it('renders the Something Went Wrong component when the query errors', async () => {
       useMovePaymentRequestsQueries.mockReturnValue(errorReturnValue);
-      useMoveDetailsQueries.mockReturnValue(errorReturnValue);
 
       renderMovePaymentRequests(testProps);
 
@@ -322,7 +367,6 @@ describe('MovePaymentRequests', () => {
   describe('with multiple payment requests', () => {
     beforeEach(() => {
       useMovePaymentRequestsQueries.mockReturnValue(multiplePaymentRequests);
-      useMoveDetailsQueries.mockReturnValue(orders);
     });
 
     it('renders without errors', () => {
@@ -364,7 +408,6 @@ describe('MovePaymentRequests', () => {
   describe('renders side navigation for each section', () => {
     beforeEach(() => {
       useMovePaymentRequestsQueries.mockReturnValue(singleReviewedPaymentRequest);
-      useMoveDetailsQueries.mockReturnValue(orders);
     });
 
     it.each([
@@ -408,7 +451,6 @@ describe('MovePaymentRequests', () => {
   describe('with no payment requests for move', () => {
     beforeEach(() => {
       useMovePaymentRequestsQueries.mockReturnValue(emptyPaymentRequests);
-      useMoveDetailsQueries.mockReturnValue(orders);
     });
 
     it('does not render side navigation for payment request section', () => {
@@ -453,7 +495,6 @@ describe('MovePaymentRequests', () => {
   describe('a billable weight', () => {
     beforeEach(() => {
       useMovePaymentRequestsQueries.mockReturnValue(emptyPaymentRequests);
-      useMoveDetailsQueries.mockReturnValue(orders);
     });
 
     it('navigates the user to the reivew billable weight page', async () => {

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 
 import styles from '../TXOMoveInfo/TXOTab.module.scss';
 import EditMaxBillableWeightModal from '../../../components/Office/EditMaxBillableWeightModal/EditMaxBillableWeightModal';
-import returnLowestValue from '../../../utils/returnLowestValue';
 
 import moveTaskOrderStyles from './MoveTaskOrder.module.scss';
 
@@ -45,6 +44,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { setFlashMessage } from 'store/flash/actions';
 import { MatchShape } from 'types/router';
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
+import { includedStatuses, useCalculatedWeightRequested } from 'hooks/custom';
 
 function formatShipmentDate(shipmentDateString) {
   if (shipmentDateString == null) {
@@ -64,15 +64,6 @@ function showShipmentFilter(shipment) {
     shipment.status === shipmentStatuses.CANCELLATION_REQUESTED ||
     shipment.status === shipmentStatuses.DIVERSION_REQUESTED ||
     shipment.status === shipmentStatuses.CANCELED
-  );
-}
-
-// only sum estimated/actual/reweigh weights for shipments in these statuses
-function includedStatuses(status) {
-  return (
-    status === shipmentStatuses.APPROVED ||
-    status === shipmentStatuses.DIVERSION_REQUESTED ||
-    status === shipmentStatuses.CANCELLATION_REQUESTED
   );
 }
 
@@ -346,15 +337,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   }, [mtoShipments, setExcessWeightRiskCount, order, estimatedWeightTotal, move]);
 
   // Edge case of diversion shipments being counted twice
-  const moveWeightTotal = useMemo(() => {
-    return (
-      mtoShipments
-        ?.filter((s) => includedStatuses(s.status) && (s.primeActualWeight || s.reweigh?.weight))
-        .reduce((prev, current) => {
-          return prev + returnLowestValue(current.primeActualWeight, current.reweigh?.weight);
-        }, 0) || null
-    );
-  }, [mtoShipments]);
+  const moveWeightTotal = useCalculatedWeightRequested(mtoShipments);
 
   useEffect(() => {
     // attach scroll listener

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -44,7 +44,7 @@ import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { setFlashMessage } from 'store/flash/actions';
 import { MatchShape } from 'types/router';
 import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
-import { includedStatuses, useCalculatedWeightRequested } from 'hooks/custom';
+import { includedStatusesForCalculatingWeights, useCalculatedWeightRequested } from 'hooks/custom';
 
 function formatShipmentDate(shipmentDateString) {
   if (shipmentDateString == null) {
@@ -314,9 +314,9 @@ export const MoveTaskOrder = ({ match, ...props }) => {
     let excessBillableWeightCount = 0;
     const riskOfExcessAcknowledged = !!move?.excess_weight_acknowledged_at;
 
-    if (mtoShipments?.some((s) => s.primeEstimatedWeight && includedStatuses(s.status))) {
+    if (mtoShipments?.some((s) => s.primeEstimatedWeight && includedStatusesForCalculatingWeights(s.status))) {
       estimatedWeightCalc = mtoShipments
-        ?.filter((s) => s.primeEstimatedWeight && includedStatuses(s.status))
+        ?.filter((s) => s.primeEstimatedWeight && includedStatusesForCalculatingWeights(s.status))
         .reduce((prev, current) => {
           return prev + current.primeEstimatedWeight;
         }, 0);


### PR DESCRIPTION
## Description

Wrote up some custom hooks to calculate the total billable weight and the total weight requested.
Replaced some spots where the custom hook would be useful at.
I fixed up the MovePaymentRequests tests since they were spitting out a bunch of console errors

## Reviewer Notes

Did I change the shipment list item to use the correct value?
Is the logic for calculating the total billable weight and the total weight requested correct?
Are things living in the right places?
Did I name things ok?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make office_client_run
make server_run
```
Login as a TIO and use any of the following moves (I can not ensure the integrity of any other moves):
Move with billable weights
Locator BILWEI

Reweigh with multiple shipments 
Locator MULTRW

Shipment missing reweigh
Locator MISHRW

Max billable weight exceeded
Locator MAXCED

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9313) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._


![image](https://user-images.githubusercontent.com/6477059/132930471-7a2f0982-83dd-4444-b708-6efc300d78fe.png)
