### PR TITLE
MB-9625 Remove sandy and lynzt CAC access records

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -670,3 +670,4 @@
 20210917011433_add_default_sit_days_allowance_to_existing_hhg_shipments.up.sql
 20210923180711_fix_shuttle_params.up.sql
 20210925020348_add_prime_simulator_role.up.sql
+20210930202639_remove_sandy_and_lynzt_cac_access.up.sql

--- a/migrations/app/schema/20210930202639_remove_sandy_and_lynzt_cac_access.up.sql
+++ b/migrations/app/schema/20210930202639_remove_sandy_and_lynzt_cac_access.up.sql
@@ -1,0 +1,4 @@
+-- Remove sandy's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='0beb55298a9bf146e53213266fc45fcc2b83c22ab2721aea9c2bce0a9ccc4acd';
+-- Remove lynzt's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='38789424b4a63082a8f911ba2015b7c414ad50e77de94ea0b251ad7d70ff7ed2';


### PR DESCRIPTION
## Description

As part of off boarding need to remove CAC sha's from our databases. This PR does that for @sandy-wright and @lynzt 

## Setup

Run migrations confirm their records are gone from `client_certs`

```sh
make db_dev_reset db_dev_migrate
```

Run SQL
```sql
select * from "client_certs" where sha256_digest in ('38789424b4a63082a8f911ba2015b7c414ad50e77de94ea0b251ad7d70ff7ed2', '0beb55298a9bf146e53213266fc45fcc2b83c22ab2721aea9c2bce0a9ccc4acd');
```

Expect zero rows returned

## Code Review Verification Steps

* [X] Any new migrations/schema changes:
  * [X] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/wiki/migrate-the-database#zero-downtime-migrations))
  * [X] Have been communicated to #g-database
* [X] Request review from a member of a different team.
* [X] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9625) for this change
* [Jira story for Lynzt Removal](https://dp3.atlassian.net/browse/MMDM-3323) for this change
* [Jira story for Sandy Removal](https://dp3.atlassian.net/browse/MMDM-3327) for this change