### PR TITLE
[MB-9678] Fix typo in scripts/zips-for-gbloc

### DIFF
--- a/scripts/zips-for-gbloc
+++ b/scripts/zips-for-gbloc
@@ -15,7 +15,7 @@ printf "Here are a few ZIP codes in the %s GBLOC: \\n\\n" "$gbloc"
 # The -t option prints just the values as opposed to the default formatting that
 # includes the column name underlined
 psql -t postgres://"$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME" << EOF
-SELECT postal_code FROM postal_code_to_gbloc
+SELECT postal_code FROM postal_code_to_gblocs
 WHERE gbloc = UPPER('$gbloc')
 LIMIT 10;
 EOF


### PR DESCRIPTION
I renamed the table and forgot to update this script.

## Setup to Run Your Code
Run the script and make sure it doesn't crash
```
scripts/zips-for-gbloc lknq
```
should look like this:
```sh
marty@Martys-MacBook-Pro mymove % scripts/zips-for-gbloc lknq
Here are a few ZIP codes in the lknq GBLOC:

 85325
 85328
 85333
 85334
 85336
 85344
 85346
 85347
 85348
 85349
 ```