### PR TITLE
MB-10097 (Frontend, SC) Service Counselor can't edit Customer Remarks

### DIFF
--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.jsx
@@ -14,6 +14,7 @@ import { SCRequestShipmentCancellationModal } from 'components/Office/ServicesCo
 import formStyles from 'styles/form.module.scss';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { Form } from 'components/form/Form';
+import DataTable from 'components/DataTable';
 import { DatePickerInput } from 'components/form/fields';
 import { AddressFields } from 'components/form/AddressFields/AddressFields';
 import { ContactInfoFields } from 'components/form/ContactInfoFields/ContactInfoFields';
@@ -94,6 +95,7 @@ const ServicesCounselingShipmentForm = ({
   const optionalLabel = <span className={formStyles.optional}>Optional</span>;
   const { moveCode } = match.params;
   const moveDetailsPath = generatePath(servicesCounselingRoutes.MOVE_VIEW_PATH, { moveCode });
+  const customerRemarksDisplay = mtoShipment.customerRemarks ? mtoShipment.customerRemarks : '-';
 
   const submitMTOShipment = ({
     shipmentOption,
@@ -346,19 +348,7 @@ const ServicesCounselingShipmentForm = ({
                     <h2>
                       Remarks <span className="float-right">{optionalLabel}</span>
                     </h2>
-                    <Label htmlFor="customerRemarks">Customer remarks</Label>
-                    <Hint>
-                      <p>500 characters</p>
-                    </Hint>
-                    <Field
-                      as={Textarea}
-                      data-testid="remarks"
-                      name="customerRemarks"
-                      className={`${formStyles.remarks}`}
-                      placeholder=""
-                      id="customerRemarks"
-                      maxLength={500}
-                    />
+                    <DataTable columnHeaders={['Customer remarks']} dataRow={[customerRemarksDisplay]} />
 
                     <Label htmlFor="counselorRemarks">Counselor remarks</Label>
                     <Hint>

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.module.scss
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.module.scss
@@ -47,4 +47,8 @@
   .buttonGroup {
     display: flex;
   }
+
+  table {
+    width: 100%;
+  }
 }

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.stories.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.stories.jsx
@@ -76,6 +76,11 @@ const mockMtoShipment = {
   },
 };
 
+const mockMtoShipmentNoCustomerRemarks = {
+  ...mockMtoShipment,
+  customerRemarks: '',
+};
+
 export default {
   title: 'Office Components / Forms / ServicesCounselingShipmentForm',
   component: ServicesCounselingShipmentForm,
@@ -94,5 +99,15 @@ export const EditHHGShipment = () => (
     selectedMoveType={SHIPMENT_OPTIONS.HHG}
     isCreatePage={false}
     mtoShipment={mockMtoShipment}
+  />
+);
+
+// edit shipment stories, no customer remarks (form should prefill)
+export const EditHHGShipmentNoCustRemarks = () => (
+  <ServicesCounselingShipmentForm
+    {...defaultProps}
+    selectedMoveType={SHIPMENT_OPTIONS.HHG}
+    isCreatePage={false}
+    mtoShipment={mockMtoShipmentNoCustomerRemarks}
   />
 );

--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
@@ -109,7 +109,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('Phone')[1]).toHaveAttribute('name', 'delivery.agent.phone');
       expect(screen.getAllByLabelText('Email')[1]).toHaveAttribute('name', 'delivery.agent.email');
 
-      expect(screen.getByLabelText('Customer remarks')).toBeInstanceOf(HTMLTextAreaElement);
+      expect(screen.getByText('Customer remarks')).toBeTruthy();
 
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);
 
@@ -193,7 +193,8 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getAllByLabelText('Last name')[1]).toHaveValue('Baker');
       expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('863-555-9664');
       expect(screen.getAllByLabelText('Email')[1]).toHaveValue('rbaker@email.com');
-      expect(screen.getByLabelText('Customer remarks')).toHaveValue('mock customer remarks');
+      expect(screen.getByText('Customer remarks')).toBeTruthy();
+      expect(screen.getByText('mock customer remarks')).toBeTruthy();
       expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');
     });
   });
@@ -223,7 +224,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.queryByText('Delivery location')).not.toBeInTheDocument();
       expect(screen.queryByText(/Receiving agent/)).not.toBeInTheDocument();
 
-      expect(screen.getByLabelText('Customer remarks')).toBeInstanceOf(HTMLTextAreaElement);
+      expect(screen.getByText('Customer remarks')).toBeTruthy();
 
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);
     });
@@ -260,7 +261,7 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getByLabelText('Phone')).toHaveAttribute('name', 'delivery.agent.phone');
       expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'delivery.agent.email');
 
-      expect(screen.getByLabelText('Customer remarks')).toBeInstanceOf(HTMLTextAreaElement);
+      expect(screen.getByText('Customer remarks')).toBeTruthy();
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);
 
       expect(
@@ -310,13 +311,12 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(defaultProps.history.push).not.toHaveBeenCalled();
     });
 
-    it('saves the update to the counselor and customer remarks when the save button is clicked', async () => {
+    it('saves the update to the counselor remarks when the save button is clicked', async () => {
       const newCounselorRemarks = 'Counselor remarks';
-      const newCustomerRemarks = 'Customer remarks';
 
       const expectedPayload = {
         body: {
-          customerRemarks: newCustomerRemarks,
+          customerRemarks: 'mock customer remarks',
           counselorRemarks: newCounselorRemarks,
           destinationAddress: {
             street_address_1: '441 SW Rio de la Plata Drive',
@@ -374,12 +374,6 @@ describe('ServicesCounselingShipmentForm component', () => {
           isCreatePage={false}
         />,
       );
-
-      const customerRemarks = await screen.findByLabelText('Customer remarks');
-
-      userEvent.clear(customerRemarks);
-
-      userEvent.type(customerRemarks, newCustomerRemarks);
 
       const counselorRemarks = await screen.findByLabelText('Counselor remarks');
 


### PR DESCRIPTION
## Description

Customer remarks aren’t editable when editing a shipment.

[Expected design](https://app.zeplin.io/project/6050d929f680860e968372c9/screen/60d4b8e7606309ba4cf52fee)

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Make sure data is up to date:

```
make db_dev_e2e_populate
```

Build and run the office app:

```
make server_run
make client_run
```
Log in as a Services Counselor and view a shipment. With customer remarks, the remarks should be visible. Without remarks there should be a dash.

To check storybook changes locally:

```
make storybook
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-10097) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
![Screen Shot 2021-11-16 at 1 29 59 PM](https://user-images.githubusercontent.com/1587316/142044416-4082cc98-912d-4cdf-9193-41796d6269cd.png)


