### PR TITLE
[MB-9308] Lookup for WeightAdjusted

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -416,7 +416,13 @@ func ServiceParamLookupInitialize(
 	if err != nil {
 		return nil, err
 	}
-
+	paramKey = models.ServiceItemParamNameWeightAdjusted
+	err = s.setLookup(appCtx, serviceItemCode, paramKey, WeightAdjustedLookup{
+		MTOShipment: mtoShipment,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &s, nil
 }
 

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -196,6 +196,14 @@ func ServiceParamLookupInitialize(
 		return nil, err
 	}
 
+	paramKey = models.ServiceItemParamNameWeightAdjusted
+	err = s.setLookup(appCtx, serviceItemCode, paramKey, WeightAdjustedLookup{
+		MTOShipment: mtoShipment,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	paramKey = models.ServiceItemParamNameWeightBilled
 	err = s.setLookup(appCtx, serviceItemCode, paramKey, WeightBilledLookup{
 		MTOShipment: mtoShipment,
@@ -416,13 +424,7 @@ func ServiceParamLookupInitialize(
 	if err != nil {
 		return nil, err
 	}
-	paramKey = models.ServiceItemParamNameWeightAdjusted
-	err = s.setLookup(appCtx, serviceItemCode, paramKey, WeightAdjustedLookup{
-		MTOShipment: mtoShipment,
-	})
-	if err != nil {
-		return nil, err
-	}
+
 	return &s, nil
 }
 

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -172,6 +172,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedW
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
+			Move: mtoServiceItem.MoveTaskOrder,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -170,9 +170,6 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedW
 			},
 		})
 
-	var shipment models.MTOShipment
-	suite.NoError(suite.DB().Find(&shipment, *mtoServiceItem.MTOShipmentID))
-
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
 			PaymentRequest: models.PaymentRequest{

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -157,8 +157,10 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithShuttleWe
 }
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedWeight(adjustedWeight *unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			ReService: models.ReService{
 				Code: code,
 				Name: string(code),
@@ -172,7 +174,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedW
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
-			Move: mtoServiceItem.MoveTaskOrder,
+			Move: move,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -156,7 +156,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithShuttleWe
 	return mtoServiceItem, paymentRequest, paramLookup
 }
 
-func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedWeight(adjustedWeight unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedWeight(adjustedWeight *unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
 			ReService: models.ReService{
@@ -166,7 +166,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithAdjustedW
 			MTOShipment: models.MTOShipment{
 				PrimeActualWeight: &originalWeight,
 				ShipmentType:      shipmentType,
-				BillableWeightCap: &adjustedWeight,
+				BillableWeightCap: adjustedWeight,
 			},
 		})
 

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup.go
@@ -14,9 +14,9 @@ type WeightAdjustedLookup struct {
 
 func (r WeightAdjustedLookup) lookup(appCtx appcontext.AppContext, keyData *ServiceItemParamKeyData) (string, error) {
 	if r.MTOShipment.BillableWeightCap == nil {
-		return "", fmt.Errorf("could not find adjusted weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
+		return "", nil
 	}
 
-	value := fmt.Sprintf("%d", int(*r.MTOShipment.BillableWeightCap))
+	value := fmt.Sprintf("%d", (*r.MTOShipment.BillableWeightCap).Int())
 	return value, nil
 }

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup.go
@@ -1,0 +1,22 @@
+package serviceparamvaluelookups
+
+import (
+	"fmt"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// WeightAdjustedLookup does lookup on adjusted weight billed
+type WeightAdjustedLookup struct {
+	MTOShipment models.MTOShipment
+}
+
+func (r WeightAdjustedLookup) lookup(appCtx appcontext.AppContext, keyData *ServiceItemParamKeyData) (string, error) {
+	if r.MTOShipment.BillableWeightCap == nil {
+		return "", fmt.Errorf("could not find adjusted weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
+	}
+
+	value := fmt.Sprintf("%d", int(*r.MTOShipment.BillableWeightCap))
+	return value, nil
+}

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
@@ -1,0 +1,32 @@
+package serviceparamvaluelookups
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ServiceParamValueLookupsSuite) TestWeightAdjustedLookup() {
+	key := models.ServiceItemParamNameWeightAdjusted
+
+	suite.Run("adjusted weight is present on MTO Shipment", func() {
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
+		suite.FatalNoError(err)
+		suite.Equal("1234", valueStr)
+	})
+
+	suite.Run("nil AdjustedWeight should not cause an error", func() {
+		// Set the adjusted weight to nil
+		mtoServiceItem, paymentRequest, _ := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoShipment := mtoServiceItem.MTOShipment
+		mtoShipment.BillableWeightCap = nil
+		suite.MustSave(&mtoShipment)
+
+		paramLookup, err := ServiceParamLookupInitialize(suite.TestAppContext(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+
+		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
+		suite.NoError(err)
+		suite.Equal("", valueStr)
+	})
+}

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
@@ -9,7 +9,8 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightAdjustedLookup() {
 	key := models.ServiceItemParamNameWeightAdjusted
 
 	suite.Run("adjusted weight is present on MTO Shipment", func() {
-		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1000), unit.Pound(2000), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		adjustedWeight := unit.Pound(1000)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(&adjustedWeight, unit.Pound(2000), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
 		suite.FatalNoError(err)
 		suite.Equal("1000", valueStr)
@@ -17,9 +18,8 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightAdjustedLookup() {
 
 	suite.Run("nil AdjustedWeight should not cause an error", func() {
 		// Set the adjusted weight to nil
-		mtoServiceItem, paymentRequest, _ := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1234), unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		mtoServiceItem, paymentRequest, _ := suite.setupTestMTOServiceItemWithAdjustedWeight(nil, unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		mtoShipment := mtoServiceItem.MTOShipment
-		mtoShipment.BillableWeightCap = nil
 		suite.MustSave(&mtoShipment)
 
 		paramLookup, err := ServiceParamLookupInitialize(suite.TestAppContext(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
@@ -18,12 +18,7 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightAdjustedLookup() {
 
 	suite.Run("nil AdjustedWeight should not cause an error", func() {
 		// Set the adjusted weight to nil
-		mtoServiceItem, paymentRequest, _ := suite.setupTestMTOServiceItemWithAdjustedWeight(nil, unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
-		mtoShipment := mtoServiceItem.MTOShipment
-		suite.MustSave(&mtoShipment)
-
-		paramLookup, err := ServiceParamLookupInitialize(suite.TestAppContext(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
-		suite.FatalNoError(err)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(nil, unit.Pound(450), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 
 		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
 		suite.NoError(err)

--- a/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_adjusted_lookup_test.go
@@ -9,10 +9,10 @@ func (suite *ServiceParamValueLookupsSuite) TestWeightAdjustedLookup() {
 	key := models.ServiceItemParamNameWeightAdjusted
 
 	suite.Run("adjusted weight is present on MTO Shipment", func() {
-		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1234), unit.Pound(1234), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
+		_, _, paramLookup := suite.setupTestMTOServiceItemWithAdjustedWeight(unit.Pound(1000), unit.Pound(2000), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.TestAppContext(), key)
 		suite.FatalNoError(err)
-		suite.Equal("1234", valueStr)
+		suite.Equal("1000", valueStr)
 	})
 
 	suite.Run("nil AdjustedWeight should not cause an error", func() {


### PR DESCRIPTION
## Description

The `WeightAdjusted` param corresponds to the max billable weight set by the TIO (which is saved in `MTOShipment.BillableWeightCap`).

## Reviewer Notes

Is there more we can be doing to test this?

## Setup

I don't think there are ways to test this other than making sure tests pass. The field that the param comes from is not editable yet (that's coming in [MB-9425](https://dp3.atlassian.net/browse/MB-9425)).

```sh
make server_test
```

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9308) for this change