### PR TITLE
MB-10494-add-new-migration-to-index-users_roles-table

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -685,3 +685,4 @@
 20211112193224_support_noninstallation_locations.up.sql
 20211112205920_add_noninstallation_locations.up.sql
 20211123155748_domestic_nts_packing_metadata.up.sql
+20211202213138_index_user_roles_table.up.sql

--- a/migrations/app/schema/20211202213138_index_user_roles_table.up.sql
+++ b/migrations/app/schema/20211202213138_index_user_roles_table.up.sql
@@ -1,0 +1,5 @@
+-- Add a database migration to index the user_id and deleted_at columns of the users_roles table.
+CREATE INDEX users_roles_user_id_idx ON users_roles(user_id);
+CREATE INDEX users_roles_not_deleted_partial_idx ON users_roles (deleted_at)
+    WHERE users_roles.deleted_at IS NULL;
+COMMENT ON INDEX users_roles_not_deleted_partial_idx IS 'indexes user_roles that are not deleted';

--- a/migrations/app/schema/20211202213138_index_user_roles_table.up.sql
+++ b/migrations/app/schema/20211202213138_index_user_roles_table.up.sql
@@ -1,5 +1,5 @@
 -- Add a database migration to index the user_id and deleted_at columns of the users_roles table.
-CREATE INDEX users_roles_user_id_idx ON users_roles(user_id);
+CREATE INDEX users_roles_user_id_idx ON users_roles (user_id);
 CREATE INDEX users_roles_not_deleted_partial_idx ON users_roles (deleted_at)
     WHERE users_roles.deleted_at IS NULL;
-COMMENT ON INDEX users_roles_not_deleted_partial_idx IS 'indexes user_roles that are not deleted';
+COMMENT ON INDEX users_roles_not_deleted_partial_idx IS 'indexes users_roles that are not deleted';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10494) for this change

## Summary

Add a database migration to index the user_id and partially index deleted_at columns of the users_roles table.

## Setup to Run Your Code

<details>
<summary>Run office load testing in master and see how long it takes for issues in office user endpoints to arise. Then switch to my branch and make sure you have enough data in your database `make db_dev_e2e_populate`. Run load testing again in my branch. </summary>

##### Terminal 1

In the load testing repo run

```sh
make load_test_office
```

##### Terminal 2

Start the Go server locally in the mymove repo

```sh
make server_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->


### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
