### PR TITLE
MB-9937: Service Counselors can edit LOAs

### DIFF
--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -47,25 +47,27 @@ const OrdersDetailForm = ({
           label="TAC"
           id="hhgTacInput"
           mask="****"
+          inputTestId="hhgTacInput"
           warning={hhgTacWarning}
           validate={validateHHGTac}
         />
       )}
-      {showHHGSac && <TextField name="sac" label="SAC" id="hhgSacInput" optional />}
+      {showHHGSac && <TextField name="sac" label="SAC" id="hhgSacInput" data-testid="hhgSacInput" optional />}
 
       {showNTSTac && showNTSSac && <h3>NTS accounting codes</h3>}
       {showNTSTac && (
         <MaskedTextField
-          name="nts_tac"
+          name="ntsTac"
           label="TAC"
           id="ntsTacInput"
           mask="****"
+          inputTestId="ntsTacInput"
           warning={ntsTacWarning}
           validate={validateNTSTac}
           optional
         />
       )}
-      {showNTSSac && <TextField name="nts_sac" label="SAC" id="ntsSacInput" optional />}
+      {showNTSSac && <TextField name="ntsSac" label="SAC" id="ntsSacInput" data-testid="ntsSacInput" optional />}
 
       {showOrdersAcknowledgement && (
         <div className={styles.wrappedCheckbox}>

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -94,8 +94,8 @@ export const InitialValues = () => {
           ordersTypeDetail: 'HHG_PERMITTED',
           tac: 'Tac',
           sac: 'Sac',
-          nts_tac: 'Tac',
-          nts_sac: 'Sac',
+          ntsTac: 'Tac',
+          ntsSac: 'Sac',
           ordersAcknowledgement: true,
         }}
         validationSchema={Yup.object({
@@ -109,8 +109,8 @@ export const InitialValues = () => {
           ordersTypeDetail: Yup.string().required('Required'),
           tac: Yup.string().required('Required'),
           sac: Yup.string().required('Required'),
-          nts_tac: Yup.string().required('Required'),
-          nts_sac: Yup.string().required('Required'),
+          ntsTac: Yup.string().required('Required'),
+          ntsSac: Yup.string().required('Required'),
         })}
       >
         <form>
@@ -141,8 +141,8 @@ export const FieldsHidden = (args) => {
           ordersTypeDetail: 'HHG_PERMITTED',
           tac: 'Tac',
           sac: 'Sac',
-          nts_tac: 'Tac',
-          nts_sac: 'Sac',
+          ntsTac: 'Tac',
+          ntsSac: 'Sac',
         }}
         validationSchema={Yup.object({
           originDutyStation: Yup.object().defined('Required'),

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -102,6 +102,10 @@ const ServicesCounselingMoveDetails = ({ customerEditAlert }) => {
     issuedDate: order.date_issued,
     reportByDate: order.report_by_date,
     ordersType: order.order_type,
+    tacMDC: order.tac,
+    sacSDN: order.sac,
+    NTStac: order.ntsTac,
+    NTSsac: order.ntsSac,
   };
 
   // use mutation calls

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -68,6 +68,7 @@ const ServicesCounselingOrders = () => {
 
   const onSubmit = (values) => {
     const body = {
+      ...values,
       originDutyStationId: values.originDutyStation.id,
       newDutyStationId: values.newDutyStation.id,
       issueDate: formatSwaggerDate(values.issueDate),
@@ -84,6 +85,10 @@ const ServicesCounselingOrders = () => {
     reportByDate: order?.report_by_date,
     departmentIndicator: order?.department_indicator,
     ordersType: order?.order_type,
+    tac: order?.tac,
+    sac: order?.sac,
+    ntsTac: order?.ntsTac,
+    ntsSac: order?.ntsSac,
   };
 
   return (

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { mount } from 'enzyme';
 import { render, screen } from '@testing-library/react';
 
 import ServicesCounselingOrders from 'pages/Office/ServicesCounselingOrders/ServicesCounselingOrders';
@@ -78,6 +77,8 @@ const useOrdersDocumentQueriesReturnValue = {
       report_by_date: '2018-08-01',
       tac: 'F8E1',
       sac: 'E2P3',
+      ntsTac: 'C2E3',
+      ntsSac: 'R6X1',
     },
   },
 };
@@ -126,30 +127,47 @@ describe('Orders page', () => {
   });
 
   describe('Basic rendering', () => {
-    useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+    it('renders the sidebar orders detail form', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
 
-    const wrapper = mount(
-      <MockProviders initialEntries={['moves/FP24I2/orders']}>
-        <ServicesCounselingOrders />
-      </MockProviders>,
-    );
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <ServicesCounselingOrders />
+        </MockProviders>,
+      );
 
-    it('renders the sidebar orders detail form', () => {
-      expect(wrapper.find('OrdersDetailForm').exists()).toBe(true);
+      expect(await screen.findByLabelText('Current duty location')).toBeInTheDocument();
     });
 
-    it('renders the sidebar elements', () => {
-      expect(wrapper.find({ 'data-testid': 'view-orders-header' }).text()).toBe('View orders');
-      // There is only 1 button, but mount-rendering react-uswds Button component has inner buttons
-      expect(wrapper.find({ 'data-testid': 'view-allowances' }).at(0).text()).toBe('View allowances');
+    it('renders the sidebar elements', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <ServicesCounselingOrders />
+        </MockProviders>,
+      );
+
+      expect(await screen.findByTestId('view-orders-header')).toHaveTextContent('View orders');
+      expect(screen.getByTestId('view-allowances')).toHaveTextContent('View allowances');
     });
 
-    it('populates initial field values', () => {
-      expect(wrapper.find('Select[name="originDutyStation"]').prop('value')).toEqual(mockOriginDutyStation);
-      expect(wrapper.find('Select[name="newDutyStation"]').prop('value')).toEqual(mockDestinationDutyStation);
-      expect(wrapper.find('input[name="issueDate"]').prop('value')).toBe('15 Mar 2018');
-      expect(wrapper.find('input[name="reportByDate"]').prop('value')).toBe('01 Aug 2018');
-      expect(wrapper.find('select[name="ordersType"]').prop('value')).toBe('PERMANENT_CHANGE_OF_STATION');
+    it('populates initial field values', async () => {
+      useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+
+      render(
+        <MockProviders initialEntries={['moves/FP24I2/orders']}>
+          <ServicesCounselingOrders />
+        </MockProviders>,
+      );
+
+      expect(await screen.findByText(mockOriginDutyStation.name)).toBeInTheDocument();
+      expect(screen.getByText(mockDestinationDutyStation.name)).toBeInTheDocument();
+      expect(screen.getByLabelText('Orders type')).toHaveValue('PERMANENT_CHANGE_OF_STATION');
+      expect(screen.getByTestId('hhgTacInput')).toHaveValue('F8E1');
+      expect(screen.getByTestId('hhgSacInput')).toHaveValue('E2P3');
+      expect(screen.getByTestId('ntsTacInput')).toHaveValue('C2E3');
+      expect(screen.getByTestId('ntsSacInput')).toHaveValue('R6X1');
     });
   });
 });


### PR DESCRIPTION
## Jira ticket for this change: [MB-9937](https://dp3.atlassian.net/browse/MB-9937)

## Summary

This pull request modifies the Service Counselor Orders page to use the `ntsTac` and `ntsSac` fields, both in setting initial Formik values that are used in the `OrdersDetailForm` component, and in creating the payload that's sent to the update orders endpoint when the page's form is submitted.

Some tests are also re-written to use React Testing Library, instead of Enzyme, and to check for the newly populated fields.

This pull request also modifies the Service Counselor Move Details page, to pass the lines of accounting into the `OrdersList` component, so that values entered in the `OrdersDetailForm` are visible in an additional location. (This might be outside the specific scope of the ticket, but it was a very easy change.)

@transcom/truss-design: A previous ticket was in charge of updating the `OrdersDetailForm` component with the additional lines of accounting fields, but didn't wire them up to anything. This ticket is for that wiring; as a result, there should be no UI changes besides values correctly populating into those TAC and SAC fields.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Login to the office application locally, as a Service Counselor user.

2. View any user in the SC queue (from the devseed data). Scroll down to the "Orders" panel, and click the "View and edit orders" button. 

    **Note**: When clicked, a full-screen browser exception may pop up (it would read "Unhandled Rejection (InvalidPDFException): Invalid PDF structure" along the top line in red text). This is an issue with the interaction of our procedurally generated devseed data and the PDF file display component, and unrelated to the work done in this pull request. You can click the "x" in the top right corner of this error message to dismiss it, and continue using the page normally.

3. Fill out values for `TAC` and `SAC` in the `HHG accounting codes` and `NTS accounting codes` section, then click the "Save" button.

4. You will be taken back to the move details page. Verify that the values for `HHG TAC`, `HHG SAC`, `NTS TAC` and `NTS SAC` are what you entered in the previous step.

5. Click "View and edit orders" again. Verify that the values for the accounting codes fields are what you entered in Step 3.

## Verification Steps for Author

These are to be checked by the author.

- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots

* [LOA values displaying in the OrdersList component](https://user-images.githubusercontent.com/83614364/145103552-5b82784a-d2d6-4f73-8be4-0d35e0b7eb0b.png)
* [LOA values entered in the OrdersDetailForm component](https://user-images.githubusercontent.com/83614364/145103633-ba9176c3-663e-44b4-87c1-9b11364c0e01.png)
* [Fullscreen browser error message, unrelated to this work](https://user-images.githubusercontent.com/83614364/145103700-be210f3f-982e-4c7d-8d12-141d024e3630.png)

