### PR TITLE
MB-10908: Adds TAC validation to TXO and Service Counselor edit orders pages

### DIFF
--- a/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
+++ b/src/pages/Office/ServicesCounselingOrders/ServicesCounselingOrders.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { generatePath } from 'react-router';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { Button } from '@trussworks/react-uswds';
@@ -15,10 +15,12 @@ import { ORDERS_TYPE_OPTIONS } from 'constants/orders';
 import { ORDERS } from 'constants/queryKeys';
 import { servicesCounselingRoutes } from 'constants/routes';
 import { useOrdersDocumentQueries } from 'hooks/queries';
-import { counselingUpdateOrder } from 'services/ghcApi';
+import { getTacValid, counselingUpdateOrder } from 'services/ghcApi';
 import { dropdownInputOptions, formatSwaggerDate } from 'shared/formatters';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { TAC_VALIDATION_ACTIONS, reducer, initialState } from 'reducers/tacValidation';
+import { LOA_TYPE } from 'shared/constants';
 
 const ordersTypeDropdownOptions = dropdownInputOptions(ORDERS_TYPE_OPTIONS);
 
@@ -37,6 +39,7 @@ const validationSchema = Yup.object({
 const ServicesCounselingOrders = () => {
   const history = useHistory();
   const { moveCode } = useParams();
+  const [tacValidationState, tacValidationDispatch] = useReducer(reducer, null, initialState);
   const { move, orders, isLoading, isError } = useOrdersDocumentQueries(moveCode);
   const orderId = move?.ordersId;
 
@@ -61,7 +64,64 @@ const ServicesCounselingOrders = () => {
     },
   });
 
+  const handleHHGTacValidation = async (value) => {
+    if (value && value.length === 4 && value !== tacValidationState[LOA_TYPE.HHG].tac) {
+      const response = await getTacValid({ tac: value });
+      tacValidationDispatch({
+        type: TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE,
+        loaType: LOA_TYPE.HHG,
+        isValid: response.isValid,
+        tac: value,
+      });
+    }
+  };
+
+  const handleNTSTacValidation = async (value) => {
+    if (value && value.length === 4 && value !== tacValidationState[LOA_TYPE.NTS].tac) {
+      const response = await getTacValid({ tac: value });
+      tacValidationDispatch({
+        type: TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE,
+        loaType: LOA_TYPE.NTS,
+        isValid: response.isValid,
+        tac: value,
+      });
+    }
+  };
+
   const order = Object.values(orders)?.[0];
+
+  useEffect(() => {
+    if (isLoading || isError) {
+      return;
+    }
+
+    const checkHHGTac = async () => {
+      const response = await getTacValid({ tac: order.tac });
+      tacValidationDispatch({
+        type: TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE,
+        loaType: LOA_TYPE.HHG,
+        isValid: response.isValid,
+        tac: order.tac,
+      });
+    };
+
+    const checkNTSTac = async () => {
+      const response = await getTacValid({ tac: order.ntsTac });
+      tacValidationDispatch({
+        type: TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE,
+        loaType: LOA_TYPE.NTS,
+        isValid: response.isValid,
+        tac: order.ntsTac,
+      });
+    };
+
+    if (order?.tac && order.tac.length === 4) {
+      checkHHGTac();
+    }
+    if (order?.ntsTac && order.ntsTac.length === 4) {
+      checkNTSTac();
+    }
+  }, [order?.tac, order?.ntsTac, isLoading, isError]);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
@@ -91,10 +151,16 @@ const ServicesCounselingOrders = () => {
     ntsSac: order?.ntsSac,
   };
 
+  const tacWarningMsg =
+    'This TAC does not appear in TGET, so it might not be valid. Make sure it matches what‘s on the orders before you continue.';
+
   return (
     <div className={styles.sidebar}>
       <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onSubmit}>
         {(formik) => {
+          const hhgTacWarning = tacValidationState[LOA_TYPE.HHG].isValid ? '' : tacWarningMsg;
+          const ntsTacWarning = tacValidationState[LOA_TYPE.NTS].isValid ? '' : tacWarningMsg;
+
           return (
             <form onSubmit={formik.handleSubmit}>
               <div className={styles.content}>
@@ -125,6 +191,10 @@ const ServicesCounselingOrders = () => {
                     showOrdersTypeDetail={false}
                     ordersType={order.order_type}
                     setFieldValue={formik.setFieldValue}
+                    hhgTacWarning={hhgTacWarning}
+                    ntsTacWarning={ntsTacWarning}
+                    validateHHGTac={handleHHGTacValidation}
+                    validateNTSTac={handleNTSTacValidation}
                   />
                 </div>
                 <div className={styles.bottom}>

--- a/src/reducers/tacValidation.js
+++ b/src/reducers/tacValidation.js
@@ -1,0 +1,35 @@
+import { LOA_TYPE } from 'shared/constants';
+
+export const TAC_VALIDATION_ACTIONS = {
+  VALIDATION_RESPONSE: 'VALIDATION_RESPONSE',
+};
+
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE: {
+      return {
+        ...state,
+        [action.loaType]: {
+          isValid: action.isValid,
+          tac: action.tac,
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export const initialState = () => {
+  return {
+    [LOA_TYPE.HHG]: {
+      isValid: true,
+      tac: '',
+    },
+    [LOA_TYPE.NTS]: {
+      isValid: true,
+      tac: '',
+    },
+  };
+};

--- a/src/reducers/tacValidation.test.js
+++ b/src/reducers/tacValidation.test.js
@@ -1,0 +1,25 @@
+import { TAC_VALIDATION_ACTIONS, initialState, reducer } from './tacValidation';
+
+describe('reducers/tacValidation', () => {
+  it('creates an initialState', () => {
+    expect(initialState()).toEqual({
+      HHG: { isValid: true, tac: '' },
+      NTS: { isValid: true, tac: '' },
+    });
+  });
+
+  it('accepts validation actions', () => {
+    const state = initialState();
+    expect(
+      reducer(state, {
+        type: TAC_VALIDATION_ACTIONS.VALIDATION_RESPONSE,
+        loaType: 'HHG',
+        isValid: false,
+        tac: '1234',
+      }),
+    ).toEqual({
+      NTS: { isValid: true, tac: '' },
+      HHG: { isValid: false, tac: '1234' },
+    });
+  });
+});


### PR DESCRIPTION
## Jira ticket for this change: [MB-10908](https://dp3.atlassian.net/browse/MB-10908)

## Summary

This pull request restores asynchronous TAC validation for the TXO version of the Edit Orders page, and adds it to the Service Counselor version of the same page.

It also does a few minor things:

* HHG SAC was marked as a required field in the TXO version of this page; that's been restored to optional.
* Tests are added to the TXO and Service Counselor versions of the Edit Orders page around TAC validation; this required some refactoring to make mocked TXO validation work correctly without emitting error messages.
* The common logic for dealing with the validation has been moved into a reducer function, which has been added in `src/reducers`.

**Note**: Valid demo TAC values that are loaded with devseed data are as follows:

* 1111, 2222, 3333,... 9999
* E11A, E12A, E13A,... E19A

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. In the office app, sign in locally as Service Counselor user. Select any move from the queue.
2. Scroll down to the "Edit orders" button and click it to be brought to the Edit orders page. (There may be a fullscreen PDF error that displays due to the way test data is generated; ignore that.)
3. Verify that the existing HHG TAC value (likely "F8E1") is displaying a warning message about not being in "TGET." Change this to one of the valid TAC codes above and verify that the warning message no longer displays.
4. Enter a value for the NTS TAC value and verify that the warning message displays or doesn't based on the code's validity.
5. Sign out, then sign in locally as a TOO user. Select any move from the queue and verify that the validation works as for the HHG and NTS TAC code fields in the same way as a Service Counselor.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

