### PR TITLE
[ MB-12050 ] Refactor GHCAPI handlers for AuditableAppContextFromRequestWithErrors

### DIFF
--- a/pkg/apperror/errors.go
+++ b/pkg/apperror/errors.go
@@ -326,3 +326,20 @@ func NewUnprocessableEntityError(message string) UnprocessableEntityError {
 func (e UnprocessableEntityError) Error() string {
 	return e.message
 }
+
+// Generic InternalServerError for internal errors that aren't covered by other, more specific errors
+type InternalServerError struct {
+	message string
+}
+
+// NewSessionError returns a new InternalServerError
+func NewInternalServerError(message string) InternalServerError {
+	return InternalServerError{
+		message: message,
+	}
+}
+
+// Error is the string representation of the InternalServerError
+func (e InternalServerError) Error() string {
+	return e.message
+}

--- a/pkg/apperror/errors.go
+++ b/pkg/apperror/errors.go
@@ -309,3 +309,20 @@ func NewSessionError(message string) SessionError {
 func (e SessionError) Error() string {
 	return e.message
 }
+
+// We should log Unprocessable Entity Errors generated in the Handlers
+type UnprocessableEntityError struct {
+	message string
+}
+
+// NewUnprocessableEntityError returns a new UnprocessableEntityError
+func NewUnprocessableEntityError(message string) UnprocessableEntityError {
+	return UnprocessableEntityError{
+		message: message,
+	}
+}
+
+// Error is the string representation of the UnprocessableEntityError
+func (e UnprocessableEntityError) Error() string {
+	return e.message
+}

--- a/pkg/apperror/errors.go
+++ b/pkg/apperror/errors.go
@@ -292,3 +292,20 @@ func (e EventError) Error() string {
 func (e EventError) Unwrap() error {
 	return e.error
 }
+
+// We should log Session Errors generated in the Handlers
+type SessionError struct {
+	message string
+}
+
+// NewSessionError returns a new SessionError
+func NewSessionError(message string) SessionError {
+	return SessionError{
+		message: message,
+	}
+}
+
+// Error is the string representation of the SessionError
+func (e SessionError) Error() string {
+	return e.message
+}

--- a/pkg/handlers/ghcapi/documents.go
+++ b/pkg/handlers/ghcapi/documents.go
@@ -44,23 +44,23 @@ type GetDocumentHandler struct {
 
 // Handle creates a new Document from a request payload
 func (h GetDocumentHandler) Handle(params documentop.GetDocumentParams) middleware.Responder {
-	return h.AuditableAppContextFromRequest(params.HTTPRequest,
-		func(appCtx appcontext.AppContext) middleware.Responder {
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 			documentID, err := uuid.FromString(params.DocumentID.String())
 			if err != nil {
-				return handlers.ResponseForError(appCtx.Logger(), err)
+				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
 			document, err := models.FetchDocument(appCtx.DB(), appCtx.Session(), documentID, false)
 			if err != nil {
-				return handlers.ResponseForError(appCtx.Logger(), err)
+				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
 			documentPayload, err := payloadForDocumentModel(h.FileStorer(), document)
 			if err != nil {
-				return handlers.ResponseForError(appCtx.Logger(), err)
+				return handlers.ResponseForError(appCtx.Logger(), err), err
 			}
 
-			return documentop.NewGetDocumentOK().WithPayload(documentPayload)
+			return documentop.NewGetDocumentOK().WithPayload(documentPayload), nil
 		})
 }

--- a/pkg/handlers/ghcapi/move.go
+++ b/pkg/handlers/ghcapi/move.go
@@ -26,12 +26,12 @@ type GetMoveHandler struct {
 
 // Handle handles the getMove by locator request
 func (h GetMoveHandler) Handle(params moveop.GetMoveParams) middleware.Responder {
-	return h.AuditableAppContextFromRequest(params.HTTPRequest,
-		func(appCtx appcontext.AppContext) middleware.Responder {
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
 			locator := params.Locator
 			if locator == "" {
-				return moveop.NewGetMoveBadRequest()
+				return moveop.NewGetMoveBadRequest(), apperror.NewBadDataError("missing required parameter: locator")
 			}
 
 			move, err := h.FetchMove(appCtx, locator, nil)
@@ -40,14 +40,14 @@ func (h GetMoveHandler) Handle(params moveop.GetMoveParams) middleware.Responder
 				appCtx.Logger().Error("Error retrieving move by locator", zap.Error(err))
 				switch err.(type) {
 				case apperror.NotFoundError:
-					return moveop.NewGetMoveNotFound()
+					return moveop.NewGetMoveNotFound(), err
 				default:
-					return moveop.NewGetMoveInternalServerError()
+					return moveop.NewGetMoveInternalServerError(), err
 				}
 			}
 
 			payload := payloads.Move(move)
-			return moveop.NewGetMoveOK().WithPayload(payload)
+			return moveop.NewGetMoveOK().WithPayload(payload), nil
 		})
 }
 
@@ -58,21 +58,23 @@ type SetFinancialReviewFlagHandler struct {
 
 // Handle flags a move for financial review
 func (h SetFinancialReviewFlagHandler) Handle(params moveop.SetFinancialReviewFlagParams) middleware.Responder {
-	return h.AuditableAppContextFromRequest(params.HTTPRequest,
-		func(appCtx appcontext.AppContext) middleware.Responder {
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
 			moveID := uuid.FromStringOrNil(params.MoveID.String())
 
 			remarks := params.Body.Remarks
 			flagForReview := params.Body.FlagForReview
 			if flagForReview == nil {
-				payload := payloadForValidationError("Unable to flag move for financial review", "missing FlagForReview field", h.GetTraceIDFromRequest(params.HTTPRequest), validate.NewErrors())
-				return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload)
+				badDataError := apperror.NewBadDataError("missing FlagForReview field")
+				payload := payloadForValidationError("Unable to flag move for financial review", badDataError.Error(), h.GetTraceIDFromRequest(params.HTTPRequest), validate.NewErrors())
+				return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload), badDataError
 			}
 			// We require remarks when the move is going to be flagged for review.
 			if *flagForReview && remarks == nil {
-				payload := payloadForValidationError("Unable to flag move for financial review", "missing remarks field", h.GetTraceIDFromRequest(params.HTTPRequest), validate.NewErrors())
-				return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload)
+				badDataError := apperror.NewBadDataError("missing remarks field")
+				payload := payloadForValidationError("Unable to flag move for financial review", badDataError.Error(), h.GetTraceIDFromRequest(params.HTTPRequest), validate.NewErrors())
+				return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload), badDataError
 			}
 
 			move, err := h.SetFinancialReviewFlag(appCtx, moveID, *params.IfMatch, *flagForReview, remarks)
@@ -81,20 +83,20 @@ func (h SetFinancialReviewFlagHandler) Handle(params moveop.SetFinancialReviewFl
 				appCtx.Logger().Error("Error flagging move for financial review", zap.Error(err))
 				switch err.(type) {
 				case apperror.NotFoundError:
-					return moveop.NewSetFinancialReviewFlagNotFound()
+					return moveop.NewSetFinancialReviewFlagNotFound(), err
 				case apperror.PreconditionFailedError:
-					return moveop.NewSetFinancialReviewFlagPreconditionFailed()
+					return moveop.NewSetFinancialReviewFlagPreconditionFailed(), err
 				case apperror.InvalidInputError:
 					var e *apperror.InvalidInputError
 					_ = errors.As(err, &e)
 					payload := payloadForValidationError("Unable to flag move for financial review", err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)
-					return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload)
+					return moveop.NewSetFinancialReviewFlagUnprocessableEntity().WithPayload(payload), err
 				default:
-					return moveop.NewSetFinancialReviewFlagInternalServerError()
+					return moveop.NewSetFinancialReviewFlagInternalServerError(), err
 				}
 			}
 
 			payload := payloads.Move(move)
-			return moveop.NewSetFinancialReviewFlagOK().WithPayload(payload)
+			return moveop.NewSetFinancialReviewFlagOK().WithPayload(payload), nil
 		})
 }

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -441,7 +441,12 @@ func (h AcknowledgeExcessWeightRiskHandler) Handle(
 		})
 }
 
