### PR TITLE
Fix flaky TestListPaymentRequestWithSortOrder server test

### DIFF
--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -361,6 +361,12 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 	//
 	officeUser := testdatagen.MakeTIOOfficeUser(suite.DB(), testdatagen.Assertions{})
 
+	originDutyStation1 := testdatagen.MakeDutyStation(suite.DB(), testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			Name: "Scott AFB",
+		},
+	})
+
 	hhgMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			FirstName: models.StringPointer("Leo"),
@@ -371,6 +377,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 			SelectedMoveType: &hhgMoveType,
 			Locator:          "ZZZZ",
 		},
+		OriginDutyStation: originDutyStation1,
 	})
 	// Fake this as a day and a half in the past so floating point age values can be tested
 	prevCreatedAt := time.Now().Add(time.Duration(time.Hour * -36))
@@ -381,8 +388,11 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 			Status:    models.PaymentRequestStatusReviewed,
 			CreatedAt: prevCreatedAt,
 		},
-		OriginDutyStation: models.DutyStation{
-			Name: "Scott AFB",
+	})
+
+	originDutyStation2 := testdatagen.MakeDutyStation(suite.DB(), testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			Name: "Applewood, CA 99999",
 		},
 	})
 
@@ -400,9 +410,7 @@ func (suite *PaymentRequestServiceSuite) TestListPaymentRequestWithSortOrder() {
 		PaymentRequest: models.PaymentRequest{
 			Status: models.PaymentRequestStatusPaid,
 		},
-		OriginDutyStation: models.DutyStation{
-			Name: "Applewood, CA 99999",
-		},
+		OriginDutyStation: originDutyStation2,
 	})
 
 	testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{


### PR DESCRIPTION
## Description

This PR attempts to fix a flaky server test that has been randomly failing the last couple of days ([see example](https://app.circleci.com/pipelines/github/transcom/mymove/37133/workflows/59fdabca-b1be-47e3-a117-1ed5f0c773e2/jobs/566566)).  The two subtests that are failing attempt to check whether the sort order being returned by the database matches the expected sort order.  The problem appears to be a difference in sort collation between sorting in Postgres and sorting in Go.  This difference causes a potential failure when two duty station names are generated where one starts with an upper case letter and the other starts with a lower case letter (note that we generate a random duty station name when creating a duty station if one is not provided via an assertion).

Looking at the test setup, I don’t think the intention was to have randomly generated duty station names.  There are some names attempting to be set, but they weren't actually being set based on how the assertions propagate down through the testdatagen makers (e.g., there's an `OriginDutyStation` and a `DutyStation` in the assertions, each used in different places).  So, we were getting the random duty station names.  I just adjusted the test setup to explicitly create a couple of duty stations first, use them in the assertions, and now the origin duty stations are set as expected.  Both explicitly set duty station names use capital letters, so this hopefully bypasses any collation concerns and fixes the flaky test.

## Setup

Run `make server_test` and ensure there are no test failures.
