### PR TITLE
[MB-11487] Add assertions around details on customer reviewing NTS-release shipment info

### DIFF
--- a/cypress/integration/mymove/ntsr.js
+++ b/cypress/integration/mymove/ntsr.js
@@ -17,6 +17,7 @@ describe('Customer NTSr Setup flow', function () {
   it('Edits an NTSr shipment from review page', function () {
     cy.apiSignInAsUser(ntsUser);
     customerVisitsReviewPage();
+    customerReviewsShipmentInfoOnReviewPage();
     customerEditsNTSRShipmentFromReviewPage();
   });
 
@@ -72,6 +73,29 @@ function customerEditsNTSRShipmentFromReviewPage() {
   cy.get('[data-testid="ntsr-summary"]').contains('123 Oak Street');
   cy.get('[data-testid="ntsr-summary"]').contains('Ketchum Ash');
   cy.get('[data-testid="ntsr-summary"]').contains('Warning: fragile');
+}
+
+function customerReviewsShipmentInfoOnReviewPage() {
+  cy.get('[data-testid="review-move-header"]').contains('Review your details');
+
+  // Requested delivery date
+  cy.get('[data-testid="ntsr-summary"]').last().contains('15 Mar 2020');
+
+  // Destination
+  cy.get('[data-testid="ntsr-summary"]').last().contains('987 Any Avenue P.O. Box 9876');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('Fairfield, CA 94535');
+
+  // Second destination
+  cy.get('[data-testid="ntsr-summary"]').last().contains('123 Any Street P.O. Box 12345');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('Beverly Hills, CA 90210');
+
+  // Receiving agent
+  cy.get('[data-testid="ntsr-summary"]').last().contains('Jason Ash');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('202-555-9301');
+  cy.get('[data-testid="ntsr-summary"]').last().contains('jason.ash@example.com');
+
+  // Remarks
+  cy.get('[data-testid="ntsr-summary"]').last().contains('Please treat gently');
 }
 
 function customerVisitsReviewPage() {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11487) for this change

## Summary

Similar to https://github.com/transcom/mymove/pull/8254 but for the NTS-release side. There already were assertions about the details after creation, so I just added one about the details after editing the shipment.

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. `make e2e test`
2. Run the customer ntsr.js test suite, ensure it passes.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
