### PR TITLE
MB-10498: Increase open file limit in AWS

### DIFF
--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -596,6 +596,13 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 			Command:     []*string{},
 			Secrets:     secrets,
 			Environment: containerEnvironment,
+			Ulimits: []*ecs.Ulimit{
+				{
+					Name:      aws.String("nofile"),
+					SoftLimit: aws.Int64(10000),
+					HardLimit: aws.Int64(10000),
+				},
+			},
 			LogConfiguration: &ecs.LogConfiguration{
 				LogDriver: aws.String("awslogs"),
 				Options: map[string]*string{


### PR DESCRIPTION
## Description

When running the load test, AWS reported errors about the number of open files. This increases the limit

## Reviewer Notes

This has been deployed to loadtest env and confirmed to fix the problem.

