### PR TITLE
MB-10436: Create AccountingCodesModal

### DIFF
--- a/src/components/Office/AccountingCodeSection/AccountingCodeSection.jsx
+++ b/src/components/Office/AccountingCodeSection/AccountingCodeSection.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Label, FormGroup, Radio, Grid } from '@trussworks/react-uswds';
+import { Label, FormGroup, Radio } from '@trussworks/react-uswds';
 import { useField } from 'formik';
 
 import styles from './AccountingCodeSection.module.scss';
@@ -24,14 +24,10 @@ const AccountingCodeSection = ({ label, fieldName, shipmentTypes, emptyMessage }
 
   if (shipmentTypePairs.length === 0) {
     return (
-      <Grid row>
-        <Grid col={12}>
-          <FormGroup>
-            <Label>{label}</Label>
-            <p className={styles.SectionDefaultText}>{emptyMessage}</p>
-          </FormGroup>
-        </Grid>
-      </Grid>
+      <FormGroup>
+        <Label>{label}</Label>
+        <p className={styles.SectionDefaultText}>{emptyMessage}</p>
+      </FormGroup>
     );
   }
 
@@ -54,18 +50,16 @@ const AccountingCodeSection = ({ label, fieldName, shipmentTypes, emptyMessage }
   });
 
   return (
-    <Grid row>
-      <Grid col={12}>
-        <FormGroup className={styles.Section}>
-          <Label>{label}</Label>
-          {fields}
-        </FormGroup>
+    <>
+      <FormGroup className={styles.Section}>
+        <Label>{label}</Label>
+        {fields}
+      </FormGroup>
 
-        <button type="button" onClick={handleClear} className={styles.SectionClear}>
-          Clear selection
-        </button>
-      </Grid>
-    </Grid>
+      <button type="button" onClick={handleClear} className={styles.SectionClear}>
+        Clear selection
+      </button>
+    </>
   );
 };
 

--- a/src/components/Office/AccountingCodeSection/AccountingCodeSection.jsx
+++ b/src/components/Office/AccountingCodeSection/AccountingCodeSection.jsx
@@ -1,13 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Fieldset, Label, FormGroup, Radio, Button, Grid } from '@trussworks/react-uswds';
+import { Label, FormGroup, Radio, Grid } from '@trussworks/react-uswds';
 import { useField } from 'formik';
 
-import styles from './AccountingCodes.module.scss';
+import styles from './AccountingCodeSection.module.scss';
 
-import formStyles from 'styles/form.module.scss';
-import shipmentFormStyles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
-import SectionWrapper from 'components/Customer/SectionWrapper';
 import { AccountingCodesShape } from 'types/accountingCodes';
 
 const AccountingCodeSection = ({ label, fieldName, shipmentTypes, emptyMessage }) => {
@@ -79,54 +76,4 @@ AccountingCodeSection.propTypes = {
   shipmentTypes: AccountingCodesShape.isRequired,
 };
 
-const AccountingCodes = ({ optional, TACs, SACs, onEditCodesClick }) => {
-  const hasCodes = Object.keys(TACs).length + Object.keys(SACs).length > 0;
-
-  return (
-    <SectionWrapper className={formStyles.formSection}>
-      <Fieldset>
-        <h2 className={shipmentFormStyles.SectionHeader}>
-          Accounting codes
-          {optional && (
-            <span className="float-right">
-              <span className={formStyles.optional}>Optional</span>
-            </span>
-          )}
-        </h2>
-
-        <AccountingCodeSection
-          label="TAC"
-          emptyMessage="No TAC code entered."
-          fieldName="tacType"
-          shipmentTypes={TACs}
-        />
-        <AccountingCodeSection
-          label="SAC (optional)"
-          emptyMessage="No SAC code entered."
-          fieldName="sacType"
-          shipmentTypes={SACs}
-        />
-
-        <Button type="button" onClick={onEditCodesClick} secondary={hasCodes} className={styles.addCodeBtn}>
-          {hasCodes ? 'Add or edit codes' : 'Add code'}
-        </Button>
-      </Fieldset>
-    </SectionWrapper>
-  );
-};
-
-AccountingCodes.defaultProps = {
-  optional: true,
-  TACs: {},
-  SACs: {},
-  onEditCodesClick: () => {},
-};
-
-AccountingCodes.propTypes = {
-  optional: PropTypes.bool,
-  TACs: AccountingCodesShape,
-  SACs: AccountingCodesShape,
-  onEditCodesClick: PropTypes.func,
-};
-
-export default AccountingCodes;
+export default AccountingCodeSection;

--- a/src/components/Office/AccountingCodeSection/AccountingCodeSection.module.scss
+++ b/src/components/Office/AccountingCodeSection/AccountingCodeSection.module.scss
@@ -22,7 +22,3 @@
     @include u-text('primary-dark');
   }
 }
