### PR TITLE
Update pre commit hadolint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,7 +132,7 @@ repos:
         pass_filenames: false
 
   - repo: git://github.com/trussworks/pre-commit-hooks
-    rev: v1.1.0
+    rev: v1.1.1
     hooks:
       - id: gen-docs
         args: ['docs/adr']


### PR DESCRIPTION
## Description

Upgrade to a version of trussworks/pre-commit-hooks that supports hadolint on M1 Macs 

See https://github.com/trussworks/pre-commit-hooks/releases/tag/v1.1.1

## Reviewer Notes

Having someone with an M1 and a non-M1 mac try would be helpful.

## Setup

Make sure the following works with no errors

```sh
pre-commit run hadolint --verbose --all-files
```

Sample output
```sh
Run hadolint Dockerfile linter...........................................Passed
- hook id: hadolint
- duration: 0.3s

```

## Code Review Verification Steps

* [X] Request review from a member of a different team.

## References

* [This slack thread](https://trussworks.slack.com/archives/C02KTA0RS57/p1643762508474119) for this change.
* [This slack thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1639414590066100) explains more about the approach used.
