### PR TITLE
MB-9925 Move appcontext to be in request context

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -886,6 +886,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	root := mux.NewRouter()
 	root.Use(sessionCookieMiddleware)
 	root.Use(middleware.RequestLogger(logger))
+	root.Use(middleware.AppContextMiddleware(appCtx))
 
 	debug := root.PathPrefix("/debug/pprof/").Subrouter()
 	debug.Use(userAuthMiddleware)

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -556,7 +556,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	isLoggedInMiddleware := authentication.IsLoggedInMiddleware(logger)
 	clientCertMiddleware := authentication.ClientCertMiddleware(appCtx)
 
-	handlerContext := handlers.NewHandlerContext(appCtx)
+	handlerContext := handlers.NewHandlerContext()
 	handlerContext.SetSessionManagers(sessionManagers)
 	handlerContext.SetCookieSecret(clientAuthSecretKey)
 	handlerContext.SetUseSecureCookie(useSecureCookie)

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/handlers"
@@ -180,15 +182,16 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 		IDToken:         fakeToken,
 		Hostname:        OfficeTestHost,
 	}
-	ctx := auth.SetSessionInRequestContext(req, &session)
+
+	initialCtx := auth.SetSessionInRequestContext(req, &session)
+	ctx := appcontext.NewContext(initialCtx, suite.AppContextForTest())
+
 	req = req.WithContext(ctx)
 	sessionManagers := setupSessionManagers()
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := officeSession.LoadAndSave(NewLogoutHandler(authContext, context))
 
 	rr := httptest.NewRecorder()
