### PR TITLE
MB-10433 Don't show estimated weight for NTSR

### DIFF
--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -153,6 +153,7 @@ const ShipmentDetailsMain = ({
           ifMatchEtag: shipment.eTag,
           reweighID: shipment.reweigh?.id,
           reweighWeight: shipment.reweigh?.weight,
+          shipmentType: shipment.shipmentType,
         }}
         handleRequestReweighModal={handleRequestReweighModal}
       />

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.jsx
@@ -10,6 +10,8 @@ import styles from './ShipmentWeightDetails.module.scss';
 
 import returnLowestValue from 'utils/returnLowestValue';
 import { formatWeight } from 'shared/formatters';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+import { ShipmentOptionsOneOf } from 'types/shipment';
 
 const ShipmentWeightDetails = ({ estimatedWeight, actualWeight, shipmentInfo, handleRequestReweighModal }) => {
   const lowestWeight = returnLowestValue(actualWeight, shipmentInfo.reweighWeight);
@@ -29,13 +31,19 @@ const ShipmentWeightDetails = ({ estimatedWeight, actualWeight, shipmentInfo, ha
   );
   return (
     <div className={classnames('maxw-tablet', styles.ShipmentWeightDetails)}>
-      <DataTableWrapper className={classnames('maxw-mobile', 'table--data-point-group')}>
-        <DataTable
-          columnHeaders={['Estimated weight']}
-          dataRow={estimatedWeight ? [formatWeight(estimatedWeight)] : ['']}
-        />
-      </DataTableWrapper>
-      <DataTableWrapper className={classnames('maxw-mobile', 'table--data-point-group')}>
+      {shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.NTSR && (
+        <DataTableWrapper className={classnames('maxw-mobile', 'table--data-point-group')}>
+          <DataTable
+            columnHeaders={['Estimated weight']}
+            dataRow={estimatedWeight ? [formatWeight(estimatedWeight)] : ['']}
+          />
+        </DataTableWrapper>
+      )}
+      <DataTableWrapper
+        className={classnames('table--data-point-group', {
+          'maxw-mobile': shipmentInfo.shipmentType !== SHIPMENT_OPTIONS.NTSR,
+        })}
+      >
         <DataTable columnHeaders={[reweighHeader]} dataRow={lowestWeight ? [formatWeight(lowestWeight)] : ['']} />
       </DataTableWrapper>
     </div>
@@ -50,6 +58,7 @@ ShipmentWeightDetails.propTypes = {
     ifMatchEtag: PropTypes.string,
     reweighID: PropTypes.string,
     reweighWeight: PropTypes.number,
+    shipmentType: ShipmentOptionsOneOf.isRequired,
   }).isRequired,
   handleRequestReweighModal: PropTypes.func.isRequired,
 };

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.module.scss
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.module.scss
@@ -7,6 +7,9 @@
   > div:first-child {
     @include u-margin-right(2);
   }
+  > div:only-child {
+      @include u-margin-right(0);
+    }
   .rightAlignButtonWrapper {
     display: flex;
     justify-content: flex-end;

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.stories.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ShipmentWeightDetails from 'components/Office/ShipmentWeightDetails/ShipmentWeightDetails';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 export default {
   title: 'Office Components/ShipmentWeightDetails',
@@ -17,11 +18,13 @@ const shipmentInfoReweighRequested = {
   shipmentID: 'shipment1',
   ifMatchEtag: 'etag1',
   reweighID: 'reweighRequestID',
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 const shipmentInfoNoReweigh = {
   shipmentID: 'shipment1',
   ifMatchEtag: 'etag1',
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 export const WithNoDetails = () => <ShipmentWeightDetails shipmentInfo={shipmentInfoNoReweigh} />;
@@ -32,4 +35,12 @@ export const WithDetailsNoReweighRequested = () => (
 
 export const WithDetailsReweighRequested = () => (
   <ShipmentWeightDetails estimatedWeight={1000} actualWeight={1000} shipmentInfo={shipmentInfoReweighRequested} />
+);
+
+export const NTSRWithDetails = () => (
+  <ShipmentWeightDetails
+    estimatedWeight={null}
+    actualWeight={1000}
+    shipmentInfo={{ ...shipmentInfoNoReweigh, shipmentType: SHIPMENT_OPTIONS.NTSR }}
+  />
 );

--- a/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
+++ b/src/components/Office/ShipmentWeightDetails/ShipmentWeightDetails.test.jsx
@@ -3,15 +3,19 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import ShipmentWeightDetails from './ShipmentWeightDetails';
 
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
 const shipmentInfoReweighRequested = {
   shipmentID: 'shipment1',
   ifMatchEtag: 'etag1',
   reweighID: 'reweighRequestID',
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 const shipmentInfoNoReweigh = {
   shipmentID: 'shipment1',
   ifMatchEtag: 'etag1',
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 const shipmentInfoReweigh = {
@@ -19,6 +23,7 @@ const shipmentInfoReweigh = {
   ifMatchEtag: 'etag1',
   reweighID: 'reweighRequestID',
   reweighWeight: 1000,
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 const handleRequestReweighModal = jest.fn();
@@ -44,7 +49,7 @@ describe('ShipmentWeightDetails', () => {
     expect(reweighButton).toBeTruthy();
   });
 
-  it('renders with estimated weight', async () => {
+  it('renders with estimated weight if not an NTSR', async () => {
     render(
       <ShipmentWeightDetails
         estimatedWeight={11000}
@@ -56,6 +61,19 @@ describe('ShipmentWeightDetails', () => {
 
     const estWeight = await screen.findByText('11,000 lbs');
     expect(estWeight).toBeTruthy();
+  });
+
+  it('renders without estimated weight if an NTSR', async () => {
+    render(
+      <ShipmentWeightDetails
+        estimatedWeight={null}
+        actualWeight={12000}
+        shipmentInfo={{ ...shipmentInfoReweighRequested, shipmentType: SHIPMENT_OPTIONS.NTSR }}
+        handleRequestReweighModal={handleRequestReweighModal}
+      />,
+    );
+
+    expect(screen.queryByText('Estimated weight')).not.toBeInTheDocument();
   });
 
   it('renders with shipment weight', async () => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10433) for this change

## Summary
No estimated weight is collected for NTS-release, so it shouldn’t be displayed on the MTO tab

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Run DEVSEED_SUBSCENARIO=nts_and_ntsr make db_dev_e2e_populate
2. Login as a a TOO
3. Look at the NTSSUB move and approve both shipments
4. Look at the MTO tab and view that the NTS shipment shows estimated weIght while the NTS shipment doesn't

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
![Screen Shot 2022-01-13 at 1 02 55 PM](https://user-images.githubusercontent.com/14057912/149392944-c13c1828-0b47-4691-ab30-9d469dbadeb9.png)
![Screen Shot 2022-01-13 at 1 03 15 PM](https://user-images.githubusercontent.com/14057912/149392970-9b49b750-e049-42a9-8147-460657505d02.png)