-func (h UpdateOrderHandler) triggerUpdateOrderEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.UpdateOrderParams) {
+func (h UpdateOrderHandler) triggerUpdateOrderEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.UpdateOrderParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcUpdateOrderEndpointKey,
 		// Endpoint that is being handled
@@ -451,14 +456,18 @@ func (h UpdateOrderHandler) triggerUpdateOrderEvent(appCtx appcontext.AppContext
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
 		appCtx.Logger().Error("ghcapi.UpdateOrderHandler could not generate the event")
 	}
 }
 
-func (h CounselingUpdateOrderHandler) triggerCounselingUpdateOrderEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.CounselingUpdateOrderParams) {
+func (h CounselingUpdateOrderHandler) triggerCounselingUpdateOrderEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.CounselingUpdateOrderParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcCounselingUpdateOrderEndpointKey,
 		// Endpoint that is being handled
@@ -468,14 +477,18 @@ func (h CounselingUpdateOrderHandler) triggerCounselingUpdateOrderEvent(appCtx a
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
 		appCtx.Logger().Error("ghcapi.UpdateAllowanceHandler could not generate the event")
 	}
 }
 
-func (h UpdateAllowanceHandler) triggerUpdatedAllowanceEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.UpdateAllowanceParams) {
+func (h UpdateAllowanceHandler) triggerUpdatedAllowanceEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.UpdateAllowanceParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcUpdateAllowanceEndpointKey,
 		// Endpoint that is being handled
@@ -485,14 +498,18 @@ func (h UpdateAllowanceHandler) triggerUpdatedAllowanceEvent(appCtx appcontext.A
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
 		appCtx.Logger().Error("ghcapi.UpdateAllowanceHandler could not generate the event")
 	}
 }
 