@@ -388,9 +391,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateUser() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -436,9 +437,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 	officeSession := sessionManagers[2]
 	scsContext := setupScsSession(ctx, &session, officeSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -473,9 +472,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateOfficeUser() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -531,9 +528,7 @@ func (suite *AuthSuite) TestRedirectLoginGovErrorMsg() {
 	officeSession := sessionManagers[2]
 	scsContext := setupScsSession(ctx, &session, officeSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -598,9 +593,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
 	adminSession := sessionManagers[1]
 	scsContext := setupScsSession(ctx, &session, adminSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -645,9 +638,7 @@ func (suite *AuthSuite) TestAuthKnownServiceMember() {
 	milSession := sessionManagers[0]
 	scsContext := setupScsSession(ctx, &session, milSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -720,9 +711,7 @@ func (suite *AuthSuite) TestAuthUnknownServiceMember() {
 	)
 	mockSender := setUpMockNotificationSender() // We should get an email for this activity
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -810,9 +799,7 @@ func (suite *AuthSuite) TestAuthorizeDeactivateAdmin() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -850,9 +837,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDeactivated() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -889,9 +874,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeNotFound() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -939,9 +922,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
 	officeSession := sessionManagers[2]
 	scsContext := setupScsSession(ctx, &session, officeSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -981,9 +962,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDeactivated() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -1020,9 +999,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminNotFound() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -1068,9 +1045,7 @@ func (suite *AuthSuite) TestAuthorizeKnownUserAdminNotFound() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -1118,9 +1093,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminLogsIn() {
 	adminSession := sessionManagers[1]
 	scsContext := setupScsSession(ctx, &session, adminSession)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := CallbackHandler{
 		authContext,
 		context,
@@ -1164,9 +1137,7 @@ func (suite *AuthSuite) TestLoginGovAuthenticatedRedirect() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	h := RedirectHandler{
 		authContext,
 		context,

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -54,9 +54,7 @@ func (suite *AuthSuite) TestCreateUserHandlerMilMove() {
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateUserHandler(authContext, context, appnames)
 
@@ -96,9 +94,7 @@ func (suite *AuthSuite) TestCreateUserHandlerOffice() {
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateUserHandler(authContext, context, appnames)
 
@@ -173,9 +169,7 @@ func (suite *AuthSuite) TestCreateUserHandlerDPS() {
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateUserHandler(authContext, context, appnames)
 
@@ -223,7 +217,7 @@ func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 
 	appCtx := suite.AppContextForTest()
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := NewCreateUserHandler(authContext, context, appnames)
 
 	rr := httptest.NewRecorder()
@@ -282,9 +276,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 	rr := httptest.NewRecorder()
 	milSession.LoadAndSave(handler).ServeHTTP(rr, req.WithContext(ctx))
@@ -327,9 +319,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToOffice() {
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 
 	rr := httptest.NewRecorder()
@@ -365,9 +355,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToAdmin() {
 	adminSession := sessionManagers[1]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 
@@ -404,9 +392,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromOfficeToMilMove() {
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 
@@ -442,9 +428,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromOfficeToAdmin() {
 	sessionManagers := setupSessionManagers()
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 	adminSession := sessionManagers[1]
@@ -482,9 +466,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromAdminToMilMove() {
 	milSession := sessionManagers[0]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 
@@ -522,9 +504,7 @@ func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromAdminToOffice() {
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := NewCreateAndLoginUserHandler(authContext, context, appnames)
 

--- a/pkg/handlers/adminapi/access_code_test.go
+++ b/pkg/handlers/adminapi/access_code_test.go
@@ -48,10 +48,8 @@ func (suite *HandlerSuite) TestIndexAccessCodesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexAccessCodesHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			NewQueryFilter:        query.NewQueryFilter,
 			AccessCodeListFetcher: accesscode.NewAccessCodeListFetcher(queryBuilder),
 			NewPagination:         pagination.NewPagination,
@@ -83,10 +81,8 @@ func (suite *HandlerSuite) TestIndexAccessCodesHandler() {
 			mock.Anything,
 		).Return(nil, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexAccessCodesHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			NewQueryFilter:        newQueryFilter,
 			AccessCodeListFetcher: accessCodeListFetcher,
 			NewPagination:         pagination.NewPagination,

--- a/pkg/handlers/adminapi/admin_users_test.go
+++ b/pkg/handlers/adminapi/admin_users_test.go
@@ -48,10 +48,8 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexAdminUsersHandler{
-			HandlerContext:       handlers.NewHandlerContext(appCtx),
+			HandlerContext:       handlers.NewHandlerContext(),
 			NewQueryFilter:       query.NewQueryFilter,
 			AdminUserListFetcher: adminuser.NewAdminUserListFetcher(queryBuilder),
 			NewPagination:        pagination.NewPagination,
@@ -86,10 +84,8 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 			mock.Anything,
 		).Return(1, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexAdminUsersHandler{
-			HandlerContext:       handlers.NewHandlerContext(appCtx),
+			HandlerContext:       handlers.NewHandlerContext(),
 			NewQueryFilter:       newQueryFilter,
 			AdminUserListFetcher: adminUserListFetcher,
 			NewPagination:        pagination.NewPagination,
@@ -121,10 +117,8 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexAdminUsersHandler{
-			HandlerContext:       handlers.NewHandlerContext(appCtx),
+			HandlerContext:       handlers.NewHandlerContext(),
 			NewQueryFilter:       newQueryFilter,
 			AdminUserListFetcher: adminUserListFetcher,
 			NewPagination:        pagination.NewPagination,
@@ -164,10 +158,8 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminuser.NewAdminUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -194,10 +186,8 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 			mock.Anything,
 		).Return(adminUser, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserFetcher,
 			newQueryFilter,
 		}
@@ -221,10 +211,8 @@ func (suite *HandlerSuite) TestGetAdminUserHandler() {
 			mock.Anything,
 		).Return(models.AdminUser{}, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserFetcher,
 			newQueryFilter,
 		}
@@ -273,10 +261,8 @@ func (suite *HandlerSuite) TestCreateAdminUserHandler() {
 			&adminUser,
 			mock.Anything).Return(&adminUser, nil, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserCreator,
 			newQueryFilter,
 		}
@@ -293,10 +279,8 @@ func (suite *HandlerSuite) TestCreateAdminUserHandler() {
 			&adminUser,
 			mock.Anything).Return(&adminUser, nil, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserCreator,
 			newQueryFilter,
 		}
@@ -334,10 +318,8 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 			params.AdminUser,
 		).Return(&adminUser, nil, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserUpdater,
 			newQueryFilter,
 		}
@@ -355,10 +337,8 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 			params.AdminUser,
 		).Return(&adminUser, nil, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateAdminUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			adminUserUpdater,
 			newQueryFilter,
 		}
@@ -376,10 +356,8 @@ func (suite *HandlerSuite) TestUpdateAdminUserHandler() {
 		params.AdminUser,
 	).Return(nil, err, nil).Once()
 
-	appCtx := suite.AppContextForTest()
-
 	handler := UpdateAdminUserHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		adminUserUpdater,
 		newQueryFilter,
 	}

--- a/pkg/handlers/adminapi/electronic_orders_test.go
+++ b/pkg/handlers/adminapi/electronic_orders_test.go
@@ -38,10 +38,8 @@ func (suite *HandlerSuite) TestGetElectronicOrdersTotalsHandler() {
 			mock.Anything,
 		).Return(map[interface{}]int{models.IssuerArmy: 2}, nil)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetElectronicOrdersTotalsHandler{
-			HandlerContext:                      handlers.NewHandlerContext(appCtx),
+			HandlerContext:                      handlers.NewHandlerContext(),
 			ElectronicOrderCategoryCountFetcher: electronicOrderCategoryCountFetcher,
 			NewQueryFilter:                      newQueryFilter,
 		}
@@ -65,10 +63,8 @@ func (suite *HandlerSuite) TestGetElectronicOrdersTotalsHandler() {
 			mock.Anything,
 		).Return(nil, err)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetElectronicOrdersTotalsHandler{
-			HandlerContext:                      handlers.NewHandlerContext(appCtx),
+			HandlerContext:                      handlers.NewHandlerContext(),
 			ElectronicOrderCategoryCountFetcher: electronicOrderCategoryCountFetcher,
 			NewQueryFilter:                      newQueryFilter,
 		}

--- a/pkg/handlers/adminapi/moves_test.go
+++ b/pkg/handlers/adminapi/moves_test.go
@@ -41,10 +41,8 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexMovesHandler{
-			HandlerContext:  handlers.NewHandlerContext(appCtx),
+			HandlerContext:  handlers.NewHandlerContext(),
 			NewQueryFilter:  query.NewQueryFilter,
 			MoveListFetcher: move.NewMoveListFetcher(queryBuilder),
 			NewPagination:   pagination.NewPagination,
@@ -73,10 +71,8 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 			mock.Anything,
 		).Return(nil, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexMovesHandler{
-			HandlerContext:  handlers.NewHandlerContext(appCtx),
+			HandlerContext:  handlers.NewHandlerContext(),
 			NewQueryFilter:  newQueryFilter,
 			MoveListFetcher: moveListFetcher,
 			NewPagination:   pagination.NewPagination,
@@ -105,10 +101,8 @@ func (suite *HandlerSuite) TestUpdateMoveHandler() {
 	builder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 
-	appCtx := suite.AppContextForTest()
-
 	handler := UpdateMoveHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		movetaskorder.NewMoveTaskOrderUpdater(
 			builder,
 			mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter),
@@ -172,10 +166,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			MoveID:      *handlers.FmtUUID(defaultMove.ID),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 		}
 
 		response := handler.Handle(params)
@@ -193,10 +185,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			MoveID:      *handlers.FmtUUID(badUUID),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 		}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/adminapi/notifications_test.go
+++ b/pkg/handlers/adminapi/notifications_test.go
@@ -42,10 +42,8 @@ func (suite *HandlerSuite) TestIndexNotificationsHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexNotificationsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -82,10 +80,8 @@ func (suite *HandlerSuite) TestIndexNotificationsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexNotificationsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    listFetcher,
 			NewPagination:  pagination.NewPagination,

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -55,10 +55,8 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOfficeUsersHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -85,10 +83,8 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOfficeUsersHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewQueryFilter: query.NewQueryFilter,
 			NewPagination:  pagination.NewPagination,
@@ -125,10 +121,8 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetOfficeUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			officeuser.NewOfficeUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -152,10 +146,8 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetOfficeUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			officeuser.NewOfficeUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -179,10 +171,8 @@ func (suite *HandlerSuite) TestGetOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetOfficeUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			officeuser.NewOfficeUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -239,10 +229,8 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateOfficeUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -279,10 +267,8 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateOfficeUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			officeuser.NewOfficeUserCreator(queryBuilder, suite.TestNotificationSender()),
 			query.NewQueryFilter,
 			usersroles.NewUsersRolesCreator(),
@@ -296,10 +282,8 @@ func (suite *HandlerSuite) TestCreateOfficeUserHandler() {
 func (suite *HandlerSuite) TestUpdateOfficeUserHandler() {
 	mockUpdater := mocks.OfficeUserUpdater{}
 
-	appCtx := suite.AppContextForTest()
-
 	handler := UpdateOfficeUserHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		&mockUpdater,
 		query.NewQueryFilter,
 		usersroles.NewUsersRolesCreator(), // a special can of worms, TODO mocked tests

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -40,10 +40,8 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOfficesHandler{
-			HandlerContext:    handlers.NewHandlerContext(appCtx),
+			HandlerContext:    handlers.NewHandlerContext(),
 			NewQueryFilter:    query.NewQueryFilter,
 			OfficeListFetcher: office.NewOfficeListFetcher(queryBuilder),
 			NewPagination:     pagination.NewPagination,
@@ -78,10 +76,8 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.Anything,
 		).Return(1, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOfficesHandler{
-			HandlerContext:    handlers.NewHandlerContext(appCtx),
+			HandlerContext:    handlers.NewHandlerContext(),
 			NewQueryFilter:    newQueryFilter,
 			OfficeListFetcher: officeListFetcher,
 			NewPagination:     pagination.NewPagination,
@@ -113,10 +109,8 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOfficesHandler{
-			HandlerContext:    handlers.NewHandlerContext(appCtx),
+			HandlerContext:    handlers.NewHandlerContext(),
 			NewQueryFilter:    newQueryFilter,
 			OfficeListFetcher: officeListFetcher,
 			NewPagination:     pagination.NewPagination,

--- a/pkg/handlers/adminapi/organizations_test.go
+++ b/pkg/handlers/adminapi/organizations_test.go
@@ -41,10 +41,8 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOrganizationsHandler{
-			HandlerContext:          handlers.NewHandlerContext(appCtx),
+			HandlerContext:          handlers.NewHandlerContext(),
 			NewQueryFilter:          query.NewQueryFilter,
 			OrganizationListFetcher: organization2.NewOrganizationListFetcher(queryBuilder),
 			NewPagination:           pagination.NewPagination,
@@ -79,10 +77,8 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 			mock.Anything,
 		).Return(1, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOrganizationsHandler{
-			HandlerContext:          handlers.NewHandlerContext(appCtx),
+			HandlerContext:          handlers.NewHandlerContext(),
 			NewQueryFilter:          newQueryFilter,
 			OrganizationListFetcher: organizationListFetcher,
 			NewPagination:           pagination.NewPagination,
@@ -115,10 +111,8 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexOrganizationsHandler{
-			HandlerContext:          handlers.NewHandlerContext(appCtx),
+			HandlerContext:          handlers.NewHandlerContext(),
 			NewQueryFilter:          newQueryFilter,
 			OrganizationListFetcher: organizationListFetcher,
 			NewPagination:           pagination.NewPagination,

--- a/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
@@ -50,10 +50,8 @@ func (suite *HandlerSuite) TestIndexTSPPsHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexTSPPsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			TransportationServiceProviderPerformanceListFetcher: tsp.NewTransportationServiceProviderPerformanceListFetcher(queryBuilder),
 			NewPagination: pagination.NewPagination,
@@ -88,10 +86,8 @@ func (suite *HandlerSuite) TestIndexTSPPsHandler() {
 			mock.Anything,
 		).Return(1, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexTSPPsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			TransportationServiceProviderPerformanceListFetcher: ListFetcher,
 			NewPagination: pagination.NewPagination,
@@ -119,10 +115,8 @@ func (suite *HandlerSuite) TestIndexTSPPsHandler() {
 			mock.Anything,
 		).Return(nil, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexTSPPsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			TransportationServiceProviderPerformanceListFetcher: ListFetcher,
 			NewPagination: pagination.NewPagination,
@@ -161,10 +155,8 @@ func (suite *HandlerSuite) TestGetTSPPHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetTSPPHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			TransportationServiceProviderPerformanceFetcher: tsp.NewTransportationServiceProviderPerformanceFetcher(queryBuilder),
 		}
@@ -191,10 +183,8 @@ func (suite *HandlerSuite) TestGetTSPPHandler() {
 			mock.Anything,
 		).Return(tspp, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetTSPPHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			TransportationServiceProviderPerformanceFetcher: Fetcher,
 		}
@@ -218,10 +208,8 @@ func (suite *HandlerSuite) TestGetTSPPHandler() {
 			mock.Anything,
 		).Return(models.TransportationServiceProviderPerformance{}, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetTSPPHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			TransportationServiceProviderPerformanceFetcher: Fetcher,
 		}

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -81,10 +81,8 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 
 		uploadInformationFetcher := upload.NewUploadInformationFetcher()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUploadHandler{
-			HandlerContext:           handlers.NewHandlerContext(appCtx),
+			HandlerContext:           handlers.NewHandlerContext(),
 			UploadInformationFetcher: uploadInformationFetcher,
 		}
 
@@ -108,10 +106,8 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 			mock.Anything,
 		).Return(uploaded, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUploadHandler{
-			HandlerContext:           handlers.NewHandlerContext(appCtx),
+			HandlerContext:           handlers.NewHandlerContext(),
 			UploadInformationFetcher: uploadInformationFetcher,
 		}
 
@@ -134,10 +130,8 @@ func (suite *HandlerSuite) TestGetUploadHandler() {
 			mock.Anything,
 		).Return(services.UploadInformation{}, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUploadHandler{
-			HandlerContext:           handlers.NewHandlerContext(appCtx),
+			HandlerContext:           handlers.NewHandlerContext(),
 			UploadInformationFetcher: uploadInformationFetcher,
 		}
 

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -72,10 +72,8 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			userservice.NewUserFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -102,10 +100,8 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 			mock.Anything,
 		).Return(user, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			userFetcher,
 			newQueryFilter,
 		}
@@ -129,10 +125,8 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 			mock.Anything,
 		).Return(models.User{}, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetUserHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			userFetcher,
 			newQueryFilter,
 		}
@@ -172,10 +166,8 @@ func (suite *HandlerSuite) TestIndexUsersHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexUsersHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -212,10 +204,8 @@ func (suite *HandlerSuite) TestIndexUsersHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexUsersHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    userListFetcher,
 			NewPagination:  pagination.NewPagination,
@@ -243,9 +233,7 @@ func (suite *HandlerSuite) TestUpdateUserHandler() {
 	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
 	sessionManagers := setupSessionManagers()
 
-	appCtx := suite.AppContextForTest()
-
-	handlerContext := handlers.NewHandlerContext(appCtx)
+	handlerContext := handlers.NewHandlerContext()
 	handlerContext.SetSessionManagers(sessionManagers)
 	queryBuilder := query.NewQueryBuilder()
 	officeUpdater := officeuser.NewOfficeUserUpdater(queryBuilder)

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -40,9 +40,9 @@ func (suite *HandlerSuite) TestIndexWebhookSubscriptionsHandler() {
 			HTTPRequest: req,
 		}
 		queryBuilder := query.NewQueryBuilder()
-		appCtx := suite.AppContextForTest()
+
 		handler := IndexWebhookSubscriptionsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: query.NewQueryFilter,
 			ListFetcher:    fetch.NewListFetcher(queryBuilder),
 			NewPagination:  pagination.NewPagination,
@@ -85,10 +85,8 @@ func (suite *HandlerSuite) TestIndexWebhookSubscriptionsHandler() {
 			mock.Anything,
 		).Return(0, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := IndexWebhookSubscriptionsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			NewQueryFilter: newQueryFilter,
 			ListFetcher:    webhookSubscriptionListFetcher,
 			NewPagination:  pagination.NewPagination,
@@ -117,10 +115,8 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhooksubscriptionservice.NewWebhookSubscriptionFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -154,10 +150,8 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 			mock.Anything,
 		).Return(models.WebhookSubscription{}, expectedError).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhookSubscriptionFetcher,
 			query.NewQueryFilter,
 		}
@@ -198,10 +192,8 @@ func (suite *HandlerSuite) TestCreateWebhookSubscriptionHandler() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	handler := CreateWebhookSubscriptionHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		webhooksubscription.NewWebhookSubscriptionCreator(queryBuilder),
 		query.NewQueryFilter,
 	}
@@ -253,10 +245,8 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -293,10 +283,8 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -340,10 +328,8 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
@@ -369,10 +355,8 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateWebhookSubscriptionHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -62,7 +62,6 @@ type FeatureFlag struct {
 
 // A single handlerContext is passed to each handler
 type handlerContext struct {
-	appCtx                appcontext.AppContext
 	cookieSecret          string
 	planner               route.Planner
 	ghcPlanner            route.Planner
@@ -80,16 +79,14 @@ type handlerContext struct {
 	sessionManagers       [3]*scs.SessionManager
 }
 
-// NewHandlerContext returns a new handlerContext with its required private fields set.
-func NewHandlerContext(appCtx appcontext.AppContext) HandlerContext {
-	return &handlerContext{
-		appCtx: appCtx,
-	}
+// NewHandlerContext returns a new handlerContext
+func NewHandlerContext() HandlerContext {
+	return &handlerContext{}
 }
 
 // AppContextFromRequest builds an AppContext from the http request
 func (hctx *handlerContext) AppContextFromRequest(r *http.Request) appcontext.AppContext {
-	return appcontext.NewAppContextFromContext(r.Context(), hctx.appCtx)
+	return appcontext.FromContext(r.Context())
 }
 
 // FileStorer returns the storage to use in the current context

--- a/pkg/handlers/dpsapi/authentication_test.go
+++ b/pkg/handlers/dpsapi/authentication_test.go
@@ -19,7 +19,7 @@ import (
 func (suite *HandlerSuite) TestGetUserHandler() {
 	appCtx := suite.AppContextForTest()
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetIWSPersonLookup(iws.TestingPersonLookup{})
 	dpsParams := dpsauth.Params{
 		CookieSecret:  []byte("cookie secret"),

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -34,9 +34,7 @@ func (suite *HandlerSuite) AfterTest() {
 }
 
 func (suite *HandlerSuite) createHandlerContext() handlers.HandlerContext {
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -26,9 +26,7 @@ func (suite *HandlerSuite) TestGetCustomerHandlerIntegration() {
 		CustomerID:  strfmt.UUID(customer.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetCustomerHandler{
 		context,
 		customerservice.NewCustomerFetcher(),
@@ -80,9 +78,7 @@ func (suite *HandlerSuite) TestUpdateCustomerHandler() {
 		Body:        body,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := UpdateCustomerHandler{
 		context,
 		customerservice.NewCustomerUpdater(),

--- a/pkg/handlers/ghcapi/documents_test.go
+++ b/pkg/handlers/ghcapi/documents_test.go
@@ -33,9 +33,7 @@ func (suite *HandlerSuite) TestGetDocumentHandler() {
 	req = suite.AuthenticateRequest(req, document.ServiceMember)
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := GetDocumentHandler{context}

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -63,9 +63,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 		MoveTaskOrderID: moveTaskOrder.ID.String(),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMoveTaskOrderHandler{
 		context,
 		movetaskorder.NewMoveTaskOrderFetcher(),
@@ -123,9 +121,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 			ServiceItemCodes: &serviceItemCodes,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter()
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
@@ -191,9 +187,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 		IfMatch:         etag.GenerateEtag(time.Now()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	// Stale ETags are already unit tested in the move_task_order_updater_test,
 	// so we can mock this here to speed up the test and avoid hitting the DB
@@ -230,9 +224,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
@@ -266,9 +258,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
@@ -356,9 +346,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -44,10 +44,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	suite.T().Run("Successful move fetch", func(t *testing.T) {
 		mockFetcher := mocks.MoveFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			MoveFetcher:    &mockFetcher,
 		}
 
@@ -78,10 +76,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	suite.T().Run("Unsuccessful move fetch - empty string bad request", func(t *testing.T) {
 		mockFetcher := mocks.MoveFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			MoveFetcher:    &mockFetcher,
 		}
 
@@ -92,10 +88,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	suite.T().Run("Unsuccessful move fetch - locator not found", func(t *testing.T) {
 		mockFetcher := mocks.MoveFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			MoveFetcher:    &mockFetcher,
 		}
 
@@ -112,10 +106,8 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	suite.T().Run("Unsuccessful move fetch - internal server error", func(t *testing.T) {
 		mockFetcher := mocks.MoveFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetMoveHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			MoveFetcher:    &mockFetcher,
 		}
 
@@ -151,10 +143,8 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 	suite.T().Run("Successful flag", func(t *testing.T) {
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := SetFinancialReviewFlagHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -179,10 +169,8 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 		}
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := SetFinancialReviewFlagHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 
@@ -192,10 +180,8 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 	suite.T().Run("Unsuccessful flag - move not found", func(t *testing.T) {
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := SetFinancialReviewFlagHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -211,10 +197,8 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 	suite.T().Run("Unsuccessful flag - internal server error", func(t *testing.T) {
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := SetFinancialReviewFlagHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",
@@ -231,10 +215,8 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 	suite.T().Run("Unsuccessful flag - bad etag", func(t *testing.T) {
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := SetFinancialReviewFlagHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
 		mockFlagSetter.On("SetFinancialReviewFlag",

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -40,10 +40,8 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 			mock.Anything,
 		).Return(nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOAgentsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			ListFetcher:    listFetcher,
 		}
 
@@ -66,10 +64,8 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 			mock.Anything,
 		).Return(errors.New("an error happened")).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOAgentsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			ListFetcher:    listFetcher,
 		}
 		response := handler.Handle(params)
@@ -92,10 +88,8 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 			mock.Anything,
 		).Return(models.ErrFetchNotFound).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOAgentsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 			ListFetcher:    listFetcher,
 		}
 		response := handler.Handle(params)

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -62,10 +62,8 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 		listFetcher := fetch.NewListFetcher(queryBuilder)
 		fetcher := fetch.NewFetcher(queryBuilder)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOServiceItemsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			listFetcher,
 			fetcher,
 		}
@@ -82,10 +80,8 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOServiceItemsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}
@@ -115,10 +111,8 @@ func (suite *HandlerSuite) TestListMTOServiceItemHandler() {
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOServiceItemsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}
@@ -173,10 +167,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(errors.New("Not found error")).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 		}
@@ -201,10 +193,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(&models.MTOServiceItem{ID: serviceItemID}, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 		}
@@ -229,10 +219,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil, apperror.NewPreconditionFailedError(serviceItemID, errors.New("oh no"))).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 		}
@@ -257,10 +245,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil, errors.New("oh no")).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 		}
@@ -278,10 +264,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 			mock.Anything,
 		).Return(nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: &serviceItemStatusUpdater,
 			Fetcher:               &fetcher,
 		}
@@ -313,10 +297,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		mtoServiceItemStatusUpdater := mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: mtoServiceItemStatusUpdater,
 			Fetcher:               fetcher,
 		}
@@ -353,10 +335,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 		fetcher := fetch.NewFetcher(queryBuilder)
 		mtoServiceItemStatusUpdater := mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOServiceItemStatusHandler{
-			HandlerContext:        handlers.NewHandlerContext(appCtx),
+			HandlerContext:        handlers.NewHandlerContext(),
 			MTOServiceItemUpdater: mtoServiceItemStatusUpdater,
 			Fetcher:               fetcher,
 		}

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -143,10 +143,8 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		mtoServiceItem := subtestData.mtoServiceItem
 		sitExtension := subtestData.sitExtension
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			mtoshipment.NewMTOShipmentFetcher(),
 			mtoshipment.NewShipmentSITStatus(),
 		}
@@ -186,10 +184,8 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		params := subtestData.params
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			mockMTOShipmentFetcher,
 			mtoshipment.NewShipmentSITStatus(),
 		}
@@ -207,10 +203,8 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 
 		mockMTOShipmentFetcher := &mocks.MTOShipmentFetcher{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			mockMTOShipmentFetcher,
 			mtoshipment.NewShipmentSITStatus(),
 		}
@@ -233,8 +227,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := DeleteShipmentHandler{
 			handlerContext,
@@ -258,8 +252,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := DeleteShipmentHandler{
 			handlerContext,
@@ -284,8 +278,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := DeleteShipmentHandler{
 			handlerContext,
@@ -309,8 +303,8 @@ func (suite *HandlerSuite) TestDeleteShipmentHandler() {
 
 		req := httptest.NewRequest("DELETE", fmt.Sprintf("/shipments/%s", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := DeleteShipmentHandler{
 			handlerContext,
@@ -368,8 +362,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		handler := ApproveShipmentHandler{
@@ -398,8 +392,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -426,8 +420,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -454,8 +448,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -482,8 +476,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -510,8 +504,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -538,8 +532,8 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentHandler{
 			handlerContext,
@@ -575,8 +569,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		handler := RequestShipmentDiversionHandler{
@@ -605,8 +599,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -633,8 +627,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -661,8 +655,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -689,8 +683,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -717,8 +711,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -745,8 +739,8 @@ func (suite *HandlerSuite) TestRequestShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentDiversionHandler{
 			handlerContext,
@@ -783,8 +777,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		handler := ApproveShipmentDiversionHandler{
@@ -813,8 +807,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -841,8 +835,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -869,8 +863,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -897,8 +891,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -925,8 +919,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -953,8 +947,8 @@ func (suite *HandlerSuite) TestApproveShipmentDiversionHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/approve-diversion", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveShipmentDiversionHandler{
 			handlerContext,
@@ -989,8 +983,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		handler := RejectShipmentHandler{
@@ -1023,8 +1017,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1055,8 +1049,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1087,8 +1081,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1119,8 +1113,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1151,8 +1145,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1183,8 +1177,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1218,8 +1212,8 @@ func (suite *HandlerSuite) TestRejectShipmentHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/reject", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RejectShipmentHandler{
 			handlerContext,
@@ -1257,8 +1251,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		handler := RequestShipmentCancellationHandler{
@@ -1287,8 +1281,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1315,8 +1309,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1343,8 +1337,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1371,8 +1365,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1399,8 +1393,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1427,8 +1421,8 @@ func (suite *HandlerSuite) TestRequestShipmentCancellationHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-cancellation", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := RequestShipmentCancellationHandler{
 			handlerContext,
@@ -1461,8 +1455,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 		handlerContext.SetNotificationSender(suite.TestNotificationSender())
 		planner := &routemocks.Planner{}
@@ -1516,8 +1510,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", uuid.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		planner := &routemocks.Planner{}
 		planner.On("TransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -1560,8 +1554,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		planner := &routemocks.Planner{}
 		planner.On("TransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -1605,8 +1599,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		planner := &routemocks.Planner{}
 		planner.On("TransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -1651,8 +1645,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		planner := &routemocks.Planner{}
 		planner.On("TransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -1696,8 +1690,8 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/request-reweigh", shipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		planner := &routemocks.Planner{}
 		planner.On("TransitDistance",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -1755,8 +1749,8 @@ func (suite *HandlerSuite) TestApproveSITExtensionHandler() {
 		sitExtensionApprover := mtoshipment.NewSITExtensionApprover(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/approve", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := ApproveSITExtensionHandler{
 			handlerContext,
@@ -1805,8 +1799,8 @@ func (suite *HandlerSuite) TestDenySITExtensionHandler() {
 		sitExtensionDenier := mtoshipment.NewSITExtensionDenier(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/deny", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := DenySITExtensionHandler{
 			handlerContext,
@@ -1842,8 +1836,8 @@ func (suite *HandlerSuite) CreateSITExtensionAsTOO() {
 		sitExtensionCreatorAsTOO := mtoshipment.NewCreateSITExtensionAsTOO()
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/sit-extension/", mtoShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := CreateSITExtensionAsTOOHandler{
 			handlerContext,
@@ -1888,8 +1882,8 @@ func (suite *HandlerSuite) CreateSITExtensionAsTOO() {
 		sitExtensionCreatorAsTOO := mtoshipment.NewCreateSITExtensionAsTOO()
 		req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/sit-extension/", mtoShipment.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 
 		handler := CreateSITExtensionAsTOOHandler{
 			handlerContext,
@@ -1982,8 +1976,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("Successful POST - Integration Test", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2010,8 +2004,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("POST failure - 500", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2039,8 +2033,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("POST failure - 422 -- Bad agent IDs set on shipment", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2073,8 +2067,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("POST failure - 422 - invalid input, missing pickup address", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2104,8 +2098,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("POST failure - 404 -- not found", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2130,8 +2124,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	suite.Run("POST failure - 400 -- nil body", func() {
 		// Set the traceID so we can use it to find the webhook notification
-		appCtx := suite.AppContextForTest()
-		handlerContext := handlers.NewHandlerContext(appCtx)
+
+		handlerContext := handlers.NewHandlerContext()
 		handlerContext.SetTraceID(uuid.Must(uuid.NewV4()))
 
 		subtestData := suite.makeCreateMTOShipmentSubtestData()
@@ -2245,10 +2239,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockSender := suite.TestNotificationSender()
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, paymentRequestShipmentRecalculator)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoshipment.NewShipmentSITStatus(),
@@ -2292,10 +2284,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockSender := suite.TestNotificationSender()
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, paymentRequestShipmentRecalculator)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoshipment.NewShipmentSITStatus(),
@@ -2320,10 +2310,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockSender := suite.TestNotificationSender()
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, paymentRequestShipmentRecalculator)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoshipment.NewShipmentSITStatus(),
@@ -2352,10 +2340,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockSender := suite.TestNotificationSender()
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, paymentRequestShipmentRecalculator)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoshipment.NewShipmentSITStatus(),
@@ -2383,10 +2369,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockSender := suite.TestNotificationSender()
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, paymentRequestShipmentRecalculator)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoshipment.NewShipmentSITStatus(),
@@ -2413,10 +2397,8 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mockUpdater := mocks.MTOShipmentUpdater{}
 		fetcher := fetch.NewFetcher(builder)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			&mockUpdater,
 			mtoshipment.NewShipmentSITStatus(),

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -44,9 +44,7 @@ func (suite *HandlerSuite) TestGetOrderHandlerIntegration() {
 		HTTPRequest: request,
 		OrderID:     strfmt.UUID(order.ID.String()),
 	}
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetOrdersHandler{
 		context,
 		orderservice.NewOrderFetcher(),
@@ -100,9 +98,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		orderFetcher.On("FetchOrder", mock.AnythingOfType("*appcontext.appContext"),
 			order.ID).Return(&order, nil)
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetOrdersHandler{
 			context,
 			&orderFetcher,
@@ -142,9 +138,7 @@ func (suite *HandlerSuite) TestWeightAllowances() {
 		orderFetcher.On("FetchOrder", mock.AnythingOfType("*appcontext.appContext"),
 			order.ID).Return(&order, nil)
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetOrdersHandler{
 			context,
 			&orderFetcher,
@@ -411,9 +405,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -458,9 +450,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have TXO role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -496,9 +486,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	// be authorized to update orders. If not, we also need to prevent them from
 	// clicking the Edit Orders button in the frontend.
 	suite.Run("Allows a TIO to update orders", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		move := subtestData.move
 		order := subtestData.order
@@ -531,9 +519,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -564,9 +550,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -597,9 +581,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -652,9 +634,7 @@ func (suite *HandlerSuite) TestUpdateOrderEventTrigger() {
 	updater.On("UpdateOrderAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, *params.Body, params.IfMatch).Return(&order, move.ID, nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := UpdateOrderHandler{
 		context,
 		updater,
@@ -707,9 +687,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	request := httptest.NewRequest("PATCH", "/counseling/orders/{orderID}", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -747,9 +725,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have Counselor role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -781,9 +757,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -813,9 +787,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -845,9 +817,7 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -960,9 +930,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/allowances", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1003,9 +971,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1037,9 +1003,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1069,9 +1033,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1101,9 +1063,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1155,9 +1115,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceEventTrigger() {
 	updater.On("UpdateAllowanceAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, *params.Body, params.IfMatch).Return(&order, move.ID, nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := UpdateAllowanceHandler{
 		context,
 		updater,
@@ -1199,9 +1157,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	request := httptest.NewRequest("PATCH", "/counseling/orders/{orderID}/allowances", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		order := move.Orders
 
@@ -1240,9 +1196,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have Counselor role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		order := move.Orders
 
@@ -1273,9 +1227,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		order := move.Orders
 
@@ -1304,9 +1256,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		order := move.Orders
 
@@ -1335,9 +1285,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		order := move.Orders
 
@@ -1370,9 +1318,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/update-max-billable-weight/tio", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1406,9 +1352,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have TIO role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1439,9 +1383,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1473,9 +1415,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1507,9 +1447,7 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1545,9 +1483,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	request := httptest.NewRequest("PATCH", "/orders/{orderID}/update-billable-weight", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1581,9 +1517,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1614,9 +1548,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1647,9 +1579,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1680,9 +1610,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
 		order := subtestData.order
 		body := subtestData.body
@@ -1736,9 +1664,7 @@ func (suite *HandlerSuite) TestUpdateBillableWeightEventTrigger() {
 	updater.On("UpdateBillableWeightAsTOO", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, dbAuthorizedWeight, params.IfMatch).Return(&order, move.ID, nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := UpdateBillableWeightHandler{
 		context,
 		updater,
@@ -1763,9 +1689,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	request := httptest.NewRequest("POST", "/orders/{orderID}/acknowledge-excess-weight-risk", nil)
 
 	suite.Run("Returns 200 when all validations pass", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		now := time.Now()
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{ExcessWeightQualifiedAt: &now},
@@ -1798,9 +1722,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		now := time.Now()
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{ExcessWeightQualifiedAt: &now},
@@ -1830,9 +1752,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		now := time.Now()
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{ExcessWeightQualifiedAt: &now},
@@ -1863,9 +1783,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 412 when eTag does not match", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		now := time.Now()
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{ExcessWeightQualifiedAt: &now},
@@ -1896,9 +1814,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 	})
 
 	suite.Run("Returns 422 when updater service returns validation errors", func() {
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		now := time.Now()
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{ExcessWeightQualifiedAt: &now},
@@ -1951,9 +1867,7 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskEventTrigger() {
 	updater.On("AcknowledgeExcessWeightRisk", mock.AnythingOfType("*appcontext.appContext"),
 		order.ID, params.IfMatch).Return(&move, nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := AcknowledgeExcessWeightRiskHandler{
 		context,
 		updater,

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -57,10 +57,8 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetPaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentrequest.NewPaymentRequestFetcher(),
 		}
 		response := handler.Handle(params)
@@ -99,10 +97,8 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetPaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestFetcher,
 		}
 		response := handler.Handle(params)
@@ -123,10 +119,8 @@ func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := GetPaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestFetcher,
 		}
 		response := handler.Handle(params)
@@ -164,9 +158,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 			Locator:     move.Locator,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerContext:            context,
 			PaymentRequestListFetcher: paymentrequest.NewPaymentRequestListFetcher(),
@@ -203,9 +195,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 			Locator:     "ABC123",
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerContext:            context,
 			PaymentRequestListFetcher: paymentRequestListFetcher,
@@ -229,9 +219,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 			Locator:     "ABC123",
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetPaymentRequestForMoveHandler{
 			HandlerContext:            context,
 			PaymentRequestListFetcher: paymentRequestListFetcher,
@@ -275,10 +263,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -308,10 +294,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: statusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -350,10 +334,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 				PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 			}
 
-			appCtx := suite.AppContextForTest()
-
 			handler := UpdatePaymentRequestStatusHandler{
-				HandlerContext:              handlers.NewHandlerContext(appCtx),
+				HandlerContext:              handlers.NewHandlerContext(),
 				PaymentRequestStatusUpdater: statusUpdater,
 				PaymentRequestFetcher:       paymentRequestFetcher,
 			}
@@ -386,10 +368,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -424,10 +404,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(availablePaymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -459,10 +437,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -491,10 +467,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -523,10 +497,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -555,10 +527,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -722,10 +692,8 @@ func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
 			PaymentRequestID: strfmt.UUID(pendingPaymentRequest.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ShipmentsSITBalanceHandler{
-			HandlerContext:             handlers.NewHandlerContext(appCtx),
+			HandlerContext:             handlers.NewHandlerContext(),
 			ShipmentsPaymentSITBalance: paymentrequest.NewPaymentRequestShipmentsSITBalance(),
 		}
 
@@ -760,10 +728,8 @@ func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ShipmentsSITBalanceHandler{
-			HandlerContext:             handlers.NewHandlerContext(appCtx),
+			HandlerContext:             handlers.NewHandlerContext(),
 			ShipmentsPaymentSITBalance: paymentrequest.NewPaymentRequestShipmentsSITBalance(),
 		}
 
@@ -783,10 +749,8 @@ func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ShipmentsSITBalanceHandler{
-			HandlerContext:             handlers.NewHandlerContext(appCtx),
+			HandlerContext:             handlers.NewHandlerContext(),
 			ShipmentsPaymentSITBalance: paymentrequest.NewPaymentRequestShipmentsSITBalance(),
 		}
 

--- a/pkg/handlers/ghcapi/payment_service_items_test.go
+++ b/pkg/handlers/ghcapi/payment_service_items_test.go
@@ -61,10 +61,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 	suite.Run("Successful patch - Approval - Integration Test", func() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		suite.NoError(subtestData.params.Body.Validate(strfmt.Default))
@@ -78,10 +76,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 	suite.Run("404 - Integration Test", func() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.PaymentServiceItemID = uuid.Nil.String()
@@ -95,10 +91,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 	suite.Run("422 - Fails to reject without rejectionReason - Integration Test", func() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 
@@ -114,10 +108,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 		subtestData := suite.makeUpdatePaymentSubtestData()
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.IfMatch = etag.GenerateEtag(paymentServiceItem.UpdatedAt)
@@ -142,10 +134,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 			},
 		})
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		subtestData.params.IfMatch = etag.GenerateEtag(deniedPaymentServiceItem.UpdatedAt)
@@ -182,10 +172,8 @@ func (suite *HandlerSuite) TestUpdatePaymentServiceItemHandler() {
 			},
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentServiceItemStatusHandler{
-			HandlerContext:                  handlers.NewHandlerContext(appCtx),
+			HandlerContext:                  handlers.NewHandlerContext(),
 			PaymentServiceItemStatusUpdater: paymentServiceItemService.NewPaymentServiceItemStatusUpdater(),
 		}
 		traceID, err := uuid.NewV4()

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -68,9 +68,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandler() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -126,9 +124,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerMoveInfo() {
 			HTTPRequest: request,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := GetMovesQueueHandler{
 			context,
 			&orderFetcher,
@@ -185,9 +181,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesBranchFilter() {
 		Branch:      models.StringPointer("AIR_FORCE"),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -257,9 +251,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerStatuses() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -375,9 +367,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerFilters() {
 	request := httptest.NewRequest("GET", "/queues/moves", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -581,9 +571,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerCustomerInfoFilters() {
 	request := httptest.NewRequest("GET", "/queues/moves", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -698,9 +686,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedRole() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -724,9 +710,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerUnauthorizedUser() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -768,9 +752,7 @@ func (suite *HandlerSuite) TestGetMoveQueuesHandlerEmptyResults() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMovesQueueHandler{
 		context,
 		order.NewOrderFetcher(),
@@ -829,9 +811,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetPaymentRequestsQueueHandler{
 		context,
 		paymentrequest.NewPaymentRequestListFetcher(),
@@ -885,9 +865,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueSubmittedAtFilter() {
 	request := httptest.NewRequest("GET", "/queues/payment-requests", nil)
 	request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetPaymentRequestsQueueHandler{
 		context,
 		paymentrequest.NewPaymentRequestListFetcher(),
@@ -953,9 +931,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerUnauthorizedRole() 
 		PerPage:     swag.Int64(1),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetPaymentRequestsQueueHandler{
 		context,
 		paymentrequest.NewPaymentRequestListFetcher(),
@@ -984,9 +960,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerServerError() {
 		PerPage:     swag.Int64(1),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetPaymentRequestsQueueHandler{
 		context,
 		&paymentRequestListFetcher,
@@ -1015,9 +989,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandlerEmptyResults() {
 		PerPage:     swag.Int64(1),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetPaymentRequestsQueueHandler{
 		context,
 		&paymentRequestListFetcher,
@@ -1152,9 +1124,7 @@ func (suite *HandlerSuite) makeServicesCounselingSubtestData() (subtestData *ser
 	request := httptest.NewRequest("GET", "/queues/counseling", nil)
 	subtestData.request = suite.AuthenticateOfficeRequest(request, officeUser)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	subtestData.handler = GetServicesCounselingQueueHandler{
 		context,
 		order.NewOrderFetcher(),

--- a/pkg/handlers/ghcapi/tac_test.go
+++ b/pkg/handlers/ghcapi/tac_test.go
@@ -33,9 +33,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 				Tac:         tc.tacCode,
 			}
 
-			appCtx := suite.AppContextForTest()
-
-			context := handlers.NewHandlerContext(appCtx)
+			context := handlers.NewHandlerContext()
 			handler := TacValidationHandler{context}
 			response := handler.Handle(params)
 
@@ -55,9 +53,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 			Tac:         tac,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := TacValidationHandler{context}
 		response := handler.Handle(params)
 
@@ -75,9 +71,7 @@ func (suite *HandlerSuite) TestTacValidation() {
 			Tac:         tac,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		handler := TacValidationHandler{context}
 		response := handler.Handle(params)
 

--- a/pkg/handlers/internalapi/access_code_test.go
+++ b/pkg/handlers/internalapi/access_code_test.go
@@ -39,9 +39,7 @@ func (suite *HandlerSuite) TestFetchAccessCodeHandler_Success() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFeatureFlag(
 		handlers.FeatureFlag{Name: cli.FeatureFlagAccessCode, Active: true},
 	)
@@ -75,9 +73,7 @@ func (suite *HandlerSuite) TestFetchAccessCodeHandler_Failure() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFeatureFlag(
 		handlers.FeatureFlag{Name: cli.FeatureFlagAccessCode, Active: true},
 	)
@@ -106,9 +102,7 @@ func (suite *HandlerSuite) TestFetchAccessCodeHandler_FeatureFlagIsOff() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFeatureFlag(
 		handlers.FeatureFlag{Name: cli.FeatureFlagAccessCode, Active: false},
 	)
@@ -141,9 +135,7 @@ func (suite *HandlerSuite) TestValidateAccessCodeHandler_Valid() {
 		Code:        &fullCode,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	accessCodeValidator := &mocks.AccessCodeValidator{}
 	accessCodeValidator.On("ValidateAccessCode",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -188,9 +180,7 @@ func (suite *HandlerSuite) TestValidateAccessCodeHandler_Invalid() {
 		Code:        &fullCode,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	accessCodeValidator := &mocks.AccessCodeValidator{}
 	accessCodeValidator.On("ValidateAccessCode",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -238,9 +228,7 @@ func (suite *HandlerSuite) TestClaimAccessCodeHandler_Success() {
 		ClaimedAt:       &claimedAt,
 		ServiceMemberID: &serviceMember.ID,
 	}
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	accessCodeClaimer := &mocks.AccessCodeClaimer{}
 	accessCodeClaimer.On("ClaimAccessCode",
 		mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/handlers/internalapi/addresses_test.go
+++ b/pkg/handlers/internalapi/addresses_test.go
@@ -57,9 +57,7 @@ func (suite *HandlerSuite) TestShowAddressHandler() {
 				AddressID:   *handlers.FmtUUID(ts.ID),
 			}
 
-			appCtx := suite.AppContextForTest()
-
-			handler := ShowAddressHandler{handlers.NewHandlerContext(appCtx)}
+			handler := ShowAddressHandler{handlers.NewHandlerContext()}
 			res := handler.Handle(params)
 
 			response := res.(*addressop.ShowAddressOK)

--- a/pkg/handlers/internalapi/backup_contacts_test.go
+++ b/pkg/handlers/internalapi/backup_contacts_test.go
@@ -34,9 +34,7 @@ func (suite *HandlerSuite) TestCreateBackupContactHandler() {
 
 	params.HTTPRequest = suite.AuthenticateRequest(req, serviceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreateBackupContactHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateBackupContactHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	_, ok := response.(*contactop.CreateServiceMemberBackupContactCreated)
@@ -78,9 +76,7 @@ func (suite *HandlerSuite) TestIndexBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexBackupContactsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexBackupContactsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.IndexServiceMemberBackupContactsOK)
@@ -110,9 +106,7 @@ func (suite *HandlerSuite) TestIndexBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexBackupContactsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexBackupContactsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)
@@ -136,9 +130,7 @@ func (suite *HandlerSuite) TestShowBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := ShowBackupContactHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ShowBackupContactHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.ShowServiceMemberBackupContactOK)
@@ -164,9 +156,7 @@ func (suite *HandlerSuite) TestShowBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := ShowBackupContactHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ShowBackupContactHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)
@@ -198,9 +188,7 @@ func (suite *HandlerSuite) TestUpdateBackupContactsHandler() {
 	}
 	params.HTTPRequest = suite.AuthenticateRequest(req, contact.ServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := UpdateBackupContactHandler{handlers.NewHandlerContext(appCtx)}
+	handler := UpdateBackupContactHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	okResponse := response.(*contactop.UpdateServiceMemberBackupContactCreated)
@@ -234,9 +222,7 @@ func (suite *HandlerSuite) TestUpdateBackupContactsHandlerWrongUser() {
 	// Logged in as other user
 	params.HTTPRequest = suite.AuthenticateRequest(req, otherServiceMember)
 
-	appCtx := suite.AppContextForTest()
-
-	handler := UpdateBackupContactHandler{handlers.NewHandlerContext(appCtx)}
+	handler := UpdateBackupContactHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	errResponse := response.(*handlers.ErrResponse)

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -77,9 +77,7 @@ func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 12, 26, 0, 0, 0, 0, time.UTC)),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	showHandler := ShowAvailableMoveDatesHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowAvailableMoveDatesHandler{handlers.NewHandlerContext()}
 	response := showHandler.Handle(params)
 
 	suite.IsType(&calendarop.ShowAvailableMoveDatesOK{}, response)

--- a/pkg/handlers/internalapi/documents_test.go
+++ b/pkg/handlers/internalapi/documents_test.go
@@ -29,9 +29,7 @@ func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 	req = suite.AuthenticateRequest(req, serviceMember)
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreateDocumentHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateDocumentHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	createdResponse, ok := response.(*documentop.CreateDocumentCreated)
@@ -79,9 +77,7 @@ func (suite *HandlerSuite) TestShowDocumentHandler() {
 	req = suite.AuthenticateRequest(req, document.ServiceMember)
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := ShowDocumentHandler{context}

--- a/pkg/handlers/internalapi/dps_auth_cookie_url_test.go
+++ b/pkg/handlers/internalapi/dps_auth_cookie_url_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestDPSAuthCookieURLHandler() {
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	dpsAuthParams := dpsauth.Params{
 		SDDCProtocol:   "http",
 		SDDCHostname:   "testhost",

--- a/pkg/handlers/internalapi/duty_stations_test.go
+++ b/pkg/handlers/internalapi/duty_stations_test.go
@@ -60,9 +60,7 @@ func (suite *HandlerSuite) TestSearchDutyStationHandler() {
 		Search:      "first",
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := SearchDutyStationsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := SearchDutyStationsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(newSearchParams)
 
 	// Assert we got back the 201 response

--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -26,10 +26,8 @@ func (suite *HandlerSuite) TestIndexEntitlementsHandlerReturns200() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: index entitlements endpoint is hit
-	handler := IndexEntitlementsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexEntitlementsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -56,10 +54,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns200() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -86,10 +82,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns409IfPPM() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 409 status code
@@ -114,10 +108,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns404IfNoPpmOrHhg(
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 404 status code
@@ -140,10 +132,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns404IfNoMoveOrOrd
 		MoveID:      strfmt.UUID(badMoveID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 404 status code
@@ -177,10 +167,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns404IfNoRank() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 404 status code
@@ -205,10 +193,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerManagesNilPPMWeightEsti
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: validate entitlements endpoint is hit
-	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code

--- a/pkg/handlers/internalapi/generic_move_documents_test.go
+++ b/pkg/handlers/internalapi/generic_move_documents_test.go
@@ -43,9 +43,7 @@ func (suite *HandlerSuite) TestCreateGenericMoveDocumentHandler() {
 		MoveID:                           strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateGenericMoveDocumentHandler{context}

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -54,9 +54,7 @@ func (suite *HandlerSuite) TestCreateMoveDocumentHandler() {
 		MoveID:                           strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateGenericMoveDocumentHandler{context}
@@ -117,9 +115,7 @@ func (suite *HandlerSuite) TestIndexMoveDocumentsHandler() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := IndexMoveDocumentsHandler{context}
@@ -191,9 +187,7 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerNoMissingFiel
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := IndexMoveDocumentsHandler{context}
@@ -256,9 +250,7 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerMissingFields
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := IndexMoveDocumentsHandler{context}
@@ -325,10 +317,8 @@ func (suite *HandlerSuite) TestUpdateMoveDocumentHandler() {
 
 	moveDocumentUpdateHandler := &mocks.MoveDocumentUpdater{}
 
-	appCtx := suite.AppContextForTest()
-
 	handler := UpdateMoveDocumentHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		moveDocumentUpdateHandler,
 	}
 
@@ -392,10 +382,8 @@ func (suite *HandlerSuite) TestDeleteMoveDocumentHandler() {
 		MoveDocumentID: strfmt.UUID(moveDocument.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	handler := DeleteMoveDocumentHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 	}
 
 	response := handler.Handle(deleteMoveDocParams)

--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -57,10 +57,8 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			QueueType:   queueType,
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		// And: show Queue is queried
-		showHandler := ShowQueueHandler{handlers.NewHandlerContext(appCtx)}
+		showHandler := ShowQueueHandler{handlers.NewHandlerContext()}
 		showResponse := showHandler.Handle(params)
 
 		// Then: Expect a 200 status code
@@ -94,10 +92,8 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 			QueueType:   queueType,
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		// And: show Queue is queried
-		showHandler := ShowQueueHandler{handlers.NewHandlerContext(appCtx)}
+		showHandler := ShowQueueHandler{handlers.NewHandlerContext()}
 		showResponse := showHandler.Handle(params)
 
 		// Then: Expect a 403 status code
@@ -121,10 +117,8 @@ func (suite *HandlerSuite) TestShowQueueHandlerNotFound() {
 		QueueType:   queueType,
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: show Queue is queried
-	showHandler := ShowQueueHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowQueueHandler{handlers.NewHandlerContext()}
 	showResponse := showHandler.Handle(params)
 
 	// Then: Expect a 404 status code

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -52,9 +52,8 @@ func (suite *HandlerSuite) TestPatchMoveHandler() {
 		PatchMovePayload: &patchPayload,
 	}
 	// And: a move is patched
-	appCtx := suite.AppContextForTest()
 
-	handler := PatchMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -86,9 +85,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 		PatchMovePayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseForbidden(response)
@@ -115,9 +112,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoMove() {
 		PatchMovePayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseNotFound(response)
@@ -138,9 +133,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoType() {
 		PatchMovePayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&moveop.PatchMoveCreated{}, response)
@@ -163,10 +156,8 @@ func (suite *HandlerSuite) TestShowMoveHandler() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: show Move is queried
-	showHandler := ShowMoveHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowMoveHandler{handlers.NewHandlerContext()}
 	showResponse := showHandler.Handle(params)
 
 	// Then: Expect a 200 status code
@@ -193,10 +184,8 @@ func (suite *HandlerSuite) TestShowMoveWrongUser() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: Show move is queried
-	showHandler := ShowMoveHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowMoveHandler{handlers.NewHandlerContext()}
 	showResponse := showHandler.Handle(showMoveParams)
 	// Then: expect a forbidden response
 	suite.CheckResponseForbidden(showResponse)
@@ -230,8 +219,8 @@ func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// When: a move is submitted
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+
+		context := handlers.NewHandlerContext()
 		context.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{context, moverouter.NewMoveRouter()}
 		response := handler.Handle(params)
@@ -280,8 +269,8 @@ func (suite *HandlerSuite) TestSubmitMoveForApprovalHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// And: a move is submitted
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+
+		context := handlers.NewHandlerContext()
 		context.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{context, moverouter.NewMoveRouter()}
 		response := handler.Handle(params)
@@ -331,8 +320,8 @@ func (suite *HandlerSuite) TestSubmitMoveForServiceCounselingHandler() {
 			SubmitMoveForApprovalPayload: &newSubmitMoveForApprovalPayload,
 		}
 		// When: a move is submitted
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+
+		context := handlers.NewHandlerContext()
 		context.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal"))
 		handler := SubmitMoveHandler{context, moverouter.NewMoveRouter()}
 		response := handler.Handle(params)
@@ -436,8 +425,7 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 		mock.Anything,
 	).Return(1125, nil)
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 
 	showHandler := ShowMoveDatesSummaryHandler{context}
@@ -509,8 +497,7 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryForbiddenUser() {
 		mock.Anything,
 	).Return(1125, nil)
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 
 	showHandler := ShowMoveDatesSummaryHandler{context}
@@ -615,8 +602,7 @@ func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
 		PreparationDate: preparationDate,
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -669,8 +655,8 @@ func (suite *HandlerSuite) TestSubmitAmendedOrdersHandler() {
 			MoveID:      strfmt.UUID(move.ID.String()),
 		}
 		// And: a move is submitted
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+
+		context := handlers.NewHandlerContext()
 
 		handler := SubmitAmendedOrdersHandler{context, moverouter.NewMoveRouter()}
 		response := handler.Handle(params)

--- a/pkg/handlers/internalapi/moving_expense_documents_test.go
+++ b/pkg/handlers/internalapi/moving_expense_documents_test.go
@@ -50,8 +50,7 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandler() {
 		MoveID:                             strfmt.UUID(move.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateMovingExpenseDocumentHandler{context}
@@ -116,8 +115,8 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandlerReceiptMissingN
 		CreateMovingExpenseDocumentPayload: &newMovingExpenseDocPayload,
 		MoveID:                             strfmt.UUID(move.ID.String()),
 	}
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateMovingExpenseDocumentHandler{context}
@@ -152,8 +151,8 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandlerNoUploadsAndNot
 		CreateMovingExpenseDocumentPayload: &newMovingExpenseDocPayload,
 		MoveID:                             strfmt.UUID(move.ID.String()),
 	}
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateMovingExpenseDocumentHandler{context}
@@ -187,8 +186,8 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandlerStorageExpense(
 		CreateMovingExpenseDocumentPayload: &newMovingExpenseDocPayload,
 		MoveID:                             strfmt.UUID(move.ID.String()),
 	}
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateMovingExpenseDocumentHandler{context}

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -138,10 +138,9 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		params := subtestData.params
 		fetcher := fetch.NewFetcher(subtestData.builder)
 		creator := mtoshipment.NewMTOShipmentCreator(subtestData.builder, fetcher, moveRouter)
-		appCtx := suite.AppContextForTest()
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 		response := handler.Handle(subtestData.params)
@@ -174,10 +173,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(subtestData.builder)
 		creator := mtoshipment.NewMTOShipmentCreator(subtestData.builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 
@@ -217,10 +214,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			},
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 
@@ -239,10 +234,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		unauthorizedParams := subtestData.params
 		unauthorizedParams.HTTPRequest = unauthorizedReq
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 
@@ -257,10 +250,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(subtestData.builder)
 		creator := mtoshipment.NewMTOShipmentCreator(subtestData.builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 
@@ -278,10 +269,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(subtestData.builder)
 		creator := mtoshipment.NewMTOShipmentCreator(subtestData.builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 		}
 
@@ -297,10 +286,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		subtestData := suite.makeCreateSubtestData()
 		mockCreator := mocks.MTOShipmentCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 		}
 
@@ -430,10 +417,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -468,10 +454,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -494,10 +479,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -514,10 +498,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -534,10 +517,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -565,10 +547,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 			moveWeights,
 			suite.TestNotificationSender(),
 			paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -589,10 +570,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -610,10 +590,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
 		updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
-		appCtx := suite.AppContextForTest()
 
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			updater,
 		}
 
@@ -639,7 +618,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	//  appCtx := suite.AppContextForTest()
 	//
 	// 	handler := UpdateMTOShipmentHandler{
-	// 		handlers.NewHandlerContext(appCtx),
+	// 		handlers.NewHandlerContext(),
 	// 		updater,
 	// 	}
 
@@ -677,10 +656,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	suite.Run("PATCH failure - 500", func() {
 		mockUpdater := mocks.MTOShipmentUpdater{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockUpdater,
 		}
 
@@ -782,10 +759,9 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		listFetcher := fetch.NewListFetcher(queryBuilder)
 		fetcher := fetch.NewFetcher(queryBuilder)
-		appCtx := suite.AppContextForTest()
 
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			listFetcher,
 			fetcher,
 		}
@@ -852,10 +828,9 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
-		appCtx := suite.AppContextForTest()
 
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}
@@ -875,10 +850,9 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		}
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
-		appCtx := suite.AppContextForTest()
 
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}
@@ -892,10 +866,9 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		subtestData := suite.makeListSubtestData()
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
-		appCtx := suite.AppContextForTest()
 
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}
@@ -916,10 +889,9 @@ func (suite *HandlerSuite) TestListMTOShipmentsHandler() {
 		subtestData := suite.makeListSubtestData()
 		mockListFetcher := mocks.ListFetcher{}
 		mockFetcher := mocks.Fetcher{}
-		appCtx := suite.AppContextForTest()
 
 		handler := ListMTOShipmentsHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockListFetcher,
 			&mockFetcher,
 		}

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -48,9 +48,9 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 	// And: a move is approved
-	appCtx := suite.AppContextForTest()
+
 	handler := ApproveMoveHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -85,9 +85,9 @@ func (suite *HandlerSuite) TestApproveMoveHandlerIncompleteOrders() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 	// And: move handler is hit
-	appCtx := suite.AppContextForTest()
+
 	handler := ApproveMoveHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -112,9 +112,9 @@ func (suite *HandlerSuite) TestApproveMoveHandlerForbidden() {
 		MoveID:      strfmt.UUID(move.ID.String()),
 	}
 	// And: a move is approved
-	appCtx := suite.AppContextForTest()
+
 	handler := ApproveMoveHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		moveRouter,
 	}
 	response := handler.Handle(params)
@@ -170,8 +170,8 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	}
 
 	// And: a move is canceled
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetNotificationSender(suite.TestNotificationSender())
 	handler := CancelMoveHandler{context, moveRouter}
 	response := handler.Handle(params)
@@ -207,8 +207,8 @@ func (suite *HandlerSuite) TestCancelMoveHandlerForbidden() {
 		CancelMove:  reasonPayload,
 	}
 	// And: a move is canceled
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetNotificationSender(suite.TestNotificationSender())
 	handler := CancelMoveHandler{context, moveRouter}
 	response := handler.Handle(params)
@@ -242,8 +242,8 @@ func (suite *HandlerSuite) TestApprovePPMHandler() {
 	}
 
 	// And: a ppm is approved
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetNotificationSender(suite.TestNotificationSender())
 	handler := ApprovePPMHandler{context}
 	response := handler.Handle(params)
@@ -276,8 +276,8 @@ func (suite *HandlerSuite) TestApprovePPMHandlerForbidden() {
 	}
 
 	// And: a ppm is approved
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetNotificationSender(suite.TestNotificationSender())
 	handler := ApprovePPMHandler{context}
 	response := handler.Handle(params)
@@ -299,10 +299,8 @@ func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 		ReimbursementID: strfmt.UUID(reimbursement.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: a reimbursement is approved
-	handler := ApproveReimbursementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ApproveReimbursementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect a 200 status code
@@ -326,10 +324,8 @@ func (suite *HandlerSuite) TestApproveReimbursementHandlerForbidden() {
 		ReimbursementID: strfmt.UUID(reimbursement.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// And: a reimbursement is approved
-	handler := ApproveReimbursementHandler{handlers.NewHandlerContext(appCtx)}
+	handler := ApproveReimbursementHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	// Then: expect Forbidden response

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -55,8 +55,8 @@ func (suite *HandlerSuite) TestCreateOrder() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	createHandler := CreateOrdersHandler{context}
 
@@ -101,8 +101,8 @@ func (suite *HandlerSuite) TestShowOrder() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	showHandler := ShowOrdersHandler{context}
 
@@ -149,8 +149,8 @@ func (suite *HandlerSuite) TestUploadAmendedOrder() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	uploadAmendedHandler := UploadAmendedOrdersHandler{
 		HandlerContext: context,
@@ -202,9 +202,9 @@ func (suite *HandlerSuite) TestUpdateOrder() {
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
-	appCtx := suite.AppContextForTest()
 
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	updateHandler := UpdateOrdersHandler{context}
 

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -34,8 +34,8 @@ func (suite *HandlerSuite) assertPDFPageCount(count int, file afero.File, storer
 }
 
 func (suite *HandlerSuite) createHandlerContext() handlers.HandlerContext {
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 

--- a/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
@@ -157,7 +157,7 @@ func (suite *HandlerSuite) TestShowPPMEstimateHandler() {
 		WeightEstimate:       7500,
 	}
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -201,7 +201,7 @@ func (suite *HandlerSuite) TestShowPPMEstimateHandlerLowWeight() {
 		WeightEstimate:       600,
 	}
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
@@ -155,7 +155,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerForbidden() {
 		OrdersID:             strfmt.UUID(ordersID.String()),
 	}
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -191,7 +191,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandler() {
 		OrdersID:             strfmt.UUID(ordersID.String()),
 	}
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -234,7 +234,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerLowWeight() {
 		OrdersID:             strfmt.UUID(ordersID.String()),
 	}
 
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	planner := &mocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/handlers/internalapi/personally_procured_move_sit_estimate_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_sit_estimate_test.go
@@ -44,8 +44,8 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerSuccess() {
 	estimateCalculator.On("CalculateEstimates",
 		mock.AnythingOfType("*appcontext.appContext"),
 		mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, nil).Once()
-	appCtx := suite.AppContextForTest()
-	showEstimateHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+	showEstimateHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 	showResponse := showEstimateHandler.Handle(params)
 
 	// Then: Expect a 200 status code
@@ -84,8 +84,8 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerWithError() {
 		estimateCalculator.On("CalculateEstimates",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, nil).Once()
-		appCtx := suite.AppContextForTest()
-		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 		showResponse := showHandler.Handle(params)
 
 		suite.CheckResponseNotFound(showResponse)
@@ -112,8 +112,8 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerWithError() {
 		estimateCalculator.On("CalculateEstimates",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, nil).Once()
-		appCtx := suite.AppContextForTest()
-		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 		showResponse := showHandler.Handle(params)
 
 		suite.CheckResponseNotFound(showResponse)
@@ -138,8 +138,8 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerWithError() {
 		estimateCalculator.On("CalculateEstimates",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, nil).Once()
-		appCtx := suite.AppContextForTest()
-		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 		showResponse := showHandler.Handle(params)
 
 		suite.IsType(&ppmop.ShowPPMSitEstimateUnprocessableEntity{}, showResponse)
@@ -164,8 +164,8 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerWithError() {
 		estimateCalculator.On("CalculateEstimates",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, nil).Once()
-		appCtx := suite.AppContextForTest()
-		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+		showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 		showResponse := showHandler.Handle(params)
 
 		suite.IsType(&ppmop.ShowPPMSitEstimateUnprocessableEntity{}, showResponse)
@@ -195,8 +195,8 @@ func (suite *HandlerSuite) TestShowPpmSitEstimateHandlerEstimateCalculationFails
 	estimateCalculator.On("CalculateEstimates",
 		mock.AnythingOfType("*appcontext.appContext"),
 		mock.AnythingOfType("*models.PersonallyProcuredMove"), mock.Anything).Return(mockedSitCharge, mockedCost, mockedError).Once()
-	appCtx := suite.AppContextForTest()
-	showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+
+	showHandler := ShowPPMSitEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 	showResponse := showHandler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, showResponse)

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -187,9 +187,7 @@ func (suite *HandlerSuite) TestCreatePPMHandler() {
 		HTTPRequest:                         request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreatePersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreatePersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(newPPMParams)
 	// assert we got back the 201 response
 	createdResponse := response.(*ppmop.CreatePersonallyProcuredMoveCreated)
@@ -242,9 +240,8 @@ func (suite *HandlerSuite) TestSubmitPPMHandler() {
 	}
 
 	// submit the PPM
-	appCtx := suite.AppContextForTest()
 
-	handler := SubmitPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := SubmitPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(submitPPMParams)
 	okResponse := response.(*ppmop.SubmitPersonallyProcuredMoveOK)
 	submitPPMPayload := okResponse.Payload
@@ -304,9 +301,7 @@ func (suite *HandlerSuite) TestIndexPPMHandler() {
 		HTTPRequest: req,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexPersonallyProcuredMovesHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexPersonallyProcuredMovesHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(indexPPMParams)
 
 	// assert we got back the 201 response
@@ -386,9 +381,7 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	planner := &routemocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -501,7 +494,7 @@ func (suite *HandlerSuite) TestUpdatePPMEstimateHandler() {
 	}
 
 	mileage := 900
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	planner := &routemocks.Planner{}
 	planner.On("Zip5TransitDistanceLineHaul",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -545,7 +538,7 @@ func (suite *HandlerSuite) TestUpdatePPMEstimateHandler() {
 		mock.AnythingOfType("*appcontext.appContext"),
 		mock.AnythingOfType("*models.PersonallyProcuredMove"), move.ID).Return(mockedSitCharge, mockedCost, nil).Once()
 
-	updatePPMEstimateHandler := UpdatePersonallyProcuredMoveEstimateHandler{handlers.NewHandlerContext(appCtx), estimateCalculator}
+	updatePPMEstimateHandler := UpdatePersonallyProcuredMoveEstimateHandler{handlers.NewHandlerContext(), estimateCalculator}
 	updatePPMEstimateHandler.SetPlanner(planner)
 	updatePPMEstimateResponse := updatePPMEstimateHandler.Handle(updatePPMEstimateParams)
 
@@ -613,7 +606,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 		mock.Anything,
 	).Return(900, nil)
 
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	handler.SetPlanner(planner)
 	response := handler.Handle(patchPPMParams)
 
@@ -674,9 +667,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(patchPPMParams)
 
 	suite.CheckResponseForbidden(response)
@@ -729,9 +720,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(patchPPMParams)
 	suite.CheckResponseForbidden(response)
 }
@@ -768,9 +757,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerNoMove() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(patchPPMParams)
 
 	// assert we got back the badrequest response
@@ -819,9 +806,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerAdvance() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(patchPPMParams)
 
 	created, ok := response.(*ppmop.PatchPersonallyProcuredMoveOK)
@@ -883,9 +868,9 @@ func (suite *HandlerSuite) TestPatchPPMHandlerAdvance() {
 		PatchPersonallyProcuredMovePayload: &payload,
 	}
 
-	appCtx := suite.AppContextForTest()
 
-	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(appCtx)}
+
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(patchPPMParams)
 
 	suite.CheckResponseBadRequest(response)
@@ -958,7 +943,7 @@ func (suite *HandlerSuite) TestRequestPPMPayment() {
 		PersonallyProcuredMoveID: strfmt.UUID(ppm1.ID.String()),
 	}
 
-	handler := RequestPPMPaymentHandler{handlers.NewHandlerContext(appCtx)}
+	handler := RequestPPMPaymentHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(requestPaymentParams)
 
 	created, ok := response.(*ppmop.RequestPPMPaymentOK)
@@ -1001,9 +986,7 @@ func (suite *HandlerSuite) TestRequestPPMExpenseSummaryHandler() {
 		PersonallyProcuredMoveID: strfmt.UUID(ppm.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := RequestPPMExpenseSummaryHandler{handlers.NewHandlerContext(appCtx)}
+	handler := RequestPPMExpenseSummaryHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(requestExpenseSumParams)
 
 	expenseSummary, ok := response.(*ppmop.RequestPPMExpenseSummaryOK)

--- a/pkg/handlers/internalapi/postal_codes_test.go
+++ b/pkg/handlers/internalapi/postal_codes_test.go
@@ -32,8 +32,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 		PostalCodeType: postalCodeTypeString,
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	postalCodeValidator := &mocks.PostalCodeValidator{}
 	postalCodeValidator.On("ValidatePostalCode",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -72,8 +71,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
 		PostalCodeType: postalCodeTypeString,
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	postalCodeValidator := &mocks.PostalCodeValidator{}
 	postalCodeValidator.On("ValidatePostalCode",
 		mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -47,8 +47,8 @@ func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 		ServiceMemberID: strfmt.UUID(newServiceMember.ID.String()),
 	}
 	// And: show ServiceMember is queried
-	appCtx := suite.AppContextForTest()
-	showHandler := ShowServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+
+	showHandler := ShowServiceMemberHandler{handlers.NewHandlerContext()}
 	response := showHandler.Handle(params)
 
 	// Then: Expect a 200 status code
@@ -72,8 +72,8 @@ func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 		ServiceMemberID: strfmt.UUID(notLoggedInUser.ID.String()),
 	}
 	// And: Show servicemember is queried
-	appCtx := suite.AppContextForTest()
-	showHandler := ShowServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+
+	showHandler := ShowServiceMemberHandler{handlers.NewHandlerContext()}
 	response := showHandler.Handle(showServiceMemberParams)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -96,8 +96,8 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
 		CreateServiceMemberPayload: &newServiceMemberPayload,
 		HTTPRequest:                req,
 	}
-	appCtx := suite.AppContextForTest()
-	handler := CreateServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+
+	handler := CreateServiceMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.CookieUpdateResponder{}, response)
@@ -160,8 +160,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 		HTTPRequest:                req,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := CreateServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateServiceMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.CookieUpdateResponder{}, response)
@@ -279,8 +278,8 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	handler := PatchServiceMemberHandler{context}
 	response := handler.Handle(params)
@@ -423,8 +422,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerSubmittedMove() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := PatchServiceMemberHandler{context}
@@ -488,8 +486,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerWrongUser() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PatchServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchServiceMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -519,8 +516,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoServiceMember() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PatchServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchServiceMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)
@@ -551,8 +547,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoChange() {
 		PatchServiceMemberPayload: &patchPayload,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PatchServiceMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PatchServiceMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&servicememberop.PatchServiceMemberOK{}, response)
@@ -577,8 +572,8 @@ func (suite *HandlerSuite) TestShowServiceMemberOrders() {
 	}
 
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	handler := ShowServiceMemberOrdersHandler{context}
 

--- a/pkg/handlers/internalapi/signed_certifications_test.go
+++ b/pkg/handlers/internalapi/signed_certifications_test.go
@@ -44,9 +44,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandler() {
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	_, ok := response.(*certop.CreateSignedCertificationCreated)
@@ -92,9 +90,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandlerMismatchedUser() 
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseForbidden(response)
@@ -130,9 +126,7 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandlerBadMoveID() {
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext(appCtx)}
+	handler := CreateSignedCertificationHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseNotFound(response)
@@ -172,9 +166,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandlerBadMoveID() {
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseNotFound(response)
@@ -211,9 +203,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandlerMismatchedUser() {
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.CheckResponseForbidden(response)
@@ -244,9 +234,7 @@ func (suite *HandlerSuite) TestIndexSignedCertificationHandler() {
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-
-	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	okResponse, ok := response.(*certop.IndexSignedCertificationOK)

--- a/pkg/handlers/internalapi/transportation_offices_test.go
+++ b/pkg/handlers/internalapi/transportation_offices_test.go
@@ -21,8 +21,7 @@ func (suite *HandlerSuite) TestShowDutyStationTransportationOfficeHandler() {
 		HTTPRequest:   req,
 		DutyStationID: *handlers.FmtUUID(station.ID),
 	}
-	appCtx := suite.AppContextForTest()
-	showHandler := ShowDutyStationTransportationOfficeHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowDutyStationTransportationOfficeHandler{handlers.NewHandlerContext()}
 	response := showHandler.Handle(params)
 
 	suite.Assertions.IsType(&transportationofficeop.ShowDutyStationTransportationOfficeOK{}, response)
@@ -46,8 +45,7 @@ func (suite *HandlerSuite) TestShowDutyStationTransportationOfficeHandlerNoOffic
 		HTTPRequest:   req,
 		DutyStationID: *handlers.FmtUUID(station.ID),
 	}
-	appCtx := suite.AppContextForTest()
-	showHandler := ShowDutyStationTransportationOfficeHandler{handlers.NewHandlerContext(appCtx)}
+	showHandler := ShowDutyStationTransportationOfficeHandler{handlers.NewHandlerContext()}
 	response := showHandler.Handle(params)
 
 	suite.Assertions.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -39,8 +39,7 @@ func makeRequest(suite *HandlerSuite, params uploadop.CreateUploadParams, servic
 
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	handler := CreateUploadHandler{context}
 	response := handler.Handle(params)
@@ -182,8 +181,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 	req = suite.AuthenticateRequest(req, uploadUser.Document.ServiceMember)
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	handler := DeleteUploadHandler{context}
 	response := handler.Handle(params)
@@ -225,8 +223,7 @@ func (suite *HandlerSuite) TestDeleteUploadsHandlerSuccess() {
 	req = suite.AuthenticateRequest(req, uploadUser1.Document.ServiceMember)
 	params.HTTPRequest = req
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3)
 	handler := DeleteUploadsHandler{context}
 	response := handler.Handle(params)
@@ -258,8 +255,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerFailure() {
 
 	fakeS3Failure := storageTest.NewFakeS3Storage(false)
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetFileStorer(fakeS3Failure)
 	handler := DeleteUploadHandler{context}
 	response := handler.Handle(params)

--- a/pkg/handlers/internalapi/users_test.go
+++ b/pkg/handlers/internalapi/users_test.go
@@ -26,9 +26,7 @@ func (suite *HandlerSuite) TestUnknownLoggedInUserHandler() {
 	}
 	builder := officeuser.NewOfficeUserFetcherPop()
 
-	appCtx := suite.AppContextForTest()
-
-	handler := ShowLoggedInUserHandler{handlers.NewHandlerContext(appCtx), builder}
+	handler := ShowLoggedInUserHandler{handlers.NewHandlerContext(), builder}
 
 	response := handler.Handle(params)
 
@@ -65,9 +63,7 @@ func (suite *HandlerSuite) TestServiceMemberLoggedInUserRequiringAccessCodeHandl
 		HTTPRequest: req,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	featureFlag := handlers.FeatureFlag{Name: "requires-access-code", Active: true}
 	context.SetFeatureFlag(featureFlag)
 	builder := officeuser.NewOfficeUserFetcherPop()
@@ -100,9 +96,7 @@ func (suite *HandlerSuite) TestServiceMemberLoggedInUserNotRequiringAccessCodeHa
 		HTTPRequest: req,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	featureFlag := handlers.FeatureFlag{Name: "requires-access-code", Active: false}
 	context.SetFeatureFlag(featureFlag)
 	builder := officeuser.NewOfficeUserFetcherPop()
@@ -138,9 +132,7 @@ func (suite *HandlerSuite) TestServiceMemberNoTransportationOfficeLoggedInUserHa
 	}
 	builder := officeuser.NewOfficeUserFetcherPop()
 
-	appCtx := suite.AppContextForTest()
-
-	handler := ShowLoggedInUserHandler{handlers.NewHandlerContext(appCtx), builder}
+	handler := ShowLoggedInUserHandler{handlers.NewHandlerContext(), builder}
 
 	response := handler.Handle(params)
 
@@ -164,9 +156,7 @@ func (suite *HandlerSuite) TestServiceMemberNoMovesLoggedInUserHandler() {
 		HTTPRequest: req,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	builder := officeuser.NewOfficeUserFetcherPop()
 

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -61,8 +61,7 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerValidate() {
 		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateWeightTicketSetDocumentHandler{context}
@@ -116,8 +115,7 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreate() {
 		suite.Run(t.weightTicketSetType, func() {
 			newWeightTicketSetDocParams := createWeightTicketSetDocument(suite, t.weightTicketSetType)
 
-			appCtx := suite.AppContextForTest()
-			context := handlers.NewHandlerContext(appCtx)
+			context := handlers.NewHandlerContext()
 			fakeS3 := storageTest.NewFakeS3Storage(true)
 			context.SetFileStorer(fakeS3)
 			handler := CreateWeightTicketSetDocumentHandler{context}
@@ -169,8 +167,7 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreateFailure() {
 			MoveID:                     strfmt.UUID(ppm.MoveID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		context.SetFileStorer(fakeS3)
 		handler := CreateWeightTicketSetDocumentHandler{context}
@@ -203,8 +200,7 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreateFailure() {
 			MoveID:                     strfmt.UUID(ppm.MoveID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		fakeS3 := storageTest.NewFakeS3Storage(true)
 		context.SetFileStorer(fakeS3)
 		handler := CreateWeightTicketSetDocumentHandler{context}

--- a/pkg/handlers/ordersapi/get_orders_by_issuer_and_orders_num_test.go
+++ b/pkg/handlers/ordersapi/get_orders_by_issuer_and_orders_num_test.go
@@ -28,8 +28,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumSuccess() {
 		OrdersNum:   order.OrdersNumber,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.Assertions.IsType(&ordersoperations.GetOrdersByIssuerAndOrdersNumOK{}, response)
@@ -52,8 +51,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumNoApiPerm() {
 		OrdersNum:   "8675309",
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -129,8 +127,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumReadPerms() {
 				OrdersNum:   order.OrdersNumber,
 			}
 
-			appCtx := suite.AppContextForTest()
-			handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext(appCtx)}
+			handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)
@@ -159,8 +156,7 @@ func (suite *HandlerSuite) TestGetOrdersByIssuerAndOrdersNumNotFound() {
 		OrdersNum:   ordersNum,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersByIssuerAndOrdersNumHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/get_orders_test.go
+++ b/pkg/handlers/ordersapi/get_orders_test.go
@@ -30,8 +30,7 @@ func (suite *HandlerSuite) TestGetOrdersSuccess() {
 		UUID:        strfmt.UUID(order.ID.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&ordersoperations.GetOrdersOK{}, response)
@@ -53,8 +52,7 @@ func (suite *HandlerSuite) TestGetOrdersNoApiPerm() {
 		UUID:        strfmt.UUID(uuid.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -129,8 +127,7 @@ func (suite *HandlerSuite) TestGetOrdersReadPerms() {
 				UUID:        strfmt.UUID(order.ID.String()),
 			}
 
-			appCtx := suite.AppContextForTest()
-			handler := GetOrdersHandler{handlers.NewHandlerContext(appCtx)}
+			handler := GetOrdersHandler{handlers.NewHandlerContext()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)
@@ -156,8 +153,7 @@ func (suite *HandlerSuite) TestGetOrdersMissingUUID() {
 		UUID:        strfmt.UUID(uuid.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := GetOrdersHandler{handlers.NewHandlerContext(appCtx)}
+	handler := GetOrdersHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/index_orders_for_member_test.go
+++ b/pkg/handlers/ordersapi/index_orders_for_member_test.go
@@ -33,8 +33,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumSuccess() {
 		Edipi:       order.Edipi,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&ordersoperations.IndexOrdersForMemberOK{}, response)
@@ -62,8 +61,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumNoApiPerm() {
 		Edipi:       "1234567890",
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -86,8 +84,7 @@ func (suite *HandlerSuite) TestIndexOrdersForMemberNumNoReadPerms() {
 		Edipi:       "1234567890",
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext(appCtx)}
+	handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -162,8 +159,7 @@ func (suite *HandlerSuite) TestIndexOrderForMemberReadPerms() {
 				Edipi:       order.Edipi,
 			}
 
-			appCtx := suite.AppContextForTest()
-			handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext(appCtx)}
+			handler := IndexOrdersForMemberHandler{handlers.NewHandlerContext()}
 			response := handler.Handle(params)
 
 			suite.Assertions.IsType(&ordersoperations.IndexOrdersForMemberOK{}, response)

--- a/pkg/handlers/ordersapi/post_revision_test.go
+++ b/pkg/handlers/ordersapi/post_revision_test.go
@@ -59,8 +59,7 @@ func (suite *HandlerSuite) TestPostRevision() {
 		Revision:    &rev,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PostRevisionHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PostRevisionHandler{handlers.NewHandlerContext()}
 	suite.T().Run("NewSuccess", func(t *testing.T) {
 		response := handler.Handle(params)
 
@@ -172,8 +171,7 @@ func (suite *HandlerSuite) TestPostRevisionNoApiPerm() {
 		OrdersNum:   "8675309",
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PostRevisionHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PostRevisionHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -228,8 +226,7 @@ func (suite *HandlerSuite) TestPostRevisionWritePerms() {
 				OrdersNum:   "8675309",
 			}
 
-			appCtx := suite.AppContextForTest()
-			handler := PostRevisionHandler{handlers.NewHandlerContext(appCtx)}
+			handler := PostRevisionHandler{handlers.NewHandlerContext()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/ordersapi/post_revision_to_orders_test.go
+++ b/pkg/handlers/ordersapi/post_revision_to_orders_test.go
@@ -63,8 +63,7 @@ func (suite *HandlerSuite) TestPostRevisionToOrders() {
 		Revision:    &rev,
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext()}
 	suite.T().Run("Success", func(t *testing.T) {
 		response := handler.Handle(params)
 
@@ -122,8 +121,7 @@ func (suite *HandlerSuite) TestPostRevisionToOrdersNoApiPerm() {
 		UUID:        strfmt.UUID(id.String()),
 	}
 
-	appCtx := suite.AppContextForTest()
-	handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext(appCtx)}
+	handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext()}
 	response := handler.Handle(params)
 
 	suite.IsType(&handlers.ErrResponse{}, response)
@@ -199,8 +197,7 @@ func (suite *HandlerSuite) TestPostRevisionToOrdersWritePerms() {
 				UUID:        strfmt.UUID(origOrder.ID.String()),
 			}
 
-			appCtx := suite.AppContextForTest()
-			handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext(appCtx)}
+			handler := PostRevisionToOrdersHandler{handlers.NewHandlerContext()}
 			response := handler.Handle(params)
 
 			suite.IsType(&handlers.ErrResponse{}, response)

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -51,8 +51,7 @@ func (suite *HandlerSuite) TestListMovesHandlerReturnsUpdated() {
 	since := handlers.FmtDateTime(lastFetch)
 	request := httptest.NewRequest("GET", fmt.Sprintf("/moves?since=%s", since.String()), nil)
 	params := movetaskorderops.ListMovesParams{HTTPRequest: request, Since: since}
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	// make the request
 	handler := ListMovesHandler{HandlerContext: context, MoveTaskOrderFetcher: movetaskorder.NewMoveTaskOrderFetcher()}
@@ -68,8 +67,7 @@ func (suite *HandlerSuite) TestListMovesHandlerReturnsUpdated() {
 
 func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	request := httptest.NewRequest("GET", "/move-task-orders/{moveTaskOrderID}", nil)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMoveTaskOrderHandler{context,
 		movetaskorder.NewMoveTaskOrderFetcher(),
 	}
@@ -172,8 +170,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 	request := httptest.NewRequest("POST", "/move-task-orders/{moveTaskOrderID}", nil)
-	appCtx := suite.AppContextForTest()
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 	handler := CreateExcessWeightRecordHandler{
@@ -269,9 +266,8 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		updater := movetaskorder.NewMoveTaskOrderUpdater(queryBuilder, siCreator, moveRouter)
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
-		appCtx := suite.AppContextForTest()
 		handler := UpdateMTOPostCounselingInformationHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoChecker,
@@ -314,9 +310,8 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		fetcher := fetch.NewFetcher(queryBuilder)
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
 		updater := movetaskorder.NewMoveTaskOrderUpdater(queryBuilder, siCreator, moveRouter)
-		appCtx := suite.AppContextForTest()
 		handler := UpdateMTOPostCounselingInformationHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			fetcher,
 			updater,
 			mtoChecker,
@@ -331,9 +326,8 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
-		appCtx := suite.AppContextForTest()
 		handler := UpdateMTOPostCounselingInformationHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -357,9 +351,8 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
-		appCtx := suite.AppContextForTest()
 		handler := UpdateMTOPostCounselingInformationHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,
@@ -381,9 +374,8 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
 
-		appCtx := suite.AppContextForTest()
 		handler := UpdateMTOPostCounselingInformationHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockFetcher,
 			&mockUpdater,
 			mtoChecker,

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -52,9 +52,9 @@ func (suite *HandlerSuite) makeUpdateMTOAgentSubtestData() (subtestData *updateM
 	}
 
 	// Create handler and request
-	appCtx := suite.AppContextForTest()
+
 	subtestData.handler = UpdateMTOAgentHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		mtoagent.NewMTOAgentUpdater(movetaskorder.NewMoveTaskOrderChecker()),
 	}
 	subtestData.req = httptest.NewRequest("PUT", fmt.Sprintf("/mto-shipments/%s/agents/%s", subtestData.agent.MTOShipmentID.String(), subtestData.agent.ID.String()), nil)
@@ -273,9 +273,9 @@ func (suite *HandlerSuite) makeCreateMTOAgentSubtestData() (subtestData *createM
 	}
 
 	// Create Handler
-	appCtx := suite.AppContextForTest()
+
 	subtestData.handler = CreateMTOAgentHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		mtoagent.NewMTOAgentCreator(movetaskorder.NewMoveTaskOrderChecker()),
 	}
 	subtestData.req = httptest.NewRequest("POST", fmt.Sprintf("/mto-shipments/%s/agents", subtestData.mtoShipment.ID), nil)

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -90,10 +90,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -110,10 +108,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -136,10 +132,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -159,10 +153,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -182,10 +174,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -206,10 +196,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -238,10 +226,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -263,10 +249,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -286,10 +270,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -375,10 +357,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -402,10 +382,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -428,10 +406,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDomesticCratingHandler() {
 		subtestData := makeSubtestData()
 		mockCreator := mocks.MTOServiceItemCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -506,10 +482,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -540,10 +514,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -582,10 +554,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -652,10 +622,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITNoA
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -746,10 +714,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemOriginSITHandlerWithDOFSITWit
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -906,10 +872,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -935,10 +899,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -960,10 +922,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -1002,10 +962,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -1029,10 +987,8 @@ func (suite *HandlerSuite) TestCreateMTOServiceItemDestSITHandler() {
 		moveRouter := moverouter.NewMoveRouter()
 		creator := mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -1101,10 +1057,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemDDDSIT() {
 		queryBuilder := query.NewQueryBuilder()
 		moveRouter := moverouter.NewMoveRouter()
 
-		appCtx := suite.AppContextForTest()
-
 		subtestData.handler = UpdateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder, moveRouter),
 		}
 
@@ -1266,10 +1220,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemDOPSIT() {
 		}
 		subtestData.reqPayload.SetID(strfmt.UUID(subtestData.dopsit.ID.String()))
 
-		appCtx := suite.AppContextForTest()
-
 		subtestData.handler = UpdateMTOServiceItemHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			mtoserviceitem.NewMTOServiceItemUpdater(queryBuilder, moveRouter),
 		}
 

--- a/pkg/handlers/primeapi/mto_shipment_address_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_address_test.go
@@ -53,11 +53,9 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressHandler() {
 		PostalCode:     "94055",
 	}
 
-	appCtx := suite.AppContextForTest()
-
 	// Create handler
 	handler := UpdateMTOShipmentAddressHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		mtoshipment.NewMTOShipmentAddressUpdater(),
 	}
 

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -95,10 +95,9 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	suite.T().Run("Successful POST - Integration Test", func(t *testing.T) {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
-		appCtx := suite.AppContextForTest()
 
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -114,10 +113,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	suite.T().Run("POST failure - 500", func(t *testing.T) {
 		mockCreator := mocks.MTOShipmentCreator{}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockCreator,
 			mtoChecker,
 		}
@@ -142,10 +139,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -172,10 +167,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -192,10 +185,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -213,10 +204,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -235,10 +224,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -262,10 +249,8 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 		fetcher := fetch.NewFetcher(builder)
 		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreateMTOShipmentHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			creator,
 			mtoChecker,
 		}
@@ -376,9 +361,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 	paymentRequestShipmentRecalculator := paymentrequest.NewPaymentRequestShipmentRecalculator(recalculator)
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 	handler := UpdateMTOShipmentHandler{
 		context,
@@ -808,9 +791,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressLogic() {
 	paymentRequestShipmentRecalculator := paymentrequest.NewPaymentRequestShipmentRecalculator(recalculator)
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 	handler := UpdateMTOShipmentHandler{
 		context,
@@ -971,9 +952,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 	paymentRequestShipmentRecalculator := paymentrequest.NewPaymentRequestShipmentRecalculator(recalculator)
 	updater := mtoshipment.NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, suite.TestNotificationSender(), paymentRequestShipmentRecalculator)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 	handler := UpdateMTOShipmentHandler{
 		context,
@@ -1419,9 +1398,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 		mock.Anything,
 	).Return(400, nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	context.SetPlanner(planner)
 	moveRouter := moverouter.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -108,10 +108,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 				return paymentRequest.PaymentServiceItems[0].MTOServiceItemID == subtestData.serviceItemID1
 			})).Return(&returnedPaymentRequest, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -166,10 +164,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -218,10 +214,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -259,10 +253,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -285,10 +277,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, errors.New("creator failed")).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -320,10 +310,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -351,10 +339,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -395,10 +381,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -436,10 +420,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -476,10 +458,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -694,10 +674,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerNewPaymentRequestCreat
 			ghcrateengine.NewServiceItemPricer(),
 		)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -769,10 +747,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 			ghcrateengine.NewServiceItemPricer(),
 		)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 
@@ -833,10 +809,8 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandlerInvalidMTOReferenceID(
 			ghcrateengine.NewServiceItemPricer(),
 		)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := CreatePaymentRequestHandler{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			paymentRequestCreator,
 		}
 

--- a/pkg/handlers/primeapi/reweigh_test.go
+++ b/pkg/handlers/primeapi/reweigh_test.go
@@ -59,11 +59,9 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 	recalculator := paymentrequest.NewPaymentRequestRecalculator(creator, statusUpdater)
 	paymentRequestShipmentRecalculator := paymentrequest.NewPaymentRequestShipmentRecalculator(recalculator)
 
-	appCtx := suite.AppContextForTest()
-
 	// Create handler
 	handler := UpdateReweighHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		reweighservice.NewReweighUpdater(movetaskorder.NewMoveTaskOrderChecker(), paymentRequestShipmentRecalculator),
 	}
 

--- a/pkg/handlers/primeapi/sit_extension_test.go
+++ b/pkg/handlers/primeapi/sit_extension_test.go
@@ -41,11 +41,9 @@ func (suite *HandlerSuite) CreateSITExtensionHandler() {
 	// Create move router for SitExtension Createor
 	moveRouter := moverouter.NewMoveRouter()
 
-	appCtx := suite.AppContextForTest()
-
 	// Create handler
 	handler := CreateSITExtensionHandler{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		sitextensionservice.NewSitExtensionCreator(moveRouter),
 	}
 

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -23,9 +23,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 
 	paymentRequest := testdatagen.MakeDefaultPaymentRequest(suite.DB())
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 	context.SetFileStorer(fakeS3)
 

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -53,9 +53,7 @@ func (suite *HandlerSuite) TestListMTOsHandler() {
 
 	params := movetaskorderops.ListMTOsParams{HTTPRequest: request}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	handler := ListMTOsHandler{
 		HandlerContext:       context,
@@ -78,9 +76,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		HTTPRequest: request,
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 
 	suite.T().Run("successfully hide fake moves", func(t *testing.T) {
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
@@ -179,9 +175,7 @@ func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
@@ -209,9 +203,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		MoveTaskOrderID: move.ID.String(),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := GetMoveTaskOrderHandlerFunc{context,
 		movetaskorder.NewMoveTaskOrderFetcher(),
 	}
@@ -286,9 +278,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 	// Create the handler object
 	request := httptest.NewRequest("POST", "/move-task-orders", nil)
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	handler := CreateMoveTaskOrderHandler{context,
 		internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
 	}

--- a/pkg/handlers/supportapi/mto_service_item_test.go
+++ b/pkg/handlers/supportapi/mto_service_item_test.go
@@ -72,9 +72,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerApproveSuccess()
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	handler := UpdateMTOServiceItemStatusHandler{context,
@@ -122,9 +120,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerRejectSuccess() 
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	handler := UpdateMTOServiceItemStatusHandler{context,
@@ -172,9 +168,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandlerRejectionFailedN
 		IfMatch:          etag.GenerateEtag(mtoServiceItem.UpdatedAt),
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	context := handlers.NewHandlerContext(appCtx)
+	context := handlers.NewHandlerContext()
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	handler := UpdateMTOServiceItemStatusHandler{context,

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -98,10 +98,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 
 	updater := mtoshipment.NewMTOShipmentStatusUpdater(queryBuilder, siCreator, planner)
 
-	appCtx := suite.AppContextForTest()
-
 	handler := UpdateMTOShipmentStatusHandlerFunc{
-		handlers.NewHandlerContext(appCtx),
+		handlers.NewHandlerContext(),
 		fetcher,
 		updater,
 	}
@@ -110,10 +108,8 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 
-		appCtx := suite.AppContextForTest()
-
 		mockHandler := UpdateMTOShipmentStatusHandlerFunc{
-			handlers.NewHandlerContext(appCtx),
+			handlers.NewHandlerContext(),
 			&mockFetcher,
 			&mockUpdater,
 		}

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -58,10 +58,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(),
 		}
@@ -93,10 +91,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 		}
 		queryBuilder := query.NewQueryBuilder()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentrequest.NewPaymentRequestStatusUpdater(queryBuilder),
 			PaymentRequestFetcher:       paymentrequest.NewPaymentRequestFetcher(),
 		}
@@ -131,10 +127,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -165,10 +159,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -196,10 +188,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -226,10 +216,8 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 			PaymentRequestID: strfmt.UUID(paymentRequestID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := UpdatePaymentRequestStatusHandler{
-			HandlerContext:              handlers.NewHandlerContext(appCtx),
+			HandlerContext:              handlers.NewHandlerContext(),
 			PaymentRequestStatusUpdater: paymentRequestStatusUpdater,
 			PaymentRequestFetcher:       paymentRequestFetcher,
 		}
@@ -253,10 +241,8 @@ func (suite *HandlerSuite) TestListMTOPaymentRequestHandler() {
 			MoveTaskOrderID: strfmt.UUID(mtoID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOPaymentRequestsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 		}
 
 		response := handler.Handle(params)
@@ -276,10 +262,8 @@ func (suite *HandlerSuite) TestListMTOPaymentRequestHandler() {
 			MoveTaskOrderID: strfmt.UUID(mto.ID.String()),
 		}
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ListMTOPaymentRequestsHandler{
-			HandlerContext: handlers.NewHandlerContext(appCtx),
+			HandlerContext: handlers.NewHandlerContext(),
 		}
 
 		response := handler.Handle(params)
@@ -336,10 +320,8 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 
 	icnSequencer := sequence.NewDatabaseSequencer(ediinvoice.ICNSequenceName)
 
-	appCtx := suite.AppContextForTest()
-
 	handler := GetPaymentRequestEDIHandler{
-		HandlerContext:                    handlers.NewHandlerContext(appCtx),
+		HandlerContext:                    handlers.NewHandlerContext(),
 		PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 		GHCPaymentRequestInvoiceGenerator: invoice.NewGHCPaymentRequestInvoiceGenerator(icnSequencer, clock.NewMock()),
 	}
@@ -395,10 +377,8 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		mockGenerator := &mocks.GHCPaymentRequestInvoiceGenerator{}
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, apperror.NewInvalidInputError(paymentRequestID, nil, validate.NewErrors(), ""))
 
-		appCtx := suite.AppContextForTest()
-
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerContext:                    handlers.NewHandlerContext(appCtx),
+			HandlerContext:                    handlers.NewHandlerContext(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -419,10 +399,8 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		mockGenerator := &mocks.GHCPaymentRequestInvoiceGenerator{}
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, apperror.NewConflictError(paymentRequestID, "conflict error"))
 
-		appCtx := suite.AppContextForTest()
-
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerContext:                    handlers.NewHandlerContext(appCtx),
+			HandlerContext:                    handlers.NewHandlerContext(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -458,10 +436,8 @@ func (suite *HandlerSuite) TestGetPaymentRequestEDIHandler() {
 		errStr := "some error"
 		mockGenerator.On("Generate", mock.AnythingOfType("*appcontext.appContext"), mock.Anything, mock.Anything).Return(ediinvoice.Invoice858C{}, errors.New(errStr)).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		mockGeneratorHandler := GetPaymentRequestEDIHandler{
-			HandlerContext:                    handlers.NewHandlerContext(appCtx),
+			HandlerContext:                    handlers.NewHandlerContext(),
 			PaymentRequestFetcher:             paymentrequest.NewPaymentRequestFetcher(),
 			GHCPaymentRequestInvoiceGenerator: mockGenerator,
 		}
@@ -586,10 +562,8 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 	paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 	paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(reviewedPRs[0], nil)
 
-	appCtx := suite.AppContextForTest()
-
 	handler := ProcessReviewedPaymentRequestsHandler{
-		HandlerContext:                handlers.NewHandlerContext(appCtx),
+		HandlerContext:                handlers.NewHandlerContext(),
 		PaymentRequestFetcher:         paymentRequestFetcher,
 		PaymentRequestStatusUpdater:   paymentRequestStatusUpdater,
 		PaymentRequestReviewedFetcher: paymentRequestReviewedFetcher,
@@ -739,10 +713,8 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(nilPr, errors.New("could not fetch payment request"))
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ProcessReviewedPaymentRequestsHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			PaymentRequestFetcher:         paymentRequestFetcher,
 			PaymentRequestStatusUpdater:   paymentRequestStatusUpdater,
 			PaymentRequestReviewedFetcher: paymentRequestReviewedFetcher,
@@ -780,10 +752,8 @@ func (suite *HandlerSuite) TestProcessReviewedPaymentRequestsHandler() {
 		paymentRequestFetcher := &mocks.PaymentRequestFetcher{}
 		paymentRequestFetcher.On("FetchPaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.Anything).Return(reviewedPRs[0], nil)
 
-		appCtx := suite.AppContextForTest()
-
 		handler := ProcessReviewedPaymentRequestsHandler{
-			HandlerContext:                handlers.NewHandlerContext(appCtx),
+			HandlerContext:                handlers.NewHandlerContext(),
 			PaymentRequestFetcher:         paymentRequestFetcher,
 			PaymentRequestStatusUpdater:   paymentRequestStatusUpdater,
 			PaymentRequestReviewedFetcher: paymentRequestReviewedFetcher,
@@ -832,10 +802,8 @@ func (suite *HandlerSuite) TestRecalculatePaymentRequestHandler() {
 			paymentRequestID,
 		).Return(&samplePaymentRequest, nil).Once()
 
-		appCtx := suite.AppContextForTest()
-
 		handler := RecalculatePaymentRequestHandler{
-			HandlerContext:             handlers.NewHandlerContext(appCtx),
+			HandlerContext:             handlers.NewHandlerContext(),
 			PaymentRequestRecalculator: mockRecalculator,
 		}
 
@@ -909,10 +877,8 @@ func (suite *HandlerSuite) TestRecalculatePaymentRequestHandler() {
 				paymentRequestID,
 			).Return(nil, testCase.testErr)
 
-			appCtx := suite.AppContextForTest()
-
 			handler := RecalculatePaymentRequestHandler{
-				HandlerContext:             handlers.NewHandlerContext(appCtx),
+				HandlerContext:             handlers.NewHandlerContext(),
 				PaymentRequestRecalculator: mockRecalculator,
 			}
 

--- a/pkg/handlers/supportapi/webhook_notification_test.go
+++ b/pkg/handlers/supportapi/webhook_notification_test.go
@@ -38,9 +38,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			Body:        requestPayload,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		context.SetTraceID(uuid.Must(uuid.NewV4()))
 		handler := CreateWebhookNotificationHandler{context}
 
@@ -75,9 +73,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			HTTPRequest: request,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		context.SetTraceID(uuid.Must(uuid.NewV4()))
 		handler := CreateWebhookNotificationHandler{context}
 
@@ -119,9 +115,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 			Body:        requestPayload,
 		}
 
-		appCtx := suite.AppContextForTest()
-
-		context := handlers.NewHandlerContext(appCtx)
+		context := handlers.NewHandlerContext()
 		context.SetTraceID(uuid.Must(uuid.NewV4()))
 		handler := CreateWebhookNotificationHandler{context}
 

--- a/pkg/middleware/appcontext.go
+++ b/pkg/middleware/appcontext.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+)
+
+// AppContextMiddleware returns a handler that inject the AppContext into the request context
+func AppContextMiddleware(appCtx appcontext.AppContext) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			newCxt := appcontext.NewContext(ctx, appCtx)
+
+			next.ServeHTTP(w, r.WithContext(newCxt))
+		})
+	}
+}

--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -54,8 +54,8 @@ func (suite *EventServiceSuite) Test_EventTrigger() {
 			Path: "",
 		},
 	}
-	appCtx := suite.AppContextForTest()
-	handler := handlers.NewHandlerContext(appCtx)
+
+	handler := handlers.NewHandlerContext()
 
 	// Test successful event passing with Support API
 	suite.T().Run("Success with support api endpoint", func(t *testing.T) {
@@ -187,9 +187,7 @@ func (suite *EventServiceSuite) Test_MTOEventTrigger() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := handlers.NewHandlerContext(appCtx)
+	handler := handlers.NewHandlerContext()
 	traceID, _ := uuid.NewV4()
 	handler.SetTraceID(traceID)
 
@@ -249,9 +247,7 @@ func (suite *EventServiceSuite) Test_MTOShipmentEventTrigger() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := handlers.NewHandlerContext(appCtx)
+	handler := handlers.NewHandlerContext()
 	traceID, _ := uuid.NewV4()
 	handler.SetTraceID(traceID)
 
@@ -311,9 +307,7 @@ func (suite *EventServiceSuite) Test_MTOServiceItemEventTrigger() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := handlers.NewHandlerContext(appCtx)
+	handler := handlers.NewHandlerContext()
 
 	// Test successful event passing with Support API
 	suite.T().Run("Success with GHC ServiceItem endpoint", func(t *testing.T) {
@@ -343,9 +337,7 @@ func (suite *EventServiceSuite) TestOrderEventTrigger() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := handlers.NewHandlerContext(appCtx)
+	handler := handlers.NewHandlerContext()
 	traceID, _ := uuid.NewV4()
 	handler.SetTraceID(traceID)
 
@@ -387,9 +379,7 @@ func (suite *EventServiceSuite) TestNotificationEventHandler() {
 		},
 	}
 
-	appCtx := suite.AppContextForTest()
-
-	handler := handlers.NewHandlerContext(appCtx)
+	handler := handlers.NewHandlerContext()
 	traceID, _ := uuid.NewV4()
 	handler.SetTraceID(traceID)
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1715,7 +1715,7 @@ func createHHGMoveWithPaymentRequest(appCtx appcontext.AppContext, userUploader 
 	)
 
 	handler := primeapi.CreatePaymentRequestHandler{
-		HandlerContext:        handlers.NewHandlerContext(appCtx),
+		HandlerContext:        handlers.NewHandlerContext(),
 		PaymentRequestCreator: paymentRequestCreator,
 	}
 


### PR DESCRIPTION
## Description

Proof of concept of using `AppContext` in middleware instead of as a field on the `handlerContext` struct.

Main things to focus on are the first commit: https://github.com/transcom/mymove/pull/7752/commits/3125c5899262e17a9fd157dc801ace59a00abdd6

and the changes to `contexts.go`: https://github.com/transcom/mymove/pull/7752/commits/c97387015ad3f7aceb743b184cf6b7e5b597d2b3#diff-218b8e3f456a4d95176b572dead5bf50215b43f5b1823f6013eb899a1fec4c3c 

Tests are broken because the setup for tests that need the handler would now need to set up the appCtx in the request context, but I have a comment below highlighting how they could be fixed.