### PR TITLE
[MB-9339] Fix parameter associations for shuttle services

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -667,3 +667,4 @@
 20210831214156_add_sit_pr_start_and_end_dates.up.sql
 20210903211741_recalculation_payment_request.up.sql
 20210909171753_add_demo_tls_cert.up.sql
+20210923180711_fix_shuttle_params.up.sql

--- a/migrations/app/schema/20210923180711_fix_shuttle_params.up.sql
+++ b/migrations/app/schema/20210923180711_fix_shuttle_params.up.sql
@@ -1,0 +1,5 @@
+-- Delete association between shuttle service items and the WeightAdjusted and WeightReweigh parameters
+-- since those do not apply to shuttling. These had been inadvertently added in a previous migration.
+DELETE FROM service_params
+WHERE service_id IN (SELECT id FROM re_services WHERE code IN ('DOSHUT', 'DDSHUT', 'IOSHUT', 'IDSHUT'))
+  AND service_item_param_key_id IN (SELECT id FROM service_item_param_keys WHERE key IN ('WeightAdjusted', 'WeightReweigh'));


### PR DESCRIPTION
## Description

In #7248, I had inadvertently added the `WeightAdjusted` and `WeightReweigh` pricing parameters to the shuttle-based service items.  However, the shuttle services do not use those parameters as their weights don't come from the shipment level, but instead come from the service item itself.  This PR contains a database migration that removes those two parameters from all shuttle service items. 

For more context, see [this Slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1632418503383500?thread_ts=1632148212.311200&cid=CP6F568DC).

## Setup

`make clean server_build db_dev_reset db_dev_migrate`

Now run this SQL query:

```sql
select rs.code, sipk.key from service_params
inner join service_item_param_keys sipk on service_params.service_item_param_key_id = sipk.id
inner join re_services rs on service_params.service_id = rs.id
where rs.code like '%SHUT' and sipk.key like 'Weight%'
order by rs.code, sipk.key
```

You should see the weight-related parameters for all the shuttle items.  Verify that `WeightAdjusted` and `WeightReweigh` are no longer present.  In total, 8 rows should have been deleted from the `service_params` table.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9339) for this change
