### PR TITLE
MB-11402 Adds e2e test coverage for TOO shipment editing

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -3150,6 +3150,7 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	createHHGNeedsServicesCounselingWithLocator(appCtx, "SCE3ET")
 	createHHGNeedsServicesCounselingWithLocator(appCtx, "SCE4ET")
 	createHHGNeedsServicesCounselingWithDestinationAddressAndType(appCtx)
+	createHHGNoGovCounselingForRetirementWithDestinationAddressAndType(appCtx)
 	createBasicNTSMove(appCtx, userUploader)
 	createBasicMovePPM01(appCtx, userUploader)
 	createBasicMovePPM02(appCtx, userUploader)

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -4896,6 +4896,43 @@ func createHHGNeedsServicesCounseling(appCtx appcontext.AppContext) {
 	})
 }
 
+func createHHGNoGovCounselingForRetirementWithDestinationAddressAndType(appCtx appcontext.AppContext) {
+	db := appCtx.DB()
+	submittedAt := time.Now()
+	orders := testdatagen.MakeOrderWithoutDefaults(db, testdatagen.Assertions{
+		DutyStation: models.DutyStation{
+			ProvidesServicesCounseling: false,
+		},
+		Order: models.Order{OrdersType: internalmessages.OrdersTypeRETIREMENT},
+	})
+
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			Locator:     "PCCIV1",
+			Status:      models.MoveStatusSUBMITTED,
+			SubmittedAt: &submittedAt,
+		},
+		Order: orders,
+	})
+
+	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
+	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
+	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	destinationAddressType := models.DestinationAddressTypeHomeOfRecord
+
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:           models.MTOShipmentTypeHHG,
+			Status:                 models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:    &requestedPickupDate,
+			RequestedDeliveryDate:  &requestedDeliveryDate,
+			DestinationAddressID:   &destinationAddress.ID,
+			DestinationAddressType: &destinationAddressType,
+		},
+	})
+}
+
 func createHHGNeedsServicesCounselingWithDestinationAddressAndType(appCtx appcontext.AppContext) {
 	db := appCtx.DB()
 	submittedAt := time.Now()

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -286,6 +286,9 @@ func subScenarioMisc(appCtx appcontext.AppContext, userUploader *uploader.UserUp
 		createMoveWith2MinimalShipments(appCtx, userUploader)
 		createApprovedMoveWithMinimalShipment(appCtx, userUploader)
 
+		// A move for a retiree
+		createHHGNoGovCounselingForRetirementWithDestinationAddressAndType(appCtx)
+
 		// Prime API
 		createWebhookSubscriptionForPaymentRequestUpdate(appCtx)
 		// This move below is a PPM move in DRAFT status. It should probably


### PR DESCRIPTION
## Summary

This adds in some e2e test coverage in `tooFlows.js` so that we're running through editing a shipment and also running through an edit to the shipment destination address type. We completed some earlier work focused on the services counseling role that gave shared functionality to the TOO, so this seeks to make sure we have a similar level of test coverage for the interactions.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the e2e test locally.

```sh
make db_test_reset
make e2e_test
```


</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

