### PR TITLE
MB-10673 Add callout  to est weight display if any shipments are non GHC

### DIFF
--- a/src/components/Office/WeightDisplay/WeightDisplay.module.scss
+++ b/src/components/Office/WeightDisplay/WeightDisplay.module.scss
@@ -36,5 +36,8 @@
 
   .details {
     @include u-font-size('base', 3);
+    small {
+      color: $base;
+    }
   }
 }

--- a/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
@@ -16,7 +16,7 @@ export default {
 
 const ExternalVendorShipmentMessage = () => (
   <small>
-    1 prime shipment not moved by GHC prime. <a href="">View move details</a>
+    1 shipment not moved by GHC prime. <a href="">View move details</a>
   </small>
 );
 

--- a/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
+++ b/src/components/Office/WeightDisplay/WeightDisplay.stories.jsx
@@ -14,6 +14,12 @@ export default {
   },
 };
 
+const ExternalVendorShipmentMessage = () => (
+  <small>
+    1 prime shipment not moved by GHC prime. <a href="">View move details</a>
+  </small>
+);
+
 const Template = (args) => <WeightDisplay {...args} />;
 
 export const WithNoWeight = Template.bind({});
@@ -36,4 +42,14 @@ WithWeightAndDetailsTag.args = {
 export const WithWeightAndDetailsText = Template.bind({});
 WithWeightAndDetailsText.args = {
   children: '110% of estimated weight',
+};
+
+export const WithWeightAndExternalVendorNTSRShipment = Template.bind({});
+WithWeightAndExternalVendorNTSRShipment.args = {
+  children: <ExternalVendorShipmentMessage />,
+};
+
+export const WithWeightAndExternalVendorNTSRShipmentAndTag = Template.bind({});
+WithWeightAndExternalVendorNTSRShipmentAndTag.args = {
+  children: [<Tag>Risk of excess</Tag>, <br />, <ExternalVendorShipmentMessage />],
 };

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { Alert, Button, Grid, GridContainer, Tag } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { queryCache, useMutation } from 'react-query';
@@ -79,6 +79,15 @@ function showShipmentFilter(shipment) {
   );
 }
 
