### PR TITLE
[MB-9608] Support deprecated payment requests

### DIFF
--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -35,7 +35,7 @@ func createHHGMove150Kb(db *pop.Connection, userUploader *uploader.UserUploader,
 	move := makeMoveForOrders(orders, db, "S150KB", models.MoveStatusSUBMITTED)
 	shipment := makeShipmentForMove(move, models.MTOShipmentStatusApproved, db)
 	paymentRequestID := uuid.Must(uuid.FromString("68034aa3-831c-4d2d-9fd4-b66bc0cc5130"))
-	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID, models.PaymentRequestStatusPending)
 }
 
 func createHHGMove2mb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
@@ -45,7 +45,7 @@ func createHHGMove2mb(db *pop.Connection, userUploader *uploader.UserUploader, p
 	move := makeMoveForOrders(orders, db, "MED2MB", models.MoveStatusSUBMITTED)
 	shipment := makeShipmentForMove(move, models.MTOShipmentStatusApproved, db)
 	paymentRequestID := uuid.Must(uuid.FromString("4de88d57-9723-446b-904c-cf8d0a834687"))
-	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID, models.PaymentRequestStatusPending)
 }
 
 func createHHGMove25mb(db *pop.Connection, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
@@ -55,7 +55,7 @@ func createHHGMove25mb(db *pop.Connection, userUploader *uploader.UserUploader, 
 	move := makeMoveForOrders(orders, db, "LG25MB", models.MoveStatusSUBMITTED)
 	shipment := makeShipmentForMove(move, models.MTOShipmentStatusApproved, db)
 	paymentRequestID := uuid.Must(uuid.FromString("aca5cc9c-c266-4a7d-895d-dc3c9c0d9894"))
-	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID)
+	makePaymentRequestForShipment(move, shipment, db, primeUploader, filterFile, paymentRequestID, models.PaymentRequestStatusPending)
 }
 
 func makeServiceMember(db *pop.Connection) models.ServiceMember {
@@ -233,13 +233,13 @@ func makeShipmentForMove(move models.Move, shipmentStatus models.MTOShipmentStat
 	return MTOShipment
 }
 
-func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment, db *pop.Connection, primeUploader *uploader.PrimeUploader, fileNames *[]string, paymentRequestID uuid.UUID) {
+func makePaymentRequestForShipment(move models.Move, shipment models.MTOShipment, db *pop.Connection, primeUploader *uploader.PrimeUploader, fileNames *[]string, paymentRequestID uuid.UUID, status models.PaymentRequestStatus) {
 	paymentRequest := testdatagen.MakePaymentRequest(db, testdatagen.Assertions{
 		PaymentRequest: models.PaymentRequest{
 			ID:            paymentRequestID,
 			MoveTaskOrder: move,
 			IsFinal:       false,
-			Status:        models.PaymentRequestStatusPending,
+			Status:        status,
 		},
 		Move: move,
 	})

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -205,6 +205,7 @@ func subScenarioReweighs(appCtx appcontext.AppContext, userUploader *uploader.Us
 		createReweighWithShipmentMissingReweigh(appCtx, userUploader, primeUploader, moveRouter)
 		createReweighWithShipmentMaxBillableWeightExceeded(appCtx, userUploader, primeUploader, moveRouter)
 		createReweighWithShipmentNoEstimatedWeight(appCtx, userUploader, primeUploader, moveRouter)
+		createReweighWithShipmentDeprecatedPaymentRequest(appCtx, userUploader, primeUploader, moveRouter)
 		createReweighWithMixedShipmentStatuses(appCtx, userUploader)
 	}
 }

--- a/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
+++ b/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
@@ -60,7 +60,7 @@ const ExpandableServiceItemRow = ({
         <td data-testid="serviceItemStatus">
           {paymentIsDeprecated && (
             <div>
-              <span>-</span>
+              <span data-testid="deprecated-marker">-</span>
             </div>
           )}
           {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.REQUESTED && !paymentIsDeprecated && (

--- a/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
+++ b/src/components/Office/ExpandableServiceItemRow/ExpandableServiceItemRow.jsx
@@ -12,7 +12,13 @@ import { MTOServiceItemShape } from 'types/order';
 import { formatCents, toDollarString } from 'shared/formatters';
 import ServiceItemCalculations from 'components/Office/ServiceItemCalculations/ServiceItemCalculations';
 
-const ExpandableServiceItemRow = ({ serviceItem, additionalServiceItemData, index, disableExpansion }) => {
+const ExpandableServiceItemRow = ({
+  additionalServiceItemData,
+  disableExpansion,
+  index,
+  paymentIsDeprecated,
+  serviceItem,
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const canClickToExpandContent = (canShowExpandableContent, item) => {
     return canShowExpandableContent && item.status !== PAYMENT_SERVICE_ITEM_STATUS.REQUESTED;
@@ -52,19 +58,24 @@ const ExpandableServiceItemRow = ({ serviceItem, additionalServiceItemData, inde
         </td>
         <td data-testid="serviceItemAmount">{toDollarString(formatCents(serviceItem.priceCents))}</td>
         <td data-testid="serviceItemStatus">
-          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.REQUESTED && (
+          {paymentIsDeprecated && (
+            <div>
+              <span>-</span>
+            </div>
+          )}
+          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.REQUESTED && !paymentIsDeprecated && (
             <div className={styles.needsReview}>
               <FontAwesomeIcon icon="exclamation-circle" />
               <span>Needs review</span>
             </div>
           )}
-          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.APPROVED && (
+          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.APPROVED && !paymentIsDeprecated && (
             <div className={styles.accepted}>
               <FontAwesomeIcon icon="check" />
               <span>Accepted</span>
             </div>
           )}
-          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.DENIED && (
+          {serviceItem.status === PAYMENT_SERVICE_ITEM_STATUS.DENIED && !paymentIsDeprecated && (
             <div className={styles.rejected}>
               <FontAwesomeIcon icon="times" />
               <span>Rejected</span>
@@ -93,6 +104,7 @@ ExpandableServiceItemRow.propTypes = {
   index: PropTypes.number.isRequired,
   disableExpansion: PropTypes.bool,
   additionalServiceItemData: MTOServiceItemShape,
+  paymentIsDeprecated: PropTypes.bool.isRequired,
 };
 
 ExpandableServiceItemRow.defaultProps = {

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import PropTypes, { arrayOf, shape } from 'prop-types';
+import { arrayOf, shape, bool, node, string } from 'prop-types';
 import classnames from 'classnames';
 import moment from 'moment';
 import { Button, Tag } from '@trussworks/react-uswds';
@@ -199,10 +199,10 @@ PaymentRequestCard.propTypes = {
   hasBillableWeightIssues: bool.isRequired,
   shipmentsInfo: arrayOf(
     shape({
-      mtoShipmentID: PropTypes.string,
-      shipmentAddress: PropTypes.node,
-      departureDate: PropTypes.string,
-      shipmentModificationType: PropTypes.string,
+      mtoShipmentID: string,
+      shipmentAddress: node,
+      departureDate: string,
+      shipmentModificationType: string,
     }),
   ),
 };

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -1,5 +1,5 @@
-import React, { useState, Fragment } from 'react';
-import PropTypes, { arrayOf, shape, bool } from 'prop-types';
+import React, { useState } from 'react';
+import PropTypes, { arrayOf, shape } from 'prop-types';
 import classnames from 'classnames';
 import moment from 'moment';
 import { Button, Tag } from '@trussworks/react-uswds';
@@ -10,6 +10,7 @@ import styles from './PaymentRequestCard.module.scss';
 
 import { HistoryShape } from 'types/router';
 import { PaymentRequestShape } from 'types';
+import { PAYMENT_REQUEST_STATUS } from 'shared/constants';
 import { formatDateFromIso, formatCents, toDollarString } from 'shared/formatters';
 import PaymentRequestDetails from 'components/Office/PaymentRequestDetails/PaymentRequestDetails';
 import { groupByShipment } from 'utils/serviceItems';
@@ -70,7 +71,13 @@ const PaymentRequestCard = ({ paymentRequest, shipmentsInfo, history, hasBillabl
   const showDetailsChevron = showDetails ? 'chevron-up' : 'chevron-down';
   const showDetailsText = showDetails ? 'Hide request details' : 'Show request details';
   const handleToggleDetails = () => setShowDetails((prevState) => !prevState);
-
+  const ViewDocuments =
+    paymentRequest.status !== PAYMENT_REQUEST_STATUS.DEPRECATED ? (
+      <a href={`payment-requests/${paymentRequest.id}`}>
+        <FontAwesomeIcon icon="copy" />
+        View documents
+      </a>
+    ) : null;
   return (
     <div className={classnames(styles.PaymentRequestCard, 'container')}>
       <div className={styles.summary}>
@@ -143,14 +150,7 @@ const PaymentRequestCard = ({ paymentRequest, shipmentsInfo, history, hasBillabl
             <dt>SAC/SDN:</dt>
             <dd>{sac}</dd>
           </dl>
-          {paymentRequest.status === 'PENDING' ? (
-            <a href="orders">View orders</a>
-          ) : (
-            <a href={`payment-requests/${paymentRequest.id}`}>
-              <FontAwesomeIcon icon="copy" />
-              View documents
-            </a>
-          )}
+          {paymentRequest.status === 'PENDING' ? <a href="orders">View orders</a> : ViewDocuments}
           <div className={styles.toggleDrawer}>
             {showRequestDetailsButton && (
               <Button

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import PaymentRequestCard from './PaymentRequestCard';
 
@@ -195,6 +195,46 @@ describe('PaymentRequestCard', () => {
       );
       const reviewButton = screen.getByRole('button', { name: 'Review service items' });
       expect(reviewButton).not.toHaveAttribute('disabled', '');
+    });
+  });
+
+  describe('deprecated payment requests', () => {
+    const deprecatedPaymentRequest = {
+      id: '29474c6a-69b6-4501-8e08-670a12512e5f',
+      createdAt: '2020-12-01T00:00:00.000Z',
+      moveTaskOrderID: 'f8c2f97f-99e7-4fb1-9cc4-473debd04dbc',
+      paymentRequestNumber: '1843-9061-2',
+      moveTaskOrder: move,
+      status: 'DEPRECATED',
+      serviceItems: [
+        {
+          id: '09474c6a-69b6-4501-8e08-670a12512a5f',
+          createdAt: '2020-12-01T00:00:00.000Z',
+          mtoServiceItemID: 'f8c2f97f-99e7-4fb1-9cc4-473debd24dbc',
+          priceCents: 2000001,
+          status: 'REQUESTED',
+        },
+      ],
+    };
+
+    it('does not have a view documents link', () => {
+      render(
+        <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+          <PaymentRequestCard paymentRequest={deprecatedPaymentRequest} shipmentInfo={shipmentInfo} />
+        </MockProviders>,
+      );
+      expect(screen.queryByText('View documents')).not.toBeInTheDocument();
+    });
+
+    it('does not have service item status', () => {
+      render(
+        <MockProviders initialEntries={[`/moves/${testMoveLocator}/payment-requests`]}>
+          <PaymentRequestCard paymentRequest={deprecatedPaymentRequest} shipmentInfo={shipmentInfo} />
+        </MockProviders>,
+      );
+      fireEvent.click(screen.getByTestId('showRequestDetailsButton'));
+      expect(screen.queryByText('Needs review')).not.toBeInTheDocument();
+      expect(screen.getByTestId('deprecated-marker')).toBeInTheDocument();
     });
   });
 

--- a/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
+++ b/src/components/Office/PaymentRequestDetails/PaymentRequestDetails.jsx
@@ -6,7 +6,7 @@ import ShipmentModificationTag from '../../ShipmentModificationTag/ShipmentModif
 
 import styles from './PaymentRequestDetails.module.scss';
 
-import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { PAYMENT_REQUEST_STATUS, SHIPMENT_OPTIONS } from 'shared/constants';
 import { PaymentServiceItemShape } from 'types';
 import { MTOServiceItemShape } from 'types/order';
 import { formatDateFromIso } from 'shared/formatters';
@@ -88,6 +88,7 @@ const PaymentRequestDetails = ({ serviceItems, shipment, paymentRequestStatus })
                   key={item.id}
                   index={index}
                   disableExpansion={paymentRequestStatus === PAYMENT_REQUEST_STATUSES.PENDING}
+                  paymentIsDeprecated={paymentRequestStatus === PAYMENT_REQUEST_STATUS.DEPRECATED}
                 />
               );
             })}


### PR DESCRIPTION
## Description

Hide certain elements of payment request view when a payment request is ddeprecated

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
Log in as TIO
View payment request with locator `DEPPRQ`
Payment request panel should be folded
Unfold payment request panel
It should have `-` for service item status

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9608) for this change

## Screenshots

![Uploading Screen Shot 2021-10-04 at 11.49.21 PM.png…]()


