### PR TITLE
MB-11427 Using Validate for Swagger NullableString type

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3289,16 +3289,36 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "ntsSac": {
-          "title": "NTS SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "ntsTac": {
-          "title": "NTS TAC",
-          "maxLength": 4,
-          "minLength": 4,
-          "$ref": "#/definitions/NullableString",
-          "example": "F8J1"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS TAC"
+            },
+            {
+              "minLength": 10
+            },
+            {
+              "maxLength": 10
+            },
+            {
+              "example": "F8J1"
+            }
+          ]
         },
         "ordersType": {
           "$ref": "#/definitions/OrdersType"
@@ -3316,9 +3336,17 @@ func init() {
           "example": "2018-04-26"
         },
         "sac": {
-          "title": "HHG SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "HHG SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "tac": {
           "type": "string",
@@ -5630,14 +5658,22 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "ntsSac": {
-          "title": "NTS SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "ntsTac": {
           "title": "NTS TAC",
-          "maxLength": 4,
-          "minLength": 4,
+          "maxLength": 10,
+          "minLength": 10,
           "$ref": "#/definitions/NullableString",
           "example": "F8J1"
         },
@@ -5671,9 +5707,17 @@ func init() {
           "example": "2018-04-26"
         },
         "sac": {
-          "title": "HHG SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "HHG SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "tac": {
           "type": "string",
@@ -10013,16 +10057,36 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "ntsSac": {
-          "title": "NTS SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "ntsTac": {
-          "title": "NTS TAC",
-          "maxLength": 4,
-          "minLength": 4,
-          "$ref": "#/definitions/NullableString",
-          "example": "F8J1"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS TAC"
+            },
+            {
+              "minLength": 10
+            },
+            {
+              "maxLength": 10
+            },
+            {
+              "example": "F8J1"
+            }
+          ]
         },
         "ordersType": {
           "$ref": "#/definitions/OrdersType"
@@ -10040,9 +10104,17 @@ func init() {
           "example": "2018-04-26"
         },
         "sac": {
-          "title": "HHG SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "HHG SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "tac": {
           "type": "string",
@@ -12361,14 +12433,22 @@ func init() {
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
         "ntsSac": {
-          "title": "NTS SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "NTS SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "ntsTac": {
           "title": "NTS TAC",
-          "maxLength": 4,
-          "minLength": 4,
+          "maxLength": 10,
+          "minLength": 10,
           "$ref": "#/definitions/NullableString",
           "example": "F8J1"
         },
@@ -12402,9 +12482,17 @@ func init() {
           "example": "2018-04-26"
         },
         "sac": {
-          "title": "HHG SAC",
-          "$ref": "#/definitions/NullableString",
-          "example": "N002214CSW32Y9"
+          "allOf": [
+            {
+              "$ref": "#/definitions/NullableString"
+            },
+            {
+              "title": "HHG SAC"
+            },
+            {
+              "example": "N002214CSW32Y9"
+            }
+          ]
         },
         "tac": {
           "type": "string",

--- a/pkg/gen/ghcmessages/counseling_update_order_payload.go
+++ b/pkg/gen/ghcmessages/counseling_update_order_payload.go
@@ -34,12 +34,10 @@ type CounselingUpdateOrderPayload struct {
 	// Format: uuid
 	NewDutyStationID *strfmt.UUID `json:"newDutyStationId"`
 
-	// NTS SAC
-	// Example: N002214CSW32Y9
+	// nts sac
 	NtsSac nullable.String `json:"ntsSac,omitempty"`
 
-	// NTS TAC
-	// Example: F8J1
+	// nts tac
 	NtsTac nullable.String `json:"ntsTac,omitempty"`
 
 	// orders type
@@ -60,8 +58,7 @@ type CounselingUpdateOrderPayload struct {
 	// Format: date
 	ReportByDate *strfmt.Date `json:"reportByDate"`
 
-	// HHG SAC
-	// Example: N002214CSW32Y9
+	// sac
 	Sac nullable.String `json:"sac,omitempty"`
 
 	// HHG TAC

--- a/pkg/gen/ghcmessages/update_order_payload.go
+++ b/pkg/gen/ghcmessages/update_order_payload.go
@@ -37,8 +37,7 @@ type UpdateOrderPayload struct {
 	// Format: uuid
 	NewDutyStationID *strfmt.UUID `json:"newDutyStationId"`
 
-	// NTS SAC
-	// Example: N002214CSW32Y9
+	// nts sac
 	NtsSac nullable.String `json:"ntsSac,omitempty"`
 
 	// NTS TAC
@@ -73,8 +72,7 @@ type UpdateOrderPayload struct {
 	// Format: date
 	ReportByDate *strfmt.Date `json:"reportByDate"`
 
-	// HHG SAC
-	// Example: N002214CSW32Y9
+	// sac
 	Sac nullable.String `json:"sac,omitempty"`
 
 	// HHG TAC

--- a/pkg/swagger/nullable/string.go
+++ b/pkg/swagger/nullable/string.go
@@ -82,7 +82,15 @@ func (s *String) Validate(formats strfmt.Registry) error {
 		// you could use the validate functions with hardcoded values. I don't think we can store
 		// the validation constants in a shared lib (to make it generic) because we don't know which fieldname
 		// is being used here
-		if err := validate.MaxLength("value", "body", *s.Value, 4); err != nil {
+
+		// Tested this call out with maxLength: 2 and got he following errors:
+		// Error:      	Received unexpected error:
+		//	            validation failure list:
+		//	            ntsSac.value in body should be at most 2 chars long
+		//	            ntsTac.value in body should be at most 2 chars long
+		//	            sac.value in body should be at most 2 chars long
+
+		if err := validate.MaxLength("value", "body", *s.Value, 10); err != nil {
 			return err
 		}
 	}

--- a/pkg/swagger/nullable/string.go
+++ b/pkg/swagger/nullable/string.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // recognize the JSON null
@@ -58,6 +59,34 @@ func (s *String) UnmarshalJSON(data []byte) error {
 // String always validates ok
 // this is called from the go swagger generated code
 func (s *String) Validate(formats strfmt.Registry) error {
+	if s.Present && s.Value != nil {
+		/*  this only works for types listed in go/pkg/mod/github.com/go-openapi/strfmt@v0.21.1/format.go
+		    and 'string' isn't one of those.
+		    Note sure if using the `Add` function would work here, you'd be passing in a the type
+		    `string` and a validator to use.
+
+		    The below call got the following errors:
+		                	            	validation failure list:
+		                	            	ntsSacstring is an invalid type name
+		                	            	ntsTacstring is an invalid type name
+		                	            	sacstring is an invalid type name
+		                	Test:       	TestHandlerSuite/TestUpdateOrderHandlerWithAmendedUploads
+
+		if err := validate.FormatOf("value", "body", "string", *s.Value, formats); err != nil {
+			return err
+		}
+		 */
+
+		// This seems like it would give us what we want, but you'd have to create new
+		// NullableString types like NullableStringTAC and NullableStringSAC and then
+		// you could use the validate functions hardcoded. I don't think we store
+		// the validation constants in a shared lib because we don't know which fieldname
+		// is being updated
+		if err := validate.MaxLength("value", "body", *s.Value, 4); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/swagger/nullable/string.go
+++ b/pkg/swagger/nullable/string.go
@@ -79,9 +79,9 @@ func (s *String) Validate(formats strfmt.Registry) error {
 
 		// This seems like it would give us what we want, but you'd have to create new
 		// NullableString types like NullableStringTAC and NullableStringSAC and then
-		// you could use the validate functions hardcoded. I don't think we store
-		// the validation constants in a shared lib because we don't know which fieldname
-		// is being updated
+		// you could use the validate functions with hardcoded values. I don't think we can store
+		// the validation constants in a shared lib (to make it generic) because we don't know which fieldname
+		// is being used here
 		if err := validate.MaxLength("value", "body", *s.Value, 4); err != nil {
 			return err
 		}

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2530,19 +2530,22 @@ definitions:
         example: 'F8J1'
         x-nullable: true
       sac:
-        title: HHG SAC
-        example: 'N002214CSW32Y9'
-        $ref: definitions/NullableString.yaml
+        allOf:
+          - $ref: definitions/NullableString.yaml
+          - title: HHG SAC
+          - example: 'N002214CSW32Y9'
       ntsTac:
-        title: NTS TAC
-        minLength: 4
-        maxLength: 4
-        example: 'F8J1'
-        $ref: definitions/NullableString.yaml
+        allOf:
+          - $ref: definitions/NullableString.yaml
+          - title: NTS TAC
+          - minLength: 10
+          - maxLength: 10
+          - example: 'F8J1'
       ntsSac:
-        title: NTS SAC
-        example: 'N002214CSW32Y9'
-        $ref: definitions/NullableString.yaml
+        allOf:
+          - $ref: definitions/NullableString.yaml
+          - title: NTS SAC
+          - example: 'N002214CSW32Y9'
     required:
       - issueDate
       - reportByDate
@@ -2589,19 +2592,21 @@ definitions:
         example: 'F8J1'
         x-nullable: true
       sac:
-        title: HHG SAC
-        example: 'N002214CSW32Y9'
-        $ref: definitions/NullableString.yaml
+        allOf:
+          - $ref: definitions/NullableString.yaml
+          - title: HHG SAC
+          - example: 'N002214CSW32Y9'
       ntsTac:
-        title: NTS TAC
-        minLength: 4
-        maxLength: 4
-        example: 'F8J1'
-        $ref: definitions/NullableString.yaml
+          $ref: definitions/NullableString.yaml
+          title: NTS TAC
+          minLength: 10
+          maxLength: 10
+          example: 'F8J1'
       ntsSac:
-        title: NTS SAC
-        example: 'N002214CSW32Y9'
-        $ref: definitions/NullableString.yaml
+        allOf:
+          - $ref: definitions/NullableString.yaml
+          - title: NTS SAC
+          - example: 'N002214CSW32Y9'
       departmentIndicator:
         $ref: '#/definitions/DeptIndicator'
         x-nullable: true

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2625,19 +2625,22 @@ definitions:
         example: F8J1
         x-nullable: true
       sac:
-        title: HHG SAC
-        example: N002214CSW32Y9
-        $ref: '#/definitions/NullableString'
+        allOf:
+          - $ref: '#/definitions/NullableString'
+          - title: HHG SAC
+          - example: N002214CSW32Y9
       ntsTac:
-        title: NTS TAC
-        minLength: 4
-        maxLength: 4
-        example: F8J1
-        $ref: '#/definitions/NullableString'
+        allOf:
+          - $ref: '#/definitions/NullableString'
+          - title: NTS TAC
+          - minLength: 10
+          - maxLength: 10
+          - example: F8J1
       ntsSac:
-        title: NTS SAC
-        example: N002214CSW32Y9
-        $ref: '#/definitions/NullableString'
+        allOf:
+          - $ref: '#/definitions/NullableString'
+          - title: NTS SAC
+          - example: N002214CSW32Y9
     required:
       - issueDate
       - reportByDate
@@ -2684,19 +2687,21 @@ definitions:
         example: F8J1
         x-nullable: true
       sac:
-        title: HHG SAC
-        example: N002214CSW32Y9
-        $ref: '#/definitions/NullableString'
+        allOf:
+          - $ref: '#/definitions/NullableString'
+          - title: HHG SAC
+          - example: N002214CSW32Y9
       ntsTac:
+        $ref: '#/definitions/NullableString'
         title: NTS TAC
-        minLength: 4
-        maxLength: 4
+        minLength: 10
+        maxLength: 10
         example: F8J1
-        $ref: '#/definitions/NullableString'
       ntsSac:
-        title: NTS SAC
-        example: N002214CSW32Y9
-        $ref: '#/definitions/NullableString'
+        allOf:
+          - $ref: '#/definitions/NullableString'
+          - title: NTS SAC
+          - example: N002214CSW32Y9
       departmentIndicator:
         $ref: '#/definitions/DeptIndicator'
         x-nullable: true


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11427) for this change

## Summary

* Adding `allOf`, I don't think is giving the results expected. It's omitting the other sibling properties instead of including them all. Not having it seems to be working. 
* Changed the minLength and maxLength to see if the generated code would have any changes, doesn't seem to
* I don't see a way to be able to pull in the values minLength and maxLength, the swagger generator drops these fields completely. Seems like you'd have to hardcode the values in the `Validate` function. Because of this we'd need specific types for each field.



## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
