### PR TITLE
MB-9319, MB-9321: Fix console warnings emitted by client tests

### DIFF
--- a/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
+++ b/src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
@@ -18,7 +18,7 @@ describe('BackupContactInfoFields component', () => {
   });
 
   describe('with pre-filled values', () => {
-    it('renders a legend and all backup contact info inputs', () => {
+    it('renders a legend and all backup contact info inputs', async () => {
       const initialValues = {
         email: 'test@example.com',
         name: 'test',
@@ -30,13 +30,13 @@ describe('BackupContactInfoFields component', () => {
           <BackupContactInfoFields legend="Backup contact" />
         </Formik>,
       );
-      expect(screen.getByLabelText('Name')).toHaveValue(initialValues.name);
-      expect(screen.getByLabelText('Email')).toHaveValue(initialValues.email);
-      expect(screen.getByLabelText('Phone')).toHaveValue(initialValues.telephone);
+      expect(await screen.findByLabelText('Name')).toHaveValue(initialValues.name);
+      expect(await screen.findByLabelText('Email')).toHaveValue(initialValues.email);
+      expect(await screen.findByLabelText('Phone')).toHaveValue(initialValues.telephone);
     });
   });
 
-  it('can namespace fields', () => {
+  it('can namespace fields', async () => {
     const namespace = 'backup_contact';
 
     const initialBackupInfo = {
@@ -54,8 +54,9 @@ describe('BackupContactInfoFields component', () => {
         <BackupContactInfoFields legend="Backup contact" name={namespace} />
       </Formik>,
     );
-    expect(screen.getByLabelText('Name')).toHaveValue(initialBackupInfo.name);
-    expect(screen.getByLabelText('Email')).toHaveValue(initialBackupInfo.email);
-    expect(screen.getByLabelText('Phone')).toHaveValue(initialBackupInfo.telephone);
+
+    expect(await screen.findByLabelText('Name')).toHaveValue(initialBackupInfo.name);
+    expect(await screen.findByLabelText('Email')).toHaveValue(initialBackupInfo.email);
+    expect(await screen.findByLabelText('Phone')).toHaveValue(initialBackupInfo.telephone);
   });
 });

--- a/src/pages/MyMove/Profile/BackupContact.test.jsx
+++ b/src/pages/MyMove/Profile/BackupContact.test.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ConnectedBackupContact, { BackupContact } from './BackupContact';
@@ -47,14 +46,17 @@ describe('BackupContact page', () => {
 
   it('back button goes to the BACKUP ADDRESS step', async () => {
     // Need to provide initial values because we aren't testing the form here, and just want to submit immediately
-    const { queryByText } = render(<BackupContact {...testProps} currentBackupContacts={testBackupContacts} />);
+    render(<BackupContact {...testProps} currentBackupContacts={testBackupContacts} />);
 
-    const backButton = queryByText('Back');
+    const backButton = screen.getByText('Back');
     expect(backButton).toBeInTheDocument();
     userEvent.click(backButton);
 
-    expect(testProps.push).toHaveBeenCalledWith('/service-member/backup-address');
+    await waitFor(() => {
+      expect(testProps.push).toHaveBeenCalledWith('/service-member/backup-address');
+    });
   });
+
   describe('if there is an existing backup contact', () => {
     it('next button submits the form and goes to the Home step', async () => {
       patchBackupContact.mockImplementation(() => Promise.resolve(testBackupContactValues));
@@ -108,6 +110,7 @@ describe('BackupContact page', () => {
       expect(testProps.push).not.toHaveBeenCalled();
     });
   });
+
   describe('if there is no existing backup contact', () => {
     it('next button submits the form and goes to the Home step', async () => {
       createBackupContactForServiceMember.mockImplementation(() => Promise.resolve(testBackupContactValues));
@@ -167,6 +170,7 @@ describe('BackupContact page', () => {
       expect(testProps.push).not.toHaveBeenCalled();
     });
   });
+
   afterEach(jest.resetAllMocks);
 });
 
@@ -190,7 +194,7 @@ describe('requireCustomerState BackupContact', () => {
     currentBackupContacts: [],
   };
 
-  it('dispatches a redirect if the current state is earlier than the "BACKUP MAILING ADDRESS COMPLETE" state', () => {
+  it('dispatches a redirect if the current state is earlier than the "BACKUP MAILING ADDRESS COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -222,17 +226,20 @@ describe('requireCustomerState BackupContact', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupContact {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/backup-address'));
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Backup contact');
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/backup-address'));
+    });
   });
 
-  it('does not redirect if the current state equals the "BACKUP MAILING ADDRESS COMPLETE" state', () => {
+  it('does not redirect if the current state equals the "BACKUP MAILING ADDRESS COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -267,17 +274,20 @@ describe('requireCustomerState BackupContact', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupContact {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Backup contact');
+
+    await waitFor(() => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('does redirect if the profile is complete', () => {
+  it('does redirect if the profile is complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -317,13 +327,16 @@ describe('requireCustomerState BackupContact', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupContact {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Backup contact');
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    });
   });
 });

--- a/src/pages/MyMove/Profile/BackupMailingAddress.test.jsx
+++ b/src/pages/MyMove/Profile/BackupMailingAddress.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
 import { render, waitFor } from '@testing-library/react';
@@ -133,7 +132,7 @@ describe('requireCustomerState BackupMailingAddress', () => {
     push: jest.fn(),
   };
 
-  it('dispatches a redirect if the current state is earlier than the "ADDRESS COMPLETE" state', () => {
+  it('dispatches a redirect if the current state is earlier than the "ADDRESS COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -162,17 +161,18 @@ describe('requireCustomerState BackupMailingAddress', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupMailingAddress {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/current-address'));
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(push('/service-member/current-address'));
+    });
   });
 
-  it('does not redirect if the current state equals the "ADDRESS COMPLETE" state', () => {
+  it('does not redirect if the current state equals the "ADDRESS COMPLETE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -204,17 +204,18 @@ describe('requireCustomerState BackupMailingAddress', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupMailingAddress {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not redirect if the current state is after the "ADDRESS COMPLETE" state and profile is not complete', () => {
+  it('does not redirect if the current state is after the "ADDRESS COMPLETE" state and profile is not complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -249,17 +250,18 @@ describe('requireCustomerState BackupMailingAddress', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupMailingAddress {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('does redirect if the profile is complete', () => {
+  it('does redirect if the profile is complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -299,13 +301,14 @@ describe('requireCustomerState BackupMailingAddress', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedBackupMailingAddress {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    });
   });
 });


### PR DESCRIPTION
## Description

As part of the [TRA epic](https://dp3.atlassian.net/browse/MB-8944) to clear out console warnings/errors during front-end test runs, this pull request fulfills a ticket to resolve emitted messages from the following test fixtures:

* src/components/form/BackupContactInfoFields/BackupContactInfoFields.test.jsx
* src/pages/MyMove/Profile/BackupContact.test.jsx
* src/pages/MyMove/Profile/BackupMailingAddress.test.jsx

## Reviewer Notes

Ensure that _all_ client and integration tests pass, and that the edited test files do not emit any console messages during testing. There should be no perceptible UI changes to the user.

## Setup

```sh
yarn test Backup
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Part of epic [MB-8944](https://dp3.atlassian.net/browse/MB-8944).
* Closes [MB-9319](https://dp3.atlassian.net/browse/MB-9319) and [MB-9321](https://dp3.atlassian.net/browse/MB-9321).