### PR TITLE
[MB-11649] Trigger result refresh in move queue when user hits enter in a text box

### DIFF
--- a/src/components/Table/Filters/TextBoxFilter.jsx
+++ b/src/components/Table/Filters/TextBoxFilter.jsx
@@ -9,6 +9,11 @@ const TextBoxFilter = ({ column: { filterValue, setFilter, id } }) => {
       id={id}
       name={id}
       defaultValue={filterValue || ''}
+      onKeyUp={(e) => {
+        if (e.key === 'Enter') {
+          setFilter(e.target.value || undefined); // Set undefined to remove the filter entirely
+        }
+      }}
       onBlur={(e) => {
         setFilter(e.target.value || undefined); // Set undefined to remove the filter entirely
       }}

--- a/src/components/Table/Filters/TextBoxFilter.test.jsx
+++ b/src/components/Table/Filters/TextBoxFilter.test.jsx
@@ -1,18 +1,72 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import TextBoxFilter from './TextBoxFilter';
 
-describe('React table', () => {
+describe('Table/Filters/TextBoxFilter', () => {
   it('renders without crashing', () => {
-    const wrapper = mount(
+    render(
       <TextBoxFilter
         column={{
-          filterValue: '',
+          filterValue: 'test value',
           setFilter: jest.fn(),
         }}
       />,
     );
-    expect(wrapper.find(TextBoxFilter).length).toBe(1);
+
+    expect(screen.getByRole('textbox')).toHaveValue('test value');
+  });
+
+  it('triggers on setFilter on blur', () => {
+    const setFilter = jest.fn();
+    render(
+      <TextBoxFilter
+        column={{
+          filterValue: '',
+          setFilter,
+        }}
+      />,
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'Test Value');
+    expect(setFilter).not.toBeCalled();
+    userEvent.tab();
+    expect(setFilter).toBeCalledWith('Test Value');
+  });
+
+  it('triggers on setFilter on enter', () => {
+    const setFilter = jest.fn();
+    render(
+      <TextBoxFilter
+        column={{
+          filterValue: '',
+          setFilter,
+        }}
+      />,
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'Test Value{enter}');
+    expect(setFilter).toBeCalledWith('Test Value');
+  });
+
+  it('triggers setFilter with undefined given empty input', () => {
+    const setFilter = jest.fn();
+    render(
+      <TextBoxFilter
+        column={{
+          filterValue: '',
+          setFilter,
+        }}
+      />,
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.click(textbox);
+    expect(setFilter).not.toBeCalled();
+    userEvent.tab();
+    expect(setFilter).toBeCalledWith(undefined);
   });
 });


### PR DESCRIPTION
## Jira ticket for this change: [MB-11649](https://dp3.atlassian.net/browse/MB-11649)

## Summary

This pull request fixes a UX issue, updating the `TextBoxFilter` subcomponent (used by the `TableQueue` component, which is displayed in the move queue for Service Counselor, TIO, and TOO users) to update whenever a user entering text in the field hits "Enter," rather than just updating on blur.

This pull request also re-writes the tests for this subcomponent in the modern React Testing Library style.

There are no visible UI changes to this component, just behavioral changes.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Sign in locally to the office application as a Service Counselor, TOO, or TIO user.
2. On the move queue, select the text box at the top of the "Move Locator" column. Type in the (case-sensitive) move code for any move on the page, and (without blurring focus) validate that no change is made to the rows in the table.
3. Hit "enter" within that textbox, and validate that the rows are refetched/redisplayed with your filter enabled.
4. Clear the text in the textbox and hit "enter" again, and validate that the rows are refetched/redisplayed with filtering removed.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
