### PR TITLE
MB-9285 Add move weights to MTO left nav

### DIFF
--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -14,7 +14,6 @@ import moveTaskOrderStyles from './MoveTaskOrder.module.scss';
 
 import { milmoveLog, MILMOVE_LOG_LEVEL } from 'utils/milmoveLog';
 import hasRiskOfExcess from 'utils/hasRiskOfExcess';
-import handleScroll from 'utils/handleScroll';
 import customerContactTypes from 'constants/customerContactTypes';
 import dimensionTypes from 'constants/dimensionTypes';
 import { MTO_SERVICE_ITEMS, MOVES, MTO_SHIPMENTS, ORDERS } from 'constants/queryKeys';
@@ -86,11 +85,14 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   const [selectedShipment, setSelectedShipment] = useState(undefined);
   const [selectedServiceItem, setSelectedServiceItem] = useState(undefined);
   const [sections, setSections] = useState([]);
-  const [nonShipmentSections, setNonShipmentSections] = useState([]);
   const [activeSection, setActiveSection] = useState('');
   const [unapprovedServiceItemsForShipment, setUnapprovedServiceItemsForShipment] = useState({});
   const [unapprovedSITExtensionForShipment, setUnApprovedSITExtensionForShipment] = useState({});
   const [estimatedWeightTotal, setEstimatedWeightTotal] = useState(null);
