### PR TITLE
MB-10086 Removes type='number' from ShipmentWeightInput text field

### DIFF
--- a/src/components/Office/ShipmentWeightInput/ShipmentWeightInput.jsx
+++ b/src/components/Office/ShipmentWeightInput/ShipmentWeightInput.jsx
@@ -18,7 +18,7 @@ const ShipmentWeightInput = () => {
               Shipment weight (lbs)
               <span className="float-right">Optional</span>
             </Label>
-            <Field as={TextInput} type="number" id="primeActualWeight" name="primeActualWeight" />
+            <Field as={TextInput} id="primeActualWeight" name="primeActualWeight" />
           </FormGroup>
         </Grid>
       </Fieldset>

--- a/src/components/Office/ShipmentWeightInput/ShipmentWeightInput.test.jsx
+++ b/src/components/Office/ShipmentWeightInput/ShipmentWeightInput.test.jsx
@@ -17,11 +17,11 @@ describe('components/Office/ShipmentWeightInput', () => {
 
   it('populates Formik initialValues', () => {
     render(
-      <Formik initialValues={{ primeActualWeight: 4500 }}>
+      <Formik initialValues={{ primeActualWeight: '4500' }}>
         <ShipmentWeightInput />
       </Formik>,
     );
 
-    expect(screen.getByLabelText(/Shipment weight \(lbs\)/)).toHaveValue(4500);
+    expect(screen.getByLabelText(/Shipment weight \(lbs\)/)).toHaveValue('4500');
   });
 });

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -225,7 +225,7 @@ export function formatMtoShipmentForAPI({
   }
 
   if (primeActualWeight) {
-    formattedMtoShipment.primeActualWeight = primeActualWeight;
+    formattedMtoShipment.primeActualWeight = Number(primeActualWeight);
   }
 
   if (tacType) {

--- a/src/utils/formatMtoShipment.test.js
+++ b/src/utils/formatMtoShipment.test.js
@@ -314,7 +314,7 @@ describe('formatMtoShipmentForAPI', () => {
       ...mtoShipmentParams,
       shipmentType: SHIPMENT_OPTIONS.NTSR,
       delivery: { ...deliveryInfo },
-      primeActualWeight: 4000,
+      primeActualWeight: '4000',
     };
 
     const actual = formatMtoShipmentForAPI(params);


### PR DESCRIPTION
## Jira ticket for this change: [MB-10086](https://dp3.atlassian.net/browse/MB-10086)

## Summary

This pull request removes the `type="number"` attribute from the text field in the `ShipmentWeightInput` component, which will no longer cause some browsers to render a set of increment/decrement arrow controls inside that field.

Other code which receives the value from that field has been updated to transform the value from that text field into a number, if that value is present.

## Setup to Run Your Code

<details>
Start Storybook locally.

```sh
make storybook
```
</details>

### Additional steps

1. View the modified component in Storybook (`Office Components` -> `Forms` -> `ServicesCounselingShipmentForm` -> `ShipmentWeightInput`), and verify that the text field does not display increment/decrement buttons when focused.
2. In the parent component to the modified component (`ServicesCounselingShipmentForm`), view the `NTS Release Shipment` story. Fill in a value for Shipment weight, as well as all other required fields, and then click the "Save" button.
3. Open the "Actions" tab in the Storybook developer console; the submitted payload should be expandable, and it should include a `primeActualWeight` value. Verify that value is what you entered in the field, and is not a string.

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

### Frontend

- [x] User facing changes have been reviewed by design.
- [x] There are no aXe warnings for UI.
- [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [x] There are no new console errors in the browser devtools
- [x] There are no new console errors in the test output