### PR TITLE
[MB-8758] Use correct operation ID for SIT extension approve/deny

### DIFF
--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -239,7 +239,7 @@ export function approveSITExtension({
   schemaKey = 'mtoShipment',
   body,
 }) {
-  const operationPath = 'shipment.approveSitExtension';
+  const operationPath = 'shipment.approveSITExtension';
   return makeGHCRequest(
     operationPath,
     {
@@ -260,7 +260,7 @@ export function denySITExtension({
   schemaKey = 'mtoShipment',
   body,
 }) {
-  const operationPath = 'shipment.denySitExtension';
+  const operationPath = 'shipment.denySITExtension';
   return makeGHCRequest(
     operationPath,
     {


### PR DESCRIPTION
## Description

https://github.com/transcom/mymove/pull/7408 changed the name from Sit to SIT in the API and that in turn meant that the operation ID that the front end uses to call the API needed to be updated.

## Setup

make server_run, make client_run

## Code Review Verification Steps

Use the `PENDNG` move code and make sure that approval/denial works.