### PR TITLE
[MB-9796] Part 3: Insert non-installation locations into duty_stations

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -199,7 +199,7 @@ describe('TOO user', () => {
         .type('JB McGuire-Dix-Lakehurst')
         .get('[class*="-menu"]')
         .find('[class*="-option"]')
-        .eq(1)
+        .eq(3)
         .click(0, 0);
 
       cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -682,3 +682,4 @@
 20211101220502_add_nts_shipment_columns.up.sql
 20211109231452_create_zip_to_gbloc_table.up.sql
 20211112193224_support_noninstallation_locations.up.sql
+20211112205920_add_noninstallation_locations.up.sql

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -73,6 +73,10 @@ func FetchDSContactInfo(db *pop.Connection, dutyStationID *uuid.UUID) (*DutyStat
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
+			// This is temporary. Non-installation duty locations do not have transportation offices
+			// so we can't look up their contact information. This default here allows us to avoid
+			// crashing when we're generating notifications. In the future, we need to update all the
+			// text relating to transportation office contact info because it's not meaningful for most moves.
 			return &DutyStationTransportInfo{Name: "Unknown Office", PhoneLine: "555-555-5555"}, nil
 		default:
 			return nil, err

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -105,13 +105,18 @@ func FetchDutyStationByName(tx *pop.Connection, name string) (DutyStation, error
 func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
 
+	// There are several (35 out of 40874) non-installation locations that you can't find in the top 5
+	// search results for their ZIP code when sorted by similarity.
+	// I'm increasing the number of results from the duty_stations query from 5 to 11 to make
+	// sure everything is searchable.
+	// We should find a more elegant solution and bring this number back down.
 	sqlQuery := `
 with names as (
 (select id as duty_station_id, name, similarity(name, $1) as sim
 from duty_stations
 where similarity(name, $1) > 0.03
 order by sim desc
-limit 5)
+limit 11)
 union
 (select duty_station_id, name, similarity(name, $1) as sim
 from duty_station_names
@@ -124,7 +129,7 @@ from names n
 inner join duty_stations ds on n.duty_station_id = ds.id
 group by ds.id, ds.name, ds.affiliation, ds.address_id, ds.created_at, ds.updated_at, ds.transportation_office_id, ds.provides_services_counseling
 order by max(n.sim) desc, ds.name
-limit 7`
+limit 11`
 
 	query := tx.Q().RawQuery(sqlQuery, search)
 	if err := query.All(&stations); err != nil {


### PR DESCRIPTION
## Description
In this PR, we're adding non-installation duty locations to the `duty_stations` table.
There is a non-installation location for approximately every unique `(zip, city, state)` in the United States.
They come from [ZIP CODE TO GBLOC DATA](https://docs.google.com/spreadsheets/d/1CtE8bwOhVIFr2L0IEfOKWu72bVi6ISf2/). Note that we're using `PREFERRED LAST LINE CITY STATE NAME` for the city name, and not `CITY STATE NAME`. There are significantly more records in the data file than there are in our migration, as the data file includes multiple more granular place names for each `PREFERRED LAST LINE CITY STATE NAME`.

This will allow users to select non-installation locations by ZIP code.

However, the application doesn't fully support these locations yet because they don't have transportation offices.
I added kind of a hack to prevent things from crashing during onboarding (and a story to solve the issue in a better way), but until we update routing, the system won't know which GBLOC to use for moves originating from these locations.

This onboarding issue that I fixed happens because we try to look up contact information for the transportation office, which is `NULL`. This contact information gets included in notification messages. This contact information isn't really meaningful for non-installation moves, so I just included a placeholder for now.

Until we update routing, the system will also be unable to figure out what GBLOC to use for moves originating from these locations.

## Reviewer Notes
To generate the migration, I used [some SQL](https://gist.github.com/mboren/8bd3648878fb76d5a703ae5c703724cc) to load the CSV we were given into a temporary table and setup the new records we needed to add in other temporary tables. Then I used `pg_dump` on the new tables and did a little bit of cleanup to get a usable migration file.

Fun fact: I noticed that replacing the `created_at` and `updated_at` timestamps that we get from `pg_dump` with `NOW()` reduces the file size a lot and speeds up the migration by ~8%.

## Setup

Run migrations and make sure nothing breaks
```sh
make db_dev_migrate
```
Go through customer onboarding until you get to a duty station select box, try searching for some ZIP codes, and make sure you're getting what you would expect based on [ZIP CODE TO GBLOC DATA](https://docs.google.com/spreadsheets/d/1CtE8bwOhVIFr2L0IEfOKWu72bVi6ISf2/).
Select a non-installation location (something with a ZIP code in its name) for the origin duty location.
Finish onboarding and submit the move, just to make sure that nothing breaks.

### Check that the right duty locations provide services counseling
The most important thing to verify is that duty locations that provide services counseling are correct.
```sql
create view services_counseling_postal_codes as
select a.postal_code
from duty_stations
     join addresses a ON duty_stations.address_id = a.id
where affiliation is not null and provides_services_counseling;

-- Find non-installation locations that don't provide services counseling, and share a ZIP code with an installation location that provides services counseling
-- Should have zero results
select * from duty_stations
    join addresses a on duty_stations.address_id = a.id
where duty_stations.affiliation is null
  and duty_stations.provides_services_counseling is false
  and a.postal_code in
      (select * from services_counseling_postal_codes);

-- Find non-installation locations that provide services counseling, and share a ZIP code with an installation location that provides services counseling
-- Should have 95 results (1 more than the installation locations that provide services counseling because Tinker AFB and Oklahoma City share the same ZIP code)
select * from duty_stations
    join addresses a on duty_stations.address_id = a.id
where duty_stations.affiliation is null
  and duty_stations.provides_services_counseling
  and a.postal_code in
    (select * from services_counseling_postal_codes);

-- Find non-installation locations that provide services counseling, and don't share a ZIP code with an installation location that provides services counseling
-- Should have no results
select * from duty_stations
      join addresses a on duty_stations.address_id = a.id
where duty_stations.affiliation is null
  and duty_stations.provides_services_counseling
  and a.postal_code not in
      (select * from services_counseling_postal_codes);
```

### method for generating the migration
- Download this script: https://gist.github.com/mboren/8bd3648878fb76d5a703ae5c703724cc
- Download [ZIP CODE TO GBLOC DATA.csv](https://drive.google.com/file/d/1igfhDGe4rs-B2jOT2JpiVOmq-FNWW_Ly/view)
- Run the script
```sh
make db_dev_reset
make db_dev_migrate
psql --variable "ON_ERROR_STOP=1" postgres://postgres:mysecretpassword@localhost:5432/dev_db -f generate_non_installation_location_records.sql
```
This will create 3 new tables:
`temp_zip_to_gbloc`: this holds all the data from "ZIP TO GBLOC DATA.csv", with a few column names changed for convenience.
`temp_duty_stations`: holds all the non-installation duty locations that need to be created
`temp_addresses`: holds new addresses for the the new duty locations

To generate the migration in this PR, we just have to dump `temp_duty_stations` and `temp_addresses`
```sh
pg_dump -h localhost -U postgres dev_db --table temp_duty_stations -t temp_addresses --section=data > non_installation_duty_stations.sql
```
To transform this into the final migration, I removed the postgres config changes at the start of the file, removed the `temp_` prefix from  `temp_duty_stations` and `temp_addresses`, and replaced all the timestamps with `NOW()`
If you remove the UUIDs you should be able to diff this against my migration.


## Code Review Verification Steps

* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
* [ ] User facing changes have been reviewed by design.


## References

* [Jira story](https://dp3.atlassian.net/browse/MB-9796) for this change

## Screenshots
Here's a bunch of different search results, mostly based on stuff that was in the designs.
![image](https://user-images.githubusercontent.com/2627844/142294432-12f8e85d-f1dd-4947-82a5-de55b0bae08b.png)
![image](https://user-images.githubusercontent.com/2627844/142294449-4324d3ba-8fc5-4e8e-bf87-660a27c42bff.png)
![image](https://user-images.githubusercontent.com/2627844/142294480-7477ece8-c900-4523-8f61-104fcfbd5e2f.png)
![image](https://user-images.githubusercontent.com/2627844/142294515-2fc82065-5443-4d33-8d78-59b7751efcb4.png)
![image](https://user-images.githubusercontent.com/2627844/142294594-5026c3f8-df6a-4413-9af3-19a69c1cbff9.png)
![image](https://user-images.githubusercontent.com/2627844/142294632-0ccce825-d107-4942-b3e1-5b04bf32800c.png)