-
-.addCodeBtn {
-  width: auto;
-}

--- a/src/components/Office/AccountingCodeSection/AccountingCodeSection.test.jsx
+++ b/src/components/Office/AccountingCodeSection/AccountingCodeSection.test.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
+
+import AccountingCodeSection from './AccountingCodeSection';
+
+describe('components/Office/AccountingCodeSection', () => {
+  it('should render without codes', () => {
+    render(
+      <Formik initialValues={{}}>
+        <AccountingCodeSection
+          label="Test Code Section"
+          emptyMessage="No codes entered."
+          fieldName="testSection"
+          shipmentTypes={{}}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByText('No codes entered.')).toBeInTheDocument();
+  });
+
+  it('should render a single code and select it by default', async () => {
+    render(
+      <Formik initialValues={{}}>
+        <AccountingCodeSection
+          label="Test Code Section"
+          emptyMessage="No codes entered."
+          fieldName="testSection"
+          shipmentTypes={{ HHG: '1234' }}
+        />
+      </Formik>,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('1234 (HHG)')).toBeChecked());
+  });
+
+  it('should render multiple codes and not default either of them', () => {
+    render(
+      <Formik initialValues={{}}>
+        <AccountingCodeSection
+          label="Test Code Section"
+          emptyMessage="No codes entered."
+          fieldName="testSection"
+          shipmentTypes={{ HHG: '1234', NTS: '2345' }}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('1234 (HHG)')).not.toBeChecked();
+    expect(screen.getByLabelText('2345 (NTS)')).not.toBeChecked();
+  });
+
+  it('should respond to initialValues', () => {
+    render(
+      <Formik initialValues={{ testSection: 'NTS' }}>
+        <AccountingCodeSection
+          label="Test Code Section"
+          emptyMessage="No codes entered."
+          fieldName="testSection"
+          shipmentTypes={{ HHG: '1234', NTS: '2345' }}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText('1234 (HHG)')).not.toBeChecked();
+    expect(screen.getByLabelText('2345 (NTS)')).toBeChecked();
+  });
+
+  it('should clear values if the clear button is selected', async () => {
+    render(
+      <Formik initialValues={{ testSection: 'NTS' }}>
+        <AccountingCodeSection
+          label="Test Code Section"
+          emptyMessage="No codes entered."
+          fieldName="testSection"
+          shipmentTypes={{ HHG: '1234', NTS: '2345' }}
+        />
+      </Formik>,
+    );
+
+    userEvent.click(screen.getByText('Clear selection'));
+    await waitFor(() => expect(screen.getByLabelText('2345 (NTS)')).not.toBeChecked());
+  });
+});

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
@@ -1,7 +1,87 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Formik } from 'formik';
+import { Button } from '@trussworks/react-uswds';
 
