### PR TITLE
[MB-9338] Update lookup for WeightBilled pricing parameter

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -68,6 +68,32 @@ func TestServiceParamValueLookupsSuite(t *testing.T) {
 	ts.PopTestSuite.TearDown()
 }
 
+func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithOriginalWeightOnly(originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
+		testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: code,
+				Name: string(code),
+			},
+			MTOShipment: models.MTOShipment{
+				PrimeActualWeight: &originalWeight,
+				ShipmentType:      shipmentType,
+			},
+		})
+
+	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
+		testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
+			},
+		})
+
+	paramLookup, err := ServiceParamLookupInitialize(suite.TestAppContext(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+	suite.FatalNoError(err)
+
+	return mtoServiceItem, paymentRequest, paramLookup
+}
+
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithWeight(estimatedWeight unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -69,8 +69,10 @@ func TestServiceParamValueLookupsSuite(t *testing.T) {
 }
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithOriginalWeightOnly(originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			ReService: models.ReService{
 				Code: code,
 				Name: string(code),
@@ -83,6 +85,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithOriginalW
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},
@@ -95,8 +98,10 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithOriginalW
 }
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithWeight(estimatedWeight unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			ReService: models.ReService{
 				Code: code,
 				Name: string(code),
@@ -110,6 +115,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithWeight(es
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},
@@ -122,9 +128,10 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithWeight(es
 }
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithReweigh(reweighWeight unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
-
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			ReService: models.ReService{
 				Code: code,
 				Name: string(code),
@@ -142,6 +149,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithReweigh(r
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},
@@ -154,8 +162,10 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithReweigh(r
 }
 
 func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithShuttleWeight(estimatedWeight unit.Pound, originalWeight unit.Pound, code models.ReServiceCode, shipmentType models.MTOShipmentType) (models.MTOServiceItem, models.PaymentRequest, *ServiceItemParamKeyData) {
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			ReService: models.ReService{
 				Code: code,
 				Name: string(code),
@@ -171,6 +181,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithShuttleWe
 
 	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 		testdatagen.Assertions{
+			Move: move,
 			PaymentRequest: models.PaymentRequest{
 				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 			},

--- a/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_lookup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/unit"
 )
 
@@ -17,6 +18,7 @@ type WeightBilledLookup struct {
 func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *ServiceItemParamKeyData) (string, error) {
 	var estimatedWeight *unit.Pound
 	var originalWeight *unit.Pound
+	var value string
 
 	switch keyData.MTOServiceItem.ReService.Code {
 	case models.ReServiceCodeDOSHUT,
@@ -35,28 +37,41 @@ func (r WeightBilledLookup) lookup(appCtx appcontext.AppContext, keyData *Servic
 			// TODO: Do we need a different error -- is this a "normal" scenario?
 			return "", fmt.Errorf("could not find actual weight for MTOServiceItemID [%s]", keyData.MTOServiceItem.ID)
 		}
-	default:
-		// Make sure there's an estimated weight since that's nullable
-		estimatedWeight = r.MTOShipment.PrimeEstimatedWeight
 
-		// Make sure there's an actual weight since that's nullable
+		if estimatedWeight != nil {
+			estimatedWeightCap := math.Round(float64(*estimatedWeight) * 1.10)
+			if float64(*originalWeight) > estimatedWeightCap {
+				value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(estimatedWeightCap))
+			} else {
+				value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+			}
+		} else {
+			value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+		}
+	default:
+		// Make sure there's an actual weight since that's nullable but required for pricing
 		originalWeight = r.MTOShipment.PrimeActualWeight
 		if originalWeight == nil {
 			// TODO: Do we need a different error -- is this a "normal" scenario?
 			return "", fmt.Errorf("could not find actual weight for MTOShipmentID [%s]", r.MTOShipment.ID)
 		}
-	}
 
-	var value string
-	if estimatedWeight != nil {
-		estimatedWeightCap := math.Round(float64(*estimatedWeight) * 1.10)
-		if float64(*originalWeight) > estimatedWeightCap {
-			value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(estimatedWeightCap))
-		} else {
-			value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+		// Make sure the reweigh (if any) is loaded since that's expected by the calculate shipment billable weight service.
+		err := appCtx.DB().Load(&r.MTOShipment, "Reweigh")
+		if err != nil {
+			return "", err
 		}
-	} else {
-		value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*originalWeight))
+
+		calculator := mtoshipment.NewShipmentBillableWeightCalculator()
+		billableWeightInputs, err := calculator.CalculateShipmentBillableWeight(&r.MTOShipment)
+		if err != nil {
+			return "", err
+		}
+		if billableWeightInputs.CalculatedBillableWeight == nil {
+			return "", fmt.Errorf("got a nil calculated billable weight from service for MTOShipmentID [%s]", r.MTOShipment.ID)
+		}
+
+		value = applyMinimum(keyData.MTOServiceItem.ReService.Code, r.MTOShipment.ShipmentType, int(*billableWeightInputs.CalculatedBillableWeight))
 	}
 
 	return value, nil


### PR DESCRIPTION
## Description

This PR adjusts the lookup for the `WeightBilled` pricing parameter so that it takes into account the new reweigh and/or adjusted weights as part of PO5.  To calculate the billable weight, I use the new `ShipmentBillableWeightCalculator` service created by the Voltron team.

## Reviewer Notes

- I also refactored/optimized some test setup to minimize the amount of test data created (previously, it was creating a lot of extra move-related data).  I created a new helper function to make things more DRY.
- While working on this, I found an issue related to caching of lookups (like the `WeightBilled` one) that could lead to incorrect pricing in some scenarios.  Addressing this was beyond the scope of this PR, so I've created [another story for it](https://dp3.atlassian.net/browse/MB-9497).

## Setup

Server tests exercise several scenarios.

To test it in the app, create a payment request on a move/shipment as usual with some weight-based service item like `DLH`.  Verify the params in the response JSON and/or the database and ensure that `WeightBilled` is set to the appropriate value for your scenario.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9338) for this change