+const externalVendorShipmentMessage = (shipmentCount, moveCode) => (
+  <small>
+    {shipmentCount} prime shipment not moved by GHC prime.{' '}
+    <Link className="usa-link" to={`/moves/${moveCode}`}>
+      View move details
+    </Link>
+  </small>
+);
+
 export const MoveTaskOrder = ({ match, ...props }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
@@ -97,6 +106,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
   const [unapprovedServiceItemsForShipment, setUnapprovedServiceItemsForShipment] = useState({});
   const [unapprovedSITExtensionForShipment, setUnApprovedSITExtensionForShipment] = useState({});
   const [estimatedWeightTotal, setEstimatedWeightTotal] = useState(null);
+  const [externalVendorShipmentCount, setExternalVendorShipmentCount] = useState(0);
 
   const nonShipmentSections = useMemo(() => {
     return ['move-weights'];
@@ -472,6 +482,11 @@ export const MoveTaskOrder = ({ match, ...props }) => {
         ? mtoShipments.filter((shipment) => shipment.status === shipmentStatuses.SUBMITTED).length
         : 0;
       setUnapprovedShipmentCount(shipmentCount);
+
+      const externalVendorShipments = mtoShipments?.length
+        ? mtoShipments.filter((shipment) => shipment.usesExternalVendor).length
+        : 0;
+      setExternalVendorShipmentCount(externalVendorShipments);
     }
   }, [mtoShipments, setUnapprovedShipmentCount]);
 
@@ -703,6 +718,10 @@ export const MoveTaskOrder = ({ match, ...props }) => {
             <WeightDisplay heading="Weight allowance" weightValue={order.entitlement.totalWeight} />
             <WeightDisplay heading="Estimated weight (total)" weightValue={estimatedWeightTotal}>
               {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && <Tag>Risk of excess</Tag>}
+              {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && externalVendorShipmentCount && (
+                <br />
+              )}
+              {externalVendorShipmentCount && externalVendorShipmentMessage(externalVendorShipmentCount, moveCode)}
             </WeightDisplay>
             <WeightDisplay
               heading="Max billable weight"

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -79,15 +79,6 @@ function showShipmentFilter(shipment) {
   );
 }
 
-const externalVendorShipmentMessage = (shipmentCount, moveCode) => (
-  <small>
-    {shipmentCount} prime shipment not moved by GHC prime.{' '}
-    <Link className="usa-link" to={`/moves/${moveCode}`}>
-      View move details
-    </Link>
-  </small>
-);
-
 export const MoveTaskOrder = ({ match, ...props }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isCancelModalVisible, setIsCancelModalVisible] = useState(false);
@@ -721,7 +712,14 @@ export const MoveTaskOrder = ({ match, ...props }) => {
               {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && externalVendorShipmentCount && (
                 <br />
               )}
-              {externalVendorShipmentCount && externalVendorShipmentMessage(externalVendorShipmentCount, moveCode)}
+              {externalVendorShipmentCount && (
+                <small>
+                  {externalVendorShipmentCount} shipment not moved by GHC prime.{' '}
+                  <Link className="usa-link" to={`/moves/${moveCode}`}>
+                    View move details
+                  </Link>
+                </small>
+              )}
             </WeightDisplay>
             <WeightDisplay
               heading="Max billable weight"

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -709,10 +709,9 @@ export const MoveTaskOrder = ({ match, ...props }) => {
             <WeightDisplay heading="Weight allowance" weightValue={order.entitlement.totalWeight} />
             <WeightDisplay heading="Estimated weight (total)" weightValue={estimatedWeightTotal}>
               {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && <Tag>Risk of excess</Tag>}
-              {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) && externalVendorShipmentCount && (
-                <br />
-              )}
-              {externalVendorShipmentCount && (
+              {hasRiskOfExcess(estimatedWeightTotal, order.entitlement.totalWeight) &&
+                externalVendorShipmentCount > 0 && <br />}
+              {externalVendorShipmentCount > 0 && (
                 <small>
                   {externalVendorShipmentCount} shipment not moved by GHC prime.{' '}
                   <Link className="usa-link" to={`/moves/${moveCode}`}>

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -16,6 +16,8 @@ import {
   riskOfExcessWeightQuery,
   lowerActualsMTOQuery,
   sitExtensionApproved,
+  allApprovedExternalVendorMTOQuery,
+  riskOfExcessWeightQueryExternalShipment,
 } from './moveTaskOrderUnitTestData';
 
 import { MoveTaskOrder } from 'pages/Office/MoveTaskOrder/MoveTaskOrder';
@@ -85,6 +87,9 @@ describe('MoveTaskOrder', () => {
 
       const riskOfExcessTag = await screen.queryByText(/Risk of excess/);
       expect(riskOfExcessTag).toBeFalsy();
+
+      const externalVendorShipmentCount = await screen.queryByText(/1 prime shipment not moved by GHC prime./);
+      expect(externalVendorShipmentCount).toBeFalsy();
     });
 
     it('displays the max billable weight', async () => {
@@ -370,6 +375,46 @@ describe('MoveTaskOrder', () => {
 
       const moveWeightTotal = await screen.getByText(/250 lbs/);
       expect(moveWeightTotal).toBeInTheDocument();
+    });
+
+    it('displays the external vendor shipment count and link to move details when there are external vendor shipments', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(allApprovedExternalVendorMTOQuery);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+            setExcessWeightRiskCount={setExcessWeightRiskCount}
+            setUnapprovedSITExtensionCount={setUnapprovedSITExtensionCount}
+          />
+        </MockProviders>,
+      );
+
+      const externalVendorShipmentCount = await screen.getByText(/1 prime shipment not moved by GHC prime./);
+      expect(externalVendorShipmentCount).toBeInTheDocument();
+    });
+
+    it('displays risk of excess tag and external vendor shipment count', async () => {
+      useMoveTaskOrderQueries.mockReturnValue(riskOfExcessWeightQueryExternalShipment);
+
+      render(
+        <MockProviders initialEntries={['moves/1000/allowances']}>
+          <MoveTaskOrder
+            {...requiredProps}
+            setUnapprovedShipmentCount={setUnapprovedShipmentCount}
+            setUnapprovedServiceItemCount={setUnapprovedServiceItemCount}
+            setExcessWeightRiskCount={setExcessWeightRiskCount}
+            setUnapprovedSITExtensionCount={setUnapprovedSITExtensionCount}
+          />
+        </MockProviders>,
+      );
+
+      const riskOfExcessTag = await screen.getByText(/Risk of excess/);
+      expect(riskOfExcessTag).toBeInTheDocument();
+      const externalVendorShipmentCount = await screen.getByText(/1 prime shipment not moved by GHC prime./);
+      expect(externalVendorShipmentCount).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.test.jsx
@@ -88,7 +88,7 @@ describe('MoveTaskOrder', () => {
       const riskOfExcessTag = await screen.queryByText(/Risk of excess/);
       expect(riskOfExcessTag).toBeFalsy();
 
-      const externalVendorShipmentCount = await screen.queryByText(/1 prime shipment not moved by GHC prime./);
+      const externalVendorShipmentCount = await screen.queryByText(/1 shipment not moved by GHC prime./);
       expect(externalVendorShipmentCount).toBeFalsy();
     });
 
@@ -392,7 +392,7 @@ describe('MoveTaskOrder', () => {
         </MockProviders>,
       );
 
-      const externalVendorShipmentCount = await screen.getByText(/1 prime shipment not moved by GHC prime./);
+      const externalVendorShipmentCount = await screen.getByText(/1 shipment not moved by GHC prime./);
       expect(externalVendorShipmentCount).toBeInTheDocument();
     });
 
@@ -413,7 +413,7 @@ describe('MoveTaskOrder', () => {
 
       const riskOfExcessTag = await screen.getByText(/Risk of excess/);
       expect(riskOfExcessTag).toBeInTheDocument();
-      const externalVendorShipmentCount = await screen.getByText(/1 prime shipment not moved by GHC prime./);
+      const externalVendorShipmentCount = await screen.getByText(/1 shipment not moved by GHC prime./);
       expect(externalVendorShipmentCount).toBeInTheDocument();
     });
   });

--- a/src/pages/Office/MoveTaskOrder/moveTaskOrderUnitTestData.js
+++ b/src/pages/Office/MoveTaskOrder/moveTaskOrderUnitTestData.js
@@ -409,6 +409,135 @@ export const allApprovedMTOQuery = {
   isSuccess: true,
 };
 
+export const allApprovedExternalVendorMTOQuery = {
+  orders: {
+    1: {
+      id: '1',
+      originDutyStation: {
+        address: {
+          streetAddress1: '',
+          city: 'Fort Knox',
+          state: 'KY',
+          postalCode: '40121',
+        },
+      },
+      destinationDutyStation: {
+        address: {
+          streetAddress1: '',
+          city: 'Fort Irwin',
+          state: 'CA',
+          postalCode: '92310',
+        },
+      },
+      entitlement: {
+        authorizedWeight: 8000,
+        totalWeight: 8500,
+      },
+    },
+  },
+  move: {
+    id: '2',
+    status: MOVE_STATUSES.APPROVALS_REQUESTED,
+    availableToPrimeAt: '2020-03-01T00:00:00.000Z',
+  },
+  mtoShipments: [
+    {
+      id: '3',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        streetAddress1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postalCode: '60601',
+      },
+      destinationAddress: {
+        streetAddress1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postalCode: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      reweigh: {
+        id: '00000000-0000-0000-0000-000000000000',
+      },
+      sitExtensions: [],
+      sitStatus: SITStatusOrigin,
+    },
+    {
+      id: '5',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.NTSR,
+      ntsRecordedWeight: 2000,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        streetAddress1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postalCode: '60601',
+      },
+      destinationAddress: {
+        streetAddress1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postalCode: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      reweigh: {
+        id: '00000000-0000-0000-0000-000000000000',
+      },
+      sitExtensions: [],
+      sitStatus: SITStatusOrigin,
+      isDiversion: false,
+      storageFacility: {
+        address: {
+          city: 'Anytown',
+          country: 'USA',
+          postalCode: '90210',
+          state: 'OK',
+          streetAddress1: '555 Main Ave',
+          streetAddress2: 'Apartment 900',
+        },
+        facilityName: 'my storage',
+        lotNumber: '2222',
+      },
+      serviceOrderNumber: '12341234',
+      requestedDeliveryDate: '26 Mar 2020',
+      tacType: 'HHG',
+      sacType: 'NTS',
+      usesExternalVendor: true,
+    },
+  ],
+  mtoServiceItems: [
+    {
+      id: '8',
+      mtoShipmentID: '3',
+      reServiceName: 'Domestic origin 1st day SIT',
+      status: SERVICE_ITEM_STATUS.SUBMITTED,
+      reServiceCode: 'DOFSIT',
+    },
+    {
+      id: '9',
+      mtoShipmentID: '4',
+      reServiceName: "Domestic origin add'l SIT",
+      status: SERVICE_ITEM_STATUS.SUBMITTED,
+      reServiceCode: 'DOASIT',
+    },
+  ],
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+};
+
 // weights returned are all null
 export const missingWeightQuery = {
   ...allApprovedMTOQuery,
@@ -950,6 +1079,109 @@ export const riskOfExcessWeightQuery = {
       primeActualWeight: 40,
       sitExtensions: [],
       sitStatus: SITStatusOrigin,
+    },
+  ],
+};
+
+export const riskOfExcessWeightQueryExternalShipment = {
+  ...allApprovedExternalVendorMTOQuery,
+  orders: {
+    1: {
+      id: '1',
+      originDutyStation: {
+        address: {
+          streetAddress1: '',
+          city: 'Fort Knox',
+          state: 'KY',
+          postalCode: '40121',
+        },
+      },
+      destinationDutyStation: {
+        address: {
+          streetAddress1: '',
+          city: 'Fort Irwin',
+          state: 'CA',
+          postalCode: '92310',
+        },
+      },
+      entitlement: {
+        authorizedWeight: 100,
+        totalWeight: 100,
+      },
+    },
+  },
+  mtoShipments: [
+    {
+      id: '3',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.HHG,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        streetAddress1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postalCode: '60601',
+      },
+      destinationAddress: {
+        streetAddress1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postalCode: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 50,
+      primeActualWeight: 50,
+      sitExtensions: [],
+      sitStatus: SITStatusOrigin,
+    },
+    {
+      id: '5',
+      moveTaskOrderID: '2',
+      shipmentType: SHIPMENT_OPTIONS.NTSR,
+      ntsRecordedWeight: 2000,
+      scheduledPickupDate: '2020-03-16',
+      requestedPickupDate: '2020-03-15',
+      pickupAddress: {
+        streetAddress1: '932 Baltic Avenue',
+        city: 'Chicago',
+        state: 'IL',
+        postalCode: '60601',
+      },
+      destinationAddress: {
+        streetAddress1: '10 Park Place',
+        city: 'Atlantic City',
+        state: 'NJ',
+        postalCode: '08401',
+      },
+      status: 'APPROVED',
+      eTag: '1234',
+      primeEstimatedWeight: 100,
+      primeActualWeight: 100,
+      reweigh: {
+        id: '00000000-0000-0000-0000-000000000000',
+      },
+      sitExtensions: [],
+      sitStatus: SITStatusOrigin,
+      isDiversion: false,
+      storageFacility: {
+        address: {
+          city: 'Anytown',
+          country: 'USA',
+          postalCode: '90210',
+          state: 'OK',
+          streetAddress1: '555 Main Ave',
+          streetAddress2: 'Apartment 900',
+        },
+        facilityName: 'my storage',
+        lotNumber: '2222',
+      },
+      serviceOrderNumber: '12341234',
+      requestedDeliveryDate: '26 Mar 2020',
+      tacType: 'HHG',
+      sacType: 'NTS',
+      usesExternalVendor: true,
     },
   ],
 };


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10673) for this change

## Summary
On MTO page, added a note with a link to the move details page if any shipments are not moved by the GHC prime.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as a TOO
3. For local, use NTSSUB move and change the NTS-release shipment to be an external vendor
4. For staging, create a move that has an HHG and an NTS-release
5. Approve the move and view the Move Task Order
6. You should see a note in the Estimated weight (Total) block indicating there are shipments not handled by the prime and a link back to the move details page.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
![Screen Shot 2022-02-22 at 6 54 15 PM](https://user-images.githubusercontent.com/1587316/155239623-5a1dbdd0-22e2-4e29-ab1c-1d73fd1f1bff.png)

