### PR TITLE
MB-9785: (DRAFT) NTS shipment database updates

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -678,3 +678,4 @@
 20211001153100_update_sit_param_keys_origin.up.sql
 20211004150738_loadtest_env.up.sql
 20211012105126_exp_dp3_cert_migration.up.sql
+20211025165833_add_nts_shipment_columns.up.sql

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -20,7 +20,7 @@ ALTER TABLE orders
 ALTER TABLE mto_shipments
 	ADD COLUMN external_vendor boolean DEFAULT false,
 	ADD COLUMN storage_facility_id uuid
-		CONSTRAINT mto_shipments_storage_facility_id REFERENCES storage_facilities,
+		CONSTRAINT mto_shipments_storage_facility_id_fkey REFERENCES storage_facilities,
 	ADD COLUMN service_order_number varchar(255);
 
 CREATE INDEX ON mto_shipments (storage_facility_id);

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -21,7 +21,7 @@ ALTER TABLE mto_shipments
 	ADD COLUMN external_vendor boolean DEFAULT false,
 	ADD COLUMN storage_facility_id uuid
 		CONSTRAINT mto_shipments_storage_facility_id REFERENCES storage_facilities,
-	ADD COLUMN service_order_number varchar;
+	ADD COLUMN service_order_number varchar(255);
 
 CREATE INDEX ON mto_shipments (storage_facility_id);
 

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -19,7 +19,7 @@ ALTER TABLE orders
 	ADD COLUMN nts_sac varchar(255);
 
 ALTER TABLE mto_shipments
-	ADD COLUMN external_vendor boolean DEFAULT false NOT NULL,
+	ADD COLUMN uses_external_vendor boolean DEFAULT false NOT NULL,
 	ADD COLUMN storage_facility_id uuid
 		CONSTRAINT mto_shipments_storage_facility_id_fkey REFERENCES storage_facilities,
 	ADD COLUMN service_order_number varchar(255);
@@ -40,6 +40,6 @@ COMMENT ON COLUMN orders.sac IS '(For HHG shipments) Shipment Account Classifica
 COMMENT ON COLUMN orders.nts_tac IS '(For NTS shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.';
 COMMENT ON COLUMN orders.nts_sac IS '(For NTS shipments) Shipment Account Classification - used for accounting';
 
-COMMENT ON COLUMN mto_shipments.external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime';
+COMMENT ON COLUMN mto_shipments.uses_external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime';
 COMMENT ON COLUMN mto_shipments.storage_facility_id IS 'The storage facility for an NTS shipment where items are stored';
 COMMENT ON COLUMN mto_shipments.service_order_number IS 'The order number for a shipment in TOPS';

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -1,21 +1,44 @@
 CREATE TABLE storage_facilities (
-	id uuid PRIMARY KEY NOT NULL,
-	name varchar,
-	address_id uuid REFERENCES addresses,
-	lot_number varchar,
-	phone varchar,
-	email varchar
+	id uuid
+		CONSTRAINT storage_facilities_pkey PRIMARY KEY,
+	created_at timestamp not null,
+    updated_at timestamp not null,
+	facility_name varchar,
+	address_id uuid
+		CONSTRAINT storage_facilities_address_id_fkey REFERENCES addresses,
+	lot_number varchar(255),
+	phone varchar(255),
+	email varchar(255)
 );
 
 CREATE INDEX ON storage_facilities (address_id);
 
 ALTER TABLE orders
-	ADD COLUMN nts_tac varchar,
-	ADD COLUMN nts_sac varchar;
+	ADD COLUMN nts_tac varchar(255),
+	ADD COLUMN nts_sac varchar(255);
 
 ALTER TABLE mto_shipments
-	ADD COLUMN external_vendor boolean,
-	ADD COLUMN storage_facility_id uuid REFERENCES storage_facilities,
+	ADD COLUMN external_vendor boolean DEFAULT false,
+	ADD COLUMN storage_facility_id uuid
+		CONSTRAINT mto_shipments_storage_facility_id REFERENCES storage_facilities,
 	ADD COLUMN service_order_number varchar;
 
 CREATE INDEX ON mto_shipments (storage_facility_id);
