### PR TITLE
Remove gex/orders references

### DIFF
--- a/scripts/deploy-app-client-tls
+++ b/scripts/deploy-app-client-tls
@@ -22,18 +22,18 @@ case "${environment}" in
     export AWS_ACCOUNT_ID=447641181206
     ;;
   exp)
-    compare_host=gex.exp.move.mil
-    health_check_hosts=gex.exp.move.mil,my.exp.move.mil,orders.exp.move.mil
+    compare_host=my.exp.move.mil
+    health_check_hosts=my.exp.move.mil
     export AWS_ACCOUNT_ID=015681133840
     ;;
   stg)
-    compare_host=gex.stg.move.mil
-    health_check_hosts=gex.stg.move.mil,my.stg.move.mil,orders.stg.move.mil
+    compare_host=my.stg.move.mil
+    health_check_hosts=my.stg.move.mil
     export AWS_ACCOUNT_ID=015932076428
     ;;
   prd)
-    compare_host=gex.move.mil
-    health_check_hosts=gex.move.mil,my.move.mil,orders.move.mil
+    compare_host=my.move.mil
+    health_check_hosts=my.move.mil
     export AWS_ACCOUNT_ID=015533997236
     ;;
   *)

--- a/scripts/deploy-app-client-tls-niprnet
+++ b/scripts/deploy-app-client-tls-niprnet
@@ -17,13 +17,13 @@ readonly environment="${1}"
 
 case "${environment}" in
   stg)
-    compare_host=gex.stg.move.mil
-    health_check_hosts=gex.stg.move.mil,my.stg.move.mil,orders.stg.move.mil
+    compare_host=my.stg.move.mil
+    health_check_hosts=my.stg.move.mil
     export AWS_ACCOUNT_ID=015932076428
     ;;
   prd)
-    compare_host=gex.move.mil
-    health_check_hosts=gex.move.mil,my.move.mil,orders.move.mil
+    compare_host=my.move.mil
+    health_check_hosts=my.move.mil
     export AWS_ACCOUNT_ID=015533997236
     ;;
   *)

--- a/scripts/health-tls-check
+++ b/scripts/health-tls-check
@@ -23,17 +23,17 @@ case "${environment}" in
     ;;
   exp)
     health_check_hosts=my.exp.move.mil,office.exp.move.mil,admin.exp.move.mil
-    tls_health_check_hosts=gex.exp.move.mil,my.exp.move.mil,orders.exp.move.mil
+    tls_health_check_hosts=my.exp.move.mil
     export AWS_ACCOUNT_ID=015681133840
     ;;
   stg)
     health_check_hosts=my.stg.move.mil,office.stg.move.mil,admin.stg.move.mil
-    tls_health_check_hosts=gex.stg.move.mil,my.stg.move.mil,orders.stg.move.mil
+    tls_health_check_hosts=my.stg.move.mil
     export AWS_ACCOUNT_ID=015932076428
     ;;
   prd)
     health_check_hosts=my.move.mil,office.move.mil,admin.move.mil
-    tls_health_check_hosts=gex.move.mil,my.move.mil,orders.move.mil
+    tls_health_check_hosts=my.move.mil
     export AWS_ACCOUNT_ID=015533997236
     ;;
   *)


### PR DESCRIPTION
Signed-off-by: travelar <erik@truss.works>

## Description

Remove health checks for gex.* and orders.*

## Reviewer Notes

Is it going to be this easy? I don't have a local environment to test this in, but I don't see this breaking anything new. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Slack Convo](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1631549414203500) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
