### PR TITLE
Psql-wrapper script use the +x pattern that we use in other places to detect NIX_Profile

### DIFF
--- a/scripts/psql-wrapper
+++ b/scripts/psql-wrapper
@@ -9,7 +9,7 @@ command="${*:-}"
 
 # nix-friendly option
 psql_exe=/usr/local/bin/psql
-if [ "${NIX_PROFILE}" ]; then
+if [ -n "${NIX_PROFILE+x}" ]; then
   psql_exe="/nix/var/nix/profiles/per-user/${LOGNAME}/mymove/bin/psql"
 fi
 


### PR DESCRIPTION
## Summary

Makes it so non-nix users can run `make db_dev_reset`


