### PR TITLE
Adding one change to make sure it doesn't save empty change records

### DIFF
--- a/migrations/app/schema/20220201170324_audit_trigger.up.sql
+++ b/migrations/app/schema/20220201170324_audit_trigger.up.sql
@@ -113,7 +113,7 @@ BEGIN
                    WHERE newkv.value IS DISTINCT FROM oldkv.value);
         audit_row.changed_data = j_diff - excluded_cols;
 
-        IF audit_row.changed_data = jsonb('{}') THEN
+        IF audit_row.changed_data = jsonb('{}') OR audit_row.changed_data IS NULL THEN
             -- All changed fields are ignored. Skip this update.
             RETURN NULL;
         END IF;


### PR DESCRIPTION
# Overview 
The only change necessary for the DB was to make sure the blank changed_data doesn't create a new record. This will help reduce storage data. 