### PR TITLE
MB-7545 Add config to pre-commit to turn on BE ato-linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,10 +60,10 @@ repos:
     hooks:
       - id: ato-linter-be
         name: ato-linter-be
-        entry: scripts/pre-commit-go-custom-linter ato-linter
+        entry: go run ./cmd/ato-linter/main.go -- ./...
         files: \.go$
         pass_filenames: false
-        language: script
+        language: golang
         exclude: >
           (?x)^(
             testdata

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,10 +60,10 @@ repos:
     hooks:
       - id: ato-linter-be
         name: ato-linter-be
-        entry: go run ./cmd/ato-linter/main.go -- ./...
+        entry: scripts/pre-commit-go-custom-linter ato-linter
         files: \.go$
         pass_filenames: false
-        language: golang
+        language: script
         exclude: >
           (?x)^(
             testdata

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
         name: ato-linter-be
         entry: scripts/pre-commit-go-custom-linter ato-linter
         files: \.go$
+        pass_filenames: false
         language: script
         exclude: >
           (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     hooks:
       - id: ato-linter-be
         name: ato-linter-be
-        entry: ato-linter
+        entry: go run ./cmd/ato-linter
         files: \.go$
         language: golang
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,9 +60,9 @@ repos:
     hooks:
       - id: ato-linter-be
         name: ato-linter-be
-        entry: go run ./cmd/ato-linter
+        entry: scripts/pre-commit-go-custom-linter ato-linter
         files: \.go$
-        language: golang
+        language: script
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.29.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
       - id: golangci-lint
         entry: bash -c 'exec golangci-lint run ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
+  - repo: local
+    hooks:
+      - id: ato-linter-be
+        name: ato-linter-be
+        entry: ato-linter
+        files: \.go$
+        language: golang
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.29.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,6 @@ repos:
         files: \.go$
         pass_filenames: false
         language: script
-        exclude: >
-          (?x)^(
-            testdata
-          )
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.29.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,10 @@ repos:
         entry: scripts/pre-commit-go-custom-linter ato-linter
         files: \.go$
         language: script
+        exclude: >
+          (?x)^(
+            testdata
+          )
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.29.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,16 +79,17 @@ DISABLE_AWS_VAULT_WRAPPER=1 aws-vault exec transcom-gov-milmove-exp -- scripts/d
 These scripts are used primarily to check our code before
 committing.
 
-| Script Name                   | Description                                                |
-| ----------------------------- | ---------------------------------------------------------- |
-| `commit-msg`                  | Ensure JIRA issue is tagged to commit message              |
-| `gen-docs-index`              | generate index for documents                               |
-| `pre-commit-go-imports`       | modify imports in go files                                 |
-| `pre-commit-go-lint`          | modify go files with linting rules                         |
-| `pre-commit-go-mod`           | modify `go.mod` and `go.sum` to match whats in the project |
-| `pre-commit-go-vet`           | analyze code with `go vet`                                 |
-| `pre-commit-swagger-validate` | run environment-specific `swagger validate`                |
-| `lint-yaml-with-spectral`     | run `spectral` linter on external APIs                     |
+| Script Name                   | Description                                                       |
+| ----------------------------- | ------------------------------------------------------------------|
+| `commit-msg`                  | Ensure JIRA issue is tagged to commit message                     |
+| `gen-docs-index`              | generate index for documents                                      |
+| `pre-commit-go-custom-linter` | run a custom linter against files (passed go files by pre-commit) |
+| `pre-commit-go-imports`       | modify imports in go files                                        |
+| `pre-commit-go-lint`          | modify go files with linting rules                                |
+| `pre-commit-go-mod`           | modify `go.mod` and `go.sum` to match whats in the project        |
+| `pre-commit-go-vet`           | analyze code with `go vet`                                        |
+| `pre-commit-swagger-validate` | run environment-specific `swagger validate`                       |
+| `lint-yaml-with-spectral`     | run `spectral` linter on external APIs                            |
 
 ## CircleCI Scripts
 

--- a/scripts/pre-commit-go-custom-linter
+++ b/scripts/pre-commit-go-custom-linter
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+#
+# Pre-commit hook to run `swagger validate` that is different based on environment
+#
+
+set -eu -o pipefail
+
+hook="$1"; shift
+
+go run ./cmd/"$hook"/main.go -- "$@"

--- a/scripts/pre-commit-go-custom-linter
+++ b/scripts/pre-commit-go-custom-linter
@@ -1,12 +1,11 @@
 #! /usr/bin/env bash
 
 #
-# Pre-commit hook to run a go custom hook against all go files (except the ones in the testdata directory (excluded by
-# pre-commit config).
+# Pre-commit hook to run a go custom hook against all go files
 #
 
 set -eu -o pipefail
 
-hook="$1"; shift
+linter="$1";
 
-go run ./cmd/"$hook"/main.go -- ./...
+go run ./cmd/"$linter"/main.go -- ./...

--- a/scripts/pre-commit-go-custom-linter
+++ b/scripts/pre-commit-go-custom-linter
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
 
 #
-# Pre-commit hook to run `swagger validate` that is different based on environment
+# Pre-commit hook to run a go custom hook against all go files (except the ones in the testdata directory (excluded by
+# pre-commit config).
 #
 
 set -eu -o pipefail
 
 hook="$1"; shift
 
-go run ./cmd/"$hook"/main.go -- "$@"
+go run ./cmd/"$hook"/main.go -- ./...


### PR DESCRIPTION
## Description

We turned on the linter in our CI pipeline in #6517, but didn't turn it on to run locally with `pre-commit` so this is enabling that.

WIP: Works locally on small sets of files, but doesn't work when files span packages. Working on figuring out how to get that to work.

## Reviewer Notes

Is there any reason not to run this with `pre-commit`?

## Setup

1. Install the linter: 

    ```shell
    go install ./cmd/ato-linter
    ```

1. Run the pre-commit checks against any file. In the example below, we'll point pre-commit to a file that should actually raise errors from the `ato-linter`:

    ```shell
    pre-commit run --files testdata/src/linter_tests/errcheck.go
    ```
Output should look something like this:
![image](https://user-images.githubusercontent.com/35938642/139156178-1d32ef89-280b-4f5c-8c44-7c014d5827a6.png)

## Code Review Verification Steps

* [ ] Request review from a member of a different team (going to post in #prac-engineering)
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-7545) for this change