### PR TITLE
[MB-9536] fix styling issues on editbillableweights

### DIFF
--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.module.scss
@@ -19,7 +19,7 @@
   font-weight: bold;
 }
 
-.remarksHeader {
+h5.remarksHeader {
   margin: 0;
   @include u-margin-top(2);
 }

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.module.scss
@@ -76,6 +76,7 @@ div.container {
     display: flex;
     flex-direction: column;
     @include u-padding-left(2);
+    @include u-padding-right(2);
     @include u-margin-top(2);
 
     h3 {


### PR DESCRIPTION
## Description

This PR makes the following styling fixes:
- On edit billable weight, increases padding on right of the remarks text area
- The saved Remarks on both the max billable and billable weight sidebar has a top margin added

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run client_run
```
- sign in as TIO
- Click "Review Weights"
- Click Edit max billable weight and add remarks. Save
- The saved remarks should have a top margin
- Click Review Shipments
- On the shipment weight sidebar, open edit the billable weight view
- The Remarks textarea should have right padding added
- Save
- The remarks should have top margin added

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9536) for this change

## Screenshots

<img width="403" alt="Screen Shot 2021-10-05 at 12 50 41 PM" src="https://user-images.githubusercontent.com/67110378/136068426-c62b5ead-f0cf-4a91-bc5c-0bd3081f720d.png">
<img width="402" alt="Screen Shot 2021-10-05 at 12 26 10 PM" src="https://user-images.githubusercontent.com/67110378/136068418-2587cfc6-b72c-4647-a6cf-e36d60aa60bf.png">
<img width="409" alt="Screen Shot 2021-10-05 at 12 48 28 PM" src="https://user-images.githubusercontent.com/67110378/136068421-39acd455-7a83-4b56-bdb5-7819bf182a4e.png">