+
+  const nonShipmentSections = useMemo(() => {
+    return ['move-weights'];
+  }, []);
 
   const { moveCode } = match.params;
   const {
@@ -384,10 +386,6 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   }, [mtoShipments, setUnapprovedShipmentCount]);
 
   useEffect(() => {
-    setNonShipmentSections(['move-weights'] || []);
-  }, []);
-
-  useEffect(() => {
     const shipmentSections = mtoShipments?.reduce((previous, shipment) => {
       if (showShipmentFilter(shipment)) {
         previous.push({
@@ -429,16 +427,6 @@ export const MoveTaskOrder = ({ match, ...props }) => {
 
   // Edge case of diversion shipments being counted twice
   const moveWeightTotal = useCalculatedWeightRequested(mtoShipments);
-
-  useEffect(() => {
-    // attach scroll listener
-    window.addEventListener('scroll', handleScroll(sections, activeSection, setActiveSection));
-
-    // remove scroll listener
-    return () => {
-      window.removeEventListener('scroll', handleScroll(sections, activeSection, setActiveSection));
-    };
-  }, [sections, activeSection]);
 
   useEffect(() => {
     let unapprovedSITExtensionCount = 0;
@@ -512,15 +500,25 @@ export const MoveTaskOrder = ({ match, ...props }) => {
         <LeftNav className={styles.sidebar}>
           {nonShipmentSections.map((s) => {
             return (
-              <a key={`sidenav_${s}`} href={`#${s}`} className={classnames({ active: s === activeSection })}>
+              <a
+                key={`sidenav_${s}`}
+                href={`#${s}`}
+                className={classnames({ active: `#${s}` === activeSection })}
+                onClick={() => setActiveSection(`#${s}`)}
+              >
                 {nonShipmentSectionLabels[`${s}`]}
               </a>
             );
           })}
           {sections.map((s) => {
-            const classes = classnames({ active: s.id === activeSection });
+            const classes = classnames({ active: `#s-${s.id}` === activeSection });
             return (
-              <a key={`sidenav_${s.id}`} href={`#s-${s.id}`} className={classes}>
+              <a
+                key={`sidenav_${s.id}`}
+                href={`#s-${s.id}`}
+                className={classes}
+                onClick={() => setActiveSection(`#s-${s.id}`)}
+              >
                 {s.label}{' '}
                 {(unapprovedServiceItemsForShipment[`${s.id}`] || unapprovedSITExtensionForShipment[`${s.id}`]) && (
                   <Tag>

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -50,6 +50,10 @@ import WeightDisplay from 'components/Office/WeightDisplay/WeightDisplay';
 import { includedStatusesForCalculatingWeights, useCalculatedWeightRequested } from 'hooks/custom';
 import { SIT_EXTENSION_STATUS } from 'constants/sitExtensions';
 
+const nonShipmentSectionLabels = {
+  'move-weights': 'Move weights',
+};
+
 function formatShipmentDate(shipmentDateString) {
   if (shipmentDateString == null) {
     return '';
@@ -82,6 +86,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   const [selectedShipment, setSelectedShipment] = useState(undefined);
   const [selectedServiceItem, setSelectedServiceItem] = useState(undefined);
   const [sections, setSections] = useState([]);
+  const [nonShipmentSections, setNonShipmentSections] = useState([]);
   const [activeSection, setActiveSection] = useState('');
   const [unapprovedServiceItemsForShipment, setUnapprovedServiceItemsForShipment] = useState({});
   const [unapprovedSITExtensionForShipment, setUnApprovedSITExtensionForShipment] = useState({});
@@ -379,6 +384,10 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   }, [mtoShipments, setUnapprovedShipmentCount]);
 
   useEffect(() => {
+    setNonShipmentSections(['move-weights'] || []);
+  }, []);
+
+  useEffect(() => {
     const shipmentSections = mtoShipments?.reduce((previous, shipment) => {
       if (showShipmentFilter(shipment)) {
         previous.push({
@@ -501,6 +510,13 @@ export const MoveTaskOrder = ({ match, ...props }) => {
     <div className={styles.tabContent}>
       <div className={styles.container}>
         <LeftNav className={styles.sidebar}>
+          {nonShipmentSections.map((s) => {
+            return (
+              <a key={`sidenav_${s}`} href={`#${s}`} className={classnames({ active: s === activeSection })}>
+                {nonShipmentSectionLabels[`${s}`]}
+              </a>
+            );
+          })}
           {sections.map((s) => {
             const classes = classnames({ active: s.id === activeSection });
             return (
@@ -571,7 +587,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
               <h6>Contract #1234567890</h6> {/* TODO - need this value from the API */}
             </div>
           </div>
-          <div className={moveTaskOrderStyles.weightHeader}>
+          <div className={moveTaskOrderStyles.weightHeader} id="move-weights">
             <WeightDisplay heading="Weight allowance" weightValue={order.entitlement.totalWeight} />
             <WeightDisplay heading="Estimated weight (total)" weightValue={estimatedWeightTotal}>
               {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && <Tag>Risk of excess</Tag>}

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -461,9 +461,18 @@ describe('MoveTaskOrder', () => {
       expect(wrapper.find('LeftNav').exists()).toBe(true);
 
       const navLinks = wrapper.find('LeftNav a');
-      expect(navLinks.length).toBe(1);
-      expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(0).prop('href')).toBe('#s-3');
+      expect(navLinks.length).toBe(2);
+      expect(navLinks.at(1).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(1).prop('href')).toBe('#s-3');
+    });
+
+    it('renders the left nav with move weights', () => {
+      expect(wrapper.find('LeftNav').exists()).toBe(true);
+
+      const navLinks = wrapper.find('LeftNav a');
+      expect(navLinks.length).toBe(2);
+      expect(navLinks.at(0).contains('Move weights')).toBe(true);
+      expect(navLinks.at(0).prop('href')).toBe('#move-weights');
     });
 
     it('renders the ShipmentContainer', () => {
@@ -529,22 +538,22 @@ describe('MoveTaskOrder', () => {
       expect(wrapper.find('LeftNav').exists()).toBe(true);
 
       const navLinks = wrapper.find('LeftNav a');
-      expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(0).contains('1'));
-      expect(navLinks.at(0).prop('href')).toBe('#s-3');
-
-      expect(navLinks.at(1).contains('NTS shipment')).toBe(true);
+      expect(navLinks.at(1).contains('HHG shipment')).toBe(true);
       expect(navLinks.at(1).contains('1'));
-      expect(navLinks.at(1).prop('href')).toBe('#s-4');
+      expect(navLinks.at(1).prop('href')).toBe('#s-3');
 
-      expect(navLinks.at(2).contains('NTS-R shipment')).toBe(true);
-      expect(navLinks.at(2).prop('href')).toBe('#s-5');
+      expect(navLinks.at(2).contains('NTS shipment')).toBe(true);
+      expect(navLinks.at(2).contains('1'));
+      expect(navLinks.at(2).prop('href')).toBe('#s-4');
 
-      expect(navLinks.at(3).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(3).prop('href')).toBe('#s-6');
+      expect(navLinks.at(3).contains('NTS-R shipment')).toBe(true);
+      expect(navLinks.at(3).prop('href')).toBe('#s-5');
 
       expect(navLinks.at(4).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(4).prop('href')).toBe('#s-7');
+      expect(navLinks.at(4).prop('href')).toBe('#s-6');
+
+      expect(navLinks.at(5).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(5).prop('href')).toBe('#s-7');
     });
 
     it('renders the ShipmentContainer', () => {
@@ -609,9 +618,9 @@ describe('MoveTaskOrder', () => {
       expect(wrapper.find('LeftNav').exists()).toBe(true);
 
       const navLinks = wrapper.find('LeftNav a');
-      expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(0).contains('1'));
-      expect(navLinks.at(0).prop('href')).toBe('#s-3');
+      expect(navLinks.at(1).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(1).contains('1'));
+      expect(navLinks.at(1).prop('href')).toBe('#s-3');
     });
 
     it('renders the ShipmentContainer', () => {
@@ -673,8 +682,8 @@ describe('MoveTaskOrder', () => {
     it('renders the left nav with tag for SIT extension request', () => {
       expect(wrapper.find('LeftNav').exists()).toBe(true);
       const navLinks = wrapper.find('LeftNav a');
-      expect(navLinks.at(0).contains('HHG shipment')).toBe(true);
-      expect(navLinks.at(0).contains('1'));
+      expect(navLinks.at(1).contains('HHG shipment')).toBe(true);
+      expect(navLinks.at(1).contains('1'));
     });
   });
   describe('SIT extension approved', () => {
@@ -699,7 +708,7 @@ describe('MoveTaskOrder', () => {
       expect(wrapper.find('LeftNav').exists()).toBe(true);
       const navLinks = wrapper.find('LeftNav a');
       // We should get just the shipment text in the nav link
-      expect(navLinks.at(0).text()).toEqual('HHG shipment ');
+      expect(navLinks.at(1).text()).toEqual('HHG shipment ');
     });
   });
 });


### PR DESCRIPTION
## Description

Currently, the only items in the MTO left nav are for shipments, so the
way we scroll to each shipment is to assign a unique CSS id for each
shipment section based on the shipment ID.

However, for the new "Move weights" item we want to add (or any other
non-shipment items we might add in the future), we can't use that
pattern, so I defined a new `nonShipmentSections` array that we can
iterate through.

Let me know if there's a better way to do this.

## Reviewer Notes

1. Sign in as a TOO
2. Click on the `PENDNG` move
3. Click on the Move task order tab
4. Click on the shipment item in the left nav. Notice that it scrolls down to the shipment
5. Click on the Move weights item in the left nav.
6. Verify that it scrolls to the move weights section.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
make db_dev_e2e_populate
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/wiki/Backend-Programming-Guide#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/wiki/migrate-the-database#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9285) for this change

## Screenshots
<img width="1351" alt="Screen Shot 2021-09-30 at 15 59 29" src="https://user-images.githubusercontent.com/811150/135522358-6c0c985e-a2a0-495a-a8d6-aa4fe27eb836.png">

