### PR TITLE
[MB-10084] Adds visible validation errors to the Storage Facility Info component

### DIFF
--- a/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
+++ b/src/components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.test.jsx
@@ -322,7 +322,6 @@ describe('ServicesCounselingShipmentForm component', () => {
       expect(screen.getByText(/Receiving agent/).parentElement).toBeInstanceOf(HTMLLegendElement);
       expect(screen.getByLabelText('First name')).toHaveAttribute('name', 'delivery.agent.firstName');
       expect(screen.getByLabelText('Last name')).toHaveAttribute('name', 'delivery.agent.lastName');
-      expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'delivery.agent.email');
 
       expect(screen.getByText('Customer remarks')).toBeTruthy();
       expect(screen.getByLabelText('Counselor remarks')).toBeInstanceOf(HTMLTextAreaElement);

--- a/src/components/Office/StorageFacilityInfo/StorageFacilityInfo.jsx
+++ b/src/components/Office/StorageFacilityInfo/StorageFacilityInfo.jsx
@@ -6,6 +6,7 @@ import formStyles from 'styles/form.module.scss';
 import styles from 'components/Office/ServicesCounselingShipmentForm/ServicesCounselingShipmentForm.module.scss';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
+import TextField from 'components/form/fields/TextField/TextField';
 
 const StorageFacilityInfo = () => {
   return (
@@ -14,10 +15,7 @@ const StorageFacilityInfo = () => {
         <h2>Storage facility info</h2>
         <Grid row>
           <Grid col={12}>
-            <FormGroup>
-              <Label htmlFor="facilityName">Facility name</Label>
-              <Field as={TextInput} id="facilityName" name="storageFacility.facilityName" />
-            </FormGroup>
+            <TextField label="Facility name" id="facilityName" name="storageFacility.facilityName" />
           </Grid>
         </Grid>
 
@@ -38,11 +36,7 @@ const StorageFacilityInfo = () => {
         <Grid row>
           <Grid col={12}>
             <FormGroup>
-              <Label htmlFor="facilityEmail" className={styles.Label}>
-                Email
-                <span className="float-right">Optional</span>
-              </Label>
-              <Field as={TextInput} id="facilityEmail" name="storageFacility.email" />
+              <TextField label="Email" id="facilityEmail" name="storageFacility.email" optional />
             </FormGroup>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Jira ticket for this change: [MB-10084](https://dp3.atlassian.net/browse/MB-10084)

## Summary

This pull request resolves an issue with acceptance testing for MB-10084; specifically, that the "Facility name" and "Email" fields that display in the `StorageFacilityInfo` component did not display error messages to users as expected when failing validation.

"Facility name" is a required field, so a user tabbing out of the field without entering a value will now see a "Required" error message; previously, an empty value for this field would prevent submission, but no indicator text or symbol would display.

"Email" is an optional field, but a user entering a value not formatted like an email address will now see a "Must be valid email" error message; previously, a malformed value for this field would prevent submission, but no indicator text or symbol would display.

@transcom/truss-design: Aside from the validation errors, no changes should be made to the UI as part of this pull request.

## Setup to Run Your Code

<details>
As NTS-release shipments are not currently createable in the UI as an office user, you can only validate this through Storybook. To start Storybook locally:

```sh
make storybook
```
</details>

### Additional steps

1. In Storybook, inside the "Office Components" section, open the "Forms" -> "ServicesCounselingShipmentForm" -> "NTS Release Shipment" story. Verify that no error messages are displaying on the untouched fields.
2. Tab or click into the "Facility name" field, then leave it without entering a value. Verify that the "Required" error message displays.
3. Re-enter the "Facility name" field and enter any string value, then leave it. Verify that the error message disappears.
4. Tab or click into the "Email" field in the "Storage facility info" section, enter a value that is not formatted like an email address, and then leave that field. Verify that the "Must be valid email" error message displays.
5. Re-enter that "Email" field and enter a value formatted like an email address (`something@example.com`), then leave it. Verify that the error message disappears.
6. Re-enter that field again and clear the value, then leave it. Verify that no error message displays to the display, as this field is optional.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots

* [Component displaying validation errors](https://user-images.githubusercontent.com/83614364/145865545-2232f36f-6237-4f8e-9648-cebefd44a69b.png)
* [Component validating, no errors](https://user-images.githubusercontent.com/83614364/145865626-d9dca6d7-5773-4cf8-a484-af0e8b142d66.png)
 