### PR TITLE
[MB-9417] Rework upload handling in recalculated payment requests

### DIFF
--- a/pkg/services/payment_request/payment_request_recalculator_test.go
+++ b/pkg/services/payment_request/payment_request_recalculator_test.go
@@ -2,6 +2,7 @@ package paymentrequest
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ const (
 	recalculateTestNewOriginalWeight    = unit.Pound(3412)
 	recalculateTestEscalationCompounded = 1.04071
 	recalculateTestZip3Distance         = 1234
+	recalculateNumProofOfServiceDocs    = 2
 )
 
 func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() {
@@ -52,13 +54,15 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 	paymentRequest, err := creator.CreatePaymentRequest(suite.TestAppContext(), &paymentRequestArg)
 	suite.FatalNoError(err)
 
-	// Add a couple of proof of service docs and prime uploads.
-	for i := 0; i < 2; i++ {
+	// Add a few proof of service docs and prime uploads.
+	var oldProofOfServiceDocIDs []string
+	for i := 0; i < recalculateNumProofOfServiceDocs; i++ {
 		proofOfServiceDoc := testdatagen.MakeProofOfServiceDoc(suite.DB(), testdatagen.Assertions{
 			ProofOfServiceDoc: models.ProofOfServiceDoc{
 				PaymentRequestID: paymentRequest.ID,
 			},
 		})
+		oldProofOfServiceDocIDs = append(oldProofOfServiceDocIDs, proofOfServiceDoc.ID.String())
 		contractor := testdatagen.MakeDefaultContractor(suite.DB())
 		testdatagen.MakePrimeUpload(suite.DB(), testdatagen.Assertions{
 			PrimeUpload: models.PrimeUpload{
@@ -74,6 +78,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 			},
 		})
 	}
+	sort.Strings(oldProofOfServiceDocIDs)
 
 	// Adjust shipment's original weight to force different pricing on a recalculation.
 	mtoShipment := move.MTOShipments[0]
@@ -87,7 +92,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 	newPaymentRequest, err := recalculator.RecalculatePaymentRequest(suite.TestAppContext(), paymentRequest.ID)
 	suite.FatalNoError(err)
 
-	// Fetch the old payment request again -- status should have changed and it should also
+	// Fetch the old payment request again -- status should have changed and it should no longer
 	// have proof of service docs now.  Need to eager fetch some related data to use in test
 	// assertions below.
 	var oldPaymentRequest models.PaymentRequest
@@ -95,7 +100,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 		EagerPreload(
 			"PaymentServiceItems.MTOServiceItem.ReService",
 			"PaymentServiceItems.PaymentServiceItemParams.ServiceItemParamKey",
-			"ProofOfServiceDocs.PrimeUploads",
+			"ProofOfServiceDocs",
 		).
 		Find(&oldPaymentRequest, paymentRequest.ID)
 	suite.FatalNoError(err)
@@ -230,29 +235,18 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 		suite.Truef(foundService, "Could not find service code %s (%s)", servicePriceParam.serviceCode, label)
 	}
 
-	// Check the proof of service docs to make sure they have the same core data
-	suite.Len(oldPaymentRequest.ProofOfServiceDocs, 2)
-	if suite.Equal(len(oldPaymentRequest.ProofOfServiceDocs), len(newPaymentRequest.ProofOfServiceDocs), "Both payment requests should have same number of proof of service docs") {
-		for i := 0; i < len(oldPaymentRequest.ProofOfServiceDocs); i++ {
-			suite.Equal(newPaymentRequest.ID, newPaymentRequest.ProofOfServiceDocs[i].PaymentRequestID, "Proof of service doc should point to the new payment request ID")
+	// Check the proof of service docs; old payment request should have no proof of service docs now; new payment
+	// request should have all the old payment request's proof of service docs.
+	suite.Len(oldPaymentRequest.ProofOfServiceDocs, 0)
+	var newProofOfServiceDocIDs []string
+	if suite.Len(newPaymentRequest.ProofOfServiceDocs, recalculateNumProofOfServiceDocs) {
+		for _, proofOfServiceDoc := range newPaymentRequest.ProofOfServiceDocs {
+			suite.Equal(newPaymentRequest.ID, proofOfServiceDoc.PaymentRequestID, "Proof of service doc should point to the new payment request ID")
+			newProofOfServiceDocIDs = append(newProofOfServiceDocIDs, proofOfServiceDoc.ID.String())
 		}
 	}
-	oldUploadIDs := make(map[uuid.UUID]int)
-	for _, proofOfServiceDoc := range oldPaymentRequest.ProofOfServiceDocs {
-		for _, primeUpload := range proofOfServiceDoc.PrimeUploads {
-			count := oldUploadIDs[primeUpload.UploadID]
-			oldUploadIDs[primeUpload.UploadID] = count + 1
-		}
-	}
-	newUploadIDs := make(map[uuid.UUID]int)
-	for _, proofOfServiceDoc := range newPaymentRequest.ProofOfServiceDocs {
-		for _, primeUpload := range proofOfServiceDoc.PrimeUploads {
-			count := newUploadIDs[primeUpload.UploadID]
-			newUploadIDs[primeUpload.UploadID] = count + 1
-		}
-	}
-	suite.Len(oldUploadIDs, 4)
-	suite.Equal(oldUploadIDs, newUploadIDs, "Referenced UploadIDs are not the same")
+	sort.Strings(newProofOfServiceDocIDs)
+	suite.Equal(oldProofOfServiceDocIDs, newProofOfServiceDocIDs, "Proof of service doc IDs differ, but should be the same")
 
 	// Make sure the links between payment requests are set up properly.
 	suite.Nil(oldPaymentRequest.RecalculationOfPaymentRequestID, "Old payment request should have nil link")


### PR DESCRIPTION
## Description

When doing the initial implementation of the payment request recalculator in #7317, we “copied” uploads by duplicating the `proof_of_service_docs` and `prime_uploads` records of the old payment request (since those records can only point to a single payment request), but pointed the `prime_uploads` records we duplicated to existing `uploads` records associated with the older deprecated payment request.  We did not change anything on S3 in terms of the physical files.

At the time, there was discussion around the feasibility of this approach in both the PR and in Slack ([see this thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1631041087129800)).

After further research and discussion ([thread 1](https://ustcdp3.slack.com/archives/CP6F568DC/p1632510729416600), [thread 2](https://ustcdp3.slack.com/archives/C021XEC7TV4/p1632515519141200)), we decided to just remap the proof of service docs from the old deprecated payment request to the new payment request.  The old payment request shouldn't have a need for proof of service docs anymore since you can't approve anything from a deprecated request (and approval is when proof of service docs matter).  We do re-associate all the doc references to the new payment request, so the docs are still there on the payment request that *can* have approvals.

This PR implements this new strategy.

## Reviewer Notes

Note that I had to avoid a linter issue -- `G601: Implicit memory aliasing in for loop` -- by creating a temporary copy of the loop variable.  We've applied a similar fix in [other places in the code](https://github.com/transcom/mymove/wiki/Using-loop-iterator-variables-in-go).

## Setup

First, build the server and set up your local DB with E2E data:
- `make clean server_build db_dev_reset db_dev_e2e_populate`

You can then use the `prime-api-client` to call the support endpoint locally.  Choose a payment request ID from the E2E data.  Note that the payment request must be in `PENDING` state (if not, an error will be reported).  Some of the E2E payment requests may not be fully set up with all prerequisite data, so it's also possible to get an error on some of the `PENDING` payment requests.

Here's one that should work out of the box (just replace the ID below if you want to try a different payment request):

- `prime-api-client --insecure support-recalculate-payment-request --id ea945ab7-099a-4819-82de-6968efe131dc | jq`

The top-level payment request information should be returned from the call above.  There should be a reference to the old payment request ID in the JSON.  Also, look at your DB and verify that the old payment request is now in `DEPRECATED` status.  You can also spin up the office UI if you'd like and find the payment requests there.

Look at your database and verify that the proof of service docs have moved from the old payment request to the new payment request.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9417) for this change
