### PR TITLE
MB-11972 - Upgrade alpine from 3.14.4 to 3.15.2

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM alpine:3.14.4
+FROM alpine:3.15.2
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM alpine:3.14.4
+FROM alpine:3.15.2
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -19,7 +19,7 @@ RUN rm -f bin/milmove && make bin/milmove
 # FINAL #
 #########
 
-FROM alpine:3.14.4
+FROM alpine:3.15.2
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.reviewapp
+++ b/Dockerfile.reviewapp
@@ -45,7 +45,7 @@ RUN set -x \
   && make bin/generate-test-data
 
 # define migrations before client build since it doesn't need client
-FROM alpine:3.14.4 as migrate
+FROM alpine:3.15.2 as migrate
 
 COPY --from=server_builder /build/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=server_builder /build/bin/milmove /bin/milmove

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM alpine:3.14.4
+FROM alpine:3.15.2
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -19,7 +19,7 @@ RUN rm -f bin/prime-api-client && make bin/prime-api-client
 # FINAL #
 #########
 
-FROM alpine:3.14.4
+FROM alpine:3.15.2
 
 # hadolint ignore=DL3017
 RUN apk upgrade --no-cache busybox


### PR DESCRIPTION
We had to temporarily downgrade alpine from 3.15.x to 3.14.4 due to [CVE-2022-0778](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0778).
Now we can re-upgrade to the newest release, 3.15.2, which has [addressed this vulnerability](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/32088).