### PR TITLE
MB-9546: Fix logger sync errors

### DIFF
--- a/cmd/big-cat/main.go
+++ b/cmd/big-cat/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)

--- a/cmd/generate-payment-request-edi/main.go
+++ b/cmd/generate-payment-request-edi/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/generate-shipment-summary/main.go
+++ b/cmd/generate-shipment-summary/main.go
@@ -94,7 +94,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -149,7 +149,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/generate_access_codes/main.go
+++ b/cmd/generate_access_codes/main.go
@@ -83,7 +83,7 @@ func main() {
 	v.AutomaticEnv()
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/ghc-pricing-parser/main.go
+++ b/cmd/ghc-pricing-parser/main.go
@@ -76,7 +76,7 @@ func main() {
 	v.AutomaticEnv()
 
 	// Create logger
-	logger, err := logging.Config(logging.WithEnvironment(v.GetString(cli.DbEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(v.GetString(cli.DbEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/ghc-transit-time-parser/main.go
+++ b/cmd/ghc-transit-time-parser/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/milmove-tasks/connect_to_gex_via_sftp.go
+++ b/cmd/milmove-tasks/connect_to_gex_via_sftp.go
@@ -43,7 +43,7 @@ func initConnectToGEXViaSFTPFlags(flag *pflag.FlagSet) {
 func connectToGEXViaSFTP(cmd *cobra.Command, args []string) error {
 	v := viper.New()
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(v.GetString(cli.LoggingEnvFlag)),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -69,7 +69,7 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 	// Create the logger
 	v := viper.New()
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(v.GetString(cli.LoggingEnvFlag)),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),
@@ -105,7 +105,7 @@ func postFileToGEX(cmd *cobra.Command, args []string) error {
 	// make sure edi ends in new line
 	ediString = strings.TrimSpace(ediString) + "\n"
 
-	certLogger, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	certLogger, _, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		logger.Fatal("Failed to initialize Zap logging", zap.Error(err))
 	}

--- a/cmd/milmove-tasks/process_edis.go
+++ b/cmd/milmove-tasks/process_edis.go
@@ -99,7 +99,7 @@ func initProcessEDIsFlags(flag *pflag.FlagSet) {
 func processEDIs(cmd *cobra.Command, args []string) error {
 	v := viper.New()
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(v.GetString(cli.LoggingEnvFlag)),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),
@@ -196,7 +196,7 @@ func processEDIs(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO I don't know why we need a separate logger for cert stuff
-	certLogger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	certLogger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		logger.Fatal("Failed to initialize Zap logging", zap.Error(err))
 	}

--- a/cmd/milmove-tasks/save_ghc_fuel_price_data.go
+++ b/cmd/milmove-tasks/save_ghc_fuel_price_data.go
@@ -70,7 +70,7 @@ func saveGHCFuelPriceData(cmd *cobra.Command, args []string) error {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/milmove-tasks/send_payment_reminder_email.go
+++ b/cmd/milmove-tasks/send_payment_reminder_email.go
@@ -70,7 +70,7 @@ func sendPaymentReminder(cmd *cobra.Command, args []string) error {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/milmove-tasks/send_post_move_survey_email.go
+++ b/cmd/milmove-tasks/send_post_move_survey_email.go
@@ -78,7 +78,7 @@ func sendPostMoveSurvey(cmd *cobra.Command, args []string) error {
 	dbEnv := v.GetString(cli.DbEnvFlag)
 	offsetDays := v.GetInt(offsetFlag)
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/milmove/gen_duty_stations_migration.go
+++ b/cmd/milmove/gen_duty_stations_migration.go
@@ -128,7 +128,7 @@ func genDutyStationsMigration(cmd *cobra.Command, args []string) error {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
-	logger, err := logging.Config(logging.WithEnvironment(v.GetString(cli.LoggingEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(v.GetString(cli.LoggingEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/main_test.go
+++ b/cmd/milmove/main_test.go
@@ -55,7 +55,7 @@ func TestWebServerSuite(t *testing.T) {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
-	logger, err := logging.Config(logging.WithEnvironment(v.GetString(cli.DbEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(v.GetString(cli.DbEnvFlag)), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/milmove/migrate.go
+++ b/cmd/milmove/migrate.go
@@ -119,7 +119,7 @@ func migrateFunction(cmd *cobra.Command, args []string) error {
 
 	loggingEnv := v.GetString(cli.LoggingEnvFlag)
 
-	logger, errLogging := logging.Config(
+	logger, _, errLogging := logging.Config(
 		logging.WithEnvironment(loggingEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/model-vet/main.go
+++ b/cmd/model-vet/main.go
@@ -204,7 +204,7 @@ func main() {
 
 	dbEnv := v.GetString(cli.DbEnvFlag)
 
-	logger, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	logger, _, err := logging.Config(logging.WithEnvironment(dbEnv), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/send-to-gex/main.go
+++ b/cmd/send-to-gex/main.go
@@ -116,7 +116,7 @@ func main() {
 
 	logger.Println(ediString)
 
-	certLogger, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
+	certLogger, _, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/cmd/tls-checker/main.go
+++ b/cmd/tls-checker/main.go
@@ -243,11 +243,18 @@ func checkURLWillNotConnect(httpClient *http.Client, url string, logger *zap.Log
 	return nil
 }
 
-func createLogger(env string, level string) (*zap.Logger, error) {
+func createLogger(env string, level string) (*zap.Logger, func(), error) {
+	// No sync of the logger is necessary when logging to stderr as is
+	// the default. This logging package does not provide an option to
+	// override the logging destination, so this is always correct
+	//
+	// If an option is added in the future, this will need to be updated
+	noopLoggerSync := func() {}
+
 	loglevel := zapcore.Level(uint8(0))
 	err := (&loglevel).UnmarshalText([]byte(level))
 	if err != nil {
-		return nil, err
+		return nil, noopLoggerSync, err
 	}
 	atomicLevel := zap.NewAtomicLevel()
 	atomicLevel.SetLevel(loglevel)
@@ -260,7 +267,8 @@ func createLogger(env string, level string) (*zap.Logger, error) {
 	loggerConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	loggerConfig.Level = atomicLevel
 	loggerConfig.DisableStacktrace = true
-	return loggerConfig.Build(zap.AddStacktrace(zap.ErrorLevel))
+	logger, err := loggerConfig.Build(zap.AddStacktrace(zap.ErrorLevel))
+	return logger, noopLoggerSync, err
 }
 
 func getTLSName(tlsVersion uint16) string {
@@ -319,16 +327,12 @@ func main() {
 		}
 	}()
 
-	logger, err := createLogger(v.GetString("log-env"), v.GetString("log-level"))
+	logger, loggerSync, err := createLogger(v.GetString("log-env"), v.GetString("log-level"))
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
-	defer func() {
-		if loggerSyncErr := logger.Sync(); loggerSyncErr != nil {
-			logger.Error("Failed to sync logger", zap.Error(loggerSyncErr))
-		}
-	}()
+	defer loggerSync()
 
 	err = checkConfig(v)
 	if err != nil {

--- a/cmd/webhook-client/command_test.go
+++ b/cmd/webhook-client/command_test.go
@@ -23,7 +23,7 @@ type WebhookClientTestingSuite struct {
 }
 
 func TestWebhookClientTestingSuite(t *testing.T) {
-	logger, _ := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
+	logger, _, _ := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
 
 	ts := &WebhookClientTestingSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/cmd/webhook-client/main.go
+++ b/cmd/webhook-client/main.go
@@ -42,7 +42,7 @@ func InitRootConfig(v *viper.Viper) (*pop.Connection, utils.Logger, error) {
 	// LOGGER SETUP
 	// Get the db env to configure the logger level
 	dbEnv := v.GetString(cli.DbEnvFlag)
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment(dbEnv),
 		logging.WithLoggingLevel(v.GetString(cli.LoggingLevelFlag)),
 		logging.WithStacktraceLength(v.GetInt(cli.StacktraceLengthFlag)),

--- a/cmd/webhook-client/webhook/webhook_test.go
+++ b/cmd/webhook-client/webhook/webhook_test.go
@@ -42,7 +42,7 @@ type WebhookClientTestingSuite struct {
 }
 
 func TestWebhookClientTestingSuite(t *testing.T) {
-	logger, _ := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
+	logger, _, _ := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
 
 	ts := &WebhookClientTestingSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -55,7 +55,7 @@ func (suite *certTestSuite) SetViper(v *viper.Viper) {
 
 func TestCertSuite(t *testing.T) {
 
-	logger, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
+	logger, _, err := logging.Config(logging.WithEnvironment("development"), logging.WithLoggingLevel("debug"))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -54,7 +54,7 @@ func (suite *cliTestSuite) SetViper(v *viper.Viper) {
 
 func TestCLISuite(t *testing.T) {
 
-	logger, err := logging.Config(
+	logger, _, err := logging.Config(
 		logging.WithEnvironment("development"),
 		logging.WithLoggingLevel("debug"),
 		logging.WithStacktraceLength(10),

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -48,7 +48,7 @@ func WithStacktraceLength(length int) ZapConfigOption {
 }
 
 // Config configures a Zap logger based on the environment string and debugLevel
-func Config(opts ...ZapConfigOption) (*zap.Logger, error) {
+func Config(opts ...ZapConfigOption) (*zap.Logger, func(), error) {
 	config := &ZapConfig{}
 
 	for _, opt := range opts {
@@ -87,7 +87,15 @@ func Config(opts ...ZapConfigOption) (*zap.Logger, error) {
 		loggerConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	}
 
-	return loggerConfig.Build()
+	// No sync of the logger is necessary when logging to stderr as is
+	// the default. This logging package does not provide an option to
+	// override the logging destination, so this is always correct
+	//
+	// If an option is added in the future, this will need to be updated
+	noopLoggerSync := func() {}
+
+	logger, err := loggerConfig.Build()
+	return logger, noopLoggerSync, err
 }
 
 type filteredConsoleEncoder struct {


### PR DESCRIPTION
## Description

Fix spurious log sync errors

## Setup

Start the server and see no errors!

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
