### PR TITLE
Convert more tests to transaction style

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/contract_code_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/contract_code_lookup_test.go
@@ -1,8 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -14,7 +12,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestContractCodeLookup() {
 	key := models.ServiceItemParamNameContractCode
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
@@ -25,7 +23,7 @@ func (suite *ServiceParamValueLookupsSuite) TestContractCodeLookup() {
 		suite.Equal(ghcrateengine.DefaultContractCode, valueStr)
 	})
 
-	suite.T().Run("golden path with param cache", func(t *testing.T) {
+	suite.Run("golden path with param cache", func() {
 
 		// MS
 		reService1 := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_billed_lookup_test.go
@@ -1,7 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -13,7 +12,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 	key := models.ServiceItemParamNameCubicFeetBilled
 
-	suite.T().Run("successful CubicFeetBilled lookup, above minimum", func(t *testing.T) {
+	suite.Run("successful CubicFeetBilled lookup, above minimum", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -54,7 +53,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 		suite.Equal("1029.33", stringValue)
 	})
 
-	suite.T().Run("When crate volume is less than minimum, billed volume should be set to minimum", func(t *testing.T) {
+	suite.Run("When crate volume is less than minimum, billed volume should be set to minimum", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -93,7 +92,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetBilledLookup() {
 		suite.Equal("4.00", stringValue)
 	})
 
-	suite.T().Run("missing dimension should error", func(t *testing.T) {
+	suite.Run("missing dimension should error", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 		suite.FatalNoError(err)

--- a/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/cubic_feet_crating_lookup_test.go
@@ -1,7 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -13,7 +12,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 	key := models.ServiceItemParamNameCubicFeetCrating
 
-	suite.T().Run("successful CubicFeetCrating lookup", func(t *testing.T) {
+	suite.Run("successful CubicFeetCrating lookup", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -54,7 +53,7 @@ func (suite *ServiceParamValueLookupsSuite) TestCubicFeetCratingLookup() {
 		suite.Equal("1029.33", stringValue)
 	})
 
-	suite.T().Run("missing dimension should error", func(t *testing.T) {
+	suite.Run("missing dimension should error", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 		suite.FatalNoError(err)

--- a/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_height_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -14,7 +13,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
 	key := models.ServiceItemParamNameDimensionHeight
 
-	suite.T().Run("successful DimensionHeight lookup", func(t *testing.T) {
+	suite.Run("successful DimensionHeight lookup", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -56,7 +55,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionHeightLookup() {
 		suite.Equal("96", strconv.Itoa(int(cratingDimension.Height.ToInches())))
 	})
 
-	suite.T().Run("missing dimension should error", func(t *testing.T) {
+	suite.Run("missing dimension should error", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 		suite.FatalNoError(err)

--- a/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_length_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -14,7 +13,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
 	key := models.ServiceItemParamNameDimensionLength
 
-	suite.T().Run("successful DimensionLength lookup", func(t *testing.T) {
+	suite.Run("successful DimensionLength lookup", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -56,7 +55,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionLengthLookup() {
 		suite.Equal("193", strconv.Itoa(int(cratingDimension.Length.ToInches())))
 	})
 
-	suite.T().Run("missing dimension should error", func(t *testing.T) {
+	suite.Run("missing dimension should error", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 		suite.FatalNoError(err)

--- a/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/dimension_width_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -14,7 +13,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
 	key := models.ServiceItemParamNameDimensionWidth
 
-	suite.T().Run("successful DimensionWidth lookup", func(t *testing.T) {
+	suite.Run("successful DimensionWidth lookup", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDCRT,
@@ -57,7 +56,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDimensionWidthLookup() {
 
 	})
 
-	suite.T().Run("missing dimension should error", func(t *testing.T) {
+	suite.Run("missing dimension should error", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 		suite.FatalNoError(err)

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"strconv"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -12,7 +11,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 	key := models.ServiceItemParamNameDistanceZip3
 
-	suite.T().Run("Calculate zip3 distance", func(t *testing.T) {
+	suite.Run("Calculate zip3 distance", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -50,7 +49,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Equal(unit.Miles(defaultZip3Distance), *mtoShipment.Distance)
 	})
 
-	suite.T().Run("Doesn't update mtoShipment distance when the pickup and destination zip3s are the same", func(t *testing.T) {
+	suite.Run("Doesn't update mtoShipment distance when the pickup and destination zip3s are the same", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -87,7 +86,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Nil(mtoShipment.Distance)
 	})
 
-	suite.T().Run("Calculate zip3 distance with param cache", func(t *testing.T) {
+	suite.Run("Calculate zip3 distance with param cache", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -168,7 +167,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Equal(expected, *paramCacheValue)
 	})
 
-	suite.T().Run("returns error if the pickup zipcode isn't at least 5 digits", func(t *testing.T) {
+	suite.Run("returns error if the pickup zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -197,7 +196,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip3Lookup() {
 		suite.Contains(err.Error(), "Shipment must have valid pickup zipcode")
 	})
 
-	suite.T().Run("returns error if the destination zipcode isn't at least 5 digits", func(t *testing.T) {
+	suite.Run("returns error if the destination zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{

--- a/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip5_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"strconv"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -12,7 +11,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 	key := models.ServiceItemParamNameDistanceZip5
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	suite.Run("golden path", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -47,7 +46,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		suite.Equal(unit.Miles(defaultZip5Distance), *mtoShipment.Distance)
 	})
 
-	suite.T().Run("doesn't update mtoShipment distance when the pickup and destination zip3s are different", func(t *testing.T) {
+	suite.Run("doesn't update mtoShipment distance when the pickup and destination zip3s are different", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -83,7 +82,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		suite.Nil(mtoShipment.Distance)
 	})
 
-	suite.T().Run("returns error if the pickup zipcode isn't at least 5 digits", func(t *testing.T) {
+	suite.Run("returns error if the pickup zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -112,7 +111,7 @@ func (suite *ServiceParamValueLookupsSuite) TestDistanceZip5Lookup() {
 		suite.Contains(err.Error(), "Shipment must have valid pickup zipcode")
 	})
 
-	suite.T().Run("returns error if the destination zipcode isn't at least 5 digits", func(t *testing.T) {
+	suite.Run("returns error if the destination zipcode isn't at least 5 digits", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			MTOShipment: testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 				PickupAddress: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{

--- a/pkg/payment_request/service_param_value_lookups/fsc_weight_based_distance_multiplier_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/fsc_weight_based_distance_multiplier_lookup_test.go
@@ -1,8 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -10,7 +8,7 @@ import (
 func (suite *ServiceParamValueLookupsSuite) TestFSCWeightBasedDistanceMultiplierLookup() {
 	key := models.ServiceItemParamNameFSCWeightBasedDistanceMultiplier
 
-	suite.T().Run("correct weight based distance multiplier is returned for billed weight less than 5,000 pounds", func(t *testing.T) {
+	suite.Run("correct weight based distance multiplier is returned for billed weight less than 5,000 pounds", func() {
 		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(3000), unit.Pound(3000), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 
@@ -18,7 +16,7 @@ func (suite *ServiceParamValueLookupsSuite) TestFSCWeightBasedDistanceMultiplier
 		suite.Equal("0.000417", valueStr)
 	})
 
-	suite.T().Run("correct weight based distance multiplier is returned for billed weight greater than 5,000 pounds but less than 10,001 pounds", func(t *testing.T) {
+	suite.Run("correct weight based distance multiplier is returned for billed weight greater than 5,000 pounds but less than 10,001 pounds", func() {
 		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(9500), unit.Pound(9500), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 
@@ -26,7 +24,7 @@ func (suite *ServiceParamValueLookupsSuite) TestFSCWeightBasedDistanceMultiplier
 		suite.Equal("0.0006255", valueStr)
 	})
 
-	suite.T().Run("correct weight based distance multiplier is returned for billed weight greater than 10,000 pounds but less than 24,001 pounds", func(t *testing.T) {
+	suite.Run("correct weight based distance multiplier is returned for billed weight greater than 10,000 pounds but less than 24,001 pounds", func() {
 		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(14750), unit.Pound(14750), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 
@@ -34,7 +32,7 @@ func (suite *ServiceParamValueLookupsSuite) TestFSCWeightBasedDistanceMultiplier
 		suite.Equal("0.000834", valueStr)
 	})
 
-	suite.T().Run("correct weight based distance multiplier is returned for billed weight greater than 24,000 pounds", func(t *testing.T) {
+	suite.Run("correct weight based distance multiplier is returned for billed weight greater than 24,000 pounds", func() {
 		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(32225), unit.Pound(32225), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 
@@ -42,7 +40,7 @@ func (suite *ServiceParamValueLookupsSuite) TestFSCWeightBasedDistanceMultiplier
 		suite.Equal("0.00139", valueStr)
 	})
 
-	suite.T().Run("correct weight based distance multiplier is returned for billed weight greater than 24,000 pounds", func(t *testing.T) {
+	suite.Run("correct weight based distance multiplier is returned for billed weight greater than 24,000 pounds", func() {
 		_, _, paramLookup := suite.setupTestMTOServiceItemWithWeight(unit.Pound(32225), unit.Pound(32225), models.ReServiceCodeDLH, models.MTOShipmentTypeHHG)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 

--- a/pkg/payment_request/service_param_value_lookups/number_days_sit_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/number_days_sit_lookup_test.go
@@ -1,7 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -13,198 +12,43 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 	key := models.ServiceItemParamNameNumberDaysSIT
 	defaultSITDaysAllowance := 90
 
-	reServiceDOFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDOFSIT,
-			Name: "Dom. Origin 1st Day SIT",
-		},
-	})
+	var serviceItemDOASITTwo models.MTOServiceItem
+	var serviceItemDOASITSix models.MTOServiceItem
+	var serviceItemDOASITFour models.MTOServiceItem
+	var serviceItemDOASITFive models.MTOServiceItem
+	var serviceItemDOASITNine models.MTOServiceItem
+	var serviceItemDOASITEleven models.MTOServiceItem
 
-	reServiceDOASIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDOASIT,
-			Name: "Dom. Origin Add'l SIT",
-		},
-	})
+	var serviceItemDOFSITSeven models.MTOServiceItem
+	var serviceItemDOFSITEight models.MTOServiceItem
+	var serviceItemDOFSITFive models.MTOServiceItem
 
-	reServiceDDFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDDFSIT,
-			Name: "Dom. Destination 1st Day SIT",
-		},
-	})
+	var serviceItemDDASITTwo models.MTOServiceItem
+	var serviceItemDDASITFour models.MTOServiceItem
+	var serviceItemDDASITFive models.MTOServiceItem
+	var serviceItemDDASITSix models.MTOServiceItem
+	var serviceItemDDASITNine models.MTOServiceItem
+	var serviceItemDDASITTen models.MTOServiceItem
 
-	reServiceDDASIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDDASIT,
-			Name: "Dom. Destination Add'l SIT",
-		},
-	})
+	var serviceItemDDFSITFive models.MTOServiceItem
+	var serviceItemDDFSITSeven models.MTOServiceItem
 
-	moveTaskOrderOne := testdatagen.MakeDefaultMove(suite.DB())
-	moveTaskOrderTwo := testdatagen.MakeDefaultMove(suite.DB())
-	moveTaskOrderThree := testdatagen.MakeDefaultMove(suite.DB())
-	moveTaskOrderFour := testdatagen.MakeDefaultMove(suite.DB())
-	moveTaskOrderFive := testdatagen.MakeDefaultMove(suite.DB())
+	var paymentRequestSeven models.PaymentRequest
+	var paymentRequestFifteen models.PaymentRequest
+	var paymentRequestSixteen models.PaymentRequest
+	var paymentRequestSeventeen models.PaymentRequest
+	var paymentRequestEighteen models.PaymentRequest
 
-	mtoShipmentOne := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
+	var reServiceDOASIT models.ReService
+	var reServiceDDASIT models.ReService
+	var reServiceDOFSIT models.ReService
 
-	mtoShipmentTwo := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
+	var mtoShipmentSeven models.MTOShipment
 
-	mtoShipmentThree := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentFour := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentFive := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentSix := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentSeven := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentEight := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentNine := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentTen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderOne,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentEleven := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderTwo,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentTwelve := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderThree,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentThirteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderThree,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentFourteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderFour,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentFifteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderFive,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	mtoShipmentSixteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: moveTaskOrderFive,
-		MTOShipment: models.MTOShipment{
-			Status:           models.MTOShipmentStatusSubmitted,
-			SITDaysAllowance: &defaultSITDaysAllowance,
-		},
-	})
-
-	moveTaskOrderOne.MTOShipments = models.MTOShipments{
-		mtoShipmentOne,
-		mtoShipmentTwo,
-		mtoShipmentThree,
-		mtoShipmentFour,
-		mtoShipmentFive,
-		mtoShipmentSix,
-		mtoShipmentSeven,
-		mtoShipmentEight,
-		mtoShipmentNine,
-		mtoShipmentTen,
-	}
-
-	moveTaskOrderTwo.MTOShipments = models.MTOShipments{
-		mtoShipmentEleven,
-	}
-
-	moveTaskOrderThree.MTOShipments = models.MTOShipments{
-		mtoShipmentTwelve,
-		mtoShipmentThirteen,
-	}
-
-	moveTaskOrderFour.MTOShipments = models.MTOShipments{
-		mtoShipmentFourteen,
-	}
-
-	moveTaskOrderFive.MTOShipments = models.MTOShipments{
-		mtoShipmentFifteen,
-		mtoShipmentSixteen,
-	}
+	var moveTaskOrderOne models.Move
+	var moveTaskOrderTwo models.Move
+	var moveTaskOrderThree models.Move
+	var moveTaskOrderFour models.Move
 
 	originSITEntryDateOne := time.Date(2020, time.July, 20, 0, 0, 0, 0, time.UTC)
 	originSITEntryDateTwo := time.Date(2020, time.August, 20, 0, 0, 0, 0, time.UTC)
@@ -218,836 +62,1034 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 	destinationSITDepartureDateTwo := time.Date(2020, time.October, 31, 0, 0, 0, 0, time.UTC)
 	destinationSITDepartureDateThree := time.Date(2020, time.November, 30, 0, 0, 0, 0, time.UTC)
 
-	serviceItemDOFSITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentOne,
-		ReService:   reServiceDOFSIT,
-	})
+	setupTestData := func() {
 
-	serviceItemDOFSITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDOFSIT,
-	})
+		reServiceDOFSIT = testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOFSIT,
+				Name: "Dom. Origin 1st Day SIT",
+			},
+		})
 
-	serviceItemDOFSITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentFour,
-		ReService:   reServiceDOFSIT,
-	})
+		reServiceDOASIT = testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOASIT,
+				Name: "Dom. Origin Add'l SIT",
+			},
+		})
 
-	serviceItemDOFSITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSix,
-		ReService:   reServiceDOFSIT,
-	})
+		reServiceDDFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDFSIT,
+				Name: "Dom. Destination 1st Day SIT",
+			},
+		})
 
-	serviceItemDOFSITFive := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSeven,
-		ReService:   reServiceDOFSIT,
-	})
+		reServiceDDASIT = testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDASIT,
+				Name: "Dom. Destination Add'l SIT",
+			},
+		})
 
-	serviceItemDOFSITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentEight,
-		ReService:   reServiceDOFSIT,
-	})
+		moveTaskOrderOne = testdatagen.MakeDefaultMove(suite.DB())
+		moveTaskOrderTwo = testdatagen.MakeDefaultMove(suite.DB())
+		moveTaskOrderThree = testdatagen.MakeDefaultMove(suite.DB())
+		moveTaskOrderFour = testdatagen.MakeDefaultMove(suite.DB())
+		moveTaskOrderFive := testdatagen.MakeDefaultMove(suite.DB())
 
-	serviceItemDOFSITSeven := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate:     &originSITEntryDateOne,
-			SITDepartureDate: &originSITDepartureDateTwo,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentTen,
-		ReService:   reServiceDOFSIT,
-	})
+		mtoShipmentOne := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOFSITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate:     &originSITEntryDateOne,
-			SITDepartureDate: &originSITDepartureDateTwo,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderTwo,
-		MTOShipment: mtoShipmentEleven,
-		ReService:   reServiceDOFSIT,
-	})
+		mtoShipmentTwo := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOFSITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderThree,
-		MTOShipment: mtoShipmentThirteen,
-		ReService:   reServiceDOFSIT,
-	})
+		mtoShipmentThree := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOFSITTen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentFifteen,
-		ReService:   reServiceDOFSIT,
-	})
+		mtoShipmentFour := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateTwo,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentOne,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentFive := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentOne,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentSix := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentSeven = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &originSITDepartureDateOne,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentEight := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITFive := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateTwo,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentFour,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentNine := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &originSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSix,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentTen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderOne,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &originSITDepartureDateOne,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentEight,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentEleven := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderTwo,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentEight,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentTwelve := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderThree,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITTen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderThree,
-		MTOShipment: mtoShipmentThirteen,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentThirteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderThree,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITEleven := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &originSITDepartureDateThree,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderThree,
-		MTOShipment: mtoShipmentThirteen,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentFourteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderFour,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITTwelve := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentFifteen,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentFifteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderFive,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDOASITThirteen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &originSITDepartureDateOne,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentFifteen,
-		ReService:   reServiceDOASIT,
-	})
+		mtoShipmentSixteen := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: moveTaskOrderFive,
+			MTOShipment: models.MTOShipment{
+				Status:           models.MTOShipmentStatusSubmitted,
+				SITDaysAllowance: &defaultSITDaysAllowance,
+			},
+		})
 
-	serviceItemDDFSITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentTwo,
-		ReService:   reServiceDDFSIT,
-	})
+		moveTaskOrderOne.MTOShipments = models.MTOShipments{
+			mtoShipmentOne,
+			mtoShipmentTwo,
+			mtoShipmentThree,
+			mtoShipmentFour,
+			mtoShipmentFive,
+			mtoShipmentSix,
+			mtoShipmentSeven,
+			mtoShipmentEight,
+			mtoShipmentNine,
+			mtoShipmentTen,
+		}
 
-	serviceItemDDFSITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDDFSIT,
-	})
+		moveTaskOrderTwo.MTOShipments = models.MTOShipments{
+			mtoShipmentEleven,
+		}
 
-	serviceItemDDFSITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentFive,
-		ReService:   reServiceDDFSIT,
-	})
+		moveTaskOrderThree.MTOShipments = models.MTOShipments{
+			mtoShipmentTwelve,
+			mtoShipmentThirteen,
+		}
 
-	serviceItemDDFSITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSix,
-		ReService:   reServiceDDFSIT,
-	})
+		moveTaskOrderFour.MTOShipments = models.MTOShipments{
+			mtoShipmentFourteen,
+		}
 