-const AccountingCodesModal = () => {
-  return <div>hey</div>;
+import styles from './AccountingCodesModal.module.scss';
+
+import AccountingCodeSection from 'components/Office/AccountingCodeSection/AccountingCodeSection';
+import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
+import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
+import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
+import { Form } from 'components/form';
+import { shipmentTypes } from 'constants/shipments';
+import { AccountingCodesShape } from 'types/accountingCodes';
+
+const AccountingCodesModal = ({ onClose, onSubmit, onEditCodesClick, shipmentType, TACs, SACs, tacType, sacType }) => {
+  const handleFormSubmit = (values) => onSubmit(values);
+
+  return (
+    <div data-testid="AccountingCodesModal" className={styles.Container}>
+      <Overlay />
+      <ModalContainer>
+        <Modal>
+          <ModalClose handleClick={onClose} />
+
+          <ModalTitle>
+            <ShipmentTag shipmentType={shipmentType} />
+            <h2 className={styles.Title}>Edit accounting codes</h2>
+          </ModalTitle>
+
+          <Formik initialValues={{ tacType, sacType }} onSubmit={handleFormSubmit}>
+            <Form>
+              <AccountingCodeSection
+                label="TAC"
+                emptyMessage="No TAC code entered."
+                fieldName="tacType"
+                shipmentTypes={TACs}
+              />
+
+              <AccountingCodeSection
+                label="SAC (optional)"
+                emptyMessage="No SAC code entered."
+                fieldName="sacType"
+                shipmentTypes={SACs}
+              />
+
+              <div>
+                <button type="button" onClick={onEditCodesClick} className={styles.EditCodes}>
+                  Add or edit codes
+                </button>
+              </div>
+              <ModalActions>
+                <Button type="submit">Save</Button>
+                <Button type="button" secondary onClick={onClose}>
+                  Cancel
+                </Button>
+              </ModalActions>
+            </Form>
+          </Formik>
+        </Modal>
+      </ModalContainer>
+    </div>
+  );
+};
+
+AccountingCodesModal.propTypes = {
+  onClose: PropTypes.func,
+  onSubmit: PropTypes.func,
+  onEditCodesClick: PropTypes.func,
+  shipmentType: PropTypes.oneOf(Object.keys(shipmentTypes)).isRequired,
+  TACs: AccountingCodesShape,
+  SACs: AccountingCodesShape,
+  tacType: PropTypes.string,
+  sacType: PropTypes.string,
+};
+
+AccountingCodesModal.defaultProps = {
+  onClose: () => {},
+  onSubmit: () => {},
+  onEditCodesClick: () => {},
+  TACs: {},
+  SACs: {},
+  tacType: '',
+  sacType: '',
 };
 
 export default AccountingCodesModal;

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AccountingCodesModal = () => {
+  return <div>hey</div>;
+};
+
+export default AccountingCodesModal;

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.module.scss
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.module.scss
@@ -1,0 +1,26 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/colors';
+
+.Title {
+  @include u-padding-top(2);
+}
+
+.TitleSection {
+  margin: 0;
+}
+
+.EditCodes {
+  @include u-text('primary');
+  @include u-font-size('body', 'xs');
+  @include u-padding(0);
+  @include u-margin-x(0);
+  @include u-margin-top(3);
+  @include u-margin-bottom(1);
+  background: none;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    @include u-text('primary-dark');
+  }
+}

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.stories.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.stories.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import AccountingCodesModal from './AccountingCodesModal';
+
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+export default {
+  title: 'Office Components/AccountingCodesModal',
+  component: AccountingCodesModal,
+};
+
+export const minimal = () => (
+  <div className="officeApp">
+    <AccountingCodesModal shipmentType={SHIPMENT_OPTIONS.NTS} />
+  </div>
+);
+
+export const withCodes = () => (
+  <div className="officeApp">
+    <AccountingCodesModal
+      shipmentType={SHIPMENT_OPTIONS.NTSR}
+      TACs={{ HHG: '1234', NTS: '2345' }}
+      SACs={{ HHG: 'CF13', NTS: 'E8A1' }}
+    />
+  </div>
+);
+
+export const withCodesAndValues = () => (
+  <div className="officeApp">
+    <AccountingCodesModal
+      shipmentType={SHIPMENT_OPTIONS.HHG}
+      TACs={{ HHG: '1234', NTS: '2345' }}
+      SACs={{ HHG: 'CF13', NTS: 'E8A1' }}
+      tacType="NTS"
+      sacType="HHG"
+    />
+  </div>
+);

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.test.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AccountingCodesModal from './AccountingCodesModal';
+
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+describe('components/Office/AccountingCodesModal', () => {
+  it('renders content with minimal props', () => {
+    render(<AccountingCodesModal shipmentType={SHIPMENT_OPTIONS.NTSR} />);
+
+    expect(screen.getByText('NTS-release')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Edit accounting codes' })).toBeInTheDocument();
+    expect(screen.getByText('No TAC code entered.')).toBeInTheDocument();
+    expect(screen.getByText('No SAC code entered.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add or edit codes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('renders full content', async () => {
+    const onClose = jest.fn();
+    const onEditCodesClick = jest.fn();
+
+    render(
+      <AccountingCodesModal
+        shipmentType={SHIPMENT_OPTIONS.NTS}
+        TACs={{ HHG: '1234', NTS: '2345' }}
+        SACs={{ HHG: 'ABCD', NTS: 'BCDE' }}
+        onClose={onClose}
+        onEditCodesClick={onEditCodesClick}
+        tacType="HHG"
+        sacType="NTS"
+      />,
+    );
+
+    expect(screen.getByLabelText('1234 (HHG)')).toBeChecked();
+    expect(screen.getByLabelText('BCDE (NTS)')).toBeChecked();
+
+    userEvent.click(screen.getByRole('button', { name: 'Add or edit codes' }));
+    await waitFor(() => expect(onEditCodesClick).toHaveBeenCalledTimes(1));
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    userEvent.click(screen.getByTestId('modalCloseButton'));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(2));
+  });
+
+  it('returns values from form', async () => {
+    const onSubmit = jest.fn();
+
+    render(
+      <AccountingCodesModal
+        shipmentType={SHIPMENT_OPTIONS.NTS}
+        TACs={{ HHG: '1234', NTS: '2345' }}
+        SACs={{ HHG: 'ABCD', NTS: 'BCDE' }}
+        onSubmit={onSubmit}
+        tacType="HHG"
+        sacType="NTS"
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ tacType: 'HHG', sacType: 'NTS' }));
+
+    userEvent.click(screen.getByLabelText('2345 (NTS)'));
+    userEvent.click(screen.getByLabelText('ABCD (HHG)'));
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ tacType: 'NTS', sacType: 'HHG' }));
+  });
+});

