### PR TITLE
MB-8841: Fixes Orders and OrdersInfoForm tests

### DIFF
--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
 
 import EditOrdersForm from './EditOrdersForm';
 
@@ -260,8 +259,10 @@ describe('EditOrdersForm component', () => {
     userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    userEvent.type(screen.getByLabelText('New duty station'), 'AFB');
-    await selectEvent.select(await screen.findByLabelText('New duty station'), /Luke/);
+    await userEvent.type(screen.getByLabelText('New duty station'), 'AFB', { delay: 100 });
+    const selectedOption = await screen.findByText(/Luke/);
+    userEvent.click(selectedOption);
+
     await waitFor(() => {
       expect(screen.getByRole('form')).toHaveFormValues({
         new_duty_station: 'Luke AFB',
@@ -320,11 +321,15 @@ describe('EditOrdersForm component', () => {
     userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    userEvent.type(screen.getByLabelText('New duty station'), 'AFB');
-    await selectEvent.select(await screen.findByLabelText('New duty station'), /Luke/);
-    expect(screen.getByRole('form')).toHaveFormValues({
-      new_duty_station: 'Luke AFB',
-    });
+    await userEvent.type(screen.getByLabelText('New duty station'), 'AFB', { delay: 100 });
+    const selectedOption = await screen.findByText(/Luke/);
+    userEvent.click(selectedOption);
+
+    await waitFor(() =>
+      expect(screen.getByRole('form')).toHaveFormValues({
+        new_duty_station: 'Luke AFB',
+      }),
+    );
 
     const submitBtn = screen.getByRole('button', { name: 'Save' });
     expect(submitBtn).not.toBeDisabled();

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
 
 import OrdersInfoForm from './OrdersInfoForm';
 
@@ -175,29 +174,28 @@ describe('OrdersInfoForm component', () => {
   });
 
   it('validates the new duty station against the current duty station', async () => {
-    const { queryByText, getByRole, getByLabelText } = render(
-      <OrdersInfoForm {...testProps} currentStation={{ name: 'Luke AFB' }} />,
-    );
+    render(<OrdersInfoForm {...testProps} currentStation={{ name: 'Luke AFB' }} />);
 
-    userEvent.selectOptions(getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
-    userEvent.type(getByLabelText('Orders date'), '08 Nov 2020');
-    userEvent.type(getByLabelText('Report-by date'), '26 Nov 2020');
-    userEvent.click(getByLabelText('No'));
+    userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+    userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+    userEvent.type(screen.getByLabelText('Report-by date'), '26 Nov 2020');
+    userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    fireEvent.change(getByLabelText('New duty station'), { target: { value: 'AFB' } });
-
-    await selectEvent.select(getByLabelText('New duty station'), /Luke/);
+    await userEvent.type(screen.getByLabelText('New duty station'), 'AFB', { delay: 100 });
+    const selectedOption = await screen.findByText(/Luke/);
+    userEvent.click(selectedOption);
 
     await waitFor(() => {
-      expect(getByRole('form')).toHaveFormValues({
+      expect(screen.getByRole('form')).toHaveFormValues({
         new_duty_station: 'Luke AFB',
       });
-      expect(getByRole('button', { name: 'Next' })).toHaveAttribute('disabled');
-      expect(
-        queryByText('You entered the same duty station for your origin and destination. Please change one of them.'),
-      ).toBeInTheDocument();
     });
+
+    expect(screen.getByRole('button', { name: 'Next' })).toHaveAttribute('disabled');
+    expect(
+      screen.getByText('You entered the same duty station for your origin and destination. Please change one of them.'),
+    ).toBeInTheDocument();
   });
 
   it('shows an error message if trying to submit an invalid form', async () => {
@@ -213,21 +211,25 @@ describe('OrdersInfoForm component', () => {
   });
 
   it('submits the form when its valid', async () => {
-    const { getByRole, getByLabelText } = render(<OrdersInfoForm {...testProps} />);
+    render(<OrdersInfoForm {...testProps} />);
 
-    userEvent.selectOptions(getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
-    userEvent.type(getByLabelText('Orders date'), '08 Nov 2020');
-    userEvent.type(getByLabelText('Report-by date'), '26 Nov 2020');
-    userEvent.click(getByLabelText('No'));
+    userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+    userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+    userEvent.type(screen.getByLabelText('Report-by date'), '26 Nov 2020');
+    userEvent.click(screen.getByLabelText('No'));
 
     // Test Duty Station Search Box interaction
-    fireEvent.change(getByLabelText('New duty station'), { target: { value: 'AFB' } });
-    await selectEvent.select(getByLabelText('New duty station'), /Luke/);
-    expect(getByRole('form')).toHaveFormValues({
-      new_duty_station: 'Luke AFB',
+    await userEvent.type(screen.getByLabelText('New duty station'), 'AFB', { delay: 100 });
+    const selectedOption = await screen.findByText(/Luke/);
+    userEvent.click(selectedOption);
+
+    await waitFor(() => {
+      expect(screen.getByRole('form')).toHaveFormValues({
+        new_duty_station: 'Luke AFB',
+      });
     });
 
-    const submitBtn = getByRole('button', { name: 'Next' });
+    const submitBtn = screen.getByRole('button', { name: 'Next' });
     userEvent.click(submitBtn);
 
     await waitFor(() => {

--- a/src/pages/MyMove/Orders.test.jsx
+++ b/src/pages/MyMove/Orders.test.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
 
 import { Orders } from './Orders';
 
@@ -192,29 +191,32 @@ describe('Orders page', () => {
 
       createOrders.mockImplementation(() => Promise.resolve(testOrdersValues));
 
-      const { queryByRole, getByLabelText, getByRole } = render(<Orders {...testProps} />);
+      render(<Orders {...testProps} />);
 
       await waitFor(() => {
-        userEvent.selectOptions(getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
+        userEvent.selectOptions(screen.getByLabelText('Orders type'), 'PERMANENT_CHANGE_OF_STATION');
       });
 
-      userEvent.type(getByLabelText('Orders date'), '08 Nov 2020');
-      userEvent.type(getByLabelText('Report-by date'), '26 Nov 2020');
-      userEvent.click(getByLabelText('No'));
+      userEvent.type(screen.getByLabelText('Orders date'), '08 Nov 2020');
+      userEvent.type(screen.getByLabelText('Report-by date'), '26 Nov 2020');
+      userEvent.click(screen.getByLabelText('No'));
 
       // Test Duty Station Search Box interaction
-      fireEvent.change(getByLabelText('New duty station'), { target: { value: 'AFB' } });
-      await selectEvent.select(getByLabelText('New duty station'), /Luke/);
+      await userEvent.type(screen.getByLabelText('New duty station'), 'AFB', { delay: 100 });
+      const selectedOption = await screen.findByText(/Luke/);
+      userEvent.click(selectedOption);
 
-      expect(getByRole('form')).toHaveFormValues({
-        orders_type: 'PERMANENT_CHANGE_OF_STATION',
-        issue_date: '08 Nov 2020',
-        report_by_date: '26 Nov 2020',
-        has_dependents: 'no',
-        new_duty_station: 'Luke AFB',
+      await waitFor(() => {
+        expect(screen.getByRole('form')).toHaveFormValues({
+          orders_type: 'PERMANENT_CHANGE_OF_STATION',
+          issue_date: '08 Nov 2020',
+          report_by_date: '26 Nov 2020',
+          has_dependents: 'no',
+          new_duty_station: 'Luke AFB',
+        });
       });
 
-      const submitButton = queryByRole('button', { name: 'Next' });
+      const submitButton = screen.getByRole('button', { name: 'Next' });
       expect(submitButton).toBeEnabled();
 
       expect(submitButton).toBeInTheDocument();


### PR DESCRIPTION
## Description

This pull request refactors tests in three suites to be more in line with current front-end testing best practices (using `screen` instead of methods returned from `render`, using RTL instead of enzyme, appropriately using `await findByWhatever` instead of `waitFor`); this should greatly reduce the incidence of these tests sporadically failing during our CircleCI `client_test` build jobs, of which these were probably the worst offenders in our front-end code base.

One specific change in this version of the pull request (as opposed to [a previous one](https://github.com/transcom/mymove/pull/7239)) is that a `delay` value of 100ms is added to `userEvent.type` commands in these three test suites. This has the effect of slowing down simulated input into the third party `react-select` combo box, which allows the (also simulated) async functions to catch up with autocomplete options.

I've run these client tests about 20 times in a CircleCI environment, and the changed tests have passed each time. Since each of these flaky tests seem to fail around 5-10% of the time, it gives me a reasonable level of confidence that we've actually resolved the issue this time.

## Reviewer Notes

There should be no visible changes to the UI (quite literally, all we're changing/adding are test files). Ensure that the modified tests aren't emitting any messages to the console during test runs.

## Setup

```sh
yarn test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-8841](https://dp3.atlassian.net/browse/MB-8841) and [MB-8842](https://dp3.atlassian.net/browse/MB-8842).
* [Common mistakes with React Testing Library](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library/)