### PR TITLE
Update nix psql_exe path so that it's aware of per-user profiles.

### DIFF
--- a/scripts/psql-wrapper
+++ b/scripts/psql-wrapper
@@ -14,7 +14,7 @@ if [ -x "/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql" ]; then
 fi
 
 if [ -n "${command[*]}" ]; then
-  exec  $psql_exe --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost:"${db_port}"/"${DB_NAME}" -c "${command}"
+  exec  "$psql_exe" --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost:"${db_port}"/"${DB_NAME}" -c "${command}"
 else
-  exec $psql_exe  --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost:"${db_port}"/"${DB_NAME}"
+  exec "$psql_exe"  --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost:"${db_port}"/"${DB_NAME}"
 fi

--- a/scripts/psql-wrapper
+++ b/scripts/psql-wrapper
@@ -9,7 +9,7 @@ command="${*:-}"
 
 # nix-friendly option
 psql_exe=/usr/local/bin/psql
-if [ -x "/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql" ]; then
+if [ "${NIX_PROFILE}" ]; then
   psql_exe="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql"
 fi
 

--- a/scripts/psql-wrapper
+++ b/scripts/psql-wrapper
@@ -9,8 +9,8 @@ command="${*:-}"
 
 # nix-friendly option
 psql_exe=/usr/local/bin/psql
-if [ -x /nix/var/nix/profiles/mymove/bin/psql ]; then
-  psql_exe=/nix/var/nix/profiles/mymove/bin/psql
+if [ -x "/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql" ]; then
+  psql_exe="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql"
 fi
 
 if [ -n "${command[*]}" ]; then


### PR DESCRIPTION
## Summary

I made the path in `scripts/psql-wrapper` match the change that happened [here](https://github.com/transcom/mymove/pull/7830/files#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R303)

## Setup to Run Your Code

##### Terminal 1

Run database setup

```sh
make db_dev_reset
```

## Verification Steps for Reviewers

Does this still work for single user installs of Nix?

