### PR TITLE
[MB-9276] Prime API totalWeight entitlement should include dependents if authorized

### DIFF
--- a/pkg/handlers/converters.go
+++ b/pkg/handlers/converters.go
@@ -111,6 +111,11 @@ func FmtInt64(i int64) *int64 {
 	return &i
 }
 
+// FmtInt converts an int to an int pointer
+func FmtInt(i int) *int {
+	return &i
+}
+
 // FmtBool converts pop type to go-swagger type
 func FmtBool(b bool) *bool {
 	return &b

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -134,13 +134,12 @@ func Order(order *models.Order) *primemessages.Order {
 	if order.Grade != nil && order.Entitlement != nil {
 		order.Entitlement.SetWeightAllotment(*order.Grade)
 	}
-	entitlements := Entitlement(order.Entitlement)
 
 	payload := primemessages.Order{
 		CustomerID:             strfmt.UUID(order.ServiceMemberID.String()),
 		Customer:               Customer(&order.ServiceMember),
 		DestinationDutyStation: destinationDutyStation,
-		Entitlement:            entitlements,
+		Entitlement:            Entitlement(order.Entitlement),
 		ID:                     strfmt.UUID(order.ID.String()),
 		OriginDutyStation:      originDutyStation,
 		OrderNumber:            order.OrdersNumber,
@@ -159,8 +158,8 @@ func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 		return nil
 	}
 	var totalWeight int64
-	if entitlement.WeightAllotment() != nil {
-		totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
+	if weightAllowance := entitlement.WeightAllowance(); weightAllowance != nil {
+		totalWeight = int64(*weightAllowance)
 	}
 	var authorizedWeight *int64
 	if entitlement.AuthorizedWeight() != nil {

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -145,8 +145,8 @@ func Entitlement(entitlement *models.Entitlement) *supportmessages.Entitlement {
 		return nil
 	}
 	var totalWeight int64
-	if entitlement.WeightAllotment() != nil {
-		totalWeight = int64(entitlement.WeightAllotment().TotalWeightSelf)
+	if weightAllowance := entitlement.WeightAllowance(); weightAllowance != nil {
+		totalWeight = int64(*weightAllowance)
 	}
 	var authorizedWeight *int64
 	if entitlement.AuthorizedWeight() != nil {
@@ -170,10 +170,11 @@ func Entitlement(entitlement *models.Entitlement) *supportmessages.Entitlement {
 		ProGearWeight:                  int64(entitlement.ProGearWeight),
 		ProGearWeightSpouse:            int64(entitlement.ProGearWeightSpouse),
 		RequiredMedicalEquipmentWeight: int64(entitlement.RequiredMedicalEquipmentWeight),
-		StorageInTransit:               sit,
-		TotalDependents:                totalDependents,
-		TotalWeight:                    totalWeight,
-		ETag:                           etag.GenerateEtag(entitlement.UpdatedAt),
+		OrganizationalClothingAndIndividualEquipment: entitlement.OrganizationalClothingAndIndividualEquipment,
+		StorageInTransit: sit,
+		TotalDependents:  totalDependents,
+		TotalWeight:      totalWeight,
+		ETag:             etag.GenerateEtag(entitlement.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload_test.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload_test.go
@@ -2,6 +2,14 @@ package payloads
 
 import (
 	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/handlers"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -9,4 +17,123 @@ import (
 func TestOrder(t *testing.T) {
 	order := &models.Order{}
 	Order(order)
+}
+
+func TestEntitlement(t *testing.T) {
+
+	t.Run("Success - Returns the entitlement payload with only required fields", func(t *testing.T) {
+		entitlement := models.Entitlement{
+			ID:                             uuid.Must(uuid.NewV4()),
+			DependentsAuthorized:           nil,
+			TotalDependents:                nil,
+			NonTemporaryStorage:            nil,
+			PrivatelyOwnedVehicle:          nil,
+			DBAuthorizedWeight:             nil,
+			StorageInTransit:               nil,
+			RequiredMedicalEquipmentWeight: 0,
+			OrganizationalClothingAndIndividualEquipment: false,
+			ProGearWeight:       0,
+			ProGearWeightSpouse: 0,
+			CreatedAt:           time.Now(),
+			UpdatedAt:           time.Now(),
+		}
+
+		payload := Entitlement(&entitlement)
+
+		assert.Equal(t, strfmt.UUID(entitlement.ID.String()), payload.ID)
+		assert.Equal(t, int64(0), payload.RequiredMedicalEquipmentWeight)
+		assert.Equal(t, false, payload.OrganizationalClothingAndIndividualEquipment)
+		assert.Equal(t, int64(0), payload.ProGearWeight)
+		assert.Equal(t, int64(0), payload.ProGearWeightSpouse)
+		assert.NotEmpty(t, payload.ETag)
+		assert.Equal(t, etag.GenerateEtag(entitlement.UpdatedAt), payload.ETag)
+
+		assert.Nil(t, payload.AuthorizedWeight)
+		assert.Nil(t, payload.DependentsAuthorized)
+		assert.Nil(t, payload.NonTemporaryStorage)
+		assert.Nil(t, payload.PrivatelyOwnedVehicle)
+
+		/* These fields are defaulting to zero if they are nil in the model */
+		assert.Equal(t, int64(0), payload.StorageInTransit)
+		assert.Equal(t, int64(0), payload.TotalDependents)
+		assert.Equal(t, int64(0), payload.TotalWeight)
+	})
+
+	t.Run("Success - Returns the entitlement payload with all optional fields populated", func(t *testing.T) {
+		entitlement := models.Entitlement{
+			ID:                             uuid.Must(uuid.NewV4()),
+			DependentsAuthorized:           handlers.FmtBool(true),
+			TotalDependents:                handlers.FmtInt(2),
+			NonTemporaryStorage:            handlers.FmtBool(true),
+			PrivatelyOwnedVehicle:          handlers.FmtBool(true),
+			DBAuthorizedWeight:             handlers.FmtInt(10000),
+			StorageInTransit:               handlers.FmtInt(45),
+			RequiredMedicalEquipmentWeight: 500,
+			OrganizationalClothingAndIndividualEquipment: true,
+			ProGearWeight:       1000,
+			ProGearWeightSpouse: 750,
+			CreatedAt:           time.Now(),
+			UpdatedAt:           time.Now(),
+		}
+
+		// TotalWeight needs to read from the internal weightAllotment, in this case 7000 lbs w/o dependents and
+		// 9000 lbs with dependents
+		entitlement.SetWeightAllotment(string(models.ServiceMemberRankE5))
+
+		payload := Entitlement(&entitlement)
+
+		assert.Equal(t, strfmt.UUID(entitlement.ID.String()), payload.ID)
+		assert.True(t, *payload.DependentsAuthorized)
+		assert.Equal(t, int64(2), payload.TotalDependents)
+		assert.True(t, *payload.NonTemporaryStorage)
+		assert.True(t, *payload.PrivatelyOwnedVehicle)
+		assert.Equal(t, int64(10000), *payload.AuthorizedWeight)
+		assert.Equal(t, int64(9000), payload.TotalWeight)
+		assert.Equal(t, int64(45), payload.StorageInTransit)
+		assert.Equal(t, int64(500), payload.RequiredMedicalEquipmentWeight)
+		assert.Equal(t, true, payload.OrganizationalClothingAndIndividualEquipment)
+		assert.Equal(t, int64(1000), payload.ProGearWeight)
+		assert.Equal(t, int64(750), payload.ProGearWeightSpouse)
+		assert.NotEmpty(t, payload.ETag)
+		assert.Equal(t, etag.GenerateEtag(entitlement.UpdatedAt), payload.ETag)
+	})
+
+	t.Run("Success - Returns the entitlement payload with total weight self when dependents are not authorized", func(t *testing.T) {
+		entitlement := models.Entitlement{
+			ID:                             uuid.Must(uuid.NewV4()),
+			DependentsAuthorized:           handlers.FmtBool(false),
+			TotalDependents:                handlers.FmtInt(2),
+			NonTemporaryStorage:            handlers.FmtBool(true),
+			PrivatelyOwnedVehicle:          handlers.FmtBool(true),
+			DBAuthorizedWeight:             handlers.FmtInt(10000),
+			StorageInTransit:               handlers.FmtInt(45),
+			RequiredMedicalEquipmentWeight: 500,
+			OrganizationalClothingAndIndividualEquipment: true,
+			ProGearWeight:       1000,
+			ProGearWeightSpouse: 750,
+			CreatedAt:           time.Now(),
+			UpdatedAt:           time.Now(),
+		}
+
+		// TotalWeight needs to read from the internal weightAllotment, in this case 7000 lbs w/o dependents and
+		// 9000 lbs with dependents
+		entitlement.SetWeightAllotment(string(models.ServiceMemberRankE5))
+
+		payload := Entitlement(&entitlement)
+
+		assert.Equal(t, strfmt.UUID(entitlement.ID.String()), payload.ID)
+		assert.False(t, *payload.DependentsAuthorized)
+		assert.Equal(t, int64(2), payload.TotalDependents)
+		assert.True(t, *payload.NonTemporaryStorage)
+		assert.True(t, *payload.PrivatelyOwnedVehicle)
+		assert.Equal(t, int64(10000), *payload.AuthorizedWeight)
+		assert.Equal(t, int64(7000), payload.TotalWeight)
+		assert.Equal(t, int64(45), payload.StorageInTransit)
+		assert.Equal(t, int64(500), payload.RequiredMedicalEquipmentWeight)
+		assert.Equal(t, true, payload.OrganizationalClothingAndIndividualEquipment)
+		assert.Equal(t, int64(1000), payload.ProGearWeight)
+		assert.Equal(t, int64(750), payload.ProGearWeightSpouse)
+		assert.NotEmpty(t, payload.ETag)
+		assert.Equal(t, etag.GenerateEtag(entitlement.UpdatedAt), payload.ETag)
+	})
 }

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -69,3 +69,16 @@ func (e *Entitlement) AuthorizedWeight() *int {
 		return nil
 	}
 }
+
+// WeightAllowance will return the service member's weight allotment based on their rank and if dependents are
+// authorized
+func (e *Entitlement) WeightAllowance() *int {
+	if weightAllotment := e.WeightAllotment(); weightAllotment != nil {
+		if e.DependentsAuthorized != nil && *e.DependentsAuthorized {
+			return &weightAllotment.TotalWeightSelfPlusDependents
+		}
+		return &weightAllotment.TotalWeightSelf
+	}
+
+	return nil
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-9276) for this change

## Summary

The Prime API model to payload response code was always defaulting to using the self weight allowance value even when the entitlement/allowance had set dependents authorized to true.

The entitlements code is a little awkward because the weight allowance lookups depend on the rank/grade of the service member, which is stored as part of the orders model.  We don't actually store the weight allowance in the database, only the authorized weight/max billable weight that the TOO/TIO can use to raise the weight limit above the standard allowances.  If the authorized weight is not set it returns the value of the weight allowance (totalWeight) to the Prime API.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Populate the database and start the server

```sh
make db_dev_e2e_populate && make server_run
```

##### Terminal 2

Start the UI locally.

```sh
make office_client_run
```

### Additional steps

1. Open up Postman and import the prime.yaml collection if it doesn't exist already.  Make sure you are targeting against the local Prime API Development environment.
2. Choose the move-task-order/getMoveTaskOrder request and change the value of moveID under the params tab to **HGNTSR**
3. Send the request and find the entitlement block in the response.
4. Verify that the totalWeight value is 8000 with dependents authorized instead of the 5000 lbs when dependents are unauthorized.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

**Prime getMove request for #HGNTSR with dependents authorized:**

<img width="1126" alt="Screen Shot 2022-01-18 at 5 23 01 PM" src="https://user-images.githubusercontent.com/52669884/150028277-d63401ed-41e7-4e2c-a347-c3355cd174ca.png">

**Prime getMove request for #HGNTSR after changing dependents authorized to false as the TOO office user**

<img width="398" alt="Screen Shot 2022-01-18 at 5 28 16 PM" src="https://user-images.githubusercontent.com/52669884/150029872-0cc3e160-b40f-40c9-82ab-a72a72572f2e.png">

<img width="1122" alt="Screen Shot 2022-01-18 at 5 30 36 PM" src="https://user-images.githubusercontent.com/52669884/150029891-b94d22db-30fa-4593-8ad8-474c8f76bec2.png">

