### PR TITLE
[MB-11016] Update react-file-viewer to resolve three security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
+    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer#ds-mb-11016-update-three-library-security-vulerability",
     "@trussworks/react-uswds": "^2.1.0",
     "bytes": "^3.1.1",
     "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer#ds-mb-11016-update-three-library-security-vulerability",
+    "@trussworks/react-file-viewer": "https://github.com/trussworks/react-file-viewer",
     "@trussworks/react-uswds": "^2.1.0",
     "bytes": "^3.1.1",
     "classnames": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,9 +3727,9 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer#ds-mb-11016-update-three-library-security-vulerability":
+"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer":
   version "1.2.1"
-  resolved "https://github.com/trussworks/react-file-viewer#3406013da1f46694d0079f5c312ae08bf88d27f1"
+  resolved "https://github.com/trussworks/react-file-viewer#3a7b0f81c55df2138e61b22179ab090778c1ad05"
   dependencies:
     pdfjs-dist "1.8.357"
     prop-types "^15.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,14 +3727,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer":
+"@trussworks/react-file-viewer@https://github.com/trussworks/react-file-viewer#ds-mb-11016-update-three-library-security-vulerability":
   version "1.2.1"
-  resolved "https://github.com/trussworks/react-file-viewer#fe70df7fe43d96a4cdc4a5314ed0496d6a84f495"
+  resolved "https://github.com/trussworks/react-file-viewer#3406013da1f46694d0079f5c312ae08bf88d27f1"
   dependencies:
     pdfjs-dist "1.8.357"
     prop-types "^15.5.10"
     react-visibility-sensor "^5.0.2"
-    three "0.126.0"
+    three "0.137.0"
 
 "@trussworks/react-uswds@^2.1.0":
   version "2.1.0"
@@ -19651,10 +19651,10 @@ third-party-web@^0.12.4:
   resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.12.5.tgz#df336053ddcbce68aa2da3787641233739ad5a64"
   integrity sha512-A8YS1bpOzm9os0w7wH/BbN5WZgzyf0zbrrWHckX57v+EkCaM7jZPoRpzgqrakh2e7IWP1KwAnMtlcGTATYZw8A==
 
-three@0.126.0:
-  version "0.126.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.0.tgz#924818341cd4441ef247e3cbf236f6160b90a216"
-  integrity sha512-/MecvboUefStCkUfXLImoJxthN+FoLPcEP7pz1r1Dd9i8BPGGuj+S1sOPRvW4Z+ViZjP2oWWm1inNC/MT52ybA==
+three@0.137.0:
+  version "0.137.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.137.0.tgz#0ebd6ba66637a332c31f234bcdd35aeec071a6e3"
+  integrity sha512-rzSDhia6cU35UCy6y+zEEws6vSgytfHqFMSaBvUcySgzwvDO6vETyswtSNi/+aVqJw8WLMwyT1mlQQ1T/dxxOA==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

Updates react-file-viewer to the newest version to resolve three library vulnerability https://github.com/trussworks/react-file-viewer/pull/6

https://github.com/transcom/mymove/security/dependabot/yarn.lock/three/open

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

Verified it by uploading to S3 in local development
![Screen Shot 2022-01-27 at 2 43 09 PM](https://user-images.githubusercontent.com/52669884/151432280-c96c9443-7c9c-4c1e-a49e-02a8d4aec17a.png) 