### PR TITLE
MB-11245 Remove CAC access for carterjones, monfresh, ronolibert, and shkeating

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -696,3 +696,4 @@
 20220107193037_add_destination_address_type_to_shipments.up.sql
 20220112013152_update_duty_locations.up.sql
 20220113172826_create_new_duty_locations.up.sql
+20220126235958_remove_cac_access_carterjones_monfresh_ronolibert_and_shkeating.up.sql

--- a/migrations/app/schema/20220126235958_remove_cac_access_carterjones_monfresh_ronolibert_and_shkeating.up.sql
+++ b/migrations/app/schema/20220126235958_remove_cac_access_carterjones_monfresh_ronolibert_and_shkeating.up.sql
@@ -1,0 +1,8 @@
+-- Remove monfresh's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='061a7533ab529e259b7afacd8ff69a3a06d57d2b3b831db924aa8b339415f2b3';
+-- Remove shkeating's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='b3c44ca81bcabee2c7dcdc8c3c6809400468d2c25dc3556e4a0e2e143fc5aa85';
+-- Remove ronolibert's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='af6f3129b664216989e983cf09f723a7617bf9d21333fd66294551cea78ba45f';
+-- Remove carterjones's CAC using unique sha256 digest of the client cert
+DELETE FROM client_certs WHERE sha256_digest='27c54b91080a7252215c68d8808de4a2d39cbc3e73fbecb9bddc621f5dde08f7';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11245) for this change

## Summary

We need to remove access for those that leave the project. In looking to see if Chris H had CAC access to the api I found 4 accounts that did which needed to be removed. Chris did not. So this PR removes those.

[the story](https://dp3.atlassian.net/browse/MB-11245) explains more about the approach used.

## Setup to Run Your Code

Just run the migrations and make sure the records do not show in the `client_certs` table.

```sh
make db_dev_reset db_dev_migrate
```

Example queries

```sql
-- Review all records
SELECT * FROM client_certs;

-- Lookup monfresh's CAC using unique sha256 digest of the client cert
SELECT * FROM client_certs WHERE sha256_digest='061a7533ab529e259b7afacd8ff69a3a06d57d2b3b831db924aa8b339415f2b3';
-- Lookup shkeating's CAC using unique sha256 digest of the client cert
SELECT * FROM client_certs WHERE sha256_digest='b3c44ca81bcabee2c7dcdc8c3c6809400468d2c25dc3556e4a0e2e143fc5aa85';
-- Lookup ronolibert's CAC using unique sha256 digest of the client cert
SELECT * FROM client_certs WHERE sha256_digest='af6f3129b664216989e983cf09f723a7617bf9d21333fd66294551cea78ba45f';
-- Lookup carterjones's CAC using unique sha256 digest of the client cert
SELECT * FROM client_certs WHERE sha256_digest='27c54b91080a7252215c68d8808de4a2d39cbc3e73fbecb9bddc621f5dde08f7';
```

You could alternately grep the migrations folder for the sha256 and see which migrations it appears. For these one to add and this one that removes them.

## Verification Steps for Author

These are to be checked by the author.

- [X] Request review from a member of a different team.
- [X] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database