### PR TITLE
MB-10739 Ensure we're using the right duty station and report by labels while editing orders

### DIFF
--- a/src/components/CustomerHeader/CustomerHeader.stories.jsx
+++ b/src/components/CustomerHeader/CustomerHeader.stories.jsx
@@ -27,9 +27,37 @@ const props = {
   moveCode: 'FKLCTR',
 };
 
+const propsRetirement = {
+  ...props,
+  order: {
+    ...props.order,
+    order_type: 'RETIREMENT',
+  },
+};
+
+const propsSeparation = {
+  ...props,
+  order: {
+    ...props.order,
+    order_type: 'SEPARATION',
+  },
+};
+
 // eslint-disable-next-line react/jsx-props-no-spreading
 export const Customer = () => (
   <div style={{ minWidth: '1000px' }}>
     <CustomerHeader {...props} />
+  </div>
+);
+
+export const CustomerRetirement = () => (
+  <div style={{ minWidth: '1000px' }}>
+    <CustomerHeader {...propsRetirement} />
+  </div>
+);
+
+export const CustomerSeparation = () => (
+  <div style={{ minWidth: '1000px' }}>
+    <CustomerHeader {...propsSeparation} />
   </div>
 );

--- a/src/components/CustomerHeader/index.jsx
+++ b/src/components/CustomerHeader/index.jsx
@@ -4,7 +4,7 @@ import { string } from 'prop-types';
 import styles from './index.module.scss';
 
 import { OrderShape, CustomerShape } from 'types/order';
