### PR TITLE
MB-11074: Updates to ShipmentCard subcomponent in billable weight review flow

### DIFF
--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { func, string, number } from 'prop-types';
+import { func, string, number, bool, node, oneOfType } from 'prop-types';
 import classnames from 'classnames';
 
 import EditBillableWeight from '../EditBillableWeight/EditBillableWeight';
@@ -14,6 +14,37 @@ import { MandatorySimpleAddressShape } from 'types/address';
 import { ShipmentOptionsOneOf } from 'types/shipment';
 import { shipmentTypeLabels } from 'content/shipments';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
+
+const ShipmentCardDetailRow = ({ display, rowTestId, className, title, content, contentTestId }) => {
+  if (display) {
+    return (
+      <div data-testid={rowTestId} className={className}>
+        <strong>{title}</strong>
+        <span data-testid={contentTestId}>{content}</span>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+ShipmentCardDetailRow.propTypes = {
+  display: bool,
+  rowTestId: string,
+  className: string,
+  title: string,
+  content: oneOfType([node, string]),
+  contentTestId: string,
+};
+
+ShipmentCardDetailRow.defaultProps = {
+  display: true,
+  rowTestId: '',
+  className: '',
+  title: '',
+  content: '',
+  contentTestId: '',
+};
 
 export default function ShipmentCard({
   billableWeight,
@@ -54,6 +85,9 @@ export default function ShipmentCard({
     showReweighWeightHighlight = true;
   }
 
+  const shipmentIsNTSR = shipmentType === SHIPMENT_OPTIONS.NTSR;
+  const dateText = shipmentIsNTSR ? 'Delivered' : 'Departed';
+
   return (
     <ShipmentContainer shipmentType={shipmentType} className={styles.container}>
       <header>
@@ -61,7 +95,7 @@ export default function ShipmentCard({
 
         <section>
           <span>
-            <strong>Departed</strong>
+            <strong>{dateText}</strong>
             <span data-testid="departureDate"> {formatDateFromIso(departedDate, 'DD MMM YYYY')}</span>
           </span>
           <span>
@@ -73,51 +107,62 @@ export default function ShipmentCard({
         </section>
       </header>
       <div className={styles.weights}>
-        <div
-          data-testid="estimatedWeightContainer"
+        <ShipmentCardDetailRow
+          display={!shipmentIsNTSR}
+          rowTestId="estimatedWeightContainer"
           className={classnames(styles.field, {
             [styles.warning]: !estimatedWeight,
           })}
-        >
-          <strong>Estimated weight</strong>
-          <span data-testid="estimatedWeight">
-            {estimatedWeight ? formatWeight(estimatedWeight) : <strong>Missing</strong>}
-          </span>
-        </div>
-        <div
-          data-testid="originalWeightContainer"
+          title="Estimated weight"
+          contentTestId="estimatedWeight"
+          content={estimatedWeight ? formatWeight(estimatedWeight) : <strong>Missing</strong>}
+        />
+
+        <ShipmentCardDetailRow
+          display={!shipmentIsNTSR}
+          rowTestId="originalWeightContainer"
           className={classnames(styles.field, {
             [styles.warning]: showOriginalWeightHighlight,
           })}
-        >
-          <strong>Original weight</strong>
-          <span data-testid="originalWeight">{formatWeight(originalWeight)}</span>
-        </div>
-        {dateReweighRequested && (
-          <div>
-            <div
-              data-testid="reweighWeightContainer"
-              className={classnames(styles.field, {
-                [styles.warning]: showReweighWeightHighlight,
-              })}
-            >
-              <strong>Reweigh weight</strong>
-              <span data-testid="reweighWeight">
-                {reweighWeight ? formatWeight(reweighWeight) : <strong>Missing</strong>}
-              </span>
-            </div>
-            <div className={reweighRemarks ? styles.field : classnames(styles.field, styles.lastRow)}>
-              <strong>Date reweigh requested</strong>
-              <span data-testid="dateReweighRequested">{formatDateFromIso(dateReweighRequested, 'DD MMM YYYY')}</span>
-            </div>
-            {reweighRemarks && (
-              <div className={classnames(styles.field, styles.remarks, styles.lastRow)}>
-                <strong>Reweigh remarks</strong>
-                <span data-testid="reweighRemarks">{reweighRemarks}</span>
-              </div>
-            )}
-          </div>
-        )}
+          title="Original weight"
+          contentTestId="originalWeight"
+          content={formatWeight(originalWeight)}
+        />
+
+        <ShipmentCardDetailRow
+          display={!shipmentIsNTSR && !!dateReweighRequested}
+          rowTestId="reweighWeightContainer"
+          className={classnames(styles.field, {
+            [styles.warning]: showReweighWeightHighlight,
+          })}
+          title="Reweigh weight"
+          contentTestId="reweighWeight"
+          content={reweighWeight ? formatWeight(reweighWeight) : <strong>Missing</strong>}
+        />
+
+        <ShipmentCardDetailRow
+          display={!shipmentIsNTSR && !!dateReweighRequested}
+          className={reweighRemarks ? styles.field : classnames(styles.field, styles.lastRow)}
+          title="Date reweigh requested"
+          contentTestId="dateReweighRequested"
+          content={formatDateFromIso(dateReweighRequested, 'DD MMM YYYY')}
+        />
+
+        <ShipmentCardDetailRow
+          display={!shipmentIsNTSR && !!dateReweighRequested && !!reweighRemarks}
+          className={classnames(styles.field, styles.remarks, styles.lastRow)}
+          title="Reweigh remarks"
+          contentTestId="reweighRemarks"
+          content={reweighRemarks}
+        />
+
+        <ShipmentCardDetailRow
+          display={shipmentIsNTSR}
+          className={classnames(styles.field, styles.lastRow)}
+          title="Shipment weight"
+          contentTestId="shipmentWeight"
+          content={formatWeight(originalWeight)}
+        />
       </div>
       <footer>
         <EditBillableWeight

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.stories.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.stories.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import ShipmentCard from './ShipmentCard';
 
+import { SHIPMENT_OPTIONS } from 'shared/constants';
+
 export default {
   title: 'Office Components/BillableWeightShipmentCard',
   component: ShipmentCard,
@@ -29,8 +31,15 @@ const props = {
   shipmentType: 'HHG',
 };
 
-export const Card = () => (
+export const HHG = () => (
   <div style={{ margin: '0 auto', height: '100%', width: 336 }}>
     <ShipmentCard {...props} />
   </div>
 );
+
+export const NTSrelease = () => (
+  <div style={{ margin: '0 auto', height: '100%', width: 336 }}>
+    <ShipmentCard {...props} shipmentType={SHIPMENT_OPTIONS.NTSR} />
+  </div>
+);
+NTSrelease.storyName = 'NTS-release';

--- a/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.test.jsx
+++ b/src/components/Office/BillableWeight/ShipmentCard/ShipmentCard.test.jsx
@@ -82,6 +82,9 @@ describe('ShipmentCard', () => {
     // addresses
     expect(screen.getByText(formatAddressShort(defaultProps.pickupAddress))).toBeInTheDocument();
     expect(screen.getByText(formatAddressShort(defaultProps.destinationAddress))).toBeInTheDocument();
+
+    // doesn't show NTS-release row
+    expect(screen.queryByTestId('shipmentWeight')).not.toBeInTheDocument();
   });
 
   describe('warning indicator', () => {
@@ -201,5 +204,34 @@ describe('ShipmentCard', () => {
     render(<ShipmentCard {...defaultProps} />);
     // labels
     expect(screen.queryByText('Reweigh remarks')).not.toBeInTheDocument();
+  });
+
+  it('renders the card as NTS-release', () => {
+    const props = {
+      billableWeight: 4014,
+      maxBillableWeight: 0,
+      dateReweighRequested: new Date().toISOString(),
+      departedDate: tomorrow.toISOString(),
+      pickupAddress: {
+        city: 'Rancho Santa Margarita',
+        state: 'CA',
+        postalCode: '92688',
+      },
+      destinationAddress: {
+        city: 'West Springfield Town',
+        state: 'MA',
+        postalCode: '01089',
+      },
+      estimatedWeight: 5000,
+      originalWeight: 4300,
+      reweighRemarks: 'Unable to perform reweigh because shipment was already unloaded',
+      editEntity: () => {},
+      shipmentType: SHIPMENT_OPTIONS.NTSR,
+    };
+
+    render(<ShipmentCard {...props} />);
+
+    expect(screen.getByTestId('shipmentWeight')).toHaveTextContent('4,300 lbs');
+    expect(screen.queryByTestId('estimatedWeight')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Jira ticket for this change: [MB-11074](https://dp3.atlassian.net/browse/MB-11074)

## Summary

This pull request implements logic and display changes to the `ShipmentCard` subcomponent inside the billable weights review flow, specifically when the user is viewing an NTS-release shipment. Specifically:

* It refactors the weight and reweigh remarks table that's present for HHG shipments in this subcomponent, and hides that content for NTS-release shipments, displaying a single line of shipment weight instead
* It replaces the text of "Departed" with "Delivered" for NTS-release shipments

Other parts of the acceptance criteria for this ticket (changing header text, hiding estimated weight) already work as-is.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. In Storybook, view the new "NTS-release" story for the `BillableWeightShipmentCard` component, and verify that it looks correct.
2. Log in to the Office application locally as a TIO user and open the `HGNTSR` move from the devseed data. Click the "Review weights" button on the next screen, and proceed through the flow until you get to the NTS-release shipment.
3. Verify that the shipment card looks correct; that estimated weight and reweigh information don't display, including after clicking the "Edit" button for this shipment.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
