### PR TITLE
[MB-10471] bump up logging for audit service to Info from Debug

### DIFF
--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -58,7 +58,7 @@ func Capture(appCtx appcontext.AppContext, model interface{}, payload interface{
 				return nil, err
 			}
 
-			appCtx.Logger().Debug("Audit patch payload", zap.String("patch_payload", string(payloadJSON)))
+			appCtx.Logger().Info("Audit patch payload", zap.String("patch_payload", string(payloadJSON)))
 		}
 	} else {
 		msg += " invalid or zero or nil model interface received from request handler"


### PR DESCRIPTION
## Description

Bumping up audit service from Debug log to Info log to see this info in CloudWatch logs.

## Reviewer Notes

n/a

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] If the change is risky, it has been tested in experimental before merging.
* [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations))
  * [ ] Have been communicated to #g-database
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
