### PR TITLE
MB-11073 (Frontend, TIO) Do not display estimated weight hint text for NTS-release shipments

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -2435,6 +2435,7 @@ func createMoveWithHHGAndNTSRPaymentRequest(appCtx appcontext.AppContext, userUp
 			PrimeActualWeight:    &actualWeight,
 			ShipmentType:         models.MTOShipmentTypeHHGOutOfNTSDom,
 			ApprovedDate:         swag.Time(time.Now()),
+			ActualPickupDate:     swag.Time(time.Now()),
 			Status:               models.MTOShipmentStatusApproved,
 			StorageFacility:      &storageFacility,
 			TACType:              &tacType,

--- a/src/components/Customer/Review/ShipmentCard/ShipmentCard.stories.jsx
+++ b/src/components/Customer/Review/ShipmentCard/ShipmentCard.stories.jsx
@@ -6,10 +6,12 @@ import PPMShipmentCard from './PPMShipmentCard';
 import NTSShipmentCard from './NTSShipmentCard';
 import NTSRShipmentCard from './NTSRShipmentCard';
 
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
 const hhgDefaultProps = {
   moveId: 'testMove123',
   shipmentNumber: 1,
-  shipmentType: 'HHG',
+  shipmentType: SHIPMENT_OPTIONS.HHG,
   shipmentId: 'ABC123K',
   requestedPickupDate: new Date('01/01/2020').toISOString(),
   pickupLocation: {
@@ -38,7 +40,7 @@ const hhgDefaultProps = {
 
 const ntsDefaultProps = {
   moveId: 'testMove123',
-  shipmentType: 'HHG_INTO_NTS_DOMESTIC',
+  shipmentType: SHIPMENT_OPTIONS.HHG_INTO_NTS_DOMESTIC,
   shipmentId: 'ABC123K',
   showEditBtn: true,
   requestedPickupDate: new Date('01/01/2020').toISOString(),
@@ -61,7 +63,7 @@ const ntsDefaultProps = {
 const ntsrDefaultProps = {
   moveId: 'testMove123',
   shipmentNumber: 1,
-  shipmentType: 'HHG_OUTOF_NTS_DOMESTIC',
+  shipmentType: SHIPMENT_OPTIONS.HHG_OUTOF_NTS_DOMESTIC,
   shipmentId: 'ABC123K',
   showEditBtn: true,
   requestedDeliveryDate: new Date('03/01/2020').toISOString(),

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -16,6 +16,7 @@ function BillableWeightHintText({
   maxBillableWeight,
   originalWeight,
   totalBillableWeight,
+  isNTSRShipment,
 }) {
   const estimatedWeightTimes110 = estimatedWeight * 1.1;
 
@@ -30,7 +31,7 @@ function BillableWeightHintText({
       <div className={styles.hintText}>
         <strong>{formatWeight(originalWeight)}</strong> <span>| original weight</span>
       </div>
-      {show110OfTotalEstimatedWeight && (
+      {show110OfTotalEstimatedWeight && !isNTSRShipment && (
         <div className={styles.hintText}>
           <strong>{formatWeight(estimatedWeightTimes110)}</strong> <span>| 110% of total estimated weight</span>
         </div>
@@ -50,6 +51,7 @@ BillableWeightHintText.propTypes = {
   maxBillableWeight: number.isRequired,
   originalWeight: number,
   totalBillableWeight: number,
+  isNTSRShipment: bool,
 };
 
 BillableWeightHintText.defaultProps = {
@@ -57,16 +59,17 @@ BillableWeightHintText.defaultProps = {
   estimatedWeight: null,
   originalWeight: null,
   totalBillableWeight: null,
+  isNTSRShipment: false,
 };
 
-function MaxBillableWeightHintText({ weightAllowance, estimatedWeight }) {
+function MaxBillableWeightHintText({ weightAllowance, estimatedWeight, isNTSRShipment }) {
   return (
     <>
       <div>
         <strong data-testid="maxWeight-weightAllowance">{formatWeight(weightAllowance)}</strong>{' '}
         <span>| weight allowance</span>
       </div>
-      {!Number.isNaN(estimatedWeight) && estimatedWeight && (
+      {!Number.isNaN(estimatedWeight) && estimatedWeight && !isNTSRShipment && (
         <div className={styles.hintText}>
           <strong data-testid="maxWeight-estimatedWeight">{formatWeight(estimatedWeight * 1.1)}</strong>{' '}
           <span>| 110% of total estimated weight</span>
@@ -79,11 +82,13 @@ function MaxBillableWeightHintText({ weightAllowance, estimatedWeight }) {
 MaxBillableWeightHintText.propTypes = {
   estimatedWeight: number,
   weightAllowance: number,
+  isNTSRShipment: bool,
 };
 
 MaxBillableWeightHintText.defaultProps = {
   estimatedWeight: null,
   weightAllowance: null,
+  isNTSRShipment: false,
 };
 
 const validationSchema = Yup.object({
@@ -101,6 +106,7 @@ export default function EditBillableWeight({
   title,
   totalBillableWeight,
   weightAllowance,
+  isNTSRShipment,
 }) {
   const [showFields, setShowFields] = useState(showFieldsInitial);
 
@@ -142,9 +148,14 @@ export default function EditBillableWeight({
                   maxBillableWeight={maxBillableWeight}
                   originalWeight={originalWeight}
                   totalBillableWeight={totalBillableWeight}
+                  isNTSRShipment={isNTSRShipment}
                 />
               ) : (
-                <MaxBillableWeightHintText weightAllowance={weightAllowance} estimatedWeight={estimatedWeight} />
+                <MaxBillableWeightHintText
+                  weightAllowance={weightAllowance}
+                  estimatedWeight={estimatedWeight}
+                  isNTSRShipment={isNTSRShipment}
+                />
               )}
               <Fieldset className={styles.fieldset}>
                 <MaskedTextField
@@ -225,6 +236,7 @@ EditBillableWeight.propTypes = {
   title: string.isRequired,
   totalBillableWeight: number,
   weightAllowance: number,
+  isNTSRShipment: bool,
 };
 
 EditBillableWeight.defaultProps = {
@@ -236,4 +248,5 @@ EditBillableWeight.defaultProps = {
   showFieldsInitial: false,
   totalBillableWeight: null,
   weightAllowance: null,
+  isNTSRShipment: false,
 };

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.stories.jsx
@@ -44,6 +44,16 @@ EmptyMaxBillableWeight.args = {
   weightAllowance: 8000,
 };
 
+export const EmptyMaxBillableWeightNTSRelease = ToggledTemplate.bind({});
+
+EmptyMaxBillableWeightNTSRelease.args = {
+  billableWeightJustification: '',
+  estimatedWeight: 13750,
+  title: 'Max billable weight',
+  weightAllowance: 8000,
+  isNTSRShipment: true,
+};
+
 export const BillableWeight = Template.bind({});
 
 BillableWeight.args = {

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.test.jsx
@@ -159,6 +159,25 @@ describe('EditBillableWeight', () => {
         });
         expect(screen.queryByText('| 110% of total estimated weight')).not.toBeInTheDocument();
       });
+      it('should not show if this is an NTS-release shipment', async () => {
+        const defaultProps = {
+          title: 'Billable weight',
+          originalWeight: 10000,
+          estimatedWeight: 13000,
+          maxBillableWeight: 6000,
+          billableWeight: 14600,
+          totalBillableWeight: 11000,
+          editEntity: () => {},
+          isNTSRShipment: true,
+        };
+
+        render(<EditBillableWeight {...defaultProps} />);
+        userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        await waitFor(() => {
+          expect(screen.queryByText(formatWeight(defaultProps.estimatedWeight * 1.1))).not.toBeInTheDocument();
+        });
+        expect(screen.queryByText('| 110% of total estimated weight')).not.toBeInTheDocument();
+      });
     });
 
     describe('to fit within the max billable weight hint text', () => {

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -13,6 +13,7 @@ import { shipmentIsOverweight } from 'utils/shipmentWeights';
 import { MandatorySimpleAddressShape } from 'types/address';
 import { ShipmentOptionsOneOf } from 'types/shipment';
 import { shipmentTypeLabels } from 'content/shipments';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 export default function ShipmentCard({
   billableWeight,
@@ -128,6 +129,7 @@ export default function ShipmentCard({
           editEntity={editEntity}
           maxBillableWeight={maxBillableWeight}
           totalBillableWeight={totalBillableWeight}
+          isNTSRShipment={shipmentType === SHIPMENT_OPTIONS.NTSR}
         />
       </footer>
     </ShipmentContainer>

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -7,11 +7,12 @@ import EditBillableWeight from '../EditBillableWeight/EditBillableWeight';
 import styles from './ShipmentCard.module.scss';
 
 import ShipmentContainer from 'components/Office/ShipmentContainer/ShipmentContainer';
-import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { formatAddressShort, formatDateFromIso } from 'shared/formatters';
 import { formatWeight } from 'utils/formatters';
 import { shipmentIsOverweight } from 'utils/shipmentWeights';
 import { MandatorySimpleAddressShape } from 'types/address';
+import { ShipmentOptionsOneOf } from 'types/shipment';
+import { shipmentTypeLabels } from 'content/shipments';
 
 export default function ShipmentCard({
   billableWeight,
@@ -28,6 +29,7 @@ export default function ShipmentCard({
   reweighWeight,
   maxBillableWeight,
   totalBillableWeight,
+  shipmentType,
 }) {
   let showOriginalWeightHighlight = false;
   let showReweighWeightHighlight = false;
@@ -52,9 +54,10 @@ export default function ShipmentCard({
   }
 
   return (
-    <ShipmentContainer shipmentType={SHIPMENT_OPTIONS.HHG} className={styles.container}>
+    <ShipmentContainer shipmentType={shipmentType} className={styles.container}>
       <header>
-        <h2>HHG</h2>
+        <h2>{shipmentTypeLabels[shipmentType]}</h2>
+
         <section>
           <span>
             <strong>Departed</strong>
@@ -146,6 +149,7 @@ ShipmentCard.propTypes = {
   reweighWeight: number,
   maxBillableWeight: number.isRequired,
   totalBillableWeight: number,
+  shipmentType: ShipmentOptionsOneOf.isRequired,
 };
 
 ShipmentCard.defaultProps = {

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.test.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.test.jsx
@@ -5,6 +5,7 @@ import ShipmentCard from './ShipmentCard';
 
 import { formatAddressShort, formatDateFromIso } from 'shared/formatters';
 import { formatWeight } from 'utils/formatters';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 const tomorrow = new Date();
 tomorrow.setDate(tomorrow.getDate() + 1);
@@ -30,6 +31,7 @@ const defaultShipmentCardProps = {
   adjustedWeight: null,
   reweighRemarks: 'Unable to perform reweigh because shipment was already unloaded',
   editEntity: () => {},
+  shipmentType: SHIPMENT_OPTIONS.HHG,
 };
 
 describe('ShipmentCard', () => {
@@ -53,6 +55,7 @@ describe('ShipmentCard', () => {
       originalWeight: 4300,
       reweighRemarks: 'Unable to perform reweigh because shipment was already unloaded',
       editEntity: () => {},
+      shipmentType: SHIPMENT_OPTIONS.HHG,
     };
 
     render(<ShipmentCard {...defaultProps} />);
@@ -192,6 +195,7 @@ describe('ShipmentCard', () => {
       estimatedWeight: 5000,
       originalWeight: 4300,
       editEntity: () => {},
+      shipmentType: SHIPMENT_OPTIONS.HHG,
     };
 
     render(<ShipmentCard {...defaultProps} />);

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.test.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsSidebar.test.jsx
@@ -52,7 +52,7 @@ const shipment = {
   serviceOrderNumber: '1234',
   tacType: LOA_TYPE.HHG,
   sacType: LOA_TYPE.NTS,
-  shipmentType: 'HHG_OUTOF_NTS_DOMESTIC',
+  shipmentType: 'HHG',
 };
 
 const ordersLOA = {

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -27,6 +27,7 @@ import {
 import { shipmentIsOverweight } from 'utils/shipmentWeights';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import SomethingWentWrong from 'shared/SomethingWentWrong';
+import { SHIPMENT_OPTIONS } from 'shared/constants';
 
 export default function ReviewBillableWeight() {
   const [selectedShipmentIndex, setSelectedShipmentIndex] = React.useState(0);
@@ -231,11 +232,12 @@ export default function ReviewBillableWeight() {
                 {shipmentIsOverweight(
                   selectedShipment.primeEstimatedWeight,
                   selectedShipment.calculatedBillableWeight,
-                ) && (
-                  <Alert slim type="warning" data-testid="shipmentBillableWeightExceeds110OfEstimated">
-                    Shipment exceeds 110% of estimated weight.
-                  </Alert>
-                )}
+                ) &&
+                  selectedShipment.shipmentType !== SHIPMENT_OPTIONS.NTSR && (
+                    <Alert slim type="warning" data-testid="shipmentBillableWeightExceeds110OfEstimated">
+                      Shipment exceeds 110% of estimated weight.
+                    </Alert>
+                  )}
                 <div className={reviewBillableWeightStyles.weightSummary}>
                   <WeightSummary
                     maxBillableWeight={maxBillableWeight}
@@ -262,6 +264,7 @@ export default function ReviewBillableWeight() {
                   reweighWeight={selectedShipment?.reweigh?.weight}
                   maxBillableWeight={maxBillableWeight}
                   totalBillableWeight={totalBillableWeight}
+                  shipmentType={selectedShipment.shipmentType}
                 />
               </div>
             </DocumentViewerSidebar.Content>

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -197,6 +197,7 @@ export default function ReviewBillableWeight() {
                 weightAllowance={weightAllowance}
                 editEntity={editEntity}
                 billableWeightJustification={move.tioRemarks}
+                isNTSRShipment={selectedShipment.shipmentType === SHIPMENT_OPTIONS.NTSR}
               />
             </DocumentViewerSidebar.Content>
             <DocumentViewerSidebar.Footer>

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.test.jsx
@@ -107,6 +107,7 @@ const mockMtoShipments = [
   {
     id: 1,
     status: shipmentStatuses.APPROVED,
+    shipmentType: 'HHG',
     calculatedBillableWeight: 3000,
     billableWeightCap: 1000,
     primeEstimatedWeight: 1000,
@@ -119,6 +120,7 @@ const mockMtoShipments = [
   {
     id: 2,
     status: shipmentStatuses.APPROVED,
+    shipmentType: 'HHG',
     calculatedBillableWeight: 2000,
     billableWeightCap: 2000,
     primeEstimatedWeight: 2000,
@@ -131,6 +133,7 @@ const mockMtoShipments = [
   {
     id: 3,
     status: shipmentStatuses.DIVERSION_REQUESTED,
+    shipmentType: 'HHG',
     calculatedBillableWeight: 3000,
     billableWeightCap: 3000,
     primeEstimatedWeight: 7000,
@@ -142,9 +145,26 @@ const mockMtoShipments = [
   },
 ];
 
+const mockMtoNTSReleaseShipments = [
+  {
+    id: 1,
+    status: shipmentStatuses.APPROVED,
+    shipmentType: 'HHG_OUTOF_NTS_DOMESTIC',
+    calculatedBillableWeight: 3000,
+    billableWeightCap: 1000,
+    primeEstimatedWeight: 1000,
+    primeActualWeight: 300,
+    reweigh: { verificationReason: 'reweigh required', requestedAt: '2021-09-01' },
+    pickupAddress: { city: 'Las Vegas', state: 'NV', postalCode: '90210' },
+    destinationAddress: { city: 'Miami', state: 'FL', postalCode: '33607' },
+    actualPickupDate: '2021-08-31',
+  },
+];
+
 const mockHasAllInformationShipment = {
   id: 1,
   status: shipmentStatuses.DIVERSION_REQUESTED,
+  shipmentType: 'HHG',
   calculatedBillableWeight: 3000,
   billableWeightCap: 3000,
   primeEstimatedWeight: 7000,
@@ -158,6 +178,7 @@ const mockHasAllInformationShipment = {
 const mockNoReweighWeightShipment = {
   id: 2,
   status: shipmentStatuses.DIVERSION_REQUESTED,
+  shipmentType: 'HHG',
   calculatedBillableWeight: 3000,
   billableWeightCap: 3000,
   primeEstimatedWeight: 7000,
@@ -171,6 +192,7 @@ const mockNoReweighWeightShipment = {
 const mockNoPrimeEstimatedWeightShipment = {
   id: 3,
   status: shipmentStatuses.DIVERSION_REQUESTED,
+  shipmentType: 'HHG',
   calculatedBillableWeight: 3000,
   billableWeightCap: 3000,
   primeActualWeight: 300,
@@ -199,6 +221,12 @@ const move = {
 const useMovePaymentRequestsReturnValue = {
   order: mockOrders['1'],
   mtoShipments: mockMtoShipments,
+  move,
+};
+
+const useMovePaymentRequestsNTSReleaseReturnValue = {
+  order: mockOrders['1'],
+  mtoShipments: mockMtoNTSReleaseShipments,
   move,
 };
 
@@ -610,6 +638,18 @@ describe('ReviewBillableWeight', () => {
       it('does not render the alert when the shipment is not overweight - the billable weight is less than the estimated weight * 110%', () => {
         useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
         useMovePaymentRequestsQueries.mockReturnValue(noAlertsReturnValue);
+
+        render(<ReviewBillableWeight />);
+
+        const reviewShipmentWeights = screen.getByRole('button', { name: 'Review shipment weights' });
+        userEvent.click(reviewShipmentWeights);
+
+        expect(screen.queryByTestId('shipmentBillableWeightExceeds110OfEstimated')).not.toBeInTheDocument();
+      });
+
+      it('does not render the alert when the shipment an NTS-release', () => {
+        useOrdersDocumentQueries.mockReturnValue(useOrdersDocumentQueriesReturnValue);
+        useMovePaymentRequestsQueries.mockReturnValue(useMovePaymentRequestsNTSReleaseReturnValue);
 
         render(<ReviewBillableWeight />);
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11073) for this change

## Summary
Added logic to hide estimated weight alert on NTS-release shipments

Also fixed:
- added data to devseed to resolve propType error on a move
- added logic to display correct shipment type on ShipmentCard


## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Create a move with an NTS-release shipment and view it as a TIO user. 
2. Click the “Review weights” button to bring up that page
3. Click the “Edit” button to change the maximum weight. 
4. Ensure that the “(pounds) | 110% of total estimated weight” line does not display for this move.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
![Screen Shot 2022-02-09 at 12 40 37 PM](https://user-images.githubusercontent.com/1587316/153258407-9440d138-bc5e-456d-9d59-6d3252e96f3a.png)