+
+COMMENT ON TABLE storage_facilities IS 'Storage facilities for NTS and NTS-Release shipments';
+COMMENT ON COLUMN storage_facilities.created_at IS 'Date & time the storage facility was created';
+COMMENT ON COLUMN storage_facilities.updated_at IS 'Date & time the storage facility was updated';
+COMMENT ON COLUMN storage_facilities.facility_name IS 'Name of storage facility';
+COMMENT ON COLUMN storage_facilities.address_id IS 'The address of the storage facility';
+COMMENT ON COLUMN storage_facilities.lot_number IS 'Lot number where goods are stored within the storage facility';
+COMMENT ON COLUMN storage_facilities.phone IS 'Phone number for contacting storage facility';
+COMMENT ON COLUMN storage_facilities.email IS 'Email address for contacting storage facility';
+
+COMMENT ON COLUMN orders.tac IS '(For HHG shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.'
+COMMENT ON COLUMN orders.sac IS '(For HHG shipments) Shipment Account Classification - used for accounting';
+COMMENT ON COLUMN orders.nts_tac IS '(For NTS shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.'
+COMMENT ON COLUMN orders.nts_sac IS '(For NTS shipments) Shipment Account Classification - used for accounting';
+
+COMMENT ON COLUMN mto_shipments.external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime'
+COMMENT ON COLUMN mto_shipments.storage_facility_id IS 'The storage facility for an NTS shipment where items are stored'
+COMMENT ON COLUMN mto_shipments.service_order_number IS 'The order number for a shipment in TOPS'

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE storage_facilities (
+	id uuid PRIMARY KEY NOT NULL,
+	name varchar,
+	address_id uuid REFERENCES addresses,
+	lot_number varchar,
+	phone varchar,
+	email varchar
+);
+
+CREATE INDEX ON storage_facilities (address_id);
+
+ALTER TABLE orders
+	ADD COLUMN nts_tac varchar,
+	ADD COLUMN nts_sac varchar;
+
+ALTER TABLE mto_shipments
+	ADD COLUMN external_vendor boolean,
+	ADD COLUMN storage_facility_id uuid REFERENCES storage_facilities,
+	ADD COLUMN service_order_number varchar;
+
+CREATE INDEX ON mto_shipments (storage_facility_id);

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -1,14 +1,15 @@
 CREATE TABLE storage_facilities (
 	id uuid
 		CONSTRAINT storage_facilities_pkey PRIMARY KEY,
-	created_at timestamp not null,
-    updated_at timestamp not null,
-	facility_name varchar,
+	facility_name varchar(255),
 	address_id uuid
 		CONSTRAINT storage_facilities_address_id_fkey REFERENCES addresses,
 	lot_number varchar(255),
 	phone varchar(255),
-	email varchar(255)
+	email varchar(255),
+	created_at timestamp not null,
+	updated_at timestamp not null
+
 );
 
 CREATE INDEX ON storage_facilities (address_id);
@@ -18,7 +19,7 @@ ALTER TABLE orders
 	ADD COLUMN nts_sac varchar(255);
 
 ALTER TABLE mto_shipments
-	ADD COLUMN external_vendor boolean DEFAULT false,
+	ADD COLUMN external_vendor boolean DEFAULT false NOT NULL,
 	ADD COLUMN storage_facility_id uuid
 		CONSTRAINT mto_shipments_storage_facility_id_fkey REFERENCES storage_facilities,
 	ADD COLUMN service_order_number varchar(255);

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -1,14 +1,14 @@
 CREATE TABLE storage_facilities (
 	id uuid
 		CONSTRAINT storage_facilities_pkey PRIMARY KEY,
-	facility_name varchar(255),
-	address_id uuid
+	facility_name varchar(255) NOT NULL,
+	address_id uuid NOT NULL
 		CONSTRAINT storage_facilities_address_id_fkey REFERENCES addresses,
 	lot_number varchar(255),
 	phone varchar(255),
 	email varchar(255),
-	created_at timestamp not null,
-	updated_at timestamp not null
+	created_at timestamp NOT NULL,
+	updated_at timestamp NOT NULL
 
 );
 

