### PR TITLE
MB-9669: Ensure auth API calls are never cached

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -1007,6 +1007,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		},
 	)
 	authMux := root.PathPrefix("/auth/").Subrouter()
+	authMux.Use(middleware.NoCache(logger))
 	authMux.Use(otelmux.Middleware("auth"))
 	authMux.Handle("/login-gov", authentication.NewRedirectHandler(authContext, handlerContext, useSecureCookie)).Methods("GET")
 	authMux.Handle("/login-gov/callback", authentication.NewCallbackHandler(authContext, handlerContext, notificationSender)).Methods("GET")
@@ -1015,6 +1016,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	if v.GetBool(cli.DevlocalAuthFlag) {
 		logger.Info("Enabling devlocal auth")
 		localAuthMux := root.PathPrefix("/devlocal-auth/").Subrouter()
+		localAuthMux.Use(middleware.NoCache(logger))
 		localAuthMux.Use(otelmux.Middleware("devlocal"))
 		localAuthMux.Handle("/login", authentication.NewUserListHandler(authContext, handlerContext)).Methods("GET")
 		localAuthMux.Handle("/login", authentication.NewAssignUserHandler(authContext, handlerContext, appnames)).Methods("POST")


### PR DESCRIPTION
## Description

Looking at the logs from the most recent occurrence (see the comments in jira), there doesn't seem to be a log for the `GET /auth/login-gov` before the redirect back to `/auth/login-gov/callback`. This is a bit of a shot in the dark, but let's make sure none of the API calls is ever cached.

## Reviewer Notes

Not positive this will fix the bug, but it also seems like the right thing to do regardless. We install this middleware for all our other API endpoints.

I deployed this on the load test environment


