### PR TITLE
Add where clause to filter out test user email from devlocal service member users list

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -227,6 +227,7 @@ func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit 
 			FROM service_members as sm
 			JOIN users on sm.user_id = users.id
 			LEFT OUTER JOIN dps_users AS du on du.login_gov_email = users.login_gov_email
+            WHERE users.login_gov_email != 'first.last@login.gov.test'
 			ORDER BY users.created_at LIMIT $1`
 	}
 


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

Before A-team starts outcome work on PPM, I thought it would be good to filter out all of the test users from the devlocal sign in screen that are created when populating the database with the e2e devseed.  These are users that have the default email `first.last@login.gov.test` when the devseed calls MakeUser/MakeServiceMember without any override assertions.  When we do create PPM specific data usually the email describes the purpose such as `needs@orde.rs`.  The devlocal login sorts users by last created date and there is a user limit so it often hides the most useful premade users.

The fetchAppUserIdentities method is only used for querying the users for devlocal so does not affect any real app usage.

This doesn't impact the office app devlocal sign in list only the customer app. 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Populate the develepment database with the e2e devseed scenario

```sh
make db_dev_e2e_populate
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. In your browser open http://milmovelocal:3000
2. Select Local Sign In from the homepage 
3. The users list should only contain the custom service member users to select from and not those created by the office.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

Before

![Screen Shot 2022-01-14 at 10 40 56 AM](https://user-images.githubusercontent.com/52669884/149543083-74007767-cc46-4359-b6e7-b155bf9cd103.png)

After

![Screen Shot 2022-01-14 at 10 36 00 AM](https://user-images.githubusercontent.com/52669884/149543113-0970f094-9584-40fa-85a0-5afd9bfe13d7.png)
