### PR TITLE
MB-9318: Cleans up CreateOrEditMtoShipment client tests

### DIFF
--- a/src/pages/MyMove/CreateOrEditMtoShipment.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.jsx
@@ -52,7 +52,7 @@ export class CreateOrEditMtoShipment extends Component {
           match={match}
           history={history}
           mtoShipment={mtoShipment}
-          selectedMoveType={type}
+          selectedMoveType={type || mtoShipment.shipmentType}
           isCreatePage={!!type}
           currentResidence={currentResidence}
           newDutyStationAddress={newDutyStationAddress}

--- a/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
+++ b/src/pages/MyMove/CreateOrEditMtoShipment.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, waitFor, screen } from '@testing-library/react';
 
 import { CreateOrEditMtoShipment } from './CreateOrEditMtoShipment';
 
@@ -65,55 +65,62 @@ const mockMtoShipment = {
   shipmentType: 'HHG',
 };
 
-const mountCreateOrEditMtoShipment = (props) => mount(<CreateOrEditMtoShipment {...defaultProps} {...props} />);
+const renderComponent = (props) => render(<CreateOrEditMtoShipment {...defaultProps} {...props} />);
 
 describe('CreateOrEditMtoShipment component', () => {
   it('fetches customer data on mount', () => {
-    mountCreateOrEditMtoShipment({
+    renderComponent({
       selectedMoveType: SHIPMENT_OPTIONS.NTSR,
     });
     expect(defaultProps.fetchCustomerData).toHaveBeenCalled();
   });
 
   describe('when creating a new shipment', () => {
-    it('redirects to the PPM start page if selected shipment type is PPM', () => {
-      mountCreateOrEditMtoShipment({
+    it('redirects to the PPM start page if selected shipment type is PPM', async () => {
+      renderComponent({
         location: {
           search: `?type=${SHIPMENT_OPTIONS.PPM}`,
         },
       });
 
-      expect(defaultProps.history.replace).toHaveBeenCalledWith('/moves/move123/ppm-start');
+      await waitFor(() => {
+        expect(defaultProps.history.replace).toHaveBeenCalledWith('/moves/move123/ppm-start');
+      });
     });
 
-    it('renders the MtoShipmentForm component right away', () => {
-      const createWrapper = mountCreateOrEditMtoShipment({
+    it('renders the MtoShipmentForm component right away', async () => {
+      renderComponent({
         location: {
           search: `?type=${SHIPMENT_OPTIONS.HHG}`,
         },
       });
-      expect(createWrapper.find('MtoShipmentForm').length).toBe(1);
-      expect(createWrapper.find('LoadingPlaceholder').exists()).toBe(false);
+
+      expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent(
+        'Movers pack and transport this shipment',
+      );
+      expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument();
     });
   });
 
   describe('when editing an existing shipment', () => {
-    const editWrapper = mountCreateOrEditMtoShipment({
-      match: getMockMatchProp('/moves/:moveId/shipments/:mtoShipmentId/edit'),
-    });
-
     it('renders the loader right away', () => {
-      expect(editWrapper.find('LoadingPlaceholder').exists()).toBe(true);
-      expect(editWrapper.find('MtoShipmentForm').length).toBe(0);
+      renderComponent({
+        match: getMockMatchProp('/moves/:moveId/shipments/:mtoShipmentId/edit'),
+      });
+
+      expect(screen.getByText('Loading, please wait...')).toBeInTheDocument();
     });
 
-    it('renders the MtoShipmentForm after an MTO shipment has loaded', () => {
-      editWrapper.setProps({
+    it('renders the MtoShipmentForm after an MTO shipment has loaded', async () => {
+      renderComponent({
+        match: getMockMatchProp('/moves/:moveId/shipments/:mtoShipmentId/edit'),
         mtoShipment: mockMtoShipment,
       });
-      editWrapper.update();
-      expect(editWrapper.find('LoadingPlaceholder').exists()).toBe(false);
-      expect(editWrapper.find('MtoShipmentForm').length).toBe(1);
+
+      expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent(
+        'Movers pack and transport this shipment',
+      );
+      expect(screen.queryByText('Loading, please wait...')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Description

As part of the [TRA epic](https://dp3.atlassian.net/browse/MB-8944) to clear out console warnings/errors during front-end test runs, this pull request fulfills a ticket to resolve emitted messages from the following test fixtures:

* src/pages/MyMove/CreateOrEditMtoShipment.test.jsx

This includes an update to the component under test, which clears up a PropType validation issue.

## Reviewer Notes

Ensure that _all_ client and integration tests pass, and that the edited test files do not emit any console messages during testing. There should be no perceptible UI changes to the user.

## Setup

```sh
yarn test Shipment
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Part of epic [MB-8944](https://dp3.atlassian.net/browse/MB-8944).
* Closes [MB-9318](https://dp3.atlassian.net/browse/MB-9318).