### PR TITLE
Add checklist item to PR template office app components in Storybook and responsive design

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -66,6 +66,7 @@ These are to be checked by a reviewer.
 - [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
 - [ ] There are no new console errors in the browser devtools
 - [ ] There are no new console errors in the test output
+- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
 
 ### Backend
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10573?atlOrigin=eyJpIjoiZGZkZWU3MDk4NzE2NGY2OGEyOGI4MmJkYTJmMWQwN2QiLCJwIjoiaiJ9) for this change

## Summary

This branch updates the PR template to include a checklist item for front end PRs that add new components. This branch asks the engineer if they ensured their component was responsive, or if its not, did the include the correct min-width styling needed to hide any broekn states that would not be shown to the end user:

> If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

Is there anything you would like reviewers to give additional scrutiny?
- did I phrase this as well as I could of?


## Setup to Run Your Code
N/A
