### PR TITLE
MB-9940-get-appcontext-linter-running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,9 +80,14 @@ repos:
     hooks:
       - id: appcontext-linter
         name: appcontext-linter
-        entry: appcontext-linter
+        entry: go/bin/appcontext-linter
         files: \.go$
         language: golang
+        exclude: >
+          (?x)^(
+            pkg/models/|
+            pkg/appcontext/
+          )
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: appcontext-linter
+        name: appcontext-linter
+        entry: appcontext-linter
+        files: \.go$
+        language: golang
+
+  - repo: local
+    hooks:
       - id: eslint
         name: eslint
         entry: node_modules/.bin/eslint --ext .js,.jsx --max-warnings=0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,19 +78,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: appcontext-linter
-        name: appcontext-linter
-        entry: go/bin/appcontext-linter
-        files: \.go$
-        language: golang
-        exclude: >
-          (?x)^(
-            pkg/models/|
-            pkg/appcontext/
-          )
-
-  - repo: local
-    hooks:
       - id: eslint
         name: eslint
         entry: node_modules/.bin/eslint --ext .js,.jsx --max-warnings=0

--- a/pkg/appcontext-linter/appctx.go
+++ b/pkg/appcontext-linter/appctx.go
@@ -9,7 +9,7 @@ import (
 )
 
 var AppContextAnalyzer = &analysis.Analyzer{
-	Name:     "appcontext-lint",
+	Name:     "appcontextlint",
 	Doc:      "Make sure appContext is properly used throughout codebase",
 	Run:      run,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},

--- a/pkg/appcontext-linter/appctx.go
+++ b/pkg/appcontext-linter/appctx.go
@@ -48,7 +48,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				// Checking the fields of the structs
 				for _, structField := range structType.Fields.List {
 					if checkForPopConnection(structField) {
-						pass.Reportf(typeSpec.Pos(), "Please remove pop.Connection from the struct if not in models")
+						pass.Reportf(typeSpec.Pos(), "Please remove pop.Connection from the struct if not in appcontext")
 						continue
 					}
 				}

--- a/pkg/appcontext-linter/appctx.go
+++ b/pkg/appcontext-linter/appctx.go
@@ -26,6 +26,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	inspector.Preorder(nodeFilter, func(node ast.Node) {
 		file := node.(*ast.File)
 
+		if file.Name.Name == "appcontext" {
+			return
+		}
+
 		for _, node := range file.Decls {
 			t, ok := node.(*ast.GenDecl)
 			if !ok {
@@ -45,6 +49,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				for _, structField := range structType.Fields.List {
 					if checkForPopConnection(structField) {
 						pass.Reportf(typeSpec.Pos(), "Please remove pop.Connection from the struct if not in models")
+						continue
 					}
 				}
 
@@ -55,7 +60,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-// TODO: Add logic to check if it's in models, add logic to get it to run in circleCI and when run locally
+// TODO: Add logic to get it to run in circleCI and when run locally
 
 func checkForPopConnection(field *ast.Field) bool {
 	// Look for a type called StarExpr where pop Connection might be

--- a/testdata/src/appctx_linter_tests/appcontext.go
+++ b/testdata/src/appctx_linter_tests/appcontext.go
@@ -2,10 +2,6 @@ package appctx_linter_tests
 
 import pop "github.com/gobuffalo/pop/v5"
 
-//type pop struct {
-//	Connection string
-//}
-
 type AppContext struct {
 	ID          string
 	Elapsed     int64
@@ -14,7 +10,7 @@ type AppContext struct {
 }
 
 // Test pop connection in struct
-type TestAppContext struct { // want "Please remove pop.Connection from the struct if not in models"
+type TestAppContext struct { // want "Please remove pop.Connection from the struct if not in appcontext"
 	DB         *pop.Connection // Look for a field whose type is Connection
 	testString string
 }


### PR DESCRIPTION
## Description

This PR gets our appcontext linter running against all files. This linter can not be hooked up to-precommit yet because there is a PR to fix certain files that are erroneously passing in pop.connection to structs, and this linter would interfere with that work. 

However, this running and can be tested by running it against all files and making sure that it excludes files that should call `pop.conneciton`, while throwing an error in files that shouldn't be calling pop.connection.
## Reviewer Notes

The only file that should ignore this linter is pkg/appcontext/context.go

## Setup

To test that this linter works as expected run:

```sh
go run ./cmd/appcontext-linter/main.go -- ./...
```
This runs the linter against all files with the `-- ./...` flag

You will see messages for the files that are currently being fixed in @ahobson's PR. Note: You will see a lot of files that get caught by the linter, and this is okay.

To check that the file condition is working comment out the following in `pkg/appcontext-linter/appctx.go`:
```golang
		if file.Name.Name == "appcontext" {
			return
		}
```
Then rerun the linter: `go run ./cmd/appcontext-linter/main.go -- ./...`

You should now see that the error message pops up for the following file
```
/pkg/appcontext/context.go
```

This is good because it means that our condition works when it is uncommented! This should successfully indicate that our linter runs as expected.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9940) for this change