-	serviceItemDDFSITFive := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSeven,
-		ReService:   reServiceDDFSIT,
-	})
+		moveTaskOrderFive.MTOShipments = models.MTOShipments{
+			mtoShipmentFifteen,
+			mtoShipmentSixteen,
+		}
 
-	serviceItemDDFSITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentNine,
-		ReService:   reServiceDDFSIT,
-	})
+		serviceItemDOFSITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentOne,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDFSITSeven := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate:     &destinationSITEntryDateOne,
-			SITDepartureDate: &destinationSITDepartureDateTwo,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentTen,
-		ReService:   reServiceDDFSIT,
-	})
+		serviceItemDOFSITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDFSITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFour,
-		MTOShipment: mtoShipmentFourteen,
-		ReService:   reServiceDDFSIT,
-	})
+		serviceItemDOFSITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentFour,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDFSITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentSixteen,
-		ReService:   reServiceDDFSIT,
-	})
+		serviceItemDOFSITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSix,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateTwo,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentTwo,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITFive = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSeven,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentTwo,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentEight,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITSeven = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate:     &originSITEntryDateOne,
+				SITDepartureDate: &originSITDepartureDateTwo,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentTen,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentThree,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITEight = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate:     &originSITEntryDateOne,
+				SITDepartureDate: &originSITDepartureDateTwo,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderTwo,
+			MTOShipment: mtoShipmentEleven,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITFive := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateTwo,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentFive,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderThree,
+			MTOShipment: mtoShipmentThirteen,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITEntryDate: &destinationSITEntryDateOne,
-			Status:       models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentSix,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOFSITTen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentFifteen,
+			ReService:   reServiceDOFSIT,
+		})
 
-	serviceItemDDASITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &destinationSITDepartureDateOne,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentNine,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOASITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateTwo,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentOne,
+			ReService:   reServiceDOASIT,
+		})
 
-	serviceItemDDASITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderOne,
-		MTOShipment: mtoShipmentNine,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOASITTwo = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentOne,
+			ReService:   reServiceDOASIT,
+		})
 
-	serviceItemDDASITTen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFour,
-		MTOShipment: mtoShipmentFourteen,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOASITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDOASIT,
+		})
 
-	serviceItemDDASITEleven := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			Status: models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentSixteen,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOASITFour = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &originSITDepartureDateOne,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDOASIT,
+		})
 
-	serviceItemDDASITTwelve := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOServiceItem: models.MTOServiceItem{
-			SITDepartureDate: &destinationSITDepartureDateThree,
-			Status:           models.MTOServiceItemStatusApproved,
-		},
-		Move:        moveTaskOrderFive,
-		MTOShipment: mtoShipmentSixteen,
-		ReService:   reServiceDDASIT,
-	})
+		serviceItemDOASITFive = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateTwo,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentFour,
+			ReService:   reServiceDOASIT,
+		})
 
-	cost := unit.Cents(20000)
+		serviceItemDOASITSix = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &originSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSix,
+			ReService:   reServiceDOASIT,
+		})
 
-	paymentRequestOne := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  1,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestOne,
-		MTOServiceItem: serviceItemDOFSITOne,
-	})
+		serviceItemDOASITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &originSITDepartureDateOne,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentEight,
+			ReService:   reServiceDOASIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestOne,
-		MTOServiceItem: serviceItemDOASITOne,
-	})
+		serviceItemDOASITNine = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentEight,
+			ReService:   reServiceDOASIT,
+		})
 
-	paymentRequestTwo := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  2,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestTwo,
-		MTOServiceItem: serviceItemDDFSITOne,
-	})
+		serviceItemDOASITTen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderThree,
+			MTOShipment: mtoShipmentThirteen,
+			ReService:   reServiceDOASIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestTwo,
-		MTOServiceItem: serviceItemDDASITOne,
-	})
+		serviceItemDOASITEleven = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &originSITDepartureDateThree,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderThree,
+			MTOShipment: mtoShipmentThirteen,
+			ReService:   reServiceDOASIT,
+		})
 
-	paymentRequestThree := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  3,
-		},
-		Move: moveTaskOrderOne,
-	})
+		serviceItemDOASITTwelve := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentFifteen,
+			ReService:   reServiceDOASIT,
+		})
 
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDOFSITTwo, "2021-11-11", "2021-11-20")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDOASITThree, "2021-11-11", "2021-11-20")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDDFSITTwo, "2021-11-11", "2021-11-20")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDDASITThree, "2021-11-11", "2021-11-20")
+		serviceItemDOASITThirteen := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &originSITDepartureDateOne,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentFifteen,
+			ReService:   reServiceDOASIT,
+		})
 
-	paymentRequestFour := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  4,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestFour,
-		MTOServiceItem: serviceItemDOFSITThree,
-	})
+		serviceItemDDFSITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentTwo,
+			ReService:   reServiceDDFSIT,
+		})
 
-	paymentRequestFive := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  5,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestFive,
-		MTOServiceItem: serviceItemDDFSITThree,
-	})
+		serviceItemDDFSITTwo := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDDFSIT,
+		})
 
-	paymentRequestSix := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  6,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestSix,
-		MTOServiceItem: serviceItemDOFSITFour,
-	})
+		serviceItemDDFSITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentFive,
+			ReService:   reServiceDDFSIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestSix,
-		MTOServiceItem: serviceItemDDFSITFour,
-	})
+		serviceItemDDFSITFour := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSix,
+			ReService:   reServiceDDFSIT,
+		})
 
-	paymentRequestSeven := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  7,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestSeven,
-		MTOServiceItem: serviceItemDOFSITFive,
-	})
+		serviceItemDDFSITFive = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSeven,
+			ReService:   reServiceDDFSIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestSeven,
-		MTOServiceItem: serviceItemDDFSITFive,
-	})
+		serviceItemDDFSITSix := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentNine,
+			ReService:   reServiceDDFSIT,
+		})
 
-	paymentRequestEight := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  8,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestEight,
-		MTOServiceItem: serviceItemDOFSITSix,
-	})
+		serviceItemDDFSITSeven = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate:     &destinationSITEntryDateOne,
+				SITDepartureDate: &destinationSITDepartureDateTwo,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentTen,
+			ReService:   reServiceDDFSIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestEight,
-		MTOServiceItem: serviceItemDOASITEight,
-	})
+		serviceItemDDFSITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFour,
+			MTOShipment: mtoShipmentFourteen,
+			ReService:   reServiceDDFSIT,
+		})
 
-	paymentRequestNine := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  9,
-		},
-		Move: moveTaskOrderOne,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestNine,
-		MTOServiceItem: serviceItemDDFSITSix,
-	})
+		serviceItemDDFSITNine := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentSixteen,
+			ReService:   reServiceDDFSIT,
+		})
 
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestNine,
-		MTOServiceItem: serviceItemDDASITEight,
-	})
+		serviceItemDDASITOne := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateTwo,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentTwo,
+			ReService:   reServiceDDASIT,
+		})
 
-	paymentRequestTen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  1,
-		},
-		Move: moveTaskOrderThree,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestTen,
-		MTOServiceItem: serviceItemDOFSITNine,
-	})
+		serviceItemDDASITTwo = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentTwo,
+			ReService:   reServiceDDASIT,
+		})
 
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestTen, serviceItemDOASITTen, "2021-11-11", "2021-11-20")
+		serviceItemDDASITThree := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDDASIT,
+		})
 
-	paymentRequestEleven := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  1,
-		},
-		Move: moveTaskOrderFour,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestEleven,
-		MTOServiceItem: serviceItemDDFSITEight,
-	})
+		serviceItemDDASITFour = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentThree,
+			ReService:   reServiceDDASIT,
+		})
 
-	paymentRequestTwelve := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  1,
-		},
-		Move: moveTaskOrderFive,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestTwelve,
-		MTOServiceItem: serviceItemDOFSITTen,
-	})
+		serviceItemDDASITFive = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateTwo,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentFive,
+			ReService:   reServiceDDASIT,
+		})
 
-	paymentServiceItemParamTwo := []testdatagen.CreatePaymentServiceItemParams{
-		{
-			Key:     models.ServiceItemParamNameNumberDaysSIT,
-			KeyType: models.ServiceItemParamTypeInteger,
-			Value:   "29",
-		},
-	}
-	testdatagen.MakePaymentServiceItemWithParams(
-		suite.DB(),
-		serviceItemDOASITTwelve.ReService.Code,
-		paymentServiceItemParamTwo,
-		testdatagen.Assertions{
+		serviceItemDDASITSix = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITEntryDate: &destinationSITEntryDateOne,
+				Status:       models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentSix,
+			ReService:   reServiceDDASIT,
+		})
+
+		serviceItemDDASITEight := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &destinationSITDepartureDateOne,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentNine,
+			ReService:   reServiceDDASIT,
+		})
+
+		serviceItemDDASITNine = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderOne,
+			MTOShipment: mtoShipmentNine,
+			ReService:   reServiceDDASIT,
+		})
+
+		serviceItemDDASITTen = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFour,
+			MTOShipment: mtoShipmentFourteen,
+			ReService:   reServiceDDASIT,
+		})
+
+		serviceItemDDASITEleven := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				Status: models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentSixteen,
+			ReService:   reServiceDDASIT,
+		})
+
+		serviceItemDDASITTwelve := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOServiceItem: models.MTOServiceItem{
+				SITDepartureDate: &destinationSITDepartureDateThree,
+				Status:           models.MTOServiceItemStatusApproved,
+			},
+			Move:        moveTaskOrderFive,
+			MTOShipment: mtoShipmentSixteen,
+			ReService:   reServiceDDASIT,
+		})
+
+		cost := unit.Cents(20000)
+
+		paymentRequestOne := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  1,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestOne,
+			MTOServiceItem: serviceItemDOFSITOne,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestOne,
+			MTOServiceItem: serviceItemDOASITOne,
+		})
+
+		paymentRequestTwo := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  2,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestTwo,
+			MTOServiceItem: serviceItemDDFSITOne,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestTwo,
+			MTOServiceItem: serviceItemDDASITOne,
+		})
+
+		paymentRequestThree := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  3,
+			},
+			Move: moveTaskOrderOne,
+		})
+
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDOFSITTwo, "2021-11-11", "2021-11-20")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDOASITThree, "2021-11-11", "2021-11-20")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDDFSITTwo, "2021-11-11", "2021-11-20")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestThree, serviceItemDDASITThree, "2021-11-11", "2021-11-20")
+
+		paymentRequestFour := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  4,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestFour,
+			MTOServiceItem: serviceItemDOFSITThree,
+		})
+
+		paymentRequestFive := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  5,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestFive,
+			MTOServiceItem: serviceItemDDFSITThree,
+		})
+
+		paymentRequestSix := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  6,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestSix,
+			MTOServiceItem: serviceItemDOFSITFour,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestSix,
+			MTOServiceItem: serviceItemDDFSITFour,
+		})
+
+		paymentRequestSeven = testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  7,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestSeven,
+			MTOServiceItem: serviceItemDOFSITFive,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestSeven,
+			MTOServiceItem: serviceItemDDFSITFive,
+		})
+
+		paymentRequestEight := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  8,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestEight,
+			MTOServiceItem: serviceItemDOFSITSix,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestEight,
+			MTOServiceItem: serviceItemDOASITEight,
+		})
+
+		paymentRequestNine := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  9,
+			},
+			Move: moveTaskOrderOne,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestNine,
+			MTOServiceItem: serviceItemDDFSITSix,
+		})
+
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestNine,
+			MTOServiceItem: serviceItemDDASITEight,
+		})
+
+		paymentRequestTen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  1,
+			},
+			Move: moveTaskOrderThree,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestTen,
+			MTOServiceItem: serviceItemDOFSITNine,
+		})
+
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestTen, serviceItemDOASITTen, "2021-11-11", "2021-11-20")
+
+		paymentRequestEleven := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  1,
+			},
+			Move: moveTaskOrderFour,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &cost,
+				Status:     models.PaymentServiceItemStatusPaid,
+			},
+			PaymentRequest: paymentRequestEleven,
+			MTOServiceItem: serviceItemDDFSITEight,
+		})
+
+		paymentRequestTwelve := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  1,
+			},
+			Move: moveTaskOrderFive,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
 			PaymentServiceItem: models.PaymentServiceItem{
 				PriceCents: &cost,
 				Status:     models.PaymentServiceItemStatusPaid,
 			},
 			PaymentRequest: paymentRequestTwelve,
