### PR TITLE
MB-11984 - Stop auto-approving moves when updating orders

### DIFF
--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -492,8 +492,10 @@ func (f *orderUpdater) updateOrderAsTOO(appCtx appcontext.AppContext, order mode
 }
 
 func (f *orderUpdater) updateMoveInTx(appCtx appcontext.AppContext, move models.Move) error {
-	if _, err := f.moveRouter.ApproveOrRequestApproval(appCtx, move); err != nil {
-		return err
+	if move.Status == models.MoveStatusAPPROVALSREQUESTED {
+		if _, err := f.moveRouter.ApproveOrRequestApproval(appCtx, move); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -94,7 +94,8 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 	suite.T().Run("Updates the order when all fields are valid", func(t *testing.T) {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
-		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
+		move := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{})
+		order := move.Orders
 
 		dateIssued := strfmt.Date(time.Now().Add(-48 * time.Hour))
 		reportByDate := strfmt.Date(time.Now().Add(72 * time.Hour))
@@ -142,6 +143,11 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.EqualValues(&updatedOriginDutyLocation.ID, fetchedSM.DutyLocationID)
 		suite.EqualValues(updatedOriginDutyLocation.ID, fetchedSM.DutyLocation.ID)
 		suite.EqualValues(updatedOriginDutyLocation.Name, fetchedSM.DutyLocation.Name)
+
+		var moveInDB models.Move
+		err = suite.DB().Find(&moveInDB, move.ID)
+		suite.NoError(err)
+		suite.Equal(move.Status, moveInDB.Status)
 	})
 
 	suite.T().Run("Rolls back transaction if Order is invalid", func(t *testing.T) {


### PR DESCRIPTION
This should fix a bug in which moves are always being approved whenever
a TOO updates any part of the orders. Instead, this should only happen
when the move is in APPROVALS_REQUESTED.

## [Jira ticket](https://dp3.atlassian.net/browse/MB-11984) for this change

## Summary

This PR should fix a bug in which moves are being automatically approved whenever a TOO updates any part of the orders.
This is slightly related to an [older ticket](https://dp3.atlassian.net/browse/MB-9305)

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Log in to the office app as a TOO
2. Navigate to a move that has status Submitted or Completed Services Counseling
3. Ensure all the required fields are filled in, and update the orders.
4. Verify that the move has not been moved to Approved when the orders have been updated. You can check this by ensuring that the new row in the move history for the order update, there is no evidence that the move has been approved (see below image)

![image](https://user-images.githubusercontent.com/97245917/159379029-ea5634a2-f350-4d25-adc9-9f896de1baac.png)
 

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->


### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.


## Screenshots
