### PR TITLE
MB-9313 Filter out shipments for reviewing billable weights

### DIFF
--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -19,7 +19,11 @@ import { useMovePaymentRequestsQueries } from 'hooks/queries';
 import { formatPaymentRequestAddressString, getShipmentModificationType } from 'utils/shipmentDisplay';
 import { shipmentStatuses } from 'constants/shipments';
 import SERVICE_ITEM_STATUSES from 'constants/serviceItems';
-import { useCalculatedTotalBillableWeight, useCalculatedWeightRequested } from 'hooks/custom';
+import {
+  includedStatusesForCalculatingWeights,
+  useCalculatedTotalBillableWeight,
+  useCalculatedWeightRequested,
+} from 'hooks/custom';
 
 const sectionLabels = {
   'billable-weights': 'Billable weights',
@@ -116,13 +120,14 @@ const MovePaymentRequests = ({
         <GridContainer className={txoStyles.gridContainer} data-testid="tio-payment-request-details">
           <h1>Payment requests</h1>
           <div className={txoStyles.section} id="billable-weights">
+            {/* Only show shipments in statuses of approved, diversion requested, or cancellation requested */}
             <BillableWeightCard
               maxBillableWeight={order?.entitlement?.authorizedWeight}
               totalBillableWeight={totalBillableWeight}
               weightRequested={weightRequested}
               weightAllowance={order?.entitlement?.totalWeight}
               onReviewWeights={handleReviewWeightsClick}
-              shipments={mtoShipments}
+              shipments={mtoShipments.filter((shipment) => includedStatusesForCalculatingWeights(shipment.status))}
             />
           </div>
           <h2>Payment requests</h2>

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -15,6 +15,7 @@ import WeightSummary from 'components/Office/WeightSummary/WeightSummary';
 import EditBillableWeight from 'components/Office/BillableWeight/EditBillableWeight/EditBillableWeight';
 import { useOrdersDocumentQueries, useMovePaymentRequestsQueries } from 'hooks/queries';
 import {
+  includedStatusesForCalculatingWeights,
   useCalculatedTotalBillableWeight,
   useCalculatedWeightRequested,
   useCalculatedEstimatedWeight,
@@ -46,11 +47,13 @@ export default function ReviewBillableWeight() {
 
   const { upload, isLoading, isError } = useOrdersDocumentQueries(moveCode);
   const { order, mtoShipments } = useMovePaymentRequestsQueries(moveCode);
-  const isLastShipment = selectedShipmentIndex === mtoShipments?.length - 1;
+  /* Only show shipments in statuses of approved, diversion requested, or cancellation requested */
+  const filteredShipments = mtoShipments.filter((shipment) => includedStatusesForCalculatingWeights(shipment.status));
+  const isLastShipment = selectedShipmentIndex === filteredShipments?.length - 1;
 
-  const totalBillableWeight = useCalculatedTotalBillableWeight(mtoShipments);
-  const weightRequested = useCalculatedWeightRequested(mtoShipments);
-  const totalEstimatedWeight = useCalculatedEstimatedWeight(mtoShipments);
+  const totalBillableWeight = useCalculatedTotalBillableWeight(filteredShipments);
+  const weightRequested = useCalculatedWeightRequested(filteredShipments);
+  const totalEstimatedWeight = useCalculatedEstimatedWeight(filteredShipments);
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
@@ -63,7 +66,7 @@ export default function ReviewBillableWeight() {
     history.push(generatePath(tioRoutes.PAYMENT_REQUESTS_PATH, { moveCode }));
   };
 
-  const selectedShipment = mtoShipments[selectedShipmentIndex];
+  const selectedShipment = filteredShipments[selectedShipmentIndex];
 
   return (
     <div className={styles.DocumentWrapper}>
@@ -85,7 +88,7 @@ export default function ReviewBillableWeight() {
                   totalBillableWeight={totalBillableWeight}
                   weightRequested={weightRequested}
                   weightAllowance={weightAllowance}
-                  shipments={mtoShipments}
+                  shipments={filteredShipments}
                 />
               </div>
               <EditBillableWeight
@@ -109,7 +112,7 @@ export default function ReviewBillableWeight() {
           <DocumentViewerSidebar
             title="Review weights"
             subtitle="Shipment weights"
-            description={`Shipment ${selectedShipmentIndex + 1} of ${mtoShipments?.length}`}
+            description={`Shipment ${selectedShipmentIndex + 1} of ${filteredShipments?.length}`}
             onClose={handleClose}
           >
             <DocumentViewerSidebar.Content>
@@ -132,7 +135,7 @@ export default function ReviewBillableWeight() {
                     weightRequested={weightRequested}
                     weightAllowance={weightAllowance}
                     totalBillableWeightFlag
-                    shipments={mtoShipments}
+                    shipments={filteredShipments}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Description

Filter out shipments so that only approved, diversion requested, and cancellation requested
shipments are shown. 

## Reviewer Notes

Are the correct shipments being filtered?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make office_client_run
make server_run
```
Login as a TOO
Select the move with the locator of WTSTAT
Go to the payment requests page
That move used to show 7 different shipments in different states. There should only be 4 visible on the billable weights component
Select `Review weights`
Select `Review shipment weights`
There should be 4 shipments visible

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9313) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