-			MTOServiceItem: serviceItemDOASITTwelve,
+			MTOServiceItem: serviceItemDOFSITTen,
 		})
 
-	paymentServiceItemParamThree := []testdatagen.CreatePaymentServiceItemParams{
-		{
-			Key:     models.ServiceItemParamNameNumberDaysSIT,
-			KeyType: models.ServiceItemParamTypeInteger,
-			Value:   "32",
-		},
-	}
-	testdatagen.MakePaymentServiceItemWithParams(
-		suite.DB(),
-		serviceItemDOASITThirteen.ReService.Code,
-		paymentServiceItemParamThree,
-		testdatagen.Assertions{
+		paymentServiceItemParamTwo := []testdatagen.CreatePaymentServiceItemParams{
+			{
+				Key:     models.ServiceItemParamNameNumberDaysSIT,
+				KeyType: models.ServiceItemParamTypeInteger,
+				Value:   "29",
+			},
+		}
+		testdatagen.MakePaymentServiceItemWithParams(
+			suite.DB(),
+			serviceItemDOASITTwelve.ReService.Code,
+			paymentServiceItemParamTwo,
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: &cost,
+					Status:     models.PaymentServiceItemStatusPaid,
+				},
+				PaymentRequest: paymentRequestTwelve,
+				MTOServiceItem: serviceItemDOASITTwelve,
+			})
+
+		paymentServiceItemParamThree := []testdatagen.CreatePaymentServiceItemParams{
+			{
+				Key:     models.ServiceItemParamNameNumberDaysSIT,
+				KeyType: models.ServiceItemParamTypeInteger,
+				Value:   "32",
+			},
+		}
+		testdatagen.MakePaymentServiceItemWithParams(
+			suite.DB(),
+			serviceItemDOASITThirteen.ReService.Code,
+			paymentServiceItemParamThree,
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: &cost,
+					Status:     models.PaymentServiceItemStatusPaid,
+				},
+				PaymentRequest: paymentRequestTwelve,
+				MTOServiceItem: serviceItemDOASITThirteen,
+			})
+
+		paymentRequestThirteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusPaid,
+				RejectionReason: nil,
+				SequenceNumber:  2,
+			},
+			Move: moveTaskOrderFive,
+		})
+		testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
 			PaymentServiceItem: models.PaymentServiceItem{
 				PriceCents: &cost,
 				Status:     models.PaymentServiceItemStatusPaid,
 			},
-			PaymentRequest: paymentRequestTwelve,
-			MTOServiceItem: serviceItemDOASITThirteen,
+			PaymentRequest: paymentRequestThirteen,
+			MTOServiceItem: serviceItemDDFSITNine,
 		})
 
-	paymentRequestThirteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusPaid,
-			RejectionReason: nil,
-			SequenceNumber:  2,
-		},
-		Move: moveTaskOrderFive,
-	})
-	testdatagen.MakePaymentServiceItem(suite.DB(), testdatagen.Assertions{
-		PaymentServiceItem: models.PaymentServiceItem{
-			PriceCents: &cost,
-			Status:     models.PaymentServiceItemStatusPaid,
-		},
-		PaymentRequest: paymentRequestThirteen,
-		MTOServiceItem: serviceItemDDFSITNine,
-	})
-
-	paymentRequestFourteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  3,
-		},
-		Move: moveTaskOrderFive,
-	})
-	paymentServiceItemParamFour := []testdatagen.CreatePaymentServiceItemParams{
-		{
-			Key:     models.ServiceItemParamNameNumberDaysSIT,
-			KeyType: models.ServiceItemParamTypeInteger,
-			Value:   "27",
-		},
-	}
-	testdatagen.MakePaymentServiceItemWithParams(
-		suite.DB(),
-		serviceItemDDASITEleven.ReService.Code,
-		paymentServiceItemParamFour,
-		testdatagen.Assertions{
-			PaymentServiceItem: models.PaymentServiceItem{
-				PriceCents: &cost,
-				Status:     models.PaymentServiceItemStatusDenied,
+		paymentRequestFourteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  3,
 			},
-			PaymentRequest: paymentRequestFourteen,
-			MTOServiceItem: serviceItemDDASITEleven,
+			Move: moveTaskOrderFive,
+		})
+		paymentServiceItemParamFour := []testdatagen.CreatePaymentServiceItemParams{
+			{
+				Key:     models.ServiceItemParamNameNumberDaysSIT,
+				KeyType: models.ServiceItemParamTypeInteger,
+				Value:   "27",
+			},
+		}
+		testdatagen.MakePaymentServiceItemWithParams(
+			suite.DB(),
+			serviceItemDDASITEleven.ReService.Code,
+			paymentServiceItemParamFour,
+			testdatagen.Assertions{
+				PaymentServiceItem: models.PaymentServiceItem{
+					PriceCents: &cost,
+					Status:     models.PaymentServiceItemStatusDenied,
+				},
+				PaymentRequest: paymentRequestFourteen,
+				MTOServiceItem: serviceItemDDASITEleven,
+			})
+
+		paymentRequestFifteen = testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  10,
+			},
+			Move: moveTaskOrderOne,
 		})
 
-	paymentRequestFifteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  10,
-		},
-		Move: moveTaskOrderOne,
-	})
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITTwo, "2021-10-11", "2021-10-20")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITFour, "2021-10-21", "2021-10-30")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDDASITFour, "2021-11-01", "2021-11-10")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITSix, "2021-11-01", "2021-11-10")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDDASITSix, "2021-11-11", "2021-11-20")
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITNine, "2021-11-11", "2021-11-20")
 
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITTwo, "2021-10-11", "2021-10-20")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITFour, "2021-10-21", "2021-10-30")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDDASITFour, "2021-11-01", "2021-11-10")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITSix, "2021-11-01", "2021-11-10")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDDASITSix, "2021-11-11", "2021-11-20")
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestFifteen, serviceItemDOASITNine, "2021-11-11", "2021-11-20")
+		paymentRequestSixteen = testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  1,
+			},
+			Move: moveTaskOrderTwo,
+		})
 
-	paymentRequestSixteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  1,
-		},
-		Move: moveTaskOrderTwo,
-	})
+		paymentRequestSeventeen = testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  2,
+			},
+			Move: moveTaskOrderThree,
+		})
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestSeventeen, serviceItemDOASITEleven, "2021-11-21", "2021-11-30")
 
-	paymentRequestSeventeen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  2,
-		},
-		Move: moveTaskOrderThree,
-	})
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestSeventeen, serviceItemDOASITEleven, "2021-11-21", "2021-11-30")
+		paymentRequestEighteen = testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  2,
+			},
+			Move: moveTaskOrderFour,
+		})
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestEighteen, serviceItemDDASITTen, "2021-11-11", "2021-11-20")
 
-	paymentRequestEighteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  2,
-		},
-		Move: moveTaskOrderFour,
-	})
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestEighteen, serviceItemDDASITTen, "2021-11-11", "2021-11-20")
+		paymentRequestNineteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
+			PaymentRequest: models.PaymentRequest{
+				IsFinal:         true,
+				Status:          models.PaymentRequestStatusReviewedAllRejected,
+				RejectionReason: nil,
+				SequenceNumber:  4,
+			},
+			Move: moveTaskOrderFive,
+		})
+		suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestNineteen, serviceItemDDASITTwelve, "2021-11-11", "2021-11-20")
+	}
 
-	paymentRequestNineteen := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
-		PaymentRequest: models.PaymentRequest{
-			IsFinal:         true,
-			Status:          models.PaymentRequestStatusReviewedAllRejected,
-			RejectionReason: nil,
-			SequenceNumber:  4,
-		},
-		Move: moveTaskOrderFive,
-	})
-	suite.makeAdditionalDaysSITPaymentServiceItem(paymentRequestNineteen, serviceItemDDASITTwelve, "2021-11-11", "2021-11-20")
+	suite.Run("an MTO Shipment has multiple Origin MTO Service Items with different SIT Entry Dates", func() {
+		setupTestData()
 
-	suite.T().Run("an MTO Shipment has multiple Origin MTO Service Items with different SIT Entry Dates", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITTwo.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1056,7 +1098,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "multiple Origin MTO Service Items with different SIT Entry Dates")
 	})
 
