### PR TITLE
Bump js-cookie version to 3.x: MB-9397

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "http-proxy-middleware": "^2.0.1",
     "is-mobile": "3.0.0",
     "jest-canvas-mock": "^2.3.1",
-    "js-cookie": "^2.2.0",
+    "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "normalizr": "^3.6.1",

--- a/public/swagger-ui/admin.html
+++ b/public/swagger-ui/admin.html
@@ -69,7 +69,7 @@
 
 <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
 <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
-<script src="/swagger-ui/js.cookie.js"></script>
+<script src="/swagger-ui/dist/js.cookie.mjs"></script>
 <script>
     window.onload = function() {
         // Intercept the request to add csrf token and only allow requests to the current domain.

--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -69,7 +69,7 @@
 
 <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
 <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
-<script src="/swagger-ui/js.cookie.js"></script>
+<script src="/swagger-ui/dist/js.cookie.mjs"></script>
 <script>
     window.onload = function() {
         // Intercept the request to add csrf token and only allow requests to the current domain.

--- a/public/swagger-ui/ghc.html
+++ b/public/swagger-ui/ghc.html
@@ -68,7 +68,7 @@
 
 <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
 <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
-<script src="/swagger-ui/js.cookie.js"></script>
+<script src="/swagger-ui/dist/js.cookie.mjs"></script>
 <script>
     window.onload = function() {
         // Intercept the request to add csrf token and only allow requests to the current domain.

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -69,7 +69,7 @@
 
 <script src="/swagger-ui/swagger-ui-bundle.js"> </script>
 <script src="/swagger-ui/swagger-ui-standalone-preset.js"> </script>
-<script src="/swagger-ui/js.cookie.js"></script>
+<script src="/swagger-ui/dist/js.cookie.mjs"></script>
 <script>
     window.onload = function() {
         // Intercept the request to add csrf token and only allow requests to the current domain.

--- a/scripts/copy-swagger-ui
+++ b/scripts/copy-swagger-ui
@@ -5,4 +5,4 @@
 # will need to be manually updated based on node_modules/swagger-ui-dist/index.html
 # if it ever changes.
 cp node_modules/swagger-ui-dist/{*.js,*.css,*.png} public/swagger-ui
-cp node_modules/js-cookie/src/js.cookie.js public/swagger-ui
+cp node_modules/js-cookie/dist/js.cookie.mjs public/swagger-ui

--- a/yarn.lock
+++ b/yarn.lock
@@ -12094,10 +12094,10 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
-js-cookie@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-levenshtein@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
## Description

Update `js-cookie` from 2.x to v3.x

## Reviewer Notes

I'm not fully sure why `scripts/copy-swagger-ui ` needs to copy those assets

## Setup

`make client_test`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9397) for this change

