### PR TITLE
Fix mock issue when running db_dev_e2e_populate

### DIFF
--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1455,7 +1455,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 
 	// called for zip 3 domestic linehaul service item
 	planner.On("Zip3TransitDistance", mock.AnythingOfType("*appcontext.appContext"),
-		"94535", "94535").Return(348, nil).Once()
+		"94535", "94535").Return(348, nil).Times(2)
 
 	// called for zip 5 domestic linehaul service item
 	planner.On("Zip5TransitDistance", mock.AnythingOfType("*appcontext.appContext"), "94535", "94535").Return(348, nil).Once()
@@ -1465,7 +1465,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 		"90210", "90211").Return(3, nil).Times(7)
 
 	// called for domestic shorthaul service item
-	planner.On("Zip3TransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(5)
+	planner.On("Zip3TransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(10)
 
 	// called for domestic origin SIT pickup service item
 	planner.On("Zip3TransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "94535").Return(348, nil).Once()


### PR DESCRIPTION
## Summary

In #8226, I partially turned off the payment request cache because it could lead to incorrect pricing in some scenarios (plus it didn't seem to be having the performance impact we had first thought).  Unfortunately, I didn't realize that we limit mock calls in one spot in some E2E test data setup for a payment request, so `make db_dev_e2e_populate` started to fail in `master`.  I'm not exactly sure the reasoning behind why we have the limits there, but I didn't want to remove all the limits entirely without digging in further.  So, to get us moving again, this PR just increases the limits on two distance calls (when the zip3s match) to be the minimum threshold required for a successful run.

## Setup to Run Your Code

Run `make db_dev_reset db_dev_e2e_populate` and verify that it completes successfully.
