### PR TITLE
[MB-10537] Part 3: Insert new duty locations

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -695,3 +695,4 @@
 20211229190325_delete_incorrect_duty_stations.up.sql
 20220107193037_add_destination_address_type_to_shipments.up.sql
 20220112013152_update_duty_locations.up.sql
+20220113172826_create_new_duty_locations.up.sql

--- a/migrations/app/schema/20220113172826_create_new_duty_locations.up.sql
+++ b/migrations/app/schema/20220113172826_create_new_duty_locations.up.sql
@@ -1,8 +1,17 @@
+-- Clean up some empty strings that should have been NULL from the last migration
+UPDATE transportation_offices
+SET hours = NULL
+WHERE hours = '';
+
+UPDATE transportation_offices
+SET services = NULL
+WHERE services = '';
+
 -- NAVSUP FLC San Diego
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('8ea692be-424a-4355-b1ff-1c72e4bee245', '2623 LeHardy St.', 'Bldg. 3376', 'San Diego', 'CA', '92136', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('27002d34-e9ea-4ef5-a086-f23d07c4088c', 'NAVSUP FLC San Diego', 'LKNQ', '8ea692be-424a-4355-b1ff-1c72e4bee245', 0, 0, '', now(), now());
+  VALUES ('27002d34-e9ea-4ef5-a086-f23d07c4088c', 'NAVSUP FLC San Diego', 'LKNQ', '8ea692be-424a-4355-b1ff-1c72e4bee245', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('183019a0-5ed5-4f65-90ba-546ade3cf723', 'n/a', 'San Diego', 'CA', '92136', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -12,7 +21,7 @@ INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_of
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('9672422e-6918-48ff-be43-becd025a0e52', 'Counseling Office', 'End of Route 238', 'Yorktown', 'VA', '23690', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('4ed2762d-73bc-4c62-bea9-725c5c64cb62', 'USCG Training Center Yorktown', 'AGFM', '9672422e-6918-48ff-be43-becd025a0e52', 0, 0, '', now(), now());
+  VALUES ('4ed2762d-73bc-4c62-bea9-725c5c64cb62', 'USCG Training Center Yorktown', 'AGFM', '9672422e-6918-48ff-be43-becd025a0e52', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('e749736a-3b40-475b-b83e-6525f280f9b4', 'n/a', 'Yorktown', 'VA', '23690', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -34,7 +43,7 @@ INSERT INTO duty_station_names (id, name, duty_station_id, created_at, updated_a
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('3b11a8c4-5e23-4afe-b00b-edda2be5d56d', 'USCG Tracen', '1 Munro Ave', 'Cape May', 'NJ', '08204', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('7ac0f374-b97a-4b98-9878-eabef89adff9', 'USCG Training Center Cape May', 'AGFM', '3b11a8c4-5e23-4afe-b00b-edda2be5d56d', 0, 0, '', now(), now());
+  VALUES ('7ac0f374-b97a-4b98-9878-eabef89adff9', 'USCG Training Center Cape May', 'AGFM', '3b11a8c4-5e23-4afe-b00b-edda2be5d56d', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('f21af5e6-52a8-4328-9bb8-1f5a972ebd01', 'n/a', 'Cape May', 'NJ', '08204', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -44,7 +53,7 @@ INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_of
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('b7f7367d-d632-462a-ab7c-688687533e11', 'USCG Base Boston Personnel Service Division', '427 Commercial St', 'Boston', 'MA', '02109', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('cf1addea-a4f9-4173-8506-2bb82a064cb7', 'USCG Base Boston', 'AGFM', 'b7f7367d-d632-462a-ab7c-688687533e11', 0, 0, '', now(), now());
+  VALUES ('cf1addea-a4f9-4173-8506-2bb82a064cb7', 'USCG Base Boston', 'AGFM', 'b7f7367d-d632-462a-ab7c-688687533e11', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('9870776a-8df9-481c-84ad-34b8c579c510', 'n/a', 'Boston', 'MA', '02109', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -54,7 +63,7 @@ INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_of
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('71e8ae89-de1b-456f-8555-e3499ff869b3', '1050 Register St.', NULL, 'Charleston', 'SC', '29405', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('b429ec35-eb8b-4c35-979b-e96cb9a9cbf7', 'USCG Base Charleston', 'AGFM', '71e8ae89-de1b-456f-8555-e3499ff869b3', 0, 0, '', now(), now());
+  VALUES ('b429ec35-eb8b-4c35-979b-e96cb9a9cbf7', 'USCG Base Charleston', 'AGFM', '71e8ae89-de1b-456f-8555-e3499ff869b3', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('5c2f4497-bc71-41ad-a5a1-f4be491df4cb', 'n/a', 'Charleston', 'SC', '29405', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -76,7 +85,7 @@ INSERT INTO duty_station_names (id, name, duty_station_id, created_at, updated_a
 INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
   VALUES ('52b86914-a467-4d0d-8ff2-4d4cf9958915', '1001 South Seaside Ave', NULL, 'San Pedro', 'CA', '90731', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('f3ce3548-fb03-4e2e-b986-386a1adf2400', 'USCG Base Los Angeles/Long Beach', 'LKNQ', '52b86914-a467-4d0d-8ff2-4d4cf9958915', 0, 0, '', now(), now());
+  VALUES ('f3ce3548-fb03-4e2e-b986-386a1adf2400', 'USCG Base Los Angeles/Long Beach', 'LKNQ', '52b86914-a467-4d0d-8ff2-4d4cf9958915', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('e11ee632-869f-4eba-8d6a-01a4524668e5', 'n/a', 'San Pedro', 'CA', '90731', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
@@ -116,7 +125,7 @@ INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_of
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('9b5006fa-8812-4f9b-a73f-1e184f29719c', 'n/a', 'Seal Beach', 'CA', '90740', now(), now());
 INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
-  VALUES ('a0de70b3-e7e9-4e47-8c7e-3f9f7ba4c5ab', 'NAVSUP FLC Seal Beach', 'LKNQ', '9b5006fa-8812-4f9b-a73f-1e184f29719c', 0, 0, '', now(), now());
+  VALUES ('a0de70b3-e7e9-4e47-8c7e-3f9f7ba4c5ab', 'NAVSUP FLC Seal Beach', 'LKNQ', '9b5006fa-8812-4f9b-a73f-1e184f29719c', 0, 0, NULL, now(), now());
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
   VALUES ('f7c383a5-8faf-47db-8ea8-c2e356d7ba90', 'n/a', 'Seal Beach', 'CA', '90740', now(), now());
 INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)

--- a/migrations/app/schema/20220113172826_create_new_duty_locations.up.sql
+++ b/migrations/app/schema/20220113172826_create_new_duty_locations.up.sql
@@ -1,0 +1,123 @@
+-- NAVSUP FLC San Diego
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('8ea692be-424a-4355-b1ff-1c72e4bee245', '2623 LeHardy St.', 'Bldg. 3376', 'San Diego', 'CA', '92136', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('27002d34-e9ea-4ef5-a086-f23d07c4088c', 'NAVSUP FLC San Diego', 'LKNQ', '8ea692be-424a-4355-b1ff-1c72e4bee245', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('183019a0-5ed5-4f65-90ba-546ade3cf723', 'n/a', 'San Diego', 'CA', '92136', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('4bc45615-59b7-42cb-98a2-edf423c63cd7', 'NAVSUP FLC San Diego', 'NAVY', '183019a0-5ed5-4f65-90ba-546ade3cf723', '27002d34-e9ea-4ef5-a086-f23d07c4088c', TRUE, now(), now());
+
+-- USCG Training Center Yorktown
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('9672422e-6918-48ff-be43-becd025a0e52', 'Counseling Office', 'End of Route 238', 'Yorktown', 'VA', '23690', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('4ed2762d-73bc-4c62-bea9-725c5c64cb62', 'USCG Training Center Yorktown', 'AGFM', '9672422e-6918-48ff-be43-becd025a0e52', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('e749736a-3b40-475b-b83e-6525f280f9b4', 'n/a', 'Yorktown', 'VA', '23690', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('9fcc7ac7-2ef5-4ff1-a273-835c005c4590', 'USCG Training Center Yorktown', 'COAST_GUARD', 'e749736a-3b40-475b-b83e-6525f280f9b4', '4ed2762d-73bc-4c62-bea9-725c5c64cb62', TRUE, now(), now());
+
+-- Detroit Arsenal
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('23ef1356-fe98-470d-894d-62c44b9300e9', '6501 E. 11 Mile Road', 'Building 232, Room 105', 'Warren', 'MI', '48397', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('07c5e487-ee37-4e43-b2db-2b4bd79ea7e5', 'Detroit Arsenal', 'BGAC', '23ef1356-fe98-470d-894d-62c44b9300e9', 0, 0, 'Mon - Fri 7:30 a.m. - 4:00 p.m. Sat and Sun – closed', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('3ca863c7-e580-43ee-b3de-9a5fda49f33b', 'n/a', 'Warren', 'MI', '48397', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('4e1ca127-b2ed-4689-8c0f-1e73931acc34', 'Detroit Arsenal', 'ARMY', '3ca863c7-e580-43ee-b3de-9a5fda49f33b', '07c5e487-ee37-4e43-b2db-2b4bd79ea7e5', TRUE, now(), now());
+INSERT INTO duty_station_names (id, name, duty_station_id, created_at, updated_at)
+  VALUES ('6f276f80-4cd4-40dd-b9dd-1018add01d6c', 'ASC Detroit Arsenal', '4e1ca127-b2ed-4689-8c0f-1e73931acc34', now(), now());
+
+-- USCG Training Center Cape May
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('3b11a8c4-5e23-4afe-b00b-edda2be5d56d', 'USCG Tracen', '1 Munro Ave', 'Cape May', 'NJ', '08204', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('7ac0f374-b97a-4b98-9878-eabef89adff9', 'USCG Training Center Cape May', 'AGFM', '3b11a8c4-5e23-4afe-b00b-edda2be5d56d', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('f21af5e6-52a8-4328-9bb8-1f5a972ebd01', 'n/a', 'Cape May', 'NJ', '08204', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('7e07d6c1-5a42-49f2-b8f0-a4877d59d123', 'USCG Training Center Cape May', 'COAST_GUARD', 'f21af5e6-52a8-4328-9bb8-1f5a972ebd01', '7ac0f374-b97a-4b98-9878-eabef89adff9', TRUE, now(), now());
+
+-- USCG Base Boston
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('b7f7367d-d632-462a-ab7c-688687533e11', 'USCG Base Boston Personnel Service Division', '427 Commercial St', 'Boston', 'MA', '02109', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('cf1addea-a4f9-4173-8506-2bb82a064cb7', 'USCG Base Boston', 'AGFM', 'b7f7367d-d632-462a-ab7c-688687533e11', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('9870776a-8df9-481c-84ad-34b8c579c510', 'n/a', 'Boston', 'MA', '02109', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('2de8c9ab-88dc-4327-9e5e-104de4320289', 'USCG Base Boston', 'COAST_GUARD', '9870776a-8df9-481c-84ad-34b8c579c510', 'cf1addea-a4f9-4173-8506-2bb82a064cb7', TRUE, now(), now());
+
+-- USCG Base Charleston
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('71e8ae89-de1b-456f-8555-e3499ff869b3', '1050 Register St.', NULL, 'Charleston', 'SC', '29405', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('b429ec35-eb8b-4c35-979b-e96cb9a9cbf7', 'USCG Base Charleston', 'AGFM', '71e8ae89-de1b-456f-8555-e3499ff869b3', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('5c2f4497-bc71-41ad-a5a1-f4be491df4cb', 'n/a', 'Charleston', 'SC', '29405', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('3f8d9425-cc97-4f7c-b7f1-cdf8aa53f2a7', 'USCG Base Charleston', 'COAST_GUARD', '5c2f4497-bc71-41ad-a5a1-f4be491df4cb', 'b429ec35-eb8b-4c35-979b-e96cb9a9cbf7', TRUE, now(), now());
+
+-- USCG Base Saint Louis
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('0bd9da86-dc4d-42ae-a49a-d6ef4ffa8636', 'Base Detachment Saint Louis', '1222 Spruce Street, Suite 2.107', 'Saint Louis', 'MO', '63103', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('254765b6-1781-4441-b7f1-27c42beaa583', 'USCG Base Saint Louis', 'AGFM', '0bd9da86-dc4d-42ae-a49a-d6ef4ffa8636', 0, 0, '0730 - 1530 Mon - Fri, Closed Weekends and Holidays', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('e55017f0-b50d-4969-aae5-3d19f44cfda5', 'n/a', 'Saint Louis', 'MO', '63103', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('623347bc-adcf-4392-a196-73828035989a', 'USCG Base Saint Louis', 'COAST_GUARD', 'e55017f0-b50d-4969-aae5-3d19f44cfda5', '254765b6-1781-4441-b7f1-27c42beaa583', TRUE, now(), now());
+INSERT INTO duty_station_names (id, name, duty_station_id, created_at, updated_at)
+  VALUES ('f6bd981a-81a5-470e-965f-8b1a57c28a11', 'USCG Base St. Louis', '623347bc-adcf-4392-a196-73828035989a', now(), now());
+
+-- USCG Base Los Angeles/Long Beach
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('52b86914-a467-4d0d-8ff2-4d4cf9958915', '1001 South Seaside Ave', NULL, 'San Pedro', 'CA', '90731', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('f3ce3548-fb03-4e2e-b986-386a1adf2400', 'USCG Base Los Angeles/Long Beach', 'LKNQ', '52b86914-a467-4d0d-8ff2-4d4cf9958915', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('e11ee632-869f-4eba-8d6a-01a4524668e5', 'n/a', 'San Pedro', 'CA', '90731', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('ed1c2157-cb75-42a9-a2e7-5826f1c506f6', 'USCG Base Los Angeles/Long Beach', 'COAST_GUARD', 'e11ee632-869f-4eba-8d6a-01a4524668e5', 'f3ce3548-fb03-4e2e-b986-386a1adf2400', TRUE, now(), now());
+
+-- Joint Base Lewis-McChord (Fort Lewis)
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('445ef0c0-21eb-4dd0-bb02-068fc68eba84', 'Building 2140 Liggett Ave.', NULL, 'Fort Lewis', 'WA', '98433', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('c21c5710-e2ff-4548-827b-0b26f83d3119', 'Joint Base Lewis-McChord (Fort Lewis)', 'JEAT', '445ef0c0-21eb-4dd0-bb02-068fc68eba84', 0, 0, 'Mon - Fri 7:30 a.m. – 3:30 p.m. Closed Sat - Sun & Holidays', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('fdb361f0-2624-4709-bf00-5eae6da130d0', 'n/a', 'Fort Lewis', 'WA', '98433', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('8385e3c1-1884-4b41-9e32-02c0b7718d7b', 'Joint Base Lewis-McChord (Fort Lewis)', 'ARMY', 'fdb361f0-2624-4709-bf00-5eae6da130d0', 'c21c5710-e2ff-4548-827b-0b26f83d3119', TRUE, now(), now());
+INSERT INTO duty_station_names (id, name, duty_station_id, created_at, updated_at)
+  VALUES ('1ac218f6-cb6c-4de0-9677-8a04351fa344', 'JBLM-Lewis', '8385e3c1-1884-4b41-9e32-02c0b7718d7b', now(), now());
+
+-- Yuma Proving Ground
+INSERT INTO addresses (id, street_address_1, street_address_2, city, state, postal_code, created_at, updated_at)
+  VALUES ('2b06bfc0-88e0-44b5-89da-faf5e710f366', '301 C. St.', 'Bldg. 2710', 'Yuma', 'AZ', '85365', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('7145e8fe-465b-44e5-a486-b893357148ef', 'Yuma Proving Ground', 'LKNQ', '2b06bfc0-88e0-44b5-89da-faf5e710f366', 0, 0, 'Mon - Thu 6:00 a.m. - 4:30 p.m. Fri - Sun and Holidays - closed', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('94b9d187-abdd-4087-b48f-a88b6e980286', 'n/a', 'Yuma', 'AZ', '85365', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('75d5f1bc-4e15-48ec-acfc-acd60ba913f6', 'Yuma Proving Ground', 'ARMY', '94b9d187-abdd-4087-b48f-a88b6e980286', '7145e8fe-465b-44e5-a486-b893357148ef', TRUE, now(), now());
+
+-- Schriever doesn't need to create a transportation office because it uses Peterson AFB's transportation office
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('26f3b7eb-3794-4184-bc9f-cba51cf891d5', 'n/a', 'Colorado Springs', 'CO', '80914', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('5589e5d4-b3ca-4b87-b6f3-cc0203143b6f', 'Schriever AFB', 'AIR_FORCE', '26f3b7eb-3794-4184-bc9f-cba51cf891d5', 'cc107598-3d72-4679-a4aa-c28d1fd2a016', TRUE, now(), now());
+
+-- NAVSUP FLC Seal Beach
+-- We don't have info for the transportation office for this base, so the address info
+-- is just made up to fit the duty location for now.
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('9b5006fa-8812-4f9b-a73f-1e184f29719c', 'n/a', 'Seal Beach', 'CA', '90740', now(), now());
+INSERT INTO transportation_offices (id, name, gbloc, address_id, latitude, longitude, hours, created_at, updated_at)
+  VALUES ('a0de70b3-e7e9-4e47-8c7e-3f9f7ba4c5ab', 'NAVSUP FLC Seal Beach', 'LKNQ', '9b5006fa-8812-4f9b-a73f-1e184f29719c', 0, 0, '', now(), now());
+INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at)
+  VALUES ('f7c383a5-8faf-47db-8ea8-c2e356d7ba90', 'n/a', 'Seal Beach', 'CA', '90740', now(), now());
+INSERT INTO duty_locations (id, name, affiliation, address_id, transportation_office_id, provides_services_counseling, updated_at, created_at)
+  VALUES ('068d3bd9-d30b-4411-9d02-199d265932c7', 'NAVSUP FLC Seal Beach', 'NAVY', 'f7c383a5-8faf-47db-8ea8-c2e356d7ba90', 'a0de70b3-e7e9-4e47-8c7e-3f9f7ba4c5ab', FALSE, now(), now());


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10537) for this change

## Summary
This migration handles all of the stuff in [this spreadsheet](https://docs.google.com/spreadsheets/d/1Uj6pYYagV_P2GXENEpZ7EwjMRrrKRUBT/edit#gid=16697612) with the status `NEW RECORD`.
The spreadsheet contains changes suggested by USTC after reviewing our duty station data.

This PR follows #8017 and #7977, which cover all the other stuff in there.

Since we're adding new duty locations, we needed to add corresponding Transportation Offices.
This has turned out to be hard to get, so we've only got partial information for these, and we'll have to
come back another time and update the transportation offices.

I split the insertions up by Duty Location, but I could have done one bulk insert for each of the tables that are used. The bulk insert approach would run faster, but this migration already runs in less than a second, and I think it would be a bit harder to review. I'm down to rearrange it if people disagree though.

## Setup to Run Your Code
<details>
<summary> 💻 click me to see the instructions</summary>


Most of the testing will be done on the database.

### Setup
Run migrations
```
make db_dev_migrate
```

Start a sql console with
```sh
psql-dev
```
Make temporary local tables to hold the data that describes how the duty locations should be updated. This will allow us to run queries that compare the DB after the migration with the updates that were supposed to happen.
```sql
drop table if exists duty_station_update;
create table duty_station_update
    (
        duty_station_id text,
        gbloc text,
        name text,
        street_address_1 text,
        postal_code text,
        full_postal_code text,
        city text,
        state text,
        affiliation text,
        provides_services_counseling text,
        status text,
        new_duty_station_name text,
        new_GBLOC text,
        alt_name text,
        new_provides_services_counseling text,
        new_city text,
        new_state text,
        new_zip text,
        new_affiliation text,
        remarks text
);
drop table if exists transportation_office_cleanup;
create table transportation_office_cleanup
(
    operating_branch text,
    name text,
    latitude text,
    longitude text,
    hours text,
    services text,
    gbloc text,
    "Phone Number" text,
    street_address_1 text,
    street_address_2 text,
    city text,
    state text,
    postal_code text
);

```
Download both of these spreadsheets as CSVs:
- [Duty Stations in MilMove Database UPDATED 12 Jan 2022](https://docs.google.com/spreadsheets/d/1Uj6pYYagV_P2GXENEpZ7EwjMRrrKRUBT/edit#gid=16697612) 
- [Transportation Office Data Cleanup](https://ustcdp3.slack.com/files/U01TULMFLES/F02SZLT2LNA/transportation_office_data_cleanup.xlsx)
Load the data files into a database table (these meta-command need to be run in the actual psql console. Everything else can be run however you like.)

```sql
\copy duty_station_update from '~/Downloads/Duty Stations in MilMove Database UPDATED 12 Jan 2022.csv' DELIMITER ',' CSV HEADER
\copy transportation_office_cleanup from '~/Downloads/Transportation Office Data Cleanup.csv' delimiter ',' csv header
```

### Testing

This query shows you all the new records that were added, side by side with the cols from the imported data. If you run it you should see 12 rows. 


```sql
select dl.name, dsu.new_duty_station_name, t.gbloc, dsu.new_GBLOC, dl.provides_services_counseling, dsu.new_provides_services_counseling, a.city, dsu.new_city, a.state, dsu.new_state, a.postal_code, dsu.new_zip, dl.affiliation, dsu.new_affiliation, t.hours, toc.hours
from duty_station_update dsu
         join duty_locations dl ON dsu.new_duty_station_name = dl.name
         left join transportation_offices t ON dl.transportation_office_id = t.id
         join addresses a ON dl.address_id = a.id
         join addresses ta ON t.address_id = ta.id
         left join transportation_office_cleanup toc ON dl.name = toc.name
where dsu.status = 'NEW RECORD';
```

This query checks to (almost) all the columns in the new records against the data we imported. It should return zero rows.
```sql
select dl.name, dsu.new_duty_station_name, t.gbloc, dsu.new_GBLOC, dl.provides_services_counseling, dsu.new_provides_services_counseling, a.city, dsu.new_city, a.state, dsu.new_state, a.postal_code, dsu.new_zip, dl.affiliation, dsu.new_affiliation, t.hours, toc.hours, ta.city, toc.city, ta.state, toc.state, ta.postal_code, toc.postal_code
from duty_station_update dsu
         join duty_locations dl ON dsu.new_duty_station_name = dl.name
         join transportation_offices t ON dl.transportation_office_id = t.id
         join addresses a ON dl.address_id = a.id
         join addresses ta ON t.address_id = ta.id
left join transportation_office_cleanup toc ON dl.name = toc.name
where dsu.status = 'NEW RECORD'
and (dl.name != dsu.new_duty_station_name OR t.gbloc != dsu.new_GBLOC OR
     dl.provides_services_counseling != dsu.new_provides_services_counseling::boolean OR a.city != dsu.new_city OR
     a.state != dsu.new_state OR a.postal_code != dsu.new_zip OR dl.affiliation != dsu.new_affiliation OR 
     ta.state != toc.state OR ta.postal_code != toc.postal_code
     -- OR ta.city != toc.city OR t.hours != toc.hours
    );
```
If we uncomment the two columns that were skipped we should get 1 row as a result.
This is because we got [an additional request to link Schriever AFB to Peterson AFB's transportation office](https://ustcdp3.slack.com/archives/C02AXHB7YRE/p1641927179003700?thread_ts=1641242926.121900&cid=C02AXHB7YRE) after that data was sent and I haven't updated the file (which would certainly have taken less time than explaining this, oops).

```sql
select dl.name, dsu.new_duty_station_name, t.gbloc, dsu.new_GBLOC, dl.provides_services_counseling, dsu.new_provides_services_counseling, a.city, dsu.new_city, a.state, dsu.new_state, a.postal_code, dsu.new_zip, dl.affiliation, dsu.new_affiliation, t.hours, toc.hours, ta.city, toc.city, ta.state, toc.state, ta.postal_code, toc.postal_code
from duty_station_update dsu
         join duty_locations dl ON dsu.new_duty_station_name = dl.name
         join transportation_offices t ON dl.transportation_office_id = t.id
         join addresses a ON dl.address_id = a.id
         join addresses ta ON t.address_id = ta.id
left join transportation_office_cleanup toc ON dl.name = toc.name
where dsu.status = 'NEW RECORD'
and (dl.name != dsu.new_duty_station_name OR t.gbloc != dsu.new_GBLOC OR
     dl.provides_services_counseling != dsu.new_provides_services_counseling::boolean OR a.city != dsu.new_city OR
     a.state != dsu.new_state OR a.postal_code != dsu.new_zip OR dl.affiliation != dsu.new_affiliation OR 
     ta.state != toc.state OR ta.postal_code != toc.postal_code
     OR ta.city != toc.city OR t.hours != toc.hours
    );
```
So let's double check that I did that right
```sql
select name, transportation_office_id from duty_locations where name in ('Schriever AFB', 'Peterson AFB');
```
You should get two rows with matching `transportation_office_id`s.
```
dev_db=# select name, transportation_office_id from duty_locations where name in ('Schriever AFB', 'Peterson AFB');
     name      |       transportation_office_id
---------------+--------------------------------------
 Peterson AFB  | cc107598-3d72-4679-a4aa-c28d1fd2a016
 Schriever AFB | cc107598-3d72-4679-a4aa-c28d1fd2a016
(2 rows)
```

</details>

### Additional steps
A quick way to verify that these changes have been made through the UI would be to get to a duty location search box (either by signing up as a new customer, or editing orders as a TOO), and then searching for some of the new duty locations to make sure they show up.

Here's a list of all the new duty stations
```
NAVSUP FLC San Diego
USCG Training Center Yorktown
Detroit Arsenal
USCG Training Center Cape May
USCG Base Boston
USCG Base Charleston
USCG Base Saint Louis
USCG Base Los Angeles/Long Beach
Joint Base Lewis-McChord (Fort Lewis)
Yuma Proving Ground
Schriever AFB
NAVSUP FLC Seal Beach
```
(Eagle eyed readers may notice that we already had a Schriever AFB, but it was renamed to Schriever SFB in the last migration, and a new record was added for Schriever AFB in this migration. Yes, this is a bit convoluted)

## Verification Steps for Author

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

### Database

#### Any new migrations/schema changes:

- [x] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [x] Have been communicated to #g-database