### PR TITLE
[MB-11329] Fix issue where NTS-Release shipments don't appear in TOO queue

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -790,8 +790,10 @@ func QueueMoves(moves []models.Move) *ghcmessages.QueueMoves {
 			// though there can never be more than one GBLOC for a move.
 			gbloc = ghcmessages.GBLOC(move.ShipmentGBLOC[0].GBLOC)
 		} else {
-			// If the move doesn't have any shipments, we cannot assign it a GBLOC
-			gbloc = ""
+			// If the move's first shipment doesn't have a pickup address (like with an NTS-Release),
+			// we need to fall back to the origin duty location GBLOC.  If that's not available for
+			// some reason, then we should get the empty string (no GBLOC).
+			gbloc = ghcmessages.GBLOC(move.OriginDutyLocationGBLOC.GBLOC)
 		}
 
 		queueMoves[i] = &ghcmessages.QueueMove{

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -320,7 +320,7 @@ func gblocFilterForSC(gbloc *string) QueryOption {
 }
 
 func gblocFilterForTOO(gbloc *string) QueryOption {
-	// The SC should only see moves where the GBLOC for the first shipment's pickup address matches the given GBLOC
+	// The TOO should only see moves where the GBLOC for the first shipment's pickup address matches the given GBLOC
 	// unless we're dealing with an NTS-Release shipment. For NTS-Release shipments, we drop back to looking at the
 	// origin duty station's GBLOC since an NTS-Release does not populate the pickup address.
 	return func(query *pop.Query) {

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -24,8 +24,6 @@ type orderFetcher struct {
 type QueryOption func(*pop.Query)
 
 func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid.UUID, params *services.ListOrderParams) ([]models.Move, int, error) {
-	// Now that we've joined orders and move_orders, we only want to return orders that
-	// have an associated move.
 	var moves []models.Move
 	var transportationOffice models.TransportationOffice
 	// select the GBLOC associated with the transportation office of the session's current office user
@@ -43,7 +41,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 	// Essentially these are private functions that return query objects that we can mash together to form a complete
 	// query from modular parts.
 
-	// The services counselot queue does not base exclude marine results.
+	// The services counselor queue does not base exclude marine results.
 	// Only the TIO and TOO queues should.
 	needsCounseling := false
 	if len(params.Status) > 0 {
@@ -68,13 +66,17 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 	}
 
 	// We need to use two different GBLOC filter queries because:
-	//  - The Services Counselor queue filters based on the GBLOC of the transportation office
-	//  - The TOO queue uses the GBLOC we get from the first shipment's postal code
+	//  - The Services Counselor queue filters based on the GBLOC of the origin duty station's
+	//    transportation office
+	//  - The TOO queue uses the GBLOC we get from examining the postal code of the first shipment's
+	//    pickup address. However, if that shipment happens to be an NTS-Release, we instead drop
+	//    back to the GBLOC of the origin duty station's transportation office since an NTS-Release
+	//    does not populate the pickup address field.
 	var gblocQuery QueryOption
 	if needsCounseling {
-		gblocQuery = gblocFilter(gblocToFilterBy)
+		gblocQuery = gblocFilterForSC(gblocToFilterBy)
 	} else {
-		gblocQuery = shipmentGBLOCFilter(gblocToFilterBy)
+		gblocQuery = gblocFilterForTOO(gblocToFilterBy)
 	}
 	locatorQuery := locatorFilter(params.Locator)
 	dodIDQuery := dodIDFilter(params.DodID)
@@ -182,8 +184,6 @@ func NewOrderFetcher() services.OrderFetcher {
 
 // FetchOrder retrieves an Order for a given UUID
 func (f orderFetcher) FetchOrder(appCtx appcontext.AppContext, orderID uuid.UUID) (*models.Order, error) {
-	// Now that we've joined orders and move_orders, we only want to return orders that
-	// have an associated move_task_order.
 	order := &models.Order{}
 	err := appCtx.DB().Q().Eager(
 		"ServiceMember.BackupContacts",
@@ -310,8 +310,8 @@ func requestedMoveDateFilter(requestedMoveDate *string) QueryOption {
 	}
 }
 
-// Need to fix GBLOC for services counselor
-func gblocFilter(gbloc *string) QueryOption {
+func gblocFilterForSC(gbloc *string) QueryOption {
+	// The SC should only see moves where the origin duty station's GBLOC matches the given GBLOC.
 	return func(query *pop.Query) {
 		if gbloc != nil {
 			query.Where("o_gbloc.gbloc = ?", *gbloc)
@@ -319,10 +319,15 @@ func gblocFilter(gbloc *string) QueryOption {
 	}
 }
 
-func shipmentGBLOCFilter(gbloc *string) QueryOption {
+func gblocFilterForTOO(gbloc *string) QueryOption {
+	// The SC should only see moves where the GBLOC for the first shipment's pickup address matches the given GBLOC
+	// unless we're dealing with an NTS-Release shipment. For NTS-Release shipments, we drop back to looking at the
+	// origin duty station's GBLOC since an NTS-Release does not populate the pickup address.
 	return func(query *pop.Query) {
 		if gbloc != nil {
-			query.Where("move_to_gbloc.gbloc = ?", *gbloc)
+			// Note: extra parens necessary to keep precedence correct when AND'ing all filters together.
+			query.Where("((mto_shipments.shipment_type != ? AND move_to_gbloc.gbloc = ?) OR (mto_shipments.shipment_type = ? AND o_gbloc.gbloc = ?))",
+				models.MTOShipmentTypeHHGOutOfNTSDom, *gbloc, models.MTOShipmentTypeHHGOutOfNTSDom, *gbloc)
 		}
 	}
 }

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -583,32 +583,18 @@ func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOC
 		suite.Equal(lknqMove.ID, moves[0].ID)
 	})
 }
-func (suite *OrderServiceSuite) TestListOrdersForNTSRelease() {
+func (suite *OrderServiceSuite) TestListOrdersForTOOWithNTSRelease() {
 	// Make an NTS-Release shipment (and a move).  Should not have a pickup address.
 	move := testdatagen.MakeNTSRMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 
-	// These users should both have the same transportation office.
-	scOfficeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{})
+	// Make a TOO user and the postal code to GBLOC link.
 	tooOfficeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{})
-
-	// Make the postal code to GBLOC link.
 	testdatagen.MakePostalCodeToGBLOC(suite.DB(), move.Orders.OriginDutyLocation.Address.PostalCode, tooOfficeUser.TransportationOffice.Gbloc)
 
 	orderFetcher := NewOrderFetcher()
+	moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), tooOfficeUser.ID, &services.ListOrderParams{})
 
-	suite.T().Run("returns NTS-Release move as SC", func(t *testing.T) {
-		moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), scOfficeUser.ID, &services.ListOrderParams{})
-
-		suite.FatalNoError(err)
-		suite.Equal(1, moveCount)
-		suite.Len(moves, 1)
-	})
-
-	suite.T().Run("returns NTS-Release move as TOO", func(t *testing.T) {
-		moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), tooOfficeUser.ID, &services.ListOrderParams{})
-
-		suite.FatalNoError(err)
-		suite.Equal(1, moveCount)
-		suite.Len(moves, 1)
-	})
+	suite.FatalNoError(err)
+	suite.Equal(1, moveCount)
+	suite.Len(moves, 1)
 }

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *OrderServiceSuite) TestOrderFetcher() {
+func (suite *OrderServiceSuite) TestFetchOrder() {
 	expectedMove := testdatagen.MakeDefaultMove(suite.DB())
 	expectedOrder := expectedMove.Orders
 	orderFetcher := NewOrderFetcher()
@@ -36,7 +36,7 @@ func (suite *OrderServiceSuite) TestOrderFetcher() {
 	suite.Equal(expectedMove.Locator, order.Moves[0].Locator)
 }
 
-func (suite *OrderServiceSuite) TestOrderFetcherWithEmptyFields() {
+func (suite *OrderServiceSuite) TestFetchOrderWithEmptyFields() {
 	// When move_orders and orders were consolidated, we moved the OriginDutyLocation
 	// field that used to only exist on the move_orders table into the orders table.
 	// This means that existing orders in production won't have any values in the
@@ -66,7 +66,7 @@ func (suite *OrderServiceSuite) TestOrderFetcherWithEmptyFields() {
 	suite.Nil(order.Grade)
 }
 
-func (suite *OrderServiceSuite) TestListMoves() {
+func (suite *OrderServiceSuite) TestListOrders() {
 	// Create a Move without a shipment to test that only Orders with shipments
 	// are displayed to the TOO
 	testdatagen.MakeDefaultMove(suite.DB())
@@ -75,7 +75,7 @@ func (suite *OrderServiceSuite) TestListMoves() {
 
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 	//"30813"
-	// May have to create postalcodetogbolc for office user
+	// May have to create postalcodetogbloc for office user
 	testdatagen.MakePostalCodeToGBLOC(suite.DB(),
 		expectedMove.MTOShipments[0].PickupAddress.PostalCode,
 		officeUser.TransportationOffice.Gbloc)
@@ -215,7 +215,7 @@ func (suite *OrderServiceSuite) TestListMoves() {
 	})
 }
 
-func (suite *OrderServiceSuite) TestListMovesUSMCGBLOC() {
+func (suite *OrderServiceSuite) TestListOrdersUSMCGBLOC() {
 	orderFetcher := NewOrderFetcher()
 
 	suite.T().Run("returns USMC order for USMC office user", func(t *testing.T) {
@@ -253,7 +253,7 @@ func (suite *OrderServiceSuite) TestListMovesUSMCGBLOC() {
 	})
 }
 
-func (suite *OrderServiceSuite) TestListMovesMarines() {
+func (suite *OrderServiceSuite) TestListOrdersMarines() {
 	suite.T().Run("does not return moves where the service member affiliation is Marines for non-USMC office user", func(t *testing.T) {
 		orderFetcher := NewOrderFetcher()
 		marines := models.AffiliationMARINES
@@ -273,7 +273,7 @@ func (suite *OrderServiceSuite) TestListMovesMarines() {
 	})
 }
 
-func (suite *OrderServiceSuite) TestListMovesWithEmptyFields() {
+func (suite *OrderServiceSuite) TestListOrdersWithEmptyFields() {
 	expectedOrder := testdatagen.MakeDefaultOrder(suite.DB())
 
 	expectedOrder.Entitlement = nil
@@ -312,7 +312,7 @@ func (suite *OrderServiceSuite) TestListMovesWithEmptyFields() {
 
 }
 
-func (suite *OrderServiceSuite) TestListMovesWithPagination() {
+func (suite *OrderServiceSuite) TestListOrdersWithPagination() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 
 	// Map default shipment postal code to office user's GBLOC
@@ -333,7 +333,7 @@ func (suite *OrderServiceSuite) TestListMovesWithPagination() {
 
 }
 
-func (suite *OrderServiceSuite) TestListMovesWithSortOrder() {
+func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 	// SET UP: Dates for sorting by Requested Move Date
 	// - We want dates 2 and 3 to sandwich requestedMoveDate1 so we can test that the min() query is working
 	requestedMoveDate1 := time.Date(testdatagen.GHCTestYear, 02, 20, 0, 0, 0, 0, time.UTC)
@@ -503,7 +503,7 @@ func (suite *OrderServiceSuite) TestListMovesWithSortOrder() {
 	})
 }
 
-func (suite *OrderServiceSuite) TestListMovesNeedingServicesCounselingWithGBLOCSortFilter() {
+func (suite *OrderServiceSuite) TestListOrdersNeedingServicesCounselingWithGBLOCSortFilter() {
 
 	// TESTCASE SCENARIO
 	// Under test: OrderFetcher.ListOrders function
@@ -581,5 +581,34 @@ func (suite *OrderServiceSuite) TestListMovesNeedingServicesCounselingWithGBLOCS
 		suite.NoError(err)
 		suite.Equal(1, len(moves))
 		suite.Equal(lknqMove.ID, moves[0].ID)
+	})
+}
+func (suite *OrderServiceSuite) TestListOrdersForNTSRelease() {
+	// Make an NTS-Release shipment (and a move).  Should not have a pickup address.
+	move := testdatagen.MakeNTSRMoveWithShipment(suite.DB(), testdatagen.Assertions{})
+
+	// These users should both have the same transportation office.
+	scOfficeUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{})
+	tooOfficeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{})
+
+	// Make the postal code to GBLOC link.
+	testdatagen.MakePostalCodeToGBLOC(suite.DB(), move.Orders.OriginDutyLocation.Address.PostalCode, tooOfficeUser.TransportationOffice.Gbloc)
+
+	orderFetcher := NewOrderFetcher()
+
+	suite.T().Run("returns NTS-Release move as SC", func(t *testing.T) {
+		moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), scOfficeUser.ID, &services.ListOrderParams{})
+
+		suite.FatalNoError(err)
+		suite.Equal(1, moveCount)
+		suite.Len(moves, 1)
+	})
+
+	suite.T().Run("returns NTS-Release move as TOO", func(t *testing.T) {
+		moves, moveCount, err := orderFetcher.ListOrders(suite.AppContextForTest(), tooOfficeUser.ID, &services.ListOrderParams{})
+
+		suite.FatalNoError(err)
+		suite.Equal(1, moveCount)
+		suite.Len(moves, 1)
 	})
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11329) for this change

## Summary

Prior to this PR, if you had a move with either 1) a single NTS-Release shipment, or 2) multiple shipments with the first created being an NTS-Release, the move would appear in the services counselor queue but disappear when it got moved over to the TOO queue.  This turned out to be a side-effect of us changing the TOO queue a couple of months ago in #7877 to use the first shipment's pickup address's zip to determine the GBLOC for the move (previously, we had use the origin duty station's zip to determine the GBLOC).  NTS-Release shipments do not have a pickup address, so the query inadvertently was filtering them out.  This PR fixes that by looking at the origin duty station's zip instead if we're dealing with an NTS-Release shipment in the TOO queue.

See [this Slack thread](https://ustcdp3.slack.com/archives/C029R9LDTD4/p1642551903048800) for more background on the bug as well as how we decided to use the origin duty station's zip in this case.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

As a customer, create a move with just an NTS-Release shipment.  Now go to the office app as a services counselor.  Verify that your move shows up in the services counselor queue.  Then, edit the NTS-Release shipment to add any required information and then submit the move to the TOO.  Now go to the office app as a TOO.  Verify that your move shows up in the TOO queue and that a GBLOC is noted in its listing.

Try the same thing with a move that has multiple shipments but with an NTS-Release as the first created one.  Verify as before.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
