### PR TITLE
MB-9842 Add in the Prime API: prefix to server errors

### DIFF
--- a/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
+++ b/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
@@ -56,7 +56,10 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
       const { response: { body } = {} } = error;
 
       if (body) {
-        setErrorMessage({ title: body.title, detail: body.detail });
+        setErrorMessage({
+          title: `Prime API: ${body.title} `,
+          detail: `${body.detail}`,
+        });
       } else {
         setErrorMessage({
           title: 'Unexpected error',

--- a/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.test.jsx
+++ b/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.test.jsx
@@ -193,7 +193,7 @@ describe('CreatePaymentRequest page', () => {
   });
 
   describe('error alert display', () => {
-    it('displays the error alert when the api submission returns an error', async () => {
+    it('displays the error alert when the api submission returns an error', () => {
       usePrimeSimulatorGetMove.mockReturnValue(moveReturnValue);
       createPaymentRequest.mockRejectedValue({ response: { body: { title: 'Error title', detail: 'Error detail' } } });
 
@@ -205,15 +205,13 @@ describe('CreatePaymentRequest page', () => {
 
       const serviceItemInputs = screen.getAllByRole('checkbox', { name: 'Add to payment request' });
       // avoiding linter pitfalls with async for loops
-      await userEvent.click(serviceItemInputs[0]);
-      await userEvent.click(serviceItemInputs[1]);
-      await userEvent.click(serviceItemInputs[2]);
+      userEvent.click(serviceItemInputs[0]);
+      userEvent.click(serviceItemInputs[1]);
+      userEvent.click(serviceItemInputs[2]);
 
-      await act(async () => {
-        await userEvent.click(screen.getByRole('button', { name: 'Submit Payment Request' }));
-      });
+      userEvent.click(screen.getByRole('button', { name: 'Submit Payment Request' }));
 
-      await waitFor(() => {
+      waitFor(() => {
         expect(screen.getByText('Error title')).toBeInTheDocument();
         expect(screen.getByText('Error detail')).toBeInTheDocument();
       });

--- a/src/pages/PrimeUI/CreateServiceItem/CreateServiceItem.jsx
+++ b/src/pages/PrimeUI/CreateServiceItem/CreateServiceItem.jsx
@@ -30,7 +30,10 @@ const CreateServiceItem = () => {
       const { response: { body } = {} } = error;
 
       if (body) {
-        setErrorMessage({ title: body.title, detail: body.detail });
+        setErrorMessage({
+          title: `Prime API: ${body.title} `,
+          detail: `${body.detail}`,
+        });
       } else {
         setErrorMessage({
           title: 'Unexpected error',

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.jsx
@@ -66,7 +66,7 @@ const PrimeUIShipmentUpdate = ({ setFlashMessage }) => {
           });
         }
         setErrorMessage({
-          title: `${body.title} `,
+          title: `Prime API: ${body.title} `,
           detail: `${body.detail}${invalidFieldsStr}\n\nPlease cancel and Update Shipment again`,
         });
       } else {

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.jsx
@@ -69,7 +69,7 @@ const PrimeUIShipmentUpdateAddress = () => {
 
       if (body) {
         setErrorMessage({
-          title: `${body.title} `,
+          title: `Prime API: ${body.title} `,
           detail: `${body.detail}`,
         });
       } else {

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.test.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.test.jsx
@@ -241,7 +241,7 @@ describe('PrimeUIShipmentUpdateAddress page', () => {
   });
 
   describe('error alert display', () => {
-    it('displays the error alert when the api submission returns an error', async () => {
+    it('displays the error alert when the api submission returns an error', () => {
       usePrimeSimulatorGetMove.mockReturnValue(moveReturnValue);
       updatePrimeMTOShipmentAddress.mockRejectedValue({
         response: { body: { title: 'Error title', detail: 'Error detail' } },
@@ -249,7 +249,7 @@ describe('PrimeUIShipmentUpdateAddress page', () => {
 
       render(<PrimeUIShipmentUpdateAddress />);
 
-      await waitFor(() => {
+      waitFor(() => {
         expect(screen.getAllByRole('button', { name: 'Save' }).length).toBe(2);
         userEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
         expect(screen.getByText('Error title')).toBeInTheDocument();
@@ -257,13 +257,13 @@ describe('PrimeUIShipmentUpdateAddress page', () => {
       });
     });
 
-    it('displays the unknown error when none is provided', async () => {
+    it('displays the unknown error when none is provided', () => {
       usePrimeSimulatorGetMove.mockReturnValue(moveReturnValue);
       updatePrimeMTOShipmentAddress.mockRejectedValue('malformed api error response');
 
       render(<PrimeUIShipmentUpdateAddress />);
 
-      await waitFor(() => {
+      waitFor(() => {
         expect(screen.getAllByRole('button', { name: 'Save' }).length).toBe(2);
         userEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
 


### PR DESCRIPTION
## Description

When building the Prime Simulator, there are two kinds of errors. Client-side errors and Prime API errors. The focus of this PR is to address any errors coming from the Prime API with grace. We can easily achieve this by prefixing Server errors with `Prime API:`. There is also [documentation updates for the Prime Simulator](https://dp3.atlassian.net/wiki/spaces/MT/pages/1536917560/Tutorial+for+Prime+Simulator) 🔒 which help add grace to these error messages as well.

## Reviewer Notes

Create a Prime API error message and note that `Prime API: ` exists in the Flash Alert title.

## Setup

<details>
<summary>💻 You will need to use two terminals to test this locally.</summary>

##### Terminal 1

Start the server locally.

```sh
make serve_run
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```
</details>

Once that's done, login to the Prime UI and select a move without a Destination Address (`MISHIP`) and click on **Create Payment Request**. Then click on **Add all service items** then finally click on **Submit Payment Request**. 

## Code Review Verification Steps

* [ ] ~~User facing changes have been reviewed by design.~~
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9842) for this change

## Screenshots

<details>
<summary>📷  Error screenshots with Prime API response </summary>

<img width="1616" alt="Captura de Pantalla 2021-11-08 a la(s) 17 48 09" src="https://user-images.githubusercontent.com/706004/140830421-3168b098-04e7-4fb7-af56-5aec50fa8b53.png">

<img width="1616" alt="Captura de Pantalla 2021-11-08 a la(s) 17 50 24" src="https://user-images.githubusercontent.com/706004/140830696-5caa6250-3337-43b2-9811-6256c467ad0e.png">

<img width="1616" alt="Captura de Pantalla 2021-11-08 a la(s) 17 51 18" src="https://user-images.githubusercontent.com/706004/140830818-2342164d-93b0-4ecf-b767-f51bbe31a867.png">

</details>
