### PR TITLE
MB-11502 Add E2E tests for NTS Workflow, Prime + Ext Vendor for the TOO

### DIFF
--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -143,8 +143,7 @@ describe('TOO user', () => {
     cy.url().should('include', `/moves/${moveLocator}/mto`);
 
     // Move Task Order page
-    const shipments = cy.get('[data-testid="ShipmentContainer"]');
-    shipments.should('have.length', 1);
+    cy.get('[data-testid="ShipmentContainer"]').should('have.length', 1);
 
     cy.contains('Approved service items (12 items)');
     cy.contains('Rejected service items').should('not.exist');
@@ -167,7 +166,7 @@ describe('TOO user', () => {
     });
 
     cy.get('[data-testid="modal"]').within(($modal) => {
-      expect($modal).to.be.visible;
+      cy.get($modal).should('be.visible');
       cy.get('button[type="submit"]').should('be.disabled');
       cy.get('[data-testid="textInput"]').type('my very valid reason');
       cy.get('button[type="submit"]').click();

--- a/cypress/integration/office/txo/tooFlowsNTS.js
+++ b/cypress/integration/office/txo/tooFlowsNTS.js
@@ -1,0 +1,431 @@
+import { TOOOfficeUserType } from '../../../support/constants';
+
+describe('TOO user', () => {
+  before(() => {
+    cy.prepareOfficeApp();
+  });
+
+  beforeEach(() => {
+    cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
+    cy.intercept('**/ghc/v1/queues/moves?page=1&perPage=20&sort=status&order=asc').as('getSortedOrders');
+    cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    cy.intercept('GET', '**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
+    cy.intercept('POST', '**/ghc/v1/shipments/**/approve').as('approveShipment');
+    cy.intercept('POST', '**/ghc/v1/shipments/**/request-cancellation').as('requestShipmentCancellation');
+    cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/status').as('patchMTOStatus');
+    cy.intercept('PATCH', '**/ghc/v1/move-task-orders/**/service-items/**/status').as('patchMTOServiceItems');
+    cy.intercept('PATCH', '**/ghc/v1/move_task_orders/**/mto_shipments/**').as('patchShipment');
+    cy.intercept('PATCH', '**/ghc/v1/orders/**/allowances').as('patchAllowances');
+    cy.intercept('**/ghc/v1/moves/**/financial-review-flag').as('financialReviewFlagCompleted');
+
+    // This user has multiple roles, which is the kind of user we use to test in staging.
+    // By using this type of user, we can catch bugs like the one fixed in PR 6706.
+    const userId = 'dcf86235-53d3-43dd-8ee8-54212ae3078f';
+    cy.apiSignInAsUser(userId, TOOOfficeUserType);
+  });
+
+  // TODO FOR NTS-RELEASE
+  // Enter/edit shipment weight if needed -- user will look up in TOPS and manually enter
+  // TOO has to enter Service Order Number (SON) for NTS-RELEASE shipments prior to posting to the MTO
+
+  // This test covers editing the NTS shipment and prepares it for approval
+  it('TOO can edit a request for Domestic NTS Shipment handled by the Prime', () => {
+    navigateToMove('PRINTS');
+
+    cy.contains('Approve selected').should('be.disabled');
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[data-testid="shipment-display-checkbox"]').should('be.disabled');
+        cy.get('[data-icon="chevron-down"]').click();
+
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityName"]').should('exist');
+        cy.get('[data-testid="storageFacilityName"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="serviceOrderNumber"]').should('exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityAddress"]').should('exist');
+        cy.get('[data-testid="storageFacilityAddress"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="tacType"]').should('exist');
+      });
+
+    editTacSac();
+
+    // Edit shipments to enter missing info
+    cy.get('[data-testid="ShipmentContainer"] .usa-button').last().click();
+    cy.waitFor(['@getMTOServiceItems, @getMoves']);
+
+    // Basic info
+    cy.get('#requestedPickupDate').clear().type('16 Mar 2022').blur();
+    cy.get('[data-testid="useCurrentResidence"]').click({ force: true });
+
+    // Storage facility info
+    cy.get('#facilityName').type('Sample Facility Name');
+    cy.get('#facilityPhone').type('999-999-9999');
+    cy.get('#facilityEmail').type('sample@example.com');
+    cy.get('#facilityServiceOrderNumber').type('999999');
+
+    // Storage facility address
+    cy.get('input[name="storageFacility.address.streetAddress1"]').type('148 S East St');
+    cy.get('input[name="storageFacility.address.streetAddress2"]').type('Suite 7A');
+    cy.get('input[name="storageFacility.address.city"]').type('Sample City');
+    cy.get('select[name="storageFacility.address.state"]').select('GA');
+    cy.get('input[name="storageFacility.address.postalCode"]').type('30301');
+    cy.get('#facilityLotNumber').type('1111111');
+
+    // TAC and SAC
+    cy.get('[data-testid="radio"] [for="tacType-NTS"]').click();
+    cy.get('[data-testid="radio"] [for="sacType-HHG"]').click();
+
+    cy.get('[data-testid="submitForm"]').click();
+
+    cy.wait('@patchShipment');
+
+    // edit the NTS shipment to be handled by an external vendor
+    cy.get('[data-testid="ShipmentContainer"] .usa-button').last().click();
+    cy.waitFor(['@getMTOServiceItems, @getMoves']);
+
+    cy.get('label[for="vendorExternal"]').click();
+    cy.get('[data-testid="submitForm"]').click();
+
+    cy.wait('@patchShipment');
+    cy.get('[data-testid="ShipmentContainer"] [data-testid="tag"]').contains('external vendor');
+
+    // edit the NTS shipment back to being handled by the GHC Prime contractor
+    cy.get('[data-testid="ShipmentContainer"] .usa-button').last().click();
+    cy.waitFor(['@getMTOServiceItems, @getMoves']);
+
+    cy.get('[data-testid="alert"]').contains('The GHC prime contractor is not handling the shipment.');
+
+    cy.get('label[for="vendorPrime"]').click();
+    cy.get('[data-testid="submitForm"]').click();
+
+    cy.wait('@patchShipment');
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[data-testid="shipment-display-checkbox"]').should('be.enabled');
+        cy.get('[data-testid="tag"]').should('not.exist');
+        cy.get('[data-icon="chevron-down"]').click();
+
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityName"]').should('not.exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="serviceOrderNumber"]').should('not.exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityAddress"]').should('not.exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="tacType"]').should('not.exist');
+      });
+  });
+
+  it('TOO can approve an NTS shipment handled by the Prime', () => {
+    // Make sure that it shows all the relevant information on the approve page
+    // captures the information about the NTS Facility and relevant storage information
+    // verifies that all the information is shown for NTS shipments handled by the GHC Contractor
+    navigateToMove('PRINTS');
+
+    cy.get('#approved-shipments').should('not.exist');
+    cy.get('#requested-shipments');
+    cy.contains('Approve selected').should('be.disabled');
+
+    // Select & approve items
+    cy.get('input[data-testid="shipment-display-checkbox"]').should('have.length', 2);
+    cy.get('input[data-testid="shipment-display-checkbox"]').then(($shipmentsCheckbox) => {
+      // Select each shipment
+      $shipmentsCheckbox.each((i, el) => {
+        const { id } = el;
+        cy.get(`label[for="${id}"]`).click({ force: true }); // force because of shipment wrapping bug
+      });
+      // Select additional service items
+      cy.get('label[for="shipmentManagementFee"]').click();
+      cy.get('label[for="counselingFee"]').click();
+      // Open modal
+      const button = cy.contains('Approve selected');
+      button.should('be.enabled');
+      button.click();
+      cy.get('#approvalConfirmationModal [data-testid="modal"]').then(($modal) => {
+        cy.get($modal).should('be.visible');
+        // Verify modal content
+        cy.contains('Preview and post move task order');
+        cy.get('#approvalConfirmationModal [data-testid="ShipmentContainer"]').should(
+          'have.length',
+          $shipmentsCheckbox.length,
+        );
+        cy.contains('Approved service items for this move')
+          .next('table')
+          .should('contain', 'Move management')
+          .and('contain', 'Counseling');
+
+        cy.get('[data-testid="modal"] [data-testid="ShipmentContainer"]')
+          .last()
+          .within(() => {
+            cy.get('[data-testid="usesExternalVendor"]').should('exist');
+            cy.get('[data-testid="tacType"]').should('exist');
+            cy.get('[data-testid="sacType"]').should('exist');
+          });
+        // Click approve
+        cy.contains('Approve and send').click();
+      });
+    });
+
+    cy.wait(['@approveShipment', '@patchMTOStatus']);
+
+    // Redirected to Move Task Order page
+    cy.url().should('include', `/moves/PRINTS/mto`);
+  });
+
+  it('TOO can view and edit Domestic NTS Shipments handled by the Prime on the MTO page', () => {
+    navigateToMove('PRINTS');
+    cy.get('[data-testid="MoveTaskOrder-Tab"]').click();
+    cy.wait(['@getMTOShipments', '@getMTOServiceItems']);
+
+    cy.get('[id="move-weights"] div').contains('1 shipment not moved by GHC prime.').should('not.exist');
+
+    cy.get('[data-testid="ShipmentContainer"]').should('have.length', 2);
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        // non-temp storage header
+        cy.get('h2').contains('Non-temp storage');
+        // pickup address header
+        cy.get('[class*="ShipmentAddresses_mtoShipmentAddresses"]').contains('Pickup address');
+        // facility address header
+        cy.get('[class*="ShipmentAddresses_mtoShipmentAddresses"]').contains('Facility address');
+
+        // Confirming expected data
+        // facility info and address
+        // service order number
+        // accounting codes
+        cy.get('[class*="ShipmentDetailsSidebar"]').within(() => {
+          cy.get('section header').first().contains('Facility info and address');
+          cy.get('section').first().contains('148 S East St');
+
+          cy.get('section header').eq(1).contains('Service order number');
+          cy.get('section').eq(1).contains('999999');
+
+          cy.get('section header').last().contains('Accounting codes');
+          cy.get('section').last().contains('F123');
+        });
+
+        // edit facility info and address
+        cy.get('[data-testid="edit-facility-info-modal-open"]').click();
+      });
+
+    cy.get('[data-testid="modal"]').within(($modal) => {
+      cy.get($modal).should('be.visible');
+      // Storage facility info
+      cy.get('#facilityName').clear().type('New Facility Name');
+      cy.get('#facilityPhone').clear().type('999-999-9999');
+      cy.get('#facilityEmail').clear().type('new@example.com');
+      cy.get('#facilityServiceOrderNumber').clear().type('098098');
+
+      // Storage facility address
+      cy.get('input[name="storageFacility.address.streetAddress1"]').clear().type('265 S East St');
+      cy.get('#facilityLotNumber').clear().type('1111111');
+
+      cy.get('button[type="submit"]').click();
+    });
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[class*="ShipmentDetailsSidebar"]').within(() => {
+          cy.get('section header').first().contains('Facility info and address');
+          cy.get('section').first().contains('New Facility Name');
+          cy.get('section').first().contains('265 S East St');
+          cy.get('section').first().contains('Lot 1111111');
+        });
+
+        // edit service order number
+        cy.get('[data-testid="service-order-number-modal-open"]').click();
+      });
+
+    cy.get('[data-testid="modal"]').within(($modal) => {
+      cy.get($modal).should('be.visible');
+
+      cy.get('[data-testid="textInput"]').clear().type('ORDER456');
+
+      cy.get('button[type="submit"]').click();
+    });
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[class*="ShipmentDetailsSidebar"] section').eq(1).contains('ORDER456');
+
+        // edit accounting codes
+        cy.get('[data-testid="edit-accounting-codes-modal-open"]').click();
+      });
+
+    cy.get('[data-testid="modal"]').within(($modal) => {
+      cy.get($modal).should('be.visible');
+
+      cy.get('[data-testid="radio"] [for="tacType-HHG"]').click();
+      cy.get('[data-testid="radio"] [for="sacType-NTS"]').click();
+
+      cy.get('button[type="submit"]').click();
+    });
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[class*="ShipmentDetailsSidebar"]').within(() => {
+          cy.get('section').last().contains('F123');
+          cy.get('section').last().contains('4K988AS098F');
+        });
+
+        cy.get('[data-testid="ApprovedServiceItemsTable"] h3').last().contains('Approved service items (5 items)');
+      });
+  });
+
+  it('TOO can approve an HHG shipment with an NTS Shipment handled by an external vendor', () => {
+    navigateToMove('PRXNTS');
+
+    cy.get('#approved-shipments').should('not.exist');
+    cy.get('#requested-shipments');
+    cy.contains('Approve selected').should('be.disabled');
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[data-icon="chevron-down"]').click();
+
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityName"]').should('exist');
+        cy.get('[data-testid="storageFacilityName"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="serviceOrderNumber"]').should('exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityAddress"]').should('exist');
+        cy.get('[data-testid="storageFacilityAddress"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="tacType"]').should('exist');
+      });
+
+    editTacSac();
+
+    // Select & approve items
+    cy.get('input[data-testid="shipment-display-checkbox"]').then(($shipmentsCheckbox) => {
+      // Select each shipment
+      $shipmentsCheckbox.each((i, el) => {
+        const { id } = el;
+        cy.get(`label[for="${id}"]`).click({ force: true }); // force because of shipment wrapping bug
+      });
+      // Select additional service items
+      cy.get('label[for="shipmentManagementFee"]').click();
+      cy.get('label[for="counselingFee"]').click();
+      // Open modal
+      const button = cy.contains('Approve selected');
+      button.should('be.enabled');
+      button.click();
+      cy.get('#approvalConfirmationModal [data-testid="modal"]').then(($modal) => {
+        cy.get($modal).should('be.visible');
+        // Verify modal content
+        cy.contains('Preview and post move task order');
+        cy.get('#approvalConfirmationModal [data-testid="ShipmentContainer"]').should('have.length', 1);
+        cy.contains('Approved service items for this move')
+          .next('table')
+          .should('contain', 'Move management')
+          .and('contain', 'Counseling');
+
+        // Click approve
+        cy.contains('Approve and send').click();
+      });
+    });
+
+    cy.wait(['@approveShipment', '@patchMTOStatus']);
+
+    // Redirected to Move Task Order page
+    cy.url().should('include', `/moves/PRXNTS/mto`);
+    cy.wait(['@getMTOShipments']);
+    // Confirm estimated weight shows expected extra shipment detail link
+    cy.get('[id="move-weights"] div').contains('1 shipment not moved by GHC prime.');
+  });
+
+  it('TOO can submit service items on an NTS-only move handled by an external vendor', () => {
+    navigateToMove('EXTNTS');
+
+    cy.get('#approved-shipments').should('not.exist');
+    cy.get('#requested-shipments');
+    cy.contains('Approve selected').should('be.disabled');
+
+    cy.get('[data-testid="ShipmentContainer"]')
+      .last()
+      .within(() => {
+        cy.get('[data-testid="shipment-display-checkbox"]').should('not.exist');
+        cy.get('[data-icon="chevron-down"]').click();
+
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityName"]').should('exist');
+        cy.get('[data-testid="storageFacilityName"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="serviceOrderNumber"]').should('exist');
+        cy.get('div[class*="missingInfoError"] [data-testid="storageFacilityAddress"]').should('exist');
+        cy.get('[data-testid="storageFacilityAddress"]').contains('Missing');
+        cy.get('div[class*="missingInfoError"] [data-testid="tacType"]').should('exist');
+      });
+
+    editTacSac();
+
+    // Select & approve items
+    cy.get('input[data-testid="shipment-display-checkbox"]').should('not.exist');
+    // Select additional service items
+    cy.get('label[for="shipmentManagementFee"]').click();
+    cy.get('label[for="counselingFee"]').click();
+    // Open modal
+    const button = cy.contains('Approve selected');
+    button.should('be.enabled');
+    button.click();
+    cy.get('#approvalConfirmationModal [data-testid="modal"]').then(($modal) => {
+      cy.get($modal).should('be.visible');
+      // Verify modal content
+      cy.contains('Preview and post move task order');
+      cy.get('#approvalConfirmationModal [data-testid="ShipmentContainer"]').should('not.exist');
+      cy.contains('Approved service items for this move')
+        .next('table')
+        .should('contain', 'Move management')
+        .and('contain', 'Counseling');
+
+      // Click approve
+      cy.contains('Approve and send').click();
+    });
+
+    cy.wait(['@patchMTOStatus']);
+
+    // Redirected to Move Task Order page
+    cy.url().should('include', `/moves/EXTNTS/mto`);
+
+    cy.get('[role="main"]').contains('This move does not have any approved shipments yet.');
+  });
+});
+
+function editTacSac() {
+  cy.get('[data-testid="ShipmentContainer"] .usa-button').last().click();
+  cy.waitFor(['@getMTOServiceItems']);
+
+  cy.get('[data-testid="grid"] button').contains('Add or edit codes').click();
+
+  cy.get('form').within(($form) => {
+    cy.get('select[name="departmentIndicator"]').select('21 Army', { force: true });
+    cy.get('input[name="ordersNumber"]').click().clear().type('ORDER66');
+    cy.get('select[name="ordersType"]').select('Permanent Change Of Station (PCS)');
+    cy.get('select[name="ordersTypeDetail"]').select('Shipment of HHG Permitted');
+
+    cy.get('[data-testid="hhgTacInput"]').click().clear().type('E15A');
+    cy.get('[data-testid="hhgSacInput"]').click().clear().type('4K988AS098F');
+    cy.get('[data-testid="ntsTacInput"]').click().clear().type('F123');
+    cy.get('[data-testid="ntsSacInput"]').click().clear().type('3L988AS098F');
+    // Edit orders page | Save
+    cy.get('[data-testid="button"]').contains('Save').click();
+  });
+
+  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+  cy.get('[data-testid="tacMDC"]').contains('E15A');
+  cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
+  cy.get('[data-testid="NTStac"]').contains('F123');
+  cy.get('[data-testid="NTSsac"]').contains('3L988AS098F');
+}
+
+function navigateToMove(moveLocator) {
+  // TOO Moves queue
+  cy.wait(['@getSortedOrders']);
+  cy.contains(moveLocator).click();
+  cy.url().should('include', `/moves/${moveLocator}/details`);
+
+  // Move Details page
+  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+}

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ato": "file:./eslint-plugin-ato",
-    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-security": "^1.4.0",

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -3817,11 +3817,8 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	// Create a move with an HHG and NTS external vendor-handled shipment
 	createMoveWithHHGAndNTSShipments(appCtx, "PRXNTS", true)
 
