### PR TITLE
[MB-10958] Rename duty_station_names table (this branch is just for testing on experimental)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for exp deploys. See the branch settings below.
-  exp-branch: &exp-branch mb-MB-10958-rename-duty-station-names-exp-test
+  exp-branch: &exp-branch placeholder_branch_name
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -49,22 +49,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
+  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
+  client-ignore-branch: &client-ignore-branch placeholder_branch_name
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
+  server-ignore-branch: &server-ignore-branch placeholder_branch_name
 
 executors:
   av_medium:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for exp deploys. See the branch settings below.
-  exp-branch: &exp-branch placeholder_branch_name
+  exp-branch: &exp-branch mb-MB-10958-rename-duty-station-names-exp-test
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -49,22 +49,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch mb-MB-10958-rename-duty-station-names-exp-test
 
 executors:
   av_medium:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -697,3 +697,4 @@
 20220112013152_update_duty_locations.up.sql
 20220113172826_create_new_duty_locations.up.sql
 20220126235958_remove_cac_access_carterjones_monfresh_ronolibert_and_shkeating.up.sql
+20220202213113_rename_duty_station_names.up.sql

--- a/migrations/app/schema/20220202213113_rename_duty_station_names.up.sql
+++ b/migrations/app/schema/20220202213113_rename_duty_station_names.up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE duty_station_names RENAME TO duty_location_names;
+
+ALTER TABLE duty_location_names RENAME COLUMN duty_station_id TO duty_location_id;
+
+ALTER INDEX IF EXISTS duty_station_names_pkey RENAME TO duty_location_names_pkey;
+
+ALTER INDEX IF EXISTS duty_station_names_duty_station_id_idx RENAME TO duty_location_names_duty_location_id_idx;
+
+ALTER INDEX IF EXISTS duty_station_names_name_trgm_idx RENAME TO duty_location_names_name_trgm_idx;
+
+ALTER INDEX IF EXISTS duty_station_names_name_idx RENAME TO duty_location_names_name_idx;
+
+ALTER TABLE duty_location_names RENAME CONSTRAINT duty_location_names_duty_station_id_fkey TO duty_location_names_duty_location_id_fkey;
+
+CREATE VIEW duty_station_names AS
+    SELECT id, name, duty_location_id as duty_station_id, created_at, updated_at
+    FROM duty_location_names;
+
+COMMENT ON VIEW duty_station_names IS 'This is temporary view to assist with migration of name from duty station -> duty location.';


### PR DESCRIPTION
We're using duty_location_names instead of duty_station_names.
I also added a view in this migration that allows code that references
the old names to continue working.

## [Jira ticket](tbd) for this change

## Summary

Is there anything you would like reviewers to give additional scrutiny?

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
