### PR TITLE
Fix the diagnostic command

### DIFF
--- a/scripts/check-docker-size
+++ b/scripts/check-docker-size
@@ -7,7 +7,7 @@
 set -eu -o pipefail
 
 # Location of the reserved docker disk space
-DOCKER_RAW=~/Library/Containers/com.docker.docker/Data/vms/0/Docker.raw
+DOCKER_RAW=$(find ~/Library/Containers/com.docker.docker/Data -name Docker.raw)
 
 # Listing the actual used size by docker requires du
 SIZE_ACTUAL=$(/usr/bin/du "${DOCKER_RAW}" | cut -f1)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11902) for this change

## Summary

It looks like `Docker.raw` location has changed. The **Disk utilization
in Docker for Mac** states that this is in a different place compared to
where it was when this was originally written. This uses `find` to start
at the `Data` path to locate the `Docker.raw` file rather than relying
on a strictly hard-coded file path.

=> Official Docker Documentation https://docs.docker.com/desktop/mac/space/

## Verifying this code

Run the following command in the repository on macOS.

```sh
make diagnostic
```
