### PR TITLE
MB-9047: Removes Storage In Transit field from entitlement display

### DIFF
--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -7,7 +7,7 @@ import MaskedTextField from 'components/form/fields/MaskedTextField';
 import { DropdownInput, CheckboxField } from 'components/form/fields';
 import { DropdownArrayOf } from 'types/form';
 import { EntitlementShape } from 'types/order';
-import { formatWeight, formatDaysInTransit } from 'shared/formatters';
+import { formatWeight } from 'shared/formatters';
 import Hint from 'components/Hint';
 
 const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions, editableAuthorizedWeight }) => {
@@ -107,8 +107,6 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         )}
         <dt>Weight allowance</dt>
         <dd data-testid="weightAllowance">{formatWeight(entitlements.totalWeight)}</dd>
-        <dt>Storage in-transit</dt>
-        <dd data-testid="storageInTransit">{formatDaysInTransit(entitlements.storageInTransit)}</dd>
       </dl>
       <div className={styles.wrappedCheckbox}>
         <CheckboxField id="dependentsAuthorizedInput" name="dependentsAuthorized" label="Dependents authorized" />

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.stories.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.stories.jsx
@@ -41,7 +41,6 @@ const entitlement = {
   proGearWeightSpouse: 500,
   requiredMedicalEquipmentWeight: 1000,
   organizationalClothingAndIndividualEquipment: true,
-  storageInTransit: 90,
   totalWeight: 12875,
   totalDependents: 2,
 };

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.test.jsx
@@ -92,16 +92,6 @@ describe('AllowancesDetailForm', () => {
     expect(screen.getByTestId('proGearWeightSpouseHint')).toHaveTextContent('Max. 500 lbs');
   });
 
