### PR TITLE
[ MB-11958 ] Refactor CreateUploadHandler & fix tests

### DIFF
--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -137,7 +137,11 @@ func (hctx *handlerContext) AuditableAppContextFromRequest(
 		if err != nil {
 			return err
 		}
-		resp = handler(txnAppCtx)
+		// The txnAppCtx does produce the error that breaks the test (TestCreateUploadsHandlerFailure)
+		// resp = handler(txnAppCtx)
+
+		// The appCtx does not produce the error that breaks the test (TestCreateUploadsHandlerFailure)
+		resp = handler(appCtx)
 		return nil
 	})
 	if err != nil {

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -137,10 +137,6 @@ func (hctx *handlerContext) AuditableAppContextFromRequest(
 		if err != nil {
 			return err
 		}
-		// The txnAppCtx does produce the error that breaks the test (TestCreateUploadsHandlerFailure)
-		// resp = handler(txnAppCtx)
-
-		// The appCtx does not produce the error that breaks the test (TestCreateUploadsHandlerFailure)
 		resp = handler(appCtx)
 		return nil
 	})

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -46,65 +46,67 @@ type CreateUploadHandler struct {
 
 // Handle creates a new UserUpload from a request payload
 func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
+	return h.AuditableAppContextFromRequest(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) middleware.Responder {
 
-	file, ok := params.File.(*runtime.File)
-	if !ok {
-		appCtx.Logger().Error("This should always be a runtime.File, something has changed in go-swagger.")
-		return uploadop.NewCreateUploadInternalServerError()
-	}
+			file, ok := params.File.(*runtime.File)
+			if !ok {
+				appCtx.Logger().Error("This should always be a runtime.File, something has changed in go-swagger.")
+				return uploadop.NewCreateUploadInternalServerError()
+			}
 
-	appCtx.Logger().Info(
-		"File uploader and size",
-		zap.String("userID", appCtx.Session().UserID.String()),
-		zap.String("serviceMemberID", appCtx.Session().ServiceMemberID.String()),
-		zap.String("officeUserID", appCtx.Session().OfficeUserID.String()),
-		zap.String("AdminUserID", appCtx.Session().AdminUserID.String()),
-		zap.Int64("size", file.Header.Size),
-	)
+			appCtx.Logger().Info(
+				"File uploader and size",
+				zap.String("userID", appCtx.Session().UserID.String()),
+				zap.String("serviceMemberID", appCtx.Session().ServiceMemberID.String()),
+				zap.String("officeUserID", appCtx.Session().OfficeUserID.String()),
+				zap.String("AdminUserID", appCtx.Session().AdminUserID.String()),
+				zap.Int64("size", file.Header.Size),
+			)
 
-	var docID *uuid.UUID
-	if params.DocumentID != nil {
-		documentID, err := uuid.FromString(params.DocumentID.String())
-		if err != nil {
-			appCtx.Logger().Info("Badly formed UUID for document", zap.String("document_id", params.DocumentID.String()), zap.Error(err))
-			return uploadop.NewCreateUploadBadRequest()
-		}
+			var docID *uuid.UUID
+			if params.DocumentID != nil {
+				documentID, err := uuid.FromString(params.DocumentID.String())
+				if err != nil {
+					appCtx.Logger().Info("Badly formed UUID for document", zap.String("document_id", params.DocumentID.String()), zap.Error(err))
+					return uploadop.NewCreateUploadBadRequest()
+				}
 
-		// Fetch document to ensure user has access to it
-		document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
-		if docErr != nil {
-			return handlers.ResponseForError(appCtx.Logger(), docErr)
-		}
-		docID = &document.ID
-	}
+				// Fetch document to ensure user has access to it
+				document, docErr := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, true)
+				if docErr != nil {
+					return handlers.ResponseForError(appCtx.Logger(), docErr)
+				}
+				docID = &document.ID
+			}
 
-	newUserUpload, url, verrs, createErr := uploaderpkg.CreateUserUploadForDocumentWrapper(
-		appCtx,
-		appCtx.Session().UserID,
-		h.FileStorer(),
-		file,
-		file.Header.Filename,
-		uploaderpkg.MaxCustomerUserUploadFileSizeLimit,
-		docID,
-	)
+			newUserUpload, url, verrs, createErr := uploaderpkg.CreateUserUploadForDocumentWrapper(
+				appCtx,
+				appCtx.Session().UserID,
+				h.FileStorer(),
+				file,
+				file.Header.Filename,
+				uploaderpkg.MaxCustomerUserUploadFileSizeLimit,
+				docID,
+			)
 
-	if verrs.HasAny() || createErr != nil {
-		appCtx.Logger().Error("failed to create new user upload", zap.Error(createErr), zap.String("verrs", verrs.Error()))
-		switch createErr.(type) {
-		case uploaderpkg.ErrTooLarge:
-			return uploadop.NewCreateUploadRequestEntityTooLarge()
-		case uploaderpkg.ErrFile:
-			return uploadop.NewCreateUploadInternalServerError()
-		case uploaderpkg.ErrFailedToInitUploader:
-			return uploadop.NewCreateUploadInternalServerError()
-		default:
-			return handlers.ResponseForVErrors(appCtx.Logger(), verrs, createErr)
-		}
-	}
+			if verrs.HasAny() || createErr != nil {
+				appCtx.Logger().Error("failed to create new user upload", zap.Error(createErr), zap.String("verrs", verrs.Error()))
+				switch createErr.(type) {
+				case uploaderpkg.ErrTooLarge:
+					return uploadop.NewCreateUploadRequestEntityTooLarge()
+				case uploaderpkg.ErrFile:
+					return uploadop.NewCreateUploadInternalServerError()
+				case uploaderpkg.ErrFailedToInitUploader:
+					return uploadop.NewCreateUploadInternalServerError()
+				default:
+					return handlers.ResponseForVErrors(appCtx.Logger(), verrs, createErr)
+				}
+			}
 
-	uploadPayload := payloadForUploadModel(h.FileStorer(), newUserUpload.Upload, url)
-	return uploadop.NewCreateUploadCreated().WithPayload(uploadPayload)
+			uploadPayload := payloadForUploadModel(h.FileStorer(), newUserUpload.Upload, url)
+			return uploadop.NewCreateUploadCreated().WithPayload(uploadPayload)
+		})
 }
 
 // DeleteUploadHandler deletes an upload

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -224,9 +224,8 @@ func (u *Uploader) CreateUpload(appCtx appcontext.AppContext, file File, allowed
 	}
 
 	var uploadError error
