### PR TITLE
[MB-10779] (hopefully) fix flaky TOO test by speeding up duty location search

### DIFF
--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -104,7 +104,7 @@ func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
 
 	// The % operator filters out strings that are below this similarity threshold
-	err := tx.Q().RawQuery("SET pg_trgm.similarity_threshold = 0.02").Exec()
+	err := tx.Q().RawQuery("SET pg_trgm.similarity_threshold = 0.03").Exec()
 	if err != nil {
 		return stations, err
 	}

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -103,17 +103,23 @@ func FetchDutyStationByName(tx *pop.Connection, name string) (DutyStation, error
 func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
 
+	// The % operator filters out strings that are below this similarity threshold
+	err := tx.Q().RawQuery("SET pg_trgm.similarity_threshold = 0.02").Exec()
+	if err != nil {
+		return stations, err
+	}
+
 	sqlQuery := `
 with names as (
 (select id as duty_station_id, name, similarity(name, $1) as sim
 from duty_stations
-where similarity(name, $1) > 0.03
+where name % $1
 order by sim desc
 limit 5)
 union
 (select duty_station_id, name, similarity(name, $1) as sim
 from duty_station_names
-where similarity(name, $1) > 0.03
+where name % $1
 order by sim desc
 limit 5)
 union


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10779) for this change
## Summary
I changed the search query to use the `%` operator instead of the `similarity` function.
`select ... where similarity(foo, bar) > threshold` should be the same as 
```
set pg_trgm.similarity_threshold = threshold;
...
select ... where foo % bar;
```

This operator can take advantage of the GIN index we have on `duty_stations.name`, while similarity can not.
They both come from the same postgres module and use the same similarity score function, so they should work the same.
(I initially thought they were slightly different, but just as I was about to sign off for the night i realized i was wrong, and they should probably be identical. Somebody should verify this though.)

Before this change, in the browser console, I was seeing search requests take 200-300ms.
After this change, I'm seeing more like 50-90ms. 

[slack thread for context](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1639605618096700)
[slack thread about how to set the postgres config variable](https://ustcdp3.slack.com/archives/CSGDM3NUW/p1639681918045500)

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
