### PR TITLE
[MB-11565] Use swagger 0.29.0 for code generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
 
   # the cypress image to use
   cypress: &cypress milmove/circleci-docker:milmove-cypress-d919f8549bdb6891ff4bb06ba8bce74d515f322b

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: '2.1'
 
 # References for variables shared across the file
 references:
-  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
 
   # the cypress image to use
   cypress: &cypress milmove/circleci-docker:milmove-cypress-d919f8549bdb6891ff4bb06ba8bce74d515f322b

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -3,7 +3,7 @@
 ###########
 
 # Base builder so the ci build image hash is referenced once
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 ENV CIRCLECI=docker
 ENV REACT_APP_NODE_ENV=development

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -3,7 +3,7 @@
 ###########
 
 # Base builder so the ci build image hash is referenced once
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 ENV CIRCLECI=docker
 ENV REACT_APP_NODE_ENV=development

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_dp3
+++ b/Dockerfile.webhook_client_dp3
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_dp3
+++ b/Dockerfile.webhook_client_dp3
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
+FROM milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 as builder
+FROM milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 as builder
 
 # Prepare public DOD certificates.
 # hadolint ignore=DL3002

--- a/Makefile
+++ b/Makefile
@@ -1122,8 +1122,8 @@ pretty: gofmt ## Run code through JS and Golang formatters
 
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
-	docker pull milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
-	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 bash
+	docker pull milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
+	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16 bash
 
 .PHONY: prune_images
 prune_images:  ## Prune docker images

