### PR TITLE
MB-9607 yellow alert should go away

### DIFF
--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -205,7 +205,10 @@ export default function ReviewBillableWeight() {
                     Shipment missing information
                   </Alert>
                 )}
-                {shipmentIsOverweight(selectedShipment.primeEstimatedWeight, selectedShipment.primeActualWeight) && (
+                {shipmentIsOverweight(
+                  selectedShipment.primeEstimatedWeight,
+                  selectedShipment.calculatedBillableWeight,
+                ) && (
                   <Alert slim type="warning">
                     Shipment exceeds 110% of estimated weight.
                   </Alert>

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -209,7 +209,7 @@ export default function ReviewBillableWeight() {
                   selectedShipment.primeEstimatedWeight,
                   selectedShipment.calculatedBillableWeight,
                 ) && (
-                  <Alert slim type="warning">
+                  <Alert slim type="warning" data-testid="shipmentBillableWeightExceeds110OfEstimated">
                     Shipment exceeds 110% of estimated weight.
                   </Alert>
                 )}

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -201,7 +201,7 @@ export default function ReviewBillableWeight() {
                 )}
                 {((!selectedShipment?.reweigh?.weight && selectedShipment?.reweigh?.requestedAt) ||
                   !selectedShipment.primeEstimatedWeight) && (
-                  <Alert slim type="warning">
+                  <Alert slim type="warning" data-testid="shipmentMissingInformation">
                     Shipment missing information
                   </Alert>
                 )}

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -275,7 +275,7 @@ describe('ReviewBillableWeight', () => {
       expect(screen.getByTestId('totalBillableWeight').textContent).toBe('8,000 lbs');
     });
 
-    it('renders max billable weight and edit view', () => {
+    it('renders max billable weight and edit view', async () => {
       useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
       useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
       const weightAllowance = formatWeight(useMovePaymentRequestsReturnValue.order.entitlement.totalWeight);
@@ -283,7 +283,7 @@ describe('ReviewBillableWeight', () => {
       render(<ReviewBillableWeight />);
 
       userEvent.click(screen.getByText('Edit'));
-      expect(screen.getByTestId('maxWeight-weightAllowance').textContent).toBe(weightAllowance);
+      expect((await screen.findByTestId('maxWeight-weightAllowance')).textContent).toBe(weightAllowance);
       expect(screen.getByTestId('maxWeight-estimatedWeight').textContent).toBe('11,000 lbs');
     });
   });
@@ -480,14 +480,14 @@ describe('ReviewBillableWeight', () => {
       expect(screen.queryByTestId('maxBillableWeightAlert')).toBeInTheDocument();
     });
 
-    it('renders max billable weight alert in edit view when billable weight is exceeded', () => {
+    it('renders max billable weight alert in edit view when billable weight is exceeded', async () => {
       useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
       useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
 
       render(<ReviewBillableWeight />);
 
       userEvent.click(screen.getByText('Edit'));
-      expect(screen.queryByTestId('maxBillableWeightAlert')).toBeInTheDocument();
+      expect(await screen.findByTestId('maxBillableWeightAlert')).toBeInTheDocument();
     });
 
     it('renders missing shipment weights may impact max billable weight when a shipment is missing a reweigh weight', () => {
@@ -517,14 +517,16 @@ describe('ReviewBillableWeight', () => {
       expect(screen.queryByTestId('maxBillableWeightMissingShipmentWeightAlert')).not.toBeInTheDocument();
     });
 
-    it('does not render a max billable weight alert in edit view when billable weight is not exceeded', () => {
+    it('does not render a max billable weight alert in edit view when billable weight is not exceeded', async () => {
       useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
       useMovePaymentRequestsQueries.mockReturnValue(useNonMaxBillableWeightExceededReturnValue);
 
       render(<ReviewBillableWeight />);
 
       userEvent.click(screen.getByText('Edit'));
-      expect(screen.queryByTestId('maxBillableWeightAlert')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId('maxBillableWeightAlert')).not.toBeInTheDocument();
+      });
     });
 
     it('does not render a max billable weight alert in shipment view when billable weight is not exceeded', () => {

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -543,5 +543,25 @@ describe('ReviewBillableWeight', () => {
         expect(screen.queryByTestId('maxBillableWeightMissingShipmentWeightAlert')).not.toBeInTheDocument();
       });
     });
+
+    describe('shipment exceeds 110% of estimated weight', () => {
+      it('renders the alert when the shipment is overweight - the billable weight is greater than the estimated weight * 110%', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        expect(screen.queryByTestId('shipmentBillableWeightExceeds110OfEstimated')).not.toBeInTheDocument();
+      });
+
+      it('does not render the alert when the shipment is not overweight - the billable weight is less than the estimated weight * 110%', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        expect(screen.queryByTestId('shipmentBillableWeightExceeds110OfEstimated')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -203,12 +203,12 @@ const useNonMaxBillableWeightExceededReturnValue = {
 
 const useMissingShipmentWeightNoReweighReturnValue = {
   order: mockOrders['1'],
-  mtoShipments: [mockHasAllInformationShipment, mockNoReweighWeightShipment],
+  mtoShipments: [mockNoReweighWeightShipment, mockHasAllInformationShipment],
 };
 
 const useMissingShipmentWeightNoPrimeEstimatedWeightReturnValue = {
   order: mockOrders['1'],
-  mtoShipments: [mockHasAllInformationShipment, mockNoPrimeEstimatedWeightShipment],
+  mtoShipments: [mockNoPrimeEstimatedWeightShipment, mockHasAllInformationShipment],
 };
 
 const noAlertsReturnValue = {
@@ -544,6 +544,44 @@ describe('ReviewBillableWeight', () => {
       });
     });
 
+    describe('shipment missing information', () => {
+      it('renders the alert when the shipment is missing a reweigh weight', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoReweighReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
+
+        expect(screen.getByTestId('shipmentMissingInformation')).toBeInTheDocument();
+      });
+
+      it('renders the alert when the shipment is missing a prime estimated weight', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoPrimeEstimatedWeightReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
+
+        expect(screen.getByTestId('shipmentMissingInformation')).toBeInTheDocument();
+      });
+
+      it('does not render when the shipment is not missing a reweigh or a prime estimated ewight', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
+
+        expect(screen.queryByTestId('shipmentMissingInformation')).not.toBeInTheDocument();
+      });
+    });
+
     describe('shipment exceeds 110% of estimated weight', () => {
       it('renders the alert when the shipment is overweight - the billable weight is greater than the estimated weight * 110%', () => {
         useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
@@ -551,7 +589,10 @@ describe('ReviewBillableWeight', () => {
 
         render(<ReviewBillableWeight />);
 
-        expect(screen.queryByTestId('shipmentBillableWeightExceeds110OfEstimated')).not.toBeInTheDocument();
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
+
+        expect(screen.getByTestId('shipmentBillableWeightExceeds110OfEstimated')).toBeInTheDocument();
       });
 
       it('does not render the alert when the shipment is not overweight - the billable weight is less than the estimated weight * 110%', () => {
@@ -559,6 +600,9 @@ describe('ReviewBillableWeight', () => {
         useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
 
         render(<ReviewBillableWeight />);
+
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
 
         expect(screen.queryByTestId('shipmentBillableWeightExceeds110OfEstimated')).not.toBeInTheDocument();
       });

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -469,75 +469,79 @@ describe('ReviewBillableWeight', () => {
   });
 
   describe('check that the various alerts show up when expected', () => {
-    it('renders max billable weight alert in shipment view when billable weight is exceeded', () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
+    describe('max billable weight alert', () => {
+      it('renders in shipment view when billable weight is exceeded', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
 
-      render(<ReviewBillableWeight />);
+        render(<ReviewBillableWeight />);
 
-      userEvent.click(screen.getByText('Edit'));
-      userEvent.click(screen.getByText('Review shipment weights'));
-      expect(screen.queryByTestId('maxBillableWeightAlert')).toBeInTheDocument();
-    });
+        userEvent.click(screen.getByText('Edit'));
+        userEvent.click(screen.getByText('Review shipment weights'));
+        expect(screen.queryByTestId('maxBillableWeightAlert')).toBeInTheDocument();
+      });
 
-    it('renders max billable weight alert in edit view when billable weight is exceeded', async () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
+      it('renders in edit view when billable weight is exceeded', async () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsReturnValue);
 
-      render(<ReviewBillableWeight />);
+        render(<ReviewBillableWeight />);
 
-      userEvent.click(screen.getByText('Edit'));
-      expect(await screen.findByTestId('maxBillableWeightAlert')).toBeInTheDocument();
-    });
+        userEvent.click(screen.getByText('Edit'));
+        expect(await screen.findByTestId('maxBillableWeightAlert')).toBeInTheDocument();
+      });
 
-    it('renders missing shipment weights may impact max billable weight when a shipment is missing a reweigh weight', () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoReweighReturnValue);
+      it('does not render in edit view when billable weight is not exceeded', async () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useNonMaxBillableWeightExceededReturnValue);
 
-      render(<ReviewBillableWeight />);
+        render(<ReviewBillableWeight />);
 
-      expect(screen.getByTestId('maxBillableWeightMissingShipmentWeightAlert')).toBeInTheDocument();
-    });
+        userEvent.click(screen.getByText('Edit'));
+        await waitFor(() => {
+          expect(screen.queryByTestId('maxBillableWeightAlert')).not.toBeInTheDocument();
+        });
+      });
 
-    it('renders missing shipment weights may impact max billable weight when a shipment is missing a prime estimated weight', () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoPrimeEstimatedWeightReturnValue);
+      it('does not render in shipment view when billable weight is not exceeded', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useNonMaxBillableWeightExceededReturnValue);
 
-      render(<ReviewBillableWeight />);
+        render(<ReviewBillableWeight />);
 
-      expect(screen.getByTestId('maxBillableWeightMissingShipmentWeightAlert')).toBeInTheDocument();
-    });
-
-    it('does not render a missing shipment weights may impact max billable weight when none of the shipments are missing reweigh or prime estimated weight information', () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
-
-      render(<ReviewBillableWeight />);
-
-      expect(screen.queryByTestId('maxBillableWeightMissingShipmentWeightAlert')).not.toBeInTheDocument();
-    });
-
-    it('does not render a max billable weight alert in edit view when billable weight is not exceeded', async () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useNonMaxBillableWeightExceededReturnValue);
-
-      render(<ReviewBillableWeight />);
-
-      userEvent.click(screen.getByText('Edit'));
-      await waitFor(() => {
+        userEvent.click(screen.getByText('Edit'));
+        userEvent.click(screen.getByText('Review shipment weights'));
         expect(screen.queryByTestId('maxBillableWeightAlert')).not.toBeInTheDocument();
       });
     });
 
-    it('does not render a max billable weight alert in shipment view when billable weight is not exceeded', () => {
-      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
-      useMovePaymentRequestsQueries.mockReturnValue(useNonMaxBillableWeightExceededReturnValue);
+    describe('missing shipment weights may impact max billable weight', () => {
+      it('renders when a shipment is missing a reweigh weight', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoReweighReturnValue);
 
-      render(<ReviewBillableWeight />);
+        render(<ReviewBillableWeight />);
 
-      userEvent.click(screen.getByText('Edit'));
-      userEvent.click(screen.getByText('Review shipment weights'));
-      expect(screen.queryByTestId('maxBillableWeightAlert')).not.toBeInTheDocument();
+        expect(screen.getByTestId('maxBillableWeightMissingShipmentWeightAlert')).toBeInTheDocument();
+      });
+
+      it('renders when a shipment is missing a prime estimated weight', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMissingShipmentWeightNoPrimeEstimatedWeightReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        expect(screen.getByTestId('maxBillableWeightMissingShipmentWeightAlert')).toBeInTheDocument();
+      });
+
+      it('does not render when none of the shipments are missing reweigh or prime estimated weight information', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        expect(screen.queryByTestId('maxBillableWeightMissingShipmentWeightAlert')).not.toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Changed the logic to use the calculated billable weight instead of the prime actual weight since the calculated billable weight gets changed by the TIO. 
Added some tests.

## Reviewer Notes

Do the tests cover the case well enough? 
I've also added tests for the "shipment missing information" alert. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make office_client_run
make server_run
```

1. Select the move with the locator `BILWEI`. 
2. It should already have a flag for shipment over weight. 
3. Click on the `Review weights` button. You will be taken to a new page .
4. Click on the `Review shipment weights` button.
5. There should be alert saying "Shipment exceeds 110% of estimated weight". 
6. Edit the shipment weight so that it is less than the estimated weight * 110%.
7. The alert should disappear.

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9607) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
