### PR TITLE
MB-11608 Update ppm shipment to have more required fields

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -703,3 +703,4 @@
 20220204213113_rename_duty_station_names.up.sql
 20220207230521_adjust_pricing_params_for_ntsr.up.sql
 20220208225215_add_draft_to_ppm_shipment_status.up.sql
+20220218230224_update_ppm_shipments_to_have_more_required_fields.up.sql

--- a/migrations/app/schema/20220218230224_update_ppm_shipments_to_have_more_required_fields.up.sql
+++ b/migrations/app/schema/20220218230224_update_ppm_shipments_to_have_more_required_fields.up.sql
@@ -1,0 +1,41 @@
+-- We are changing a few fields to be required and thus not nullable. We don't have data in production, but people may
+-- have already run the devseed creation functions or used other methods to create ppm_shipments records. To account for
+-- that, we want to ensure that any records that have null values in the columns that will be required have something
+-- set so that this migration doesn't run into any issues.
+
+-- Set sensible values for newly required fields if they don't already have values.
+DO $$
+DECLARE
+	rec RECORD;
+BEGIN
+	FOR rec in SELECT ppm.id, res_addr.postal_code as pickup_postal_code, dl_addr.postal_code as dest_postal_code
+			   from ppm_shipments ppm
+						inner join mto_shipments ship on ppm.shipment_id = ship.id
+						inner join moves on ship.move_id = moves.id
+						inner join orders on moves.orders_id = orders.id
+						inner join duty_locations dl on orders.new_duty_station_id = dl.id
+						inner join addresses dl_addr on dl.address_id = dl_addr.id
+						inner join service_members sm on orders.service_member_id = sm.id
+						inner join addresses res_addr on sm.residential_address_id = res_addr.id
+			   WHERE ppm.pickup_postal_code IS NULL
+				  OR ppm.destination_postal_code IS NULL
+				  OR ppm.expected_departure_date IS NULL
+				  OR ppm.sit_expected IS NULL
+		LOOP
+			UPDATE ppm_shipments
+			SET
+				pickup_postal_code = COALESCE(pickup_postal_code, rec.pickup_postal_code),
+				destination_postal_code = COALESCE(destination_postal_code, rec.dest_postal_code),
+				expected_departure_date = COALESCE(expected_departure_date, now()),
+				sit_expected = COALESCE(sit_expected, FALSE)
+			WHERE id = rec.id;
+		END LOOP;
+END $$;
+
+-- Make the columns not nullable
+ALTER TABLE ppm_shipments
+	ALTER COLUMN expected_departure_date SET NOT NULL,
+	ALTER COLUMN pickup_postal_code SET NOT NULL,
+	ALTER COLUMN destination_postal_code SET NOT NULL,
+	ALTER COLUMN sit_expected SET DEFAULT FALSE,  -- This is a default we want to have going forward.
+	ALTER COLUMN sit_expected SET NOT NULL;

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -34,16 +34,16 @@ type PPMShipment struct {
 	CreatedAt                      time.Time         `json:"created_at" db:"created_at"`
 	UpdatedAt                      time.Time         `json:"updated_at" db:"updated_at"`
 	Status                         PPMShipmentStatus `json:"status" db:"status"`
-	ExpectedDepartureDate          *time.Time        `json:"expected_departure_date" db:"expected_departure_date"`
+	ExpectedDepartureDate          time.Time         `json:"expected_departure_date" db:"expected_departure_date"`
 	ActualMoveDate                 *time.Time        `json:"actual_move_date" db:"actual_move_date"`
 	SubmittedAt                    *time.Time        `json:"submitted_at" db:"submitted_at"`
 	ReviewedAt                     *time.Time        `json:"reviewed_at" db:"reviewed_at"`
 	ApprovedAt                     *time.Time        `json:"approved_at" db:"approved_at"`
-	PickupPostalCode               *string           `json:"pickup_postal_code" db:"pickup_postal_code"`
+	PickupPostalCode               string            `json:"pickup_postal_code" db:"pickup_postal_code"`
 	SecondaryPickupPostalCode      *string           `json:"secondary_pickup_postal_code" db:"secondary_pickup_postal_code"`
-	DestinationPostalCode          *string           `json:"destination_postal_code" db:"destination_postal_code"`
+	DestinationPostalCode          string            `json:"destination_postal_code" db:"destination_postal_code"`
 	SecondaryDestinationPostalCode *string           `json:"secondary_destination_postal_code" db:"secondary_destination_postal_code"`
-	SitExpected                    *bool             `json:"sit_expected" db:"sit_expected"`
+	SitExpected                    bool              `json:"sit_expected" db:"sit_expected"`
 	EstimatedWeight                *unit.Pound       `json:"estimated_weight" db:"estimated_weight"`
 	NetWeight                      *unit.Pound       `json:"net_weight" db:"net_weight"`
 	HasProGear                     *bool             `json:"has_pro_gear" db:"has_pro_gear"`

--- a/pkg/services/ppmshipment/ppm_shipment_creator_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator_test.go
@@ -54,10 +54,10 @@ func (suite *PPMShipmentSuite) TestPPMShipmentCreator() {
 
 		// Set required fields to their pointer values:
 		subtestData := suite.createSubtestData()
-		subtestData.newPPMShipment.ExpectedDepartureDate = models.TimePointer(time.Now())
-		subtestData.newPPMShipment.PickupPostalCode = models.StringPointer("90909")
-		subtestData.newPPMShipment.DestinationPostalCode = models.StringPointer("90905")
-		subtestData.newPPMShipment.SitExpected = models.BoolPointer(false)
+		subtestData.newPPMShipment.ExpectedDepartureDate = time.Now()
+		subtestData.newPPMShipment.PickupPostalCode = "90909"
+		subtestData.newPPMShipment.DestinationPostalCode = "90905"
+		subtestData.newPPMShipment.SitExpected = false
 
 		createdPPMShipment, err := subtestData.ppmShipmentCreator.CreatePPMShipmentWithDefaultCheck(suite.AppContextForTest(), subtestData.newPPMShipment)
 

--- a/pkg/services/ppmshipment/rules.go
+++ b/pkg/services/ppmshipment/rules.go
@@ -47,24 +47,22 @@ func checkRequiredFields() ppmShipmentValidator {
 	return ppmShipmentValidatorFunc(func(_ appcontext.AppContext, newPPMShipment models.PPMShipment, oldPPMShipment *models.PPMShipment, _ *models.MTOShipment) error {
 		verrs := validate.NewErrors()
 
+		// TODO: We'll need to add logic for when a shipment is being updated, otherwise the code below could break.
+		// Look at pkg/services/reweigh/rules.go  checkRequiredFields() for an example.
+
 		// Check that we have something in the expectedDepartureDate field:
-		if newPPMShipment.ExpectedDepartureDate == nil || newPPMShipment.ExpectedDepartureDate.IsZero() {
-			verrs.Add("expectedDepartureDate", "cannot be nil or a zero value")
+		if newPPMShipment.ExpectedDepartureDate.IsZero() {
+			verrs.Add("expectedDepartureDate", "cannot be a zero value")
 		}
 
 		// Check that we have something in the pickupPostalCode field:
-		if newPPMShipment.PickupPostalCode == nil || *newPPMShipment.PickupPostalCode == "" {
+		if newPPMShipment.PickupPostalCode == "" {
 			verrs.Add("pickupPostalCode", "cannot be nil or empty")
 		}
 
 		// Check that we have something in the destinationPostalCode field:
-		if newPPMShipment.DestinationPostalCode == nil || *newPPMShipment.DestinationPostalCode == "" {
+		if newPPMShipment.DestinationPostalCode == "" {
 			verrs.Add("destinationPostalCode", "cannot be nil or empty")
-		}
-
-		// Check that we have something in the sit Expected field:
-		if newPPMShipment.SitExpected == nil {
-			verrs.Add("sitExpected", "cannot be nil")
 		}
 
 		return verrs

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -28,7 +28,6 @@ var DevSeedScenario = devSeedScenario{
 // Setup initializes the run setup for the devseed scenario
 func (e *devSeedScenario) Setup(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
 	db := appCtx.DB()
-	logger := appCtx.Logger()
 	moveRouter := moverouter.NewMoveRouter()
 
 	// Testdatagen factories will create new random duty stations so let's get the standard ones in the migrations
@@ -55,10 +54,10 @@ func (e *devSeedScenario) Setup(appCtx appcontext.AppContext, userUploader *uplo
 		"ppm_and_hhg":                  subScenarioPPMAndHHG(appCtx, userUploader, moveRouter),
 		"ppm_office_queue":             subScenarioPPMOfficeQueue(appCtx, userUploader, moveRouter),
 		"shipment_hhg_cancelled":       subScenarioShipmentHHGCancelled(appCtx, allDutyLocations, originDutyLocationsInGBLOC),
-		"txo_queues":                   subScenarioTXOQueues(appCtx, userUploader, logger),
+		"txo_queues":                   subScenarioTXOQueues(appCtx, userUploader),
 		"misc":                         subScenarioMisc(appCtx, userUploader, primeUploader, moveRouter),
 		"reweighs":                     subScenarioReweighs(appCtx, userUploader, primeUploader, moveRouter),
-		"nts_and_ntsr":                 subScenarioNTSandNTSR(appCtx, userUploader, primeUploader, moveRouter),
+		"nts_and_ntsr":                 subScenarioNTSandNTSR(appCtx, userUploader, moveRouter),
 		"sit_extensions":               subScenarioSITExtensions(appCtx, userUploader, primeUploader),
 	}
 }

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -597,6 +597,56 @@ func createMoveWithPPMAndHHG(appCtx appcontext.AppContext, userUploader *uploade
 	}
 }
 
+func createUnsubmittedMoveWithMinimumPPMShipment(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
+	/*
+	 * A service member with orders and a minimal PPM Shipment. This means the PPM only has required fields.
+	 */
+	email := "dates_and_locations@ppm.unsubmitted"
+	uuidStr := "bbb469f3-f4bc-420d-9755-b9569f81715e"
+	loginGovUUID := uuid.Must(uuid.NewV4())
+
+	testdatagen.MakeUser(appCtx.DB(), testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovUUID:  &loginGovUUID,
+			LoginGovEmail: email,
+			Active:        true,
+		},
+	})
+
+	smIDPPM := "635e4c37-63b8-4860-9239-0e743ec383b0"
+	smWithPPM := testdatagen.MakeExtendedServiceMember(appCtx.DB(), testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.Must(uuid.FromString(smIDPPM)),
+			UserID:        uuid.Must(uuid.FromString(uuidStr)),
+			FirstName:     models.StringPointer("Minimal"),
+			LastName:      models.StringPointer("PPM"),
+			Edipi:         models.StringPointer("8937816489"),
+			PersonalEmail: models.StringPointer(email),
+		},
+	})
+
+	move := testdatagen.MakeMove(appCtx.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			ServiceMemberID: uuid.Must(uuid.FromString(smIDPPM)),
+			ServiceMember:   smWithPPM,
+		},
+		UserUploader: userUploader,
+		Move: models.Move{
+			ID:               uuid.Must(uuid.FromString("16cb4b73-cc0e-48c5-8cc7-b2a2ac52c342")),
+			Locator:          "PPMMIN",
+			SelectedMoveType: &ppmMoveType,
+		},
+	})
+
+	testdatagen.MakeMinimalPPMShipment(appCtx.DB(), testdatagen.Assertions{
+		Move: move,
+		PPMShipment: models.PPMShipment{
+			ID: uuid.Must(uuid.FromString("ffc95935-6781-4f95-9f35-16a5994cab56")),
+		},
+	})
+}
+
 func createMoveWithPPM(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, moveRouter services.MoveRouter) {
 	db := appCtx.DB()
 	/*
@@ -2911,7 +2961,7 @@ func createMoveWithHHGAndNTSRPaymentRequest(appCtx appcontext.AppContext, userUp
 	})
 }
 
-func createMoveWithHHGAndNTSRMissingInfo(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, moveRouter services.MoveRouter) {
+func createMoveWithHHGAndNTSRMissingInfo(appCtx appcontext.AppContext, moveRouter services.MoveRouter) {
 	db := appCtx.DB()
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
@@ -2953,7 +3003,7 @@ func createMoveWithHHGAndNTSRMissingInfo(appCtx appcontext.AppContext, userUploa
 	}
 }
 
-func createMoveWithHHGAndNTSMissingInfo(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, moveRouter services.MoveRouter) {
+func createMoveWithHHGAndNTSMissingInfo(appCtx appcontext.AppContext, moveRouter services.MoveRouter) {
 	db := appCtx.DB()
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{
@@ -5162,7 +5212,7 @@ func createHHGMoveWithRiskOfExcess(appCtx appcontext.AppContext, userUploader *u
 	makePaymentRequestForShipment(appCtx, move, shipment, primeUploader, filterFile, paymentRequestID, models.PaymentRequestStatusPending)
 }
 
-func createMoveWithDivertedShipments(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) {
+func createMoveWithDivertedShipments(appCtx appcontext.AppContext) {
 	db := appCtx.DB()
 	move := testdatagen.MakeMove(db, testdatagen.Assertions{
 		Move: models.Move{

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
-	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -96,6 +95,7 @@ func subScenarioPPMOnboarding(appCtx appcontext.AppContext, userUploader *upload
 		createTXOUSMC(appCtx)
 
 		// Onboarding
+		createUnsubmittedMoveWithMinimumPPMShipment(appCtx, userUploader)
 		createMoveWithPPM(appCtx, userUploader, moveRouter)
 	}
 }
@@ -155,7 +155,7 @@ func subScenarioHHGServicesCounseling(appCtx appcontext.AppContext, userUploader
 	}
 }
 
-func subScenarioTXOQueues(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, logger *zap.Logger) func() {
+func subScenarioTXOQueues(appCtx appcontext.AppContext, userUploader *uploader.UserUploader) func() {
 	return func() {
 		createTOO(appCtx)
 		createTIO(appCtx)
@@ -218,7 +218,7 @@ func subScenarioDivertedShipments(appCtx appcontext.AppContext, userUploader *up
 		createTXOUSMC(appCtx)
 
 		// Create diverted shipments that need TOO approval
-		createMoveWithDivertedShipments(appCtx, userUploader)
+		createMoveWithDivertedShipments(appCtx)
 
 		// Create diverted shipments that are approved and appear on the Move Task Order page
 		createRandomMove(appCtx, nil, allDutyLocations, originDutyLocationsInGBLOC, true, testdatagen.Assertions{
@@ -259,14 +259,14 @@ func subScenarioSITExtensions(appCtx appcontext.AppContext, userUploader *upload
 	}
 }
 
-func subScenarioNTSandNTSR(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader, moveRouter services.MoveRouter) func() {
+func subScenarioNTSandNTSR(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, moveRouter services.MoveRouter) func() {
 	return func() {
 		createTXO(appCtx)
 		createTXOServicesCounselor(appCtx)
 
 		// Create some submitted Moves for TXO users
-		createMoveWithHHGAndNTSRMissingInfo(appCtx, userUploader, moveRouter)
-		createMoveWithHHGAndNTSMissingInfo(appCtx, userUploader, moveRouter)
+		createMoveWithHHGAndNTSRMissingInfo(appCtx, moveRouter)
+		createMoveWithHHGAndNTSMissingInfo(appCtx, moveRouter)
 		createMoveWithNTSAndNTSR(
 			appCtx,
 			userUploader,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11608) for this change

## Summary

We want to make a few of the `PPMShipment` (table name: `ppm_shipments`) fields required, and so we're changing them to not be nullable in the db, and making the model fields not be pointers. The fields we're changing (there are fields between them, just left them out for a shorter cut): 

```go
ExpectedDepartureDate          time.Time         `json:"expected_departure_date" db:"expected_departure_date"`
PickupPostalCode               string            `json:"pickup_postal_code" db:"pickup_postal_code"`
DestinationPostalCode          string            `json:"destination_postal_code" db:"destination_postal_code"`
SitExpected                    bool              `json:"sit_expected" db:"sit_expected"`
```

I also added a testdatagen function to create a move with a PPMShipment that has just been started to make it easier for myself to look at the data and test the migration.

I got the idea to use `COALESCE` from this [article on conditional updates](https://medium.com/developer-rants/conditional-update-in-postgresql-a27ddb5dd35).

## Setup to Run Your Code

<details>
<summary>💻 Setup</summary>

### Start the Dev DB

```sh
make db_dev_run
```

### Test Changes 

Now you can do this a few ways, I'll list two.

#### Query

I personally connect to the DB using Goland's (and jetbrains' in general) DB tools, but I found this in the handbook on [how you can connect other tools to the DB](https://transcom.github.io/mymove-docs/docs/backend/setup/configure-postico-or-tableplus-to-connect-to-mymove-db).

I was using this to check the data before and after running the migration:

```sql
select sm.first_name, sm.last_name, ppm.expected_departure_date, ppm.pickup_postal_code, res_addr.postal_code, ppm.destination_postal_code, dl_addr.postal_code, ppm.sit_expected
from ppm_shipments ppm
    inner join mto_shipments ship on ppm.shipment_id = ship.id
    inner join moves on ship.move_id = moves.id
    inner join orders on moves.orders_id = orders.id
    inner join duty_locations dl on orders.new_duty_station_id = dl.id
    inner join addresses dl_addr on dl.address_id = dl_addr.id
    inner join service_members sm on orders.service_member_id = sm.id
    inner join addresses res_addr on sm.residential_address_id = res_addr.id
```

#### Run migration on existing data

If you've already generated PPM data in the past, you should be able to run this migration on top of your past data without issues. It should set sensible values for previously nullable fields.

```sh
make db_dev_migrate
```

#### Run migrations from scratch

You can also run the migrations from scratch if you prefer:

```sh
make db_dev_fresh
```

#### Checking Data

You can use the query above, or look through the tables directly if you prefer. You should see that all `ppm_shipments` records should now have the newly required fields filled in.

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database