--- a/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211025165833_add_nts_shipment_columns.up.sql
@@ -34,11 +34,11 @@ COMMENT ON COLUMN storage_facilities.lot_number IS 'Lot number where goods are s
 COMMENT ON COLUMN storage_facilities.phone IS 'Phone number for contacting storage facility';
 COMMENT ON COLUMN storage_facilities.email IS 'Email address for contacting storage facility';
 
-COMMENT ON COLUMN orders.tac IS '(For HHG shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.'
+COMMENT ON COLUMN orders.tac IS '(For HHG shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.';
 COMMENT ON COLUMN orders.sac IS '(For HHG shipments) Shipment Account Classification - used for accounting';
-COMMENT ON COLUMN orders.nts_tac IS '(For NTS shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.'
+COMMENT ON COLUMN orders.nts_tac IS '(For NTS shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.';
 COMMENT ON COLUMN orders.nts_sac IS '(For NTS shipments) Shipment Account Classification - used for accounting';
 
-COMMENT ON COLUMN mto_shipments.external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime'
-COMMENT ON COLUMN mto_shipments.storage_facility_id IS 'The storage facility for an NTS shipment where items are stored'
-COMMENT ON COLUMN mto_shipments.service_order_number IS 'The order number for a shipment in TOPS'
+COMMENT ON COLUMN mto_shipments.external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime';
+COMMENT ON COLUMN mto_shipments.storage_facility_id IS 'The storage facility for an NTS shipment where items are stored';
+COMMENT ON COLUMN mto_shipments.service_order_number IS 'The order number for a shipment in TOPS';

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -111,6 +111,10 @@ type MTOShipment struct {
 	RejectionReason                  *string           `db:"rejection_reason"`
 	Distance                         *unit.Miles       `db:"distance"`
 	Reweigh                          *Reweigh          `has_one:"reweighs" fk_id:"shipment_id"`
+	ExternalVendor                   bool              `db:"external_vendor"`
+	StorageFacility                  *StorageFacility  `belongs_to:"storage_facilities" fk_id:"storage_facility_id"`
+	StorageFacilityID                *uuid.UUID        `db:"storage_facility_id"`
+	ServiceOrderNumber               *string           `db:"service_order_number"`
 	CreatedAt                        time.Time         `db:"created_at"`
 	UpdatedAt                        time.Time         `db:"updated_at"`
 	DeletedAt                        *time.Time        `db:"deleted_at"`

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -111,7 +111,7 @@ type MTOShipment struct {
 	RejectionReason                  *string           `db:"rejection_reason"`
 	Distance                         *unit.Miles       `db:"distance"`
 	Reweigh                          *Reweigh          `has_one:"reweighs" fk_id:"shipment_id"`
-	ExternalVendor                   bool              `db:"external_vendor"`
+	UsesExternalVendor               bool              `db:"uses_external_vendor"`
 	StorageFacility                  *StorageFacility  `belongs_to:"storage_facilities" fk_id:"storage_facility_id"`
 	StorageFacilityID                *uuid.UUID        `db:"storage_facility_id"`
 	ServiceOrderNumber               *string           `db:"service_order_number"`
@@ -154,6 +154,8 @@ func (m *MTOShipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	if m.SITDaysAllowance != nil {
 		vs = append(vs, &validators.IntIsGreaterThan{Field: *m.SITDaysAllowance, Compared: -1, Name: "SITDaysAllowance"})
 	}
+	vs = append(vs, &OptionalUUIDIsPresent{Field: m.StorageFacilityID, Name: "StorageFacilityID"})
+	vs = append(vs, &StringIsNilOrNotBlank{Field: m.ServiceOrderNumber, Name: "ServiceOrderNumber"})
 	return validate.Validate(vs...), nil
 }
 

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -63,6 +63,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			BillableWeightJustification: &billableWeightJustification,
 			SITDaysAllowance:            &sitDaysAllowance,
 			ServiceOrderNumber:          &serviceOrderNumber,
+			StorageFacilityID:           &uuid.Nil,
 		}
 		expErrors := map[string][]string{
 			"prime_estimated_weight":        {"-1000 is not greater than -1."},
@@ -72,6 +73,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			"billable_weight_justification": {"BillableWeightJustification can not be blank."},
 			"sitdays_allowance":             {"-1 is not greater than -1."},
 			"service_order_number":          {"ServiceOrderNumber can not be blank."},
+			"storage_facility_id":           {"StorageFacilityID can not be blank."},
 		}
 		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
 	})

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -53,6 +53,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		billableWeightCap := unit.Pound(-1)
 		billableWeightJustification := ""
 		sitDaysAllowance := -1
