### PR TITLE
MB-9785: Database updates for PO8

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -679,3 +679,4 @@
 20211004150738_loadtest_env.up.sql
 20211012105126_exp_dp3_cert_migration.up.sql
 20211015201518_financial_review_flag.up.sql
+20211101220502_add_nts_shipment_columns.up.sql

--- a/migrations/app/schema/20211101220502_add_nts_shipment_columns.up.sql
+++ b/migrations/app/schema/20211101220502_add_nts_shipment_columns.up.sql
@@ -1,0 +1,45 @@
+CREATE TABLE storage_facilities (
+	id uuid
+		CONSTRAINT storage_facilities_pkey PRIMARY KEY,
+	facility_name varchar(255) NOT NULL,
+	address_id uuid NOT NULL
+		CONSTRAINT storage_facilities_address_id_fkey REFERENCES addresses,
+	lot_number varchar(255),
+	phone varchar(255),
+	email varchar(255),
+	created_at timestamp NOT NULL,
+	updated_at timestamp NOT NULL
+
+);
+
+CREATE INDEX ON storage_facilities (address_id);
+
+ALTER TABLE orders
+	ADD COLUMN nts_tac varchar(255),
+	ADD COLUMN nts_sac varchar(255);
+
+ALTER TABLE mto_shipments
+	ADD COLUMN uses_external_vendor boolean DEFAULT false NOT NULL,
+	ADD COLUMN storage_facility_id uuid
+		CONSTRAINT mto_shipments_storage_facility_id_fkey REFERENCES storage_facilities,
+	ADD COLUMN service_order_number varchar(255);
+
+CREATE INDEX ON mto_shipments (storage_facility_id);
+
+COMMENT ON TABLE storage_facilities IS 'Storage facilities for NTS and NTS-Release shipments';
+COMMENT ON COLUMN storage_facilities.created_at IS 'Date & time the storage facility was created';
+COMMENT ON COLUMN storage_facilities.updated_at IS 'Date & time the storage facility was updated';
+COMMENT ON COLUMN storage_facilities.facility_name IS 'Name of storage facility';
+COMMENT ON COLUMN storage_facilities.address_id IS 'The address of the storage facility';
+COMMENT ON COLUMN storage_facilities.lot_number IS 'Lot number where goods are stored within the storage facility';
+COMMENT ON COLUMN storage_facilities.phone IS 'Phone number for contacting storage facility';
+COMMENT ON COLUMN storage_facilities.email IS 'Email address for contacting storage facility';
+
+COMMENT ON COLUMN orders.tac IS '(For HHG shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.';
+COMMENT ON COLUMN orders.sac IS '(For HHG shipments) Shipment Account Classification - used for accounting';
+COMMENT ON COLUMN orders.nts_tac IS '(For NTS shipments) Lines of accounting are specified on the customer''s move orders, issued by their branch of service, and indicate the exact accounting codes the service will use to pay for the move. The Transportation Ordering Officer adds this information to the MTO.';
+COMMENT ON COLUMN orders.nts_sac IS '(For NTS shipments) Shipment Account Classification - used for accounting';
+
+COMMENT ON COLUMN mto_shipments.uses_external_vendor IS 'Whether this shipment is handled by an external vendor, or by the prime';
+COMMENT ON COLUMN mto_shipments.storage_facility_id IS 'The storage facility for an NTS shipment where items are stored';
+COMMENT ON COLUMN mto_shipments.service_order_number IS 'The order number for a shipment in TOPS';

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -111,6 +111,10 @@ type MTOShipment struct {
 	RejectionReason                  *string           `db:"rejection_reason"`
 	Distance                         *unit.Miles       `db:"distance"`
 	Reweigh                          *Reweigh          `has_one:"reweighs" fk_id:"shipment_id"`
+	UsesExternalVendor               bool              `db:"uses_external_vendor"`
+	StorageFacility                  *StorageFacility  `belongs_to:"storage_facilities" fk:"storage_facility_id"`
+	StorageFacilityID                *uuid.UUID        `db:"storage_facility_id"`
+	ServiceOrderNumber               *string           `db:"service_order_number"`
 	CreatedAt                        time.Time         `db:"created_at"`
 	UpdatedAt                        time.Time         `db:"updated_at"`
 	DeletedAt                        *time.Time        `db:"deleted_at"`
@@ -150,6 +154,8 @@ func (m *MTOShipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	if m.SITDaysAllowance != nil {
 		vs = append(vs, &validators.IntIsGreaterThan{Field: *m.SITDaysAllowance, Compared: -1, Name: "SITDaysAllowance"})
 	}
+	vs = append(vs, &OptionalUUIDIsPresent{Field: m.StorageFacilityID, Name: "StorageFacilityID"})
+	vs = append(vs, &StringIsNilOrNotBlank{Field: m.ServiceOrderNumber, Name: "ServiceOrderNumber"})
 	return validate.Validate(vs...), nil
 }
 

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -53,6 +53,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		billableWeightCap := unit.Pound(-1)
 		billableWeightJustification := ""
 		sitDaysAllowance := -1
+		serviceOrderNumber := ""
 		invalidMTOShipment := models.MTOShipment{
 			MoveTaskOrderID:             uuid.Must(uuid.NewV4()),
 			Status:                      models.MTOShipmentStatusRejected,
@@ -61,6 +62,8 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			BillableWeightCap:           &billableWeightCap,
 			BillableWeightJustification: &billableWeightJustification,
 			SITDaysAllowance:            &sitDaysAllowance,
+			ServiceOrderNumber:          &serviceOrderNumber,
+			StorageFacilityID:           &uuid.Nil,
 		}
 		expErrors := map[string][]string{
 			"prime_estimated_weight":        {"-1000 is not greater than -1."},
@@ -69,6 +72,8 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 			"billable_weight_cap":           {"-1 is less than zero."},
 			"billable_weight_justification": {"BillableWeightJustification can not be blank."},
 			"sitdays_allowance":             {"-1 is not greater than -1."},
+			"service_order_number":          {"ServiceOrderNumber can not be blank."},
+			"storage_facility_id":           {"StorageFacilityID can not be blank."},
 		}
 		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
 	})

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -54,6 +54,8 @@ type Order struct {
 	Status                      OrderStatus                        `json:"status" db:"status"`
 	TAC                         *string                            `json:"tac" db:"tac"`
 	SAC                         *string                            `json:"sac" db:"sac"`
+	NtsTAC                      *string                            `json:"nts_tac" db:"nts_tac"`
+	NtsSAC                      *string                            `json:"nts_sac" db:"nts_sac"`
 	DepartmentIndicator         *string                            `json:"department_indicator" db:"department_indicator"`
 	Grade                       *string                            `json:"grade" db:"grade"`
 	Entitlement                 *Entitlement                       `belongs_to:"entitlements" fk_id:"entitlement_id"`
@@ -77,6 +79,8 @@ func (o *Order) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.StringIsPresent{Field: string(o.Status), Name: "Status"},
 		&StringIsNilOrNotBlank{Field: o.TAC, Name: "TransportationAccountingCode"},
 		&StringIsNilOrNotBlank{Field: o.SAC, Name: "SAC"},
+		&StringIsNilOrNotBlank{Field: o.NtsTAC, Name: "NtsTAC"},
+		&StringIsNilOrNotBlank{Field: o.NtsSAC, Name: "NtsSAC"},
 		&StringIsNilOrNotBlank{Field: o.DepartmentIndicator, Name: "DepartmentIndicator"},
 		&CannotBeTrueIfFalse{Field1: o.SpouseHasProGear, Name1: "SpouseHasProGear", Field2: o.HasDependents, Name2: "HasDependents"},
 		&OptionalUUIDIsPresent{Field: o.EntitlementID, Name: "EntitlementID"},

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -14,16 +14,25 @@ import (
 )
 
 func (suite *ModelSuite) TestBasicOrderInstantiation() {
-	order := &Order{}
+	order := &Order{
+		TAC:    swag.String(""),
+		SAC:    swag.String(""),
+		NtsTAC: swag.String(""),
+		NtsSAC: swag.String(""),
+	}
 
 	expErrors := map[string][]string{
-		"orders_type":         {"OrdersType can not be blank."},
-		"issue_date":          {"IssueDate can not be blank."},
-		"report_by_date":      {"ReportByDate can not be blank."},
-		"service_member_id":   {"ServiceMemberID can not be blank."},
-		"new_duty_station_id": {"NewDutyStationID can not be blank."},
-		"status":              {"Status can not be blank."},
-		"uploaded_orders_id":  {"UploadedOrdersID can not be blank."},
+		"orders_type":                    {"OrdersType can not be blank."},
+		"issue_date":                     {"IssueDate can not be blank."},
+		"report_by_date":                 {"ReportByDate can not be blank."},
+		"service_member_id":              {"ServiceMemberID can not be blank."},
+		"new_duty_station_id":            {"NewDutyStationID can not be blank."},
+		"status":                         {"Status can not be blank."},
+		"uploaded_orders_id":             {"UploadedOrdersID can not be blank."},
+		"transportation_accounting_code": {"TAC must be exactly 4 alphanumeric characters.", "TransportationAccountingCode can not be blank."},
+		"sac":                            {"SAC can not be blank."},
+		"nts_tac":                        {"NtsTAC can not be blank."},
+		"nts_sac":                        {"NtsSAC can not be blank."},
 	}
 
 	suite.verifyValidationErrors(order, expErrors)

--- a/pkg/models/storage_facility.go
+++ b/pkg/models/storage_facility.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
+)
+
+type StorageFacility struct {
+	ID           uuid.UUID `json:"id" db:"id"`
+	FacilityName string    `json:"facility_name" db:"facility_name"`
+	Address      Address   `belongs_to:"addresses" fk_id:"address_id"`
+	AddressID    uuid.UUID `json:"address_id" db:"address_id"`
+	LotNumber    *string   `json:"lot_number" db:"lot_number"`
+	Phone        *string   `json:"phone" db:"phone"`
+	Email        *string   `json:"email" db:"email"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
+}
+
+type StorageFacilities []StorageFacility
+
+func (f *StorageFacility) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.UUIDIsPresent{Field: f.AddressID, Name: "AddressID"},
+		&validators.StringIsPresent{Field: f.FacilityName, Name: "FacilityName"},
+		&StringIsNilOrNotBlank{Field: f.LotNumber, Name: "LotNumber"},
+		&StringIsNilOrNotBlank{Field: f.Phone, Name: "Phone"},
+		&StringIsNilOrNotBlank{Field: f.Email, Name: "Email"},
+	), nil
+}

--- a/pkg/models/storage_facility_test.go
+++ b/pkg/models/storage_facility_test.go
@@ -1,0 +1,39 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestStorageFacilityValidation() {
+	suite.T().Run("test valid StorageFacility", func(t *testing.T) {
+		validMTOShipment := models.StorageFacility{
+			FacilityName: "Test Storage Facility",
+			AddressID:    uuid.Must(uuid.NewV4()),
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validMTOShipment, expErrors)
+	})
+
+	suite.T().Run("test invalid StorageFacility", func(t *testing.T) {
+		lotNumber := ""
+		phone := ""
+		email := ""
+		invalidMTOShipment := models.StorageFacility{
+			LotNumber: &lotNumber,
+			Phone:     &phone,
+			Email:     &email,
+		}
+		expErrors := map[string][]string{
+			"address_id":    {"AddressID can not be blank."},
+			"facility_name": {"FacilityName can not be blank."},
+			"lot_number":    {"LotNumber can not be blank."},
+			"phone":         {"Phone can not be blank."},
+			"email":         {"Email can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidMTOShipment, expErrors)
+	})
+}


### PR DESCRIPTION
## Description

This pull request makes database changes for the work upcoming in product outcome 8 (NTS shipments). It adds a new table, `storage_facilities`, and adds columns to the `mto_shipments` and `orders` tables to store additional data around NTS shipments.

This is a direct port of work done in a previous [draft pull request](https://github.com/transcom/mymove/pull/7623); I've created a fresh PR since the copy of `master` on that branch was several weeks stale.

## Reviewer Notes

Check with the previous draft pull request to make sure the review comments are implemented, and that these changes adequately encapsulate all of the work we want for this upcoming product outcome. Ensure I didn't inadvertently break anything, because this is my first time playing with the DB on this project 😅 .

There should be no behavioral or UI changes as a result of this pull request.

## Setup

To create the migrations:

```sh
make db_dev_reset
make db_dev_migrate
```

To run the server tests:

```sh
make server_test
```

## Code Review Verification Steps

* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [x] Have been communicated to #g-database
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* Closes [MB-9875](https://dp3.atlassian.net/browse/MB-9785).