-func (h CounselingUpdateAllowanceHandler) triggerCounselingUpdateAllowanceEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.CounselingUpdateAllowanceParams) {
+func (h CounselingUpdateAllowanceHandler) triggerCounselingUpdateAllowanceEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.CounselingUpdateAllowanceParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcCounselingUpdateAllowanceEndpointKey,
 		// Endpoint that is being handled
@@ -502,14 +519,19 @@ func (h CounselingUpdateAllowanceHandler) triggerCounselingUpdateAllowanceEvent(
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
-		appCtx.Logger().Error("ghcapi.CounselingUpdateAllowanceHandler could not generate the event")
+		appCtx.Logger().
+			Error("ghcapi.CounselingUpdateAllowanceHandler could not generate the event")
 	}
 }
 
-func (h UpdateBillableWeightHandler) triggerUpdatedBillableWeightEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.UpdateBillableWeightParams) {
+func (h UpdateBillableWeightHandler) triggerUpdatedBillableWeightEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.UpdateBillableWeightParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcUpdateBillableWeightEndpointKey,
 		// Endpoint that is being handled
@@ -519,14 +541,18 @@ func (h UpdateBillableWeightHandler) triggerUpdatedBillableWeightEvent(appCtx ap
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
 		appCtx.Logger().Error("ghcapi.UpdateBillableWeightHandler could not generate the event")
 	}
 }
 
-func (h UpdateMaxBillableWeightAsTIOHandler) triggerUpdatedMaxBillableWeightAsTIOEvent(appCtx appcontext.AppContext, orderID uuid.UUID, moveID uuid.UUID, params orderop.UpdateMaxBillableWeightAsTIOParams) {
+func (h UpdateMaxBillableWeightAsTIOHandler) triggerUpdatedMaxBillableWeightAsTIOEvent(
+	appCtx appcontext.AppContext,
+	orderID uuid.UUID,
+	moveID uuid.UUID,
+	params orderop.UpdateMaxBillableWeightAsTIOParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcUpdateMaxBillableWeightAsTIOEndpointKey,
 		// Endpoint that is being handled
@@ -536,14 +562,18 @@ func (h UpdateMaxBillableWeightAsTIOHandler) triggerUpdatedMaxBillableWeightAsTI
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
-		appCtx.Logger().Error("ghcapi.UpdateMaxBillableWeightAsTIOHandler could not generate the event")
+		appCtx.Logger().
+			Error("ghcapi.UpdateMaxBillableWeightAsTIOHandler could not generate the event")
 	}
 }
 
