### PR TITLE
MB-9298 Update move status when pending sit extension is created

### DIFF
--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -133,7 +133,7 @@ func NewPrimeAPIHandler(ctx handlers.HandlerContext) http.Handler {
 
 	primeAPI.MtoShipmentCreateSITExtensionHandler = CreateSITExtensionHandler{
 		ctx,
-		sitextension.NewSitExtensionCreator(),
+		sitextension.NewSitExtensionCreator(moveRouter),
 	}
 
 	return primeAPI.Serve(nil)

--- a/pkg/handlers/primeapi/sit_extension_test.go
+++ b/pkg/handlers/primeapi/sit_extension_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	sitextensionservice "github.com/transcom/mymove/pkg/services/sit_extension"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -36,10 +38,13 @@ func (suite *HandlerSuite) CreateSITExtensionHandler() {
 		RequestReason:     &reason,
 	}
 
+	// Create move router for SitExtension Createor
+	moveRouter := moverouter.NewMoveRouter()
+
 	// Create handler
 	handler := CreateSITExtensionHandler{
 		handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-		sitextensionservice.NewSitExtensionCreator(),
+		sitextensionservice.NewSitExtensionCreator(moveRouter),
 	}
 
 	suite.T().Run("Success 201 - Creat SIT extension", func(t *testing.T) {

--- a/pkg/services/sit_extension/sit_extension_creator_test.go
+++ b/pkg/services/sit_extension/sit_extension_creator_test.go
@@ -8,55 +8,109 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	movefetcher "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
 	// Create new mtoShipment
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{})
+	move := testdatagen.MakeAvailableMove(suite.DB())
+	shipment := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &move, testdatagen.Assertions{})
 
 	// Create a valid SIT Extension for the move
 	sit := &models.SITExtension{
 		RequestReason: models.SITExtensionRequestReasonAwaitingCompletionOfResidence,
-		Status:        models.SITExtensionStatusApproved,
-		MTOShipmentID: mtoShipment.ID,
+		MTOShipmentID: shipment.ID,
 		RequestedDays: 10,
 	}
 
 	appCtx := appcontext.NewAppContext(suite.DB(), suite.logger)
 
-	suite.T().Run("CreateSITExtension - Success", func(t *testing.T) {
+	// Create move router for SitExtension Createor
+	moveRouter := moverouter.NewMoveRouter()
+	sitExtensionCreator := NewSitExtensionCreator(moveRouter)
+	movefetcher := movefetcher.NewMoveTaskOrderFetcher()
+
+	suite.T().Run("Success - CreateSITExtension with no status passed in", func(t *testing.T) {
 		// Under test:	CreateSITExtension
 		// Set up:		Established valid shipment and valid SIT extension
 		// Expected:	New reweigh successfully created
-		sitExtensionCreator := NewSitExtensionCreator()
-		createdSITExtension, err := sitExtensionCreator.CreateSITExtension(appCtx, sit)
+		createdSITExtension, sitErr := sitExtensionCreator.CreateSITExtension(appCtx, sit)
 
-		suite.Nil(err)
+		// Retrieve updated move
+		searchParams := services.MoveTaskOrderFetcherParams{
+			IncludeHidden:   false,
+			MoveTaskOrderID: move.ID,
+		}
+		updatedMove, moveErr := movefetcher.FetchMoveTaskOrder(appCtx, &searchParams)
+
+		suite.Nil(sitErr)
+		suite.Nil(moveErr)
 		suite.NotNil(createdSITExtension)
-		suite.Equal(mtoShipment.ID, createdSITExtension.MTOShipmentID)
-
+		suite.Equal(models.SITExtensionStatusPending, createdSITExtension.Status)
+		suite.Equal(sit.RequestedDays, createdSITExtension.RequestedDays)
+		suite.Equal(sit.RequestReason, createdSITExtension.RequestReason)
+		suite.Equal(shipment.ID, createdSITExtension.MTOShipmentID)
+		suite.Equal(move.ID, updatedMove.ID)
+		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, updatedMove.Status)
 	})
 
 	// InvalidInputError
-	suite.T().Run("SIT Extension with validation errors returns an InvalidInputError", func(t *testing.T) {
+	suite.T().Run("Failure - SIT Extension with validation errors returns an InvalidInputError", func(t *testing.T) {
 		badRequestReason := models.SITExtensionRequestReason("none")
 		sit.RequestReason = badRequestReason
-		sitExtensionCreator := NewSitExtensionCreator()
 		createdSITExtension, err := sitExtensionCreator.CreateSITExtension(appCtx, sit)
 
 		suite.Error(err)
 		suite.Nil(createdSITExtension)
 		suite.IsType(services.InvalidInputError{}, err)
+
+		// Reset request reason to correct reason
+		sit.RequestReason = models.SITExtensionRequestReasonAwaitingCompletionOfResidence
 	})
 
-	suite.T().Run("Not Found Error", func(t *testing.T) {
+	suite.T().Run("Failure - Not Found Error", func(t *testing.T) {
 		notFoundUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
 		sit.MTOShipmentID = notFoundUUID
-		sitExtensionCreator := NewSitExtensionCreator()
 		createdSITExtension, err := sitExtensionCreator.CreateSITExtension(appCtx, sit)
 
 		suite.Nil(createdSITExtension)
 		suite.IsType(services.NotFoundError{}, err)
+
+		// Reset shipment id to correct id
+		sit.MTOShipmentID = shipment.ID
+	})
+
+	suite.T().Run("Success - CreateSITExtension with status passed in ", func(t *testing.T) {
+		// Create new mtoShipment
+		move2 := testdatagen.MakeAvailableMove(suite.DB())
+		shipment2 := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &move, testdatagen.Assertions{})
+
+		// Create a valid SIT Extension for the move
+		sit2 := &models.SITExtension{
+			RequestReason: models.SITExtensionRequestReasonAwaitingCompletionOfResidence,
+			MTOShipmentID: shipment2.ID,
+			Status:        models.SITExtensionStatusApproved,
+			RequestedDays: 10,
+		}
+		createdSITExtension, sitErr2 := sitExtensionCreator.CreateSITExtension(appCtx, sit2)
+
+		// Retrieve updated move
+		searchParams2 := services.MoveTaskOrderFetcherParams{
+			IncludeHidden:   false,
+			MoveTaskOrderID: move2.ID,
+		}
+		updatedMove, moveErr2 := movefetcher.FetchMoveTaskOrder(appCtx, &searchParams2)
+
+		suite.Nil(sitErr2)
+		suite.Nil(moveErr2)
+		suite.NotNil(createdSITExtension)
+		suite.Equal(shipment2.ID, createdSITExtension.MTOShipmentID)
+		suite.Equal(models.SITExtensionStatusApproved, createdSITExtension.Status)
+		suite.Equal(sit2.RequestedDays, createdSITExtension.RequestedDays)
+		suite.Equal(sit2.RequestReason, createdSITExtension.RequestReason)
+		suite.Equal(move2.ID, updatedMove.ID)
+		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds logic to the create sit extension service. When a sit extension is created with a pending sit extension, the move status is updated to approvals requested. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

To execute the tests, run `make server_test`

To test manually, complete the following steps:

* Execute `make server_run`
* Using postman, use the `listMoves` endpoint to retrieve a list of prime available moves and copy a move id
* Use the `getMove` endpoint and the copied move id to retrieve the move details
* Copy the shipment ID from the returned move
* Use the createSitExtension endpoint with the copied shipment id and the following request body

```
{
    "requestReason": "IMPENDING_ASSIGNEMENT",
    "contractorRemarks": "We need SIT additional days. The customer has not found a house yet.",
    "requestedDays": 30
}
```

*  Use the DB to view the move status or confirm through the UI that the move shows up in the TOO queue with the approvals requested status.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9298) for this change