-import { formatCustomerDate } from 'utils/formatters';
+import { formatCustomerDate, formatLabelReportByDate } from 'utils/formatters';
 import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders.js';
 
 const CustomerHeader = ({ customer, order, moveCode }) => {
@@ -19,16 +19,7 @@ const CustomerHeader = ({ customer, order, moveCode }) => {
    * Date of retirement (RETIREMENT)
    * Date of separation (SEPARATION)
    */
-  const reportDateLabel = ((type) => {
-    switch (type) {
-      case 'RETIREMENT':
-        return 'Date of retirement';
-      case 'SEPARATION':
-        return 'Date of separation';
-      default:
-        return 'Report by date';
-    }
-  })(order_type);
+  const reportDateLabel = formatLabelReportByDate(order_type);
 
   return (
     <div className={styles.custHeader}>

--- a/src/components/Office/DefinitionLists/OrdersList.jsx
+++ b/src/components/Office/DefinitionLists/OrdersList.jsx
@@ -8,6 +8,7 @@ import { OrdersInfoShape } from 'types/order';
 import { formatDate } from 'shared/dates';
 import { departmentIndicatorReadable, ordersTypeReadable, ordersTypeDetailReadable } from 'shared/formatters';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
+import { formatLabelReportByDate } from 'utils/formatters';
 
 const OrdersList = ({ ordersInfo, showMissingWarnings }) => {
   const { ordersType } = ordersInfo;
@@ -15,22 +16,7 @@ const OrdersList = ({ ordersInfo, showMissingWarnings }) => {
   const isSeparatee = ordersType === 'SEPARATION';
   const missingText = showMissingWarnings ? 'Missing' : '—';
 
-  /**
-   * Depending on the order type, this row dt label can be either:
-   * Report by date (PERMANENT_CHANGE_OF_STATION)
-   * Date of retirement (RETIREMENT)
-   * Date of separation (SEPARATION)
-   */
-  const reportDateRowLabel = ((type) => {
-    switch (type) {
-      case 'RETIREMENT':
-        return 'Date of retirement';
-      case 'SEPARATION':
-        return 'Date of separation';
-      default:
-        return 'Report by date';
-    }
-  })(ordersType);
+  const reportDateRowLabel = formatLabelReportByDate(ordersType);
 
   return (
     <div className={styles.OfficeDefinitionLists}>

--- a/src/components/Office/DefinitionLists/OrdersList.stories.jsx
+++ b/src/components/Office/DefinitionLists/OrdersList.stories.jsx
@@ -51,6 +51,50 @@ export const AsServiceCounselor = () => (
   </div>
 );
 
+export const AsServiceCounselorProcessingRetirement = () => (
+  <div className="officeApp">
+    <OrdersList
+      showMissingWarnings={false}
+      ordersInfo={{
+        currentDutyStation: object('ordersInfo.currentDutyStation', { name: 'JBSA Lackland' }),
+        newDutyStation: object('ordersInfo.newDutyStation', { name: 'JB Lewis-McChord' }),
+        issuedDate: text('ordersInfo.issuedDate', '2020-03-08'),
+        reportByDate: text('ordersInfo.reportByDate', '2020-04-01'),
+        departmentIndicator: '',
+        ordersNumber: '',
+        ordersType: 'RETIREMENT',
+        ordersTypeDetail: '',
+        tacMDC: '',
+        sacSDN: '',
+        NTSsac: '',
+        NTStac: '',
+      }}
+    />
+  </div>
+);
+
+export const AsServiceCounselorProcessingSeparation = () => (
+  <div className="officeApp">
+    <OrdersList
+      showMissingWarnings={false}
+      ordersInfo={{
+        currentDutyStation: object('ordersInfo.currentDutyStation', { name: 'JBSA Lackland' }),
+        newDutyStation: object('ordersInfo.newDutyStation', { name: 'JB Lewis-McChord' }),
+        issuedDate: text('ordersInfo.issuedDate', '2020-03-08'),
+        reportByDate: text('ordersInfo.reportByDate', '2020-04-01'),
+        departmentIndicator: '',
+        ordersNumber: '',
+        ordersType: 'SEPARATION',
+        ordersTypeDetail: '',
+        tacMDC: '',
+        sacSDN: '',
+        NTSsac: '',
+        NTStac: '',
+      }}
+    />
+  </div>
+);
+
 export const AsTOO = () => (
   <div className="officeApp">
     <OrdersList
@@ -63,6 +107,50 @@ export const AsTOO = () => (
         departmentIndicator: '',
         ordersNumber: '',
         ordersType: '',
+        ordersTypeDetail: '',
+        tacMDC: '',
+        sacSDN: '',
+        NTSsac: '',
+        NTStac: '',
+      }}
+    />
+  </div>
+);
+
+export const AsTOOProcessingRetirement = () => (
+  <div className="officeApp">
+    <OrdersList
+      showMissingWarnings
+      ordersInfo={{
+        currentDutyStation: object('ordersInfo.currentDutyStation', { name: 'JBSA Lackland' }),
+        newDutyStation: object('ordersInfo.newDutyStation', { name: 'JB Lewis-McChord' }),
+        issuedDate: text('ordersInfo.issuedDate', '2020-03-08'),
+        reportByDate: text('ordersInfo.reportByDate', '2020-04-01'),
+        departmentIndicator: '',
+        ordersNumber: '',
+        ordersType: 'RETIREMENT',
+        ordersTypeDetail: '',
+        tacMDC: '',
+        sacSDN: '',
+        NTSsac: '',
+        NTStac: '',
+      }}
+    />
+  </div>
+);
+
+export const AsTOOProcessingSeparation = () => (
+  <div className="officeApp">
+    <OrdersList
+      showMissingWarnings
+      ordersInfo={{
+        currentDutyStation: object('ordersInfo.currentDutyStation', { name: 'JBSA Lackland' }),
+        newDutyStation: object('ordersInfo.newDutyStation', { name: 'JB Lewis-McChord' }),
+        issuedDate: text('ordersInfo.issuedDate', '2020-03-08'),
+        reportByDate: text('ordersInfo.reportByDate', '2020-04-01'),
+        departmentIndicator: '',
+        ordersNumber: '',
+        ordersType: 'SEPARATION',
         ordersTypeDetail: '',
         tacMDC: '',
         sacSDN: '',

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -3,6 +3,7 @@ import { func, string, bool } from 'prop-types';
 
 import styles from './OrdersDetailForm.module.scss';
 
+import { formatLabelReportByDate } from 'utils/formatters';
 import { CheckboxField, DropdownInput, DatePickerInput, DutyStationInput } from 'components/form/fields';
 import TextField from 'components/form/fields/TextField/TextField';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
@@ -24,13 +25,20 @@ const OrdersDetailForm = ({
   showNTSTac,
   showNTSSac,
   showOrdersAcknowledgement,
+  ordersType,
 }) => {
+  const reportDateRowLabel = formatLabelReportByDate(ordersType);
+  // The text is different if the customer is retiring or separating.
+  const newDutyStationLabel = ['RETIREMENT', 'SEPARATION'].includes(ordersType)
+    ? 'HOR, HOS or PLEAD'
+    : 'New duty location';
+
   return (
     <div className={styles.OrdersDetailForm}>
       <DutyStationInput name="originDutyStation" label="Current duty location" displayAddress={false} />
-      <DutyStationInput name="newDutyStation" label="New duty location" displayAddress={false} />
+      <DutyStationInput name="newDutyStation" label={newDutyStationLabel} displayAddress={false} />
       <DatePickerInput name="issueDate" label="Date issued" />
-      <DatePickerInput name="reportByDate" label="Report by date" />
+      <DatePickerInput name="reportByDate" label={reportDateRowLabel} />
       {showDepartmentIndicator && (
         <DropdownInput name="departmentIndicator" label="Department indicator" options={deptIndicatorOptions} />
       )}
@@ -98,6 +106,7 @@ OrdersDetailForm.propTypes = {
   showNTSTac: bool,
   showNTSSac: bool,
   showOrdersAcknowledgement: bool,
+  ordersType: string.isRequired,
 };
 
 OrdersDetailForm.defaultProps = {

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { func, string, bool } from 'prop-types';
 
 import styles from './OrdersDetailForm.module.scss';
@@ -27,9 +27,10 @@ const OrdersDetailForm = ({
   showOrdersAcknowledgement,
   ordersType,
 }) => {
-  const reportDateRowLabel = formatLabelReportByDate(ordersType);
+  const [formOrdersType, setFormOrdersType] = useState(ordersType);
+  const reportDateRowLabel = formatLabelReportByDate(formOrdersType);
   // The text is different if the customer is retiring or separating.
-  const newDutyStationLabel = ['RETIREMENT', 'SEPARATION'].includes(ordersType)
+  const newDutyStationLabel = ['RETIREMENT', 'SEPARATION'].includes(formOrdersType)
     ? 'HOR, HOS or PLEAD'
     : 'New duty location';
 
@@ -43,7 +44,12 @@ const OrdersDetailForm = ({
         <DropdownInput name="departmentIndicator" label="Department indicator" options={deptIndicatorOptions} />
       )}
       {showOrdersNumber && <TextField name="ordersNumber" label="Orders number" id="ordersNumberInput" />}
-      <DropdownInput name="ordersType" label="Orders type" options={ordersTypeOptions} />
+      <DropdownInput
+        name="ordersType"
+        label="Orders type"
+        options={ordersTypeOptions}
+        onChange={(e) => setFormOrdersType(e.target.value)}
+      />
       {showOrdersTypeDetail && (
         <DropdownInput name="ordersTypeDetail" label="Orders type detail" options={ordersTypeDetailOptions} />
       )}

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -26,6 +26,7 @@ const OrdersDetailForm = ({
   showNTSSac,
   showOrdersAcknowledgement,
   ordersType,
+  setFieldValue,
 }) => {
   const [formOrdersType, setFormOrdersType] = useState(ordersType);
   const reportDateRowLabel = formatLabelReportByDate(formOrdersType);
@@ -48,7 +49,10 @@ const OrdersDetailForm = ({
         name="ordersType"
         label="Orders type"
         options={ordersTypeOptions}
-        onChange={(e) => setFormOrdersType(e.target.value)}
+        onChange={(e) => {
+          setFormOrdersType(e.target.value);
+          setFieldValue('ordersType', e.target.value);
+        }}
       />
       {showOrdersTypeDetail && (
         <DropdownInput name="ordersTypeDetail" label="Orders type detail" options={ordersTypeDetailOptions} />
@@ -113,6 +117,7 @@ OrdersDetailForm.propTypes = {
   showNTSSac: bool,
   showOrdersAcknowledgement: bool,
   ordersType: string.isRequired,
+  setFieldValue: func.isRequired,
 };
 
 OrdersDetailForm.defaultProps = {

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -73,6 +73,7 @@ export const EmptyValues = () => (
           deptIndicatorOptions={deptIndicatorOptions}
           ordersTypeOptions={ordersTypeOptions}
           ordersTypeDetailOptions={ordersTypeDetailOptions}
+          ordersType={ORDERS_TYPE_OPTIONS.PERMANENT_CHANGE_OF_STATION}
         />
       </form>
     </Formik>
@@ -171,3 +172,33 @@ export const FieldsHidden = (args) => {
     </div>
   );
 };
+
+export const Retiree = () => (
+  <div style={{ width: '400px' }}>
+    <Formik>
+      <form>
+        <OrdersDetailForm
+          deptIndicatorOptions={deptIndicatorOptions}
+          ordersTypeOptions={ordersTypeOptions}
+          ordersTypeDetailOptions={ordersTypeDetailOptions}
+          ordersType="RETIREMENT"
+        />
+      </form>
+    </Formik>
+  </div>
+);
+
+export const Separatee = () => (
+  <div style={{ width: '400px' }}>
+    <Formik>
+      <form>
+        <OrdersDetailForm
+          deptIndicatorOptions={deptIndicatorOptions}
+          ordersTypeOptions={ordersTypeOptions}
+          ordersTypeDetailOptions={ordersTypeDetailOptions}
+          ordersType="SEPARATION"
+        />
+      </form>
+    </Formik>
+  </div>
+);

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -115,15 +115,19 @@ export const InitialValues = () => {
           ntsSac: Yup.string().required('Required'),
         })}
       >
-        <form>
-          <OrdersDetailForm
-            deptIndicatorOptions={deptIndicatorOptions}
-            ordersTypeOptions={ordersTypeOptions}
-            ordersTypeDetailOptions={ordersTypeDetailOptions}
-            showOrdersAcknowledgement
-            setFieldValue={Formik.setFieldValue}
-          />
-        </form>
+        {(formik) => {
+          return (
+            <form>
+              <OrdersDetailForm
+                deptIndicatorOptions={deptIndicatorOptions}
+                ordersTypeOptions={ordersTypeOptions}
+                ordersTypeDetailOptions={ordersTypeDetailOptions}
+                showOrdersAcknowledgement
+                setFieldValue={formik.setFieldValue}
+              />
+            </form>
+          );
+        }}
       </Formik>
     </div>
   );
@@ -162,15 +166,19 @@ export const FieldsHidden = (args) => {
           ntsSac: Yup.string().required('Required'),
         })}
       >
-        <form>
-          <OrdersDetailForm
-            deptIndicatorOptions={deptIndicatorOptions}
-            ordersTypeOptions={ordersTypeOptions}
-            ordersTypeDetailOptions={ordersTypeDetailOptions}
-            setFieldValue={Formik.setFieldValue}
-            {...args}
-          />
-        </form>
+        {(formik) => {
+          return (
+            <form>
+              <OrdersDetailForm
+                deptIndicatorOptions={deptIndicatorOptions}
+                ordersTypeOptions={ordersTypeOptions}
+                ordersTypeDetailOptions={ordersTypeDetailOptions}
+                setFieldValue={formik.setFieldValue}
+                {...args}
+              />
+            </form>
+          );
+        }}
       </Formik>
     </div>
   );
@@ -178,32 +186,72 @@ export const FieldsHidden = (args) => {
 
 export const Retiree = () => (
   <div style={{ width: '400px' }}>
-    <Formik>
-      <form>
-        <OrdersDetailForm
-          deptIndicatorOptions={deptIndicatorOptions}
-          ordersTypeOptions={ordersTypeOptions}
-          ordersTypeDetailOptions={ordersTypeDetailOptions}
-          ordersType="RETIREMENT"
-          setFieldValue={Formik.setFieldValue}
-        />
-      </form>
+    <Formik
+      initialValues={{
+        originDutyStation,
+        newDutyStation,
+        issueDate: '2020-03-08',
+        reportByDate: '2020-04-01',
+        departmentIndicator: 'NAVY_AND_MARINES',
+        ordersNumber: '999999999',
+        ordersType: 'RETIREMENT',
+        ordersTypeDetail: 'HHG_PERMITTED',
+        tac: 'Tac',
+        sac: 'Sac',
+        ntsTac: 'Tac',
+        ntsSac: 'Sac',
+        ordersAcknowledgement: true,
+      }}
+    >
+      {(formik) => {
+        return (
+          <form>
+            <OrdersDetailForm
+              deptIndicatorOptions={deptIndicatorOptions}
+              ordersTypeOptions={ordersTypeOptions}
+              ordersTypeDetailOptions={ordersTypeDetailOptions}
+              ordersType="RETIREMENT"
+              setFieldValue={formik.setFieldValue}
+            />
+          </form>
+        );
+      }}
     </Formik>
   </div>
 );
 
 export const Separatee = () => (
   <div style={{ width: '400px' }}>
-    <Formik>
-      <form>
-        <OrdersDetailForm
-          deptIndicatorOptions={deptIndicatorOptions}
-          ordersTypeOptions={ordersTypeOptions}
-          ordersTypeDetailOptions={ordersTypeDetailOptions}
-          ordersType="SEPARATION"
-          setFieldValue={Formik.setFieldValue}
-        />
-      </form>
+    <Formik
+      initialValues={{
+        originDutyStation,
+        newDutyStation,
+        issueDate: '2020-03-08',
+        reportByDate: '2020-04-01',
+        departmentIndicator: 'NAVY_AND_MARINES',
+        ordersNumber: '999999999',
+        ordersType: 'SEPARATION',
+        ordersTypeDetail: 'HHG_PERMITTED',
+        tac: 'Tac',
+        sac: 'Sac',
+        ntsTac: 'Tac',
+        ntsSac: 'Sac',
+        ordersAcknowledgement: true,
+      }}
+    >
+      {(formik) => {
+        return (
+          <form>
+            <OrdersDetailForm
+              deptIndicatorOptions={deptIndicatorOptions}
+              ordersTypeOptions={ordersTypeOptions}
+              ordersTypeDetailOptions={ordersTypeDetailOptions}
+              ordersType="SEPARATION"
+              setFieldValue={formik.setFieldValue}
+            />
+          </form>
+        );
+      }}
     </Formik>
   </div>
 );

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.stories.jsx
@@ -74,6 +74,7 @@ export const EmptyValues = () => (
           ordersTypeOptions={ordersTypeOptions}
           ordersTypeDetailOptions={ordersTypeDetailOptions}
           ordersType={ORDERS_TYPE_OPTIONS.PERMANENT_CHANGE_OF_STATION}
+          setFieldValue={Formik.setFieldValue}
         />
       </form>
     </Formik>
@@ -120,6 +121,7 @@ export const InitialValues = () => {
             ordersTypeOptions={ordersTypeOptions}
             ordersTypeDetailOptions={ordersTypeDetailOptions}
             showOrdersAcknowledgement
+            setFieldValue={Formik.setFieldValue}
           />
         </form>
       </Formik>
@@ -165,6 +167,7 @@ export const FieldsHidden = (args) => {
             deptIndicatorOptions={deptIndicatorOptions}
             ordersTypeOptions={ordersTypeOptions}
             ordersTypeDetailOptions={ordersTypeDetailOptions}
+            setFieldValue={Formik.setFieldValue}
             {...args}
           />
         </form>
@@ -182,6 +185,7 @@ export const Retiree = () => (
           ordersTypeOptions={ordersTypeOptions}
           ordersTypeDetailOptions={ordersTypeDetailOptions}
           ordersType="RETIREMENT"
+          setFieldValue={Formik.setFieldValue}
         />
       </form>
     </Formik>
@@ -197,6 +201,7 @@ export const Separatee = () => (
           ordersTypeOptions={ordersTypeOptions}
           ordersTypeDetailOptions={ordersTypeDetailOptions}
           ordersType="SEPARATION"
+          setFieldValue={Formik.setFieldValue}
         />
       </form>
     </Formik>

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
@@ -49,6 +49,7 @@ const defaultProps = {
   showOrdersAcknowledgement: true,
   validateTac: jest.fn,
   ordersType: 'PERMANENT_CHANGE_OF_STATION',
+  setFieldValue: jest.fn,
 };
 
 function renderOrdersDetailForm(props) {

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.test.jsx
@@ -48,6 +48,7 @@ const defaultProps = {
   ordersTypeDetailOptions,
   showOrdersAcknowledgement: true,
   validateTac: jest.fn,
+  ordersType: 'PERMANENT_CHANGE_OF_STATION',
 };
 
 function renderOrdersDetailForm(props) {
@@ -122,5 +123,41 @@ describe('OrdersDetailForm', () => {
     expect(screen.queryByLabelText('TAC')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('SAC')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('I have read the new orders')).not.toBeInTheDocument();
+  });
+
+  it('has the right labels for a retiree', async () => {
+    renderOrdersDetailForm({
+      showDepartmentIndicator: false,
+      showOrdersNumber: false,
+      showOrdersTypeDetail: false,
+      showHHGTac: false,
+      showHHGSac: false,
+      showNTSTac: false,
+      showNTSSac: false,
+      showOrdersAcknowledgement: false,
+      ordersType: 'RETIREMENT',
+    });
+
+    // correct labels are visible
+    expect(await screen.findByLabelText('Date of retirement')).toBeInTheDocument();
+    expect(await screen.findByLabelText('HOR, HOS or PLEAD')).toBeInTheDocument();
+  });
+
+  it('has the right labels for a separatee', async () => {
+    renderOrdersDetailForm({
+      showDepartmentIndicator: false,
+      showOrdersNumber: false,
+      showOrdersTypeDetail: false,
+      showHHGTac: false,
+      showHHGSac: false,
+      showNTSTac: false,
+      showNTSSac: false,
+      showOrdersAcknowledgement: false,
+      ordersType: 'SEPARATION',
+    });
+
+    // correct labels are visible
+    expect(await screen.findByLabelText('Date of separation')).toBeInTheDocument();
+    expect(await screen.findByLabelText('HOR, HOS or PLEAD')).toBeInTheDocument();
   });
 });

--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -168,6 +168,7 @@ const Orders = () => {
                     tacWarning={tacWarning}
                     validateTac={handleTacValidation}
                     showOrdersAcknowledgement={hasAmendedOrders}
+                    ordersType={order.order_type}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -169,6 +169,7 @@ const Orders = () => {
                     validateTac={handleTacValidation}
                     showOrdersAcknowledgement={hasAmendedOrders}
                     ordersType={order.order_type}
+                    setFieldValue={formik.setFieldValue}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -124,6 +124,7 @@ const ServicesCounselingOrders = () => {
                     showOrdersNumber={false}
                     showOrdersTypeDetail={false}
                     ordersType={order.order_type}
+                    setFieldValue={formik.setFieldValue}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -123,6 +123,7 @@ const ServicesCounselingOrders = () => {
                     showDepartmentIndicator={false}
                     showOrdersNumber={false}
                     showOrdersTypeDetail={false}
+                    ordersType={order.order_type}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -103,3 +103,19 @@ export const formatDelimitedNumber = (number) => {
   const numberString = number.toString();
   return Number(numberString.replace(/,/g, ''));
 };
+/**
+ * Depending on the order type, this will return:
+ * Report by date (PERMANENT_CHANGE_OF_STATION)
+ * Date of retirement (RETIREMENT)
+ * Date of separation (SEPARATION)
+ */
+export const formatLabelReportByDate = (orderType) => {
+  switch (orderType) {
+    case 'RETIREMENT':
+      return 'Date of retirement';
+    case 'SEPARATION':
+      return 'Date of separation';
+    default:
+      return 'Report by date';
+  }
+};


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10739) for this change

## Summary

This should make sure we're using the right labeling for the date and location fields on the OrdersDetailForm component. While I was in there I also moved the label formatting logic so that it's in a formatter function and added some storybook stories for these order types (also to cover some past work we did where I realized we didn't have that coverage).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app 
2. Login as a services counselor
3. Edit orders and check to ensure the labels match what's prescribed in the jira task

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
