### PR TITLE
MB-11032: Estimated Pro Gear can be 0

### DIFF
--- a/src/components/Customer/PPMBooking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
+++ b/src/components/Customer/PPMBooking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
@@ -22,19 +22,17 @@ const validationSchema = Yup.object().shape({
   estimatedWeight: Yup.number().min(1, 'Enter a weight greater than 0 lbs').required('Required'),
   hasProGear: Yup.boolean().required('Required'),
   proGearWeight: Yup.number()
-    .min(1, 'Enter a weight greater than 0 lbs')
+    .min(0, 'Enter a weight 0lbs or greater')
     .when(['hasProGear', 'spouseProGearWeight'], {
       is: (hasProGear, spouseProGearWeight) => hasProGear && !spouseProGearWeight,
       then: (schema) =>
         schema
           .required(`Enter a weight into at least one pro-gear field. If you won't have pro-gear, select No above.`)
           .max(2000, 'Enter a weight less than 2,000 lbs'),
-      otherwise: Yup.number()
-        .min(1, 'Enter a weight greater than 0 lbs')
-        .max(2000, 'Enter a weight less than 2,000 lbs'),
+      otherwise: Yup.number().min(0, 'Enter a weight 0lbs or greater').max(2000, 'Enter a weight less than 2,000 lbs'),
     }),
   spouseProGearWeight: Yup.number()
-    .min(1, 'Enter a weight greater than 0 lbs')
+    .min(0, 'Enter a weight 0lbs or greater')
     .max(500, 'Enter a weight less than 500 lbs'),
 });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11032) for this change

## Summary

This PR adjusts the PR https://github.com/transcom/mymove/pull/8173 so that estimated pro gear weights and individuals can accept a 0 value. To test, select yes for if you have pro gear and input 0 for either the individual or spouse pro gear

This can be tested directly here: https://604991-114694829-gh.circle-artifacts.com/0/storybook/index.html?path=/story/customer-components-ppm-booking-estimated-weights-and-pro-gear--blank-estimated-weights-pro-gear

## Screenshots
<img width="745" alt="Screen Shot 2022-02-23 at 12 33 06 PM" src="https://user-images.githubusercontent.com/67110378/155375233-b78791ee-efdc-4710-b4d1-7da1c73b033c.png">
