### PR TITLE
MB-10426 too preview modal should display shipment details

### DIFF
--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
@@ -168,7 +168,7 @@ const NTSRShipmentInfoList = ({
     </div>
   );
   return (
-    <dl className={classNames(className, styles.ShipmentDefinitionLists)} data-testid="shipment-info-list">
+    <dl className={classNames(className, styles.ShipmentDefinitionLists)} data-testid="nts-release-shipment-info-list">
       {(isExpanded || primeActualWeightElementFlags.alwaysShow) && primeActualWeightElement}
       {(isExpanded || storageFacilityInfoElementFlags.alwaysShow) && storageFacilityInfoElement}
       {(isExpanded || serviceOrderNumberElementFlags.alwaysShow) && serviceOrderNumberElement}

--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import styles from './ShipmentDefinitionLists.module.scss';
+import shipmentDefinitionListsStyles from './ShipmentDefinitionLists.module.scss';
 
+import styles from 'styles/descriptionList.module.scss';
 import { formatDate } from 'shared/dates';
 import { ShipmentShape } from 'types/shipment';
 import { formatAddress, formatAgent } from 'utils/shipmentDisplay';
@@ -39,7 +40,7 @@ const NTSRShipmentInfoList = ({
 
     if (errorIfMissing.includes(fieldname) && !shipment[fieldname]) {
       alwaysShow = true;
-      classes = classNames(styles.row, styles.missingInfoError);
+      classes = classNames(styles.row, shipmentDefinitionListsStyles.missingInfoError);
       return {
         alwaysShow,
         classes,
@@ -47,7 +48,7 @@ const NTSRShipmentInfoList = ({
     }
     if (warnIfMissing.includes(fieldname) && !shipment[fieldname]) {
       alwaysShow = true;
-      classes = classNames(styles.row, styles.warning);
+      classes = classNames(styles.row, shipmentDefinitionListsStyles.warning);
       return {
         alwaysShow,
         classes,
@@ -168,7 +169,16 @@ const NTSRShipmentInfoList = ({
     </div>
   );
   return (
-    <dl className={classNames(className, styles.ShipmentDefinitionLists)} data-testid="nts-release-shipment-info-list">
+    <dl
+      className={classNames(
+        shipmentDefinitionListsStyles.ShipmentDefinitionLists,
+        styles.descriptionList,
+        styles.tableDisplay,
+        styles.compact,
+        className,
+      )}
+      data-testid="nts-release-shipment-info-list"
+    >
       {(isExpanded || primeActualWeightElementFlags.alwaysShow) && primeActualWeightElement}
       {(isExpanded || storageFacilityInfoElementFlags.alwaysShow) && storageFacilityInfoElement}
       {(isExpanded || serviceOrderNumberElementFlags.alwaysShow) && serviceOrderNumberElement}

--- a/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
@@ -4,50 +4,28 @@
 @import 'shared/styles/_variables';
 
 .ShipmentDefinitionLists {
-
-  dt {
-    @include u-text('bold');
-    @include u-text('base-darker');
-    width: 25%;
-  }
-
-  dd {
-    @include u-margin(0);
-    width: 75%;
-  }
-
-  dt,
-  dd {
-    @include u-border-top('1px');
-    @include u-border-top('base-lighter');
-    @include u-padding-y(1.5);
-    display: table-cell;
-    @include u-padding-x(1);
-  }
-
-  .row {
-    @include u-font('body', 'xs');
-    @include u-line-height('body', 2);
-    display: flex;
-  }
-
-  .row:first-of-type{
-    dt,
-    dd {
-      @include u-border-top(0);
-      @include u-padding-y(1.5)
+  .missingInfoError {
+    dt {
+      @include u-border-left(0.5); //4px
+      @include u-border-left('error');
+    }
+    // These first-child styles added here since the descriptionList compact
+    // display removes the border.
+    dt:first-child {
+      @include u-border-left(0.5); //4px
+      @include u-padding-left(0.5); // Adjust padding so that content still ines up
     }
   }
 
-
-  .missingInfoError {
-    color: $error;
-    @include u-border-left(0.5); //4px
-    @include u-border-left('error');
-    @include u-font-weight(bold);
-  }
-
   .warning {
-    border-left: 4px solid $mm-gold;
+    dt {
+      border-left: 4px solid $mm-gold;
+    }
+    // These first-child styles added here since the descriptionList compact
+    // display removes the border.
+    dt:first-child {
+      @include u-border-left(0.5); //4px
+      @include u-padding-left(0.5); // Adjust padding so that content still ines up
+    }
   }
 }

--- a/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
@@ -40,7 +40,7 @@ const ShipmentInfoList = ({ className, shipment }) => {
       )}
       <div className={styles.row}>
         <dt>Destination address</dt>
-        <dd data-testid="shipmentDestinationAddress">{formatAddress(destinationAddress)}</dd>
+        <dd data-testid="destinationAddress">{formatAddress(destinationAddress)}</dd>
       </div>
       {secondaryDeliveryAddress && (
         <div className={styles.row}>

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import * as PropTypes from 'prop-types';
+
+import { ShipmentShape } from 'types/shipment';
+import ShipmentInfoList from 'components/Office/DefinitionLists/ShipmentInfoList';
+import NTSRShipmentInfoList from 'components/Office/DefinitionLists/NTSRShipmentInfoList';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+const ShipmentInfoListSelector = ({
+  className,
+  shipment,
+  isExpanded,
+  warnIfMissing,
+  errorIfMissing,
+  showWhenCollapsed,
+  shipmentType,
+}) => {
+  switch (shipmentType) {
+    case SHIPMENT_OPTIONS.HHG:
+      return <ShipmentInfoList className={className} shipment={shipment} shipmentType={shipmentType} />;
+    case SHIPMENT_OPTIONS.NTSR:
+      return (
+        <NTSRShipmentInfoList
+          shipment={shipment}
+          isExpanded={isExpanded}
+          warnIfMissing={warnIfMissing}
+          errorIfMissing={errorIfMissing}
+          showWhenCollapsed={showWhenCollapsed}
+        />
+      );
+    default:
+      return (
+        <ShipmentInfoList
+          className={className}
+          shipment={shipment}
+          shipmentType={shipmentType}
+          isExpanded={isExpanded}
+        />
+      );
+  }
+};
+
+ShipmentInfoListSelector.propTypes = {
+  className: PropTypes.string,
+  shipment: ShipmentShape.isRequired,
+  isExpanded: PropTypes.bool,
+  warnIfMissing: PropTypes.arrayOf(PropTypes.string),
+  errorIfMissing: PropTypes.arrayOf(PropTypes.string),
+  showWhenCollapsed: PropTypes.arrayOf(PropTypes.string),
+  shipmentType: PropTypes.oneOf([
+    SHIPMENT_OPTIONS.HHG,
+    SHIPMENT_OPTIONS.HHG_SHORTHAUL_DOMESTIC,
+    SHIPMENT_OPTIONS.HHG_LONGHAUL_DOMESTIC,
+    SHIPMENT_OPTIONS.NTS,
+    SHIPMENT_OPTIONS.NTSR,
+  ]),
+};
+
+ShipmentInfoListSelector.defaultProps = {
+  shipmentType: SHIPMENT_OPTIONS.HHG,
+  className: '',
+  isExpanded: false,
+  warnIfMissing: [],
+  errorIfMissing: [],
+  showWhenCollapsed: [],
+};
+
+export default ShipmentInfoListSelector;

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.jsx
@@ -21,6 +21,7 @@ const ShipmentInfoListSelector = ({
     case SHIPMENT_OPTIONS.NTSR:
       return (
         <NTSRShipmentInfoList
+          className={className}
           shipment={shipment}
           isExpanded={isExpanded}
           warnIfMissing={warnIfMissing}

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.test.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.test.jsx
@@ -55,6 +55,7 @@ describe('Shipment Info List', () => {
   it.each([
     ['HHG', SHIPMENT_OPTIONS.HHG, 'shipment-info-list'],
     ['NTS-release', SHIPMENT_OPTIONS.NTSR, 'nts-release-shipment-info-list'],
+    ['default', SHIPMENT_OPTIONS.HHG, 'shipment-info-list'],
   ])('when the shipment type is %s it selects the %s shipment', async (_, shipmentType, testId) => {
     render(<ShipmentInfoListSelector shipment={info} shipmentType={shipmentType} />);
 

--- a/src/components/Office/DefinitionLists/ShipmentInfoListSelector.test.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoListSelector.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ShipmentInfoListSelector from './ShipmentInfoListSelector';
+
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+const info = {
+  requestedPickupDate: '2020-03-26',
+  pickupAddress: {
+    streetAddress1: '812 S 129th St',
+    city: 'San Antonio',
+    state: 'TX',
+    postalCode: '78234',
+  },
+  secondaryPickupAddress: {
+    streetAddress1: '800 S 2nd St',
+    city: 'San Antonio',
+    state: 'TX',
+    postalCode: '78234',
+  },
+  destinationAddress: {
+    streetAddress1: '441 SW Rio de la Plata Drive',
+    city: 'Tacoma',
+    state: 'WA',
+    postalCode: '98421',
+  },
+  secondaryDeliveryAddress: {
+    streetAddress1: '987 Fairway Dr',
+    city: 'Tacoma',
+    state: 'WA',
+    postalCode: '98421',
+  },
+  agents: [
+    {
+      agentType: 'RELEASING_AGENT',
+      firstName: 'Quinn',
+      lastName: 'Ocampo',
+      phone: '999-999-9999',
+      email: 'quinnocampo@myemail.com',
+    },
+    {
+      agentType: 'RECEIVING_AGENT',
+      firstName: 'Kate',
+      lastName: 'Smith',
+      phone: '419-555-9999',
+      email: 'ksmith@email.com',
+    },
+  ],
+  counselorRemarks: 'counselor approved',
+  customerRemarks: 'customer requested',
+};
+
+describe('Shipment Info List', () => {
+  it.each([
+    ['HHG', SHIPMENT_OPTIONS.HHG, 'shipment-info-list'],
+    ['NTS-release', SHIPMENT_OPTIONS.NTSR, 'nts-release-shipment-info-list'],
+  ])('when the shipment type is %s it selects the %s shipment', async (_, shipmentType, testId) => {
+    render(<ShipmentInfoListSelector shipment={info} shipmentType={shipmentType} />);
+
+    expect(await screen.findByTestId(testId)).toBeInTheDocument();
+  });
+});

--- a/src/components/Office/RequestedShipments/RequestedShipments.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.jsx
@@ -44,16 +44,11 @@ const RequestedShipments = ({
 
   const shipmentDisplayInfo = (shipment, dutyStationPostal) => {
     return {
+      ...shipment,
       heading: shipmentTypeLabels[shipment.shipmentType],
       isDiversion: shipment.diversion,
       shipmentStatus: shipment.status,
-      requestedPickupDate: shipment.requestedPickupDate,
-      pickupAddress: shipment.pickupAddress,
-      secondaryPickupAddress: shipment.secondaryPickupAddress,
       destinationAddress: shipment.destinationAddress || dutyStationPostal,
-      secondaryDeliveryAddress: shipment.secondaryDeliveryAddress,
-      counselorRemarks: shipment.counselorRemarks,
-      customerRemarks: shipment.customerRemarks,
     };
   };
 

--- a/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
+++ b/src/components/Office/RequestedShipments/RequestedShipments.test.jsx
@@ -389,10 +389,10 @@ describe('RequestedShipments', () => {
     const wrapper = mount(requestedShipmentsComponent);
     // The first shipment has a destination address so will not use the duty station postal code
     const destination = shipments[0].destinationAddress;
-    expect(wrapper.find('[data-testid="shipmentDestinationAddress"]').at(0).text()).toEqual(
+    expect(wrapper.find('[data-testid="destinationAddress"]').at(0).text()).toEqual(
       `${destination.streetAddress1},\xa0${destination.city}, ${destination.state} ${destination.postalCode}`,
     );
-    expect(wrapper.find('[data-testid="shipmentDestinationAddress"]').at(1).text()).toEqual(
+    expect(wrapper.find('[data-testid="destinationAddress"]').at(1).text()).toEqual(
       ordersInfo.newDutyStation.address.postalCode,
     );
   });

--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.jsx
@@ -11,7 +11,7 @@ import { mtoShipmentTypes } from 'constants/shipments';
 import AllowancesList from 'components/Office/DefinitionLists/AllowancesList';
 import CustomerInfoList from 'components/Office/DefinitionLists/CustomerInfoList';
 import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentContainer';
-import ShipmentInfoList from 'components/Office/DefinitionLists/ShipmentInfoList';
+import ShipmentInfoListSelector from 'components/Office/DefinitionLists/ShipmentInfoListSelector';
 import ShipmentServiceItemsTable from 'components/Office/ShipmentServiceItemsTable/ShipmentServiceItemsTable';
 import { Modal, ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import { MTOShipmentShape, OrdersInfoShape } from 'types/order';
@@ -72,8 +72,10 @@ const ShipmentApprovalPreview = ({
                       {shipment.diversion && <Tag>diversion</Tag>}
                     </div>
                     <div className={styles.shipmentDetailWrapper}>
-                      <ShipmentInfoList
+                      <ShipmentInfoListSelector
                         className={styles.shipmentInfo}
+                        shipmentType={shipment.shipmentType}
+                        isExpanded
                         shipment={{
                           ...shipment,
                           destinationAddress: shipment.destinationAddress

--- a/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.test.jsx
+++ b/src/components/Office/ShipmentApprovalPreview/ShipmentApprovalPreview.test.jsx
@@ -309,10 +309,10 @@ describe('Shipment preview modal', () => {
         shipmentManagementFee
       />,
     );
-    expect(wrapper.find('[data-testid="shipmentDestinationAddress"]').at(0).text()).toEqual(
+    expect(wrapper.find('[data-testid="destinationAddress"]').at(0).text()).toEqual(
       '987 Any Avenue, Fairfield, CA 94535',
     );
-    expect(wrapper.find('[data-testid="shipmentDestinationAddress"]').at(1).text()).toEqual(
+    expect(wrapper.find('[data-testid="destinationAddress"]').at(1).text()).toEqual(
       ordersInfo.newDutyStation.address.postalCode,
     );
   });

--- a/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
+++ b/src/components/Office/ShipmentDisplay/ShipmentDisplay.jsx
@@ -7,8 +7,7 @@ import classnames from 'classnames';
 
 import { EditButton } from 'components/form/IconButtons';
 import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentContainer';
-import ShipmentInfoList from 'components/Office/DefinitionLists/ShipmentInfoList';
-import NTSRShipmentInfoList from 'components/Office/DefinitionLists/NTSRShipmentInfoList';
+import ShipmentInfoListSelector from 'components/Office/DefinitionLists/ShipmentInfoListSelector';
 import styles from 'components/Office/ShipmentDisplay/ShipmentDisplay.module.scss';
 import { LOA_TYPE, SHIPMENT_OPTIONS } from 'shared/constants';
 import { AddressShape } from 'types/address';
@@ -32,7 +31,6 @@ const ShipmentDisplay = ({
   const history = useHistory();
   const containerClasses = classnames(styles.container, { [styles.noIcon]: !showIcon });
   const [isExpanded, setIsExpanded] = useState(false);
-  let infoList;
   let tac;
   switch (displayInfo.tacType) {
     case LOA_TYPE.HHG:
@@ -57,41 +55,8 @@ const ShipmentDisplay = ({
       sac = ordersLOA.sac;
   }
 
-  const setDisplayInfo = () => {
-    switch (shipmentType) {
-      case SHIPMENT_OPTIONS.HHG:
-        infoList = (
-          <ShipmentInfoList className={styles.shipmentDisplayInfo} shipment={displayInfo} shipmentType={shipmentType} />
-        );
-        break;
-      case SHIPMENT_OPTIONS.NTSR:
-        infoList = (
-          <NTSRShipmentInfoList
-            className={styles.shipmentDisplayInfo}
-            shipment={{ ...displayInfo, tac, sac }}
-            isExpanded={isExpanded}
-            warnIfMissing={warnIfMissing}
-            errorIfMissing={errorIfMissing}
-            showWhenCollapsed={showWhenCollapsed}
-          />
-        );
-        break;
-      default:
-        infoList = (
-          <ShipmentInfoList
-            className={styles.shipmentDisplayInfo}
-            shipment={displayInfo}
-            shipmentType={shipmentType}
-            isExpanded={isExpanded}
-          />
-        );
-    }
-  };
-  setDisplayInfo();
-
   const handleExpandClick = () => {
     setIsExpanded((prev) => !prev);
-    setDisplayInfo();
   };
   const expandableIconClasses = classnames({
     'chevron-up': isExpanded,
@@ -129,7 +94,15 @@ const ShipmentDisplay = ({
 
           <FontAwesomeIcon className={styles.icon} icon={expandableIconClasses} onClick={handleExpandClick} />
         </div>
-        {infoList}
+        <ShipmentInfoListSelector
+          className={styles.shipmentDisplayInfo}
+          shipment={{ ...displayInfo, tac, sac }}
+          shipmentType={shipmentType}
+          isExpanded={isExpanded}
+          warnIfMissing={warnIfMissing}
+          errorIfMissing={errorIfMissing}
+          showWhenCollapsed={showWhenCollapsed}
+        />
         {editURL && (
           <EditButton
             onClick={() => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10426) for this change

## Summary

I created a separate component to handle determining which `ShipmentInfoList` to display. 

I also went in and migrated NTSR Shipment Info List to use the css defined in `descriptionList.module.scss`.

There's a new ticket written up to handle the cleaning up the css with the definition lists on the office side.
[https://dp3.atlassian.net/browse/MB-10912](https://dp3.atlassian.net/browse/MB-10912)

## Question(s)
Both questions below re-d by Amanda: 
https://github.com/transcom/mymove/pull/7975#issuecomment-1003051761
https://github.com/transcom/mymove/pull/7975#pullrequestreview-841969943

Should there be error or warning highlighting for missing information on the modal? 
Should the modal have the shipment info list always expanded?

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a TOO
3. Select the move with the code `NTSSUB` or any other move that contains an unapproved NTS-release shipment. 
4. On the move details page, check the checkbox on the NTS-release shipment 
5. Select either move management or counseling. 
6. Click "Approve selected shipments"

## Verification Steps for Author

These are to be checked by the author.

- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots

![image](https://user-images.githubusercontent.com/6477059/147787324-2ab2aa77-9c04-4cb8-a735-82d5464fcc5d.png)
![image](https://user-images.githubusercontent.com/6477059/147787447-31ee0950-37d4-4883-9c81-7c4eb743d954.png)
