### PR TITLE
Add migration to regrant permissions to crud user

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -691,3 +691,4 @@
 20211213235039_update_duty_station_location.up.sql
 20211214234555_move_to_gbloc_view.up.sql
 20211221182830_origin_duty_location_to_gbloc_view.up.sql
+20211222193432_regrant_access_to_views_for_crud.up.sql

--- a/migrations/app/schema/20211222193432_regrant_access_to_views_for_crud.up.sql
+++ b/migrations/app/schema/20211222193432_regrant_access_to_views_for_crud.up.sql
@@ -1,0 +1,16 @@
+-- For some reason the following migration steps haven't taken fully in all
+-- of our environments, specifically demo.
+--
+-- Running them again should not hurt anything.
+-- See also migrations/app/schema/20210113173236_create_crud_role.up.sql
+--
+-- Modify existing tables, views, and sequences.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO crud;
+GRANT USAGE, UPDATE ON ALL SEQUENCES IN SCHEMA public TO crud;
+
+-- Modify future tables, views, and sequences.
+-- Do not include `FOR ROLE` in the following statements so that:
+-- 1. when this runs in RDS, it will apply to the role running migrations.
+-- 2. when this runs in Docker, it will apply to the `postgres` role.
+ALTER DEFAULT PRIVILEGES GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO crud;
+ALTER DEFAULT PRIVILEGES GRANT USAGE, UPDATE ON SEQUENCES TO crud;


### PR DESCRIPTION
## Summary

It was discovered recently that creating a new view in the demo environment is not being created with permissions for the MilMove database user `crud` to access it. This results in a `error pq: permission denied for view duty_stations` error. 

- [this slack thread](tbd)
- [this other thread]()
- see these migrations
  - migrations/app/schema/20210113173236_create_crud_role.up.sql
- Possibly related migrations
  - migrations/app/schema/20201230070814_fix_ecs_user_in_docker.up.sql
  - migrations/app/schema/20190129115001_master_role.up.sql
  - migrations/app/secure/20190129115416_ecs_user_for_rds.up.sql
  - migrations/app/secure/20190726151515_grant_all_ecs_user.up.sql
 
This needs to be tested in experimental or demo to find out if the migration as it is would be best or if there is something else going on that is preventing permissions from being on the view. Alternate solution that worked but would require a `GRANT` statement for every future view.

```sql
GRANT SELECT, INSERT, UPDATE, DELETE ON duty_stations TO crud;
GRANT SELECT, INSERT, UPDATE, DELETE ON move_to_gbloc TO crud;
```

## Setup to Run Your Code

I can't replicate this locally. I checked and my local db has a `crud` user but that user has the correct permissions on the view. If you can replicate it locally reseting the database in exp or demo won't be needed to experiment with it. I do have this deployed to Demo for now.

### Additional steps

1. Log into the office in demo and ensure no 500 error. 
2. Use the api to retrieve move with code `7799QT` from demo

## Verification Steps for Author

These are to be checked by the author.

- [X] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [X] Request review from a member of a different team.

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
