### PR TITLE
MB-9248 Update documentation related to Swagger updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,13 +910,10 @@ the value of the `basePath:` stanza at the root of the generated
 You can view the documentation for the following APIs (powered by Swagger UI) at
 the following URLS with a local client and server running:
 
-* internal API: <http://milmovelocal:3000/swagger-ui/internal.html>
-
-* admin API: <http://milmovelocal:3000/swagger-ui/admin.html>
-
-* GHC API: <http://milmovelocal:3000/swagger-ui/ghc.html>
-
-* Prime API: <http://primelocal:3000/swagger-ui/prime.html>
+* internal API: [http://milmovelocal:3000/swagger-ui/internal.html](http://milmovelocal:3000/swagger-ui/internal.html)
+* admin API: [http://milmovelocal:3000/swagger-ui/admin.html](http://milmovelocal:3000/swagger-ui/admin.html)
+* GHC API: [http://milmovelocal:3000/swagger-ui/ghc.html](http://milmovelocal:3000/swagger-ui/ghc.html)
+* Prime API: [http://primelocal:3000/swagger-ui/prime.html](http://primelocal:3000/swagger-ui/prime.html)
 
 For more information on _API / Swagger_ definitions, please review the README
 documentation found in the `./swagger/README.md` and `./swagger-def/README.md`

--- a/README.md
+++ b/README.md
@@ -890,19 +890,37 @@ Currently, scenarios have the following numbers:
 
 ### API / Swagger
 
-Internal services (i.e. endpoints only intended for use by the React client) are defined in `swagger/internal.yaml` and served at `/internal/swagger.yaml`. These are, as the name suggests, internal endpoints and not intended for use by external clients.
+Internal services (i.e. endpoints only intended for use by the React client) are
+defined in `swagger-def/internal.yaml` and served from the value of the
+`basePath:` stanza at the root of the generated `./swagger/internal.yaml` file.
+**Internal endpoints are not intended for use by external clients**.
 
-The Orders Gateway's API is defined in the file `swagger/orders.yaml` and served at `/orders/v0/orders.yaml`.
+The Orders Gateway's API is defined in the file `swagger-def/orders.yaml` and
+served from the value of the `basePath:` stanza at the root of the generated
+`./swagger/orders.yaml` file.
 
-The Admin API is defined in the file `swagger/admin.yaml` and served at `/admin/v1/swagger.yaml`.
+The Admin API is defined in the file `swagger-def/admin.yaml` and served from
+the value of the `basePath:` stanza at the root of the generated
+`./swagger/admin.yaml` file.
 
-You can view the documentation for the following APIs (powered by Swagger UI) at the following URLS with a local client and server running:
+The Prime API is defined in the file `./swagger-def/prime.yaml` and served from
+the value of the `basePath:` stanza at the root of the generated
+`./swagger/prime.yaml` file.
+
+You can view the documentation for the following APIs (powered by Swagger UI) at
+the following URLS with a local client and server running:
 
 * internal API: <http://milmovelocal:3000/swagger-ui/internal.html>
 
 * admin API: <http://milmovelocal:3000/swagger-ui/admin.html>
 
 * GHC API: <http://milmovelocal:3000/swagger-ui/ghc.html>
+
+* Prime API: <http://primelocal:3000/swagger-ui/prime.html>
+
+For more information on _API / Swagger_ definitions, please review the README
+documentation found in the `./swagger/README.md` and `./swagger-def/README.md`
+files.
 
 ### Testing
 


### PR DESCRIPTION
## Description

Some of this documentation was out of date after the changes from #7145
and also adding in the Prime API Swagger UI link as it's helpful to have
this in general.

## Reviewer Notes

👀 Take a look at the documentation changes and make sure it makes sense.

## Setup

<details>
<summary>Run the server and client locally in separate terminals.</summary>

##### Terminal 1
```sh
make server_run
```

##### Terminal 2
```sh
make client_run
```

</details>

Once your commands are running locally, navigate to the URLs in the `./README.md` about Swagger UI. There should be API definitions from Swagger and no errors.

* internal API: [http://milmovelocal:3000/swagger-ui/internal.html](http://milmovelocal:3000/swagger-ui/internal.html)
* admin API: [http://milmovelocal:3000/swagger-ui/admin.html](http://milmovelocal:3000/swagger-ui/admin.html)
* GHC API: [http://milmovelocal:3000/swagger-ui/ghc.html](http://milmovelocal:3000/swagger-ui/ghc.html)
* Prime API: [http://primelocal:3000/swagger-ui/prime.html](http://primelocal:3000/swagger-ui/prime.html)

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9248) for this change