--- a/Makefile
+++ b/Makefile
@@ -1122,8 +1122,8 @@ pretty: gofmt ## Run code through JS and Golang formatters
 
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
-	docker pull milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
-	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4 bash
+	docker pull milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198 bash
 
 .PHONY: prune_images
 prune_images:  ## Prune docker images

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -147,10 +147,10 @@ in buildEnv {
 
     (import (builtins.fetchGit {
       # Descriptive name to make the store path easier to identify
-      name = "go-swagger-0.28.0";
+      name = "go-swagger-0.29.0";
       url = "https://github.com/NixOS/nixpkgs/";
       ref = "refs/heads/nixpkgs-unstable";
-      rev = "a2445c740efa0f5a34c1756dd28812e1b12d0b24";
+      rev = "5efc8ca954272c4376ac929f4c5ffefcc20551d5";
     }) {}).go-swagger
 
     (import (builtins.fetchGit {

--- a/pkg/gen/adminmessages/issuer.go
+++ b/pkg/gen/adminmessages/issuer.go
@@ -20,8 +20,12 @@ import (
 type Issuer string
 
 func NewIssuer(value Issuer) *Issuer {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Issuer.
+func (m Issuer) Pointer() *Issuer {
+	return &m
 }
 
 const (

--- a/pkg/gen/adminmessages/move_status.go
+++ b/pkg/gen/adminmessages/move_status.go
@@ -20,8 +20,12 @@ import (
 type MoveStatus string
 
 func NewMoveStatus(value MoveStatus) *MoveStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveStatus.
+func (m MoveStatus) Pointer() *MoveStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/adminmessages/webhook_subscription_status.go
+++ b/pkg/gen/adminmessages/webhook_subscription_status.go
@@ -20,8 +20,12 @@ import (
 type WebhookSubscriptionStatus string
 
 func NewWebhookSubscriptionStatus(value WebhookSubscriptionStatus) *WebhookSubscriptionStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated WebhookSubscriptionStatus.
+func (m WebhookSubscriptionStatus) Pointer() *WebhookSubscriptionStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/dpsmessages/affiliation.go
+++ b/pkg/gen/dpsmessages/affiliation.go
@@ -20,8 +20,12 @@ import (
 type Affiliation string
 
 func NewAffiliation(value Affiliation) *Affiliation {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Affiliation.
+func (m Affiliation) Pointer() *Affiliation {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/branch.go
+++ b/pkg/gen/ghcmessages/branch.go
@@ -20,8 +20,12 @@ import (
 type Branch string
 
 func NewBranch(value Branch) *Branch {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Branch.
+func (m Branch) Pointer() *Branch {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/customer_contact_type.go
+++ b/pkg/gen/ghcmessages/customer_contact_type.go
@@ -20,8 +20,12 @@ import (
 type CustomerContactType string
 
 func NewCustomerContactType(value CustomerContactType) *CustomerContactType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated CustomerContactType.
+func (m CustomerContactType) Pointer() *CustomerContactType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/dept_indicator.go
+++ b/pkg/gen/ghcmessages/dept_indicator.go
@@ -20,8 +20,12 @@ import (
 type DeptIndicator string
 
 func NewDeptIndicator(value DeptIndicator) *DeptIndicator {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeptIndicator.
+func (m DeptIndicator) Pointer() *DeptIndicator {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/dimension_type.go
+++ b/pkg/gen/ghcmessages/dimension_type.go
@@ -20,8 +20,12 @@ import (
 type DimensionType string
 
 func NewDimensionType(value DimensionType) *DimensionType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DimensionType.
+func (m DimensionType) Pointer() *DimensionType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/g_b_l_o_c.go
+++ b/pkg/gen/ghcmessages/g_b_l_o_c.go
@@ -20,8 +20,12 @@ import (
 type GBLOC string
 
 func NewGBLOC(value GBLOC) *GBLOC {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated GBLOC.
+func (m GBLOC) Pointer() *GBLOC {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/grade.go
+++ b/pkg/gen/ghcmessages/grade.go
@@ -20,8 +20,12 @@ import (
 type Grade string
 
 func NewGrade(value Grade) *Grade {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Grade.
+func (m Grade) Pointer() *Grade {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/l_o_a_type.go
+++ b/pkg/gen/ghcmessages/l_o_a_type.go
@@ -21,8 +21,12 @@ import (
 type LOAType string
 
 func NewLOAType(value LOAType) *LOAType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated LOAType.
+func (m LOAType) Pointer() *LOAType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/m_t_o_service_item_status.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item_status.go
@@ -20,8 +20,12 @@ import (
 type MTOServiceItemStatus string
 
 func NewMTOServiceItemStatus(value MTOServiceItemStatus) *MTOServiceItemStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOServiceItemStatus.
+func (m MTOServiceItemStatus) Pointer() *MTOServiceItemStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/m_t_o_shipment_status.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment_status.go
@@ -21,8 +21,12 @@ import (
 type MTOShipmentStatus string
 
 func NewMTOShipmentStatus(value MTOShipmentStatus) *MTOShipmentStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentStatus.
+func (m MTOShipmentStatus) Pointer() *MTOShipmentStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/m_t_o_shipment_type.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment_type.go
@@ -21,8 +21,12 @@ import (
 type MTOShipmentType string
 
 func NewMTOShipmentType(value MTOShipmentType) *MTOShipmentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentType.
+func (m MTOShipmentType) Pointer() *MTOShipmentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/move_status.go
+++ b/pkg/gen/ghcmessages/move_status.go
@@ -20,8 +20,12 @@ import (
 type MoveStatus string
 
 func NewMoveStatus(value MoveStatus) *MoveStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveStatus.
+func (m MoveStatus) Pointer() *MoveStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/orders_type.go
+++ b/pkg/gen/ghcmessages/orders_type.go
@@ -20,8 +20,12 @@ import (
 type OrdersType string
 
 func NewOrdersType(value OrdersType) *OrdersType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersType.
+func (m OrdersType) Pointer() *OrdersType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/orders_type_detail.go
+++ b/pkg/gen/ghcmessages/orders_type_detail.go
@@ -20,8 +20,12 @@ import (
 type OrdersTypeDetail string
 
 func NewOrdersTypeDetail(value OrdersTypeDetail) *OrdersTypeDetail {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersTypeDetail.
+func (m OrdersTypeDetail) Pointer() *OrdersTypeDetail {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/payment_request_status.go
+++ b/pkg/gen/ghcmessages/payment_request_status.go
@@ -20,8 +20,12 @@ import (
 type PaymentRequestStatus string
 
 func NewPaymentRequestStatus(value PaymentRequestStatus) *PaymentRequestStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PaymentRequestStatus.
+func (m PaymentRequestStatus) Pointer() *PaymentRequestStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/payment_service_item_status.go
+++ b/pkg/gen/ghcmessages/payment_service_item_status.go
@@ -20,8 +20,12 @@ import (
 type PaymentServiceItemStatus string
 
 func NewPaymentServiceItemStatus(value PaymentServiceItemStatus) *PaymentServiceItemStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PaymentServiceItemStatus.
+func (m PaymentServiceItemStatus) Pointer() *PaymentServiceItemStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/queue_move_status.go
+++ b/pkg/gen/ghcmessages/queue_move_status.go
@@ -20,8 +20,12 @@ import (
 type QueueMoveStatus string
 
 func NewQueueMoveStatus(value QueueMoveStatus) *QueueMoveStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated QueueMoveStatus.
+func (m QueueMoveStatus) Pointer() *QueueMoveStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/reweigh_requester.go
+++ b/pkg/gen/ghcmessages/reweigh_requester.go
@@ -20,8 +20,12 @@ import (
 type ReweighRequester string
 
 func NewReweighRequester(value ReweighRequester) *ReweighRequester {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ReweighRequester.
+func (m ReweighRequester) Pointer() *ReweighRequester {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/service_item_param_name.go
+++ b/pkg/gen/ghcmessages/service_item_param_name.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamName string
 
 func NewServiceItemParamName(value ServiceItemParamName) *ServiceItemParamName {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamName.
+func (m ServiceItemParamName) Pointer() *ServiceItemParamName {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/service_item_param_origin.go
+++ b/pkg/gen/ghcmessages/service_item_param_origin.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamOrigin string
 
 func NewServiceItemParamOrigin(value ServiceItemParamOrigin) *ServiceItemParamOrigin {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamOrigin.
+func (m ServiceItemParamOrigin) Pointer() *ServiceItemParamOrigin {
+	return &m
 }
 
 const (

--- a/pkg/gen/ghcmessages/service_item_param_type.go
+++ b/pkg/gen/ghcmessages/service_item_param_type.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamType string
 
 func NewServiceItemParamType(value ServiceItemParamType) *ServiceItemParamType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamType.
+func (m ServiceItemParamType) Pointer() *ServiceItemParamType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/affiliation.go
+++ b/pkg/gen/internalmessages/affiliation.go
@@ -20,8 +20,12 @@ import (
 type Affiliation string
 
 func NewAffiliation(value Affiliation) *Affiliation {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Affiliation.
+func (m Affiliation) Pointer() *Affiliation {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/backup_contact_permission.go
+++ b/pkg/gen/internalmessages/backup_contact_permission.go
@@ -20,8 +20,12 @@ import (
 type BackupContactPermission string
 
 func NewBackupContactPermission(value BackupContactPermission) *BackupContactPermission {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated BackupContactPermission.
+func (m BackupContactPermission) Pointer() *BackupContactPermission {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/dept_indicator.go
+++ b/pkg/gen/internalmessages/dept_indicator.go
@@ -20,8 +20,12 @@ import (
 type DeptIndicator string
 
 func NewDeptIndicator(value DeptIndicator) *DeptIndicator {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeptIndicator.
+func (m DeptIndicator) Pointer() *DeptIndicator {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/index_entitlements.go
+++ b/pkg/gen/internalmessages/index_entitlements.go
@@ -29,6 +29,11 @@ func (m IndexEntitlements) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName(k)
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName(k)
+				}
 				return err
 			}
 		}

--- a/pkg/gen/internalmessages/m_t_o_agent_type.go
+++ b/pkg/gen/internalmessages/m_t_o_agent_type.go
@@ -21,8 +21,12 @@ import (
 type MTOAgentType string
 
 func NewMTOAgentType(value MTOAgentType) *MTOAgentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOAgentType.
+func (m MTOAgentType) Pointer() *MTOAgentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/m_t_o_shipment_status.go
+++ b/pkg/gen/internalmessages/m_t_o_shipment_status.go
@@ -20,8 +20,12 @@ import (
 type MTOShipmentStatus string
 
 func NewMTOShipmentStatus(value MTOShipmentStatus) *MTOShipmentStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentStatus.
+func (m MTOShipmentStatus) Pointer() *MTOShipmentStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/m_t_o_shipment_type.go
+++ b/pkg/gen/internalmessages/m_t_o_shipment_type.go
@@ -21,8 +21,12 @@ import (
 type MTOShipmentType string
 
 func NewMTOShipmentType(value MTOShipmentType) *MTOShipmentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentType.
+func (m MTOShipmentType) Pointer() *MTOShipmentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/method_of_receipt.go
+++ b/pkg/gen/internalmessages/method_of_receipt.go
@@ -20,8 +20,12 @@ import (
 type MethodOfReceipt string
 
 func NewMethodOfReceipt(value MethodOfReceipt) *MethodOfReceipt {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MethodOfReceipt.
+func (m MethodOfReceipt) Pointer() *MethodOfReceipt {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/move_document_status.go
+++ b/pkg/gen/internalmessages/move_document_status.go
@@ -20,8 +20,12 @@ import (
 type MoveDocumentStatus string
 
 func NewMoveDocumentStatus(value MoveDocumentStatus) *MoveDocumentStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveDocumentStatus.
+func (m MoveDocumentStatus) Pointer() *MoveDocumentStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/move_document_type.go
+++ b/pkg/gen/internalmessages/move_document_type.go
@@ -21,8 +21,12 @@ import (
 type MoveDocumentType string
 
 func NewMoveDocumentType(value MoveDocumentType) *MoveDocumentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveDocumentType.
+func (m MoveDocumentType) Pointer() *MoveDocumentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/move_status.go
+++ b/pkg/gen/internalmessages/move_status.go
@@ -20,8 +20,12 @@ import (
 type MoveStatus string
 
 func NewMoveStatus(value MoveStatus) *MoveStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveStatus.
+func (m MoveStatus) Pointer() *MoveStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/moving_expense_type.go
+++ b/pkg/gen/internalmessages/moving_expense_type.go
@@ -20,8 +20,12 @@ import (
 type MovingExpenseType string
 
 func NewMovingExpenseType(value MovingExpenseType) *MovingExpenseType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MovingExpenseType.
+func (m MovingExpenseType) Pointer() *MovingExpenseType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/orders_status.go
+++ b/pkg/gen/internalmessages/orders_status.go
@@ -20,8 +20,12 @@ import (
 type OrdersStatus string
 
 func NewOrdersStatus(value OrdersStatus) *OrdersStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersStatus.
+func (m OrdersStatus) Pointer() *OrdersStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/orders_type.go
+++ b/pkg/gen/internalmessages/orders_type.go
@@ -20,8 +20,12 @@ import (
 type OrdersType string
 
 func NewOrdersType(value OrdersType) *OrdersType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersType.
+func (m OrdersType) Pointer() *OrdersType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/orders_type_detail.go
+++ b/pkg/gen/internalmessages/orders_type_detail.go
@@ -20,8 +20,12 @@ import (
 type OrdersTypeDetail string
 
 func NewOrdersTypeDetail(value OrdersTypeDetail) *OrdersTypeDetail {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersTypeDetail.
+func (m OrdersTypeDetail) Pointer() *OrdersTypeDetail {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/p_p_m_status.go
+++ b/pkg/gen/internalmessages/p_p_m_status.go
@@ -20,8 +20,12 @@ import (
 type PPMStatus string
 
 func NewPPMStatus(value PPMStatus) *PPMStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PPMStatus.
+func (m PPMStatus) Pointer() *PPMStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/reimbursement_status.go
+++ b/pkg/gen/internalmessages/reimbursement_status.go
@@ -20,8 +20,12 @@ import (
 type ReimbursementStatus string
 
 func NewReimbursementStatus(value ReimbursementStatus) *ReimbursementStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ReimbursementStatus.
+func (m ReimbursementStatus) Pointer() *ReimbursementStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/selected_move_type.go
+++ b/pkg/gen/internalmessages/selected_move_type.go
@@ -20,8 +20,12 @@ import (
 type SelectedMoveType string
 
 func NewSelectedMoveType(value SelectedMoveType) *SelectedMoveType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SelectedMoveType.
+func (m SelectedMoveType) Pointer() *SelectedMoveType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/service_member_rank.go
+++ b/pkg/gen/internalmessages/service_member_rank.go
@@ -20,8 +20,12 @@ import (
 type ServiceMemberRank string
 
 func NewServiceMemberRank(value ServiceMemberRank) *ServiceMemberRank {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceMemberRank.
+func (m ServiceMemberRank) Pointer() *ServiceMemberRank {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/signed_certification_type.go
+++ b/pkg/gen/internalmessages/signed_certification_type.go
@@ -20,8 +20,12 @@ import (
 type SignedCertificationType string
 
 func NewSignedCertificationType(value SignedCertificationType) *SignedCertificationType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SignedCertificationType.
+func (m SignedCertificationType) Pointer() *SignedCertificationType {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/signed_certification_type_create.go
+++ b/pkg/gen/internalmessages/signed_certification_type_create.go
@@ -20,8 +20,12 @@ import (
 type SignedCertificationTypeCreate string
 
 func NewSignedCertificationTypeCreate(value SignedCertificationTypeCreate) *SignedCertificationTypeCreate {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SignedCertificationTypeCreate.
+func (m SignedCertificationTypeCreate) Pointer() *SignedCertificationTypeCreate {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/t_shirt_size.go
+++ b/pkg/gen/internalmessages/t_shirt_size.go
@@ -20,8 +20,12 @@ import (
 type TShirtSize string
 
 func NewTShirtSize(value TShirtSize) *TShirtSize {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated TShirtSize.
+func (m TShirtSize) Pointer() *TShirtSize {
+	return &m
 }
 
 const (

--- a/pkg/gen/internalmessages/weight_ticket_set_type.go
+++ b/pkg/gen/internalmessages/weight_ticket_set_type.go
@@ -20,8 +20,12 @@ import (
 type WeightTicketSetType string
 
 func NewWeightTicketSetType(value WeightTicketSetType) *WeightTicketSetType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated WeightTicketSetType.
+func (m WeightTicketSetType) Pointer() *WeightTicketSetType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/affiliation.go
+++ b/pkg/gen/ordersmessages/affiliation.go
@@ -20,8 +20,12 @@ import (
 type Affiliation string
 
 func NewAffiliation(value Affiliation) *Affiliation {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Affiliation.
+func (m Affiliation) Pointer() *Affiliation {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/issuer.go
+++ b/pkg/gen/ordersmessages/issuer.go
@@ -20,8 +20,12 @@ import (
 type Issuer string
 
 func NewIssuer(value Issuer) *Issuer {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Issuer.
+func (m Issuer) Pointer() *Issuer {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/orders_type.go
+++ b/pkg/gen/ordersmessages/orders_type.go
@@ -37,8 +37,12 @@ import (
 type OrdersType string
 
 func NewOrdersType(value OrdersType) *OrdersType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersType.
+func (m OrdersType) Pointer() *OrdersType {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/rank.go
+++ b/pkg/gen/ordersmessages/rank.go
@@ -20,8 +20,12 @@ import (
 type Rank string
 
 func NewRank(value Rank) *Rank {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Rank.
+func (m Rank) Pointer() *Rank {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/status.go
+++ b/pkg/gen/ordersmessages/status.go
@@ -20,8 +20,12 @@ import (
 type Status string
 
 func NewStatus(value Status) *Status {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Status.
+func (m Status) Pointer() *Status {
+	return &m
 }
 
 const (

--- a/pkg/gen/ordersmessages/tour_type.go
+++ b/pkg/gen/ordersmessages/tour_type.go
@@ -23,8 +23,12 @@ import (
 type TourType string
 
 func NewTourType(value TourType) *TourType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated TourType.
+func (m TourType) Pointer() *TourType {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/m_t_o_agent_type.go
+++ b/pkg/gen/primemessages/m_t_o_agent_type.go
@@ -24,8 +24,12 @@ import (
 type MTOAgentType string
 
 func NewMTOAgentType(value MTOAgentType) *MTOAgentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOAgentType.
+func (m MTOAgentType) Pointer() *MTOAgentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_model_type.go
@@ -29,8 +29,12 @@ import (
 type MTOServiceItemModelType string
 
 func NewMTOServiceItemModelType(value MTOServiceItemModelType) *MTOServiceItemModelType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOServiceItemModelType.
+func (m MTOServiceItemModelType) Pointer() *MTOServiceItemModelType {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/m_t_o_service_item_status.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_status.go
@@ -20,8 +20,12 @@ import (
 type MTOServiceItemStatus string
 
 func NewMTOServiceItemStatus(value MTOServiceItemStatus) *MTOServiceItemStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOServiceItemStatus.
+func (m MTOServiceItemStatus) Pointer() *MTOServiceItemStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/m_t_o_shipment_type.go
+++ b/pkg/gen/primemessages/m_t_o_shipment_type.go
@@ -27,8 +27,12 @@ import (
 type MTOShipmentType string
 
 func NewMTOShipmentType(value MTOShipmentType) *MTOShipmentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentType.
+func (m MTOShipmentType) Pointer() *MTOShipmentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/payment_request_status.go
+++ b/pkg/gen/primemessages/payment_request_status.go
@@ -20,8 +20,12 @@ import (
 type PaymentRequestStatus string
 
 func NewPaymentRequestStatus(value PaymentRequestStatus) *PaymentRequestStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PaymentRequestStatus.
+func (m PaymentRequestStatus) Pointer() *PaymentRequestStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/payment_service_item_status.go
+++ b/pkg/gen/primemessages/payment_service_item_status.go
@@ -20,8 +20,12 @@ import (
 type PaymentServiceItemStatus string
 
 func NewPaymentServiceItemStatus(value PaymentServiceItemStatus) *PaymentServiceItemStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PaymentServiceItemStatus.
+func (m PaymentServiceItemStatus) Pointer() *PaymentServiceItemStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/re_service_code.go
+++ b/pkg/gen/primemessages/re_service_code.go
@@ -24,8 +24,12 @@ import (
 type ReServiceCode string
 
 func NewReServiceCode(value ReServiceCode) *ReServiceCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ReServiceCode.
+func (m ReServiceCode) Pointer() *ReServiceCode {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/reweigh_requester.go
+++ b/pkg/gen/primemessages/reweigh_requester.go
@@ -20,8 +20,12 @@ import (
 type ReweighRequester string
 
 func NewReweighRequester(value ReweighRequester) *ReweighRequester {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ReweighRequester.
+func (m ReweighRequester) Pointer() *ReweighRequester {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/service_item_param_name.go
+++ b/pkg/gen/primemessages/service_item_param_name.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamName string
 
 func NewServiceItemParamName(value ServiceItemParamName) *ServiceItemParamName {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamName.
+func (m ServiceItemParamName) Pointer() *ServiceItemParamName {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/service_item_param_origin.go
+++ b/pkg/gen/primemessages/service_item_param_origin.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamOrigin string
 
 func NewServiceItemParamOrigin(value ServiceItemParamOrigin) *ServiceItemParamOrigin {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamOrigin.
+func (m ServiceItemParamOrigin) Pointer() *ServiceItemParamOrigin {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/service_item_param_type.go
+++ b/pkg/gen/primemessages/service_item_param_type.go
@@ -20,8 +20,12 @@ import (
 type ServiceItemParamType string
 
 func NewServiceItemParamType(value ServiceItemParamType) *ServiceItemParamType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ServiceItemParamType.
+func (m ServiceItemParamType) Pointer() *ServiceItemParamType {
+	return &m
 }
 
 const (

--- a/pkg/gen/primemessages/update_m_t_o_service_item_model_type.go
+++ b/pkg/gen/primemessages/update_m_t_o_service_item_model_type.go
@@ -27,8 +27,12 @@ import (
 type UpdateMTOServiceItemModelType string
 
 func NewUpdateMTOServiceItemModelType(value UpdateMTOServiceItemModelType) *UpdateMTOServiceItemModelType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated UpdateMTOServiceItemModelType.
+func (m UpdateMTOServiceItemModelType) Pointer() *UpdateMTOServiceItemModelType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/dept_indicator.go
+++ b/pkg/gen/supportmessages/dept_indicator.go
@@ -20,8 +20,12 @@ import (
 type DeptIndicator string
 
 func NewDeptIndicator(value DeptIndicator) *DeptIndicator {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated DeptIndicator.
+func (m DeptIndicator) Pointer() *DeptIndicator {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/m_t_o_agent_type.go
+++ b/pkg/gen/supportmessages/m_t_o_agent_type.go
@@ -21,8 +21,12 @@ import (
 type MTOAgentType string
 
 func NewMTOAgentType(value MTOAgentType) *MTOAgentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOAgentType.
+func (m MTOAgentType) Pointer() *MTOAgentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_model_type.go
@@ -29,8 +29,12 @@ import (
 type MTOServiceItemModelType string
 
 func NewMTOServiceItemModelType(value MTOServiceItemModelType) *MTOServiceItemModelType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOServiceItemModelType.
+func (m MTOServiceItemModelType) Pointer() *MTOServiceItemModelType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/m_t_o_service_item_status.go
+++ b/pkg/gen/supportmessages/m_t_o_service_item_status.go
@@ -20,8 +20,12 @@ import (
 type MTOServiceItemStatus string
 
 func NewMTOServiceItemStatus(value MTOServiceItemStatus) *MTOServiceItemStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOServiceItemStatus.
+func (m MTOServiceItemStatus) Pointer() *MTOServiceItemStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/m_t_o_shipment_type.go
+++ b/pkg/gen/supportmessages/m_t_o_shipment_type.go
@@ -21,8 +21,12 @@ import (
 type MTOShipmentType string
 
 func NewMTOShipmentType(value MTOShipmentType) *MTOShipmentType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MTOShipmentType.
+func (m MTOShipmentType) Pointer() *MTOShipmentType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/move_status.go
+++ b/pkg/gen/supportmessages/move_status.go
@@ -20,8 +20,12 @@ import (
 type MoveStatus string
 
 func NewMoveStatus(value MoveStatus) *MoveStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated MoveStatus.
+func (m MoveStatus) Pointer() *MoveStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/orders_status.go
+++ b/pkg/gen/supportmessages/orders_status.go
@@ -20,8 +20,12 @@ import (
 type OrdersStatus string
 
 func NewOrdersStatus(value OrdersStatus) *OrdersStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersStatus.
+func (m OrdersStatus) Pointer() *OrdersStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/orders_type.go
+++ b/pkg/gen/supportmessages/orders_type.go
@@ -20,8 +20,12 @@ import (
 type OrdersType string
 
 func NewOrdersType(value OrdersType) *OrdersType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersType.
+func (m OrdersType) Pointer() *OrdersType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/orders_type_detail.go
+++ b/pkg/gen/supportmessages/orders_type_detail.go
@@ -20,8 +20,12 @@ import (
 type OrdersTypeDetail string
 
 func NewOrdersTypeDetail(value OrdersTypeDetail) *OrdersTypeDetail {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated OrdersTypeDetail.
+func (m OrdersTypeDetail) Pointer() *OrdersTypeDetail {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/payment_request_status.go
+++ b/pkg/gen/supportmessages/payment_request_status.go
@@ -20,8 +20,12 @@ import (
 type PaymentRequestStatus string
 
 func NewPaymentRequestStatus(value PaymentRequestStatus) *PaymentRequestStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated PaymentRequestStatus.
+func (m PaymentRequestStatus) Pointer() *PaymentRequestStatus {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/rank.go
+++ b/pkg/gen/supportmessages/rank.go
@@ -20,8 +20,12 @@ import (
 type Rank string
 
 func NewRank(value Rank) *Rank {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated Rank.
+func (m Rank) Pointer() *Rank {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/re_service_code.go
+++ b/pkg/gen/supportmessages/re_service_code.go
@@ -24,8 +24,12 @@ import (
 type ReServiceCode string
 
 func NewReServiceCode(value ReServiceCode) *ReServiceCode {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated ReServiceCode.
+func (m ReServiceCode) Pointer() *ReServiceCode {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/selected_move_type.go
+++ b/pkg/gen/supportmessages/selected_move_type.go
@@ -20,8 +20,12 @@ import (
 type SelectedMoveType string
 
 func NewSelectedMoveType(value SelectedMoveType) *SelectedMoveType {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated SelectedMoveType.
+func (m SelectedMoveType) Pointer() *SelectedMoveType {
+	return &m
 }
 
 const (

--- a/pkg/gen/supportmessages/webhook_notification_status.go
+++ b/pkg/gen/supportmessages/webhook_notification_status.go
@@ -20,8 +20,12 @@ import (
 type WebhookNotificationStatus string
 
 func NewWebhookNotificationStatus(value WebhookNotificationStatus) *WebhookNotificationStatus {
-	v := value
-	return &v
+	return &value
+}
+
+// Pointer returns a pointer to a freshly-allocated WebhookNotificationStatus.
+func (m WebhookNotificationStatus) Pointer() *WebhookNotificationStatus {
+	return &m
 }
 
 const (

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+  image=milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-assets
+++ b/scripts/gen-assets
@@ -24,7 +24,7 @@ if [ -n "${CIRCLECI+x}" ]; then
 else
   # Locally we need to download the docker image to get the binary
   echo "RUNNING LOCALLY"
-  image=milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
+  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
   docker pull -q "${image}"
   docker run -it --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" go-bindata -modtime "${modtime}" -o "${output_file}" -pkg "${package_name}" "${input_dirs[@]}"
 fi

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 if [ "${CIRCLECI+x}" ]; then
   LOCAL_SWAGGER="/usr/local/bin/swagger"
-elif swagger version 2>/dev/null | grep -F -q -E 'version: v?0.28.0'; then
+elif swagger version 2>/dev/null | grep -F -q -E 'version: v?0.29.0'; then
   LOCAL_SWAGGER=$(which swagger)
 fi
 
@@ -13,7 +13,7 @@ if [ -n "${LOCAL_SWAGGER+x}" ]; then
   echo "Using local swagger"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
+  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
   docker pull -q "${image}"
 fi
 

--- a/scripts/gen-server
+++ b/scripts/gen-server
@@ -13,7 +13,7 @@ if [ -n "${LOCAL_SWAGGER+x}" ]; then
   echo "Using local swagger"
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+  image=milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
   docker pull -q "${image}"
 fi
 

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -19,7 +19,7 @@ if [[ -n "${LOCAL_SWAGGER+x}" ]]; then
   done
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+  image=milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
   docker pull -q "${image}"
   for filename in "$@"; do
     docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"

--- a/scripts/pre-commit-swagger-validate
+++ b/scripts/pre-commit-swagger-validate
@@ -9,7 +9,7 @@ set -eu -o pipefail
 UNAME_S=$(uname -s)
 if [ "$UNAME_S" == "Linux" ]; then
   LOCAL_SWAGGER="/usr/local/bin/swagger"
-elif swagger version 2>/dev/null | grep -F -q -E 'version: v?0.28.0'; then
+elif swagger version 2>/dev/null | grep -F -q -E 'version: v?0.29.0'; then
   LOCAL_SWAGGER=$(which swagger)
 fi
 
@@ -19,7 +19,7 @@ if [[ -n "${LOCAL_SWAGGER+x}" ]]; then
   done
 else
   # Locally we need to download the docker image to get the binary
-  image=milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
+  image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
   docker pull -q "${image}"
   for filename in "$@"; do
     docker run --rm=true -v "${PWD}:${PWD}" -w "${PWD}" "${image}" swagger validate "${filename}"

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-circleci_build_image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
+circleci_build_image=milmove/circleci-docker:milmove-app-7a53b275e24f79a860fa6180b6d983bf9110fc16
 
 set -eux -o pipefail
 

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-circleci_build_image=milmove/circleci-docker:milmove-app-3739e422811794dd0ebe5ab1f0244764520a18c4
+circleci_build_image=milmove/circleci-docker:milmove-app-4d16fb0527a338a1d96296001295e4a9b6d65198
 
 set -eux -o pipefail
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11565) for this change

## Summary

This PR updates our Docker references to use an image that has go-swagger 0.29.0 (the latest version).  In turn, I have run `make server_generate` using it; this PR includes any changes to the generated files.  Part of the reason to get on the latest version is to make it easier to install and run the `swagger` utility locally to avoid long execution times using Docker on Apple Silicon machines.

Note that there are two commits -- the first updates all the hashes and references to go-swagger 0.29.0.  The second contains all the generated files that changed.

Although about 80 generated files changed, almost all of the changes are just adding a new `Pointer` method to enum types.

See the [go-swagger 0.29.0 release notes](https://github.com/go-swagger/go-swagger/releases/tag/v0.29.0) for more details.

Here is the corresponding PR in the circleci-docker repository: https://github.com/transcom/circleci-docker/pull/209.  **I am currently referencing hashes from that branch, but will update this PR with the merged hash after this PR has gone through some initial vetting.**

## Setup to Run Your Code

Make sure that all tests still pass.  Exercise the app a bit and make sure nothing strange seems to be happening.

Run a `make server_generate` and see that everything still works and that there are no local changes after regenerating.  Get a local version of go-swagger 0.29.0 and see if the local version is used instead of running the one in the Docker image.  If you use homebrew, you can `brew install go-swagger` to get a local version.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?
