### PR TITLE
MB-10883 enable services counselors to edit destination type for shipments

### DIFF
--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -19,6 +19,8 @@ describe('Services counselor user', () => {
       'patchServiceCounselingCompleted',
     );
     cy.intercept('**/ghc/v1/moves/**/financial-review-flag').as('financialReviewFlagCompleted');
+    cy.intercept('POST', '**/ghc/v1/mto-shipments').as('createShipment');
+    cy.intercept('PATCH', '**/ghc/v1/move_task_orders/**/mto_shipments/**').as('patchShipment');
 
     const userId = 'a6c8663f-998f-4626-a978-ad60da2476ec';
     cy.apiSignInAsUser(userId, ServicesCounselorOfficeUserType);
@@ -108,5 +110,52 @@ describe('Services counselor user', () => {
 
     // Verify sucess alert and tag
     cy.contains('Move unflagged for financial review.');
+  });
+
+  it('is able to add a shipment', () => {
+    cy.wait(['@getSortedMoves']);
+    // It doesn't matter which move we click on in the queue.
+    cy.get('td').first().click();
+    cy.url().should('include', `details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    // add a shipment
+    cy.get('[data-testid="dropdown"]').first().select('HHG');
+    cy.get('#requestedPickupDate').clear().type('16 Mar 2022').blur();
+    cy.get('[data-testid="useCurrentResidence"]').click({ force: true });
+    cy.get('#requestedDeliveryDate').clear().type('16 Mar 2022').blur();
+    cy.get('#has-delivery-address').click({ force: true });
+    cy.get('input[name="delivery.address.streetAddress1"]').type('7 q st');
+    cy.get('input[name="delivery.address.city"]').type('city');
+    cy.get('select[name="delivery.address.state"]').select('OH');
+    cy.get('input[name="delivery.address.postalCode"]').type('90210');
+    cy.get('select[name="destinationAddressType"]').select('Home of record');
+    cy.get('[data-testid="submitForm"]').click();
+    // the shipment should be saved with the type
+    cy.wait('@createShipment');
+  });
+
+  it('is able to edit a shipment', () => {
+    cy.wait(['@getSortedMoves']);
+    // It doesn't matter which move we click on in the queue.
+    cy.get('td').first().click();
+    cy.url().should('include', `details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    // add a shipment
+    cy.get('[data-testid="ShipmentContainer"] .usa-button').first().click();
+    cy.get('#requestedPickupDate').clear().type('16 Mar 2022').blur();
+    cy.get('[data-testid="useCurrentResidence"]').click({ force: true });
+    cy.get('#requestedDeliveryDate').clear().type('16 Mar 2022').blur();
+    cy.get('#has-delivery-address').click({ force: true });
+    cy.get('input[name="delivery.address.streetAddress1"]').clear().type('7 q st');
+    cy.get('input[name="delivery.address.city"]').clear().type('city');
+    cy.get('select[name="delivery.address.state"]').select('OH');
+    cy.get('input[name="delivery.address.postalCode"]').clear().type('90210');
+    cy.get('select[name="destinationAddressType"]').select('Home of selection');
+    cy.get('[data-testid="submitForm"]').click();
+    // the shipment should be saved with the type
+    cy.wait('@patchShipment');
+    cy.get('.usa-alert__text').contains('Your changes were saved.');
   });
 });

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -769,7 +769,7 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 			if queueIncludeShipmentStatus(shipment.Status) {
 				if earliestRequestedPickup == nil {
 					earliestRequestedPickup = shipment.RequestedPickupDate
-				} else if shipment.RequestedPickupDate.Before(*earliestRequestedPickup) {
+				} else if shipment.RequestedPickupDate != nil && shipment.RequestedPickupDate.Before(*earliestRequestedPickup) {
 					earliestRequestedPickup = shipment.RequestedPickupDate
 				}
 				validMTOShipments = append(validMTOShipments, shipment)

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -416,7 +416,12 @@ const ShipmentForm = ({
                 )}
 
                 <div className={`${formStyles.formActions} ${styles.buttonGroup}`}>
-                  <Button disabled={isSubmitting || !isValid} type="submit" onClick={handleSubmit}>
+                  <Button
+                    data-testid="submitForm"
+                    disabled={isSubmitting || !isValid}
+                    type="submit"
+                    onClick={handleSubmit}
+                  >
                     Save
                   </Button>
                   <Button

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -16,14 +16,16 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import { Form } from 'components/form/Form';
 import ShipmentAccountingCodes from 'components/Office/ShipmentAccountingCodes/ShipmentAccountingCodes';
 import ShipmentWeightInput from 'components/Office/ShipmentWeightInput/ShipmentWeightInput';
-import { DatePickerInput } from 'components/form/fields';
+import { DatePickerInput, DropdownInput } from 'components/form/fields';
 import { AddressFields } from 'components/form/AddressFields/AddressFields';
 import { ContactInfoFields } from 'components/form/ContactInfoFields/ContactInfoFields';
 import StorageFacilityInfo from 'components/Office/StorageFacilityInfo/StorageFacilityInfo';
 import StorageFacilityAddress from 'components/Office/StorageFacilityAddress/StorageFacilityAddress';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { servicesCounselingRoutes, tooRoutes } from 'constants/routes';
-import { formatWeight } from 'shared/formatters';
+import { dropdownInputOptions, formatWeight } from 'shared/formatters';
+import { ORDERS_TYPE } from 'constants/orders';
+import { shipmentDestinationAddressTypes } from 'constants/shipments';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { AddressShape, SimpleAddressShape } from 'types/address';
 import { HhgShipmentShape, MtoShipmentShape } from 'types/customerShapes';
@@ -52,6 +54,7 @@ const ShipmentForm = ({
   TACs,
   SACs,
   userRole,
+  orderType,
 }) => {
   const [errorMessage, setErrorMessage] = useState(null);
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
@@ -105,6 +108,9 @@ const ShipmentForm = ({
   const isTOO = userRole === roleTypes.TOO;
   const isServiceCounselor = userRole === roleTypes.SERVICES_COUNSELOR;
 
+  const isRetirementOrSeparation = orderType === ORDERS_TYPE.RETIREMENT || orderType === ORDERS_TYPE.SEPARATION;
+  const shipmentDestinationAddressOptions = dropdownInputOptions(shipmentDestinationAddressTypes);
+
   const shipmentNumber = shipmentType === SHIPMENT_OPTIONS.HHG ? getShipmentNumber() : null;
   const initialValues = formatMtoShipmentForDisplay(
     isCreatePage ? { userRole } : { userRole, agents: mtoShipment.mtoAgents, ...mtoShipment },
@@ -131,6 +137,7 @@ const ShipmentForm = ({
     serviceOrderNumber,
     storageFacility,
     usesExternalVendor,
+    destinationAddressType,
   }) => {
     const deliveryDetails = delivery;
     if (hasDeliveryAddress === 'no') {
@@ -150,6 +157,7 @@ const ShipmentForm = ({
       serviceOrderNumber,
       storageFacility,
       usesExternalVendor,
+      destinationAddressType,
     });
 
     const updateMTOShipmentPayload = {
@@ -361,10 +369,19 @@ const ShipmentForm = ({
                           </div>
                         </FormGroup>
                         {hasDeliveryAddress === 'yes' ? (
-                          <AddressFields name="delivery.address" render={(fields) => <>{fields}</>} />
+                          <>
+                            <AddressFields name="delivery.address" render={(fields) => <>{fields}</>} />
+                            <DropdownInput
+                              label="Destination type"
+                              name="destinationAddressType"
+                              options={shipmentDestinationAddressOptions}
+                              id="destinationAddressType"
+                            />
+                          </>
                         ) : (
                           <p>
-                            We can use the zip of their new duty location:
+                            We can use the zip of their{' '}
+                            {isRetirementOrSeparation ? 'HOR, HOS or PLEAD:' : 'new duty location:'}
                             <br />
                             <strong>
                               {newDutyStationAddress.city}, {newDutyStationAddress.state}{' '}
@@ -443,6 +460,7 @@ ShipmentForm.propTypes = {
   TACs: AccountingCodesShape,
   SACs: AccountingCodesShape,
   userRole: oneOf(officeRoles).isRequired,
+  orderType: oneOf(ORDERS_TYPE).isRequired,
 };
 
 ShipmentForm.defaultProps = {

--- a/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
@@ -76,6 +76,21 @@ const mockMtoShipment = {
   ],
 };
 
+const mockShipmentWithDestinationType = {
+  ...mockMtoShipment,
+  destinationAddressType: 'HOME_OF_SELECTION',
+};
+
+const defaultPropsRetirement = {
+  ...defaultProps,
+  orderType: 'RETIREMENT',
+};
+
+const defaultPropsSeparation = {
+  ...defaultProps,
+  orderType: 'SEPARATION',
+};
+
 describe('ShipmentForm component', () => {
   describe('when creating a new shipment', () => {
     it('does not show the delete shipment button', async () => {
@@ -165,6 +180,18 @@ describe('ShipmentForm component', () => {
       expect(screen.getAllByLabelText('ZIP')[1]).toHaveAttribute('name', 'delivery.address.postalCode');
     });
 
+    it('renders a delivery address type for retirement orders type', async () => {
+      render(<ShipmentForm {...defaultPropsRetirement} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
+      userEvent.click(screen.getByLabelText('Yes'));
+      expect(screen.getAllByLabelText('Destination type')[0]).toHaveAttribute('name', 'destinationAddressType');
+    });
+
+    it('renders a delivery address type for separation orders type', async () => {
+      render(<ShipmentForm {...defaultPropsSeparation} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
+      userEvent.click(screen.getByLabelText('Yes'));
+      expect(screen.getAllByLabelText('Destination type')[0]).toHaveAttribute('name', 'destinationAddressType');
+    });
+
     it('does not render an Accounting Codes section', async () => {
       render(<ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} />);
 
@@ -218,6 +245,46 @@ describe('ShipmentForm component', () => {
       expect(screen.getByText('Customer remarks')).toBeTruthy();
       expect(screen.getByText('mock customer remarks')).toBeTruthy();
       expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');
+    });
+  });
+
+  describe('editing an already existing HHG shipment for retiree/separatee', () => {
+    it('renders the HHG shipment form with pre-filled values', async () => {
+      render(
+        <ShipmentForm
+          {...defaultPropsRetirement}
+          isCreatePage={false}
+          selectedMoveType={SHIPMENT_OPTIONS.HHG}
+          mtoShipment={mockShipmentWithDestinationType}
+        />,
+      );
+
+      expect(await screen.findByLabelText('Requested pickup date')).toHaveValue('01 Mar 2020');
+      expect(screen.getByLabelText('Use current address')).not.toBeChecked();
+      expect(screen.getAllByLabelText('Address 1')[0]).toHaveValue('812 S 129th St');
+      expect(screen.getAllByLabelText(/Address 2/)[0]).toHaveValue('');
+      expect(screen.getAllByLabelText('City')[0]).toHaveValue('San Antonio');
+      expect(screen.getAllByLabelText('State')[0]).toHaveValue('TX');
+      expect(screen.getAllByLabelText('ZIP')[0]).toHaveValue('78234');
+      expect(screen.getAllByLabelText('First name')[0]).toHaveValue('Jason');
+      expect(screen.getAllByLabelText('Last name')[0]).toHaveValue('Ash');
+      expect(screen.getAllByLabelText('Phone')[0]).toHaveValue('999-999-9999');
+      expect(screen.getAllByLabelText('Email')[0]).toHaveValue('jasn@email.com');
+      expect(screen.getByLabelText('Requested delivery date')).toHaveValue('30 Mar 2020');
+      expect(screen.getByLabelText('Yes')).toBeChecked();
+      expect(screen.getAllByLabelText('Address 1')[1]).toHaveValue('441 SW Rio de la Plata Drive');
+      expect(screen.getAllByLabelText(/Address 2/)[1]).toHaveValue('');
+      expect(screen.getAllByLabelText('City')[1]).toHaveValue('Tacoma');
+      expect(screen.getAllByLabelText('State')[1]).toHaveValue('WA');
+      expect(screen.getAllByLabelText('ZIP')[1]).toHaveValue('98421');
+      expect(screen.getAllByLabelText('First name')[1]).toHaveValue('Riley');
+      expect(screen.getAllByLabelText('Last name')[1]).toHaveValue('Baker');
+      expect(screen.getAllByLabelText('Phone')[1]).toHaveValue('863-555-9664');
+      expect(screen.getAllByLabelText('Email')[1]).toHaveValue('rbaker@email.com');
+      expect(screen.getByText('Customer remarks')).toBeTruthy();
+      expect(screen.getByText('mock customer remarks')).toBeTruthy();
+      expect(screen.getByLabelText('Counselor remarks')).toHaveValue('mock counselor remarks');
+      expect(screen.getByLabelText('Destination type')).toHaveValue('HOME_OF_SELECTION');
     });
   });
 

--- a/src/constants/shipments.js
+++ b/src/constants/shipments.js
@@ -34,4 +34,11 @@ export const shipmentStatuses = {
   DIVERSION_REQUESTED: 'DIVERSION_REQUESTED',
 };
 
+export const shipmentDestinationAddressTypes = {
+  HOME_OF_RECORD: 'Home of record',
+  HOME_OF_SELECTION: 'Home of selection',
+  PLACE_ENTERED_ACTIVE_DUTY: 'Place entered active duty',
+  OTHER_THAN_AUTHORIZED: 'Other than authorized',
+};
+
 export const LONGHAUL_MIN_DISTANCE = 50;

--- a/src/pages/Office/EditShipmentDetails/EditShipmentDetails.jsx
+++ b/src/pages/Office/EditShipmentDetails/EditShipmentDetails.jsx
@@ -69,6 +69,7 @@ const EditShipmentDetails = ({ match }) => {
                   TACs={TACs}
                   SACs={SACs}
                   userRole={roleTypes.TOO}
+                  orderType={order.order_type}
                 />
               </Grid>
             </Grid>

--- a/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.jsx
+++ b/src/pages/Office/ServicesCounselingAddShipment/ServicesCounselingAddShipment.jsx
@@ -72,6 +72,7 @@ const ServicesCounselingAddShipment = ({ match }) => {
                   TACs={TACs}
                   SACs={SACs}
                   userRole={roleTypes.SERVICES_COUNSELOR}
+                  orderType={order.order_type}
                 />
               </Grid>
             </Grid>

--- a/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.jsx
+++ b/src/pages/Office/ServicesCounselingEditShipmentDetails/ServicesCounselingEditShipmentDetails.jsx
@@ -77,6 +77,7 @@ const ServicesCounselingEditShipmentDetails = ({ match, onUpdate }) => {
                   TACs={TACs}
                   SACs={SACs}
                   userRole={roleTypes.SERVICES_COUNSELOR}
+                  orderType={order.order_type}
                 />
               </Grid>
             </Grid>

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -257,9 +257,11 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert }) => {
               className={scMoveDetailsStyles.noPaddingBottom}
               editButton={
                 counselorCanEdit && (
-                  <ButtonDropdown onChange={handleButtonDropdownChange}>
+                  <ButtonDropdown data-testid="addShipmentButton" onChange={handleButtonDropdownChange}>
                     <option value="">Add a new shipment</option>
-                    <option value={SHIPMENT_OPTIONS_URL.HHG}>HHG</option>
+                    <option test-dataid="hhgOption" value={SHIPMENT_OPTIONS_URL.HHG}>
+                      HHG
+                    </option>
                     <option value={SHIPMENT_OPTIONS_URL.NTS}>NTS</option>
                     <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
                   </ButtonDropdown>

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -104,6 +104,7 @@ export function formatMtoShipmentForDisplay({
   storageFacility,
   usesExternalVendor,
   userRole,
+  destinationAddressType,
 }) {
   const displayValues = {
     shipmentType,
@@ -172,6 +173,10 @@ export function formatMtoShipmentForDisplay({
     displayValues.hasDeliveryAddress = 'yes';
   }
 
+  if (destinationAddressType) {
+    displayValues.destinationAddressType = destinationAddressType;
+  }
+
   if (secondaryDeliveryAddress) {
     displayValues.secondaryDelivery.address = { ...emptyAddressShape, ...secondaryDeliveryAddress };
     displayValues.hasSecondaryDelivery = 'yes';
@@ -218,6 +223,7 @@ export function formatMtoShipmentForAPI({
   serviceOrderNumber,
   storageFacility,
   usesExternalVendor,
+  destinationAddressType,
 }) {
   const formattedMtoShipment = {
     moveTaskOrderID: moveId,
@@ -225,6 +231,7 @@ export function formatMtoShipmentForAPI({
     customerRemarks,
     counselorRemarks,
     agents: [],
+    destinationAddressType,
   };
 
   if (pickup?.requestedDate && pickup.requestedDate !== '') {
@@ -244,6 +251,10 @@ export function formatMtoShipmentForAPI({
 
     if (delivery.address) {
       formattedMtoShipment.destinationAddress = formatAddressForAPI(delivery.address);
+    }
+
+    if (destinationAddressType) {
+      formattedMtoShipment.destinationAddressType = destinationAddressType;
     }
 
     if (delivery.agent) {

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2551,11 +2551,11 @@ definitions:
       date_issued:
         type: string
         format: date
-        example: 2020-01-01
+        example: '2020-01-01'
       report_by_date:
         type: string
         format: date
-        example: 2020-01-01
+        example: '2020-01-01'
       department_indicator:
         $ref: '#/definitions/DeptIndicator'
         x-nullable: true
@@ -2599,13 +2599,13 @@ definitions:
         type: string
         description: The date and time that these orders were cut.
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Orders date
       reportByDate:
         type: string
         description: Report By Date
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Report-by date
       ordersType:
         $ref: '#/definitions/OrdersType'
@@ -2654,13 +2654,13 @@ definitions:
         type: string
         description: The date and time that these orders were cut.
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Orders date
       reportByDate:
         type: string
         description: Report By Date
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Report-by date
       ordersType:
         $ref: '#/definitions/OrdersType'
@@ -3785,7 +3785,7 @@ definitions:
       firstAvailableDeliveryDate:
         format: date
         type: string
-        example: 2020-12-31
+        example: '2020-12-31'
         description: First available date that Prime can deliver SIT service item.
   MTOServiceItemCustomerContacts:
     type: array

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -52,7 +52,7 @@ definitions:
         $ref: '#/definitions/TShirtSize'
       original_move_date:
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: When do you plan to move?
         x-nullable: true
@@ -136,12 +136,12 @@ definitions:
       original_move_date:
         type: string
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: When do you plan to move?
         x-nullable: true
       actual_move_date:
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: When did you actually move?
         x-nullable: true
@@ -230,13 +230,13 @@ definitions:
         $ref: '#/definitions/TShirtSize'
       original_move_date:
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: When do you plan to move?
         x-nullable: true
       actual_move_date:
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: When did you actually move?
         x-nullable: true
@@ -341,11 +341,11 @@ definitions:
         type: string
         format: date
         title: When do you plan to move?
-        example: 2018-04-26
+        example: '2018-04-26'
         x-nullable: true
       actual_move_date:
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: When did you actually move?
         x-nullable: true
@@ -353,13 +353,13 @@ definitions:
         type: string
         format: date-time
         title: When was the ppm move submitted?
-        example: 2019-03-26T13:19:56-04:00
+        example: '2019-03-26T13:19:56-04:00'
         x-nullable: true
       approve_date:
         type: string
         format: date-time
         title: When was the ppm move approved?
-        example: 2019-03-26T13:19:56-04:00
+        example: '2019-03-26T13:19:56-04:00'
         x-nullable: true
       pickup_postal_code:
         type: string
@@ -493,7 +493,7 @@ definitions:
         type: string
         format: date-time
         title: When was the ppm move submitted?
-        example: 2019-03-26T13:19:56-04:00
+        example: '2019-03-26T13:19:56-04:00'
     required:
       - submit_date
   PPMSitEstimate:
@@ -567,7 +567,7 @@ definitions:
         type: string
         format: date-time
         title: When was the ppm move approved?
-        example: 2019-03-26T13:19:56-04:00
+        example: '2019-03-26T13:19:56-04:00'
     required:
       - approve_date
   IndexPersonallyProcuredMovePayload:
@@ -766,7 +766,7 @@ definitions:
       weight_ticket_date:
         title: Weight ticket date
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         x-nullable: true
       trailer_ownership_missing:
@@ -777,13 +777,13 @@ definitions:
         type: string
         format: date
         title: Start date of storage for storage expenses
-        example: 2018-04-26
+        example: '2018-04-26'
         x-nullable: true
       storage_end_date:
         type: string
         format: date
         title: End date of storage for storage expenses
-        example: 2018-04-26
+        example: '2018-04-26'
         x-nullable: true
     required:
       - id
@@ -886,13 +886,13 @@ definitions:
         type: string
         format: date
         title: Start date of storage for storage expenses
-        example: 2018-04-26
+        example: '2018-04-26'
         x-nullable: true
       storage_end_date:
         type: string
         format: date
         title: End date of storage for storage expenses
-        example: 2018-04-26
+        example: '2018-04-26'
         x-nullable: true
     required:
       - title
@@ -980,7 +980,7 @@ definitions:
       weight_ticket_date:
         title: Full Weight Ticket Date
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         x-nullable: true
       trailer_ownership_missing:
@@ -1696,7 +1696,7 @@ definitions:
       requested_date:
         x-nullable: true
         type: string
-        example: 2018-04-26
+        example: '2018-04-26'
         format: date
         title: Requested Date
     required:
@@ -1819,13 +1819,13 @@ definitions:
         type: string
         description: The date and time that these orders were cut.
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Date issued
       report_by_date:
         type: string
         description: Report By Date
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Report by
       status:
         $ref: '#/definitions/OrdersStatus'
@@ -1906,13 +1906,13 @@ definitions:
         type: string
         description: The date and time that these orders were cut.
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Orders date
       report_by_date:
         type: string
         description: Report By Date
         format: date
-        example: 2018-04-26
+        example: '2018-04-26'
         title: Report-by date
       orders_type:
         $ref: '#/definitions/OrdersType'
@@ -2013,17 +2013,17 @@ definitions:
       move_date:
         type: string
         format: date
-        example: 2018-04-25
+        example: '2018-04-25'
         x-nullable: true
       submitted_date:
         type: string
         format: date-time
-        example: 2018-04-25
+        example: '2018-04-25'
         x-nullable: true
       last_modified_date:
         type: string
         format: date-time
-        example: 2017-07-21T17:32:28Z
+        example: '2017-07-21T17:32:28Z'
       created_at:
         type: string
         format: date-time
@@ -2040,7 +2040,7 @@ definitions:
       pm_survey_conducted_date:
         type: string
         format: date-time
-        example: 2017-07-21T17:32:28Z
+        example: '2017-07-21T17:32:28Z'
         x-nullable: true
       origin_gbloc:
         type: string
@@ -2055,12 +2055,12 @@ definitions:
       delivered_date:
         type: string
         format: date-time
-        example: 2017-07-21T17:32:28Z
+        example: '2017-07-21T17:32:28Z'
         x-nullable: true
       invoice_approved_date:
         type: string
         format: date-time
-        example: 2017-07-21T17:32:28Z
+        example: '2017-07-21T17:32:28Z'
         x-nullable: true
       weight_allotment:
         $ref: '#/definitions/WeightAllotment'
@@ -2069,12 +2069,12 @@ definitions:
       actual_move_date:
         type: string
         format: date
-        example: 2018-04-25
+        example: '2018-04-25'
         x-nullable: true
       original_move_date:
         type: string
         format: date
-        example: 2018-04-25
+        example: '2018-04-25'
         x-nullable: true
     required:
       - id
@@ -2100,37 +2100,37 @@ definitions:
       move_date:
         type: string
         format: date
-        example: 2018-09-25
+        example: '2018-09-25'
       pack:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
       pickup:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
       transit:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
       delivery:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
       report:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
     required:
       - id
       - move_id
@@ -2146,13 +2146,13 @@ definitions:
       start_date:
         type: string
         format: date
-        example: 2018-09-25
+        example: '2018-09-25'
       available:
         type: array
         items:
           type: string
           format: date
-          example: 2018-09-25
+          example: '2018-09-25'
     required:
       - start_date
       - available
@@ -2227,7 +2227,7 @@ definitions:
       claimed_at:
         type: string
         format: date-time
-        example: 2018-04-12T23:20:50.52Z
+        example: '2018-04-12T23:20:50.52Z'
         description: when the access code was claimed or used
         x-nullable: true
     required:


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10883) for this change

## Summary

It adds the destination address type field to the add and edit forms for MTOShipments. Also adds in e2e test coverage for both actions.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as a services counselor
2. Edit or add a shipment
3. Select 'yes' for knowing the destination address
4. Select a type and fill out the address
5. Save the thing -- you won't yet see it on the ShipmentDisplay component, that's being done in another task/PR.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
