### PR TITLE
[MB-10970] Update remarks section helper text for NTS-Release shipments

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -433,7 +433,12 @@ class MtoShipmentForm extends Component {
                           <Callout>
                             Examples
                             <ul>
-                              {isNTSR && <li>The storage facility or address where your items are currently stored</li>}
+                              {isNTSR && (
+                                <li>
+                                  Details about the facility where your things are now, including the name or address
+                                  (if you know them)
+                                </li>
+                              )}
                               <li>Large, bulky, or fragile items</li>
                               <li>Access info for your origin or destination address</li>
                               <li>You’re shipping weapons or alcohol</li>

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -105,7 +105,9 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByLabelText('Email')[1]).toHaveAttribute('name', 'delivery.agent.email');
 
       expect(
-        screen.queryByText('The storage facility or address where your items are currently stored'),
+        screen.queryByText(
+          'Details about the facility where your things are now, including the name or address (if you know them)',
+        ),
       ).not.toBeInTheDocument();
 
       expect(
@@ -778,7 +780,9 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getAllByText('Pickup location')).toHaveLength(1);
       expect(screen.queryByText(/Receiving agent/)).not.toBeInTheDocument();
       expect(
-        screen.queryByText('The storage facility or address where your items are currently stored'),
+        screen.queryByText(
+          'Details about the facility where your things are now, including the name or address (if you know them)',
+        ),
       ).not.toBeInTheDocument();
 
       expect(
@@ -836,7 +840,9 @@ describe('MtoShipmentForm component', () => {
       expect(screen.getByLabelText('Email')).toHaveAttribute('name', 'delivery.agent.email');
 
       expect(
-        screen.queryByText('The storage facility or address where your items are currently stored'),
+        screen.queryByText(
+          'Details about the facility where your things are now, including the name or address (if you know them)',
+        ),
       ).toBeInTheDocument();
 
       expect(


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10970) for this change

## Summary

This PR is just a simple text change to the remarks helper text when a customer is setting up an NTS-Release shipment.  A few tests had to be adjusted as well.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

As a customer, go through onboarding and set up an NTS-Release shipment.  You should see the new "Details about the facility..." helper text instead of the old "The storage facility or address..." text.  Note that this should only appear on NTS-Release shipments, so make sure it does not appear on HHG or NTS shipment types.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

<img width="647" alt="Screen Shot 2022-02-22 at 10 35 03 AM" src="https://user-images.githubusercontent.com/4960757/155166196-8c8befd0-4f6c-4a11-b75e-f84b2b0a75e8.png">

