### PR TITLE
MB-10490 swagger refactor

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3175,6 +3175,9 @@ func init() {
           "x-nullable": true,
           "example": "USA"
         },
+        "eTag": {
+          "type": "string"
+        },
         "id": {
           "type": "string",
           "format": "uuid",
@@ -9781,6 +9784,9 @@ func init() {
           "default": "USA",
           "x-nullable": true,
           "example": "USA"
+        },
+        "eTag": {
+          "type": "string"
         },
         "id": {
           "type": "string",

--- a/pkg/gen/internalmessages/address.go
+++ b/pkg/gen/internalmessages/address.go
@@ -29,6 +29,9 @@ type Address struct {
 	// Example: USA
 	Country *string `json:"country,omitempty"`
 
+	// e tag
+	ETag string `json:"eTag,omitempty"`
+
 	// id
 	// Example: c56a4180-65aa-42ec-a945-5fd21dec0538
 	// Format: uuid

--- a/swagger-def/definitions/Address.yaml
+++ b/swagger-def/definitions/Address.yaml
@@ -1,0 +1,150 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  streetAddress1:
+    type: string
+    example: 123 Main Ave
+    title: Street address 1
+  streetAddress2:
+    type: string
+    example: Apartment 9000
+    x-nullable: true
+    title: Street address 2
+  streetAddress3:
+    type: string
+    example: Montmârtre
+    x-nullable: true
+    title: Address Line 3
+  city:
+    type: string
+    example: Anytown
+    title: City
+  eTag:
+    type: string
+  state:
+    title: State
+    type: string
+    x-display-value:
+      AL: AL
+      AK: AK
+      AR: AR
+      AZ: AZ
+      CA: CA
+      CO: CO
+      CT: CT
+      DC: DC
+      DE: DE
+      FL: FL
+      GA: GA
+      HI: HI
+      IA: IA
+      ID: ID
+      IL: IL
+      IN: IN
+      KS: KS
+      KY: KY
+      LA: LA
+      MA: MA
+      MD: MD
+      ME: ME
+      MI: MI
+      MN: MN
+      MO: MO
+      MS: MS
+      MT: MT
+      NC: NC
+      ND: ND
+      NE: NE
+      NH: NH
+      NJ: NJ
+      NM: NM
+      NV: NV
+      NY: NY
+      OH: OH
+      OK: OK
+      OR: OR
+      PA: PA
+      RI: RI
+      SC: SC
+      SD: SD
+      TN: TN
+      TX: TX
+      UT: UT
+      VA: VA
+      VT: VT
+      WA: WA
+      WI: WI
+      WV: WV
+      WY: WY
+    enum:
+      - AL
+      - AK
+      - AR
+      - AZ
+      - CA
+      - CO
+      - CT
+      - DC
+      - DE
+      - FL
+      - GA
+      - HI
+      - IA
+      - ID
+      - IL
+      - IN
+      - KS
+      - KY
+      - LA
+      - MA
+      - MD
+      - ME
+      - MI
+      - MN
+      - MO
+      - MS
+      - MT
+      - NC
+      - ND
+      - NE
+      - NH
+      - NJ
+      - NM
+      - NV
+      - NY
+      - OH
+      - OK
+      - OR
+      - PA
+      - RI
+      - SC
+      - SD
+      - TN
+      - TX
+      - UT
+      - VA
+      - VT
+      - WA
+      - WI
+      - WV
+      - WY
+  postalCode:
+    type: string
+    format: zip
+    title: ZIP
+    example: '90210'
+    pattern: '^(\d{5}([\-]\d{4})?)$'
+  country:
+    type: string
+    title: Country
+    x-nullable: true
+    example: 'USA'
+    default: USA
+required:
+  - streetAddress1
+  - city
+  - state
+  - postalCode

--- a/swagger-def/definitions/Affiliation.yaml
+++ b/swagger-def/definitions/Affiliation.yaml
@@ -1,0 +1,15 @@
+type: string
+x-nullable: true
+title: Branch of service
+enum: &AFFILIATION
+  - ARMY
+  - NAVY
+  - MARINES
+  - AIR_FORCE
+  - COAST_GUARD
+x-display-value:
+  ARMY: Army
+  NAVY: Navy
+  MARINES: Marine Corps
+  AIR_FORCE: Air Force
+  COAST_GUARD: Coast Guard

--- a/swagger-def/definitions/DutyStation.yaml
+++ b/swagger-def/definitions/DutyStation.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  name:
+    type: string
+    example: Fort Bragg North Station
+  address_id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  address:
+    $ref: 'Address.yaml'
+  eTag:
+    type: string

--- a/swagger-def/definitions/DutyStationPayload.yaml
+++ b/swagger-def/definitions/DutyStationPayload.yaml
@@ -1,0 +1,33 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  name:
+    type: string
+    example: Fort Bragg North Station
+  address_id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  address:
+    $ref: 'Address.yaml'
+  affiliation:
+    $ref: 'Affiliation.yaml'
+  transportation_office:
+    $ref: 'TransportationOffice.yaml'
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time
+required:
+  - id
+  - name
+  - address_id
+  - address
+  - affiliation
+  - created_at
+  - updated_at

--- a/swagger-def/definitions/StorageFacility.yaml
+++ b/swagger-def/definitions/StorageFacility.yaml
@@ -8,7 +8,7 @@ properties:
   facilityName:
     type: string
   address:
-    $ref: '../ghc.yaml#/definitions/Address'
+    $ref: 'Address.yaml'
   lotNumber:
     type: string
     x-nullable: true

--- a/swagger-def/definitions/TransportationOffice.yaml
+++ b/swagger-def/definitions/TransportationOffice.yaml
@@ -1,0 +1,42 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+    example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  name:
+    type: string
+    example: Fort Bragg North Station
+  address:
+    $ref: 'Address.yaml'
+  phone_lines:
+    type: array
+    items:
+      type: string
+      format: telephone
+      pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+      example: 212-555-5555
+  gbloc:
+    type: string
+    pattern: '^[A-Z]{4}$'
+    example: JENQ
+  latitude:
+    type: number
+    format: float
+    example: 29.382973
+  longitude:
+    type: number
+    format: float
+    example: -98.62759
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time
+required:
+  - id
+  - name
+  - address
+  - created_at
+  - updated_at

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2030,157 +2030,6 @@ definitions:
           type: string
     required:
       - invalid_fields
-  Address:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      streetAddress1:
-        type: string
-        example: 123 Main Ave
-        title: Street address 1
-      streetAddress2:
-        type: string
-        example: Apartment 9000
-        x-nullable: true
-        title: Street address 2
-      streetAddress3:
-        type: string
-        example: Montmârtre
-        x-nullable: true
-        title: Address Line 3
-      city:
-        type: string
-        example: Anytown
-        title: City
-      eTag:
-        type: string
-      state:
-        title: State
-        type: string
-        x-display-value:
-          AL: AL
-          AK: AK
-          AR: AR
-          AZ: AZ
-          CA: CA
-          CO: CO
-          CT: CT
-          DC: DC
-          DE: DE
-          FL: FL
-          GA: GA
-          HI: HI
-          IA: IA
-          ID: ID
-          IL: IL
-          IN: IN
-          KS: KS
-          KY: KY
-          LA: LA
-          MA: MA
-          MD: MD
-          ME: ME
-          MI: MI
-          MN: MN
-          MO: MO
-          MS: MS
-          MT: MT
-          NC: NC
-          ND: ND
-          NE: NE
-          NH: NH
-          NJ: NJ
-          NM: NM
-          NV: NV
-          NY: NY
-          OH: OH
-          OK: OK
-          OR: OR
-          PA: PA
-          RI: RI
-          SC: SC
-          SD: SD
-          TN: TN
-          TX: TX
-          UT: UT
-          VA: VA
-          VT: VT
-          WA: WA
-          WI: WI
-          WV: WV
-          WY: WY
-        enum:
-          - AL
-          - AK
-          - AR
-          - AZ
-          - CA
-          - CO
-          - CT
-          - DC
-          - DE
-          - FL
-          - GA
-          - HI
-          - IA
-          - ID
-          - IL
-          - IN
-          - KS
-          - KY
-          - LA
-          - MA
-          - MD
-          - ME
-          - MI
-          - MN
-          - MO
-          - MS
-          - MT
-          - NC
-          - ND
-          - NE
-          - NH
-          - NJ
-          - NM
-          - NV
-          - NY
-          - OH
-          - OK
-          - OR
-          - PA
-          - RI
-          - SC
-          - SD
-          - TN
-          - TX
-          - UT
-          - VA
-          - VT
-          - WA
-          - WI
-          - WV
-          - WY
-      postalCode:
-        type: string
-        format: zip
-        title: ZIP
-        example: '90210'
-        pattern: '^(\d{5}([\-]\d{4})?)$'
-      country:
-        type: string
-        title: Country
-        x-nullable: true
-        example: 'USA'
-        default: USA
-    required:
-      - streetAddress1
-      - city
-      - state
-      - postalCode
   BackupContact:
     type: object
     properties:
@@ -2240,7 +2089,7 @@ definitions:
         example: David
         x-nullable: true
       current_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       backup_contact:
         $ref: '#/definitions/BackupContact'
       id:
@@ -2283,27 +2132,9 @@ definitions:
         example: David
         x-nullable: true
       current_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       backup_contact:
         $ref: '#/definitions/BackupContact'
-  DutyStation:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address_id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      address:
-        $ref: '#/definitions/Address'
-      eTag:
-        type: string
   Entitlements:
     properties:
       id:
@@ -2604,9 +2435,9 @@ definitions:
       entitlement:
         $ref: '#/definitions/Entitlements'
       destinationDutyStation:
-        $ref: '#/definitions/DutyStation'
+        $ref: 'definitions/DutyStation.yaml'
       originDutyStation:
-        $ref: '#/definitions/DutyStation'
+        $ref: 'definitions/DutyStation.yaml'
       moveTaskOrderID:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         format: uuid
@@ -2941,9 +2772,9 @@ definitions:
         format: date-time
         type: string
       destinationAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       pickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       destinationDutyStation:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
@@ -3291,16 +3122,16 @@ definitions:
         example: true
       pickupAddress:
         x-nullable: true
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       destinationAddress:
         x-nullable: true
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryPickupAddress:
         x-nullable: true
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryDeliveryAddress:
         x-nullable: true
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       customerRemarks:
         type: string
         example: handle with care
@@ -3402,10 +3233,10 @@ definitions:
         x-nullable: true
       pickupAddress:
         allOf:
-          - $ref: '#/definitions/Address'
+          - $ref: 'definitions/Address.yaml'
       destinationAddress:
         allOf:
-          - $ref: '#/definitions/Address'
+          - $ref: 'definitions/Address.yaml'
         x-nullable: true
       agents:
         $ref: '#/definitions/MTOAgents'
@@ -3485,11 +3316,11 @@ definitions:
       pickupAddress:
         description: The address where the movers should pick up this shipment.
         allOf:
-          - $ref: '#/definitions/Address'
+          - $ref: 'definitions/Address.yaml'
       destinationAddress:
         description: Where the movers should deliver this shipment.
         allOf:
-          - $ref: '#/definitions/Address'
+          - $ref: 'definitions/Address.yaml'
       shipmentType:
         $ref: '#/definitions/MTOShipmentType'
       tacType:
@@ -3911,9 +3742,9 @@ definitions:
       shipmentsCount:
         type: integer
       originDutyLocation:
-        $ref: '#/definitions/DutyStation'
+        $ref: 'definitions/DutyStation.yaml'
       destinationDutyStation:
-        $ref: '#/definitions/DutyStation'
+        $ref: 'definitions/DutyStation.yaml'
       originGBLOC:
         $ref: '#/definitions/GBLOC'
   QueueMovesResult:
@@ -3960,7 +3791,7 @@ definitions:
       originGBLOC:
         $ref: '#/definitions/GBLOC'
       originDutyLocation:
-        $ref: '#/definitions/DutyStation'
+        $ref: 'definitions/DutyStation.yaml'
   QueuePaymentRequests:
     type: array
     items:

--- a/swagger-def/internal.yaml
+++ b/swagger-def/internal.yaml
@@ -41,103 +41,10 @@ definitions:
           $ref: '#/definitions/Role'
     required:
       - id
-  Affiliation:
-    type: string
-    x-nullable: true
-    title: Branch of service
-    enum: &AFFILIATION
-      - ARMY
-      - NAVY
-      - MARINES
-      - AIR_FORCE
-      - COAST_GUARD
-    x-display-value:
-      ARMY: Army
-      NAVY: Navy
-      MARINES: Marine Corps
-      AIR_FORCE: Air Force
-      COAST_GUARD: Coast Guard
-  DutyStationPayload:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address_id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      address:
-        $ref: '#/definitions/Address'
-      affiliation:
-        $ref: '#/definitions/Affiliation'
-      transportation_office:
-        $ref: '#/definitions/TransportationOffice'
-      created_at:
-        type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
-    required:
-      - id
-      - name
-      - address_id
-      - address
-      - affiliation
-      - created_at
-      - updated_at
-  TransportationOffice:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address:
-        $ref: '#/definitions/Address'
-      phone_lines:
-        type: array
-        items:
-          type: string
-          format: telephone
-          pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
-          example: 212-555-5555
-      gbloc:
-        type: string
-        pattern: '^[A-Z]{4}$'
-        example: JENQ
-      latitude:
-        type: number
-        format: float
-        example: 29.382973
-      longitude:
-        type: number
-        format: float
-        example: -98.62759
-      created_at:
-        type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
-    required:
-      - id
-      - name
-      - address
-      - created_at
-      - updated_at
   DutyStationsPayload:
     type: array
     items:
-      $ref: '#/definitions/DutyStationPayload'
+      $ref: 'definitions/DutyStationPayload.yaml'
   CreatePersonallyProcuredMovePayload:
     type: object
     properties:
@@ -1126,7 +1033,7 @@ definitions:
         x-nullable: true
         title: Best contact phone
       transportation_office:
-        $ref: '#/definitions/TransportationOffice'
+        $ref: 'definitions/TransportationOffice.yaml'
       created_at:
         type: string
         format: date-time
@@ -1158,7 +1065,7 @@ definitions:
         items:
           $ref: '#/definitions/Orders'
       affiliation:
-        $ref: '#/definitions/Affiliation'
+        $ref: 'definitions/Affiliation.yaml'
         title: Branch
       rank:
         $ref: '#/definitions/ServiceMemberRank'
@@ -1213,12 +1120,12 @@ definitions:
         x-nullable: true
         title: Email
       current_station:
-        $ref: '#/definitions/DutyStationPayload'
+        $ref: 'definitions/DutyStationPayload.yaml'
       residential_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
         title: Residential Address
       backup_mailing_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       backup_contacts:
         $ref: '#/definitions/IndexServiceMemberBackupContactsPayload'
       is_profile_complete:
@@ -1259,7 +1166,7 @@ definitions:
         x-nullable: true
         title: 'DoD ID number'
       affiliation:
-        $ref: '#/definitions/Affiliation'
+        $ref: 'definitions/Affiliation.yaml'
       rank:
         $ref: '#/definitions/ServiceMemberRank'
       first_name:
@@ -1317,9 +1224,9 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         x-nullable: true
       residential_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       backup_mailing_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
   PatchServiceMemberPayload:
     type: object
     properties:
@@ -1337,7 +1244,7 @@ definitions:
         x-nullable: true
         title: DoD ID number
       affiliation:
-        $ref: '#/definitions/Affiliation'
+        $ref: 'definitions/Affiliation.yaml'
       rank:
         $ref: '#/definitions/ServiceMemberRank'
       first_name:
@@ -1395,9 +1302,9 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         x-nullable: true
       residential_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       backup_mailing_address:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
   ServiceMemberBackupContactPayload:
     type: object
     properties:
@@ -1751,155 +1658,6 @@ definitions:
       ARMY: 21 Army
       AIR_FORCE: 57 Air Force
       COAST_GUARD: 70 Coast Guard
-  Address:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      streetAddress1:
-        type: string
-        example: 123 Main Ave
-        title: Street address 1
-      streetAddress2:
-        type: string
-        example: Apartment 9000
-        x-nullable: true
-        title: Street address 2
-      streetAddress3:
-        type: string
-        example: Montmârtre
-        x-nullable: true
-        title: Address Line 3
-      city:
-        type: string
-        example: Anytown
-        title: City
-      state:
-        title: State
-        type: string
-        x-display-value:
-          AL: AL
-          AK: AK
-          AR: AR
-          AZ: AZ
-          CA: CA
-          CO: CO
-          CT: CT
-          DC: DC
-          DE: DE
-          FL: FL
-          GA: GA
-          HI: HI
-          IA: IA
-          ID: ID
-          IL: IL
-          IN: IN
-          KS: KS
-          KY: KY
-          LA: LA
-          MA: MA
-          MD: MD
-          ME: ME
-          MI: MI
-          MN: MN
-          MO: MO
-          MS: MS
-          MT: MT
-          NC: NC
-          ND: ND
-          NE: NE
-          NH: NH
-          NJ: NJ
-          NM: NM
-          NV: NV
-          NY: NY
-          OH: OH
-          OK: OK
-          OR: OR
-          PA: PA
-          RI: RI
-          SC: SC
-          SD: SD
-          TN: TN
-          TX: TX
-          UT: UT
-          VA: VA
-          VT: VT
-          WA: WA
-          WI: WI
-          WV: WV
-          WY: WY
-        enum:
-          - AL
-          - AK
-          - AR
-          - AZ
-          - CA
-          - CO
-          - CT
-          - DC
-          - DE
-          - FL
-          - GA
-          - HI
-          - IA
-          - ID
-          - IL
-          - IN
-          - KS
-          - KY
-          - LA
-          - MA
-          - MD
-          - ME
-          - MI
-          - MN
-          - MO
-          - MS
-          - MT
-          - NC
-          - ND
-          - NE
-          - NH
-          - NJ
-          - NM
-          - NV
-          - NY
-          - OH
-          - OK
-          - OR
-          - PA
-          - RI
-          - SC
-          - SD
-          - TN
-          - TX
-          - UT
-          - VA
-          - VT
-          - WA
-          - WI
-          - WV
-          - WY
-      postalCode:
-        type: string
-        format: zip
-        title: ZIP
-        example: '90210'
-        pattern: '^(\d{5}([\-]\d{4})?)$'
-      country:
-        type: string
-        title: Country
-        x-nullable: true
-        example: 'USA'
-        default: USA
-    required:
-      - streetAddress1
-      - city
-      - state
-      - postalCode
   CreateReimbursement:
     type: object
     x-nullable: true
@@ -2080,10 +1838,10 @@ definitions:
         type: boolean
         title: Do you have a spouse who will need to move items related to their occupation (also known as spouse pro-gear)?
       origin_duty_station:
-        $ref: '#/definitions/DutyStationPayload'
+        $ref: 'definitions/DutyStationPayload.yaml'
         x-nullable: true
       new_duty_station:
-        $ref: '#/definitions/DutyStationPayload'
+        $ref: 'definitions/DutyStationPayload.yaml'
       uploaded_orders:
         $ref: '#/definitions/DocumentPayload'
       uploaded_amended_orders:
@@ -2597,13 +2355,13 @@ definitions:
       status:
         $ref: '#/definitions/MTOShipmentStatus'
       pickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       destinationAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryPickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryDeliveryAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       eTag:
         type: string
   MTOShipments:
@@ -2638,13 +2396,13 @@ definitions:
         example: handle with care
         x-nullable: true
       pickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryPickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       destinationAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryDeliveryAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       agents:
         $ref: '#/definitions/MTOAgents'
     required:
@@ -2668,13 +2426,13 @@ definitions:
         example: handle with care
         x-nullable: true
       pickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryPickupAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       destinationAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       secondaryDeliveryAddress:
-        $ref: '#/definitions/Address'
+        $ref: 'definitions/Address.yaml'
       agents:
         $ref: '#/definitions/MTOAgents'
   ClientError:
@@ -4373,7 +4131,7 @@ paths:
         '200':
           description: the instance of the transportation office for a duty station
           schema:
-            $ref: '#/definitions/TransportationOffice'
+            $ref: 'definitions/TransportationOffice.yaml'
         '400':
           description: invalid request
         '401':
@@ -4670,7 +4428,7 @@ paths:
         '200':
           description: the requested address
           schema:
-            $ref: '#/definitions/Address'
+            $ref: 'definitions/Address.yaml'
         '400':
           description: invalid request
         '403':

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2107,157 +2107,6 @@ definitions:
           type: string
     required:
       - invalid_fields
-  Address:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      streetAddress1:
-        type: string
-        example: 123 Main Ave
-        title: Street address 1
-      streetAddress2:
-        type: string
-        example: Apartment 9000
-        x-nullable: true
-        title: Street address 2
-      streetAddress3:
-        type: string
-        example: Montmârtre
-        x-nullable: true
-        title: Address Line 3
-      city:
-        type: string
-        example: Anytown
-        title: City
-      eTag:
-        type: string
-      state:
-        title: State
-        type: string
-        x-display-value:
-          AL: AL
-          AK: AK
-          AR: AR
-          AZ: AZ
-          CA: CA
-          CO: CO
-          CT: CT
-          DC: DC
-          DE: DE
-          FL: FL
-          GA: GA
-          HI: HI
-          IA: IA
-          ID: ID
-          IL: IL
-          IN: IN
-          KS: KS
-          KY: KY
-          LA: LA
-          MA: MA
-          MD: MD
-          ME: ME
-          MI: MI
-          MN: MN
-          MO: MO
-          MS: MS
-          MT: MT
-          NC: NC
-          ND: ND
-          NE: NE
-          NH: NH
-          NJ: NJ
-          NM: NM
-          NV: NV
-          NY: NY
-          OH: OH
-          OK: OK
-          OR: OR
-          PA: PA
-          RI: RI
-          SC: SC
-          SD: SD
-          TN: TN
-          TX: TX
-          UT: UT
-          VA: VA
-          VT: VT
-          WA: WA
-          WI: WI
-          WV: WV
-          WY: WY
-        enum:
-          - AL
-          - AK
-          - AR
-          - AZ
-          - CA
-          - CO
-          - CT
-          - DC
-          - DE
-          - FL
-          - GA
-          - HI
-          - IA
-          - ID
-          - IL
-          - IN
-          - KS
-          - KY
-          - LA
-          - MA
-          - MD
-          - ME
-          - MI
-          - MN
-          - MO
-          - MS
-          - MT
-          - NC
-          - ND
-          - NE
-          - NH
-          - NJ
-          - NM
-          - NV
-          - NY
-          - OH
-          - OK
-          - OR
-          - PA
-          - RI
-          - SC
-          - SD
-          - TN
-          - TX
-          - UT
-          - VA
-          - VT
-          - WA
-          - WI
-          - WV
-          - WY
-      postalCode:
-        type: string
-        format: zip
-        title: ZIP
-        example: '90210'
-        pattern: ^(\d{5}([\-]\d{4})?)$
-      country:
-        type: string
-        title: Country
-        x-nullable: true
-        example: USA
-        default: USA
-    required:
-      - streetAddress1
-      - city
-      - state
-      - postalCode
   BackupContact:
     type: object
     properties:
@@ -2363,24 +2212,6 @@ definitions:
         $ref: '#/definitions/Address'
       backup_contact:
         $ref: '#/definitions/BackupContact'
-  DutyStation:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address_id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      address:
-        $ref: '#/definitions/Address'
-      eTag:
-        type: string
   Entitlements:
     properties:
       id:
@@ -4142,6 +3973,175 @@ definitions:
       - MBFL
       - MLNQ
       - XXXX
+  Address:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      streetAddress1:
+        type: string
+        example: 123 Main Ave
+        title: Street address 1
+      streetAddress2:
+        type: string
+        example: Apartment 9000
+        x-nullable: true
+        title: Street address 2
+      streetAddress3:
+        type: string
+        example: Montmârtre
+        x-nullable: true
+        title: Address Line 3
+      city:
+        type: string
+        example: Anytown
+        title: City
+      eTag:
+        type: string
+      state:
+        title: State
+        type: string
+        x-display-value:
+          AL: AL
+          AK: AK
+          AR: AR
+          AZ: AZ
+          CA: CA
+          CO: CO
+          CT: CT
+          DC: DC
+          DE: DE
+          FL: FL
+          GA: GA
+          HI: HI
+          IA: IA
+          ID: ID
+          IL: IL
+          IN: IN
+          KS: KS
+          KY: KY
+          LA: LA
+          MA: MA
+          MD: MD
+          ME: ME
+          MI: MI
+          MN: MN
+          MO: MO
+          MS: MS
+          MT: MT
+          NC: NC
+          ND: ND
+          NE: NE
+          NH: NH
+          NJ: NJ
+          NM: NM
+          NV: NV
+          NY: NY
+          OH: OH
+          OK: OK
+          OR: OR
+          PA: PA
+          RI: RI
+          SC: SC
+          SD: SD
+          TN: TN
+          TX: TX
+          UT: UT
+          VA: VA
+          VT: VT
+          WA: WA
+          WI: WI
+          WV: WV
+          WY: WY
+        enum:
+          - AL
+          - AK
+          - AR
+          - AZ
+          - CA
+          - CO
+          - CT
+          - DC
+          - DE
+          - FL
+          - GA
+          - HI
+          - IA
+          - ID
+          - IL
+          - IN
+          - KS
+          - KY
+          - LA
+          - MA
+          - MD
+          - ME
+          - MI
+          - MN
+          - MO
+          - MS
+          - MT
+          - NC
+          - ND
+          - NE
+          - NH
+          - NJ
+          - NM
+          - NV
+          - NY
+          - OH
+          - OK
+          - OR
+          - PA
+          - RI
+          - SC
+          - SD
+          - TN
+          - TX
+          - UT
+          - VA
+          - VT
+          - WA
+          - WI
+          - WV
+          - WY
+      postalCode:
+        type: string
+        format: zip
+        title: ZIP
+        example: '90210'
+        pattern: ^(\d{5}([\-]\d{4})?)$
+      country:
+        type: string
+        title: Country
+        x-nullable: true
+        example: USA
+        default: USA
+    required:
+      - streetAddress1
+      - city
+      - state
+      - postalCode
+  DutyStation:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        example: Fort Bragg North Station
+      address_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      address:
+        $ref: '#/definitions/Address'
+      eTag:
+        type: string
   LOAType:
     description: The Line of accounting (TAC/SAC) type that will be used for the shipment
     type: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -41,99 +41,6 @@ definitions:
           $ref: '#/definitions/Role'
     required:
       - id
-  Affiliation:
-    type: string
-    x-nullable: true
-    title: Branch of service
-    enum:
-      - ARMY
-      - NAVY
-      - MARINES
-      - AIR_FORCE
-      - COAST_GUARD
-    x-display-value:
-      ARMY: Army
-      NAVY: Navy
-      MARINES: Marine Corps
-      AIR_FORCE: Air Force
-      COAST_GUARD: Coast Guard
-  DutyStationPayload:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address_id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      address:
-        $ref: '#/definitions/Address'
-      affiliation:
-        $ref: '#/definitions/Affiliation'
-      transportation_office:
-        $ref: '#/definitions/TransportationOffice'
-      created_at:
-        type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
-    required:
-      - id
-      - name
-      - address_id
-      - address
-      - affiliation
-      - created_at
-      - updated_at
-  TransportationOffice:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      name:
-        type: string
-        example: Fort Bragg North Station
-      address:
-        $ref: '#/definitions/Address'
-      phone_lines:
-        type: array
-        items:
-          type: string
-          format: telephone
-          pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
-          example: 212-555-5555
-      gbloc:
-        type: string
-        pattern: ^[A-Z]{4}$
-        example: JENQ
-      latitude:
-        type: number
-        format: float
-        example: 29.382973
-      longitude:
-        type: number
-        format: float
-        example: -98.62759
-      created_at:
-        type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
-    required:
-      - id
-      - name
-      - address
-      - created_at
-      - updated_at
   DutyStationsPayload:
     type: array
     items:
@@ -1751,155 +1658,6 @@ definitions:
       ARMY: 21 Army
       AIR_FORCE: 57 Air Force
       COAST_GUARD: 70 Coast Guard
-  Address:
-    type: object
-    properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      streetAddress1:
-        type: string
-        example: 123 Main Ave
-        title: Street address 1
-      streetAddress2:
-        type: string
-        example: Apartment 9000
-        x-nullable: true
-        title: Street address 2
-      streetAddress3:
-        type: string
-        example: Montmârtre
-        x-nullable: true
-        title: Address Line 3
-      city:
-        type: string
-        example: Anytown
-        title: City
-      state:
-        title: State
-        type: string
-        x-display-value:
-          AL: AL
-          AK: AK
-          AR: AR
-          AZ: AZ
-          CA: CA
-          CO: CO
-          CT: CT
-          DC: DC
-          DE: DE
-          FL: FL
-          GA: GA
-          HI: HI
-          IA: IA
-          ID: ID
-          IL: IL
-          IN: IN
-          KS: KS
-          KY: KY
-          LA: LA
-          MA: MA
-          MD: MD
-          ME: ME
-          MI: MI
-          MN: MN
-          MO: MO
-          MS: MS
-          MT: MT
-          NC: NC
-          ND: ND
-          NE: NE
-          NH: NH
-          NJ: NJ
-          NM: NM
-          NV: NV
-          NY: NY
-          OH: OH
-          OK: OK
-          OR: OR
-          PA: PA
-          RI: RI
-          SC: SC
-          SD: SD
-          TN: TN
-          TX: TX
-          UT: UT
-          VA: VA
-          VT: VT
-          WA: WA
-          WI: WI
-          WV: WV
-          WY: WY
-        enum:
-          - AL
-          - AK
-          - AR
-          - AZ
-          - CA
-          - CO
-          - CT
-          - DC
-          - DE
-          - FL
-          - GA
-          - HI
-          - IA
-          - ID
-          - IL
-          - IN
-          - KS
-          - KY
-          - LA
-          - MA
-          - MD
-          - ME
-          - MI
-          - MN
-          - MO
-          - MS
-          - MT
-          - NC
-          - ND
-          - NE
-          - NH
-          - NJ
-          - NM
-          - NV
-          - NY
-          - OH
-          - OK
-          - OR
-          - PA
-          - RI
-          - SC
-          - SD
-          - TN
-          - TX
-          - UT
-          - VA
-          - VT
-          - WA
-          - WI
-          - WV
-          - WY
-      postalCode:
-        type: string
-        format: zip
-        title: ZIP
-        example: '90210'
-        pattern: ^(\d{5}([\-]\d{4})?)$
-      country:
-        type: string
-        title: Country
-        x-nullable: true
-        example: USA
-        default: USA
-    required:
-      - streetAddress1
-      - city
-      - state
-      - postalCode
   CreateReimbursement:
     type: object
     x-nullable: true
@@ -2722,6 +2480,250 @@ definitions:
       - title
       - detail
     type: object
+  Address:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      streetAddress1:
+        type: string
+        example: 123 Main Ave
+        title: Street address 1
+      streetAddress2:
+        type: string
+        example: Apartment 9000
+        x-nullable: true
+        title: Street address 2
+      streetAddress3:
+        type: string
+        example: Montmârtre
+        x-nullable: true
+        title: Address Line 3
+      city:
+        type: string
+        example: Anytown
+        title: City
+      eTag:
+        type: string
+      state:
+        title: State
+        type: string
+        x-display-value:
+          AL: AL
+          AK: AK
+          AR: AR
+          AZ: AZ
+          CA: CA
+          CO: CO
+          CT: CT
+          DC: DC
+          DE: DE
+          FL: FL
+          GA: GA
+          HI: HI
+          IA: IA
+          ID: ID
+          IL: IL
+          IN: IN
+          KS: KS
+          KY: KY
+          LA: LA
+          MA: MA
+          MD: MD
+          ME: ME
+          MI: MI
+          MN: MN
+          MO: MO
+          MS: MS
+          MT: MT
+          NC: NC
+          ND: ND
+          NE: NE
+          NH: NH
+          NJ: NJ
+          NM: NM
+          NV: NV
+          NY: NY
+          OH: OH
+          OK: OK
+          OR: OR
+          PA: PA
+          RI: RI
+          SC: SC
+          SD: SD
+          TN: TN
+          TX: TX
+          UT: UT
+          VA: VA
+          VT: VT
+          WA: WA
+          WI: WI
+          WV: WV
+          WY: WY
+        enum:
+          - AL
+          - AK
+          - AR
+          - AZ
+          - CA
+          - CO
+          - CT
+          - DC
+          - DE
+          - FL
+          - GA
+          - HI
+          - IA
+          - ID
+          - IL
+          - IN
+          - KS
+          - KY
+          - LA
+          - MA
+          - MD
+          - ME
+          - MI
+          - MN
+          - MO
+          - MS
+          - MT
+          - NC
+          - ND
+          - NE
+          - NH
+          - NJ
+          - NM
+          - NV
+          - NY
+          - OH
+          - OK
+          - OR
+          - PA
+          - RI
+          - SC
+          - SD
+          - TN
+          - TX
+          - UT
+          - VA
+          - VT
+          - WA
+          - WI
+          - WV
+          - WY
+      postalCode:
+        type: string
+        format: zip
+        title: ZIP
+        example: '90210'
+        pattern: ^(\d{5}([\-]\d{4})?)$
+      country:
+        type: string
+        title: Country
+        x-nullable: true
+        example: USA
+        default: USA
+    required:
+      - streetAddress1
+      - city
+      - state
+      - postalCode
+  Affiliation:
+    type: string
+    x-nullable: true
+    title: Branch of service
+    enum:
+      - ARMY
+      - NAVY
+      - MARINES
+      - AIR_FORCE
+      - COAST_GUARD
+    x-display-value:
+      ARMY: Army
+      NAVY: Navy
+      MARINES: Marine Corps
+      AIR_FORCE: Air Force
+      COAST_GUARD: Coast Guard
+  TransportationOffice:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        example: Fort Bragg North Station
+      address:
+        $ref: '#/definitions/Address'
+      phone_lines:
+        type: array
+        items:
+          type: string
+          format: telephone
+          pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
+          example: 212-555-5555
+      gbloc:
+        type: string
+        pattern: ^[A-Z]{4}$
+        example: JENQ
+      latitude:
+        type: number
+        format: float
+        example: 29.382973
+      longitude:
+        type: number
+        format: float
+        example: -98.62759
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    required:
+      - id
+      - name
+      - address
+      - created_at
+      - updated_at
+  DutyStationPayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        example: Fort Bragg North Station
+      address_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      address:
+        $ref: '#/definitions/Address'
+      affiliation:
+        $ref: '#/definitions/Affiliation'
+      transportation_office:
+        $ref: '#/definitions/TransportationOffice'
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    required:
+      - id
+      - name
+      - address_id
+      - address
+      - affiliation
+      - created_at
+      - updated_at
 paths:
   /estimates/ppm:
     get:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10490) for this change

## Summary

For ease of renaming and maintaining backwards compatibility starting off the rename with this refactor. I added shared definitions for duty station [old], duty location [new], address, affiliation and transportation office. There's plenty of places all of those references could be de-duplicated out of in other API files, but for now I started with GHC and the internal API.

## Setup to Run Your Code

##### Terminal 1

Regenerate your swagger files, make sure all looks good.

```sh
make swagger_generate
```

Run the server

```sh
make server_run
```

Run tests, make sure nothing falls over

```sh
make server_test_standalone
```

## Verification Steps for Reviewers

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

