### PR TITLE
Adjust tests for new default gbloc value.

### DIFF
--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -823,7 +823,7 @@ func (suite *HandlerSuite) TestGetPaymentRequestsQueueHandler() {
 	suite.Equal(actualPaymentRequest.MoveTaskOrderID.String(), paymentRequest.MoveID.String())
 	suite.Equal(hhgMove.Orders.ServiceMemberID.String(), paymentRequest.Customer.ID.String())
 	suite.Equal(string(paymentRequest.Status), "Payment requested")
-	suite.Equal("LKNQ", string(paymentRequest.OriginGBLOC))
+	suite.Equal("KKFA", string(paymentRequest.OriginGBLOC))
 
 	//createdAt := actualPaymentRequest.CreatedAt
 	age := int64(2)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1851,8 +1851,8 @@ func createMoveWithServiceItemsandPaymentRequests01(appCtx appcontext.AppContext
 
 	addressAssertion := testdatagen.Assertions{
 		Address: models.Address{
-			// This is a postal code that maps to the default office user gbloc LKNQ in the PostalCodeToGBLOC table
-			PostalCode: "85325",
+			// This is a postal code that maps to the default office user gbloc KKFA in the PostalCodeToGBLOC table
+			PostalCode: "85004",
 		}}
 
 	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), addressAssertion)


### PR DESCRIPTION
## Summary

Fixes an oopsie where I didn't merge from master and missed that the default gbloc value for an office user changed. this broke server_test and e2e_test, so hopefully this will resolve that.

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Run server tests

```sh
make server_test
```

##### Terminal 2
Run e2e_test 

```sh
make e2e_test
```
</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
