### PR TITLE
[MB-8381] Revoke office user session when roles are modified

### DIFF
--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -72,6 +72,7 @@ func NewAdminAPI(ctx handlers.HandlerContext) *adminops.MymoveAPI {
 		officeUpdater,
 		query.NewQueryFilter,
 		userRolesCreator,
+		user.NewUserSessionRevocation(queryBuilder),
 	}
 
 	adminAPI.OfficeIndexOfficesHandler = IndexOfficesHandler{


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-8381) for this change

## Summary

Changes to an office user's permissions don't take effect until they get a new session.
So if you revoke a role from an office user, they will still be able to use that role until they log out and log in again.

This PR addresses this security hole by revoking the office user's session whenever role changes are made. So they will have to log in again and start a new session before being able to do anything.

One question I have: is returning a 500 error to the admin user adequate when we fail to revoke a session? 

Admins do have the ability to see if a user has an active session and manually revoke it, so if it failed due to a transient issue, they would be able to address it, if they knew to do it.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps
Sessions work differently with local sign in, so you'll have to log in with login.gov, even when testing this locally.
- Log in as an admin user (with login.gov)
- Use the admin interface to create an office user with your truss email address. Make sure they have at least one of the office user roles (TOO, TIO, or Services Counselor)
- Log in as that office user with login.gov.
- From the admin interface, make a change to the user's roles. (doesn't matter what change, add or remove any of the roles)
- Go back to your office user, make sure that if you try to do anything, you should get logged out. If you can perform any actions in your current session without getting logged out, then something is wrong.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots
