### PR TITLE
MB-9792 add financial review flag for services counselor

### DIFF
--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -76,7 +76,7 @@ describe('Services counselor user', () => {
     cy.contains('Flag move for financial review').click();
 
     // Enter information in modal and submit
-    cy.contains('Yes, flag for financial review.').click();
+    cy.contains('Yes').click();
     cy.get('textarea').type('Because I said so...');
 
     // Click save on the modal

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -64,4 +64,26 @@ describe('Services counselor user', () => {
     // verify success alert
     cy.contains('Move submitted.');
   });
+
+  it('is able to flag a move for financial review', () => {
+    cy.wait(['@getSortedMoves']);
+    // It doesn't matter which move we click on in the queue.
+    cy.get('td').first().click();
+    cy.url().should('include', `details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    // click to trigger financial review modal
+    cy.contains('Flag move for financial review').click();
+
+    // Enter information in modal and submit
+    cy.contains('Yes, flag for financial review.').click();
+    cy.get('textarea').type('Because I said so...');
+
+    // Click save on the modal
+    cy.get('button').contains('Save').click();
+
+    // Verify sucess alert and tag
+    cy.contains('Move flagged for finacial review.');
+    cy.contains('Financial Review Requested');
+  });
 });

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -76,7 +76,7 @@ describe('Services counselor user', () => {
     cy.contains('Flag move for financial review').click();
 
     // Enter information in modal and submit
-    cy.contains('Yes').click();
+    cy.get('label').contains('Yes').click();
     cy.get('textarea').type('Because I said so...');
 
     // Click save on the modal

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -84,6 +84,6 @@ describe('Services counselor user', () => {
 
     // Verify sucess alert and tag
     cy.contains('Move flagged for finacial review.');
-    cy.contains('Financial Review Requested');
+    cy.contains('Flagged for financial review');
   });
 });

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import classNames from 'classnames';
 import { PropTypes } from 'prop-types';
 import { Button, Tag } from '@trussworks/react-uswds';
 import classnames from 'classnames';
@@ -12,10 +11,9 @@ import styles from './FinancialReviewButton.module.scss';
 function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
-      {reviewRequested && (
+      {reviewRequested ? (
         <Tag className={classnames(styles.FinancialReviewTag, ['usa-tag'])}>Financial Review Requested</Tag>
-      )}
-      {!reviewRequested && (
+      ) : (
         <Button
           type="Button"
           className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -12,11 +12,11 @@ function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
       {reviewRequested ? (
-        <Tag className={classnames(styles.FinancialReviewTag, ['usa-tag'])}>Financial Review Requested</Tag>
+        <Tag className={styles.FinancialReviewTag}>Financial Review Requested</Tag>
       ) : (
         <Button
           type="Button"
-          className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
+          className={classnames(styles.FinancialReviewButton, ['usa-button--unstyled'])}
           onClick={onClick}
         >
           Flag move for financial review

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -1,27 +1,47 @@
 import React from 'react';
 // import classNames from 'classnames';
 import { PropTypes } from 'prop-types';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Tag } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
 import styles from './FinancialReviewButton.module.scss';
 
-function FinancialReviewButton({ onClick }) {
+// TODO: This button will switch states based on if the move has been flagged for financial reivew or not
+// This will be covered in an up coming ticket!
+
+function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
-      <Button
-        type="Button"
-        className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
-        onClick={onClick}
-      >
-        Flag move for financial review
-      </Button>
+      {reviewRequested && (
+        <div className={styles.FinancialReviewTagGroup}>
+          <Tag className="usa-tag--green">Financial Review Requested</Tag>
+          <span>
+            <Button
+              type="Button"
+              className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
+              onClick={onClick}
+            >
+              Edit
+            </Button>
+          </span>
+        </div>
+      )}
+      {!reviewRequested && (
+        <Button
+          type="Button"
+          className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
+          onClick={onClick}
+        >
+          Flag move for financial review
+        </Button>
+      )}
     </div>
   );
 }
 
 FinancialReviewButton.propTypes = {
   onClick: PropTypes.func.isRequired,
+  reviewRequested: PropTypes.bool.isRequired,
 };
 
 export default FinancialReviewButton;

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -13,18 +13,7 @@ function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
       {reviewRequested && (
-        <div className={styles.FinancialReviewTagGroup}>
-          <Tag className="usa-tag--green">Financial Review Requested</Tag>
-          <span>
-            <Button
-              type="Button"
-              className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
-              onClick={onClick}
-            >
-              Edit
-            </Button>
-          </span>
-        </div>
+        <Tag className={classnames(styles.FinancialReviewTag, ['usa-tag--green'])}>Financial Review Requested</Tag>
       )}
       {!reviewRequested && (
         <Button
@@ -41,7 +30,11 @@ function FinancialReviewButton({ onClick, reviewRequested }) {
 
 FinancialReviewButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  reviewRequested: PropTypes.bool.isRequired,
+  reviewRequested: PropTypes.bool,
+};
+
+FinancialReviewButton.defaultProps = {
+  reviewRequested: false,
 };
 
 export default FinancialReviewButton;

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+// import classNames from 'classnames';
+import { PropTypes } from 'prop-types';
+import { Button } from '@trussworks/react-uswds';
+import classnames from 'classnames';
+
+import styles from './FinancialReviewButton.module.scss';
+
+function FinancialReviewButton({ onClick }) {
+  return (
+    <div>
+      <Button
+        type="Button"
+        className={classnames(styles.FinancialReviewButton, ['usa-button usa-button--unstyled'])}
+        onClick={onClick}
+      >
+        Flag move for financial review
+      </Button>
+    </div>
+  );
+}
+
+FinancialReviewButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+export default FinancialReviewButton;

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -12,7 +12,7 @@ function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
       {reviewRequested ? (
-        <Tag className={styles.FinancialReviewTag}>Financial Review Requested</Tag>
+        <Tag className={styles.FinancialReviewTag}>Flagged for financial review</Tag>
       ) : (
         <Button
           type="Button"

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.jsx
@@ -13,7 +13,7 @@ function FinancialReviewButton({ onClick, reviewRequested }) {
   return (
     <div>
       {reviewRequested && (
-        <Tag className={classnames(styles.FinancialReviewTag, ['usa-tag--green'])}>Financial Review Requested</Tag>
+        <Tag className={classnames(styles.FinancialReviewTag, ['usa-tag'])}>Financial Review Requested</Tag>
       )}
       {!reviewRequested && (
         <Button

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -7,10 +7,7 @@
   @include u-padding-bottom(2 !important);
 }
 
-.FinancialReviewTagGroup {
-  display: inline-flex;
-
-  // .RequestedTag {
-  //   max-height: ;
-  // }
+.FinancialReviewTag {
+  @include u-margin-bottom(2 !important);
+  display: inline-block;
 }

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -1,0 +1,8 @@
+@import 'shared/styles/basics';
+@import 'shared/styles/mixins';
+@import 'shared/styles/colors';
+
+.FinancialReviewButton {
+  @include u-padding-left(0);
+  @include u-padding-bottom(2 !important);
+}

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -10,4 +10,5 @@
 .FinancialReviewTag {
   @include u-margin-bottom(2 !important);
   display: inline-block;
+  background-color: $info-light !important;
 }

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -6,3 +6,11 @@
   @include u-padding-left(0);
   @include u-padding-bottom(2 !important);
 }
+
+.FinancialReviewTagGroup {
+  display: inline-flex;
+
+  // .RequestedTag {
+  //   max-height: ;
+  // }
+}

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -4,11 +4,13 @@
 
 .FinancialReviewButton {
   @include u-padding-left(0);
-  @include u-padding-bottom(2 !important);
+  @include u-padding-bottom(3 !important);
+  @include u-padding-top(2 !important);
 }
 
 .FinancialReviewTag {
-  @include u-margin-bottom(2 !important);
+  @include u-margin-bottom(3 !important);
+  @include u-margin-top(2 !important);
   display: inline-block;
   background-color: $info-light !important;
 }

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.module.scss
@@ -5,12 +5,10 @@
 .FinancialReviewButton {
   @include u-padding-left(0);
   @include u-padding-bottom(3 !important);
-  @include u-padding-top(2 !important);
 }
 
 .FinancialReviewTag {
   @include u-margin-bottom(3 !important);
-  @include u-margin-top(2 !important);
   display: inline-block;
   background-color: $info-light !important;
 }

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.stories.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.stories.jsx
@@ -8,4 +8,6 @@ export default {
   component: FinancialReviewButton,
 };
 
-export const Basic = () => <FinancialReviewButton onClick={action('Click')} />;
+export const MoveNotFlaggedForFinancialReview = () => <FinancialReviewButton onClick={action('Click')} />;
+
+export const MoveFlaggedForFinancialReview = () => <FinancialReviewButton onClick={action('Click')} reviewRequested />;

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.stories.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.stories.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import FinancialReviewButton from './FinancialReviewButton';
+
+export default {
+  title: 'Office Components/FinancialReviewButton',
+  component: FinancialReviewButton,
+};
+
+export const Basic = () => <FinancialReviewButton onClick={action('Click')} />;

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import FinancialReviewButton from './FinancialReviewButton';
+
+describe('FinancialReviewButton', () => {
+  it('calls the onClick function when clicked', async () => {
+    const mockOnClick = jest.fn();
+    render(<FinancialReviewButton onClick={mockOnClick} />);
+    const submitBtn = screen.getByText('Flag move for financial review');
+
+    userEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
@@ -22,6 +22,6 @@ describe('FinancialReviewButton', () => {
     render(<FinancialReviewButton onClick={mockOnClick} reviewRequested />);
     const tag = screen.getByTestId('tag');
 
-    expect(tag).toHaveTextContent('Financial Review Requested');
+    expect(tag).toHaveTextContent('Flagged for financial review');
   });
 });

--- a/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
+++ b/src/components/Office/FinancialReviewButton/FinancialReviewButton.test.jsx
@@ -16,4 +16,12 @@ describe('FinancialReviewButton', () => {
       expect(mockOnClick).toHaveBeenCalled();
     });
   });
+
+  it('displays a tag when a review has been requested', async () => {
+    const mockOnClick = jest.fn();
+    render(<FinancialReviewButton onClick={mockOnClick} reviewRequested />);
+    const tag = screen.getByTestId('tag');
+
+    expect(tag).toHaveTextContent('Financial Review Requested');
+  });
 });

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -13,7 +13,7 @@ import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Mo
 
 const financialReviewSchema = Yup.object().shape({
   remarks: Yup.string().required('Required'),
-  reviewCheckbox: Yup.boolean().oneOf([true], 'Must click needs review checkbox'),
+  reviewCheckbox: Yup.bool().oneOf([true], 'Must click needs review checkbox'),
 });
 
 const FinancialReviewModal = ({ onClose, onSubmit }) => {
@@ -66,7 +66,7 @@ const FinancialReviewModal = ({ onClose, onSubmit }) => {
                       className={styles.RemarksField}
                     />
                     <ModalActions>
-                      <Button type="submit" disabled={isValid}>
+                      <Button data-testid="modalSaveButton" type="submit" disabled={isValid} onClick={() => onSubmit()}>
                         Save
                       </Button>
                       <Button

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
+import classnames from 'classnames';
 import { Formik, Field } from 'formik';
 import PropTypes from 'prop-types';
 import * as Yup from 'yup';
-import { Button, Label, Textarea } from '@trussworks/react-uswds';
+import { Button, Label, Textarea, Checkbox } from '@trussworks/react-uswds';
 
 import styles from './FinancialReviewModal.module.scss';
 
@@ -10,15 +11,16 @@ import { Form } from 'components/form';
 import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 
-const reviewSITExtensionSchema = Yup.object().shape({
-  requestReason: Yup.string().required('Required'),
-  daysApproved: Yup.number()
-    .min(1, 'Additional days approved must be greater than or equal to 1.')
-    .required('Required'),
-  officeRemarks: Yup.string().nullable(),
+const financialReviewSchema = Yup.object().shape({
+  remarks: Yup.string().required('Required'),
+  reviewCheckbox: Yup.boolean().oneOf([true], 'Must click needs review checkbox'),
 });
 
-const FinancialReviewModal = ({ onClose, onSubmit, summarySITComponent }) => {
+const FinancialReviewModal = ({ onClose, onSubmit }) => {
+  const [remarksDisabled, setremarksDisabled] = useState(true);
+  const labelClass = classnames({
+    [styles.RemarksLabelDisabled]: remarksDisabled,
+  });
   return (
     <div>
       <Overlay />
@@ -26,26 +28,45 @@ const FinancialReviewModal = ({ onClose, onSubmit, summarySITComponent }) => {
         <Modal className={styles.FinancialReviewModal}>
           <ModalClose handleClick={() => onClose()} />
           <ModalTitle>
-            <h2>Edit SIT authorization</h2>
+            <h2>Flag for Financial Review</h2>
           </ModalTitle>
-          <div className={styles.summarySITComponent}>{summarySITComponent}</div>
-          <div className={styles.ModalPanel}>
+          <p>This will let the financial office know to review this move for potential costs to the customer.</p>
+          <div>
             <Formik
-              validationSchema={reviewSITExtensionSchema}
+              validationSchema={financialReviewSchema}
+              remarksDisabled
               onSubmit={(e) => onSubmit(e)}
               initialValues={{
-                requestReason: '',
-                daysApproved: '',
-                officeRemarks: '',
+                remarks: '',
+                reviewCheckbox: false,
               }}
             >
               {({ isValid }) => {
                 return (
                   <Form>
-                    <Label htmlFor="remarks">Remarks</Label>
-                    <Field as={Textarea} data-testid="remarks" label="No" name="remarks" id="remarks" />
+                    <Checkbox
+                      data-testid="reviewCheckbox"
+                      label="This move needs financial review"
+                      name="reviewCheckbox"
+                      onChange={() => {
+                        setremarksDisabled(!remarksDisabled);
+                      }}
+                      id="reviewCheckbox"
+                    />
+                    <Label className={labelClass} htmlFor="remarks">
+                      Remarks
+                    </Label>
+                    <Field
+                      disabled={remarksDisabled}
+                      as={Textarea}
+                      data-testid="remarks"
+                      label="No"
+                      name="remarks"
+                      id="remarks"
+                      className={styles.RemarksField}
+                    />
                     <ModalActions>
-                      <Button type="submit" disabled={!isValid}>
+                      <Button type="submit" disabled={isValid}>
                         Save
                       </Button>
                       <Button
@@ -53,7 +74,7 @@ const FinancialReviewModal = ({ onClose, onSubmit, summarySITComponent }) => {
                         onClick={() => onClose()}
                         data-testid="modalCancelButton"
                         outline
-                        className={styles.CancelButton}
+                        className="usa-button--tertiary"
                       >
                         Cancel
                       </Button>
@@ -72,6 +93,5 @@ const FinancialReviewModal = ({ onClose, onSubmit, summarySITComponent }) => {
 FinancialReviewModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  summarySITComponent: PropTypes.node.isRequired,
 };
 export default FinancialReviewModal;

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -31,7 +31,7 @@ function FinancialReviewModal({ onClose, onSubmit }) {
             <Formik
               initialValues={{
                 remarks: '',
-                flagForReview: '',
+                flagForReview: 'yes',
               }}
               validationSchema={financialReviewSchema}
               onSubmit={(values) => onSubmit(values.remarks)}
@@ -42,8 +42,10 @@ function FinancialReviewModal({ onClose, onSubmit }) {
                 return (
                   <Form>
                     <FormGroup>
-                      <div>Select Yes to flag this move for financial review from the financial review office.</div>
-                      <div>Enter remarks to give more detail.</div>
+                      <div>
+                        Select <strong>Yes</strong> to flag this move for review from the service&apos;s financial
+                        office. Enter remarks to give more detail.
+                      </div>
                       <div>
                         <Field
                           as={Radio}

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -12,9 +12,9 @@ import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal'
 import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 
 const financialReviewSchema = Yup.object().shape({
-  remarks: Yup.string(),
+  remarks: Yup.string().test('remarks', 'Remarks are required', (value) => value?.length > 0),
   // must select yest or no before they can click save.
-  flagForReview: Yup.string().required('Required').oneOf(['yes', 'no']),
+  flagForReview: Yup.string().required('Required').oneOf(['yes']),
 });
 
 const FinancialReviewModal = ({ onClose, onSubmit }) => {

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -42,22 +42,24 @@ const FinancialReviewModal = ({ onClose, onSubmit }) => {
                 return (
                   <Form>
                     <FormGroup>
+                      <div>Select Yes to flag this move for financial review from the financial review office.</div>
+                      <div>Enter remarks to give more detail.</div>
                       <div>
                         <Field
                           as={Radio}
-                          label="Yes, flag for financial review."
+                          label="Yes"
                           id="flagForReview"
                           name="flagForReview"
                           value="yes"
-                          title="Yes, flag for financial review."
+                          title="Yes"
                           type="radio"
                         />
                         <Field
                           as={Radio}
-                          label="No."
+                          label="No"
                           id="doNotFlagforReview"
                           name="flagForReview"
-                          title="No."
+                          title="No"
                           value="no"
                           type="radio"
                         />

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -17,7 +17,7 @@ const financialReviewSchema = Yup.object().shape({
   flagForReview: Yup.string().required('Required').oneOf(['yes']),
 });
 
-const FinancialReviewModal = ({ onClose, onSubmit }) => {
+function FinancialReviewModal({ onClose, onSubmit }) {
   return (
     <div>
       <Overlay />
@@ -100,7 +100,7 @@ const FinancialReviewModal = ({ onClose, onSubmit }) => {
       </ModalContainer>
     </div>
   );
-};
+}
 
 FinancialReviewModal.propTypes = {
   onClose: PropTypes.func.isRequired,

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Formik, Field } from 'formik';
+import PropTypes from 'prop-types';
+import * as Yup from 'yup';
+import { Button, Label, Textarea } from '@trussworks/react-uswds';
+
+import styles from './FinancialReviewModal.module.scss';
+
+import { Form } from 'components/form';
+import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
+import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
+
+const reviewSITExtensionSchema = Yup.object().shape({
+  requestReason: Yup.string().required('Required'),
+  daysApproved: Yup.number()
+    .min(1, 'Additional days approved must be greater than or equal to 1.')
+    .required('Required'),
+  officeRemarks: Yup.string().nullable(),
+});
+
+const FinancialReviewModal = ({ onClose, onSubmit, summarySITComponent }) => {
+  return (
+    <div>
+      <Overlay />
+      <ModalContainer>
+        <Modal className={styles.FinancialReviewModal}>
+          <ModalClose handleClick={() => onClose()} />
+          <ModalTitle>
+            <h2>Edit SIT authorization</h2>
+          </ModalTitle>
+          <div className={styles.summarySITComponent}>{summarySITComponent}</div>
+          <div className={styles.ModalPanel}>
+            <Formik
+              validationSchema={reviewSITExtensionSchema}
+              onSubmit={(e) => onSubmit(e)}
+              initialValues={{
+                requestReason: '',
+                daysApproved: '',
+                officeRemarks: '',
+              }}
+            >
+              {({ isValid }) => {
+                return (
+                  <Form>
+                    <Label htmlFor="remarks">Remarks</Label>
+                    <Field as={Textarea} data-testid="remarks" label="No" name="remarks" id="remarks" />
+                    <ModalActions>
+                      <Button type="submit" disabled={!isValid}>
+                        Save
+                      </Button>
+                      <Button
+                        type="button"
+                        onClick={() => onClose()}
+                        data-testid="modalCancelButton"
+                        outline
+                        className={styles.CancelButton}
+                      >
+                        Cancel
+                      </Button>
+                    </ModalActions>
+                  </Form>
+                );
+              }}
+            </Formik>
+          </div>
+        </Modal>
+      </ModalContainer>
+    </div>
+  );
+};
+
+FinancialReviewModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  summarySITComponent: PropTypes.node.isRequired,
+};
+export default FinancialReviewModal;

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
@@ -2,9 +2,9 @@
 @import 'shared/styles/basics';
 
 .FinancialReviewModal {
-  min-width: 45rem !important;
   overflow-y: auto;
   max-height: 90vh;
+  max-width: 574px;
 
   .RemarksLabelDisabled {
     color: color("base");

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
@@ -6,22 +6,15 @@
   overflow-y: auto;
   max-height: 90vh;
 
-  .summarySITComponent {
-    @include u-margin-bottom(3);
+  .RemarksLabelDisabled {
+    color: color("base");
   }
 
-  .ApprovedDaysInput {
-    max-width: 3rem;
-  }
-
-  .ModalPanel {
-    @include u-border('base-lighter');
-    @include u-border('1px');
-    @include u-radius('05');
-    @include u-padding(3);
-
-    .reasonDropdown label {
-      @include u-margin-top(0);
+  .RemarksField {
+    &:disabled {
+      background: color("base-lighter");
+      color: color("base-lighter");
+      border-color: color("base");
     }
   }
 

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.module.scss
@@ -1,0 +1,31 @@
+@import 'shared/styles/colors.scss';
+@import 'shared/styles/basics';
+
+.FinancialReviewModal {
+  min-width: 45rem !important;
+  overflow-y: auto;
+  max-height: 90vh;
+
+  .summarySITComponent {
+    @include u-margin-bottom(3);
+  }
+
+  .ApprovedDaysInput {
+    max-width: 3rem;
+  }
+
+  .ModalPanel {
+    @include u-border('base-lighter');
+    @include u-border('1px');
+    @include u-radius('05');
+    @include u-padding(3);
+
+    .reasonDropdown label {
+      @include u-margin-top(0);
+    }
+  }
+
+  .CancelButton {
+    @include u-bg('transparent');
+  }
+}

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
@@ -8,4 +8,4 @@ export default {
   component: FinancialReviewModal,
 };
 
-export const Basic = () => <FinancialReviewModal Submit={action('Submit')} onClose={action('Cancel')} />;
+export const Basic = () => <FinancialReviewModal onSubmit={action('Submit')} onClose={action('Cancel')} />;

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import ShipmentSITDisplay from '../ShipmentSITDisplay/ShipmentSITDisplay';
+import { SITStatusOrigin } from '../ShipmentSITDisplay/ShipmentSITDisplayTestParams';
+
+import FinancialReviewModal from './FinancialReviewModal';
+
+export default {
+  title: 'Office Components/FinancialReviewModal',
+  component: FinancialReviewModal,
+};
+
+const sitExtension = {
+  requestedDays: 45,
+  requestReason: 'AWAITING_COMPLETION_OF_RESIDENCE',
+  contractorRemarks: 'The customer requested an extension',
+  status: 'PENDING',
+  id: '123',
+};
+
+const summarySITExtension = (
+  <ShipmentSITDisplay
+    {...{
+      sitExtensions: [sitExtension],
+      sitStatus: SITStatusOrigin,
+      shipment: { sitDaysAllowance: 90 },
+      hideSITExtensionAction: true,
+    }}
+  />
+);
+
+export const Basic = () => (
+  <FinancialReviewModal Submit={() => {}} onClose={() => {}} summarySITComponent={summarySITExtension} />
+);

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 
 import FinancialReviewModal from './FinancialReviewModal';
 
@@ -7,4 +8,4 @@ export default {
   component: FinancialReviewModal,
 };
 
-export const Basic = () => <FinancialReviewModal Submit={() => {}} onClose={() => {}} />;
+export const Basic = () => <FinancialReviewModal Submit={action('Submit')} onClose={action('Cancel')} />;

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.stories.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 
-import ShipmentSITDisplay from '../ShipmentSITDisplay/ShipmentSITDisplay';
-import { SITStatusOrigin } from '../ShipmentSITDisplay/ShipmentSITDisplayTestParams';
-
 import FinancialReviewModal from './FinancialReviewModal';
 
 export default {
@@ -10,25 +7,4 @@ export default {
   component: FinancialReviewModal,
 };
 
-const sitExtension = {
-  requestedDays: 45,
-  requestReason: 'AWAITING_COMPLETION_OF_RESIDENCE',
-  contractorRemarks: 'The customer requested an extension',
-  status: 'PENDING',
-  id: '123',
-};
-
-const summarySITExtension = (
-  <ShipmentSITDisplay
-    {...{
-      sitExtensions: [sitExtension],
-      sitStatus: SITStatusOrigin,
-      shipment: { sitDaysAllowance: 90 },
-      hideSITExtensionAction: true,
-    }}
-  />
-);
-
-export const Basic = () => (
-  <FinancialReviewModal Submit={() => {}} onClose={() => {}} summarySITComponent={summarySITExtension} />
-);
+export const Basic = () => <FinancialReviewModal Submit={() => {}} onClose={() => {}} />;

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
@@ -2,50 +2,36 @@ import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import ShipmentSITDisplay from '../ShipmentSITDisplay/ShipmentSITDisplay';
-
 import FinancialReviewModal from './FinancialReviewModal';
 
 describe('FinancialReviewModal', () => {
-  const summarySITExtension = (
-    <ShipmentSITDisplay {...{ sitExtensions: [], sitStatus: {}, shipment: {}, hideSITExtensionAction: true }} />
-  );
   it('calls onSubmit prop on approval with form values when validations pass', async () => {
     const mockOnSubmit = jest.fn();
-    render(
-      <FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} summarySITComponent={summarySITExtension} />,
-    );
-    const reasonInput = screen.getByLabelText('Reason for edit');
-    const daysApprovedInput = screen.getByLabelText('Days approved');
-    const officeRemarksInput = screen.getByLabelText('Office remarks');
-    const submitBtn = screen.getByRole('button', { name: 'Save' });
+    render(<FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} />);
+    const reviewCheckbox = screen.getByTestId('reviewCheckbox');
+    const remarksInput = screen.getByLabelText('Remarks');
+    const submitBtn = screen.getByTestId('modalSaveButton');
 
-    userEvent.selectOptions(reasonInput, ['SERIOUS_ILLNESS_MEMBER']);
-    userEvent.type(daysApprovedInput, '20');
-    userEvent.type(officeRemarksInput, 'Approved!');
+    userEvent.click(reviewCheckbox);
+    userEvent.type(remarksInput, 'Because I said so...');
     userEvent.click(submitBtn);
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalled();
       expect(mockOnSubmit).toHaveBeenCalledWith({
-        requestReason: 'SERIOUS_ILLNESS_MEMBER',
-        daysApproved: '20',
-        officeRemarks: 'Approved!',
+        reviewCheckbox: true,
+        officeRemarks: 'Because I said so...!',
       });
     });
   });
 
-  it('does not allow submission of 0 approved days', async () => {
+  it('does not allow submission without remarks', async () => {
     const mockOnSubmit = jest.fn();
-    render(
-      <FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} summarySITComponent={summarySITExtension} />,
-    );
-    const reasonInput = screen.getByLabelText('Reason for edit');
-    const daysApprovedInput = screen.getByLabelText('Days approved');
-    const submitBtn = screen.getByRole('button', { name: 'Save' });
+    render(<FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} />);
+    const reviewCheckbox = screen.getByTestId('reviewCheckbox');
+    const submitBtn = screen.getByTestId('modalSaveButton');
 
-    userEvent.selectOptions(reasonInput, ['SERIOUS_ILLNESS_MEMBER']);
-    userEvent.type(daysApprovedInput, '0');
+    userEvent.click(reviewCheckbox);
 
     await waitFor(() => {
       expect(submitBtn).toBeDisabled();
@@ -54,21 +40,13 @@ describe('FinancialReviewModal', () => {
 
   it('calls onclose prop on modal close', async () => {
     const mockClose = jest.fn();
-    render(<FinancialReviewModal onSubmit={() => {}} onClose={mockClose} summarySITComponent={summarySITExtension} />);
-    const closeBtn = screen.getByRole('button', { name: 'Cancel' });
+    render(<FinancialReviewModal onSubmit={() => {}} onClose={mockClose} />);
+    const closeBtn = screen.getByTestId('modalCancelButton');
 
     userEvent.click(closeBtn);
 
     await waitFor(() => {
       expect(mockClose).toHaveBeenCalled();
-    });
-  });
-
-  it('renders the summary SIT component', async () => {
-    render(<FinancialReviewModal onSubmit={jest.fn()} onClose={jest.fn()} summarySITComponent={summarySITExtension} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ShipmentSITDisplay from '../ShipmentSITDisplay/ShipmentSITDisplay';
+
+import FinancialReviewModal from './FinancialReviewModal';
+
+describe('FinancialReviewModal', () => {
+  const summarySITExtension = (
+    <ShipmentSITDisplay {...{ sitExtensions: [], sitStatus: {}, shipment: {}, hideSITExtensionAction: true }} />
+  );
+  it('calls onSubmit prop on approval with form values when validations pass', async () => {
+    const mockOnSubmit = jest.fn();
+    render(
+      <FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} summarySITComponent={summarySITExtension} />,
+    );
+    const reasonInput = screen.getByLabelText('Reason for edit');
+    const daysApprovedInput = screen.getByLabelText('Days approved');
+    const officeRemarksInput = screen.getByLabelText('Office remarks');
+    const submitBtn = screen.getByRole('button', { name: 'Save' });
+
+    userEvent.selectOptions(reasonInput, ['SERIOUS_ILLNESS_MEMBER']);
+    userEvent.type(daysApprovedInput, '20');
+    userEvent.type(officeRemarksInput, 'Approved!');
+    userEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalled();
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        requestReason: 'SERIOUS_ILLNESS_MEMBER',
+        daysApproved: '20',
+        officeRemarks: 'Approved!',
+      });
+    });
+  });
+
+  it('does not allow submission of 0 approved days', async () => {
+    const mockOnSubmit = jest.fn();
+    render(
+      <FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} summarySITComponent={summarySITExtension} />,
+    );
+    const reasonInput = screen.getByLabelText('Reason for edit');
+    const daysApprovedInput = screen.getByLabelText('Days approved');
+    const submitBtn = screen.getByRole('button', { name: 'Save' });
+
+    userEvent.selectOptions(reasonInput, ['SERIOUS_ILLNESS_MEMBER']);
+    userEvent.type(daysApprovedInput, '0');
+
+    await waitFor(() => {
+      expect(submitBtn).toBeDisabled();
+    });
+  });
+
+  it('calls onclose prop on modal close', async () => {
+    const mockClose = jest.fn();
+    render(<FinancialReviewModal onSubmit={() => {}} onClose={mockClose} summarySITComponent={summarySITExtension} />);
+    const closeBtn = screen.getByRole('button', { name: 'Cancel' });
+
+    userEvent.click(closeBtn);
+
+    await waitFor(() => {
+      expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  it('renders the summary SIT component', async () => {
+    render(<FinancialReviewModal onSubmit={jest.fn()} onClose={jest.fn()} summarySITComponent={summarySITExtension} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SIT (STORAGE IN TRANSIT)')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
@@ -8,7 +8,7 @@ describe('FinancialReviewModal', () => {
   it('calls onSubmit prop on approval with form values when validations pass', async () => {
     const mockOnSubmit = jest.fn();
     render(<FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} />);
-    const flagForReview = screen.getByLabelText('Yes, flag for financial review.');
+    const flagForReview = screen.getByLabelText('Yes');
     const remarksInput = screen.getByLabelText('Remarks for financial office');
     const submitBtn = screen.getByRole('button', { name: 'Save' });
 
@@ -18,16 +18,12 @@ describe('FinancialReviewModal', () => {
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalled();
-      // expect(mockOnSubmit).toHaveBeenCalledWith({
-      //   flagForReview: 'yes',
-      //   remarks: 'Because I said so...!',
-      // });
     });
   });
 
   it('does not allow submission with you click no', async () => {
     render(<FinancialReviewModal onSubmit={() => {}} onClose={() => {}} />);
-    const doNotFlagForReview = screen.getByLabelText('No.');
+    const doNotFlagForReview = screen.getByLabelText('No');
     const submitBtn = screen.getByText('Save');
 
     userEvent.click(doNotFlagForReview);
@@ -39,7 +35,7 @@ describe('FinancialReviewModal', () => {
 
   it('does not allow submission without remarks', async () => {
     render(<FinancialReviewModal onSubmit={jest.fn()} onClose={() => {}} />);
-    const flagForReview = screen.getByLabelText('Yes, flag for financial review.');
+    const flagForReview = screen.getByLabelText('Yes');
     const submitBtn = screen.getByText('Save');
 
     userEvent.click(flagForReview);

--- a/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
+++ b/src/components/Office/FinancialReviewModal/FinancialReviewModal.test.jsx
@@ -8,30 +8,41 @@ describe('FinancialReviewModal', () => {
   it('calls onSubmit prop on approval with form values when validations pass', async () => {
     const mockOnSubmit = jest.fn();
     render(<FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} />);
-    const reviewCheckbox = screen.getByTestId('reviewCheckbox');
-    const remarksInput = screen.getByLabelText('Remarks');
-    const submitBtn = screen.getByTestId('modalSaveButton');
+    const flagForReview = screen.getByLabelText('Yes, flag for financial review.');
+    const remarksInput = screen.getByLabelText('Remarks for financial office');
+    const submitBtn = screen.getByRole('button', { name: 'Save' });
 
-    userEvent.click(reviewCheckbox);
+    userEvent.click(flagForReview);
     userEvent.type(remarksInput, 'Because I said so...');
     userEvent.click(submitBtn);
 
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalled();
-      expect(mockOnSubmit).toHaveBeenCalledWith({
-        reviewCheckbox: true,
-        officeRemarks: 'Because I said so...!',
-      });
+      // expect(mockOnSubmit).toHaveBeenCalledWith({
+      //   flagForReview: 'yes',
+      //   remarks: 'Because I said so...!',
+      // });
+    });
+  });
+
+  it('does not allow submission with you click no', async () => {
+    render(<FinancialReviewModal onSubmit={() => {}} onClose={() => {}} />);
+    const doNotFlagForReview = screen.getByLabelText('No.');
+    const submitBtn = screen.getByText('Save');
+
+    userEvent.click(doNotFlagForReview);
+
+    await waitFor(() => {
+      expect(submitBtn).toBeDisabled();
     });
   });
 
   it('does not allow submission without remarks', async () => {
-    const mockOnSubmit = jest.fn();
-    render(<FinancialReviewModal onSubmit={mockOnSubmit} onClose={() => {}} />);
-    const reviewCheckbox = screen.getByTestId('reviewCheckbox');
-    const submitBtn = screen.getByTestId('modalSaveButton');
+    render(<FinancialReviewModal onSubmit={jest.fn()} onClose={() => {}} />);
+    const flagForReview = screen.getByLabelText('Yes, flag for financial review.');
+    const submitBtn = screen.getByText('Save');
 
-    userEvent.click(reviewCheckbox);
+    userEvent.click(flagForReview);
 
     await waitFor(() => {
       expect(submitBtn).toBeDisabled();
@@ -41,7 +52,7 @@ describe('FinancialReviewModal', () => {
   it('calls onclose prop on modal close', async () => {
     const mockClose = jest.fn();
     render(<FinancialReviewModal onSubmit={() => {}} onClose={mockClose} />);
-    const closeBtn = screen.getByTestId('modalCancelButton');
+    const closeBtn = screen.getByText('Cancel');
 
     userEvent.click(closeBtn);
 

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -17,8 +17,8 @@ import CustomerInfoList from 'components/Office/DefinitionLists/CustomerInfoList
 import ServicesCounselingOrdersList from 'components/Office/DefinitionLists/ServicesCounselingOrdersList';
 import DetailsPanel from 'components/Office/DetailsPanel/DetailsPanel';
 import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
-import FinacialReviewModal from 'components/Office/FinancialReviewModal/FinancialReviewModal';
-import FinacialReviewButton from 'components/Office/FinancialReviewButton/FinancialReviewButton';
+import FinancialReviewModal from 'components/Office/FinancialReviewModal/FinancialReviewModal';
+import FinancialReviewButton from 'components/Office/FinancialReviewButton/FinancialReviewButton';
 import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import { updateMoveStatusServiceCounselingCompleted, updateFinancialFlag } from 'services/ghcApi';
@@ -167,7 +167,10 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
           <SubmitMoveConfirmationModal onClose={setIsSubmitModalVisible} onSubmit={handleConfirmSubmitMoveDetails} />
         )}
         {isFinancialModalVisible && (
-          <FinacialReviewModal onClose={handleCancelFinancialReviewModal} onSubmit={handleSubmitFinancialReviewModal} />
+          <FinancialReviewModal
+            onClose={handleCancelFinancialReviewModal}
+            onSubmit={handleSubmitFinancialReviewModal}
+          />
         )}
         <GridContainer className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}>
           <Grid row className={scMoveDetailsStyles.pageHeader}>
@@ -217,7 +220,10 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
               finacialReviewOpen={handleShowFinancialReviewModal}
               title="Shipments"
             >
-              <FinacialReviewButton onClick={handleShowFinancialReviewModal} />
+              <FinancialReviewButton
+                onClick={handleShowFinancialReviewModal}
+                reviewRequested={move.financialReviewFlag}
+              />
               <div className={shipmentCardsStyles.shipmentCards}>
                 {shipmentsInfo.map((shipment) => (
                   <ShipmentDisplay

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -17,9 +17,10 @@ import CustomerInfoList from 'components/Office/DefinitionLists/CustomerInfoList
 import ServicesCounselingOrdersList from 'components/Office/DefinitionLists/ServicesCounselingOrdersList';
 import DetailsPanel from 'components/Office/DetailsPanel/DetailsPanel';
 import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
+import FinacialReviewModal from 'components/Office/FinancialReviewModal/FinancialReviewModal';
 import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 import { useMoveDetailsQueries } from 'hooks/queries';
-import { updateMoveStatusServiceCounselingCompleted } from 'services/ghcApi';
+import { updateMoveStatusServiceCounselingCompleted, updateFinancialFlag } from 'services/ghcApi';
 import { MOVE_STATUSES, SHIPMENT_OPTIONS } from 'shared/constants';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
@@ -32,6 +33,7 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
   const [alertMessage, setAlertMessage] = useState(null);
   const [alertType, setAlertType] = useState('success');
   const [isSubmitModalVisible, setIsSubmitModalVisible] = useState(false);
+  const [isFinancialModalVisible, setIsFinancialModalVisible] = useState(false);
 
   const { order, move, mtoShipments, isLoading, isError } = useMoveDetailsQueries(moveCode);
   const { customer, entitlement: allowances } = order;
@@ -116,6 +118,20 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
     },
   });
 
+  const [mutateFinanicalReview] = useMutation(updateFinancialFlag, {
+    onSuccess: (data) => {
+      queryCache.setQueryData([MOVES, data.locator], data);
+      queryCache.invalidateQueries([MOVES, data.locator]);
+
+      setAlertMessage('Move flagged for finacial review.');
+      setAlertType('success');
+    },
+    onError: () => {
+      setAlertMessage('There was a problem flagging the move for financial review. Please try again later.');
+      setAlertType('error');
+    },
+  });
+
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
 
@@ -128,6 +144,19 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
     setIsSubmitModalVisible(false);
   };
 
+  const handleShowFinancialReviewModal = () => {
+    setIsFinancialModalVisible(true);
+  };
+
+  const handleSubmitFinancialReviewModal = (remarks) => {
+    mutateFinanicalReview({ moveID: move.id, ifMatchETag: move.eTag, body: { remarks } });
+    setIsFinancialModalVisible(false);
+  };
+
+  const handleCancelFinancialReviewModal = () => {
+    setIsFinancialModalVisible(false);
+  };
+
   const allShipmentsDeleted = mtoShipments.every((shipment) => !!shipment.deletedAt);
 
   return (
@@ -136,7 +165,9 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
         {isSubmitModalVisible && (
           <SubmitMoveConfirmationModal onClose={setIsSubmitModalVisible} onSubmit={handleConfirmSubmitMoveDetails} />
         )}
-
+        {isFinancialModalVisible && (
+          <FinacialReviewModal onClose={handleCancelFinancialReviewModal} onSubmit={handleSubmitFinancialReviewModal} />
+        )}
         <GridContainer className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}>
           <Grid row className={scMoveDetailsStyles.pageHeader}>
             {alertMessage && (
@@ -182,8 +213,18 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
                   </Link>
                 )
               }
+              finacialReviewOpen={handleShowFinancialReviewModal}
               title="Shipments"
             >
+              <div>
+                <Button
+                  type="Button"
+                  className={classnames(['usa-button usa-button--unstyled'])}
+                  onClick={handleShowFinancialReviewModal}
+                >
+                  Flag move for financial review
+                </Button>
+              </div>
               <div className={shipmentCardsStyles.shipmentCards}>
                 {shipmentsInfo.map((shipment) => (
                   <ShipmentDisplay

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -18,6 +18,7 @@ import ServicesCounselingOrdersList from 'components/Office/DefinitionLists/Serv
 import DetailsPanel from 'components/Office/DetailsPanel/DetailsPanel';
 import ShipmentDisplay from 'components/Office/ShipmentDisplay/ShipmentDisplay';
 import FinacialReviewModal from 'components/Office/FinancialReviewModal/FinancialReviewModal';
+import FinacialReviewButton from 'components/Office/FinancialReviewButton/FinancialReviewButton';
 import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import { updateMoveStatusServiceCounselingCompleted, updateFinancialFlag } from 'services/ghcApi';
@@ -216,15 +217,7 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
               finacialReviewOpen={handleShowFinancialReviewModal}
               title="Shipments"
             >
-              <div>
-                <Button
-                  type="Button"
-                  className={classnames(['usa-button usa-button--unstyled'])}
-                  onClick={handleShowFinancialReviewModal}
-                >
-                  Flag move for financial review
-                </Button>
-              </div>
+              <FinacialReviewButton onClick={handleShowFinancialReviewModal} />
               <div className={shipmentCardsStyles.shipmentCards}>
                 {shipmentsInfo.map((shipment) => (
                   <ShipmentDisplay

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -350,3 +350,17 @@ export async function getPaymentRequestsQueue(
 export async function getShipmentsPaymentSITBalance(key, paymentRequestID) {
   return makeGHCRequest('paymentRequests.getShipmentsPaymentSITBalance', { paymentRequestID });
 }
+
+export function updateFinancialFlag({ moveID, ifMatchETag, normalize = true, body }) {
+  const operationPath = 'move.setFinancialReviewFlag';
+  // What is the schemakey and normalize for?
+  return makeGHCRequest(
+    operationPath,
+    {
+      moveID,
+      'If-Match': ifMatchETag,
+      body,
+    },
+    { schemaKey: 'move', normalize },
+  );
+}

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -351,7 +351,7 @@ export async function getShipmentsPaymentSITBalance(key, paymentRequestID) {
   return makeGHCRequest('paymentRequests.getShipmentsPaymentSITBalance', { paymentRequestID });
 }
 
-export function updateFinancialFlag({ moveID, ifMatchETag, normalize = true, body }) {
+export function updateFinancialFlag({ moveID, ifMatchETag, body }) {
   const operationPath = 'move.setFinancialReviewFlag';
   // What is the schemakey and normalize for?
   return makeGHCRequest(
@@ -361,6 +361,6 @@ export function updateFinancialFlag({ moveID, ifMatchETag, normalize = true, bod
       'If-Match': ifMatchETag,
       body,
     },
-    { schemaKey: 'move', normalize },
+    { normalize: false },
   );
 }


### PR DESCRIPTION
## Description

This PR adds two components: FinancialReviewModal and FinancialReviewButton. These components are added in story book and and implemented for the services counselor. I also added a cypress test. This only covers being able to mark a move for financial review, and submitting the remarks. 

The edit button and saying no on the modal are still a work in progress. Screen shots are below.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

To view in storybook run: `make storybook`
To view in the office app locally:
* Navigate to the service counselor queue in the office app
* Select a move
* Click on the finanical review button
* Click yes on the modal and enter remarks. Hit save. 
* You should see the tag and a success banner.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* https://dp3.atlassian.net/browse/MB-9568
* https://dp3.atlassian.net/browse/MB-9670

## Screenshots
<img width="1217" alt="Screen Shot 2021-11-02 at 1 58 04 PM" src="https://user-images.githubusercontent.com/56279459/139943312-91963a1e-6e18-4996-9c44-3c65e31bacc4.png">
<img width="881" alt="Screen Shot 2021-11-02 at 1 57 59 PM" src="https://user-images.githubusercontent.com/56279459/139943321-159ae506-c910-401c-9a8d-94ad2c9e7215.png">
<img width="857" alt="Screen Shot 2021-11-02 at 1 57 53 PM" src="https://user-images.githubusercontent.com/56279459/139943328-7c8fadda-28be-4273-9ecb-fe64b337511c.png">
<img width="1055" alt="Screen Shot 2021-11-02 at 1 57 48 PM" src="https://user-images.githubusercontent.com/56279459/139943338-3f04351b-eebf-4847-b9aa-5ae34dabd517.png">


