### PR TITLE
MB-10522: pin otel collector version, use aws ecr repo, use metrics config

### DIFF
--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -615,7 +615,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		containerDefinitions = append(containerDefinitions,
 			&ecs.ContainerDefinition{
 				Name:      aws.String("otel-" + containerDefName),
-				Image:     aws.String("amazon/aws-otel-collector"),
+				Image:     aws.String("amazon/aws-otel-collector:v0.14.0"),
 				Essential: aws.Bool(true),
 				Command: aws.StringSlice([]string{
 					"--config=/etc/ecs/ecs-cloudwatch-xray.yaml",

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -618,7 +618,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 				Image:     aws.String("public.ecr.aws/aws-observability/aws-otel-collector:v0.14.0"),
 				Essential: aws.Bool(true),
 				Command: aws.StringSlice([]string{
-					"--config=/etc/ecs/ecs-cloudwatch-xray.yaml",
+					"--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml",
 				}),
 				LogConfiguration: &ecs.LogConfiguration{
 					LogDriver: aws.String("awslogs"),

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -615,7 +615,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		containerDefinitions = append(containerDefinitions,
 			&ecs.ContainerDefinition{
 				Name:      aws.String("otel-" + containerDefName),
-				Image:     aws.String("amazon/aws-otel-collector:v0.14.0"),
+				Image:     aws.String("public.ecr.aws/aws-observability/aws-otel-collector:v0.14.0"),
 				Essential: aws.Bool(true),
 				Command: aws.StringSlice([]string{
 					"--config=/etc/ecs/ecs-cloudwatch-xray.yaml",


### PR DESCRIPTION
## Description

In loadtest, the metrics stopped working, seemingly after an update to the otel collector version. Pinning to v0.14.0 and using the metrics config seems to have fixed it.

Then, there was a problem somewhere in The Cloud where AWS couldn't pull down the image from docker hub, so use an AWS ECR public image.

## Reviewer Notes

The [docs](https://github.com/aws-observability/aws-otel-collector/blob/main/docs/developers/ecs-demo.md) suggest we should use the metrics config "... to consume application metrics, traces (using OTLP and Xray) and container resource utilization metrics". It's really not clear to me how exactly it is different from the other provided ECS config, but this seems to work in the load test environment.