-	// Create a move with an HHG and NTS external vendor-handled shipment
-	createMoveWithNTSShipment(appCtx, "EXTNTS", true)
-
 	// Create a move with only an NTS external vendor-handled shipment
-	createMoveWithNTSShipment(appCtx, "NTSNTS", true)
+	createMoveWithNTSShipment(appCtx, "EXTNTS", true)
 
 	createBasicMovePPM01(appCtx, userUploader)
 	createBasicMovePPM02(appCtx, userUploader)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -3810,6 +3810,19 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	createNeedsServicesCounseling(appCtx, separation, hhg, &hor, "S3PAR3")
 
 	createBasicNTSMove(appCtx, userUploader)
+
+	// Create a move with an HHG and NTS prime-handled shipment
+	createMoveWithHHGAndNTSShipments(appCtx, "PRINTS", false)
+
+	// Create a move with an HHG and NTS external vendor-handled shipment
+	createMoveWithHHGAndNTSShipments(appCtx, "PRXNTS", true)
+
+	// Create a move with an HHG and NTS external vendor-handled shipment
+	createMoveWithNTSShipment(appCtx, "EXTNTS", true)
+
+	// Create a move with only an NTS external vendor-handled shipment
+	createMoveWithNTSShipment(appCtx, "NTSNTS", true)
+
 	createBasicMovePPM01(appCtx, userUploader)
 	createBasicMovePPM02(appCtx, userUploader)
 	createBasicMovePPM03(appCtx, userUploader)

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -5923,6 +5923,85 @@ func makeSITExtensionsForShipment(appCtx appcontext.AppContext, shipment models.
 	})
 }
 
