### PR TITLE
MB-9015: remove MTOServiceItemShuttle.description and any references

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1803,8 +1803,7 @@ func init() {
           "type": "object",
           "required": [
             "reason",
-            "reServiceCode",
-            "description"
+            "reServiceCode"
           ],
           "properties": {
             "actualWeight": {
@@ -1813,11 +1812,6 @@ func init() {
               "x-nullable": true,
               "x-omitempty": false,
               "example": 4000
-            },
-            "description": {
-              "description": "Details about the shuttle service.",
-              "type": "string",
-              "example": "Things to be moved to the place by shuttle."
             },
             "estimatedWeight": {
               "description": "An estimate of how much weight from a shipment will be included in the shuttling service.",
@@ -5060,8 +5054,7 @@ func init() {
           "type": "object",
           "required": [
             "reason",
-            "reServiceCode",
-            "description"
+            "reServiceCode"
           ],
           "properties": {
             "actualWeight": {
@@ -5070,11 +5063,6 @@ func init() {
               "x-nullable": true,
               "x-omitempty": false,
               "example": 4000
-            },
-            "description": {
-              "description": "Details about the shuttle service.",
-              "type": "string",
-              "example": "Things to be moved to the place by shuttle."
             },
             "estimatedWeight": {
               "description": "An estimate of how much weight from a shipment will be included in the shuttling service.",

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -38,11 +38,6 @@ type MTOServiceItemShuttle struct {
 	// Example: 4000
 	ActualWeight *int64 `json:"actualWeight"`
 
-	// Details about the shuttle service.
-	// Example: Things to be moved to the place by shuttle.
-	// Required: true
-	Description *string `json:"description"`
-
 	// An estimate of how much weight from a shipment will be included in the shuttling service.
 	// Example: 4200
 	EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -147,11 +142,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		// Example: 4000
 		ActualWeight *int64 `json:"actualWeight"`
 
-		// Details about the shuttle service.
-		// Example: Things to be moved to the place by shuttle.
-		// Required: true
-		Description *string `json:"description"`
-
 		// An estimate of how much weight from a shipment will be included in the shuttling service.
 		// Example: 4200
 		EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -224,7 +214,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	result.statusField = base.Status
 
 	result.ActualWeight = data.ActualWeight
-	result.Description = data.Description
 	result.EstimatedWeight = data.EstimatedWeight
 	result.ReServiceCode = data.ReServiceCode
 	result.Reason = data.Reason
@@ -244,11 +233,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		// Example: 4000
 		ActualWeight *int64 `json:"actualWeight"`
 
-		// Details about the shuttle service.
-		// Example: Things to be moved to the place by shuttle.
-		// Required: true
-		Description *string `json:"description"`
-
 		// An estimate of how much weight from a shipment will be included in the shuttling service.
 		// Example: 4200
 		EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -267,8 +251,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 	}{
 
 		ActualWeight: m.ActualWeight,
-
-		Description: m.Description,
 
 		EstimatedWeight: m.EstimatedWeight,
 
@@ -340,10 +322,6 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateReServiceCode(formats); err != nil {
 		res = append(res, err)
 	}
@@ -407,15 +385,6 @@ func (m *MTOServiceItemShuttle) validateStatus(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("status")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemShuttle) validateDescription(formats strfmt.Registry) error {
-
-	if err := validate.Required("description", "body", m.Description); err != nil {
 		return err
 	}
 

--- a/pkg/gen/supportapi/embedded_spec.go
+++ b/pkg/gen/supportapi/embedded_spec.go
@@ -1566,11 +1566,6 @@ func init() {
               "x-omitempty": false,
               "example": 4000
             },
-            "description": {
-              "description": "Further details about the shuttle service.",
-              "type": "string",
-              "example": "Things to be moved to the place by shuttle."
-            },
             "estimatedWeight": {
               "description": "An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT \u0026 DOSHUT) service item.",
               "type": "integer",
@@ -4361,11 +4356,6 @@ func init() {
               "x-nullable": true,
               "x-omitempty": false,
               "example": 4000
-            },
-            "description": {
-              "description": "Further details about the shuttle service.",
-              "type": "string",
-              "example": "Things to be moved to the place by shuttle."
             },
             "estimatedWeight": {
               "description": "An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT \u0026 DOSHUT) service item.",

--- a/pkg/gen/supportmessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_shuttle.go
@@ -38,11 +38,6 @@ type MTOServiceItemShuttle struct {
 	// Example: 4000
 	ActualWeight *int64 `json:"actualWeight"`
 
-	// Further details about the shuttle service.
-	// Example: Things to be moved to the place by shuttle.
-	// Required: true
-	Description *string `json:"description"`
-
 	// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
 	// Example: 4200
 	EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -145,11 +140,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 		// Example: 4000
 		ActualWeight *int64 `json:"actualWeight"`
 
-		// Further details about the shuttle service.
-		// Example: Things to be moved to the place by shuttle.
-		// Required: true
-		Description *string `json:"description"`
-
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
 		// Example: 4200
 		EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -220,7 +210,6 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 	result.statusField = base.Status
 
 	result.ActualWeight = data.ActualWeight
-	result.Description = data.Description
 	result.EstimatedWeight = data.EstimatedWeight
 	result.ReServiceCode = data.ReServiceCode
 	result.Reason = data.Reason
@@ -240,11 +229,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 		// Example: 4000
 		ActualWeight *int64 `json:"actualWeight"`
 
-		// Further details about the shuttle service.
-		// Example: Things to be moved to the place by shuttle.
-		// Required: true
-		Description *string `json:"description"`
-
 		// An estimate of how much weight from a shipment will be included in a shuttling (DDSHUT & DOSHUT) service item.
 		// Example: 4200
 		EstimatedWeight *int64 `json:"estimatedWeight"`
@@ -261,8 +245,6 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 	}{
 
 		ActualWeight: m.ActualWeight,
-
-		Description: m.Description,
 
 		EstimatedWeight: m.EstimatedWeight,
 
@@ -334,10 +316,6 @@ func (m *MTOServiceItemShuttle) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateReServiceCode(formats); err != nil {
 		res = append(res, err)
 	}
@@ -401,15 +379,6 @@ func (m *MTOServiceItemShuttle) validateStatus(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("status")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItemShuttle) validateDescription(formats strfmt.Registry) error {
-
-	if err := validate.Required("description", "body", m.Description); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -497,7 +497,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 		payload = &cratingSI
 	case models.ReServiceCodeDDSHUT, models.ReServiceCodeDOSHUT:
 		payload = &primemessages.MTOServiceItemShuttle{
-			Description:     mtoServiceItem.Description,
 			ReServiceCode:   handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			Reason:          mtoServiceItem.Reason,
 			EstimatedWeight: handlers.FmtPoundPtr(mtoServiceItem.EstimatedWeight),

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -310,7 +310,6 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		// values to get from payload
 		model.ReService.Code = models.ReServiceCode(*shuttleService.ReServiceCode)
 		model.Reason = shuttleService.Reason
-		model.Description = shuttleService.Description
 		model.EstimatedWeight = handlers.PoundPtrFromInt64Ptr(shuttleService.EstimatedWeight)
 		model.ActualWeight = handlers.PoundPtrFromInt64Ptr(shuttleService.ActualWeight)
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -348,7 +348,6 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) supportmessages.MTOSe
 		}
 	case models.ReServiceCodeDDSHUT, models.ReServiceCodeDOSHUT:
 		payload = &supportmessages.MTOServiceItemShuttle{
-			Description:     mtoServiceItem.Description,
 			ReServiceCode:   handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			Reason:          mtoServiceItem.Reason,
 			EstimatedWeight: handlers.FmtPoundPtr(mtoServiceItem.EstimatedWeight),

--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -169,7 +169,6 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 		suite.Equal(mtoServiceItemDOSHUT.ID.String(), data.ID().String())
 		suite.Equal(mtoServiceItemDOSHUT.MTOShipmentID.String(), data.MtoShipmentID().String())
 		suite.Equal(string(mtoServiceItemDOSHUT.ReService.Code), *data.ReServiceCode)
-		suite.Equal(*mtoServiceItemDOSHUT.Description, *data.Description)
 		suite.Equal(*mtoServiceItemDOSHUT.Reason, *data.Reason)
 	})
 

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -1566,10 +1566,6 @@ definitions:
             description: >
               The contractor's explanation for why a shuttle service is requested. Used by the TOO while deciding to
               approve or reject the service item.
-          description:
-            type: string
-            example: Things to be moved to the place by shuttle.
-            description: Details about the shuttle service.
           estimatedWeight:
             type: integer
             example: 4200
@@ -1585,7 +1581,6 @@ definitions:
         required:
           - reason
           - reServiceCode
-          - description
   MTOServiceItemStatus:
     description: The status of a service item, indicating where it is in the TOO's approval process.
     type: string

--- a/swagger-def/support.yaml
+++ b/swagger-def/support.yaml
@@ -1311,10 +1311,6 @@ definitions:
             type: string
             example: Storage items need to be picked up.
             description: Explanation of why a shuttle service is required.
-          description:
-            type: string
-            example: Things to be moved to the place by shuttle.
-            description: Further details about the shuttle service.
           estimatedWeight:
             type: integer
             example: 4200

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -1789,10 +1789,6 @@ definitions:
               The contractor's explanation for why a shuttle service is
               requested. Used by the TOO while deciding to approve or reject the
               service item.
-          description:
-            type: string
-            example: Things to be moved to the place by shuttle.
-            description: Details about the shuttle service.
           estimatedWeight:
             type: integer
             example: 4200
@@ -1812,7 +1808,6 @@ definitions:
         required:
           - reason
           - reServiceCode
-          - description
   MTOServiceItemStatus:
     description: >-
       The status of a service item, indicating where it is in the TOO's approval

--- a/swagger/support.yaml
+++ b/swagger/support.yaml
@@ -1408,10 +1408,6 @@ definitions:
             type: string
             example: Storage items need to be picked up.
             description: Explanation of why a shuttle service is required.
-          description:
-            type: string
-            example: Things to be moved to the place by shuttle.
-            description: Further details about the shuttle service.
           estimatedWeight:
             type: integer
             example: 4200


### PR DESCRIPTION
## Description

Removed all references to MTOServiceItemShuttle descriptions. In theory they no longer exist in the code. 

## Reviewer Notes

I only found one spot in tests where this field was being called. Would love some input or feedback on whether this is enough coverage, and/or an intro to our testing suite. 

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?
* [ ] Tests run and are passing

## References

* [Jira story] https://dp3.atlassian.net/browse/MB-9015