### PR TITLE
[MB-10173] Hide line about storage facility on all but NTS-release form

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -429,7 +429,7 @@ class MtoShipmentForm extends Component {
                           <Callout>
                             Examples
                             <ul>
-                              <li>The storage facility or address where your items are currently stored</li>
+                              {isNTSR && <li>The storage facility or address where your items are currently stored</li>}
                               <li>Large, bulky, or fragile items</li>
                               <li>Access info for your origin or destination address</li>
                               <li>You’re shipping weapons or alcohol</li>

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -99,6 +99,10 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByLabelText('Email')[1]).toHaveAttribute('name', 'delivery.agent.email');
 
       expect(
+        screen.queryByText('The storage facility or address where your items are currently stored'),
+      ).not.toBeInTheDocument();
+
+      expect(
         screen.getByLabelText(
           'Are there things about this shipment that your counselor or movers should discuss with you?',
         ),
@@ -754,6 +758,9 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByText('Date')).toHaveLength(1);
       expect(screen.getAllByText('Pickup location')).toHaveLength(1);
       expect(screen.queryByText(/Receiving agent/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('The storage facility or address where your items are currently stored'),
+      ).not.toBeInTheDocument();
 
       expect(
         screen.getByLabelText(
@@ -796,6 +803,10 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getByLabelText('Last name')).toHaveAttribute('name', 'delivery.agent.lastName');
       expect(screen.getByLabelText('Phone')).toHaveAttribute('name', 'delivery.agent.phone');
       expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'delivery.agent.email');
+
+      expect(
+        screen.queryByText('The storage facility or address where your items are currently stored'),
+      ).toBeInTheDocument();
 
       expect(
         screen.getByLabelText(


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10173) for this change

## Summary

Is there anything you would like reviewers to give additional scrutiny?



## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Set up a new shipment and see that the bullet point "The storage facility or address where your items are currently stored" is on the remarks field for NTS-release shipments but no other shipment types.
