### PR TITLE
Mb 11351 save ntsr delivery address

### DIFF
--- a/cypress/integration/mymove/ntsr.js
+++ b/cypress/integration/mymove/ntsr.js
@@ -43,7 +43,8 @@ function customerReviewsNTSRMoveDetails() {
   cy.get('[data-testid="ntsr-summary"]').last().contains('02 Jan 2020');
 
   // Destination
-  cy.get('[data-testid="ntsr-summary"]').last().contains('30813');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('412 Avenue M');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('91111');
 
   // Receiving agent
   cy.get('[data-testid="ntsr-summary"]').last().contains('James Bond');

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -71,14 +71,18 @@ class MtoShipmentForm extends Component {
     const { history, match, selectedMoveType, isCreatePage, mtoShipment, updateMTOShipment } = this.props;
     const { moveId } = match.params;
 
+    const shipmentTypeToSave = shipmentType || selectedMoveType;
+    const isNTSR = shipmentTypeToSave === SHIPMENT_OPTIONS.NTSR;
+    const saveDeliveryAddress = hasDeliveryAddress === 'yes' || isNTSR === true;
+
     const preformattedMtoShipment = {
-      shipmentType: shipmentType || selectedMoveType,
+      shipmentType: shipmentTypeToSave,
       moveId,
       customerRemarks,
       pickup,
       delivery: {
         ...delivery,
-        address: hasDeliveryAddress === 'yes' ? delivery.address : undefined,
+        address: saveDeliveryAddress ? delivery.address : undefined,
       },
       secondaryPickup: hasSecondaryPickup ? secondaryPickup : {},
       secondaryDelivery: hasSecondaryDelivery ? secondaryDelivery : {},

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -217,7 +217,6 @@ class MtoShipmentForm extends Component {
                       {orders.has_dependents
                         ? formatWeight(serviceMember.weight_allotment?.total_weight_self_plus_dependents)
                         : formatWeight(serviceMember.weight_allotment?.total_weight_self)}{' '}
-                      total. You’ll be billed for any excess weight you move.
                     </Alert>
 
                     <Form className={formStyles.form}>

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -143,7 +143,7 @@ const ShipmentForm = ({
     destinationType,
   }) => {
     const deliveryDetails = delivery;
-    if (hasDeliveryAddress === 'no') {
+    if (hasDeliveryAddress === 'no' && shipmentType !== SHIPMENT_OPTIONS.NTSR) {
       delete deliveryDetails.address;
     }
 


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

This pr will allow the user to save the delivery address for an ntsr shipment. This should be the case for customers, service counselors, and TOOs.

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Log in as a customer and create a move.
2. Add an NTSR shipment to the move with a delivery address.
3. Click "next" and verify that the delivery address is displayed on the review page.
4. Log in to the office app as a service counselor and add an NTSR shipment to an existing move.
5. Edit the delivery address of the NTSR shipment and click "save"
6. Verify that the new delivery address has been saved.
7. Log in to the office app as a TOO and edit the move and shipment from step 4.
8. Edit the delivery address of the NTSR shipment and click "save"
9. Verify that the new delivery address has been saved.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