-  it('formats days in transit', async () => {
-    render(
-      <Formik initialValues={initialValues}>
-        <AllowancesDetailForm entitlements={entitlements} rankOptions={rankOptions} branchOptions={branchOptions} />
-      </Formik>,
-    );
-
-    expect(await screen.findByTestId('storageInTransit')).toHaveTextContent('90 days');
-  });
-
   it('renders the pro-gear hints', async () => {
     render(
       <Formik initialValues={initialValues}>

--- a/src/components/Office/DefinitionLists/AllowancesList.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import styles from './OfficeDefinitionLists.module.scss';
 
 import descriptionListStyles from 'styles/descriptionList.module.scss';
-import { formatWeight, formatDaysInTransit } from 'shared/formatters';
+import { formatWeight } from 'shared/formatters';
 import friendlyBranchRank from 'utils/branchRankFormatters';
 
 const AllowancesList = ({ info, showVisualCues }) => {
@@ -27,12 +27,6 @@ const AllowancesList = ({ info, showVisualCues }) => {
         <div className={descriptionListStyles.row}>
           <dt>Authorized weight</dt>
           <dd data-testid="authorizedWeight">{formatWeight(info.authorizedWeight)}</dd>
-        </div>
-        <div className={descriptionListStyles.row}>
-          <dt>Storage in transit</dt>
-          <dd data-testid="storageInTransit">
-            {info.storageInTransit ? formatDaysInTransit(info.storageInTransit) : ''}
-          </dd>
         </div>
         <div className={descriptionListStyles.row}>
           <dt>Dependents</dt>

--- a/src/components/Office/DefinitionLists/AllowancesList.test.jsx
+++ b/src/components/Office/DefinitionLists/AllowancesList.test.jsx
@@ -32,11 +32,6 @@ describe('AllowancesList', () => {
     expect(screen.getByText('11,000 lbs')).toBeInTheDocument();
   });
 
-  it('renders formatted storage in transit', () => {
-    render(<AllowancesList info={info} />);
-    expect(screen.getByText('90 days')).toBeInTheDocument();
-  });
-
   it('renders authorized dependents', () => {
     render(<AllowancesList info={info} />);
     expect(screen.getByTestId('dependents').textContent).toEqual('Authorized');

--- a/src/components/Office/ShipmentSITExtensions/ShipmentSITExtensions.test.jsx
+++ b/src/components/Office/ShipmentSITExtensions/ShipmentSITExtensions.test.jsx
@@ -4,16 +4,18 @@ import { render, screen } from '@testing-library/react';
 import ShipmentSITExtensions from './ShipmentSITExtensions';
 import { testProps, testPropsWithComments } from './ShipmentSITExtensionsTestParams';
 
+const noOp = () => {};
+
 describe('ShipmentSITExtensions', () => {
   it('renders the Shipment SIT Extensions', async () => {
-    render(<ShipmentSITExtensions sitExtensions={testProps} />);
+    render(<ShipmentSITExtensions sitExtensions={testProps} handleReviewSITExtension={noOp} />);
     expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeTruthy();
 
     expect(await screen.queryByText('Office remarks:')).toBeFalsy();
   });
 
   it('renders the Shipment SIT Extensions with comments', async () => {
-    render(<ShipmentSITExtensions sitExtensions={testPropsWithComments} />);
+    render(<ShipmentSITExtensions sitExtensions={testPropsWithComments} handleReviewSITExtension={noOp} />);
     expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeTruthy();
 
     await expect(screen.getByText('Office remarks:')).toBeTruthy();

--- a/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.test.jsx
@@ -156,7 +156,6 @@ describe('MoveAllowances page', () => {
       expect(screen.getByLabelText('Dependents authorized')).toBeChecked();
 
       expect(screen.getByTestId('weightAllowance')).toHaveTextContent('5,000 lbs');
-      expect(screen.getByTestId('storageInTransit')).toHaveTextContent('2 days');
     });
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.test.jsx
@@ -157,7 +157,6 @@ describe('MoveAllowances page', () => {
       expect(screen.getByLabelText('Dependents authorized')).toBeChecked();
 
       expect(screen.getByTestId('weightAllowance')).toHaveTextContent('5,000 lbs');
-      expect(screen.getByTestId('storageInTransit')).toHaveTextContent('2 days');
     });
   });
 });

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -365,18 +365,6 @@ export const formatAgeToDays = (age) => {
   return `${Math.floor(age)} days`;
 };
 
-export const formatDaysInTransit = (days) => {
-  if (days) {
-    if (days === 1) {
-      return '1 day';
-    } else {
-      return `${days} days`;
-    }
-  } else {
-    return '0 days';
-  }
-};
-
 export const formatAddressShort = (address) => {
   const { city, state, postal_code } = address;
   return `${city}, ${state} ${postal_code}`;

--- a/src/shared/formatters.test.js
+++ b/src/shared/formatters.test.js
@@ -169,21 +169,3 @@ describe('paymentRequestStatusReadable', () => {
     expect(formatters.paymentRequestStatusReadable(PAYMENT_REQUEST_STATUS.DEPRECATED)).toEqual('Deprecated');
   });
 });
-
-describe('formatDaysInTransit', () => {
-  it('returns 0 days when value is null', () => {
-    expect(formatters.formatDaysInTransit()).toEqual('0 days');
-  });
-
-  it('returns 0 days when value is zero', () => {
-    expect(formatters.formatDaysInTransit(0)).toEqual('0 days');
-  });
-
-  it('returns 1 day when value is one', () => {
-    expect(formatters.formatDaysInTransit(1)).toEqual('1 day');
-  });
-
-  it('returns plural when greater than 1', () => {
-    expect(formatters.formatDaysInTransit(2)).toEqual('2 days');
-  });
-});


### PR DESCRIPTION
## Description

The original intent of [this ticket](https://dp3.atlassian.net/browse/MB-9047) was to update the label and value formatting of the "Storage in transit" field of `AllowancesList` component, as seen by TOO, TIO, and Service Counselor users when viewing a submitted customer move. As an aside, the ticket made mention that, currently, the value for that field is displaying as blank text.

Investigation showed that this field is looking at `storageInTransit` value associated with a move's entitlements, but that this value was no longer being functionally set, as it has been superceded by the `sitDaysAllowance` value associated with individual shipments, since different shipments can in the future ostensibly have different SIT allowances.

After [discussion on Slack](https://ustcdp3.slack.com/archives/CP4979J0G/p1632765936296000), it was decided to remove the field from the `AllowancesList` component, as well as the `AllowancesDetailForm` component, which had the identical problem. This pull request does just that for those components, and removes some front-end structural code which was only used to format text for those components' removed fields.

## Reviewer Notes

Ensure that the modified components look correct, and that all tests pass. Ensure that modified client-side tests are not emitting any warning or error messages when run.

## Setup

You can view these changes in storybook (`yarn storybook`), or view the changes in the application through the TOO, TIO, or Service Counselor view by starting the Office application:

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-9047](https://dp3.atlassian.net/browse/MB-9047).

## Screenshots

* [`AllowancesList`, before change](https://user-images.githubusercontent.com/83614364/134988244-f8bfb44d-1b9f-4b1d-9fd1-99d50e973495.png)
* [`AllowancesList`, after change](https://user-images.githubusercontent.com/83614364/134988282-9538b3a0-6bef-4428-9f46-d37c68d81e39.png)
* [`AllowancesDetailForm`, before change](https://user-images.githubusercontent.com/83614364/134988347-c790945c-a15f-4c7f-949b-0b56b8a3eea1.png)
* [`AllowancesDetailForm`, after change](https://user-images.githubusercontent.com/83614364/134988391-d3829b7d-ba8c-450d-8034-8b977d81fd87.png)