### PR TITLE
[MB-9830] Prime simulator validate addtional day SIT payment request start end date params

### DIFF
--- a/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.jsx
+++ b/src/components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm.jsx
@@ -6,30 +6,32 @@ import classnames from 'classnames';
 
 import { Form } from '../../form/Form';
 import formStyles from '../../../styles/form.module.scss';
-import { ErrorMessage } from '../../form/ErrorMessage';
 import SectionWrapper from '../../Customer/SectionWrapper';
 import descriptionListStyles from '../../../styles/descriptionList.module.scss';
 import Hint from '../../Hint';
-import { ShipmentShape } from '../../../types/shipment';
-import { MTOServiceItemShape } from '../../../types';
 import ServiceItem from '../ServiceItem/ServiceItem';
 import Shipment from '../Shipment/Shipment';
 import { DatePickerInput } from '../../form/fields';
 
 import styles from './CreatePaymentRequestForm.module.scss';
 
+import { MTOServiceItemShape } from 'types';
+import { ShipmentShape } from 'types/shipment';
+import { ErrorMessage } from 'components/form';
+
 const CreatePaymentRequestForm = ({
   initialValues,
   onSubmit,
   handleSelectAll,
+  handleValidateDate,
   createPaymentRequestSchema,
   mtoShipments,
   groupedServiceItems,
 }) => (
   <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={createPaymentRequestSchema}>
-    {({ isValid, isSubmitting, errors, values, setValues }) => (
+    {({ isValid, isSubmitting, errors, values, setValues, setFieldError, setFieldTouched }) => (
       <Form className={classnames(styles.CreatePaymentRequestForm, formStyles.form)}>
-        <FormGroup error={errors != null && Object.keys(errors).length > 0}>
+        <FormGroup error={errors != null && errors.serviceItems}>
           {errors != null && errors.serviceItems && (
             <ErrorMessage display>At least 1 service item must be added when creating a payment request</ErrorMessage>
           )}
@@ -94,11 +96,31 @@ const CreatePaymentRequestForm = ({
                                   label="Payment start date"
                                   id={`paymentStart-${mtoServiceItem.id}`}
                                   name={`params.${mtoServiceItem.id}.SITPaymentRequestStart`}
+                                  validate={(fieldValue) =>
+                                    handleValidateDate(
+                                      mtoServiceItem.id,
+                                      'SITPaymentRequestStart',
+                                      fieldValue,
+                                      values,
+                                      setFieldError,
+                                      setFieldTouched,
+                                    )
+                                  }
                                 />
                                 <DatePickerInput
                                   label="Payment end date"
                                   id={`paymentEnd-${mtoServiceItem.id}`}
                                   name={`params.${mtoServiceItem.id}.SITPaymentRequestEnd`}
+                                  validate={(fieldValue) =>
+                                    handleValidateDate(
+                                      mtoServiceItem.id,
+                                      'SITPaymentRequestEnd',
+                                      fieldValue,
+                                      values,
+                                      setFieldError,
+                                      setFieldTouched,
+                                    )
+                                  }
                                 />
                               </>
                             )}
@@ -133,6 +155,7 @@ CreatePaymentRequestForm.propTypes = {
   }).isRequired,
   onSubmit: PropTypes.func.isRequired,
   handleSelectAll: PropTypes.func.isRequired,
+  handleValidateDate: PropTypes.func.isRequired,
   createPaymentRequestSchema: PropTypes.shape({
     serviceItems: PropTypes.node,
   }).isRequired,

--- a/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
+++ b/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
@@ -9,15 +9,15 @@ import { generatePath } from 'react-router';
 import { connect } from 'react-redux';
 import { func } from 'prop-types';
 
-import { createPaymentRequest } from '../../../services/primeApi';
 import scrollToTop from '../../../shared/scrollToTop';
 import CreatePaymentRequestForm from '../../../components/PrimeUI/CreatePaymentRequestForm/CreatePaymentRequestForm';
-import { primeSimulatorRoutes } from '../../../constants/routes';
-import { PRIME_SIMULATOR_MOVE } from '../../../constants/queryKeys';
-import { formatDateForSwagger } from '../../../shared/dates';
 
 import styles from './CreatePaymentRequest.module.scss';
 
+import { createPaymentRequest } from 'services/primeApi';
+import { primeSimulatorRoutes } from 'constants/routes';
+import { PRIME_SIMULATOR_MOVE } from 'constants/queryKeys';
+import { formatDateForSwagger } from 'shared/dates';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
 import SectionWrapper from 'components/Customer/SectionWrapper';
@@ -25,13 +25,6 @@ import formStyles from 'styles/form.module.scss';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 import { usePrimeSimulatorGetMove } from 'hooks/queries';
 import { setFlashMessage as setFlashMessageAction } from 'store/flash/actions';
-
-// We could ideally specify something like oneOfSchema outlined here
-// (https://gist.github.com/cb109/8eda798a4179dc21e46922a5fbb98be6) for the additional day SIT value with params
-const createPaymentRequestSchema = Yup.object().shape({
-  serviceItems: Yup.array().of(Yup.string()).min(1),
-  params: Yup.object().shape({}),
-});
 
 const CreatePaymentRequest = ({ setFlashMessage }) => {
   const { moveCodeOrID } = useParams();
@@ -81,6 +74,7 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
 
   const groupedServiceItems = useMemo(() => {
     const serviceItems = { basic: [] };
+    const additionalDaySIT = [];
     mtoServiceItems?.forEach((mtoServiceItem) => {
       if (mtoServiceItem.mtoShipmentID == null) {
         serviceItems.basic.push(mtoServiceItem);
@@ -88,6 +82,10 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
         serviceItems[mtoServiceItem.mtoShipmentID] = [mtoServiceItem];
       } else {
         serviceItems[mtoServiceItem.mtoShipmentID].push(mtoServiceItem);
+      }
+
+      if (mtoServiceItem.reServiceCode === 'DOASIT' || mtoServiceItem.reServiceCode === 'DDASIT') {
+        additionalDaySIT.push(mtoServiceItem.id);
       }
     });
     return serviceItems;
@@ -103,6 +101,40 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
 
   const initialValues = {
     serviceItems: [],
+    /* Setting initial values was supposed to change formik behavior but it made no difference
+    params: additionalDaySITItems.reduce(
+      (acc, curr) => ({ ...acc, [curr]: { SITPaymentRequestStart: '', SITPaymentRequestEnd: '' } }),
+      {},
+      ),
+    */
+  };
+
+  const dateValidationSchema = Yup.date()
+    .typeError('Enter a complete date in DD MMM YYYY format (day, month, year).')
+    .required('Required');
+
+  // We could ideally specify something like oneOfSchema outlined here
+  // (https://gist.github.com/cb109/8eda798a4179dc21e46922a5fbb98be6) for the additional day SIT value with params
+  // The behavior of Formik <FieldArray> is for dynamic lists not sparse lists as we have laid out
+  const createPaymentRequestSchema = Yup.object().shape({
+    serviceItems: Yup.array().of(Yup.string()).min(1),
+  });
+
+  const validateSITDate = async (id, fieldName, value, formValues, setFieldError, setFieldTouched) => {
+    let error;
+    // only validate service items that are being added to the payment request
+    if (formValues.serviceItems?.find((serviceItem) => serviceItem === id)) {
+      // The field won't be touched (and won't show the error) if the user tries to submit before editing the dates
+      // even though formik says it touches all fields on submission if they are in initialValues I found this not to
+      // be true.
+      setFieldTouched(`params.${id}.${fieldName}`, true, false);
+      await dateValidationSchema.validate(value).catch((err) => {
+        error = err.message;
+        // this is a way to get touched set without having to worry about other fields
+        setFieldError(`params.${id}.${fieldName}`, error);
+      });
+    }
+    return error;
   };
 
   const onSubmit = (values, formik) => {
@@ -183,6 +215,7 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
             initialValues={initialValues}
             onSubmit={onSubmit}
             handleSelectAll={handleShipmentSelectAll}
+            handleValidateDate={validateSITDate}
             createPaymentRequestSchema={createPaymentRequestSchema}
             mtoShipments={mtoShipments}
             groupedServiceItems={groupedServiceItems}

--- a/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
+++ b/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
@@ -74,7 +74,6 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
 
   const groupedServiceItems = useMemo(() => {
     const serviceItems = { basic: [] };
-    const additionalDaySIT = [];
     mtoServiceItems?.forEach((mtoServiceItem) => {
       if (mtoServiceItem.mtoShipmentID == null) {
         serviceItems.basic.push(mtoServiceItem);
@@ -82,10 +81,6 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
         serviceItems[mtoServiceItem.mtoShipmentID] = [mtoServiceItem];
       } else {
         serviceItems[mtoServiceItem.mtoShipmentID].push(mtoServiceItem);
-      }
-
-      if (mtoServiceItem.reServiceCode === 'DOASIT' || mtoServiceItem.reServiceCode === 'DDASIT') {
-        additionalDaySIT.push(mtoServiceItem.id);
       }
     });
     return serviceItems;


### PR DESCRIPTION
## Description

This PR introduces client-side validations on the create payment request form when adding an additional day SIT service item (origin or destination) start and end dates are required.

The tricky part of this is the dynamic nature of the form, normally we have a fixed number of input fields and we know the names ahead of time and can add values and validations in the Formik initialValues prop and the Yup validation schema.  Also complicating is the dependent nature of only making the fields required when the user has checked the additional day service item to add it to the payment request.

I started off trying to add validations to the validationSchema (using `Yup.lazy()`) and was able to have it fail on non-date values but getting the require to work using a `when` conditional didn't seem to be working.

The best solution I found was providing a custom validate function to the date picker inputs in the form.  I could pass back the formik state and helper functions to manipulate the form directly.  Getting the touched fields proved difficult and while Formik says it will touch all fields before submission I didn't see this maybe due to the dynamic initialValues.  Field errors only show if the field is touched and there is an error so returning an error was not enough I had to make sure Formik knew the field was also touched if the form was submitted without any edits. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```

1. Login as the prime simulator user to the office app
2. Select the `PENDNG` move and create origin/destination SIT service items using the create service item page (or find another move with SIT service items already)
3. After creating SIT service items go to the create payment request page and select the additional day SIT service item(s) to be added to the payment request but don't edit the date fields.
4. Attempt to submit the form and you should be prevented and the date fields should be marked as required.
5. Adding date values in an incorrect format (not DD MMM YYYY) will also trigger a type validation error message.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9830 for this change

## Screenshots

<img width="682" alt="Screen Shot 2021-11-01 at 9 30 20 AM" src="https://user-images.githubusercontent.com/52669884/139679704-ea22744d-71ca-4053-868a-2b4bd58b830a.png">
<img width="682" alt="Screen Shot 2021-11-01 at 9 30 27 AM" src="https://user-images.githubusercontent.com/52669884/139679707-30e0de24-b14a-428e-8f9a-7e9bbea586e6.png">
<img width="668" alt="Screen Shot 2021-11-01 at 9 31 07 AM" src="https://user-images.githubusercontent.com/52669884/139679712-e57c15f3-42c8-4aac-b30a-b225f8544a4d.png">
<img width="665" alt="Screen Shot 2021-11-01 at 9 31 31 AM" src="https://user-images.githubusercontent.com/52669884/139679730-3eb0ca74-8146-4cc6-8c87-6b18f0815b55.png">