-	suite.T().Run("an MTO Shipment has multiple Destination MTO Service Items with different SIT Entry Dates", func(t *testing.T) {
+	suite.Run("an MTO Shipment has multiple Destination MTO Service Items with different SIT Entry Dates", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITTwo.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1066,7 +1110,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 	})
 
 	// TODO can we support this case? the test data has 2 DOASIT service items, does that even make sense?
-	suite.T().Run("an MTO Shipment has multiple Origin MTO Service Items with identical SIT Entry Dates", func(t *testing.T) {
+	suite.Run("an MTO Shipment has multiple Origin MTO Service Items with identical SIT Entry Dates", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITFour.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1075,7 +1121,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 	})
 
 	// TODO can we support this case? the test data has 2 DDASIT service items on the shipment, does that even make sense?
-	suite.T().Run("an MTO Shipment has multiple Destination MTO Service Items with identical SIT Entry Dates", func(t *testing.T) {
+	suite.Run("an MTO Shipment has multiple Destination MTO Service Items with identical SIT Entry Dates", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITFour.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1083,7 +1131,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("an MTO Shipment already has an Origin MTO Service Item with a different SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has an Origin MTO Service Item with a different SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITFive.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1092,7 +1142,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "already has an Origin MTO Service Item with a different SIT Entry Date")
 	})
 
-	suite.T().Run("an MTO Shipment already has a Destination MTO Service Item with a different SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has a Destination MTO Service Item with a different SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITFive.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1101,7 +1153,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "already has a Destination MTO Service Item with a different SIT Entry Date")
 	})
 
-	suite.T().Run("an MTO Shipment already has an Origin MTO Service Item with an identical SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has an Origin MTO Service Item with an identical SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITSix.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1109,7 +1163,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("an MTO Shipment already has a Destination MTO Service Item with an identical SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has a Destination MTO Service Item with an identical SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITSix.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1117,7 +1173,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("an MTO Shipment has Origin MTO Service Items but none with a SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment has Origin MTO Service Items but none with a SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOFSITFive.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1145,7 +1203,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("an MTO Shipment has Destination MTO Service Items but none with a SIT Entry Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment has Destination MTO Service Items but none with a SIT Entry Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDFSITFive.ID, paymentRequestSeven.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1171,7 +1231,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("an MTO Shipment already has an Origin MTO Service Item with a SIT Departure Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has an Origin MTO Service Item with a SIT Departure Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITNine.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1181,7 +1243,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "with a SIT Departure Date")
 	})
 
-	suite.T().Run("an MTO Shipment already has a Destination MTO Service Item with a SIT Departure Date", func(t *testing.T) {
+	suite.Run("an MTO Shipment already has a Destination MTO Service Item with a SIT Departure Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITNine.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1191,7 +1255,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "with a SIT Departure Date")
 	})
 
-	suite.T().Run("an MTO Shipment only has a First Day SIT MTO Service Item", func(t *testing.T) {
+	suite.Run("an MTO Shipment only has a First Day SIT MTO Service Item", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOFSITSeven.ID, paymentRequestFifteen.ID, moveTaskOrderOne.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1207,7 +1273,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Contains(err.Error(), "failed to find a PaymentServiceItem for MTOServiceItem")
 	})
 
-	suite.T().Run("an MTO with one MTO Shipment with one DOFSIT payment service item", func(t *testing.T) {
+	suite.Run("an MTO with one MTO Shipment with one DOFSIT payment service item", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOFSITEight.ID, paymentRequestSixteen.ID, moveTaskOrderTwo.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1217,7 +1285,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Equal("", value)
 	})
 
-	suite.T().Run("an MTO with more than one MTO Shipment", func(t *testing.T) {
+	suite.Run("an MTO with more than one MTO Shipment", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASITEleven.ID, paymentRequestSeventeen.ID, moveTaskOrderThree.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1226,7 +1296,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Equal("10", value)
 	})
 
-	suite.T().Run("an MTO with an MTO Shipment with no SIT Departure Date", func(t *testing.T) {
+	suite.Run("an MTO with an MTO Shipment with no SIT Departure Date", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDDASITTen.ID, paymentRequestEighteen.ID, moveTaskOrderFour.ID, nil)
 		suite.FatalNoError(err)
 
@@ -1235,7 +1307,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Equal("10", value)
 	})
 
-	suite.T().Run("simple date calculation", func(t *testing.T) {
+	suite.Run("simple date calculation", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-21", "2020-07-30")
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASIT.ID, paymentRequest.ID, move.ID, nil)
 		suite.FatalNoError(err)
@@ -1245,7 +1319,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 
 		suite.Equal("10", days)
 	})
-	suite.T().Run("invalid start date", func(t *testing.T) {
+	suite.Run("invalid start date", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "not a date", "2020-07-30")
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASIT.ID, paymentRequest.ID, move.ID, nil)
 		suite.FatalNoError(err)
@@ -1254,7 +1330,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Error(err)
 		suite.Contains(err.Error(), "failed to parse SITPaymentRequestStart as a date")
 	})
-	suite.T().Run("invalid end date", func(t *testing.T) {
+	suite.Run("invalid end date", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-01", "not a date")
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASIT.ID, paymentRequest.ID, move.ID, nil)
 		suite.FatalNoError(err)
@@ -1263,7 +1341,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Error(err)
 		suite.Contains(err.Error(), "failed to parse SITPaymentRequestEnd as a date")
 	})
-	suite.T().Run("overlapping dates should error", func(t *testing.T) {
+	suite.Run("overlapping dates should error", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, _ := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-21", "2020-07-30")
 		paymentRequestOverlapping := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
 			PaymentRequest: models.PaymentRequest{
@@ -1281,7 +1361,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		_, err = paramLookup.ServiceParamValue(suite.AppContextForTest(), key)
 		suite.Error(err)
 	})
-	suite.T().Run("it shouldn't matter if dates from rejected payment requests overlap with current payment request", func(t *testing.T) {
+	suite.Run("it shouldn't matter if dates from rejected payment requests overlap with current payment request", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-21", "2020-07-30")
 
 		paymentRequestRejected := testdatagen.MakePaymentRequest(suite.DB(), testdatagen.Assertions{
@@ -1302,7 +1384,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.FatalNoError(err)
 	})
 
-	suite.T().Run("Requests for SIT additional days past the allowance for the shipment should be rejected", func(t *testing.T) {
+	suite.Run("Requests for SIT additional days past the allowance for the shipment should be rejected", func() {
+		setupTestData()
+
 		// End date is a year in the future in order to exceed allowance
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-21", "2021-07-30")
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, serviceItemDOASIT.ID, paymentRequest.ID, move.ID, nil)
@@ -1312,7 +1396,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Error(err)
 	})
 
-	suite.T().Run("SIT days remaining calculation should account for first day in SIT", func(t *testing.T) {
+	suite.Run("SIT days remaining calculation should account for first day in SIT", func() {
+		setupTestData()
+
 		// The Additional Days SIT service item should be for exactly the allowed amount,
 		// So the first day in SIT will put it over the limit.
 		move, serviceItemDOASIT, paymentRequest := suite.setupMoveWithAddlDaysSITAndPaymentRequest(reServiceDOFSIT, originSITEntryDateOne, reServiceDOASIT, "2020-07-21", "2020-10-18")
@@ -1323,7 +1409,9 @@ func (suite *ServiceParamValueLookupsSuite) TestNumberDaysSITLookup() {
 		suite.Error(err)
 	})
 
-	suite.T().Run("SIT Additional Days cannot start on the same day as the end of a previously billed date range", func(t *testing.T) {
+	suite.Run("SIT Additional Days cannot start on the same day as the end of a previously billed date range", func() {
+		setupTestData()
+
 		move, serviceItemDOASIT, _ := suite.setupMoveWithAddlDaysSITAndPaymentRequest(
 			reServiceDOFSIT,
 			originSITEntryDateOne,

--- a/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/psi_domestic_linehaul_lookup_test.go
@@ -50,7 +50,7 @@ package serviceparamvaluelookups
 // func (suite *ServiceParamValueLookupsSuite) TestPSILinehaulDomLookup() {
 // 	key := models.ServiceItemParamNamePSILinehaulDom.String()
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated", func() {
 //
 // 		psiLinehaulDom, expectedPSILinehaulDom := suite.setupPSILinehaulTestData(nil, nil)
 // 		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
@@ -60,7 +60,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expectedPSILinehaulDom.ID.String(), valueStr)
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated twice use latest", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated twice use latest", func() {
 // 		psiLinehaulDom, psiLinehaulDomDLH := suite.setupPSILinehaulTestData(nil, nil)
 //
 // 		priceCents := unit.Cents(204800)
@@ -85,7 +85,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(psiLinehaulDomSecond.ID.String(), valueStr)
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated and Denied", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated and Denied", func() {
 // 		price := unit.Cents(102400)
 // 		status := models.PaymentServiceItemStatusDenied
 // 		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(&price, &status)
@@ -98,7 +98,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expected, err.Error())
 // 	})
 //
-// 	suite.T().Run("Invalid MTO Service ID", func(t *testing.T) {
+// 	suite.Run("Invalid MTO Service ID", func() {
 // 		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(nil, nil)
 //
 // 		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
@@ -110,7 +110,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expected, err.Error())
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has NOT been calculated", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has NOT been calculated", func() {
 // 		code := models.ReServiceCodeFSC
 // 		psiLinehaulDomFSC := testdatagen.MakePaymentServiceItem(suite.DB(),
 // 			testdatagen.Assertions{
@@ -136,7 +136,7 @@ package serviceparamvaluelookups
 // func (suite *ServiceParamValueLookupsSuite) TestPSILinehaulDomPriceLookup() {
 // 	key := models.ServiceItemParamNamePSILinehaulDomPrice.String()
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated", func() {
 //
 // 		psiLinehaulDom, expectedPSILinehaulDom := suite.setupPSILinehaulTestData(nil, nil)
 // 		paramLookup := ServiceParamLookupInitialize(suite.DB(), suite.planner, psiLinehaulDom.MTOServiceItemID, psiLinehaulDom.PaymentRequestID, psiLinehaulDom.PaymentRequest.MoveTaskOrderID)
@@ -146,7 +146,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expectedPSILinehaulDom.PriceCents.String(), valueStr)
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated twice use latest", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated twice use latest", func() {
 // 		psiLinehaulDom, psiLinehaulDomDLH := suite.setupPSILinehaulTestData(nil, nil)
 //
 // 		priceCents := unit.Cents(204800)
@@ -171,7 +171,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(psiLinehaulDomSecond.PriceCents.String(), valueStr)
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has been calculated and Denied", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has been calculated and Denied", func() {
 // 		price := unit.Cents(102400)
 // 		status := models.PaymentServiceItemStatusDenied
 // 		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(&price, &status)
@@ -184,7 +184,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expected, err.Error())
 // 	})
 //
-// 	suite.T().Run("Invalid MTO Service ID", func(t *testing.T) {
+// 	suite.Run("Invalid MTO Service ID", func() {
 // 		psiLinehaulDom, _ := suite.setupPSILinehaulTestData(nil, nil)
 //
 // 		invalidMTOServiceItemID := uuid.Must(uuid.NewV4())
@@ -196,7 +196,7 @@ package serviceparamvaluelookups
 // 		suite.Equal(expected, err.Error())
 // 	})
 //
-// 	suite.T().Run("Domestic Linehaul Price has NOT been calculated", func(t *testing.T) {
+// 	suite.Run("Domestic Linehaul Price has NOT been calculated", func() {
 // 		code := models.ReServiceCodeFSC
 // 		psiLinehaulDomFSC := testdatagen.MakePaymentServiceItem(suite.DB(),
 // 			testdatagen.Assertions{

--- a/pkg/payment_request/service_param_value_lookups/requested_pickup_date_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/requested_pickup_date_lookup_test.go
@@ -2,7 +2,6 @@ package serviceparamvaluelookups
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -14,19 +13,27 @@ func (suite *ServiceParamValueLookupsSuite) TestRequestedPickupDateLookup() {
 	key := models.ServiceItemParamNameRequestedPickupDate
 
 	requestedPickupDate := time.Date(testdatagen.TestYear, time.May, 18, 0, 0, 0, 0, time.UTC)
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(),
-		testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				RequestedPickupDate: &requestedPickupDate,
-			},
-		})
 
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
-		testdatagen.Assertions{
-			Move: mtoServiceItem.MoveTaskOrder,
-		})
+	var mtoServiceItem models.MTOServiceItem
+	var paymentRequest models.PaymentRequest
 
-	suite.T().Run("golden path", func(t *testing.T) {
+	setupTestData := func() {
+		mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				MTOShipment: models.MTOShipment{
+					RequestedPickupDate: &requestedPickupDate,
+				},
+			})
+
+		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: mtoServiceItem.MoveTaskOrder,
+			})
+	}
+
+	suite.Run("golden path", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 
@@ -36,7 +43,9 @@ func (suite *ServiceParamValueLookupsSuite) TestRequestedPickupDateLookup() {
 		suite.Equal(expected, valueStr)
 	})
 
-	suite.T().Run("nil requested pickup date", func(t *testing.T) {
+	suite.Run("nil requested pickup date", func() {
+		setupTestData()
+
 		// Set the requested pickup date to nil
 		mtoShipment := mtoServiceItem.MTOShipment
 		oldRequestedPickupDate := mtoShipment.RequestedPickupDate

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -150,7 +150,7 @@ func (suite *ServiceParamValueLookupsSuite) setupTestMTOServiceItemWithShuttleWe
 }
 
 func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
-	suite.T().Run("contract passed in", func(t *testing.T) {
+	suite.Run("contract passed in", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 
@@ -158,7 +158,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		suite.Equal(ghcrateengine.DefaultContractCode, paramLookup.ContractCode)
 	})
 
-	suite.T().Run("MTOServiceItem passed in", func(t *testing.T) {
+	suite.Run("MTOServiceItem passed in", func() {
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
@@ -176,7 +176,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 	}
 
 	for _, code := range serviceCodesWithoutShipment {
-		suite.T().Run(fmt.Sprintf("MTOShipment not looked up for %s", code), func(t *testing.T) {
+		suite.Run(fmt.Sprintf("MTOShipment not looked up for %s", code), func() {
 			mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 				ReService: models.ReService{
 					Code: code,
@@ -210,7 +210,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		})
 	}
 
-	suite.T().Run("MTOShipment is looked up for other service items", func(t *testing.T) {
+	suite.Run("MTOShipment is looked up for other service items", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDLH,
@@ -229,7 +229,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("DestinationAddress is looked up for other service items", func(t *testing.T) {
+	suite.Run("DestinationAddress is looked up for other service items", func() {
 		testData := []models.MTOServiceItem{
 			testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 				ReService: models.ReService{
@@ -258,7 +258,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("DestinationAddress is not required for service items like domestic pack", func(t *testing.T) {
+	suite.Run("DestinationAddress is not required for service items like domestic pack", func() {
 		servicesToTest := []models.ReServiceCode{models.ReServiceCodeDPK, models.ReServiceCodeDNPK}
 		for _, service := range servicesToTest {
 			mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
@@ -277,7 +277,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("PickupAddress is looked up for other service items", func(t *testing.T) {
+	suite.Run("PickupAddress is looked up for other service items", func() {
 		testData := []models.MTOServiceItem{
 			testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 				ReService: models.ReService{
@@ -306,7 +306,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("PickupAddress is not required for service items like domestic unpack", func(t *testing.T) {
+	suite.Run("PickupAddress is not required for service items like domestic unpack", func() {
 		mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 			ReService: models.ReService{
 				Code: models.ReServiceCodeDUPK,
@@ -322,7 +322,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		suite.FatalNoError(err)
 	})
 
-	suite.T().Run("SITDestinationAddress is looked up for destination sit", func(t *testing.T) {
+	suite.Run("SITDestinationAddress is looked up for destination sit", func() {
 		sitFinalDestAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
 		testData := []models.MTOServiceItem{
 			testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
@@ -370,7 +370,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("SITDestinationAddress is not loaded non sit", func(t *testing.T) {
+	suite.Run("SITDestinationAddress is not loaded non sit", func() {
 		testData := []models.MTOServiceItem{
 			testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
 				ReService: models.ReService{
@@ -399,7 +399,7 @@ func (suite *ServiceParamValueLookupsSuite) TestServiceParamValueLookup() {
 		}
 	})
 
-	suite.T().Run("nil MTOServiceItemID", func(t *testing.T) {
+	suite.Run("nil MTOServiceItemID", func() {
 		badMTOServiceItemID := uuid.Must(uuid.NewV4())
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, badMTOServiceItemID, uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), nil)
 

--- a/pkg/payment_request/service_param_value_lookups/services_schedule_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/services_schedule_lookup_test.go
@@ -3,7 +3,6 @@ package serviceparamvaluelookups
 import (
 	"fmt"
 	"strconv"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -14,63 +13,73 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 	originKey := models.ServiceItemParamNameServicesScheduleOrigin
 	destKey := models.ServiceItemParamNameServicesScheduleDest
 
-	originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			PostalCode: "35007",
-		},
-	})
-	destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			PostalCode: "45007",
-		},
-	})
+	var mtoServiceItem models.MTOServiceItem
+	var paymentRequest models.PaymentRequest
+	var originDomesticServiceArea models.ReDomesticServiceArea
+	var destDomesticServiceArea models.ReDomesticServiceArea
 
-	mtoServiceItem := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		MTOShipment: models.MTOShipment{
-			PickupAddressID:      &originAddress.ID,
-			PickupAddress:        &originAddress,
-			DestinationAddressID: &destAddress.ID,
-			DestinationAddress:   &destAddress,
-		},
-	})
+	setupTestData := func() {
 
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
-		testdatagen.Assertions{
-			Move: mtoServiceItem.MoveTaskOrder,
+		originAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+			Address: models.Address{
+				PostalCode: "35007",
+			},
+		})
+		destAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+			Address: models.Address{
+				PostalCode: "45007",
+			},
 		})
 
-	originDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
-		ReDomesticServiceArea: models.ReDomesticServiceArea{
-			ServiceArea:      "004",
-			ServicesSchedule: 2,
-		},
-	})
+		mtoServiceItem = testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			MTOShipment: models.MTOShipment{
+				PickupAddressID:      &originAddress.ID,
+				PickupAddress:        &originAddress,
+				DestinationAddressID: &destAddress.ID,
+				DestinationAddress:   &destAddress,
+			},
+		})
 
-	testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
-		ReZip3: models.ReZip3{
-			Contract:            originDomesticServiceArea.Contract,
-			DomesticServiceArea: originDomesticServiceArea,
-			Zip3:                "350",
-		},
-	})
+		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: mtoServiceItem.MoveTaskOrder,
+			})
 
-	destDomesticServiceArea := testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
-		ReDomesticServiceArea: models.ReDomesticServiceArea{
-			Contract:         originDomesticServiceArea.Contract,
-			ServiceArea:      "005",
-			ServicesSchedule: 3,
-		},
-	})
+		originDomesticServiceArea = testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+			ReDomesticServiceArea: models.ReDomesticServiceArea{
+				ServiceArea:      "004",
+				ServicesSchedule: 2,
+			},
+		})
 
-	testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
-		ReZip3: models.ReZip3{
-			Contract:            destDomesticServiceArea.Contract,
-			DomesticServiceArea: destDomesticServiceArea,
-			Zip3:                "450",
-		},
-	})
+		testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+			ReZip3: models.ReZip3{
+				Contract:            originDomesticServiceArea.Contract,
+				DomesticServiceArea: originDomesticServiceArea,
+				Zip3:                "350",
+			},
+		})
 
-	suite.T().Run("lookup origin ServicesSchedule", func(t *testing.T) {
+		destDomesticServiceArea = testdatagen.MakeReDomesticServiceArea(suite.DB(), testdatagen.Assertions{
+			ReDomesticServiceArea: models.ReDomesticServiceArea{
+				Contract:         originDomesticServiceArea.Contract,
+				ServiceArea:      "005",
+				ServicesSchedule: 3,
+			},
+		})
+
+		testdatagen.MakeReZip3(suite.DB(), testdatagen.Assertions{
+			ReZip3: models.ReZip3{
+				Contract:            destDomesticServiceArea.Contract,
+				DomesticServiceArea: destDomesticServiceArea,
+				Zip3:                "450",
+			},
+		})
+	}
+
+	suite.Run("lookup origin ServicesSchedule", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), originKey)
@@ -78,7 +87,9 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 		suite.Equal(strconv.Itoa(originDomesticServiceArea.ServicesSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup dest ServicesSchedule", func(t *testing.T) {
+	suite.Run("lookup dest ServicesSchedule", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), destKey)
@@ -86,7 +97,9 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 		suite.Equal(strconv.Itoa(destDomesticServiceArea.ServicesSchedule), valueStr)
 	})
 
-	suite.T().Run("lookup origin ServicesSchedule not found", func(t *testing.T) {
+	suite.Run("lookup origin ServicesSchedule not found", func() {
+		setupTestData()
+
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
@@ -103,7 +116,9 @@ func (suite *ServiceParamValueLookupsSuite) TestServicesScheduleOrigin() {
 		suite.Contains(err.Error(), expected)
 	})
 
-	suite.T().Run("lookup dest ServicesSchedule not found", func(t *testing.T) {
+	suite.Run("lookup dest ServicesSchedule not found", func() {
+		setupTestData()
+
 		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
 		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),

--- a/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
@@ -1,8 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -23,13 +21,13 @@ func (suite *ServiceParamValueLookupsSuite) TestZipAddressLookup() {
 	paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 	suite.FatalNoError(err)
 
-	suite.T().Run("zip code for the pickup address is present on MTO Shipment", func(t *testing.T) {
+	suite.Run("zip code for the pickup address is present on MTO Shipment", func() {
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), pickupKey)
 		suite.FatalNoError(err)
 		suite.Equal(mtoServiceItem.MTOShipment.PickupAddress.PostalCode, valueStr)
 	})
 
-	suite.T().Run("zip code for the destination address is present on MTO Shipment", func(t *testing.T) {
+	suite.Run("zip code for the destination address is present on MTO Shipment", func() {
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), destKey)
 		suite.FatalNoError(err)
 		suite.Equal(mtoServiceItem.MTOShipment.DestinationAddress.PostalCode, valueStr)

--- a/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_actual_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_actual_address_lookup_test.go
@@ -1,8 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -13,57 +11,66 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGActualAddressLook
 	originZip := "30901"
 	actualOriginZipSameZip3 := "30907"
 
-	reService := testdatagen.FetchOrMakeReService(suite.DB(),
-		testdatagen.Assertions{
-			ReService: models.ReService{
-				Code: models.ReServiceCodeDOFSIT,
+	var mtoServiceItemWithSITOriginZips models.MTOServiceItem
+	var paymentRequest models.PaymentRequest
+	var mtoServiceItemNoSITOriginZips models.MTOServiceItem
+
+	setupTestData := func() {
+
+		reService := testdatagen.FetchOrMakeReService(suite.DB(),
+			testdatagen.Assertions{
+				ReService: models.ReService{
+					Code: models.ReServiceCodeDOFSIT,
+				},
 			},
-		},
-	)
+		)
 
-	originAddress := testdatagen.MakeAddress(suite.DB(),
-		testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: originZip,
+		originAddress := testdatagen.MakeAddress(suite.DB(),
+			testdatagen.Assertions{
+				Address: models.Address{
+					PostalCode: originZip,
+				},
+			})
+
+		actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
+			testdatagen.Assertions{
+				Address: models.Address{
+					PostalCode: actualOriginZipSameZip3,
+				},
+			})
+
+		move := testdatagen.MakeDefaultMove(suite.DB())
+
+		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: move,
+			})
+
+		mtoServiceItemWithSITOriginZips = testdatagen.MakeMTOServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				ReService: reService,
+				Move:      move,
+				MTOServiceItem: models.MTOServiceItem{
+					SITOriginHHGOriginalAddressID: &originAddress.ID,
+					SITOriginHHGOriginalAddress:   &originAddress,
+					SITOriginHHGActualAddressID:   &actualOriginSameZip3Address.ID,
+					SITOriginHHGActualAddress:     &actualOriginSameZip3Address,
+				},
 			},
-		})
+		)
 
-	actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
-		testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: actualOriginZipSameZip3,
+		mtoServiceItemNoSITOriginZips = testdatagen.MakeMTOServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				ReService:      reService,
+				Move:           move,
+				MTOServiceItem: models.MTOServiceItem{},
 			},
-		})
+		)
+	}
 
-	move := testdatagen.MakeDefaultMove(suite.DB())
+	suite.Run("success SIT origin actual zip lookup", func() {
+		setupTestData()
 
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
-		testdatagen.Assertions{
-			Move: move,
-		})
-
-	mtoServiceItemWithSITOriginZips := testdatagen.MakeMTOServiceItem(suite.DB(),
-		testdatagen.Assertions{
-			ReService: reService,
-			Move:      move,
-			MTOServiceItem: models.MTOServiceItem{
-				SITOriginHHGOriginalAddressID: &originAddress.ID,
-				SITOriginHHGOriginalAddress:   &originAddress,
-				SITOriginHHGActualAddressID:   &actualOriginSameZip3Address.ID,
-				SITOriginHHGActualAddress:     &actualOriginSameZip3Address,
-			},
-		},
-	)
-
-	mtoServiceItemNoSITOriginZips := testdatagen.MakeMTOServiceItem(suite.DB(),
-		testdatagen.Assertions{
-			ReService:      reService,
-			Move:           move,
-			MTOServiceItem: models.MTOServiceItem{},
-		},
-	)
-
-	suite.T().Run("success SIT origin actual zip lookup", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItemWithSITOriginZips.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 
@@ -73,7 +80,9 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGActualAddressLook
 		suite.Equal(expected, sitOriginZipActual)
 	})
 
-	suite.T().Run("fail to find SIT origin actual zip lookup", func(t *testing.T) {
+	suite.Run("fail to find SIT origin actual zip lookup", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItemNoSITOriginZips.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 

--- a/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_original_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_sit_origin_hhg_original_address_lookup_test.go
@@ -1,8 +1,6 @@
 package serviceparamvaluelookups
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -13,57 +11,65 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGOriginalAddressLo
 	originZip := "30901"
 	actualOriginZipSameZip3 := "30907"
 
-	reService := testdatagen.FetchOrMakeReService(suite.DB(),
-		testdatagen.Assertions{
-			ReService: models.ReService{
-				Code: models.ReServiceCodeDOFSIT,
+	var mtoServiceItemWithSITOriginZips models.MTOServiceItem
+	var paymentRequest models.PaymentRequest
+	var mtoServiceItemNoSITOriginZips models.MTOServiceItem
+
+	setupTestData := func() {
+		reService := testdatagen.FetchOrMakeReService(suite.DB(),
+			testdatagen.Assertions{
+				ReService: models.ReService{
+					Code: models.ReServiceCodeDOFSIT,
+				},
 			},
-		},
-	)
+		)
 
-	originAddress := testdatagen.MakeAddress(suite.DB(),
-		testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: originZip,
+		originAddress := testdatagen.MakeAddress(suite.DB(),
+			testdatagen.Assertions{
+				Address: models.Address{
+					PostalCode: originZip,
+				},
+			})
+
+		actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
+			testdatagen.Assertions{
+				Address: models.Address{
+					PostalCode: actualOriginZipSameZip3,
+				},
+			})
+
+		move := testdatagen.MakeDefaultMove(suite.DB())
+
+		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				Move: move,
+			})
+
+		mtoServiceItemWithSITOriginZips = testdatagen.MakeMTOServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				ReService: reService,
+				Move:      move,
+				MTOServiceItem: models.MTOServiceItem{
+					SITOriginHHGOriginalAddressID: &originAddress.ID,
+					SITOriginHHGOriginalAddress:   &originAddress,
+					SITOriginHHGActualAddressID:   &actualOriginSameZip3Address.ID,
+					SITOriginHHGActualAddress:     &actualOriginSameZip3Address,
+				},
 			},
-		})
+		)
 
-	actualOriginSameZip3Address := testdatagen.MakeAddress(suite.DB(),
-		testdatagen.Assertions{
-			Address: models.Address{
-				PostalCode: actualOriginZipSameZip3,
+		mtoServiceItemNoSITOriginZips = testdatagen.MakeMTOServiceItem(suite.DB(),
+			testdatagen.Assertions{
+				ReService:      reService,
+				Move:           move,
+				MTOServiceItem: models.MTOServiceItem{},
 			},
-		})
+		)
+	}
 
-	move := testdatagen.MakeDefaultMove(suite.DB())
+	suite.Run("success SIT origin original zip lookup", func() {
+		setupTestData()
 
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
-		testdatagen.Assertions{
-			Move: move,
-		})
-
-	mtoServiceItemWithSITOriginZips := testdatagen.MakeMTOServiceItem(suite.DB(),
-		testdatagen.Assertions{
-			ReService: reService,
-			Move:      move,
-			MTOServiceItem: models.MTOServiceItem{
-				SITOriginHHGOriginalAddressID: &originAddress.ID,
-				SITOriginHHGOriginalAddress:   &originAddress,
-				SITOriginHHGActualAddressID:   &actualOriginSameZip3Address.ID,
-				SITOriginHHGActualAddress:     &actualOriginSameZip3Address,
-			},
-		},
-	)
-
-	mtoServiceItemNoSITOriginZips := testdatagen.MakeMTOServiceItem(suite.DB(),
-		testdatagen.Assertions{
-			ReService:      reService,
-			Move:           move,
-			MTOServiceItem: models.MTOServiceItem{},
-		},
-	)
-
-	suite.T().Run("success SIT origin original zip lookup", func(t *testing.T) {
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItemWithSITOriginZips.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 
@@ -73,7 +79,9 @@ func (suite *ServiceParamValueLookupsSuite) TestZipSITOriginHHGOriginalAddressLo
 		suite.Equal(expected, sitOriginZipOriginal)
 	})
 
-	suite.T().Run("fail to find SIT origin original zip lookup", func(t *testing.T) {
+	suite.Run("fail to find SIT origin original zip lookup", func() {
+		setupTestData()
+
 		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItemNoSITOriginZips.ID, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
 		suite.FatalNoError(err)
 

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -448,19 +448,14 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 		}
 
 		if len(newShipment.MTOAgents) != 0 {
-			agentQuery := `UPDATE mto_agents
-					SET
-				`
-			for _, agent := range newShipment.MTOAgents {
-				copyOfAgent := agent // Make copy to avoid implicit memory aliasing of items from a range statement.
+			for i := range newShipment.MTOAgents {
+				copyOfAgent := newShipment.MTOAgents[i]
 
-				for _, dbAgent := range dbShipment.MTOAgents {
+				for j := range dbShipment.MTOAgents {
+					dbAgent := dbShipment.MTOAgents[j]
 					// if the updates already have an agent in the system
 					if dbAgent.ID == copyOfAgent.ID {
-						updateAgentQuery := generateAgentQuery()
-						params := generateMTOAgentsParams(copyOfAgent)
-
-						if err := txnAppCtx.DB().RawQuery(agentQuery+updateAgentQuery, params...).Exec(); err != nil {
+						if err := txnAppCtx.DB().Update(&copyOfAgent); err != nil {
 							return err
 						}
 					}
@@ -571,24 +566,9 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 			}
 		}
 
-		//
-		// Save all of the updated values from newShipment (MTOShipment) in raw query call to the database
-		//
-
-		// Generate query to update all mto_shipments columns
-		updateMTOShipmentQuery := generateUpdateMTOShipmentQuery()
-		// Generate slice of column values to be used for the update from the MTOShipment model
-		params := generateMTOShipmentParams(*newShipment)
-
-		// Execute query to update all mto_shipments columns with values from MTOShipment
-		if err := txnAppCtx.DB().RawQuery(updateMTOShipmentQuery, params...).Exec(); err != nil {
+		if err := txnAppCtx.DB().Update(newShipment); err != nil {
 			return err
 		}
-		// #TODO: Is there any reason we can't remove updateMTOShipmentQuery and use tx.Update?
-		//
-		// if err := tx.Update(newShipment); err != nil {
-		// 	return err
-		// }
 
 		//
 		// Perform shipment recalculate payment request
@@ -627,129 +607,6 @@ func (f *mtoShipmentUpdater) updateShipmentRecord(appCtx appcontext.AppContext, 
 
 	return nil
 
-}
-
-func generateMTOShipmentParams(mtoShipment models.MTOShipment) []interface{} {
-	return []interface{}{
-		mtoShipment.ScheduledPickupDate,
-		mtoShipment.RequestedPickupDate,
-		mtoShipment.RequestedDeliveryDate,
-		mtoShipment.CustomerRemarks,
-		mtoShipment.CounselorRemarks,
-		mtoShipment.PrimeEstimatedWeight,
-		mtoShipment.PrimeEstimatedWeightRecordedDate,
-		mtoShipment.PrimeActualWeight,
-		mtoShipment.NTSRecordedWeight,
-		mtoShipment.ShipmentType,
-		mtoShipment.ActualPickupDate,
-		mtoShipment.ApprovedDate,
-		mtoShipment.FirstAvailableDeliveryDate,
-		mtoShipment.RequiredDeliveryDate,
-		mtoShipment.Status,
-		mtoShipment.DestinationAddressID,
-		mtoShipment.PickupAddressID,
-		mtoShipment.SecondaryDeliveryAddressID,
-		mtoShipment.SecondaryPickupAddressID,
-		mtoShipment.Diversion,
-		mtoShipment.BillableWeightCap,
-		mtoShipment.BillableWeightJustification,
-		mtoShipment.TACType,
-		mtoShipment.SACType,
-		mtoShipment.UsesExternalVendor,
-		mtoShipment.ServiceOrderNumber,
-		mtoShipment.StorageFacilityID,
-		mtoShipment.ID,
-	}
-}
-
-func generateUpdateMTOShipmentQuery() string {
-	return `UPDATE mto_shipments
-		SET
-			updated_at = NOW(),
-			scheduled_pickup_date = ?,
-			requested_pickup_date = ?,
-			requested_delivery_date = ?,
-			customer_remarks = ?,
-			counselor_remarks = ?,
-			prime_estimated_weight = ?,
-			prime_estimated_weight_recorded_date = ?,
-			prime_actual_weight = ?,
-            nts_recorded_weight = ?,
-			shipment_type = ?,
-			actual_pickup_date = ?,
-			approved_date = ?,
-			first_available_delivery_date = ?,
-			required_delivery_date = ?,
-			status = ?,
-			destination_address_id = ?,
-			pickup_address_id = ?,
-			secondary_delivery_address_id = ?,
-			secondary_pickup_address_id = ?,
-			diversion = ?,
-			billable_weight_cap = ?,
-			billable_weight_justification = ?,
-			tac_type = ?,
-			sac_type = ?,
-			uses_external_vendor = ?,
-			service_order_number = ?,
-			storage_facility_id = ?
-		WHERE
-			id = ?
-	`
-}
-
-func generateMTOAgentsParams(agent models.MTOAgent) []interface{} {
-	agentID := agent.ID
-	agentType := agent.MTOAgentType
-	firstName := agent.FirstName
-	lastName := agent.LastName
-	email := agent.Email
-	phoneNo := agent.Phone
-
-	paramsArr := []interface{}{
-		agentID,
-		agentID,
-		agentType,
-		agentID,
-		firstName,
-		agentID,
-		lastName,
-		agentID,
-		email,
-		agentID,
-		phoneNo,
-	}
-
-	return paramsArr
-}
-
-func generateAgentQuery() string {
-	return `
-		updated_at =
-			CASE
-			   WHEN id = ? THEN NOW() ELSE updated_at
-			END,
-		agent_type =
-			CASE
-			   WHEN id = ? THEN ? ELSE agent_type
-			END,
-		first_name =
-			CASE
-			   WHEN id = ? THEN ? ELSE first_name
-			END,
-		last_name =
-			CASE
-			   WHEN id = ? THEN ? ELSE last_name
-			END,
-		email =
-			CASE
-			   WHEN id = ? THEN ? ELSE email
-			END,
-		phone =
-			CASE
-			   WHEN id = ? THEN ? ELSE phone
-			END;
-	`
 }
 
 type mtoShipmentStatusUpdater struct {

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -526,10 +526,20 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 		suite.Require().NoError(err)
 		suite.NotZero(updatedMTOShipment.ID, oldMTOShipment.ID)
-		suite.Equal(phone, *updatedMTOShipment.MTOAgents[0].Phone)
-		suite.Equal(*mtoAgentToCreate.FirstName, *updatedMTOShipment.MTOAgents[1].FirstName)
-		suite.Equal(*mtoAgentToCreate.LastName, *updatedMTOShipment.MTOAgents[1].LastName)
-		suite.Equal(*mtoAgentToCreate.Email, *updatedMTOShipment.MTOAgents[1].Email)
+		// the returned updatedMTOShipment does not guarantee the same
+		// order of MTOAgents
+		suite.Equal(len(updatedAgents), len(updatedMTOShipment.MTOAgents))
+		for i := range updatedMTOShipment.MTOAgents {
+			agent := updatedMTOShipment.MTOAgents[i]
+			if agent.ID == existingAgent.ID {
+				suite.Equal(phone, *agent.Phone)
+			} else {
+				// this must be the newly created agent
+				suite.Equal(*mtoAgentToCreate.FirstName, *agent.FirstName)
+				suite.Equal(*mtoAgentToCreate.LastName, *agent.LastName)
+				suite.Equal(*mtoAgentToCreate.Email, *agent.Email)
+			}
+		}
 
 		// Verify that shipment recalculate was handled correctly
 		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -1,12 +1,3 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
-// nolint:errcheck
 package mtoshipment
 
 import (
@@ -18,10 +9,10 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/auth"
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
@@ -51,7 +42,6 @@ func setUpMockNotificationSender() notifications.NotificationSender {
 }
 
 func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
-	oldMTOShipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
 	planner := &mocks.Planner{}
@@ -62,7 +52,6 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	).Return(500, nil)
 	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(NewShipmentReweighRequester())
-
 	mockShipmentRecalculator := mockservices.PaymentRequestShipmentRecalculator{}
 	mockShipmentRecalculator.On("ShipmentRecalculatePaymentRequest",
 		mock.AnythingOfType("*appcontext.appContext"),
@@ -71,69 +60,73 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	mockSender := setUpMockNotificationSender()
 	mtoShipmentUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
 
-	requestedPickupDate := *oldMTOShipment.RequestedPickupDate
 	scheduledPickupDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	firstAvailableDeliveryDate := time.Date(2019, time.March, 10, 0, 0, 0, 0, time.UTC)
 	actualPickupDate := time.Date(2020, time.June, 8, 0, 0, 0, 0, time.UTC)
-	secondaryPickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
-	secondaryDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
 	primeActualWeight := unit.Pound(1234)
 	primeEstimatedWeight := unit.Pound(1234)
-	newDestinationAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "987 Other Avenue",
-			StreetAddress2: swag.String("P.O. Box 1234"),
-			StreetAddress3: swag.String("c/o Another Person"),
-			City:           "Des Moines",
-			State:          "IA",
-			PostalCode:     "50309",
-			Country:        swag.String("US"),
-		},
-	})
 
-	newPickupAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{
-		Address: models.Address{
-			StreetAddress1: "987 Over There Avenue",
-			StreetAddress2: swag.String("P.O. Box 1234"),
-			StreetAddress3: swag.String("c/o Another Person"),
-			City:           "Houston",
-			State:          "TX",
-			PostalCode:     "77083",
-			Country:        swag.String("US"),
-		},
-	})
+	var mtoShipment models.MTOShipment
+	var oldMTOShipment models.MTOShipment
+	var secondaryPickupAddress models.Address
+	var secondaryDeliveryAddress models.Address
+	var newDestinationAddress models.Address
+	var newPickupAddress models.Address
 
-	mtoShipment := models.MTOShipment{
-		ID:                         oldMTOShipment.ID,
-		MoveTaskOrderID:            oldMTOShipment.MoveTaskOrderID,
-		DestinationAddress:         oldMTOShipment.DestinationAddress,
-		DestinationAddressID:       oldMTOShipment.DestinationAddressID,
-		PickupAddress:              oldMTOShipment.PickupAddress,
-		PickupAddressID:            oldMTOShipment.PickupAddressID,
-		RequestedPickupDate:        &requestedPickupDate,
-		ScheduledPickupDate:        &scheduledPickupDate,
-		ShipmentType:               "INTERNATIONAL_UB",
-		PrimeActualWeight:          &primeActualWeight,
-		PrimeEstimatedWeight:       &primeEstimatedWeight,
-		FirstAvailableDeliveryDate: &firstAvailableDeliveryDate,
-		Status:                     oldMTOShipment.Status,
-		ActualPickupDate:           &actualPickupDate,
-		ApprovedDate:               &firstAvailableDeliveryDate,
+	setupTestData := func() {
+		oldMTOShipment = testdatagen.MakeDefaultMTOShipment(suite.DB())
+
+		requestedPickupDate := *oldMTOShipment.RequestedPickupDate
+		secondaryPickupAddress = testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
+		secondaryDeliveryAddress = testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
+		newDestinationAddress = testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
+			Address: models.Address{
+				StreetAddress1: "987 Other Avenue",
+				StreetAddress2: swag.String("P.O. Box 1234"),
+				StreetAddress3: swag.String("c/o Another Person"),
+				City:           "Des Moines",
+				State:          "IA",
+				PostalCode:     "50309",
+				Country:        swag.String("US"),
+			},
+		})
+
+		newPickupAddress = testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{
+			Address: models.Address{
+				StreetAddress1: "987 Over There Avenue",
+				StreetAddress2: swag.String("P.O. Box 1234"),
+				StreetAddress3: swag.String("c/o Another Person"),
+				City:           "Houston",
+				State:          "TX",
+				PostalCode:     "77083",
+				Country:        swag.String("US"),
+			},
+		})
+
+		mtoShipment = models.MTOShipment{
+			ID:                         oldMTOShipment.ID,
+			MoveTaskOrderID:            oldMTOShipment.MoveTaskOrderID,
+			DestinationAddress:         oldMTOShipment.DestinationAddress,
+			DestinationAddressID:       oldMTOShipment.DestinationAddressID,
+			PickupAddress:              oldMTOShipment.PickupAddress,
+			PickupAddressID:            oldMTOShipment.PickupAddressID,
+			RequestedPickupDate:        &requestedPickupDate,
+			ScheduledPickupDate:        &scheduledPickupDate,
+			ShipmentType:               "INTERNATIONAL_UB",
+			PrimeActualWeight:          &primeActualWeight,
+			PrimeEstimatedWeight:       &primeEstimatedWeight,
+			FirstAvailableDeliveryDate: &firstAvailableDeliveryDate,
+			Status:                     oldMTOShipment.Status,
+			ActualPickupDate:           &actualPickupDate,
+			ApprovedDate:               &firstAvailableDeliveryDate,
+		}
+
+		//now := time.Now()
+		primeEstimatedWeight = unit.Pound(4500)
 	}
 
-	ghcDomesticTransitTime := models.GHCDomesticTransitTime{
-		MaxDaysTransitTime: 12,
-		WeightLbsLower:     0,
-		WeightLbsUpper:     10000,
-		DistanceMilesLower: 0,
-		DistanceMilesUpper: 10000,
-	}
-	_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
-
-	//now := time.Now()
-	primeEstimatedWeight = unit.Pound(4500)
-
-	suite.T().Run("Can retrieve existing shipment", func(t *testing.T) {
+	suite.Run("Can retrieve existing shipment", func() {
+		setupTestData()
 
 		existingShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{})
 
@@ -202,19 +195,62 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		}
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 	})
 
-	suite.T().Run("Etag is stale", func(t *testing.T) {
+	suite.Run("Updatable status returned as expected", func() {
+		var statusTests = []struct {
+			name      string
+			status    models.MTOShipmentStatus
+			updatable bool
+		}{
+			{"Draft isn't updatable", models.MTOShipmentStatusDraft, false},
+			{"Submitted is updatable", models.MTOShipmentStatusSubmitted, true},
+			{"Approved isn't updatable", models.MTOShipmentStatusApproved, false},
+		}
+
+		for _, tt := range statusTests {
+			shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+				MTOShipment: models.MTOShipment{
+					Status: tt.status,
+				},
+			})
+
+			servicesCounselor := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{})
+
+			session := auth.Session{
+				ApplicationName: auth.OfficeApp,
+				UserID:          *servicesCounselor.UserID,
+				OfficeUserID:    servicesCounselor.ID,
+			}
+			session.Roles = append(session.Roles, servicesCounselor.User.Roles...)
+
+			updatable, err := mtoShipmentUpdater.CheckIfMTOShipmentCanBeUpdated(suite.AppContextForTest(), &shipment, &session)
+
+			suite.NoError(err)
+
+			suite.Equal(tt.updatable, updatable,
+				"Expected updatable to be %v when status is %v. Got %v", tt.updatable, tt.status, updatable)
+
+			// Verify that shipment recalculate was handled correctly
+			mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		}
+	})
+
+	suite.Run("Etag is stale", func() {
+		setupTestData()
+
 		eTag := etag.GenerateEtag(time.Now())
 		_, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(suite.AppContextForTest(), &mtoShipment, eTag)
 		suite.Error(err)
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 	})
 
-	suite.T().Run("If-Unmodified-Since is equal to the updated_at date", func(t *testing.T) {
+	suite.Run("If-Unmodified-Since is equal to the updated_at date", func() {
+		setupTestData()
+
 		eTag := etag.GenerateEtag(oldMTOShipment.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(suite.AppContextForTest(), &mtoShipment, eTag)
 
@@ -230,16 +266,18 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.True(firstAvailableDeliveryDate.Equal(*updatedMTOShipment.FirstAvailableDeliveryDate))
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 	})
 
-	oldMTOShipment2 := testdatagen.MakeDefaultMTOShipment(suite.DB())
-	mtoShipment2 := models.MTOShipment{
-		ID:           oldMTOShipment2.ID,
-		ShipmentType: "INTERNATIONAL_UB",
-	}
+	suite.Run("Updater can handle optional queries set as nil", func() {
+		setupTestData()
 
-	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
+		oldMTOShipment2 := testdatagen.MakeDefaultMTOShipment(suite.DB())
+		mtoShipment2 := models.MTOShipment{
+			ID:           oldMTOShipment2.ID,
+			ShipmentType: "INTERNATIONAL_UB",
+		}
+
 		eTag := etag.GenerateEtag(oldMTOShipment2.UpdatedAt)
 		updatedMTOShipment, err := mtoShipmentUpdater.UpdateMTOShipmentCustomer(suite.AppContextForTest(), &mtoShipment2, eTag)
 
@@ -248,10 +286,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(updatedMTOShipment.MoveTaskOrder.ID, oldMTOShipment2.MoveTaskOrder.ID)
 		suite.Equal(updatedMTOShipment.ShipmentType, models.MTOShipmentTypeInternationalUB)
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 	})
 
-	suite.T().Run("Successful update to all address fields", func(t *testing.T) {
+	suite.Run("Successful update to all address fields", func() {
+		setupTestData()
+
 		// Ensure we can update every address field on the shipment
 		// Create an mtoShipment to update that has every address populated
 		oldMTOShipment3 := testdatagen.MakeDefaultMTOShipment(suite.DB())
@@ -282,11 +322,13 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(secondaryDeliveryAddress.ID, *updatedShipment.SecondaryDeliveryAddressID)
 		suite.Equal(secondaryDeliveryAddress.StreetAddress1, updatedShipment.SecondaryDeliveryAddress.StreetAddress1)
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 
 	})
 
-	suite.T().Run("Successful update to a minimal MTO shipment", func(t *testing.T) {
+	suite.Run("Successful update to a minimal MTO shipment", func() {
+		setupTestData()
+
 		// Minimal MTO Shipment has no associated addresses created by default.
 		// Part of this test ensures that if an address doesn't exist on a shipment,
 		// the updater can successfully create it.
@@ -341,10 +383,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(secondaryDeliveryAddress.ID, *newShipment.SecondaryDeliveryAddressID)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Updating a shipment does not nullify ApprovedDate", func(t *testing.T) {
+	suite.Run("Updating a shipment does not nullify ApprovedDate", func() {
+		setupTestData()
+
 		// This test was added because of a bug that nullified the ApprovedDate
 		// when ScheduledPickupDate was included in the payload. See PR #6919.
 		// ApprovedDate affects shipment diversions, so we want to make sure it
@@ -383,10 +427,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.NotEmpty(newShipment.ApprovedDate)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Successfully update MTO Agents", func(t *testing.T) {
+	suite.Run("Successfully update MTO Agents", func() {
+		setupTestData()
+
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 		mtoAgent1 := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
 			MTOAgent: models.MTOAgent{
@@ -437,10 +483,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(newLastName, *updatedMTOShipment.MTOAgents[1].LastName)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Successfully add new MTO Agent and edit another", func(t *testing.T) {
+	suite.Run("Successfully add new MTO Agent and edit another", func() {
+		setupTestData()
+
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 		existingAgent := testdatagen.MakeMTOAgent(suite.DB(), testdatagen.Assertions{
 			MTOAgent: models.MTOAgent{
@@ -484,10 +532,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(*mtoAgentToCreate.Email, *updatedMTOShipment.MTOAgents[1].Email)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Successfully add storage facility to shipment", func(t *testing.T) {
+	suite.Run("Successfully add storage facility to shipment", func() {
+		setupTestData()
+
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 		storageFacility := testdatagen.MakeDefaultStorageFacility(suite.DB())
 
@@ -504,7 +554,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.NotNil(updatedMTOShipment.StorageFacility)
 	})
 
-	suite.T().Run("Successfully edit storage facility on shipment", func(t *testing.T) {
+	suite.Run("Successfully edit storage facility on shipment", func() {
+		setupTestData()
+
 		// Create initial shipment data
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			StorageFacility: models.StorageFacility{
@@ -555,7 +607,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(newStorageFacilityAddress.StreetAddress1, updatedShipment.StorageFacility.Address.StreetAddress1)
 	})
 
-	suite.T().Run("Successfully update NTS previously recorded weight to shipment", func(t *testing.T) {
+	suite.Run("Successfully update NTS previously recorded weight to shipment", func() {
+		setupTestData()
+
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 
 		ntsRecorededWeight := unit.Pound(980)
@@ -574,7 +628,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 
 	})
 
-	suite.T().Run("Unable to update NTS previously recorded weight due to shipment type", func(t *testing.T) {
+	suite.Run("Unable to update NTS previously recorded weight due to shipment type", func() {
+		setupTestData()
+
 		shipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 
 		ntsRecorededWeight := unit.Pound(980)
@@ -597,7 +653,9 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal("field NTSRecordedWeight cannot be set for shipment type HHG", wrappedErr.Error())
 	})
 
-	suite.T().Run("Successfully divert a shipment and transition statuses", func(t *testing.T) {
+	suite.Run("Successfully divert a shipment and transition statuses", func() {
+		setupTestData()
+
 		// A diverted shipment should transition to the SUBMITTED status.
 		// If the move it is connected to is APPROVED, that move should transition to APPROVALS REQUESTED
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
@@ -635,13 +693,15 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, updatedMove.Status)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.AnythingOfType("*appcontext.appContext"), mock.AnythingOfType("uuid.UUID"))
 	})
 
 	// Test UpdateMTOShipmentPrime
 	// TODO: Add more tests, such as making sure this function fails if the
 	// move is not available to the prime.
-	suite.T().Run("Updating a shipment does not nullify ApprovedDate", func(t *testing.T) {
+	suite.Run("Updating a shipment does not nullify ApprovedDate", func() {
+		setupTestData()
+
 		// This test was added because of a bug that nullified the ApprovedDate
 		// when ScheduledPickupDate was included in the payload. See PR #6919.
 		// ApprovedDate affects shipment diversions, so we want to make sure it
@@ -695,7 +755,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.Equal(secondaryDeliveryAddress.ID, *newShipment.SecondaryDeliveryAddressID)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 }
 
@@ -850,83 +910,97 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentWithDifferentRoles() 
 }
 
 func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
 	estimatedWeight := unit.Pound(2000)
-	shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
-			ScheduledPickupDate:  &testdatagen.DateInsidePeakRateCycle,
-			PrimeEstimatedWeight: &estimatedWeight,
-			Status:               models.MTOShipmentStatusSubmitted,
-		},
-	})
-	draftShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusDraft,
-		},
-	})
-	shipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
-	})
-	shipment3 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
-	})
-	shipment4 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
-	})
-	shipmentForAutoApprove := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusSubmitted,
-		},
-	})
-	approvedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status: models.MTOShipmentStatusApproved,
-		},
-	})
-	rejectionReason := "exotic animals are banned"
-	rejectedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status:          models.MTOShipmentStatusRejected,
-			RejectionReason: &rejectionReason,
-		},
-	})
-	shipment.Status = models.MTOShipmentStatusSubmitted
-	eTag := etag.GenerateEtag(shipment.UpdatedAt)
 	status := models.MTOShipmentStatusApproved
-
-	ghcDomesticTransitTime := models.GHCDomesticTransitTime{
-		MaxDaysTransitTime: 12,
-		WeightLbsLower:     0,
-		WeightLbsUpper:     10000,
-		DistanceMilesLower: 0,
-		DistanceMilesUpper: 10000,
+	// need the re service codes to update status
+	expectedReServiceCodes := []models.ReServiceCode{
+		models.ReServiceCodeDLH,
+		models.ReServiceCodeFSC,
+		models.ReServiceCodeDOP,
+		models.ReServiceCodeDDP,
+		models.ReServiceCodeDPK,
+		models.ReServiceCodeDUPK,
 	}
-	_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
 
-	// Let's also create a transit time object with a zero upper bound for weight (this can happen in the table).
-	ghcDomesticTransitTime0LbsUpper := models.GHCDomesticTransitTime{
-		MaxDaysTransitTime: 12,
-		WeightLbsLower:     10001,
-		WeightLbsUpper:     0,
-		DistanceMilesLower: 0,
-		DistanceMilesUpper: 10000,
+	var shipmentForAutoApprove models.MTOShipment
+	var draftShipment models.MTOShipment
+	var shipment2 models.MTOShipment
+	var shipment3 models.MTOShipment
+	var shipment4 models.MTOShipment
+	var approvedShipment models.MTOShipment
+	var rejectedShipment models.MTOShipment
+	var eTag string
+	var mto models.Move
+
+	setupTestData := func() {
+		for i := range expectedReServiceCodes {
+			testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+				ReService: models.ReService{
+					Code:      expectedReServiceCodes[i],
+					Name:      "test",
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+			})
+		}
+
+		mto = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				ShipmentType:         models.MTOShipmentTypeHHGLongHaulDom,
+				ScheduledPickupDate:  &testdatagen.DateInsidePeakRateCycle,
+				PrimeEstimatedWeight: &estimatedWeight,
+				Status:               models.MTOShipmentStatusSubmitted,
+			},
+		})
+		draftShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusDraft,
+			},
+		})
+		shipment2 = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		shipment3 = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		shipment4 = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		shipmentForAutoApprove = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusSubmitted,
+			},
+		})
+		approvedShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status: models.MTOShipmentStatusApproved,
+			},
+		})
+		rejectionReason := "exotic animals are banned"
+		rejectedShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status:          models.MTOShipmentStatusRejected,
+				RejectionReason: &rejectionReason,
+			},
+		})
+		shipment.Status = models.MTOShipmentStatusSubmitted
+		eTag = etag.GenerateEtag(shipment.UpdatedAt)
 	}
-	_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime0LbsUpper)
 
 	builder := query.NewQueryBuilder()
 	moveRouter := moveservices.NewMoveRouter()
@@ -939,35 +1013,13 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 	).Return(500, nil)
 	updater := NewMTOShipmentStatusUpdater(builder, siCreator, planner)
 
-	suite.T().Run("If the mtoShipment is approved successfully it should create approved mtoServiceItems", func(t *testing.T) {
+	suite.Run("If the mtoShipment is approved successfully it should create approved mtoServiceItems", func() {
+		setupTestData()
+
 		appCtx := suite.AppContextForTest()
 		shipmentForAutoApproveEtag := etag.GenerateEtag(shipmentForAutoApprove.UpdatedAt)
 		fetchedShipment := models.MTOShipment{}
 		serviceItems := models.MTOServiceItems{}
-		var expectedReServiceCodes []models.ReServiceCode
-		expectedReServiceCodes = append(expectedReServiceCodes,
-			models.ReServiceCodeDLH,
-			models.ReServiceCodeFSC,
-			models.ReServiceCodeDOP,
-			models.ReServiceCodeDDP,
-			models.ReServiceCodeDPK,
-			models.ReServiceCodeDUPK,
-		)
-
-		var reServiceCode models.ReService
-		if err := appCtx.DB().Where("code = $1", expectedReServiceCodes[0]).First(&reServiceCode); err != nil {
-			// Something is truncating these when all server tests run, but we need some values for reServices
-			for _, serviceCode := range expectedReServiceCodes {
-				testdatagen.MakeReService(appCtx.DB(), testdatagen.Assertions{
-					ReService: models.ReService{
-						Code:      serviceCode,
-						Name:      "test",
-						CreatedAt: time.Now(),
-						UpdatedAt: time.Now(),
-					},
-				})
-			}
-		}
 
 		preApprovalTime := time.Now()
 		_, err := updater.UpdateMTOShipmentStatus(appCtx, shipmentForAutoApprove.ID, status, nil, shipmentForAutoApproveEtag)
@@ -989,8 +1041,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Assertions.WithinDuration(preApprovalTime, *serviceItems[0].ApprovedAt, 2*time.Second)
 
 		// If we've gotten the shipment updated and fetched it without error then we can inspect the
-		// service items created as a side effect to see if they are approved.
-		missingReServiceCodes := expectedReServiceCodes
+		// service items created as a side effect to see if they are
+		// approved.
+		missingReServiceCodes := make([]models.ReServiceCode, len(expectedReServiceCodes))
+		copy(missingReServiceCodes, expectedReServiceCodes)
 		for _, serviceItem := range serviceItems {
 			suite.Equal(models.MTOServiceItemStatusApproved, serviceItem.Status)
 
@@ -1013,7 +1067,32 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Empty(missingReServiceCodes)
 	})
 
-	suite.T().Run("If we act on a shipment with a weight that has a 0 upper weight it should still work", func(t *testing.T) {
+	suite.Run("If we act on a shipment with a weight that has a 0 upper weight it should still work", func() {
+		setupTestData()
+
+		ghcDomesticTransitTime := models.GHCDomesticTransitTime{
+			MaxDaysTransitTime: 12,
+			WeightLbsLower:     0,
+			WeightLbsUpper:     10000,
+			DistanceMilesLower: 0,
+			DistanceMilesUpper: 10000,
+		}
+		verrs, err := suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
+		suite.Assert().False(verrs.HasAny())
+		suite.NoError(err)
+
+		// Let's also create a transit time object with a zero upper bound for weight (this can happen in the table).
+		ghcDomesticTransitTime0LbsUpper := models.GHCDomesticTransitTime{
+			MaxDaysTransitTime: 12,
+			WeightLbsLower:     10001,
+			WeightLbsUpper:     0,
+			DistanceMilesLower: 0,
+			DistanceMilesUpper: 10000,
+		}
+		verrs, err = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime0LbsUpper)
+		suite.Assert().False(verrs.HasAny())
+		suite.NoError(err)
+
 		// This is testing that the Required Delivery Date is calculated correctly.
 		// In order for the Required Delivery Date to be calculated, the following conditions must be true:
 		// 1. The shipment is moving to the APPROVED status
@@ -1039,7 +1118,8 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 			},
 		})
 		shipmentHeavyEtag := etag.GenerateEtag(shipmentHeavy.UpdatedAt)
-		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipmentHeavy.ID, status, nil, shipmentHeavyEtag)
+
+		_, err = updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipmentHeavy.ID, status, nil, shipmentHeavyEtag)
 		suite.NoError(err)
 		serviceItems := models.MTOServiceItems{}
 		_ = suite.DB().All(&serviceItems)
@@ -1050,7 +1130,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.NotNil(fetchedShipment.RequiredDeliveryDate)
 	})
 
-	suite.T().Run("Cannot set SUBMITTED status on shipment via UpdateMTOShipmentStatus", func(t *testing.T) {
+	suite.Run("Cannot set SUBMITTED status on shipment via UpdateMTOShipmentStatus", func() {
+		setupTestData()
+
 		// The only time a shipment gets set to the SUBMITTED status is when it is created, whether by the customer
 		// or the Prime. This happens in the internal and prime API in the CreateMTOShipmentHandler. In that case,
 		// the handlers will call ShipmentRouter.Submit().
@@ -1066,7 +1148,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.EqualValues(models.MTOShipmentStatusDraft, draftShipment.Status)
 	})
 
-	suite.T().Run("Rejecting a shipment in SUBMITTED status with a rejection reason should return no error", func(t *testing.T) {
+	suite.Run("Rejecting a shipment in SUBMITTED status with a rejection reason should return no error", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(shipment2.UpdatedAt)
 		rejectionReason := "Rejection reason"
 		returnedShipment, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment2.ID, "REJECTED", &rejectionReason, eTag)
@@ -1081,7 +1165,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Equal(&rejectionReason, shipment2.RejectionReason)
 	})
 
-	suite.T().Run("Rejecting a shipment with no rejection reason returns an InvalidInputError", func(t *testing.T) {
+	suite.Run("Rejecting a shipment with no rejection reason returns an InvalidInputError", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(shipment3.UpdatedAt)
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment3.ID, "REJECTED", nil, eTag)
 
@@ -1089,7 +1175,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(apperror.InvalidInputError{}, err)
 	})
 
-	suite.T().Run("Rejecting a shipment in APPROVED status returns a ConflictStatusError", func(t *testing.T) {
+	suite.Run("Rejecting a shipment in APPROVED status returns a ConflictStatusError", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(approvedShipment.UpdatedAt)
 		rejectionReason := "Rejection reason"
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), approvedShipment.ID, "REJECTED", &rejectionReason, eTag)
@@ -1098,7 +1186,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(ConflictStatusError{}, err)
 	})
 
-	suite.T().Run("Approving a shipment in REJECTED status returns a ConflictStatusError", func(t *testing.T) {
+	suite.Run("Approving a shipment in REJECTED status returns a ConflictStatusError", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(rejectedShipment.UpdatedAt)
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), rejectedShipment.ID, "APPROVED", nil, eTag)
 
@@ -1106,7 +1196,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(ConflictStatusError{}, err)
 	})
 
-	suite.T().Run("Passing in a stale identifier returns a PreconditionFailedError", func(t *testing.T) {
+	suite.Run("Passing in a stale identifier returns a PreconditionFailedError", func() {
+		setupTestData()
+
 		staleETag := etag.GenerateEtag(time.Now())
 
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment4.ID, "APPROVED", nil, staleETag)
@@ -1115,7 +1207,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Passing in an invalid status returns a ConflictStatus error", func(t *testing.T) {
+	suite.Run("Passing in an invalid status returns a ConflictStatus error", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(shipment4.UpdatedAt)
 
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment4.ID, "invalid", nil, eTag)
@@ -1124,7 +1218,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(ConflictStatusError{}, err)
 	})
 
-	suite.T().Run("Passing in a bad shipment id returns a Not Found error", func(t *testing.T) {
+	suite.Run("Passing in a bad shipment id returns a Not Found error", func() {
+		setupTestData()
+
 		badShipmentID := uuid.FromStringOrNil("424d930b-cf8d-4c10-8059-be8a25ba952a")
 
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), badShipmentID, "APPROVED", nil, eTag)
@@ -1133,7 +1229,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Changing to APPROVED status records approved_date", func(t *testing.T) {
+	suite.Run("Changing to APPROVED status records approved_date", func() {
+		setupTestData()
+
 		shipment5 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto,
 			MTOShipment: models.MTOShipment{
@@ -1147,12 +1245,14 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment5.ID, models.MTOShipmentStatusApproved, nil, eTag)
 
 		suite.NoError(err)
-		suite.DB().Find(&shipment5, shipment5.ID)
+		suite.NoError(suite.DB().Find(&shipment5, shipment5.ID))
 		suite.Equal(models.MTOShipmentStatusApproved, shipment5.Status)
 		suite.NotNil(shipment5.ApprovedDate)
 	})
 
-	suite.T().Run("Changing to a non-APPROVED status does not record approved_date", func(t *testing.T) {
+	suite.Run("Changing to a non-APPROVED status does not record approved_date", func() {
+		setupTestData()
+
 		shipment6 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto,
 			MTOShipment: models.MTOShipment{
@@ -1167,18 +1267,20 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		_, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), shipment6.ID, models.MTOShipmentStatusRejected, &rejectionReason, eTag)
 
 		suite.NoError(err)
-		suite.DB().Find(&shipment6, shipment6.ID)
+		suite.NoError(suite.DB().Find(&shipment6, shipment6.ID))
 		suite.Equal(models.MTOShipmentStatusRejected, shipment6.Status)
 		suite.Nil(shipment6.ApprovedDate)
 	})
 
-	suite.T().Run("When move is not yet approved, cannot approve shipment", func(t *testing.T) {
+	suite.Run("When move is not yet approved, cannot approve shipment", func() {
+		setupTestData()
+
 		submittedMTO := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 		mtoShipment := submittedMTO.MTOShipments[0]
 		eTag = etag.GenerateEtag(mtoShipment.UpdatedAt)
 
 		updatedShipment, err := updater.UpdateMTOShipmentStatus(suite.AppContextForTest(), mtoShipment.ID, models.MTOShipmentStatusApproved, nil, eTag)
-		suite.DB().Find(&mtoShipment, mtoShipment.ID)
+		suite.NoError(suite.DB().Find(&mtoShipment, mtoShipment.ID))
 
 		suite.Nil(updatedShipment)
 		suite.Equal(models.MTOShipmentStatusSubmitted, mtoShipment.Status)
@@ -1187,7 +1289,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Contains(err.Error(), "Cannot approve a shipment if the move isn't approved.")
 	})
 
-	suite.T().Run("An approved shipment can change to CANCELLATION_REQUESTED", func(t *testing.T) {
+	suite.Run("An approved shipment can change to CANCELLATION_REQUESTED", func() {
+		setupTestData()
+
 		approvedShipment2 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: testdatagen.MakeAvailableMove(suite.DB()),
 			MTOShipment: models.MTOShipment{
@@ -1198,7 +1302,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 
 		updatedShipment, err := updater.UpdateMTOShipmentStatus(
 			suite.AppContextForTest(), approvedShipment2.ID, models.MTOShipmentStatusCancellationRequested, nil, eTag)
-		suite.DB().Find(&approvedShipment2, approvedShipment2.ID)
+		suite.NoError(suite.DB().Find(&approvedShipment2, approvedShipment2.ID))
 
 		suite.NoError(err)
 		suite.NotNil(updatedShipment)
@@ -1206,7 +1310,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Equal(models.MTOShipmentStatusCancellationRequested, approvedShipment2.Status)
 	})
 
-	suite.T().Run("A CANCELLATION_REQUESTED shipment can change to CANCELED", func(t *testing.T) {
+	suite.Run("A CANCELLATION_REQUESTED shipment can change to CANCELED", func() {
+		setupTestData()
+
 		cancellationRequestedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: testdatagen.MakeAvailableMove(suite.DB()),
 			MTOShipment: models.MTOShipment{
@@ -1217,7 +1323,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 
 		updatedShipment, err := updater.UpdateMTOShipmentStatus(
 			suite.AppContextForTest(), cancellationRequestedShipment.ID, models.MTOShipmentStatusCanceled, nil, eTag)
-		suite.DB().Find(&cancellationRequestedShipment, cancellationRequestedShipment.ID)
+		suite.NoError(suite.DB().Find(&cancellationRequestedShipment, cancellationRequestedShipment.ID))
 
 		suite.NoError(err)
 		suite.NotNil(updatedShipment)
@@ -1225,12 +1331,14 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Equal(models.MTOShipmentStatusCanceled, cancellationRequestedShipment.Status)
 	})
 
-	suite.T().Run("An APPROVED shipment CANNOT change to CANCELED - ERROR", func(t *testing.T) {
+	suite.Run("An APPROVED shipment CANNOT change to CANCELED - ERROR", func() {
+		setupTestData()
+
 		eTag = etag.GenerateEtag(approvedShipment.UpdatedAt)
 
 		updatedShipment, err := updater.UpdateMTOShipmentStatus(
 			suite.AppContextForTest(), approvedShipment.ID, models.MTOShipmentStatusCanceled, nil, eTag)
-		suite.DB().Find(&approvedShipment, approvedShipment.ID)
+		suite.NoError(suite.DB().Find(&approvedShipment, approvedShipment.ID))
 
 		suite.Error(err)
 		suite.Nil(updatedShipment)
@@ -1238,7 +1346,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 		suite.Equal(models.MTOShipmentStatusApproved, approvedShipment.Status)
 	})
 
-	suite.T().Run("An APPROVED shipment CAN change to Diversion Requested", func(t *testing.T) {
+	suite.Run("An APPROVED shipment CAN change to Diversion Requested", func() {
+		setupTestData()
+
 		shipmentToDivert := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto,
 			MTOShipment: models.MTOShipment{
@@ -1249,13 +1359,15 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 
 		_, err := updater.UpdateMTOShipmentStatus(
 			suite.AppContextForTest(), shipmentToDivert.ID, models.MTOShipmentStatusDiversionRequested, nil, eTag)
-		suite.DB().Find(&shipmentToDivert, shipmentToDivert.ID)
+		suite.NoError(suite.DB().Find(&shipmentToDivert, shipmentToDivert.ID))
 
 		suite.NoError(err)
 		suite.Equal(models.MTOShipmentStatusDiversionRequested, shipmentToDivert.Status)
 	})
 
-	suite.T().Run("A diversion or diverted shipment can change to APPROVED", func(t *testing.T) {
+	suite.Run("A diversion or diverted shipment can change to APPROVED", func() {
+		setupTestData()
+
 		// a diversion or diverted shipment is when the PRIME sets the diversion field to true
 		// the status must also be in diversion requested status to be approvable as well
 		diversionRequestedShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
@@ -1284,18 +1396,24 @@ func (suite *MTOShipmentServiceSuite) TestUpdateMTOShipmentStatus() {
 func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 	now := time.Now()
 	hide := false
-	primeShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-	})
-	nonPrimeShipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
-	hiddenPrimeShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-			Show:               &hide,
-		},
-	})
+	var primeShipment models.MTOShipment
+	var nonPrimeShipment models.MTOShipment
+	var hiddenPrimeShipment models.MTOShipment
+
+	setupTestData := func() {
+		primeShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+		})
+		nonPrimeShipment = testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
+		hiddenPrimeShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+				Show:               &hide,
+			},
+		})
+	}
 
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
@@ -1310,16 +1428,20 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 	mockSender := setUpMockNotificationSender()
 	updater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
 
-	suite.T().Run("Shipment exists and is available to Prime - success", func(t *testing.T) {
+	suite.Run("Shipment exists and is available to Prime - success", func() {
+		setupTestData()
+
 		isAvailable, err := updater.MTOShipmentsMTOAvailableToPrime(suite.AppContextForTest(), primeShipment.ID)
 		suite.True(isAvailable)
 		suite.NoError(err)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Shipment exists but is not available to Prime - failure", func(t *testing.T) {
+	suite.Run("Shipment exists but is not available to Prime - failure", func() {
+		setupTestData()
+
 		isAvailable, err := updater.MTOShipmentsMTOAvailableToPrime(suite.AppContextForTest(), nonPrimeShipment.ID)
 		suite.False(isAvailable)
 		suite.Error(err)
@@ -1327,10 +1449,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 		suite.Contains(err.Error(), nonPrimeShipment.ID.String())
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Shipment exists, is available, but move is disabled - failure", func(t *testing.T) {
+	suite.Run("Shipment exists, is available, but move is disabled - failure", func() {
+		setupTestData()
+
 		isAvailable, err := updater.MTOShipmentsMTOAvailableToPrime(suite.AppContextForTest(), hiddenPrimeShipment.ID)
 		suite.False(isAvailable)
 		suite.Error(err)
@@ -1338,10 +1462,12 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 		suite.Contains(err.Error(), hiddenPrimeShipment.ID.String())
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Shipment does not exist - failure", func(t *testing.T) {
+	suite.Run("Shipment does not exist - failure", func() {
+		setupTestData()
+
 		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
 		isAvailable, err := updater.MTOShipmentsMTOAvailableToPrime(suite.AppContextForTest(), badUUID)
 		suite.False(isAvailable)
@@ -1350,7 +1476,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentsMTOAvailableToPrime() {
 		suite.Contains(err.Error(), badUUID.String())
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 }
 
@@ -1368,7 +1494,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 	mockSender := setUpMockNotificationSender()
 	updater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
 
-	suite.T().Run("Updating the shipment estimated weight will flag excess weight on the move and transitions move status", func(t *testing.T) {
+	suite.Run("Updating the shipment estimated weight will flag excess weight on the move and transitions move status", func() {
 		now := time.Now()
 		pickupDate := now.AddDate(0, 0, 10)
 
@@ -1401,10 +1527,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 		suite.Equal(models.MoveStatusAPPROVALSREQUESTED, primeShipment.MoveTaskOrder.Status)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Skips calling check excess weight if estimated weight was not provided in request", func(t *testing.T) {
+	suite.Run("Skips calling check excess weight if estimated weight was not provided in request", func() {
 		moveWeights := &mockservices.MoveWeights{}
 		mockSender := setUpMockNotificationSender()
 		mockedUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
@@ -1433,13 +1559,13 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 		_, err := mockedUpdater.UpdateMTOShipmentPrime(suite.AppContextForTest(), &primeShipment, etag.GenerateEtag(primeShipment.UpdatedAt))
 		suite.NoError(err)
 
-		moveWeights.AssertNotCalled(t, "CheckExcessWeight")
+		moveWeights.AssertNotCalled(suite.T(), "CheckExcessWeight")
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Skips calling check excess weight if the updated estimated weight matches the db value", func(t *testing.T) {
+	suite.Run("Skips calling check excess weight if the updated estimated weight matches the db value", func() {
 		moveWeights := &mockservices.MoveWeights{}
 		mockSender := setUpMockNotificationSender()
 		mockedUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
@@ -1467,10 +1593,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentEstimatedWeightMoveExces
 		_, err := mockedUpdater.UpdateMTOShipmentPrime(suite.AppContextForTest(), &primeShipment, etag.GenerateEtag(primeShipment.UpdatedAt))
 		suite.NoError(err)
 
-		moveWeights.AssertNotCalled(t, "CheckExcessWeight")
+		moveWeights.AssertNotCalled(suite.T(), "CheckExcessWeight")
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 }
 
@@ -1488,7 +1614,7 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentActualWeightAutoReweigh(
 	mockSender := setUpMockNotificationSender()
 	updater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
 
-	suite.T().Run("Updating the shipment actual weight within weight allowance creates reweigh requests for", func(t *testing.T) {
+	suite.Run("Updating the shipment actual weight within weight allowance creates reweigh requests for", func() {
 		now := time.Now()
 		pickupDate := now.AddDate(0, 0, 10)
 
@@ -1520,10 +1646,10 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentActualWeightAutoReweigh(
 		suite.Equal(models.ReweighRequesterSystem, primeShipment.Reweigh.RequestedBy)
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Skips calling check auto reweigh if actual weight was not provided in request", func(t *testing.T) {
+	suite.Run("Skips calling check auto reweigh if actual weight was not provided in request", func() {
 		moveWeights := &mockservices.MoveWeights{}
 		mockSender := setUpMockNotificationSender()
 		mockedUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
@@ -1550,13 +1676,13 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentActualWeightAutoReweigh(
 		_, err := mockedUpdater.UpdateMTOShipmentPrime(suite.AppContextForTest(), &primeShipment, etag.GenerateEtag(primeShipment.UpdatedAt))
 		suite.NoError(err)
 
-		moveWeights.AssertNotCalled(t, "CheckAutoReweigh")
+		moveWeights.AssertNotCalled(suite.T(), "CheckAutoReweigh")
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 
-	suite.T().Run("Skips calling check auto reweigh if the updated actual weight matches the db value", func(t *testing.T) {
+	suite.Run("Skips calling check auto reweigh if the updated actual weight matches the db value", func() {
 		moveWeights := &mockservices.MoveWeights{}
 		mockSender := setUpMockNotificationSender()
 		mockedUpdater := NewMTOShipmentUpdater(builder, fetcher, planner, moveRouter, moveWeights, mockSender, &mockShipmentRecalculator)
@@ -1582,9 +1708,9 @@ func (suite *MTOShipmentServiceSuite) TestUpdateShipmentActualWeightAutoReweigh(
 		_, err := mockedUpdater.UpdateMTOShipmentPrime(suite.AppContextForTest(), &primeShipment, etag.GenerateEtag(primeShipment.UpdatedAt))
 		suite.NoError(err)
 
-		moveWeights.AssertNotCalled(t, "CheckAutoReweigh")
+		moveWeights.AssertNotCalled(suite.T(), "CheckAutoReweigh")
 
 		// Verify that shipment recalculate was handled correctly
-		mockShipmentRecalculator.AssertNotCalled(t, "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
+		mockShipmentRecalculator.AssertNotCalled(suite.T(), "ShipmentRecalculatePaymentRequest", mock.Anything, mock.Anything)
 	})
 }


### PR DESCRIPTION
## [MB-11029](MB-11029) and [MB-11030](MB-11030)

## Summary

Convert to transaction based tests (and clean up some complicated and unsafe updates).

See also [running server tests inside a transaction](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/)

## Setup to Run Your Code

`make server_test`

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
