### PR TITLE
MB-10877 SIT Allowance is editable by GHC API allowances handlers

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3257,6 +3257,10 @@ func init() {
           "type": "integer",
           "x-formatting": "weight",
           "example": 2000
+        },
+        "sitAllowance": {
+          "description": "the number of storage in transit days that the customer is entitled to for a given shipment on their move",
+          "type": "integer"
         }
       }
     },
@@ -5477,6 +5481,10 @@ func init() {
           "type": "integer",
           "x-formatting": "weight",
           "example": 2000
+        },
+        "sitAllowance": {
+          "description": "the number of storage in transit days that the customer is entitled to for a given shipment on their move",
+          "type": "integer"
         }
       }
     },
@@ -9926,6 +9934,11 @@ func init() {
           "minimum": 0,
           "x-formatting": "weight",
           "example": 2000
+        },
+        "sitAllowance": {
+          "description": "the number of storage in transit days that the customer is entitled to for a given shipment on their move",
+          "type": "integer",
+          "minimum": 0
         }
       }
     },
@@ -12152,6 +12165,11 @@ func init() {
           "minimum": 0,
           "x-formatting": "weight",
           "example": 2000
+        },
+        "sitAllowance": {
+          "description": "the number of storage in transit days that the customer is entitled to for a given shipment on their move",
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/pkg/gen/ghcmessages/counseling_update_allowance_payload.go
+++ b/pkg/gen/ghcmessages/counseling_update_allowance_payload.go
@@ -47,6 +47,10 @@ type CounselingUpdateAllowancePayload struct {
 	// Example: 2000
 	// Minimum: 0
 	RequiredMedicalEquipmentWeight *int64 `json:"requiredMedicalEquipmentWeight,omitempty"`
+
+	// the number of storage in transit days that the customer is entitled to for a given shipment on their move
+	// Minimum: 0
+	SitAllowance *int64 `json:"sitAllowance,omitempty"`
 }
 
 // Validate validates this counseling update allowance payload
@@ -70,6 +74,10 @@ func (m *CounselingUpdateAllowancePayload) Validate(formats strfmt.Registry) err
 	}
 
 	if err := m.validateRequiredMedicalEquipmentWeight(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitAllowance(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -149,6 +157,18 @@ func (m *CounselingUpdateAllowancePayload) validateRequiredMedicalEquipmentWeigh
 	}
 
 	if err := validate.MinimumInt("requiredMedicalEquipmentWeight", "body", *m.RequiredMedicalEquipmentWeight, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *CounselingUpdateAllowancePayload) validateSitAllowance(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitAllowance) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("sitAllowance", "body", *m.SitAllowance, 0, false); err != nil {
 		return err
 	}
 

--- a/pkg/gen/ghcmessages/update_allowance_payload.go
+++ b/pkg/gen/ghcmessages/update_allowance_payload.go
@@ -52,6 +52,10 @@ type UpdateAllowancePayload struct {
 	// Example: 2000
 	// Minimum: 0
 	RequiredMedicalEquipmentWeight *int64 `json:"requiredMedicalEquipmentWeight,omitempty"`
+
+	// the number of storage in transit days that the customer is entitled to for a given shipment on their move
+	// Minimum: 0
+	SitAllowance *int64 `json:"sitAllowance,omitempty"`
 }
 
 // Validate validates this update allowance payload
@@ -79,6 +83,10 @@ func (m *UpdateAllowancePayload) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRequiredMedicalEquipmentWeight(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSitAllowance(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -170,6 +178,18 @@ func (m *UpdateAllowancePayload) validateRequiredMedicalEquipmentWeight(formats 
 	}
 
 	if err := validate.MinimumInt("requiredMedicalEquipmentWeight", "body", *m.RequiredMedicalEquipmentWeight, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *UpdateAllowancePayload) validateSitAllowance(formats strfmt.Registry) error {
+	if swag.IsZero(m.SitAllowance) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("sitAllowance", "body", *m.SitAllowance, 0, false); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -909,6 +909,7 @@ func (suite *HandlerSuite) makeUpdateAllowanceHandlerSubtestData() (subtestData 
 		ProGearWeight:                  proGearWeight,
 		ProGearWeightSpouse:            proGearWeightSpouse,
 		RequiredMedicalEquipmentWeight: rmeWeight,
+		SitAllowance:                   swag.Int64(60),
 	}
 	return subtestData
 }
@@ -989,6 +990,7 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 		suite.Equal(*body.ProGearWeight, ordersPayload.Entitlement.ProGearWeight)
 		suite.Equal(*body.ProGearWeightSpouse, ordersPayload.Entitlement.ProGearWeightSpouse)
 		suite.Equal(*body.RequiredMedicalEquipmentWeight, ordersPayload.Entitlement.RequiredMedicalEquipmentWeight)
+		suite.Equal(*body.SitAllowance, *ordersPayload.Entitlement.StorageInTransit)
 	})
 
 	suite.Run("Returns a 403 when the user does not have TOO role", func() {
@@ -1175,6 +1177,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 		ProGearWeight:                  proGearWeight,
 		ProGearWeightSpouse:            proGearWeightSpouse,
 		RequiredMedicalEquipmentWeight: rmeWeight,
+		SitAllowance:                   swag.Int64(80),
 	}
 
 	request := httptest.NewRequest("PATCH", "/counseling/orders/{orderID}/allowances", nil)
@@ -1216,6 +1219,7 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 		suite.Equal(*body.ProGearWeight, ordersPayload.Entitlement.ProGearWeight)
 		suite.Equal(*body.ProGearWeightSpouse, ordersPayload.Entitlement.ProGearWeightSpouse)
 		suite.Equal(*body.RequiredMedicalEquipmentWeight, ordersPayload.Entitlement.RequiredMedicalEquipmentWeight)
+		suite.Equal(*body.SitAllowance, *ordersPayload.Entitlement.StorageInTransit)
 	})
 
 	suite.Run("Returns a 403 when the user does not have Counselor role", func() {

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -347,6 +347,11 @@ func allowanceFromTOOPayload(existingOrder models.Order, payload ghcmessages.Upd
 		order.Entitlement.DependentsAuthorized = payload.DependentsAuthorized
 	}
 
+	if payload.SitAllowance != nil {
+		newSITAllowance := int(*payload.SitAllowance)
+		order.Entitlement.StorageInTransit = &newSITAllowance
+	}
+
 	return order
 }
 
@@ -383,6 +388,11 @@ func allowanceFromCounselingPayload(existingOrder models.Order, payload ghcmessa
 
 	if payload.DependentsAuthorized != nil {
 		order.Entitlement.DependentsAuthorized = payload.DependentsAuthorized
+	}
+
+	if payload.SitAllowance != nil {
+		newSITAllowance := int(*payload.SitAllowance)
+		order.Entitlement.StorageInTransit = &newSITAllowance
 	}
 
 	return order

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -24,7 +24,7 @@ swagger_func() {
   if [ -n "${CIRCLECI+x}" ]; then
     # In CircleCI the docker image has the binary installed
     echo "RUNNING IN CIRCLECI"
-    /usr/bin/env swagger "$@"
+    /usr/local/bin/swagger "$@"
   else
     docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger "$@"
   fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -24,7 +24,7 @@ swagger_func() {
   if [ -n "${CIRCLECI+x}" ]; then
     # In CircleCI the docker image has the binary installed
     echo "RUNNING IN CIRCLECI"
-    /usr/local/bin/swagger "$@"
+    /usr/bin/env swagger "$@"
   else
     docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger "$@"
   fi

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2676,6 +2676,10 @@ definitions:
         description: only for Army
         type: boolean
         x-nullable: true
+      sitAllowance:
+        description: the number of storage in transit days that the customer is entitled to for a given shipment on their move
+        type: integer
+        minimum: 0
   UpdateBillableWeightPayload:
     type: object
     properties:
@@ -2742,6 +2746,10 @@ definitions:
         description: only for Army
         type: boolean
         x-nullable: true
+      sitAllowance:
+        description: the number of storage in transit days that the customer is entitled to for a given shipment on their move
+        type: integer
+        minimum: 0
   MoveTaskOrder:
     description: The Move (MoveTaskOrder)
     properties:

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2763,6 +2763,12 @@ definitions:
         description: only for Army
         type: boolean
         x-nullable: true
+      sitAllowance:
+        description: >-
+          the number of storage in transit days that the customer is entitled to
+          for a given shipment on their move
+        type: integer
+        minimum: 0
   UpdateBillableWeightPayload:
     type: object
     properties:
@@ -2829,6 +2835,12 @@ definitions:
         description: only for Army
         type: boolean
         x-nullable: true
+      sitAllowance:
+        description: >-
+          the number of storage in transit days that the customer is entitled to
+          for a given shipment on their move
+        type: integer
+        minimum: 0
   MoveTaskOrder:
     description: The Move (MoveTaskOrder)
     properties:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10877) for this change

## Summary
This makes it so the GHCAPI handlers for the TOO and the Services Counselor for editing allowances are able to edit the SIT allowance value on the entitlement table.

There will be follow up to migrate over to this value from the shipment based one in a couple of future PRs. The reason for this is that while the SIT entitlement is something that applies to the shipment it is always the same for every shipment on the same move. 


## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
