### PR TITLE
[MB-9026] display blank field in shipment card when theres no destination address

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -2626,8 +2626,9 @@ func createMoveWith2MinimalShipments(appCtx appcontext.AppContext, userUploader 
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
 			Status:  models.MoveStatusSUBMITTED,
-			Locator: "INXSWT",
+			Locator: "NOADDR",
 		},
+		UserUploader: userUploader,
 	})
 
 	requestedPickupDate := time.Now().AddDate(0, 3, 0)

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -31,7 +31,7 @@ export default function ShipmentCard({
             <strong>Departed</strong> {formatDateFromIso(departedDate, 'DD MMM YYYY')}
           </span>
           <span>
-            <strong>From</strong> {formatAddressShort(pickupAddress)}
+            <strong>From</strong> {pickupAddress && formatAddressShort(pickupAddress)}
           </span>
           <span>
             <strong>To</strong> {destinationAddress && formatAddressShort(destinationAddress)}

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -31,7 +31,7 @@ export default function ShipmentCard({
             <strong>Departed</strong> {formatDateFromIso(departedDate, 'DD MMM YYYY')}
           </span>
           <span>
-            <strong>From</strong> {pickupAddress && formatAddressShort(pickupAddress)}
+            <strong>From</strong> {formatAddressShort(pickupAddress)}
           </span>
           <span>
             <strong>To</strong> {destinationAddress && formatAddressShort(destinationAddress)}

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -31,10 +31,10 @@ export default function ShipmentCard({
             <strong>Departed</strong> {formatDateFromIso(departedDate, 'DD MMM YYYY')}
           </span>
           <span>
-            <strong>From</strong> {formatAddressShort(pickupAddress)}
+            <strong>From</strong> {pickupAddress && formatAddressShort(pickupAddress)}
           </span>
           <span>
-            <strong>To</strong> {formatAddressShort(destinationAddress)}
+            <strong>To</strong> {destinationAddress && formatAddressShort(destinationAddress)}
           </span>
         </section>
       </header>

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -104,14 +104,13 @@ const MovePaymentRequests = ({
     <div className={txoStyles.tabContent}>
       <div className={txoStyles.container} data-testid="MovePaymentRequests">
         <LeftNav className={txoStyles.sidebar}>
-          {paymentRequests.length &&
-            sections?.map((s) => {
-              return (
-                <a key={`sidenav_${s}`} href={`#${s}`} className={classnames({ active: s === activeSection })}>
-                  {sectionLabels[`${s}`]}
-                </a>
-              );
-            })}
+          {sections?.map((s) => {
+            return (
+              <a key={`sidenav_${s}`} href={`#${s}`} className={classnames({ active: s === activeSection })}>
+                {sectionLabels[`${s}`]}
+              </a>
+            );
+          })}
         </LeftNav>
         <GridContainer className={txoStyles.gridContainer} data-testid="tio-payment-request-details">
           <h1>Payment requests</h1>
@@ -127,7 +126,7 @@ const MovePaymentRequests = ({
           </div>
           <h2>Payment requests</h2>
           <div className={txoStyles.section} id="payment-requests">
-            {paymentRequests.length ? (
+            {paymentRequests?.length > 0 ? (
               paymentRequests.map((paymentRequest) => (
                 <PaymentRequestCard
                   paymentRequest={paymentRequest}

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -453,14 +453,14 @@ describe('MovePaymentRequests', () => {
       useMovePaymentRequestsQueries.mockReturnValue(emptyPaymentRequests);
     });
 
-    it('does not render side navigation for payment request section', () => {
+    it('renders side navigation for payment request section', () => {
       renderMovePaymentRequests(testProps);
       const leftNav = screen.getByRole('navigation');
       expect(leftNav).toBeInTheDocument();
 
       const paymentRequstNavLink = within(leftNav).queryByText('Payment requests');
 
-      expect(paymentRequstNavLink).toBeNull();
+      expect(paymentRequstNavLink).toBeInTheDocument();
     });
 
     it('renders with empty message when no payment requests exist', async () => {


### PR DESCRIPTION
## Description

This PR fixes an issue that surfaced in staging so that the review billable weights sidebar displays a blank field when the shipment is missing a destination address instead of crashing the page in its absence 

## Reviewer Notes

- As part of this PR I noticed the left sidebar was displaying incorrectly in the case of there being no payment request. Ensure that the left side bar looks right to you as well

## Setup

```sh
make server_run client_run
```

- submit a move in the customer app and be sure to not provide a destination address
- in the office view, as a TOO find the move that was created in the previous step
- navigate to the Payment Request tab and ensure that the left side displays correctly
- then click the Review Weights button, followed by the Review Shipment Weights button
- verify that the sidebar displays the shipment card with the destination address field as empty

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9026) for this change


## Screenshots
<img width="448" alt="Screen Shot 2021-09-17 at 3 00 20 PM" src="https://user-images.githubusercontent.com/67110378/133842609-37c97297-119f-491a-98d9-11bc597f7764.png">

