### PR TITLE
MB-9316: Cleans up DodInfo client test

### DIFF
--- a/src/pages/MyMove/Profile/DodInfo.test.jsx
+++ b/src/pages/MyMove/Profile/DodInfo.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import * as reactRedux from 'react-redux';
 import { push } from 'connected-react-router';
 import { render, waitFor } from '@testing-library/react';
@@ -124,7 +123,7 @@ describe('requireCustomerState DodInfo', () => {
     push: jest.fn(),
   };
 
-  it('does not redirect if the current state equals the "EMPTY PROFILE" state', () => {
+  it('does not redirect if the current state equals the "EMPTY PROFILE" state', async () => {
     const mockState = {
       entities: {
         user: {
@@ -142,17 +141,18 @@ describe('requireCustomerState DodInfo', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedDodInfo {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not redirect if the current state is after the "EMPTY PROFILE" state and profile is not complete', () => {
+  it('does not redirect if the current state is after the "EMPTY PROFILE" state and profile is not complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -178,17 +178,18 @@ describe('requireCustomerState DodInfo', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedDodInfo {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('does redirect if the profile is complete', () => {
+  it('does redirect if the profile is complete', async () => {
     const mockState = {
       entities: {
         user: {
@@ -228,13 +229,14 @@ describe('requireCustomerState DodInfo', () => {
       },
     };
 
-    const wrapper = mount(
+    render(
       <MockProviders initialState={mockState}>
         <ConnectedDodInfo {...props} />
       </MockProviders>,
     );
 
-    expect(wrapper.exists()).toBe(true);
-    expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(push('/'));
+    });
   });
 });


### PR DESCRIPTION
## Description

As part of the [TRA epic](https://dp3.atlassian.net/browse/MB-8944) to clear out console warnings/errors during front-end test runs, this pull request fulfills a ticket to resolve emitted messages from the following test fixtures:

* src/pages/MyMove/Profile/DodInfo.test.jsx

## Reviewer Notes

Ensure that _all_ client and integration tests pass, and that the edited test files do not emit any console messages during testing. There should be no perceptible UI changes to the user.

## Setup

```sh
yarn test DodInfo
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Part of epic [MB-8944](https://dp3.atlassian.net/browse/MB-8944).
* Closes [MB-9316](https://dp3.atlassian.net/browse/MB-9316).