### PR TITLE
[MB-9524] Edit billable weight validation

### DIFF
--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import * as Yup from 'yup';
-import { func, number, string } from 'prop-types';
+import { func, number, string, bool } from 'prop-types';
 import { Formik } from 'formik';
 import { Button, Fieldset, Label, Textarea } from '@trussworks/react-uswds';
 
@@ -88,14 +88,15 @@ export default function EditBillableWeight({
   estimatedWeight,
   maxBillableWeight,
   originalWeight,
+  showFieldsInitial,
   title,
   totalBillableWeight,
   weightAllowance,
 }) {
-  const [showEditBtn, setShowEditBtn] = useState(true);
+  const [showFields, setShowFields] = useState(showFieldsInitial);
 
   const toggleEdit = () => {
-    setShowEditBtn(!showEditBtn);
+    setShowFields((show) => !show);
   };
 
   const initialValues = {
@@ -106,7 +107,7 @@ export default function EditBillableWeight({
   return (
     <div className={styles.wrapper}>
       <h4 className={styles.header}>{title}</h4>
-      {showEditBtn ? (
+      {!showFields ? (
         <>
           <span>{billableWeight ? formatWeight(billableWeight) : formatWeight(maxBillableWeight)}</span>
           {billableWeightJustification && (
@@ -199,6 +200,7 @@ EditBillableWeight.propTypes = {
   estimatedWeight: number,
   maxBillableWeight: number,
   originalWeight: number,
+  showFieldsInitial: bool,
   title: string.isRequired,
   totalBillableWeight: number,
   weightAllowance: number,
@@ -206,10 +208,11 @@ EditBillableWeight.propTypes = {
 
 EditBillableWeight.defaultProps = {
   billableWeight: null,
+  billableWeightJustification: '',
   estimatedWeight: null,
+  maxBillableWeight: null,
   originalWeight: null,
+  showFieldsInitial: false,
   totalBillableWeight: null,
   weightAllowance: null,
-  maxBillableWeight: null,
-  billableWeightJustification: '',
 };

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import * as Yup from 'yup';
-import { func, number, string, node } from 'prop-types';
+import { func, number, string } from 'prop-types';
 import { Formik } from 'formik';
 import { Button, Fieldset, Label, Textarea } from '@trussworks/react-uswds';
 
@@ -190,18 +190,6 @@ export default function EditBillableWeight({
     </div>
   );
 }
-
-function ErrorWrapper({ children }) {
-  return <div style={styles.errorWrapper}>sds</div>;
-}
-
-ErrorWrapper.propTypes = {
-  children: node,
-};
-
-ErrorWrapper.defaultProps = {
-  children: null,
-};
 
 EditBillableWeight.propTypes = {
   billableWeight: number,

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -120,7 +120,7 @@ export default function EditBillableWeight({
           </Button>
         </>
       ) : (
-        <Formik initialValues={initialValues} validationSchema={validationSchema} validateOnBlur>
+        <Formik initialValues={initialValues} validationSchema={validationSchema} validateOnBlur validateOnChange>
           {({ handleChange, values, isValid, errors }) => (
             <div className={styles.container}>
               {billableWeight ? (
@@ -138,6 +138,7 @@ export default function EditBillableWeight({
                 <MaskedTextField
                   defaultValue="0"
                   inputClassName={styles.maxBillableWeight}
+                  inputTestId="textInput"
                   errorClassName={styles.errorMessage}
                   labelClassName={styles.label}
                   id="billableWeight"

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -121,8 +121,8 @@ export default function EditBillableWeight({
           </Button>
         </>
       ) : (
-        <Formik initialValues={initialValues} validationSchema={validationSchema} validateOnBlur validateOnChange>
-          {({ handleChange, values, isValid, errors }) => (
+        <Formik enableReinitialize initialValues={initialValues} validationSchema={validationSchema}>
+          {({ handleChange, values, isValid, errors, touched, setTouched }) => (
             <div className={styles.container}>
               {billableWeight ? (
                 <BillableWeightHintText
@@ -154,16 +154,26 @@ export default function EditBillableWeight({
                   lbs
                 </MaskedTextField>
                 <Label htmlFor="remarks">Remarks</Label>
-                <ErrorMessage className={styles.errorMessage} display={!!errors.billableWeightJustification}>
+                <ErrorMessage
+                  className={styles.errorMessage}
+                  display={!!touched.billableWeightJustification && !!errors.billableWeightJustification}
+                >
                   {errors.billableWeightJustification}
                 </ErrorMessage>
-                <div className={errors.billableWeightJustification ? 'usa-form-group--error' : ''}>
+                <div
+                  className={
+                    !!touched.billableWeightJustification && !!errors.billableWeightJustification
+                      ? 'usa-form-group--error'
+                      : ''
+                  }
+                >
                   <Textarea
                     data-testid="remarks"
                     id="billableWeightJustification"
                     maxLength={500}
                     onChange={handleChange}
                     placeholder=""
+                    onBlur={() => setTouched({ billableWeightJustification: true }, false)}
                     value={values.billableWeightJustification}
                   />
                 </div>

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -55,6 +55,8 @@
   .errorMessage {
     margin-top: 0;
     color: #b50909;
+    font-weight: 700;
+    font-size: 15px;
   }
 
   .fieldset {

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -43,12 +43,18 @@
   .maxBillableWeight {
     display: inline-block;
     width: 96px;
+    border: 1px solid #1b1b1b;
     appearance: none; // removes up and down arrow for number inputs on firefox
 
     &::-webkit-inner-spin-button,
     &::-webkit-outer-spin-button {
       appearance: none; // removes up and down arrow for number inputs on all other browsers
     }
+  }
+
+  .errorMessage {
+    margin-top: 0;
+    color: #b50909;
   }
 
   .fieldset {
@@ -62,9 +68,18 @@
     :global(.usa-textarea) {
       height: 96px;
     }
+
+    .label {
+      margin: 0;
+    }
   }
   .btnContainer {
     display: flex;
     @include u-margin-top(2);
+  }
+
+  :global(.usa-form-group--error),
+  :global(.usa-label--error) {
+    margin-top: 0;
   }
 }

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -19,12 +19,27 @@ const Template = (args) => (
   </Container>
 );
 
+const ToggledTemplate = (args) => (
+  <Container>
+    <EditBillableWeight {...args} showFieldsInitial />
+  </Container>
+);
+
 export const MaxBillableWeight = Template.bind({});
 
 MaxBillableWeight.args = {
   billableWeightJustification: 'Reduced billable weight to cap at 110% of estimated.',
   estimatedWeight: 13750,
   maxBillableWeight: 13000,
+  title: 'Max billable weight',
+  weightAllowance: 8000,
+};
+
+export const EmptyMaxBillableWeight = ToggledTemplate.bind({});
+
+MaxBillableWeight.args = {
+  billableWeightJustification: '',
+  estimatedWeight: 13750,
   title: 'Max billable weight',
   weightAllowance: 8000,
 };

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -37,7 +37,7 @@ MaxBillableWeight.args = {
 
 export const EmptyMaxBillableWeight = ToggledTemplate.bind({});
 
-MaxBillableWeight.args = {
+EmptyMaxBillableWeight.args = {
   billableWeightJustification: '',
   estimatedWeight: 13750,
   title: 'Max billable weight',

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -23,6 +23,8 @@ describe('EditBillableWeight', () => {
     expect(screen.getByText(formatWeight(defaultProps.maxBillableWeight))).toBeInTheDocument();
   });
 
+  it('should show fields are required when empty', () => {});
+
   it('renders billable weight justification', () => {
     const defaultProps = {
       title: 'Max billable weight',

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -166,8 +166,9 @@ describe('EditBillableWeight', () => {
     expect(screen.queryByText('Edit')).toBeNull();
     userEvent.clear(screen.getByTestId('textInput'));
     userEvent.clear(screen.getByTestId('remarks'));
+    screen.getByTestId('remarks').blur();
     await waitFor(() => {
-      expect(screen.queryAllByText('Required').length).toBe(2);
+      expect(screen.getByText('Required')).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
   });

--- a/src/components/form/fields/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField.jsx
@@ -11,6 +11,8 @@ const MaskedTextField = ({
   label,
   labelClassName,
   formGroupClassName,
+  inputClassName,
+  errorClassName,
   id,
   name,
   labelHint,
@@ -20,6 +22,8 @@ const MaskedTextField = ({
   lazy,
   warning,
   validate,
+  children,
+  type,
   ...props
 }) => {
   const [field, meta, helpers] = useField({ id, name, validate, ...props });
@@ -30,17 +34,18 @@ const MaskedTextField = ({
       <Label className={labelClassName} hint={labelHint} error={hasError} htmlFor={id || name}>
         {label}
       </Label>
-      <ErrorMessage display={hasError}>{meta.error}</ErrorMessage>
+      <ErrorMessage display={hasError} className={errorClassName}>
+        {meta.error}
+      </ErrorMessage>
       {!!warning && !hasError && (
         <p className="usa-hint" data-testid="textInputWarning">
           {warning}
         </p>
       )}
-
       {/* eslint-disable react/jsx-props-no-spreading */}
       <IMaskInput
-        className="usa-input"
-        type="text"
+        className={classnames('usa-input', inputClassName)}
+        type={type}
         id={id}
         name={name}
         value={value ?? defaultValue}
@@ -54,36 +59,46 @@ const MaskedTextField = ({
         }}
         {...props}
       />
+      {children}
       {/* eslint-enable react/jsx-props-no-spreading */}
     </FormGroup>
   );
 };
 
 MaskedTextField.propTypes = {
+  blocks: PropTypes.oneOfType([PropTypes.object]),
+  children: PropTypes.node,
+  defaultValue: PropTypes.string,
+  errorClassName: PropTypes.string,
   formGroupClassName: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
+  label: PropTypes.string,
   labelClassName: PropTypes.string,
   labelHint: PropTypes.string,
-  id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  defaultValue: PropTypes.string,
-  mask: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  blocks: PropTypes.oneOfType([PropTypes.object]),
   lazy: PropTypes.bool,
-  warning: PropTypes.string,
+  mask: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string,
   validate: PropTypes.func,
+  warning: PropTypes.string,
 };
 
 MaskedTextField.defaultProps = {
-  labelHint: '',
-  labelClassName: '',
-  formGroupClassName: '',
-  defaultValue: '',
-  mask: '',
   blocks: {},
+  children: null,
+  defaultValue: '',
+  errorClassName: '',
+  formGroupClassName: '',
+  inputClassName: '',
+  label: '',
+  labelClassName: '',
+  labelHint: '',
   lazy: true, // make placeholder not visible
-  warning: '',
+  mask: '',
+  type: 'text',
   validate: undefined,
+  warning: '',
 };
 
 export default MaskedTextField;

--- a/src/components/form/fields/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField.jsx
@@ -24,6 +24,7 @@ const MaskedTextField = ({
   validate,
   children,
   type,
+  inputTestId,
   ...props
 }) => {
   const [field, meta, helpers] = useField({ id, name, validate, ...props });
@@ -45,6 +46,7 @@ const MaskedTextField = ({
       {/* eslint-disable react/jsx-props-no-spreading */}
       <IMaskInput
         className={classnames('usa-input', inputClassName)}
+        data-testid={inputTestId}
         type={type}
         id={id}
         name={name}
@@ -82,6 +84,7 @@ MaskedTextField.propTypes = {
   type: PropTypes.string,
   validate: PropTypes.func,
   warning: PropTypes.string,
+  inputTestId: PropTypes.string,
 };
 
 MaskedTextField.defaultProps = {
@@ -99,6 +102,7 @@ MaskedTextField.defaultProps = {
   type: 'text',
   validate: undefined,
   warning: '',
+  inputTestId: '',
 };
 
 export default MaskedTextField;

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -107,7 +107,7 @@ export default function ReviewBillableWeight() {
         orderID: order.id,
         ifMatchETag: order.eTag,
         body: {
-          authorizedWeight: formValues.billableWeight,
+          authorizedWeight: Number(formValues.billableWeight),
           tioRemarks: formValues.billableWeightJustification,
         },
       };
@@ -116,7 +116,7 @@ export default function ReviewBillableWeight() {
       const payload = {
         body: {
           ...formValues,
-          billableWeightCap: formValues.billableWeight,
+          billableWeightCap: Number(formValues.billableWeight),
         },
         ifMatchETag: selectedShipment.eTag,
         moveTaskOrderID: selectedShipment.moveTaskOrderID,

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -196,7 +196,7 @@ export default function ReviewBillableWeight() {
                     {`Max billable weight exceeded. \nPlease resolve.`}
                   </Alert>
                 )}
-                {((!selectedShipment.reweigh?.weight && selectedShipment.reweigh?.requestedAt) ||
+                {((!selectedShipment?.reweigh?.weight && selectedShipment?.reweigh?.requestedAt) ||
                   !selectedShipment.primeEstimatedWeight) && (
                   <Alert slim type="warning">
                     Shipment missing information
@@ -222,7 +222,7 @@ export default function ReviewBillableWeight() {
                   billableWeight={selectedShipment.calculatedBillableWeight}
                   editEntity={editEntity}
                   billableWeightJustification={selectedShipment.billableWeightJustification}
-                  dateReweighRequested={selectedShipment.reweigh?.requestedAt}
+                  dateReweighRequested={selectedShipment?.reweigh?.requestedAt}
                   departedDate={selectedShipment.actualPickupDate}
                   pickupAddress={selectedShipment.pickupAddress}
                   destinationAddress={selectedShipment.destinationAddress}

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -228,8 +228,8 @@ export default function ReviewBillableWeight() {
                   destinationAddress={selectedShipment.destinationAddress}
                   estimatedWeight={selectedShipment.primeEstimatedWeight}
                   originalWeight={selectedShipment.primeActualWeight}
-                  reweighRemarks={selectedShipment.reweigh?.verificationReason}
-                  reweighWeight={selectedShipment.reweigh?.weight}
+                  reweighRemarks={selectedShipment?.reweigh?.verificationReason}
+                  reweighWeight={selectedShipment?.reweigh?.weight}
                 />
               </div>
             </DocumentViewerSidebar.Content>


### PR DESCRIPTION
## Description

Add validation to edit billable weight fields

## Setup
`make server_run`
`make office_client_run`
Log in as TIO
View payment request
Review weight
Click on `Edit`
Put an empty value for weight
Expected result: Should show required message and disabled button

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9524) for this change

## Screenshots
<img width="405" alt="Screen Shot 2021-09-28 at 8 22 32 AM" src="https://user-images.githubusercontent.com/13622298/135155263-2f54b86e-d0dd-4851-bed9-9ac524cf99da.png">
