### PR TITLE
[MB-9924] Remove the “Do you know delivery address” question and always show the delivery address field for NTS-release shipment creation

### DIFF
--- a/cypress/integration/mymove/ntsr.js
+++ b/cypress/integration/mymove/ntsr.js
@@ -90,7 +90,12 @@ function customerCreatesAnNTSRShipment() {
   // pickup date
   cy.get('input[name="delivery.requestedDate"]').type('01/02/2020').blur();
 
-  // no delivery location
+  // delivery location
+  cy.get(`input[name="delivery.address.street_address_1"]`).type('412 Avenue M');
+  cy.get(`input[name="delivery.address.street_address_2"]`).type('#3E');
+  cy.get(`input[name="delivery.address.city"]`).type('Los Angeles');
+  cy.get(`select[name="delivery.address.state"]`).select('CA');
+  cy.get(`input[name="delivery.address.postal_code"]`).type('91111').blur();
 
   // receiving agent
   cy.get(`input[name="delivery.agent.firstName"]`).type('James');

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -139,6 +139,7 @@ class MtoShipmentForm extends Component {
     const shipmentType = mtoShipment.shipmentType || selectedMoveType;
     const { showDeliveryFields, showPickupFields, schema } = getShipmentOptions(shipmentType);
     const isNTS = shipmentType === SHIPMENT_OPTIONS.NTS;
+    const isNTSR = shipmentType === SHIPMENT_OPTIONS.NTSR;
     const shipmentNumber = shipmentType === SHIPMENT_OPTIONS.HHG ? this.getShipmentNumber() : null;
 
     const initialValues = formatMtoShipmentForDisplay(isCreatePage ? {} : mtoShipment);
@@ -230,7 +231,7 @@ class MtoShipmentForm extends Component {
 
                             <AddressFields
                               name="pickup.address"
-                              legend="Location"
+                              legend="Pickup location"
                               render={(fields) => (
                                 <>
                                   <p>What address are the movers picking up from?</p>
@@ -307,31 +308,33 @@ class MtoShipmentForm extends Component {
                               />
                             </Fieldset>
 
-                            <Fieldset legend="Location">
-                              <FormGroup>
-                                <p>Do you know your delivery address yet?</p>
-                                <div className={formStyles.radioGroup}>
-                                  <Field
-                                    as={Radio}
-                                    id="has-delivery-address"
-                                    label="Yes"
-                                    name="hasDeliveryAddress"
-                                    value="yes"
-                                    title="Yes, I know my delivery address"
-                                    checked={hasDeliveryAddress === 'yes'}
-                                  />
-                                  <Field
-                                    as={Radio}
-                                    id="no-delivery-address"
-                                    label="No"
-                                    name="hasDeliveryAddress"
-                                    value="no"
-                                    title="No, I do not know my delivery address"
-                                    checked={hasDeliveryAddress === 'no'}
-                                  />
-                                </div>
-                              </FormGroup>
-                              {hasDeliveryAddress === 'yes' ? (
+                            <Fieldset legend="Delivery location">
+                              {!isNTSR && (
+                                <FormGroup>
+                                  <p>Do you know your delivery address yet?</p>
+                                  <div className={formStyles.radioGroup}>
+                                    <Field
+                                      as={Radio}
+                                      id="has-delivery-address"
+                                      label="Yes"
+                                      name="hasDeliveryAddress"
+                                      value="yes"
+                                      title="Yes, I know my delivery address"
+                                      checked={hasDeliveryAddress === 'yes'}
+                                    />
+                                    <Field
+                                      as={Radio}
+                                      id="no-delivery-address"
+                                      label="No"
+                                      name="hasDeliveryAddress"
+                                      value="no"
+                                      title="No, I do not know my delivery address"
+                                      checked={hasDeliveryAddress === 'no'}
+                                    />
+                                  </div>
+                                </FormGroup>
+                              )}
+                              {hasDeliveryAddress === 'yes' || isNTSR ? (
                                 <AddressFields
                                   name="delivery.address"
                                   render={(fields) => (

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -63,7 +63,7 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByText('Date')[0]).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Preferred pickup date')).toBeInstanceOf(HTMLInputElement);
 
-      expect(screen.getAllByText('Location')[0]).toBeInstanceOf(HTMLLegendElement);
+      expect(screen.getByText('Pickup location')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Use my current address')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('Address 1')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText(/Address 2/)).toBeInstanceOf(HTMLInputElement);
@@ -84,7 +84,7 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByText('Date')[1]).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Preferred delivery date')).toBeInstanceOf(HTMLInputElement);
 
-      expect(screen.getAllByText('Location')[1]).toBeInstanceOf(HTMLLegendElement);
+      expect(screen.getByText('Delivery location')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByTitle('Yes, I know my delivery address')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByTitle('No, I do not know my delivery address')).toBeInstanceOf(HTMLInputElement);
 
@@ -737,7 +737,7 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getByText('Date')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Preferred pickup date')).toBeInstanceOf(HTMLInputElement);
 
-      expect(screen.getByText('Location')).toBeInstanceOf(HTMLLegendElement);
+      expect(screen.getByText('Pickup location')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Use my current address')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('Address 1')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText(/Address 2/)).toBeInstanceOf(HTMLInputElement);
@@ -752,7 +752,7 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'pickup.agent.email');
 
       expect(screen.getAllByText('Date')).toHaveLength(1);
-      expect(screen.getAllByText('Location')).toHaveLength(1);
+      expect(screen.getAllByText('Pickup location')).toHaveLength(1);
       expect(screen.queryByText(/Receiving agent/)).not.toBeInTheDocument();
 
       expect(
@@ -782,12 +782,12 @@ describe('MtoShipmentForm component', () => {
       expect(screen.queryByText(/Releasing agent/)).not.toBeInTheDocument();
 
       expect(screen.getAllByText('Date')).toHaveLength(1);
-      expect(screen.getAllByText('Location')).toHaveLength(1);
+      expect(screen.getAllByText('Delivery location')).toHaveLength(1);
 
       expect(screen.getByText('Date')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Preferred delivery date')).toBeInstanceOf(HTMLInputElement);
 
-      expect(screen.getByText('Location')).toBeInstanceOf(HTMLLegendElement);
+      expect(screen.getByText('Delivery location')).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('Yes')).toBeInstanceOf(HTMLInputElement);
       expect(screen.getByLabelText('No')).toBeInstanceOf(HTMLInputElement);
 

--- a/src/components/Customer/MtoShipmentForm/getShipmentOptions.js
+++ b/src/components/Customer/MtoShipmentForm/getShipmentOptions.js
@@ -20,7 +20,7 @@ const ntsShipmentSchema = Yup.object().shape({
 });
 
 const ntsReleaseShipmentSchema = Yup.object().shape({
-  delivery: OptionalPlaceSchema,
+  delivery: RequiredPlaceSchema,
   secondaryDelivery: AdditionalAddressSchema,
   customerRemarks: Yup.string(),
 });


### PR DESCRIPTION
## Description

- Remove "do you know your delivery address yet" question for NTS-R shipments on customer shipment addition page
- Make the delivery address required for NTS-R shipments
- Update the heading to be more specific (delivery or pickup location.)
- Update tests

## Reviewer Notes

Just double check that these changes are ok for all shipment types (I didn't introduce anything  unexpected to HHG shipment forms, for example.)

## Setup

```sh
make server_run
make client_run
```

The sixth test user from the bottom allows you to edit an HHG shipment and make NTS and NTS-release shipments. Then, create an NTS-release shipment and ensure that the delivery location form is always there.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9924) for this change

![Screen Shot 2021-11-09 at 1 28 06 PM](https://user-images.githubusercontent.com/3903208/140990866-0251dfea-4644-4ba4-ac93-79c879f12993.png)