--- a/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.jsx
+++ b/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Fieldset, Button } from '@trussworks/react-uswds';
+
+import styles from './ShipmentAccountingCodes.module.scss';
+
+import formStyles from 'styles/form.module.scss';
+import shipmentFormStyles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
+import SectionWrapper from 'components/Customer/SectionWrapper';
+import AccountingCodeSection from 'components/Office/AccountingCodeSection/AccountingCodeSection';
+import { AccountingCodesShape } from 'types/accountingCodes';
+
+const AccountingCodes = ({ optional, TACs, SACs, onEditCodesClick }) => {
+  const hasCodes = Object.keys(TACs).length + Object.keys(SACs).length > 0;
+
+  return (
+    <SectionWrapper className={formStyles.formSection}>
+      <Fieldset>
+        <h2 className={shipmentFormStyles.SectionHeader}>
+          Accounting codes
+          {optional && (
+            <span className="float-right">
+              <span className={formStyles.optional}>Optional</span>
+            </span>
+          )}
+        </h2>
+
+        <AccountingCodeSection
+          label="TAC"
+          emptyMessage="No TAC code entered."
+          fieldName="tacType"
+          shipmentTypes={TACs}
+        />
+        <AccountingCodeSection
+          label="SAC (optional)"
+          emptyMessage="No SAC code entered."
+          fieldName="sacType"
+          shipmentTypes={SACs}
+        />
+
+        <Button type="button" onClick={onEditCodesClick} secondary={hasCodes} className={styles.addCodeBtn}>
+          {hasCodes ? 'Add or edit codes' : 'Add code'}
+        </Button>
+      </Fieldset>
+    </SectionWrapper>
+  );
+};
+
+AccountingCodes.defaultProps = {
+  optional: true,
+  TACs: {},
+  SACs: {},
+  onEditCodesClick: () => {},
+};
+
+AccountingCodes.propTypes = {
+  optional: PropTypes.bool,
+  TACs: AccountingCodesShape,
+  SACs: AccountingCodesShape,
+  onEditCodesClick: PropTypes.func,
+};
+
+export default AccountingCodes;

