### PR TITLE
[MB-11452] update rds certs for dp3 sites

### DIFF
--- a/Dockerfile.dp3
+++ b/Dockerfile.dp3
@@ -1,8 +1,9 @@
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base:latest
 
-COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
+# COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
+# COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove
 
 # Demo Environment certs

--- a/Dockerfile.tasks_dp3
+++ b/Dockerfile.tasks_dp3
@@ -10,9 +10,9 @@ COPY config/tls/api.loadtest.dp3.us.chain.der.p7b /config/tls/api.loadtest.dp3.u
 # Exp Environment Certs
 COPY config/tls/api.exp.dp3.us.chain.der.p7b /config/tls/api.exp.dp3.us.chain.der.p7b
 
-
-COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
+#COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
+#COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove-tasks /bin/milmove-tasks
 
 WORKDIR /bin

--- a/Dockerfile.webhook_client_dp3
+++ b/Dockerfile.webhook_client_dp3
@@ -30,7 +30,9 @@ FROM gcr.io/distroless/static:latest
 # Copy DOD certs from the builder.
 COPY --from=builder --chown=root:root /etc/ssl/certs /etc/ssl/certs
 
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
+
+#COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/webhook-client /bin/webhook-client
 
 CMD ["/bin/webhook-client", "webhook-notify"]

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ setup:
 deps_nix: install_pre_commit deps_shared ## Nix equivalent (kind of) of `deps` target.
 
 .PHONY: deps_shared
-deps_shared: client_deps bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem ## install dependencies
+deps_shared: client_deps bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem bin/rds-ca-rsa4096-g1.pem ## install dependencies
 
 .PHONY: test
 test: client_test server_test e2e_test ## Run all tests
@@ -222,6 +222,10 @@ bin/mockery: .check_go_version.stamp .check_gopath.stamp pkg/tools/tools.go
 	go build -o bin/mockery github.com/vektra/mockery/v2
 
 ### Cert Targets
+# AWS is only providing a bundle for the 2022 cert, which includes 2017? and rds-ca-rsa4096-g1
+bin/rds-ca-rsa4096-g1.pem:
+	mkdir -p bin/
+	curl -sSo bin/rds-ca-rsa4096-g1.pem https://truststore.pki.us-gov-west-1.rds.amazonaws.com/us-gov-west-1/us-gov-west-1-bundle.pem
 
 bin/rds-ca-2019-root.pem:
 	mkdir -p bin/
@@ -367,6 +371,7 @@ server_run_debug: .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp
 .PHONY: build_tools
 build_tools: bin/gin \
 	bin/mockery \
+	bin/rds-ca-rsa4096-g1.pem \
 	bin/rds-ca-2019-root.pem \
 	bin/rds-ca-us-gov-west-1-2017-root.pem \
 	bin/big-cat \
@@ -395,7 +400,7 @@ build: server_build build_tools client_build ## Build the server, tools, and cli
 # acceptance_test runs a few acceptance tests against a local or remote environment.
 # This can help identify potential errors before deploying a container.
 .PHONY: acceptance_test
-acceptance_test: bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem ## Run acceptance tests
+acceptance_test: bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem bin/rds-ca-rsa4096-g1.pem ## Run acceptance tests
 ifndef TEST_ACC_ENV
 	@echo "Running acceptance tests for webserver using local environment."
 	@echo "* Use environment XYZ by setting environment variable to TEST_ACC_ENV=XYZ."


### PR DESCRIPTION
## [MB-11452]

## Summary
AWS is requiring an update the RDS certificates. This adds the new certificate to the dockerfiles for the dp3 environments (`exp`, `demo`, `loadtest`)

As written, this is only _adding_ a new cert, not removing anything. Once the new dockerfiles are built, the change to the new cert will be made to the `exp` environment in AWS by infra and app connectivity will be tested before old certs are removed or this change is rolled out to any other environments. 