-func (h AcknowledgeExcessWeightRiskHandler) triggerAcknowledgeExcessWeightRiskEvent(appCtx appcontext.AppContext, moveID uuid.UUID, params orderop.AcknowledgeExcessWeightRiskParams) {
+func (h AcknowledgeExcessWeightRiskHandler) triggerAcknowledgeExcessWeightRiskEvent(
+	appCtx appcontext.AppContext,
+	moveID uuid.UUID,
+	params orderop.AcknowledgeExcessWeightRiskParams,
+) {
 	_, err := event.TriggerEvent(event.Event{
 		EndpointKey: event.GhcAcknowledgeExcessWeightRiskEndpointKey,
 		// Endpoint that is being handled
@@ -553,7 +583,6 @@ func (h AcknowledgeExcessWeightRiskHandler) triggerAcknowledgeExcessWeightRiskEv
 		AppContext:      appCtx,
 		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
 	})
-
 	// If the event trigger fails, just log the error.
 	if err != nil {
 		appCtx.Logger().Error("ghcapi.UpdateBillableWeightHandler could not generate the event")

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -71,7 +71,6 @@ func (h GetMovesQueueHandler) Handle(params queues.GetMovesQueueParams) middlewa
 				appCtx.Session().OfficeUserID,
 				&ListOrderParams,
 			)
-
 			if err != nil {
 				appCtx.Logger().
 					Error("error fetching list of moves for office user", zap.Error(err))

--- a/pkg/handlers/ghcapi/tac.go
+++ b/pkg/handlers/ghcapi/tac.go
@@ -1,13 +1,13 @@
 package ghcapi
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	tacop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/tac"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -23,22 +23,29 @@ type TacValidationHandler struct {
 func (h TacValidationHandler) Handle(params tacop.TacValidationParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
-			rollbackErr := fmt.Errorf("TAC validation error")
-
 			if appCtx.Session() == nil {
-				return tacop.NewTacValidationUnauthorized(), rollbackErr
+				sessionErr := apperror.NewSessionError(
+					"user is not authorized",
+				)
+				appCtx.Logger().Error(sessionErr.Error())
+				return tacop.NewTacValidationUnauthorized(), sessionErr
 			}
 
 			if !appCtx.Session().IsOfficeApp() || !appCtx.Session().IsOfficeUser() {
-				return tacop.NewTacValidationForbidden(), rollbackErr
+				sessionOfficeErr := apperror.NewSessionError(
+					"user is not authenticated with TOO office role",
+				)
+				appCtx.Logger().Error(sessionOfficeErr.Error())
+				return tacop.NewTacValidationForbidden(), sessionOfficeErr
 			}
 
 			db := appCtx.DB()
 			isValid, err := db.Where("tac = $1", strings.ToUpper(params.Tac)).Exists(&models.TransportationAccountingCode{})
 
 			if err != nil {
-				appCtx.Logger().Error("Error looking for transportation accounting code", zap.Error(err))
-				return tacop.NewTacValidationInternalServerError(), rollbackErr
+				appCtx.Logger().
+					Error("Error looking for transportation accounting code", zap.Error(err))
+				return tacop.NewTacValidationInternalServerError(), err
 			}
 
 			tacValidationPayload := &ghcmessages.TacValid{

--- a/pkg/handlers/ghcapi/tac.go
+++ b/pkg/handlers/ghcapi/tac.go
@@ -40,8 +40,8 @@ func (h TacValidationHandler) Handle(params tacop.TacValidationParams) middlewar
 			}
 
 			db := appCtx.DB()
-			isValid, err := db.Where("tac = $1", strings.ToUpper(params.Tac)).Exists(&models.TransportationAccountingCode{})
-
+			isValid, err := db.Where("tac = $1", strings.ToUpper(params.Tac)).
+				Exists(&models.TransportationAccountingCode{})
 			if err != nil {
 				appCtx.Logger().
 					Error("Error looking for transportation accounting code", zap.Error(err))


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12050) for this change

## Summary

@michaelvaldes-truss and I are refactoring handlers in the GHC API from `AuditableAppContextFromRequest` to `AuditableAppContextFromRequestWithErrors`. This is also cleaning up technical risk around errors and we'll be modifying error messaging and logging where we can when we see it.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use at least one separate terminals to test this locally.</summary>

##### Terminal 1

Run the tests for the handlers and see that they pass

```sh
go test ./pkg/handlers/ghcapi/ -v 
```

</details>

### Additional steps

There are some changes that have formatted code using these three tools:

- `gofumpt` rather than `go fmt`
- `golines` to limit line lengths beyond 120 columns
- `goimports`

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Backend

- [x] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)