### PR TITLE
MB-9872: Refactor to standardize weight allowance

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -211,8 +211,8 @@ class MtoShipmentForm extends Component {
                     <Alert type="info" noIcon>
                       Remember: You can move{' '}
                       {orders.has_dependents
-                        ? formatWeight(serviceMember.weight_allotment.total_weight_self_plus_dependents)
-                        : formatWeight(serviceMember.weight_allotment.total_weight_self)}{' '}
+                        ? formatWeight(serviceMember.weight_allotment?.total_weight_self_plus_dependents)
+                        : formatWeight(serviceMember.weight_allotment?.total_weight_self)}{' '}
                       total. You’ll be billed for any excess weight you move.
                     </Alert>
 

--- a/src/pages/MyMove/MovingInfo.jsx
+++ b/src/pages/MyMove/MovingInfo.jsx
@@ -12,7 +12,7 @@ import ScrollToTop from 'components/ScrollToTop';
 import WizardNavigation from 'components/Customer/WizardNavigation/WizardNavigation';
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { fetchLatestOrders as fetchLatestOrdersAction } from 'shared/Entities/modules/orders';
-import { formatWeight } from 'shared/formatters';
+import { formatWeight } from 'utils/formatters';
 import { selectCurrentOrders, selectServiceMemberFromLoggedInUser } from 'store/entities/selectors';
 import { RouteProps } from 'types/router';
 
@@ -54,14 +54,12 @@ export class MovingInfo extends Component {
           <Grid col desktop={{ col: 8, offset: 2 }}>
             <h1 className={styles.ShipmentsHeader}>Things to know about selecting shipments</h1>
             <SectionWrapper className={styles.Wrapper}>
-              {entitlementWeight !== 0 && (
-                <IconSection
-                  icon="weight-hanging"
-                  headline={`You can move ${formatWeight(entitlementWeight)} in this move.`}
-                >
-                  <p>You&apos;ll have to pay for any excess weight the government moves.</p>
-                </IconSection>
-              )}
+              <IconSection
+                icon="weight-hanging"
+                headline={`You can move ${formatWeight(entitlementWeight)} in this move.`}
+              >
+                <p>You&apos;ll have to pay for any excess weight the government moves.</p>
+              </IconSection>
               <IconSection icon="pencil-alt" headline="You don't need to get the details perfect.">
                 <p>
                   After you submit this information, you&apos;ll talk to a move counselor. They will verify your choices
@@ -126,8 +124,10 @@ MovingInfo.defaultProps = {
 
 function mapStateToProps(state) {
   const orders = selectCurrentOrders(state);
-  const entitlementWeight = orders.authorizedWeight;
   const serviceMember = selectServiceMemberFromLoggedInUser(state);
+  const entitlementWeight = orders.has_dependents
+    ? serviceMember?.weight_allotment?.total_weight_self_plus_dependents
+    : serviceMember?.weight_allotment?.total_weight_self;
   const serviceMemberId = serviceMember?.id;
 
   return {

--- a/src/pages/MyMove/MovingInfo.test.jsx
+++ b/src/pages/MyMove/MovingInfo.test.jsx
@@ -25,13 +25,4 @@ describe('MovingInfo component', () => {
     expect(screen.getByRole('heading', { name: /7,000 lbs/ })).toBeInTheDocument();
     expect(screen.getAllByRole('heading').length).toBe(6);
   });
-
-  it('renders with no errors when entitlement weight is 0', () => {
-    render(<MovingInfo {...testProps} entitlementWeight={0} />);
-
-    expect(
-      screen.getByRole('heading', { level: 1, name: 'Things to know about selecting shipments' }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByRole('heading').length).toBe(5);
-  });
 });

--- a/src/pages/MyMove/MovingInfo.test.jsx
+++ b/src/pages/MyMove/MovingInfo.test.jsx
@@ -25,4 +25,14 @@ describe('MovingInfo component', () => {
     expect(screen.getByRole('heading', { name: /7,000 lbs/ })).toBeInTheDocument();
     expect(screen.getAllByRole('heading').length).toBe(6);
   });
+
+  it('renders with no errors when entitlement weight is 0', () => {
+    render(<MovingInfo {...testProps} entitlementWeight={0} />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Things to know about selecting shipments' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /0 lbs/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('heading').length).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary

Remove the usage of orders.authorizedWeight in favor of using orders.has_dependents. This was done because the TOO can modify the authorizedWeight allowances.

## Verification Steps for Reviewers

Log into the customer application and see if you see the correct weight on the page shown on the screenshot below (the setup shipment step).

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Screenshots
![image](https://user-images.githubusercontent.com/84742904/151068285-4129efc3-8f53-4d86-8395-58a896a8cd52.png)
