### PR TITLE
[MB-10646] Increase width to accommodate NTS-r shipments

### DIFF
--- a/src/components/ShipmentList/ShipmentList.module.scss
+++ b/src/components/ShipmentList/ShipmentList.module.scss
@@ -19,7 +19,7 @@
 
   strong {
     white-space: nowrap;
-    @include u-minw(8);
+    @include u-minw(15);
     text-align: left;
   }
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10646) for this change

## Summary

The previous value of 8 only allowed for a minimum width of 64px. This
new value of 15 allows for a minimum width of 120px which covers the
longest title for a shipment so far, NTS-release.

Documentation on this change can be viewed in the official USWDS
documentation here: https://designsystem.digital.gov/utilities/height-and-width/#minw

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Log into MyMove as a customer.
1. Create a move with both an `HHG` and `NTS-Release` shipment.
1. View the home page and scroll down to the Shipments.
1. See that Shipment IDs are aligned.

## Verification Steps for Author

These are to be checked by the author.

- [ ] ~~Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)~~
- [ ] ~~Request review from a member of a different team.~~
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

<details>
<summary>📸  Screenshot(s)</summary>

<img width="1418" alt="Captura de Pantalla 2022-02-17 a la(s) 7 15 58 p m" src="https://user-images.githubusercontent.com/706004/154593388-8f794eaf-fded-481e-ad12-3a8d668abf43.png">


</details>