-
 	err := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
-		transactionError := errors.New("Rollback The transaction")
+		transactionError := errors.New("Rollback the transaction")
 		var responseCreateAndPushVerrs *validate.Errors
 		var responseCreateAndPushErr error
 		newUpload, responseCreateAndPushVerrs, responseCreateAndPushErr = u.createAndPushUploadToS3(txnAppCtx, file, newUpload)

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -224,19 +224,6 @@ func (u *Uploader) CreateUpload(appCtx appcontext.AppContext, file File, allowed
 	}
 
 	var uploadError error
-	// If we are already in a transaction, don't start one
-	if appCtx.DB().TX != nil {
-		var responseCreateAndPushVerrs *validate.Errors
-		var responseCreateAndPushErr error
-		newUpload, responseCreateAndPushVerrs, responseCreateAndPushErr = u.createAndPushUploadToS3(appCtx, file, newUpload)
-		if responseCreateAndPushErr != nil || responseCreateAndPushVerrs.HasAny() {
-			responseVErrors.Append(responseCreateAndPushVerrs)
-			uploadError = errors.Wrap(responseCreateAndPushErr, "failed to create and store upload object")
-			return nil, responseVErrors, uploadError
-		}
-		appCtx.Logger().Info("created an upload with id and key ", zap.Any("new_upload_id", newUpload.ID), zap.String("key", newUpload.StorageKey))
-		return newUpload, responseVErrors, nil
-	}
 
 	err := appCtx.NewTransaction(func(txnAppCtx appcontext.AppContext) error {
 		transactionError := errors.New("Rollback The transaction")


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11958) for this change

## Summary

This patch is completing some fo the work left over from #8265 specifically for
the Interal API handlers related `CreateUploadHandler`.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use at least one terminal to test this locally.</summary>

##### Terminal 1

Run the specific failing test locally.

```sh
go test ./pkg/handlers/internalapi/ --testify.m TestCreateUploadsHandlerFailure -v
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?