+		serviceOrderNumber := ""
 		invalidMTOShipment := models.MTOShipment{
 			MoveTaskOrderID:             uuid.Must(uuid.NewV4()),
 			Status:                      models.MTOShipmentStatusRejected,
@@ -61,6 +62,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			BillableWeightCap:           &billableWeightCap,
 			BillableWeightJustification: &billableWeightJustification,
 			SITDaysAllowance:            &sitDaysAllowance,
+			ServiceOrderNumber:          &serviceOrderNumber,
 		}
 		expErrors := map[string][]string{
 			"prime_estimated_weight":        {"-1000 is not greater than -1."},
@@ -69,6 +71,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			"billable_weight_cap":           {"-1 is less than zero."},
 			"billable_weight_justification": {"BillableWeightJustification can not be blank."},
 			"sitdays_allowance":             {"-1 is not greater than -1."},
+			"service_order_number":          {"ServiceOrderNumber can not be blank."},
 		}
 		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
 	})

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -79,6 +79,8 @@ func (o *Order) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.StringIsPresent{Field: string(o.Status), Name: "Status"},
 		&StringIsNilOrNotBlank{Field: o.TAC, Name: "TransportationAccountingCode"},
 		&StringIsNilOrNotBlank{Field: o.SAC, Name: "SAC"},