+func createMoveWithHHGAndNTSShipments(appCtx appcontext.AppContext, locator string, usesExternalVendor bool) {
+	db := appCtx.DB()
+	submittedAt := time.Now()
+	ntsMoveType := models.SelectedMoveTypeNTS
+	orders := testdatagen.MakeOrderWithoutDefaults(db, testdatagen.Assertions{
+		DutyLocation: models.DutyLocation{
+			ProvidesServicesCounseling: true,
+		},
+		Order: models.Order{
+			OrdersType: internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
+		},
+	})
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			Locator:          locator,
+			Status:           models.MoveStatusSUBMITTED,
+			SelectedMoveType: &ntsMoveType,
+			SubmittedAt:      &submittedAt,
+		},
+		Order: orders,
+	})
+
+	// Makes a basic HHG shipment to reflect likely real scenario
+	requestedPickupDate := submittedAt.Add(60 * 24 * time.Hour)
+	requestedDeliveryDate := requestedPickupDate.Add(7 * 24 * time.Hour)
+	destinationAddress := testdatagen.MakeDefaultAddress(db)
+	testdatagen.MakeMTOShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:          models.MTOShipmentTypeHHG,
+			Status:                models.MTOShipmentStatusSubmitted,
+			RequestedPickupDate:   &requestedPickupDate,
+			RequestedDeliveryDate: &requestedDeliveryDate,
+			DestinationAddressID:  &destinationAddress.ID,
+		},
+	})
+
+	testdatagen.MakeNTSShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:       models.MTOShipmentTypeHHGIntoNTSDom,
+			Status:             models.MTOShipmentStatusSubmitted,
+			UsesExternalVendor: usesExternalVendor,
+		},
+	})
+}
+
+func createMoveWithNTSShipment(appCtx appcontext.AppContext, locator string, usesExternalVendor bool) {
+	db := appCtx.DB()
+	submittedAt := time.Now()
+	ntsMoveType := models.SelectedMoveTypeNTS
+	orders := testdatagen.MakeOrderWithoutDefaults(db, testdatagen.Assertions{
+		DutyLocation: models.DutyLocation{
+			ProvidesServicesCounseling: true,
+		},
+		Order: models.Order{
+			OrdersType: internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
+		},
+	})
+	move := testdatagen.MakeMove(db, testdatagen.Assertions{
+		Move: models.Move{
+			Locator:          locator,
+			Status:           models.MoveStatusSUBMITTED,
+			SelectedMoveType: &ntsMoveType,
+			SubmittedAt:      &submittedAt,
+		},
+		Order: orders,
+	})
+
+	testdatagen.MakeNTSShipment(db, testdatagen.Assertions{
+		Move: move,
+		MTOShipment: models.MTOShipment{
+			ShipmentType:       models.MTOShipmentTypeHHGIntoNTSDom,
+			Status:             models.MTOShipmentStatusSubmitted,
+			UsesExternalVendor: usesExternalVendor,
+		},
+	})
+}
+
 // createRandomMove creates a random move with fake data that has been approved for usage
 func createRandomMove(
 	appCtx appcontext.AppContext,

--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -370,6 +370,18 @@ func subScenarioNTSandNTSR(appCtx appcontext.AppContext, userUploader *uploader.
 		createNeedsServicesCounselingSingleHHG(appCtx, pcos, "NTSRHG")
 		createNeedsServicesCounselingMinimalNTSR(appCtx, pcos, "NTSRMN")
 
+		// Create a move with an HHG and NTS prime-handled shipment
+		createMoveWithHHGAndNTSShipments(appCtx, "PRINTS", false)
+
+		// Create a move with an HHG and NTS external vendor-handled shipment
+		createMoveWithHHGAndNTSShipments(appCtx, "PRXNTS", true)
+
+		// Create a move with only NTS external vendor-handled shipment
+		createMoveWithNTSShipment(appCtx, "EXTNTS", true)
+
+		// Create a move with only an NTS external vendor-handled shipment
+		createMoveWithNTSShipment(appCtx, "NTSNTS", true)
+
 		// Create some submitted Moves for TXO users
 		createMoveWithHHGAndNTSRMissingInfo(appCtx, moveRouter)
 		createMoveWithHHGAndNTSMissingInfo(appCtx, moveRouter)

--- a/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
+++ b/src/components/Office/ShipmentAddresses/ShipmentAddresses.jsx
@@ -66,6 +66,7 @@ const ShipmentAddresses = ({
           destinationAddress ? formatAddress(destinationAddress) : '—',
         ]}
         icon={<FontAwesomeIcon icon="arrow-right" />}
+        data-testid="pickupDestinationAddress"
       />
     </DataTableWrapper>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,13 +8764,6 @@ eslint-module-utils@^2.6.2:
 "eslint-plugin-ato@file:./eslint-plugin-ato":
   version "1.0.0"
 
-eslint-plugin-cypress@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
-  integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
-  dependencies:
-    globals "^11.12.0"
-
 eslint-plugin-flowtype@^5.2.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz#7764cc63940f215bf3f0bd2d9a1293b2b9b2b4bb"
@@ -10266,7 +10259,7 @@ global@^4.3.2, global@^4.4.0:
     min-document "^2.19.0"
     process "^0.11.10"
 
-globals@^11.1.0, globals@^11.12.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11502) for this change

## Summary

Tests for the TOO NTS workflow, both with and without external vendor shipments.

Also removed the cypress linting plugin as it is not necessary and creates a lot of noise in the test files.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Go server locally.

```sh
make server_run
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the test server locally

```sh
make e2e_test_fresh
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

- In the Cypress UI, run `tooFlowsNTS.js`
- Alternatively, run the tests in Docker as described [in the docs](https://transcom.github.io/mymove-docs/docs/backend/testing/run-e2e-tests#in-docker)


## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
