### PR TITLE
MB-11594: Add .air.conf as an alterative to gin

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -1,0 +1,55 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# You can install air via
+#
+# go install github.com/cosmtrek/air@latest
+#
+# you can run air via
+#
+# ulimit -n 4096 && air
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp/air"
+
+[build]
+# ensure we rebuild if changes are made to swagger
+cmd = "make swagger_generate server_generate server_build"
+# Binary file yields from `cmd`.
+bin = "bin/milmove"
+# Use INTERFACE=localhost so macOS does not prompt to allow the binary to listen on the network
+full_bin = "INTERFACE=localhost bin/milmove serve"
+# Watch these filename extensions.
+include_ext = ["go","yaml"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["pkg/gen"]
+# Watch these directories if you specified.
+include_dir = ["cmd", "swagger-def", "pkg"]
+# Exclude files.
+# exclude_file = []
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true


### PR DESCRIPTION
## [MB-11594](https://dp3.atlassian.net/browse/MB-11594)

## Summary

This adds a new config for air as an optional tool.