+		&StringIsNilOrNotBlank{Field: o.NtsTAC, Name: "NtsTAC"},
+		&StringIsNilOrNotBlank{Field: o.NtsSAC, Name: "NtsSAC"},
 		&StringIsNilOrNotBlank{Field: o.DepartmentIndicator, Name: "DepartmentIndicator"},
 		&CannotBeTrueIfFalse{Field1: o.SpouseHasProGear, Name1: "SpouseHasProGear", Field2: o.HasDependents, Name2: "HasDependents"},
 		&OptionalUUIDIsPresent{Field: o.EntitlementID, Name: "EntitlementID"},

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -54,6 +54,8 @@ type Order struct {
 	Status                      OrderStatus                        `json:"status" db:"status"`
 	TAC                         *string                            `json:"tac" db:"tac"`
 	SAC                         *string                            `json:"sac" db:"sac"`
+	NtsTAC                      *string                            `json:"nts_tac" db:"nts_tac"`
+	NtsSAC                      *string                            `json:"nts_sac" db:"nts_sac"`
 	DepartmentIndicator         *string                            `json:"department_indicator" db:"department_indicator"`
 	Grade                       *string                            `json:"grade" db:"grade"`
 	Entitlement                 *Entitlement                       `belongs_to:"entitlements" fk_id:"entitlement_id"`

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -14,24 +14,26 @@ import (
 )
 
 func (suite *ModelSuite) TestBasicOrderInstantiation() {
-	ntsTac := ""
-	ntsSac := ""
 
 	order := &Order{
-		NtsTAC: &ntsTac,
-		NtsSAC: &ntsSac,
+		TAC:    swag.String(""),
+		SAC:    swag.String(""),
+		NtsTAC: swag.String(""),
+		NtsSAC: swag.String(""),
 	}
 
 	expErrors := map[string][]string{
-		"orders_type":         {"OrdersType can not be blank."},
-		"issue_date":          {"IssueDate can not be blank."},
-		"report_by_date":      {"ReportByDate can not be blank."},
-		"service_member_id":   {"ServiceMemberID can not be blank."},
-		"new_duty_station_id": {"NewDutyStationID can not be blank."},
-		"status":              {"Status can not be blank."},
-		"uploaded_orders_id":  {"UploadedOrdersID can not be blank."},
-		"nts_tac":             {"NtsTAC can not be blank."},
-		"nts_sac":             {"NtsSAC can not be blank."},
+		"orders_type":                    {"OrdersType can not be blank."},
+		"issue_date":                     {"IssueDate can not be blank."},
+		"report_by_date":                 {"ReportByDate can not be blank."},
+		"service_member_id":              {"ServiceMemberID can not be blank."},
+		"new_duty_station_id":            {"NewDutyStationID can not be blank."},
+		"status":                         {"Status can not be blank."},
+		"uploaded_orders_id":             {"UploadedOrdersID can not be blank."},
+		"transportation_accounting_code": {"TAC must be exactly 4 alphanumeric characters.", "TransportationAccountingCode can not be blank."},
+		"sac":                            {"SAC can not be blank."},
+		"nts_tac":                        {"NtsTAC can not be blank."},
+		"nts_sac":                        {"NtsSAC can not be blank."},
 	}
 
 	suite.verifyValidationErrors(order, expErrors)

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -14,7 +14,13 @@ import (
 )
 
 func (suite *ModelSuite) TestBasicOrderInstantiation() {
-	order := &Order{}
+	ntsTac := ""
+	ntsSac := ""
+
+	order := &Order{
+		NtsTAC: &ntsTac,
+		NtsSAC: &ntsSac,
+	}
 
 	expErrors := map[string][]string{
 		"orders_type":         {"OrdersType can not be blank."},
@@ -24,6 +30,8 @@ func (suite *ModelSuite) TestBasicOrderInstantiation() {
 		"new_duty_station_id": {"NewDutyStationID can not be blank."},
 		"status":              {"Status can not be blank."},
 		"uploaded_orders_id":  {"UploadedOrdersID can not be blank."},
+		"nts_tac":             {"NtsTAC can not be blank."},
+		"nts_sac":             {"NtsSAC can not be blank."},
 	}
 
 	suite.verifyValidationErrors(order, expErrors)

--- a/pkg/models/storage_facility.go
+++ b/pkg/models/storage_facility.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
+)
+
+type StorageFacility struct {
+	ID           uuid.UUID  `json:"id" db:"id"`
+	FacilityName *string    `json:"facility_name" db:"facility_name"`
+	Address      *Address   `belongs_to:"addresses" fk_id:"address_id"`
+	AddressID    *uuid.UUID `json:"address_id" db:"address_id"`
+	LotNumber    *string    `json:"lot_number" db:"lot_number"`
+	Phone        *string    `json:"phone" db:"phone"`
+	Email        *string    `json:"email" db:"email"`
+	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
+}
+
+type StorageFacilities []StorageFacility
+
+func (r *StorageFacility) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(), nil
+}

--- a/pkg/models/storage_facility.go
+++ b/pkg/models/storage_facility.go
@@ -22,6 +22,12 @@ type StorageFacility struct {
 
 type StorageFacilities []StorageFacility
 
-func (r *StorageFacility) Validate(tx *pop.Connection) (*validate.Errors, error) {
-	return validate.Validate(), nil
+func (f *StorageFacility) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&OptionalUUIDIsPresent{Field: f.AddressID, Name: "AddressID"},
+		&StringIsNilOrNotBlank{Field: f.FacilityName, Name: "FacilityName"},
+		&StringIsNilOrNotBlank{Field: f.LotNumber, Name: "LotNumber"},
+		&StringIsNilOrNotBlank{Field: f.Phone, Name: "Phone"},
+		&StringIsNilOrNotBlank{Field: f.Email, Name: "Email"},
+	), nil
 }

--- a/pkg/models/storage_facility.go
+++ b/pkg/models/storage_facility.go
@@ -5,27 +5,28 @@ import (
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
 )
 
 type StorageFacility struct {
-	ID           uuid.UUID  `json:"id" db:"id"`
-	FacilityName *string    `json:"facility_name" db:"facility_name"`
-	Address      *Address   `belongs_to:"addresses" fk_id:"address_id"`
-	AddressID    *uuid.UUID `json:"address_id" db:"address_id"`
-	LotNumber    *string    `json:"lot_number" db:"lot_number"`
-	Phone        *string    `json:"phone" db:"phone"`
-	Email        *string    `json:"email" db:"email"`
-	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
+	ID           uuid.UUID `json:"id" db:"id"`
+	FacilityName string    `json:"facility_name" db:"facility_name"`
+	Address      Address   `belongs_to:"addresses" fk_id:"address_id"`
+	AddressID    uuid.UUID `json:"address_id" db:"address_id"`
+	LotNumber    *string   `json:"lot_number" db:"lot_number"`
+	Phone        *string   `json:"phone" db:"phone"`
+	Email        *string   `json:"email" db:"email"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
 }
 
 type StorageFacilities []StorageFacility
 
 func (f *StorageFacility) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&OptionalUUIDIsPresent{Field: f.AddressID, Name: "AddressID"},
-		&StringIsNilOrNotBlank{Field: f.FacilityName, Name: "FacilityName"},
+		&validators.UUIDIsPresent{Field: f.AddressID, Name: "AddressID"},
+		&validators.StringIsPresent{Field: f.FacilityName, Name: "FacilityName"},
 		&StringIsNilOrNotBlank{Field: f.LotNumber, Name: "LotNumber"},
 		&StringIsNilOrNotBlank{Field: f.Phone, Name: "Phone"},
 		&StringIsNilOrNotBlank{Field: f.Email, Name: "Email"},

--- a/pkg/models/storage_facility_test.go
+++ b/pkg/models/storage_facility_test.go
@@ -1,0 +1,35 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestStorageFacilityValidation() {
+	suite.T().Run("test valid StorageFacility", func(t *testing.T) {
+		validMTOShipment := models.StorageFacility{}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validMTOShipment, expErrors)
+	})
+
+	suite.T().Run("test invalid StorageFacility", func(t *testing.T) {
+		facilityName := ""
+		lotNumber := ""
+		phone := ""
+		email := ""
+		invalidMTOShipment := models.StorageFacility{
+			FacilityName: &facilityName,
+			LotNumber:    &lotNumber,
+			Phone:        &phone,
+			Email:        &email,
+		}
+		expErrors := map[string][]string{
+			"facility_name": {"FacilityName can not be blank."},
+			"lot_number":    {"LotNumber can not be blank."},
+			"phone":         {"Phone can not be blank."},
+			"email":         {"Email can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
+	})
+}

--- a/pkg/models/storage_facility_test.go
+++ b/pkg/models/storage_facility_test.go
@@ -3,28 +3,32 @@ package models_test
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestStorageFacilityValidation() {
 	suite.T().Run("test valid StorageFacility", func(t *testing.T) {
-		validMTOShipment := models.StorageFacility{}
+		validMTOShipment := models.StorageFacility{
+			FacilityName: "Test Storage Facility",
+			AddressID:    uuid.Must(uuid.NewV4()),
+		}
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validMTOShipment, expErrors)
 	})
 
 	suite.T().Run("test invalid StorageFacility", func(t *testing.T) {
-		facilityName := ""
 		lotNumber := ""
 		phone := ""
 		email := ""
 		invalidMTOShipment := models.StorageFacility{
-			FacilityName: &facilityName,
-			LotNumber:    &lotNumber,
-			Phone:        &phone,
-			Email:        &email,
+			LotNumber: &lotNumber,
+			Phone:     &phone,
+			Email:     &email,
 		}
 		expErrors := map[string][]string{
+			"address_id":    {"AddressID can not be blank."},
 			"facility_name": {"FacilityName can not be blank."},
 			"lot_number":    {"LotNumber can not be blank."},
 			"phone":         {"Phone can not be blank."},


### PR DESCRIPTION
## Description

Draft pull request for NTS shipment database updates ahead of PO8. Doesn't include any handler updates yet, just a PR to assist with discussion around database strategies.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
