### PR TITLE
MB-9936 Added SC order updating functionality to ghc.yaml

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3274,13 +3274,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "maxLength": 4,
@@ -4555,13 +4555,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "x-nullable": true,
@@ -5540,13 +5540,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "maxLength": 4,
@@ -9897,13 +9897,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "maxLength": 4,
@@ -11178,13 +11178,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "x-nullable": true,
@@ -12169,13 +12169,13 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
-        "nts_sac": {
+        "ntsSac": {
           "type": "string",
           "title": "NTS SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
-        "nts_tac": {
+        "ntsTac": {
           "type": "string",
           "title": "NTS TAC",
           "maxLength": 4,

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3274,6 +3274,20 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "nts_sac": {
+          "type": "string",
+          "title": "NTS SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "nts_tac": {
+          "type": "string",
+          "title": "NTS TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
+        },
         "ordersType": {
           "$ref": "#/definitions/OrdersType"
         },
@@ -3288,6 +3302,20 @@ func init() {
           "format": "date",
           "title": "Report-by date",
           "example": "2018-04-26"
+        },
+        "sac": {
+          "type": "string",
+          "title": "HHG SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "tac": {
+          "type": "string",
+          "title": "HHG TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
         }
       }
     },
@@ -5512,6 +5540,20 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "nts_sac": {
+          "type": "string",
+          "title": "NTS SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "nts_tac": {
+          "type": "string",
+          "title": "NTS TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
+        },
         "ordersAcknowledgement": {
           "description": "Confirmation that the new amended orders were reviewed after previously approving the original orders",
           "type": "boolean",
@@ -5543,13 +5585,13 @@ func init() {
         },
         "sac": {
           "type": "string",
-          "title": "SAC",
+          "title": "HHG SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
         "tac": {
           "type": "string",
-          "title": "TAC",
+          "title": "HHG TAC",
           "maxLength": 4,
           "minLength": 4,
           "x-nullable": true,
@@ -9855,6 +9897,20 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "nts_sac": {
+          "type": "string",
+          "title": "NTS SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "nts_tac": {
+          "type": "string",
+          "title": "NTS TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
+        },
         "ordersType": {
           "$ref": "#/definitions/OrdersType"
         },
@@ -9869,6 +9925,20 @@ func init() {
           "format": "date",
           "title": "Report-by date",
           "example": "2018-04-26"
+        },
+        "sac": {
+          "type": "string",
+          "title": "HHG SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "tac": {
+          "type": "string",
+          "title": "HHG TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
         }
       }
     },
@@ -12099,6 +12169,20 @@ func init() {
           "format": "uuid",
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "nts_sac": {
+          "type": "string",
+          "title": "NTS SAC",
+          "x-nullable": true,
+          "example": "N002214CSW32Y9"
+        },
+        "nts_tac": {
+          "type": "string",
+          "title": "NTS TAC",
+          "maxLength": 4,
+          "minLength": 4,
+          "x-nullable": true,
+          "example": "F8J1"
+        },
         "ordersAcknowledgement": {
           "description": "Confirmation that the new amended orders were reviewed after previously approving the original orders",
           "type": "boolean",
@@ -12130,13 +12214,13 @@ func init() {
         },
         "sac": {
           "type": "string",
-          "title": "SAC",
+          "title": "HHG SAC",
           "x-nullable": true,
           "example": "N002214CSW32Y9"
         },
         "tac": {
           "type": "string",
-          "title": "TAC",
+          "title": "HHG TAC",
           "maxLength": 4,
           "minLength": 4,
           "x-nullable": true,

--- a/pkg/gen/ghcmessages/counseling_update_order_payload.go
+++ b/pkg/gen/ghcmessages/counseling_update_order_payload.go
@@ -33,6 +33,16 @@ type CounselingUpdateOrderPayload struct {
 	// Format: uuid
 	NewDutyStationID *strfmt.UUID `json:"newDutyStationId"`
 
+	// NTS SAC
+	// Example: N002214CSW32Y9
+	NtsSac *string `json:"nts_sac,omitempty"`
+
+	// NTS TAC
+	// Example: F8J1
+	// Max Length: 4
+	// Min Length: 4
+	NtsTac *string `json:"nts_tac,omitempty"`
+
 	// orders type
 	// Required: true
 	OrdersType *OrdersType `json:"ordersType"`
@@ -50,6 +60,16 @@ type CounselingUpdateOrderPayload struct {
 	// Required: true
 	// Format: date
 	ReportByDate *strfmt.Date `json:"reportByDate"`
+
+	// HHG SAC
+	// Example: N002214CSW32Y9
+	Sac *string `json:"sac,omitempty"`
+
+	// HHG TAC
+	// Example: F8J1
+	// Max Length: 4
+	// Min Length: 4
+	Tac *string `json:"tac,omitempty"`
 }
 
 // Validate validates this counseling update order payload
@@ -64,6 +84,10 @@ func (m *CounselingUpdateOrderPayload) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateNtsTac(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOrdersType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -73,6 +97,10 @@ func (m *CounselingUpdateOrderPayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReportByDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTac(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -102,6 +130,22 @@ func (m *CounselingUpdateOrderPayload) validateNewDutyStationID(formats strfmt.R
 	}
 
 	if err := validate.FormatOf("newDutyStationId", "body", "uuid", m.NewDutyStationID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *CounselingUpdateOrderPayload) validateNtsTac(formats strfmt.Registry) error {
+	if swag.IsZero(m.NtsTac) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 
@@ -150,6 +194,22 @@ func (m *CounselingUpdateOrderPayload) validateReportByDate(formats strfmt.Regis
 	}
 
 	if err := validate.FormatOf("reportByDate", "body", "date", m.ReportByDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *CounselingUpdateOrderPayload) validateTac(formats strfmt.Registry) error {
+	if swag.IsZero(m.Tac) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("tac", "body", *m.Tac, 4); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("tac", "body", *m.Tac, 4); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/counseling_update_order_payload.go
+++ b/pkg/gen/ghcmessages/counseling_update_order_payload.go
@@ -35,13 +35,13 @@ type CounselingUpdateOrderPayload struct {
 
 	// NTS SAC
 	// Example: N002214CSW32Y9
-	NtsSac *string `json:"nts_sac,omitempty"`
+	NtsSac *string `json:"ntsSac,omitempty"`
 
 	// NTS TAC
 	// Example: F8J1
 	// Max Length: 4
 	// Min Length: 4
-	NtsTac *string `json:"nts_tac,omitempty"`
+	NtsTac *string `json:"ntsTac,omitempty"`
 
 	// orders type
 	// Required: true
@@ -141,11 +141,11 @@ func (m *CounselingUpdateOrderPayload) validateNtsTac(formats strfmt.Registry) e
 		return nil
 	}
 
-	if err := validate.MinLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+	if err := validate.MinLength("ntsTac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 
-	if err := validate.MaxLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+	if err := validate.MaxLength("ntsTac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/order.go
+++ b/pkg/gen/ghcmessages/order.go
@@ -84,11 +84,11 @@ type Order struct {
 
 	// NTS SAC
 	// Example: N002214CSW32Y9
-	NtsSac *string `json:"nts_sac,omitempty"`
+	NtsSac *string `json:"ntsSac,omitempty"`
 
 	// NTS TAC
 	// Example: F8J1
-	NtsTac *string `json:"nts_tac,omitempty"`
+	NtsTac *string `json:"ntsTac,omitempty"`
 
 	// order number
 	// Example: 030-00362

--- a/pkg/gen/ghcmessages/update_order_payload.go
+++ b/pkg/gen/ghcmessages/update_order_payload.go
@@ -36,6 +36,16 @@ type UpdateOrderPayload struct {
 	// Format: uuid
 	NewDutyStationID *strfmt.UUID `json:"newDutyStationId"`
 
+	// NTS SAC
+	// Example: N002214CSW32Y9
+	NtsSac *string `json:"nts_sac,omitempty"`
+
+	// NTS TAC
+	// Example: F8J1
+	// Max Length: 4
+	// Min Length: 4
+	NtsTac *string `json:"nts_tac,omitempty"`
+
 	// Confirmation that the new amended orders were reviewed after previously approving the original orders
 	OrdersAcknowledgement *bool `json:"ordersAcknowledgement,omitempty"`
 
@@ -64,11 +74,11 @@ type UpdateOrderPayload struct {
 	// Format: date
 	ReportByDate *strfmt.Date `json:"reportByDate"`
 
-	// SAC
+	// HHG SAC
 	// Example: N002214CSW32Y9
 	Sac *string `json:"sac,omitempty"`
 
-	// TAC
+	// HHG TAC
 	// Example: F8J1
 	// Max Length: 4
 	// Min Length: 4
@@ -88,6 +98,10 @@ func (m *UpdateOrderPayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateNewDutyStationID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateNtsTac(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -154,6 +168,22 @@ func (m *UpdateOrderPayload) validateNewDutyStationID(formats strfmt.Registry) e
 	}
 
 	if err := validate.FormatOf("newDutyStationId", "body", "uuid", m.NewDutyStationID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *UpdateOrderPayload) validateNtsTac(formats strfmt.Registry) error {
+	if swag.IsZero(m.NtsTac) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/update_order_payload.go
+++ b/pkg/gen/ghcmessages/update_order_payload.go
@@ -38,13 +38,13 @@ type UpdateOrderPayload struct {
 
 	// NTS SAC
 	// Example: N002214CSW32Y9
-	NtsSac *string `json:"nts_sac,omitempty"`
+	NtsSac *string `json:"ntsSac,omitempty"`
 
 	// NTS TAC
 	// Example: F8J1
 	// Max Length: 4
 	// Min Length: 4
-	NtsTac *string `json:"nts_tac,omitempty"`
+	NtsTac *string `json:"ntsTac,omitempty"`
 
 	// Confirmation that the new amended orders were reviewed after previously approving the original orders
 	OrdersAcknowledgement *bool `json:"ordersAcknowledgement,omitempty"`
@@ -179,11 +179,11 @@ func (m *UpdateOrderPayload) validateNtsTac(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+	if err := validate.MinLength("ntsTac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 
-	if err := validate.MaxLength("nts_tac", "body", *m.NtsTac, 4); err != nil {
+	if err := validate.MaxLength("ntsTac", "body", *m.NtsTac, 4); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -736,6 +736,10 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 		suite.Equal(*body.IssueDate, ordersPayload.DateIssued)
 		suite.Equal(*body.ReportByDate, ordersPayload.ReportByDate)
 		suite.Equal(*body.OrdersType, ordersPayload.OrderType)
+		suite.Equal(body.Tac, ordersPayload.Tac)
+		suite.Equal(body.Sac, ordersPayload.Sac)
+		suite.Equal(body.NtsTac, ordersPayload.NtsTac)
+		suite.Equal(body.NtsSac, ordersPayload.NtsSac)
 	})
 
 	suite.Run("Returns a 403 when the user does not have Counselor role", func() {

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -265,6 +265,8 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 			OriginDutyStationID:   handlers.FmtUUID(originDutyStation.ID),
 			Tac:                   handlers.FmtString("E19A"),
 			Sac:                   handlers.FmtString("987654321"),
+			NtsTac:                handlers.FmtString("E19A"),
+			NtsSac:                handlers.FmtString("987654321"),
 			OrdersAcknowledgement: &ordersAcknowledgement,
 		}
 
@@ -305,6 +307,8 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 		suite.Equal(body.DepartmentIndicator, ordersPayload.DepartmentIndicator)
 		suite.Equal(body.Tac, ordersPayload.Tac)
 		suite.Equal(body.Sac, ordersPayload.Sac)
+		suite.Equal(body.NtsTac, ordersPayload.NtsTac)
+		suite.Equal(body.NtsSac, ordersPayload.NtsSac)
 		suite.NotNil(ordersPayload.AmendedOrdersAcknowledgedAt)
 
 		reloadErr := suite.DB().Reload(&move)
@@ -336,6 +340,8 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 			OriginDutyStationID:   handlers.FmtUUID(originDutyStation.ID),
 			Tac:                   handlers.FmtString("E19A"),
 			Sac:                   handlers.FmtString("987654321"),
+			NtsTac:                handlers.FmtString("E19A"),
+			NtsSac:                handlers.FmtString("987654321"),
 			OrdersAcknowledgement: &unacknowledgedOrders,
 		}
 
@@ -396,6 +402,8 @@ func (suite *HandlerSuite) makeUpdateOrderHandlerSubtestData() (subtestData *upd
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
 		Tac:                 handlers.FmtString("E19A"),
 		Sac:                 handlers.FmtString("987654321"),
+		NtsTac:              handlers.FmtString("E19A"),
+		NtsSac:              handlers.FmtString("987654321"),
 	}
 
 	return subtestData
@@ -447,6 +455,8 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 		suite.Equal(body.DepartmentIndicator, ordersPayload.DepartmentIndicator)
 		suite.Equal(body.Tac, ordersPayload.Tac)
 		suite.Equal(body.Sac, ordersPayload.Sac)
+		suite.Equal(body.NtsTac, ordersPayload.NtsTac)
+		suite.Equal(body.NtsSac, ordersPayload.NtsSac)
 	})
 
 	suite.Run("Returns a 403 when the user does not have TXO role", func() {
@@ -678,6 +688,10 @@ func (suite *HandlerSuite) makeCounselingUpdateOrderHandlerSubtestData() (subtes
 		OrdersType:          ghcmessages.NewOrdersType(ghcmessages.OrdersTypeRETIREMENT),
 		NewDutyStationID:    handlers.FmtUUID(destinationDutyStation.ID),
 		OriginDutyStationID: handlers.FmtUUID(originDutyStation.ID),
+		Tac:                 handlers.FmtString("E19A"),
+		Sac:                 handlers.FmtString("987654321"),
+		NtsTac:              handlers.FmtString("E19A"),
+		NtsSac:              handlers.FmtString("987654321"),
 	}
 
 	return subtestData

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -191,6 +191,15 @@ func orderFromTOOPayload(appCtx appcontext.AppContext, existingOrder models.Orde
 		order.TAC = &normalizedTac
 	}
 
+	if payload.NtsSac != nil {
+		order.NtsSAC = payload.NtsSac
+	}
+
+	if payload.NtsTac != nil {
+		normalizedNtsTac := strings.ToUpper(*payload.NtsTac)
+		order.NtsTAC = &normalizedNtsTac
+	}
+
 	if payload.OrdersType != nil {
 		order.OrdersType = internalmessages.OrdersType(*payload.OrdersType)
 	}
@@ -275,6 +284,24 @@ func orderFromCounselingPayload(existingOrder models.Order, payload ghcmessages.
 
 	if payload.OrdersType != nil {
 		order.OrdersType = internalmessages.OrdersType(*payload.OrdersType)
+	}
+
+	if payload.Sac != nil {
+		order.SAC = payload.Sac
+	}
+
+	if payload.Tac != nil {
+		normalizedTac := strings.ToUpper(*payload.Tac)
+		order.TAC = &normalizedTac
+	}
+
+	if payload.NtsSac != nil {
+		order.NtsSAC = payload.NtsSac
+	}
+
+	if payload.NtsTac != nil {
+		normalizedNtsTac := strings.ToUpper(*payload.NtsTac)
+		order.NtsTAC = &normalizedNtsTac
 	}
 
 	return order

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2697,6 +2697,30 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      tac:
+        type: string
+        title: HHG TAC
+        minLength: 4
+        maxLength: 4
+        example: 'F8J1'
+        x-nullable: true
+      sac:
+        type: string
+        title: HHG SAC
+        example: 'N002214CSW32Y9'
+        x-nullable: true
+      nts_tac:
+        type: string
+        title: NTS TAC
+        minLength: 4
+        maxLength: 4
+        example: 'F8J1'
+        x-nullable: true
+      nts_sac:
+        type: string
+        title: NTS SAC
+        example: 'N002214CSW32Y9'
+        x-nullable: true
     required:
       - issueDate
       - reportByDate
@@ -2737,14 +2761,26 @@ definitions:
         example: '030-00362'
       tac:
         type: string
-        title: TAC
+        title: HHG TAC
         minLength: 4
         maxLength: 4
         example: 'F8J1'
         x-nullable: true
       sac:
         type: string
-        title: SAC
+        title: HHG SAC
+        example: 'N002214CSW32Y9'
+        x-nullable: true
+      nts_tac:
+        type: string
+        title: NTS TAC
+        minLength: 4
+        maxLength: 4
+        example: 'F8J1'
+        x-nullable: true
+      nts_sac:
+        type: string
+        title: NTS SAC
         example: 'N002214CSW32Y9'
         x-nullable: true
       departmentIndicator:

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2651,12 +2651,12 @@ definitions:
         title: SAC
         example: 'N002214CSW32Y9'
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         example: 'F8J1'
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: 'N002214CSW32Y9'
@@ -2709,14 +2709,14 @@ definitions:
         title: HHG SAC
         example: 'N002214CSW32Y9'
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         minLength: 4
         maxLength: 4
         example: 'F8J1'
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: 'N002214CSW32Y9'
@@ -2771,14 +2771,14 @@ definitions:
         title: HHG SAC
         example: 'N002214CSW32Y9'
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         minLength: 4
         maxLength: 4
         example: 'F8J1'
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: 'N002214CSW32Y9'

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2781,6 +2781,30 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      tac:
+        type: string
+        title: HHG TAC
+        minLength: 4
+        maxLength: 4
+        example: F8J1
+        x-nullable: true
+      sac:
+        type: string
+        title: HHG SAC
+        example: N002214CSW32Y9
+        x-nullable: true
+      nts_tac:
+        type: string
+        title: NTS TAC
+        minLength: 4
+        maxLength: 4
+        example: F8J1
+        x-nullable: true
+      nts_sac:
+        type: string
+        title: NTS SAC
+        example: N002214CSW32Y9
+        x-nullable: true
     required:
       - issueDate
       - reportByDate
@@ -2821,14 +2845,26 @@ definitions:
         example: 030-00362
       tac:
         type: string
-        title: TAC
+        title: HHG TAC
         minLength: 4
         maxLength: 4
         example: F8J1
         x-nullable: true
       sac:
         type: string
-        title: SAC
+        title: HHG SAC
+        example: N002214CSW32Y9
+        x-nullable: true
+      nts_tac:
+        type: string
+        title: NTS TAC
+        minLength: 4
+        maxLength: 4
+        example: F8J1
+        x-nullable: true
+      nts_sac:
+        type: string
+        title: NTS SAC
         example: N002214CSW32Y9
         x-nullable: true
       departmentIndicator:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2733,12 +2733,12 @@ definitions:
         title: SAC
         example: N002214CSW32Y9
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         example: F8J1
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: N002214CSW32Y9
@@ -2793,14 +2793,14 @@ definitions:
         title: HHG SAC
         example: N002214CSW32Y9
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         minLength: 4
         maxLength: 4
         example: F8J1
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: N002214CSW32Y9
@@ -2855,14 +2855,14 @@ definitions:
         title: HHG SAC
         example: N002214CSW32Y9
         x-nullable: true
-      nts_tac:
+      ntsTac:
         type: string
         title: NTS TAC
         minLength: 4
         maxLength: 4
         example: F8J1
         x-nullable: true
-      nts_sac:
+      ntsSac:
         type: string
         title: NTS SAC
         example: N002214CSW32Y9


### PR DESCRIPTION
## Description

The API can be used to update TAC and SAC accounting codes and changes are saved to the database.

## Reviewer Notes

I'm not as familiar with the backend, so there may be something I missed. 

## Setup

Make sure data is up to date:

```
make db_dev_e2e_populate
```

Build and run the office app:

```
make server_run
make office_client_run
```

Run Postman with the `Updates an order (performed by a services counselor)` PATCH command and confirm that the move that is returned has the expected HHG_TAC, HHG_SAC, NTS_TAC, and NTS_SAC.

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9936) for this change