### PR TITLE
MB-9944: Use ecs cloudwatch xray config for otel collector

### DIFF
--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -618,7 +618,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 				Image:     aws.String("amazon/aws-otel-collector"),
 				Essential: aws.Bool(true),
 				Command: aws.StringSlice([]string{
-					"--config=/etc/ecs/ecs-default-config.yaml",
+					"--config=/etc/ecs/ecs-cloudwatch-xray.yaml",
 				}),
 				LogConfiguration: &ecs.LogConfiguration{
 					LogDriver: aws.String("awslogs"),


### PR DESCRIPTION
## Description

Use the ECS config as suggested in the [aws otel docs](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/ecs-demo.md)

Seems promising, but it's unclear if this will be enough to fix the problem.

## Reviewer Notes

This ran in loadtest env over the weekend and still seems to be working well