--- a/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.jsx
+++ b/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.jsx
@@ -16,7 +16,7 @@ const AccountingCodes = ({ optional, TACs, SACs, onEditCodesClick }) => {
   return (
     <SectionWrapper className={formStyles.formSection}>
       <Fieldset>
-        <h2 className={shipmentFormStyles.SectionHeader}>
+        <h2 className={shipmentFormStyles.SectionHeaderExtraSpacing}>
           Accounting codes
           {optional && (
             <span className="float-right">

--- a/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.module.scss
+++ b/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.module.scss
@@ -1,0 +1,3 @@
+.addCodeBtn {
+  width: auto;
+}

--- a/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.stories.jsx
+++ b/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, GridContainer } from '@trussworks/react-uswds';
 import { Formik } from 'formik';
 
-import AccountingCodes from './AccountingCodes';
+import ShipmentAccountingCodes from './ShipmentAccountingCodes';
 
 import styles from 'pages/Office/ServicesCounselingMoveInfo/ServicesCounselingTab.module.scss';
 import shipmentFormStyles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
@@ -10,8 +10,8 @@ import { Form } from 'components/form/Form';
 import formStyles from 'styles/form.module.scss';
 
 export default {
-  title: 'Office Components / Forms / ShipmentForm / AccountingCodes',
-  component: AccountingCodes,
+  title: 'Office Components / Forms / ShipmentForm / ShipmentAccountingCodes',
+  component: ShipmentAccountingCodes,
   decorators: [
     (Story) => (
       <GridContainer className={styles.gridContainer}>
@@ -37,25 +37,25 @@ export default {
 
 export const AsRequired = () => (
   <div className="officeApp">
-    <AccountingCodes optional={false} />{' '}
+    <ShipmentAccountingCodes optional={false} />{' '}
   </div>
 );
 
 export const WithNoTACsOrSACs = () => (
   <div className="officeApp">
-    <AccountingCodes />
+    <ShipmentAccountingCodes />
   </div>
 );
 WithNoTACsOrSACs.storyName = 'With No TACs or SACs';
 
 export const WithSingleCode = () => (
   <div className="officeApp">
-    <AccountingCodes TACs={{ HHG: '1234', NTS: undefined }} />
+    <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: undefined }} />
   </div>
 );
 
 export const WithMultipleCodes = () => (
   <div className="officeApp">
-    <AccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} SACs={{ HHG: '98765', NTS: '000012345' }} />
+    <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} SACs={{ HHG: '98765', NTS: '000012345' }} />
   </div>
 );

--- a/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.test.jsx
+++ b/src/components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes.test.jsx
@@ -3,14 +3,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 
-import AccountingCodes from './AccountingCodes';
+import ShipmentAccountingCodes from './ShipmentAccountingCodes';
 
-describe('components/Office/AccountingCodes', () => {
+describe('components/Office/ShipmentAccountingCodes', () => {
   describe('rendering', () => {
     it('renders with minimal props', () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes />
+          <ShipmentAccountingCodes />
         </Formik>,
       );
       expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/Accounting codes/);
@@ -24,7 +24,7 @@ describe('components/Office/AccountingCodes', () => {
     it('renders one or multiple TACs and SACs', async () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} SACs={{ HHG: '000012345' }} />
+          <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} SACs={{ HHG: '000012345' }} />
         </Formik>,
       );
 
@@ -41,7 +41,7 @@ describe('components/Office/AccountingCodes', () => {
     it('doesnt render undefined TAC or SAC values', async () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes TACs={{ HHG: '1234', NTS: undefined }} />
+          <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: undefined }} />
         </Formik>,
       );
 
@@ -54,7 +54,7 @@ describe('components/Office/AccountingCodes', () => {
     it('applies Formik internal values', () => {
       render(
         <Formik initialValues={{ tacType: 'NTS' }}>
-          <AccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
+          <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
         </Formik>,
       );
 
@@ -65,7 +65,7 @@ describe('components/Office/AccountingCodes', () => {
     it('does not render the "optional" text when the appropriate param is passed in', () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes optional={false} />
+          <ShipmentAccountingCodes optional={false} />
         </Formik>,
       );
 
@@ -78,7 +78,7 @@ describe('components/Office/AccountingCodes', () => {
       const onEditCodesClick = jest.fn();
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes onEditCodesClick={onEditCodesClick} />
+          <ShipmentAccountingCodes onEditCodesClick={onEditCodesClick} />
         </Formik>,
       );
 
@@ -89,7 +89,7 @@ describe('components/Office/AccountingCodes', () => {
     it('clicking a code sets the value', async () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
+          <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
         </Formik>,
       );
 
@@ -103,7 +103,7 @@ describe('components/Office/AccountingCodes', () => {
     it('clicking "Clear selection" clears the value', async () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
+          <ShipmentAccountingCodes TACs={{ HHG: '1234', NTS: '5678' }} />
         </Formik>,
       );
 
@@ -122,7 +122,7 @@ describe('components/Office/AccountingCodes', () => {
     it('clicking "Clear selection" on a single code clears the value', async () => {
       render(
         <Formik initialValues={{}}>
-          <AccountingCodes TACs={{ NTS: '5678' }} />
+          <ShipmentAccountingCodes TACs={{ NTS: '5678' }} />
         </Formik>,
       );
 

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -14,7 +14,7 @@ import { SCRequestShipmentCancellationModal } from 'components/Office/ServicesCo
 import formStyles from 'styles/form.module.scss';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { Form } from 'components/form/Form';
-import AccountingCodes from 'components/Office/AccountingCodes/AccountingCodes';
+import ShipmentAccountingCodes from 'components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes';
 import ShipmentWeightInput from 'components/Office/ShipmentWeightInput/ShipmentWeightInput';
 import { DatePickerInput } from 'components/form/fields';
 import { AddressFields } from 'components/form/AddressFields/AddressFields';
@@ -385,7 +385,7 @@ const ShipmentForm = ({
                 />
 
                 {showAccountingCodes && (
-                  <AccountingCodes
+                  <ShipmentAccountingCodes
                     TACs={TACs}
                     SACs={SACs}
                     onEditCodesClick={() => history.push(editOrdersPath)}


### PR DESCRIPTION
## Jira ticket for this change: [MB-10436](https://dp3.atlassian.net/browse/MB-10436)

## Summary

This pull request creates an AccountingCodesModal component in Storybook, for future incorporation into the TOO flow.

Since the logic is _similar_ but not identical to the existing `AccountingCodes` section in the `ShipmentForm` (which has now been renamed to the `ShipmentAccountingCodes` component for clarity), some logic from the existing component was refactored out into a separate component -- `AccountingCodeSection` -- which both the existing form section and new modal incorporate.

New tests and stories have been created for the new components.

There should not be any UI changes to the existing ShipmentAccountingCodes component.

## Setup to Run Your Code

<details>
Start the Storybook locally.

```sh
make storybook
```
</details>

### Additional steps

1. In Storybook, view the "AccountingCodesModal" component (in the "Office Components" section).
2. Verify that the component behaves correctly.
3. Verify that an existing component which incorporates newly-refactored logic ("ShipmentAccountingCodes", inside the "Office Components" -> "Forms" -> "ShipmentForm") still looks and behaves correctly.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [x] There are no new console errors in the browser devtools
- [x] There are no new console errors in the test output
- [x] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

* [Modal, without any existing TAC/SAC codes](https://user-images.githubusercontent.com/83614364/147786237-53eb3541-f950-40d1-a637-63063d20e931.png)
* [Modal, with existing TAC/SAC codes](https://user-images.githubusercontent.com/83614364/147786264-90ff4d82-e040-4532-b1f8-9aecf4a8e7fc.png)
 