### PR TITLE
MB-10437 Link edit accounting codes modal to edit link on shipment sidebar of move task order page

### DIFF
--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
@@ -6,7 +6,7 @@ import { Button } from '@trussworks/react-uswds';
 import styles from './AccountingCodesModal.module.scss';
 
 import AccountingCodeSection from 'components/Office/AccountingCodeSection/AccountingCodeSection';
-import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
+import Modal, { ModalActions, ModalClose, ModalTitle, connectModal } from 'components/Modal/Modal';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { Form } from 'components/form';
 import { shipmentTypes } from 'constants/shipments';
@@ -78,4 +78,4 @@ AccountingCodesModal.defaultProps = {
   sacType: '',
 };
 
-export default AccountingCodesModal;
+export default connectModal(AccountingCodesModal);

--- a/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
+++ b/src/components/Office/AccountingCodesModal/AccountingCodesModal.jsx
@@ -6,7 +6,6 @@ import { Button } from '@trussworks/react-uswds';
 import styles from './AccountingCodesModal.module.scss';
 
 import AccountingCodeSection from 'components/Office/AccountingCodeSection/AccountingCodeSection';
-import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import Modal, { ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { Form } from 'components/form';
@@ -17,49 +16,44 @@ const AccountingCodesModal = ({ onClose, onSubmit, onEditCodesClick, shipmentTyp
   const handleFormSubmit = (values) => onSubmit(values);
 
   return (
-    <div data-testid="AccountingCodesModal" className={styles.Container}>
-      <Overlay />
-      <ModalContainer>
-        <Modal>
-          <ModalClose handleClick={onClose} />
+    <Modal>
+      <ModalClose handleClick={onClose} />
 
-          <ModalTitle>
-            <ShipmentTag shipmentType={shipmentType} />
-            <h2 className={styles.Title}>Edit accounting codes</h2>
-          </ModalTitle>
+      <ModalTitle>
+        <ShipmentTag shipmentType={shipmentType} />
+        <h2 className={styles.Title}>Edit accounting codes</h2>
+      </ModalTitle>
 
-          <Formik initialValues={{ tacType, sacType }} onSubmit={handleFormSubmit}>
-            <Form>
-              <AccountingCodeSection
-                label="TAC"
-                emptyMessage="No TAC code entered."
-                fieldName="tacType"
-                shipmentTypes={TACs}
-              />
+      <Formik initialValues={{ tacType, sacType }} onSubmit={handleFormSubmit}>
+        <Form>
+          <AccountingCodeSection
+            label="TAC"
+            emptyMessage="No TAC code entered."
+            fieldName="tacType"
+            shipmentTypes={TACs}
+          />
 
-              <AccountingCodeSection
-                label="SAC (optional)"
-                emptyMessage="No SAC code entered."
-                fieldName="sacType"
-                shipmentTypes={SACs}
-              />
+          <AccountingCodeSection
+            label="SAC (optional)"
+            emptyMessage="No SAC code entered."
+            fieldName="sacType"
+            shipmentTypes={SACs}
+          />
 
-              <div>
-                <button type="button" onClick={onEditCodesClick} className={styles.EditCodes}>
-                  Add or edit codes
-                </button>
-              </div>
-              <ModalActions>
-                <Button type="submit">Save</Button>
-                <Button type="button" secondary onClick={onClose}>
-                  Cancel
-                </Button>
-              </ModalActions>
-            </Form>
-          </Formik>
-        </Modal>
-      </ModalContainer>
-    </div>
+          <div>
+            <button type="button" onClick={onEditCodesClick} className={styles.EditCodes}>
+              Add or edit codes
+            </button>
+          </div>
+          <ModalActions>
+            <Button type="submit">Save</Button>
+            <Button type="button" secondary onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalActions>
+        </Form>
+      </Formik>
+    </Modal>
   );
 };
 

--- a/src/components/Office/ShipmentDetails/ShipmentDetails.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.jsx
@@ -16,6 +16,7 @@ const ShipmentDetails = ({
   handleReviewSITExtension,
   handleSubmitSITExtension,
   handleEditFacilityInfo,
+  handleEditAccountingCodes,
 }) => {
   const { originDutyStation, destinationDutyStation, entitlement } = order;
   const ordersLOA = {
@@ -45,6 +46,7 @@ const ShipmentDetails = ({
         shipment={shipment}
         ordersLOA={ordersLOA}
         handleEditFacilityInfo={handleEditFacilityInfo}
+        handleEditAccountingCodes={handleEditAccountingCodes}
       />
     </div>
   );
@@ -58,6 +60,7 @@ ShipmentDetails.propTypes = {
   handleReviewSITExtension: PropTypes.func.isRequired,
   handleSubmitSITExtension: PropTypes.func.isRequired,
   handleEditFacilityInfo: PropTypes.func.isRequired,
+  handleEditAccountingCodes: PropTypes.func.isRequired,
 };
 
 export default ShipmentDetails;

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -25,6 +25,9 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAcco
     setIsEditFacilityInfoModalVisible(true);
   };
 
+  const handleShowAccountingCodesModal = () => {
+    setIsAccountingCodesModalVisible(true);
+  };
 
   return (
     <div className={className}>
@@ -121,9 +124,16 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAcco
           header={
             <>
               Accounting codes
-              <Link to="" className="usa-link float-right">
+              <Button
+                size="small"
+                type="button"
+                onClick={handleShowAccountingCodesModal}
+                className="float-right usa-link padding-right-0"
+                data-testid="edit-accounting-code-modal-open"
+                unstyled
+              >
                 Edit
-              </Link>
+              </Button>
             </>
           }
           border

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { generatePath } from 'react-router';
 import * as PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
@@ -11,8 +12,10 @@ import ConnectedEditFacilityInfoModal from 'components/Office/EditFacilityInfoMo
 import { retrieveSAC, retrieveTAC, formatAgent, formatAddress, formatAccountingCode } from 'utils/shipmentDisplay';
 import { ShipmentShape } from 'types/shipment';
 import { OrdersLOAShape } from 'types/order';
+import { tooRoutes } from 'constants/routes';
 
 const ShipmentDetailsSidebar = ({
+  history,
   className,
   shipment,
   ordersLOA,
@@ -22,6 +25,9 @@ const ShipmentDetailsSidebar = ({
   const { mtoAgents, secondaryAddresses, serviceOrderNumber, storageFacility, sacType, tacType } = shipment;
   const tac = retrieveTAC(shipment.tacType, ordersLOA);
   const sac = retrieveSAC(shipment.sacType, ordersLOA);
+
+  const moveCode = 'HGNTSR';
+  const editOrdersPath = generatePath(tooRoutes.ORDERS_EDIT_PATH, { moveCode });
 
   const [isEditFacilityInfoModalVisible, setIsEditFacilityInfoModalVisible] = useState(false);
   const [isAccountingCodesModalVisible, setIsAccountingCodesModalVisible] = useState(false);
@@ -174,6 +180,9 @@ const ShipmentDetailsSidebar = ({
 
 ShipmentDetailsSidebar.propTypes = {
   className: PropTypes.string,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }),
   shipment: ShipmentShape,
   ordersLOA: OrdersLOAShape,
   handleEditFacilityInfo: PropTypes.func.isRequired,
@@ -182,6 +191,9 @@ ShipmentDetailsSidebar.propTypes = {
 
 ShipmentDetailsSidebar.defaultProps = {
   className: '',
+  history: {
+    push: () => {},
+  },
   shipment: {},
   ordersLOA: {
     tac: '',

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -3,17 +3,22 @@ import { Link } from 'react-router-dom';
 import * as PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
-import styles from 'components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss';
 import ConnectedAccountingCodesModal from '../AccountingCodesModal/AccountingCodesModal';
 
+import styles from 'components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss';
 import SimpleSection from 'containers/SimpleSection/SimpleSection';
 import ConnectedEditFacilityInfoModal from 'components/Office/EditFacilityInfoModal/EditFacilityInfoModal';
 import { retrieveSAC, retrieveTAC, formatAgent, formatAddress, formatAccountingCode } from 'utils/shipmentDisplay';
 import { ShipmentShape } from 'types/shipment';
 import { OrdersLOAShape } from 'types/order';
 
-const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFacilityInfo }) => {
-const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAccountingCodes }) => {
+const ShipmentDetailsSidebar = ({
+  className,
+  shipment,
+  ordersLOA,
+  handleEditFacilityInfo,
+  handleEditAccountingCodes,
+}) => {
   const { mtoAgents, secondaryAddresses, serviceOrderNumber, storageFacility, sacType, tacType } = shipment;
   const tac = retrieveTAC(shipment.tacType, ordersLOA);
   const sac = retrieveSAC(shipment.sacType, ordersLOA);
@@ -45,29 +50,28 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAcco
         shipmentType={shipment.shipmentType}
       />
 
-    <div className={className}>
-        <ConnectedAccountingCodesModal
-          isOpen={isAccountingCodesModalVisible}
-          onSubmit={(accountingTypes) => {
-            handleEditAccountingCodes(accountingTypes, shipment);
-            setIsAccountingCodesModalVisible(false);
-          }}
-          onClose={() => {
-            setIsAccountingCodesModalVisible(false);
-          }}
-          onEditCodesClick={() => {}}
-          shipmentType={shipment.shipmentType}
-          TACs={{
-            HHG: ordersLOA.tac,
-            NTS: ordersLOA.ntsTac,
-          }}
-          SACs={{
-            HHG: ordersLOA.sac,
-            NTS: ordersLOA.ntsSac,
-          }}
-          tacType={shipment.tacType}
-          sacType={shipment.sacType}
-        />
+      <ConnectedAccountingCodesModal
+        isOpen={isAccountingCodesModalVisible}
+        onSubmit={(accountingTypes) => {
+          handleEditAccountingCodes(accountingTypes, shipment);
+          setIsAccountingCodesModalVisible(false);
+        }}
+        onClose={() => {
+          setIsAccountingCodesModalVisible(false);
+        }}
+        onEditCodesClick={() => history.push(editOrdersPath)}
+        shipmentType={shipment.shipmentType}
+        TACs={{
+          HHG: ordersLOA.tac,
+          NTS: ordersLOA.ntsTac,
+        }}
+        SACs={{
+          HHG: ordersLOA.sac,
+          NTS: ordersLOA.ntsSac,
+        }}
+        tacType={shipment.tacType}
+        sacType={shipment.sacType}
+      />
 
       {mtoAgents &&
         mtoAgents.map((agent) => (

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
 import styles from 'components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss';
-import AccountingCodesModal from '../AccountingCodesModal/AccountingCodesModal';
+import ConnectedAccountingCodesModal from '../AccountingCodesModal/AccountingCodesModal';
 
 import SimpleSection from 'containers/SimpleSection/SimpleSection';
 import ConnectedEditFacilityInfoModal from 'components/Office/EditFacilityInfoModal/EditFacilityInfoModal';
@@ -46,22 +46,28 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAcco
       />
 
     <div className={className}>
-      {isAccountingCodesModalVisible && (
-        <AccountingCodesModal
-          onSubmit={(e) => {
-            handleEditAccountingCodes(e, shipment);
+        <ConnectedAccountingCodesModal
+          isOpen={isAccountingCodesModalVisible}
+          onSubmit={(accountingTypes) => {
+            handleEditAccountingCodes(accountingTypes, shipment);
             setIsAccountingCodesModalVisible(false);
           }}
           onClose={() => {
             setIsAccountingCodesModalVisible(false);
           }}
           onEditCodesClick={() => {}}
-          TACs={tac}
-          SACs={sac}
+          shipmentType={shipment.shipmentType}
+          TACs={{
+            HHG: ordersLOA.tac,
+            NTS: ordersLOA.ntsTac,
+          }}
+          SACs={{
+            HHG: ordersLOA.sac,
+            NTS: ordersLOA.ntsSac,
+          }}
           tacType={shipment.tacType}
           sacType={shipment.sacType}
         />
-      )}
 
       {mtoAgents &&
         mtoAgents.map((agent) => (

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -4,6 +4,8 @@ import * as PropTypes from 'prop-types';
 import { Button } from '@trussworks/react-uswds';
 
 import styles from 'components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss';
+import AccountingCodesModal from '../AccountingCodesModal/AccountingCodesModal';
+
 import SimpleSection from 'containers/SimpleSection/SimpleSection';
 import ConnectedEditFacilityInfoModal from 'components/Office/EditFacilityInfoModal/EditFacilityInfoModal';
 import { retrieveSAC, retrieveTAC, formatAgent, formatAddress, formatAccountingCode } from 'utils/shipmentDisplay';
@@ -11,15 +13,18 @@ import { ShipmentShape } from 'types/shipment';
 import { OrdersLOAShape } from 'types/order';
 
 const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFacilityInfo }) => {
+const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditAccountingCodes }) => {
   const { mtoAgents, secondaryAddresses, serviceOrderNumber, storageFacility, sacType, tacType } = shipment;
   const tac = retrieveTAC(shipment.tacType, ordersLOA);
   const sac = retrieveSAC(shipment.sacType, ordersLOA);
 
   const [isEditFacilityInfoModalVisible, setIsEditFacilityInfoModalVisible] = useState(false);
+  const [isAccountingCodesModalVisible, setIsAccountingCodesModalVisible] = useState(false);
 
   const handleShowEditFacilityInfoModal = () => {
     setIsEditFacilityInfoModalVisible(true);
   };
+
 
   return (
     <div className={className}>
@@ -36,6 +41,24 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFaci
         serviceOrderNumber={shipment.serviceOrderNumber}
         shipmentType={shipment.shipmentType}
       />
+
+    <div className={className}>
+      {isAccountingCodesModalVisible && (
+        <AccountingCodesModal
+          onSubmit={(e) => {
+            handleEditAccountingCodes(e, shipment);
+            setIsAccountingCodesModalVisible(false);
+          }}
+          onClose={() => {
+            setIsAccountingCodesModalVisible(false);
+          }}
+          onEditCodesClick={() => {}}
+          TACs={tac}
+          SACs={sac}
+          tacType={shipment.tacType}
+          sacType={shipment.sacType}
+        />
+      )}
 
       {mtoAgents &&
         mtoAgents.map((agent) => (
@@ -134,6 +157,7 @@ ShipmentDetailsSidebar.propTypes = {
   shipment: ShipmentShape,
   ordersLOA: OrdersLOAShape,
   handleEditFacilityInfo: PropTypes.func.isRequired,
+  handleEditAccountingCodes: PropTypes.func.isRequired,
 };
 
 ShipmentDetailsSidebar.defaultProps = {

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -210,7 +210,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
     },
   });
 
-  const [mutateOrders] = useMutation(updateBillableWeight, {
+  const [mutateOrderBillableWeight] = useMutation(updateBillableWeight, {
     onSuccess: (data, variables) => {
       queryCache.invalidateQueries([MOVES, move.locator]);
       const updatedOrder = data.orders[variables.orderID];
@@ -417,7 +417,11 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   };
 
   const handleUpdateBillableWeight = (maxBillableWeight) => {
-    mutateOrders({ orderID: order.id, ifMatchETag: order.eTag, body: { authorizedWeight: maxBillableWeight } });
+    mutateOrderBillableWeight({
+      orderID: order.id,
+      ifMatchETag: order.eTag,
+      body: { authorizedWeight: maxBillableWeight },
+    });
   };
 
   const handleAcknowledgeExcessWeightRisk = () => {

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -380,6 +380,16 @@ export const MoveTaskOrder = ({ match, ...props }) => {
     });
   };
 
+  const handleEditAccountingCodes = (fields, shipment) => {
+    const body = { tacType: null, sacType: null, ...fields };
+    mutateMTOShipment({
+      moveTaskOrderID: shipment.moveTaskOrderID,
+      shipmentID: shipment.id,
+      ifMatchETag: shipment.eTag,
+      body,
+    });
+  };
+
   const handleUpdateMTOShipmentStatus = (moveTaskOrderID, mtoShipmentID, eTag) => {
     mutateMTOShipmentStatus({
       shipmentID: mtoShipmentID,
@@ -747,6 +757,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
                   handleReviewSITExtension={handleReviewSITExtension}
                   handleSubmitSITExtension={handleSubmitSITExtension}
                   handleEditFacilityInfo={handleEditFacilityInfo}
+                  handleEditAccountingCodes={handleEditAccountingCodes}
                 />
                 {requestedServiceItems?.length > 0 && (
                   <RequestedServiceItemsTable


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10437) for this change

## Summary

This patch must be merged after #8038 because these two PRs edit the same files due to the proximity of the components. The work in this patch series will have conflicts that need to be resolved after #8038 is merged into the default branch.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

##### Terminal 3

Run the populate the development database with E2E Data 

```sh
make db_dev_e2e_populate
```

</details>

### Additional steps

Perform a local login as a TXO and search for the move code `HGNTSR`. This Move should contain at least one NTS shipments, _if it doesn't then look for another_. Then click on the **Move Task Order** tab and go down to **Accounting codes** on the right hand-side of the **Non-temporary storage** section towards the bottom of the page. Then click the **Edit** button to open the modal. Edit the TAC/SAC codes and then save the to close the modal. Once closed, the modal should disappear and the **Accounting codes** section will be updated with the codes that were modified in the previous step.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [x] User facing changes have been reviewed by design.
- [x] There are no aXe warnings for UI.
- [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [x] There are no new console errors in the browser devtools
- [x] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
