### PR TITLE
Update health check to only check https

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ commands:
           no_output_timeout: 20m
       - run:
           name: Health Check
-          command: bin/health-checker --schemes http,https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 15m
+          command: bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 5m
       - run:
           name: TLS Check
           command: bin/tls-checker --schemes https --hosts << parameters.health_check_hosts >> --log-level info --timeout 15m
@@ -410,7 +410,7 @@ commands:
           no_output_timeout: 20m
       - run:
           name: Health Check
-          command: bin/health-checker --schemes http,https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 15m
+          command: bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 5m
       - run:
           name: TLS Check
           command: bin/tls-checker --schemes https --hosts << parameters.health_check_hosts >> --log-level info --timeout 15m
@@ -447,7 +447,7 @@ commands:
       - run:
           name: Health Check
           command: |
-            bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${TLS_KEY} --cert ${TLS_CERT} --ca ${TLS_CA} --tries 10 --backoff 3 --log-level info --timeout 15m
+            bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${TLS_KEY} --cert ${TLS_CERT} --ca ${TLS_CA} --tries 10 --backoff 3 --log-level info --timeout 5m
       - run:
           name: TLS Check
           command: |
@@ -485,7 +485,7 @@ commands:
       - run:
           name: Health Check
           command: |
-            bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${TLS_KEY} --cert ${TLS_CERT} --ca ${TLS_CA} --tries 10 --backoff 3 --log-level info --timeout 15m
+            bin/health-checker --schemes https --hosts << parameters.health_check_hosts >> --key ${TLS_KEY} --cert ${TLS_CERT} --ca ${TLS_CA} --tries 10 --backoff 3 --log-level info --timeout 5m
       - run:
           name: TLS Check
           command: |


### PR DESCRIPTION
## Description

Seems http health check has broken. Since we expect to use https this changes the health check to only check for https endpoints.

Also 10 tries with each having a 15 minute time out seems excessive.
This PR reduces the timeout to 5 minutes for each of the 10 tries.

[See this thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1632950530011200)