### PR TITLE
MB-11054: Creates ServiceOrderNumberModal, adds it to ShipmentDetails

### DIFF
--- a/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.jsx
+++ b/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Formik } from 'formik';
+import { Button } from '@trussworks/react-uswds';
+import * as Yup from 'yup';
+
+import Modal, { connectModal, ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
+import { Form } from 'components/form';
+import TextField from 'components/form/fields/TextField/TextField';
+
+const validationSchema = Yup.object().shape({
+  serviceOrderNumber: Yup.string()
+    .matches(/^[0-9a-zA-Z]+$/, 'Letters and numbers only')
+    .required('Required'),
+});
+
+const ServiceOrderNumberModal = ({ onClose, onSubmit, serviceOrderNumber }) => {
+  const handleFormSubmit = (values) => onSubmit(values);
+
+  return (
+    <div data-testid="ServiceOrderNumber">
+      <Modal>
+        <ModalClose handleClick={onClose} />
+
+        <ModalTitle>
+          <h2>Edit service order number</h2>
+        </ModalTitle>
+
+        <Formik initialValues={{ serviceOrderNumber }} onSubmit={handleFormSubmit} validationSchema={validationSchema}>
+          <Form>
+            <TextField label="Service order number" id="facilityServiceOrderNumber" name="serviceOrderNumber" />
+
+            <ModalActions>
+              <Button type="submit">Save</Button>
+              <Button type="button" secondary onClick={onClose}>
+                Cancel
+              </Button>
+            </ModalActions>
+          </Form>
+        </Formik>
+      </Modal>
+    </div>
+  );
+};
+
+ServiceOrderNumberModal.propTypes = {
+  onClose: PropTypes.func,
+  onSubmit: PropTypes.func,
+  serviceOrderNumber: PropTypes.string,
+};
+
+ServiceOrderNumberModal.defaultProps = {
+  onClose: () => {},
+  onSubmit: () => {},
+  serviceOrderNumber: '',
+};
+
+export default connectModal(ServiceOrderNumberModal);

--- a/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.stories.jsx
+++ b/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.stories.jsx
@@ -8,5 +8,9 @@ export default {
 };
 
 export const standard = () => {
-  return <ServiceOrderNumberModal isOpen serviceOrderNumber="AB123456" />;
+  return (
+    <div className="officeApp">
+      <ServiceOrderNumberModal isOpen serviceOrderNumber="AB123456" />;
+    </div>
+  );
 };

--- a/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.stories.jsx
+++ b/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.stories.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import ServiceOrderNumberModal from './ServiceOrderNumberModal';
+
+export default {
+  title: 'Office Components / ServiceOrderNumberModal',
+  component: ServiceOrderNumberModal,
+};
+
+export const standard = () => {
+  return <ServiceOrderNumberModal isOpen serviceOrderNumber="AB123456" />;
+};

--- a/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.test.jsx
+++ b/src/components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { screen, waitFor, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ServiceOrderNumberModal from './ServiceOrderNumberModal';
+
+describe('components/Office/ServiceOrderNumberModal', () => {
+  it('is connected', () => {
+    render(<ServiceOrderNumberModal />);
+    expect(screen.queryByRole('heading', { name: 'Edit service order number' })).not.toBeInTheDocument();
+  });
+
+  it('defaults values from props', () => {
+    render(<ServiceOrderNumberModal isOpen serviceOrderNumber="ABC123" />);
+    expect(screen.getByRole('heading', { name: 'Edit service order number' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveValue('ABC123');
+  });
+
+  it('validates input', async () => {
+    const onSubmit = jest.fn();
+    render(<ServiceOrderNumberModal isOpen onSubmit={onSubmit} />);
+
+    const textbox = screen.getByRole('textbox');
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+
+    userEvent.type(textbox, '!');
+    userEvent.click(saveButton);
+    await waitFor(() => expect(screen.getByText('Letters and numbers only')).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    userEvent.clear(textbox);
+    userEvent.click(saveButton);
+    await waitFor(() => expect(screen.getByText('Required')).toBeInTheDocument());
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    userEvent.type(textbox, 'ABC123');
+    userEvent.click(saveButton);
+    await waitFor(() => expect(screen.queryByTestId('errorMessage')).not.toBeInTheDocument());
+    expect(onSubmit).toHaveBeenCalledWith({ serviceOrderNumber: 'ABC123' });
+  });
+});

--- a/src/components/Office/ShipmentDetails/ShipmentDetails.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.jsx
@@ -16,6 +16,7 @@ const ShipmentDetails = ({
   handleReviewSITExtension,
   handleSubmitSITExtension,
   handleEditFacilityInfo,
+  handleEditServiceOrderNumber,
 }) => {
   const { originDutyStation, destinationDutyStation, entitlement } = order;
   const ordersLOA = {
@@ -45,6 +46,7 @@ const ShipmentDetails = ({
         shipment={shipment}
         ordersLOA={ordersLOA}
         handleEditFacilityInfo={handleEditFacilityInfo}
+        handleEditServiceOrderNumber={handleEditServiceOrderNumber}
       />
     </div>
   );
@@ -58,6 +60,7 @@ ShipmentDetails.propTypes = {
   handleReviewSITExtension: PropTypes.func.isRequired,
   handleSubmitSITExtension: PropTypes.func.isRequired,
   handleEditFacilityInfo: PropTypes.func.isRequired,
+  handleEditServiceOrderNumber: PropTypes.func.isRequired,
 };
 
 export default ShipmentDetails;

--- a/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetails.stories.jsx
@@ -125,8 +125,18 @@ const order = {
   ntsSac: '345',
 };
 
-export const Default = () => (
-  <div className="officeApp">
-    <ShipmentDetails shipment={shipment} order={order} />
-  </div>
-);
+export const Default = () => {
+  const [modifiedShipment, setModifiedShipment] = React.useState(shipment);
+  const handleEditSon = (values) => {
+    setModifiedShipment({
+      ...shipment,
+      serviceOrderNumber: values.serviceOrderNumber,
+    });
+  };
+
+  return (
+    <div className="officeApp">
+      <ShipmentDetails shipment={modifiedShipment} order={order} handleEditServiceOrderNumber={handleEditSon} />
+    </div>
+  );
+};

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -108,7 +108,7 @@ const ShipmentDetailsSidebar = ({
                 type="button"
                 onClick={handleShowSonModal}
                 className="float-right usa-link modal-link"
-                data-testid="edit-facility-info-modal-open"
+                data-testid="service-order-number-modal-open"
                 unstyled
               >
                 Edit

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.jsx
@@ -6,19 +6,34 @@ import { Button } from '@trussworks/react-uswds';
 import styles from 'components/Office/ShipmentDetails/ShipmentDetailsSidebar.module.scss';
 import SimpleSection from 'containers/SimpleSection/SimpleSection';
 import ConnectedEditFacilityInfoModal from 'components/Office/EditFacilityInfoModal/EditFacilityInfoModal';
+import ConnectedServiceOrderNumberModal from 'components/Office/ServiceOrderNumberModal/ServiceOrderNumberModal';
 import { retrieveSAC, retrieveTAC, formatAgent, formatAddress, formatAccountingCode } from 'utils/shipmentDisplay';
 import { ShipmentShape } from 'types/shipment';
 import { OrdersLOAShape } from 'types/order';
 
-const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFacilityInfo }) => {
+const ShipmentDetailsSidebar = ({
+  className,
+  shipment,
+  ordersLOA,
+  handleEditFacilityInfo,
+  handleEditServiceOrderNumber,
+}) => {
   const { mtoAgents, secondaryAddresses, serviceOrderNumber, storageFacility, sacType, tacType } = shipment;
   const tac = retrieveTAC(shipment.tacType, ordersLOA);
   const sac = retrieveSAC(shipment.sacType, ordersLOA);
 
   const [isEditFacilityInfoModalVisible, setIsEditFacilityInfoModalVisible] = useState(false);
+  const [isSonModalVisible, setIsSonModalVisible] = useState(false);
 
   const handleShowEditFacilityInfoModal = () => {
     setIsEditFacilityInfoModalVisible(true);
+  };
+
+  const handleShowSonModal = () => setIsSonModalVisible(true);
+  const handleCloseSonModal = () => setIsSonModalVisible(false);
+  const handleSubmitSonModal = (values) => {
+    handleEditServiceOrderNumber(values, shipment);
+    setIsSonModalVisible(false);
   };
 
   return (
@@ -35,6 +50,13 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFaci
         storageFacility={shipment.storageFacility}
         serviceOrderNumber={shipment.serviceOrderNumber}
         shipmentType={shipment.shipmentType}
+      />
+
+      <ConnectedServiceOrderNumberModal
+        isOpen={isSonModalVisible}
+        onSubmit={handleSubmitSonModal}
+        onClose={handleCloseSonModal}
+        serviceOrderNumber={shipment.serviceOrderNumber}
       />
 
       {mtoAgents &&
@@ -79,12 +101,19 @@ const ShipmentDetailsSidebar = ({ className, shipment, ordersLOA, handleEditFaci
         <SimpleSection
           key="service-order-number"
           header={
-            <>
+            <div className={styles.ShipmentDetailsSidebar}>
               Service order number
-              <Link to="" className="usa-link float-right">
+              <Button
+                size="small"
+                type="button"
+                onClick={handleShowSonModal}
+                className="float-right usa-link modal-link"
+                data-testid="edit-facility-info-modal-open"
+                unstyled
+              >
                 Edit
-              </Link>
-            </>
+              </Button>
+            </div>
           }
           border
         >
@@ -134,6 +163,7 @@ ShipmentDetailsSidebar.propTypes = {
   shipment: ShipmentShape,
   ordersLOA: OrdersLOAShape,
   handleEditFacilityInfo: PropTypes.func.isRequired,
+  handleEditServiceOrderNumber: PropTypes.func,
 };
 
 ShipmentDetailsSidebar.defaultProps = {
@@ -145,6 +175,7 @@ ShipmentDetailsSidebar.defaultProps = {
     ntsTac: '',
     ntsSac: '',
   },
+  handleEditServiceOrderNumber: () => {},
 };
 
 export default ShipmentDetailsSidebar;

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.test.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.test.jsx
@@ -126,4 +126,19 @@ describe('Shipment Details Sidebar', () => {
     // This text is in the edit facility info modal
     expect(screen.getByText('Edit facility info and address')).toBeInTheDocument();
   });
+
+  it('shows edit service order number modal on edit button click', () => {
+    render(
+      <MockProviders>
+        <ShipmentDetailsSidebar shipment={shipment} ordersLOA={ordersLOA} handleEditFacilityInfo={() => {}} />
+      </MockProviders>,
+    );
+
+    const openSonModalButton = screen.getByTestId('service-order-number-modal-open');
+
+    userEvent.click(openSonModalButton);
+
+    // This text is in the edit facility info modal
+    expect(screen.getByRole('heading', { name: 'Edit service order number' })).toBeInTheDocument();
+  });
 });

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -404,6 +404,15 @@ export const MoveTaskOrder = ({ match, ...props }) => {
     });
   };
 
+  const handleEditServiceOrderNumber = (fields, shipment) => {
+    mutateMTOShipment({
+      moveTaskOrderID: shipment.moveTaskOrderID,
+      shipmentID: shipment.id,
+      ifMatchETag: shipment.eTag,
+      body: { serviceOrderNumber: fields.serviceOrderNumber },
+    });
+  };
+
   const handleUpdateMTOServiceItemStatus = (mtoServiceItemID, mtoShipmentID, status, rejectionReason) => {
     const mtoServiceItemForRequest = shipmentServiceItems[`${mtoShipmentID}`]?.find((s) => s.id === mtoServiceItemID);
 
@@ -743,6 +752,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
                   handleReviewSITExtension={handleReviewSITExtension}
                   handleSubmitSITExtension={handleSubmitSITExtension}
                   handleEditFacilityInfo={handleEditFacilityInfo}
+                  handleEditServiceOrderNumber={handleEditServiceOrderNumber}
                 />
                 {requestedServiceItems?.length > 0 && (
                   <RequestedServiceItemsTable


### PR DESCRIPTION
## Jira ticket for this change: [MB-11054](https://dp3.atlassian.net/browse/MB-11054)

## Summary

This pull request creates a new component, a modal with a single field that allows users to edit a shipment's service order number. It links that component to the "Edit" button for a shipment's Service order number, within the Service Details sidebar in the TIO's Move task order page.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. In Storybook, view the story for the `ServiceOrderNumberModal` component inside of "Office Components". Verify that it populates a default value ("ABC123") and the validation works (a value is a required, and must only be alphanumeric).
2. View the story for the "Shipment Details" component. Validate that clicking "Edit" next to "Service order number" in the sidebar brings up the newly-created modal.
3. Verify that changing the value and clicking "Save" updates the value in the story. (This works via `useState` in Storybook.)
4. In the office application, log in locally as a TIO user and view the `HGNTSR` move.
5. Click into "Move task order" page for that move, and scroll down the NTS-release shipment. 
6. Click "Edit" next to Service order number for that shipment and change the value. Verify that the value changes, and that the value persists into the database (e.g. refresh the page and verify that the updated value displays)

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
