### PR TITLE
[MB-11962] e2e tests for TIO/NTS -R

### DIFF
--- a/cypress/integration/office/txo/tioFlows.js
+++ b/cypress/integration/office/txo/tioFlows.js
@@ -401,4 +401,201 @@ describe('TIO user', () => {
     cy.get('a[title="Home"]').click();
     cy.contains('Payment requests', { matchCase: false });
   });
+
+  it('can view calculation factors', () => {
+    cy.wait(['@getGHCClient', '@getPaymentRequests']);
+
+    // Go to known NTS-R move as TIO
+    cy.get('#locator').type('NTSRT1');
+    cy.get('th[data-testid="locator"]').first().click();
+    cy.get('[data-testid="locator-0"]').click();
+
+    // Verify we are on the Payment Requests page
+    cy.url().should('include', `/payment-requests`);
+    cy.wait(['@getMovePaymentRequests', '@getMoves', '@getOrders']);
+    cy.get('[data-testid="MovePaymentRequests"]');
+
+    // Review Weights
+    cy.get('#billable-weights').contains('Review weights').click();
+    cy.get('[data-testid="closeSidebar"]').click();
+    cy.wait(['@getMovePaymentRequests', '@getMoves', '@getOrders']);
+
+    // Review service items
+    cy.contains('Review service items').click();
+    cy.wait(['@getPaymentRequest', '@getMoves', '@getOrders']);
+
+    // Look at domestic linehaul calculations
+    cy.get('[data-testid=toggleCalculations]').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '14 cwt')
+      .and('contain', '354')
+      .and('contain', 'ZIP 803 to ZIP 805')
+      .and('contain', '21')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', 'Origin service area: 144')
+      .and('contain', '1.01000')
+      .and('contain', '$800.00');
+
+    // Approve the first service item
+    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+      completeServiceItemCard(el, true);
+    });
+
+    cy.get('[data-testid=nextServiceItem]').click();
+    cy.wait('@getPaymentRequest');
+
+    // Look at fuel surcharge calculations
+    cy.get('[data-testid=toggleCalculations]').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '14 cwt')
+      .and('contain', '354')
+      .and('contain', 'ZIP 803 to ZIP 805')
+      .and('contain', '0.15')
+      .and('contain', 'EIA diesel: $2.81')
+      .and('contain', 'Weight-based distance multiplier: 0.0004170')
+      .and('contain', '$107.00');
+
+    // Approve second
+    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+      completeServiceItemCard(el, true);
+    });
+
+    cy.get('[data-testid=nextServiceItem]').click();
+
+    // Look at domestic origin calculations
+    cy.get('[data-testid=toggleCalculations]').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '6.25')
+      .and('contain', 'Origin service area: 144')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DO Test Year')
+      .and('contain', '$150.00');
+
+    // Approve 3rd
+    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+      completeServiceItemCard(el, true);
+    });
+
+    cy.get('[data-testid=nextServiceItem]').click();
+
+    // Look at domestic destination calculations
+    cy.get('[data-testid=toggleCalculations]').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '6.25')
+      .and('contain', 'Destination service area: 144')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DDP Test Year')
+      .and('contain', '$150.00');
+
+    // Approve 4th
+    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+      completeServiceItemCard(el, true);
+    });
+
+    cy.get('[data-testid=nextServiceItem]').click();
+
+    // Look at domestic unpacking calculations
+    cy.get('[data-testid=toggleCalculations]').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '5.79')
+      .and('contain', 'Destination service schedule: 1')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DUPK Test Year')
+      .and('contain', '$459.00');
+
+    // Approve 5th
+    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+      completeServiceItemCard(el, true);
+    });
+
+    cy.get('[data-testid=nextServiceItem]').click();
+
+    // Complete Request
+    cy.contains('Complete request');
+
+    cy.contains('Authorize payment').click();
+
+    // Return to payment requests overview for move
+    cy.wait(['@getMovePaymentRequests', '@getMoves', '@getOrders']);
+    cy.get('[data-testid="MovePaymentRequests"]');
+
+    // Verify Service Item Calcs now that approved and visable
+    cy.contains('Accepted');
+
+    // Verify domestic linehaul cacls on payment request
+    cy.contains('Domestic linehaul').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '14 cwt')
+      .and('contain', '354')
+      .and('contain', 'ZIP 803 to ZIP 805')
+      .and('contain', '21')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', 'Origin service area: 144')
+      .and('contain', '1.01000')
+      .and('contain', '$800.00');
+
+    // Verify fuel surcharge calcs on payment request
+    cy.contains('Fuel surcharge').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '14 cwt')
+      .and('contain', '354')
+      .and('contain', 'ZIP 803 to ZIP 805')
+      .and('contain', '0.15')
+      .and('contain', 'EIA diesel: $2.81')
+      .and('contain', 'Weight-based distance multiplier: 0.0004170')
+      .and('contain', '$107.00');
+
+    // Verify Domestic origin price cacls on payment request
+    cy.contains('Domestic origin price').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '6.25')
+      .and('contain', 'Origin service area: 144')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DO Test Year')
+      .and('contain', '$150.00');
+
+    // Verify domestic destination price cacls on payment request
+    cy.contains('Domestic destination price').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '6.25')
+      .and('contain', 'Destination service area: 144')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DDP Test Year')
+      .and('contain', '$150.00');
+
+    // Verify domestic unpacking cacls on payment request
+    cy.contains('Domestic unpacking').click();
+    cy.get('[data-testid="ServiceItemCalculations"]')
+      .children()
+      .should('contain', '43 cwt')
+      .and('contain', '6.25')
+      .and('contain', 'Destination service area: 144')
+      .and('contain', 'Domestic non-peak')
+      .and('contain', '1.04071')
+      .and('contain', 'Base year: DDP Test Year')
+      .and('contain', '$150.00');
+
+    // calcs are good, go home
+    cy.get('a[title="Home"]').click();
+    cy.contains('Payment requests', { matchCase: false });
+  });
 });

--- a/cypress/integration/office/txo/tioFlows.js
+++ b/cypress/integration/office/txo/tioFlows.js
@@ -17,6 +17,61 @@ const completeServiceItemCard = ($serviceItem, approve = false) => {
   }
 };
 
+const approveCurrentServiceItem = () => {
+  // Approve the service item
+  cy.get('[data-testid="ServiceItemCard"]').each((el) => {
+    completeServiceItemCard(el, true);
+  });
+
+  // Go to next service item
+  cy.get('[data-testid=nextServiceItem]').click();
+};
+
+const validateDLCalcValues = () => {
+  cy.get('[data-testid="ServiceItemCalculations"]')
+    .children()
+    .should('contain', '14 cwt')
+    .and('contain', '354')
+    .and('contain', 'ZIP 803 to ZIP 805')
+    .and('contain', '21')
+    .and('contain', 'Domestic non-peak')
+    .and('contain', 'Origin service area: 144')
+    .and('contain', '1.01000')
+    .and('contain', '$800.00');
+};
+const validateFSCalcValues = () => {
+  cy.get('[data-testid="ServiceItemCalculations"]')
+    .children()
+    .should('contain', '14 cwt')
+    .and('contain', '354')
+    .and('contain', 'ZIP 803 to ZIP 805')
+    .and('contain', '0.15')
+    .and('contain', 'EIA diesel: $2.81')
+    .and('contain', 'Weight-based distance multiplier: 0.0004170')
+    .and('contain', '$107.00');
+};
+const validateDUCalcValues = () => {
+  cy.get('[data-testid="ServiceItemCalculations"]')
+    .children()
+    .should('contain', '43 cwt')
+    .and('contain', '5.79')
+    .and('contain', 'Destination service schedule: 1')
+    .and('contain', 'Domestic non-peak')
+    .and('contain', '1.04071')
+    .and('contain', 'Base year: DUPK Test Year')
+    .and('contain', '$459.00');
+};
+const validateDXCalcValues = () => {
+  cy.get('[data-testid="ServiceItemCalculations"]')
+    .children()
+    .should('contain', '43 cwt')
+    .and('contain', '6.25')
+    .and('contain', 'service area: 144')
+    .and('contain', 'Domestic non-peak')
+    .and('contain', '1.04071')
+    .and('contain', '$150.00');
+};
+
 describe('TIO user', () => {
   before(() => {
     cy.prepareOfficeApp();
@@ -327,11 +382,7 @@ describe('TIO user', () => {
     cy.wait(['@getPaymentRequest']);
 
     // Approve the service item
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-    cy.wait('@patchPaymentServiceItemStatus');
-    cy.get('[data-testid=nextServiceItem]').click();
+    approveCurrentServiceItem();
 
     // Complete Request
     cy.contains('Complete request');
@@ -424,106 +475,33 @@ describe('TIO user', () => {
     cy.contains('Review service items').click();
     cy.wait(['@getPaymentRequest', '@getMoves', '@getOrders']);
 
-    // Look at domestic linehaul calculations
+    // Verify at domestic linehaul calculations
     cy.get('[data-testid=toggleCalculations]').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '14 cwt')
-      .and('contain', '354')
-      .and('contain', 'ZIP 803 to ZIP 805')
-      .and('contain', '21')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', 'Origin service area: 144')
-      .and('contain', '1.01000')
-      .and('contain', '$800.00');
+    validateDLCalcValues();
+    approveCurrentServiceItem();
 
-    // Approve the first service item
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-
-    cy.get('[data-testid=nextServiceItem]').click();
-    cy.wait('@getPaymentRequest');
-
-    // Look at fuel surcharge calculations
+    // Verify at fuel surcharge calculations
     cy.get('[data-testid=toggleCalculations]').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '14 cwt')
-      .and('contain', '354')
-      .and('contain', 'ZIP 803 to ZIP 805')
-      .and('contain', '0.15')
-      .and('contain', 'EIA diesel: $2.81')
-      .and('contain', 'Weight-based distance multiplier: 0.0004170')
-      .and('contain', '$107.00');
+    validateFSCalcValues();
+    approveCurrentServiceItem();
 
-    // Approve second
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-
-    cy.get('[data-testid=nextServiceItem]').click();
-
-    // Look at domestic origin calculations
+    // Verify at domestic origin calculations
     cy.get('[data-testid=toggleCalculations]').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '6.25')
-      .and('contain', 'Origin service area: 144')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DO Test Year')
-      .and('contain', '$150.00');
+    validateDXCalcValues();
+    approveCurrentServiceItem();
 
-    // Approve 3rd
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-
-    cy.get('[data-testid=nextServiceItem]').click();
-
-    // Look at domestic destination calculations
+    // Verify at domestic destination calculations
     cy.get('[data-testid=toggleCalculations]').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '6.25')
-      .and('contain', 'Destination service area: 144')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DDP Test Year')
-      .and('contain', '$150.00');
+    validateDXCalcValues();
+    approveCurrentServiceItem();
 
-    // Approve 4th
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-
-    cy.get('[data-testid=nextServiceItem]').click();
-
-    // Look at domestic unpacking calculations
+    // Verify at domestic unpacking calculations
     cy.get('[data-testid=toggleCalculations]').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '5.79')
-      .and('contain', 'Destination service schedule: 1')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DUPK Test Year')
-      .and('contain', '$459.00');
-
-    // Approve 5th
-    cy.get('[data-testid="ServiceItemCard"]').each((el) => {
-      completeServiceItemCard(el, true);
-    });
-
-    cy.get('[data-testid=nextServiceItem]').click();
+    validateDUCalcValues();
+    approveCurrentServiceItem();
 
     // Complete Request
     cy.contains('Complete request');
-
     cy.contains('Authorize payment').click();
 
     // Return to payment requests overview for move
@@ -535,64 +513,28 @@ describe('TIO user', () => {
 
     // Verify domestic linehaul cacls on payment request
     cy.contains('Domestic linehaul').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '14 cwt')
-      .and('contain', '354')
-      .and('contain', 'ZIP 803 to ZIP 805')
-      .and('contain', '21')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', 'Origin service area: 144')
-      .and('contain', '1.01000')
-      .and('contain', '$800.00');
+    validateDLCalcValues();
+    cy.contains('Domestic linehaul').click();
 
     // Verify fuel surcharge calcs on payment request
     cy.contains('Fuel surcharge').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '14 cwt')
-      .and('contain', '354')
-      .and('contain', 'ZIP 803 to ZIP 805')
-      .and('contain', '0.15')
-      .and('contain', 'EIA diesel: $2.81')
-      .and('contain', 'Weight-based distance multiplier: 0.0004170')
-      .and('contain', '$107.00');
+    validateFSCalcValues();
+    cy.contains('Fuel surcharge').click();
 
     // Verify Domestic origin price cacls on payment request
     cy.contains('Domestic origin price').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '6.25')
-      .and('contain', 'Origin service area: 144')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DO Test Year')
-      .and('contain', '$150.00');
+    validateDXCalcValues();
+    cy.contains('Domestic origin price').click();
 
     // Verify domestic destination price cacls on payment request
     cy.contains('Domestic destination price').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '6.25')
-      .and('contain', 'Destination service area: 144')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DDP Test Year')
-      .and('contain', '$150.00');
+    validateDXCalcValues();
+    cy.contains('Domestic destination price').click();
 
     // Verify domestic unpacking cacls on payment request
     cy.contains('Domestic unpacking').click();
-    cy.get('[data-testid="ServiceItemCalculations"]')
-      .children()
-      .should('contain', '43 cwt')
-      .and('contain', '6.25')
-      .and('contain', 'Destination service area: 144')
-      .and('contain', 'Domestic non-peak')
-      .and('contain', '1.04071')
-      .and('contain', 'Base year: DDP Test Year')
-      .and('contain', '$150.00');
+    validateDUCalcValues();
+    cy.contains('Domestic unpacking').click();
 
     // calcs are good, go home
     cy.get('a[title="Home"]').click();

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -3052,6 +3052,640 @@ func createPrimeSimulatorMoveNeedsShipmentUpdate(appCtx appcontext.AppContext, u
 	})
 }
 
+/*
+* Create a NTS-R move with a payment request and 5 semi-realistic service items
+ */
+func createNTSRMoveWithServiceItemsAndPaymentRequest(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string) {
+	currentTime := time.Now()
+	tac := "1111"
+	tac2 := "2222"
+	sac := "3333"
+	sac2 := "4444"
+
+	// Create Customer
+	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{})
+
+	// Create Orders
+	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			ServiceMemberID: customer.ID,
+			ServiceMember:   customer,
+			TAC:             &tac,
+			NtsTAC:          &tac2,
+			SAC:             &sac,
+			NtsSAC:          &sac2,
+		},
+		UserUploader: userUploader,
+	})
+
+	// Create Move
+	selectedMoveType := models.SelectedMoveTypeNTSR
+	move := testdatagen.MakeMove(appCtx.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Locator:            locator,
+			OrdersID:           orders.ID,
+			AvailableToPrimeAt: swag.Time(time.Now()),
+			SelectedMoveType:   &selectedMoveType,
+			SubmittedAt:        &currentTime,
+		},
+		Order: orders,
+	})
+
+	// Create Pickup Address
+	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			// KKFA GBLOC
+			PostalCode: "85004",
+		},
+	})
+
+	// Create Storage Facility
+	storageFacility := testdatagen.MakeStorageFacility(appCtx.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			// KKFA GBLOC
+			PostalCode: "85005",
+		},
+	})
+
+	// Create NTS-R Shipment
+	tacType := models.LOATypeHHG
+	sacType := models.LOATypeNTS
+	serviceOrderNumber := "1234"
+	ntsrShipment := testdatagen.MakeNTSRShipment(appCtx.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+			ApprovedDate:         swag.Time(time.Now()),
+			PickupAddress:        &shipmentPickupAddress,
+			TACType:              &tacType,
+			Status:               models.MTOShipmentStatusApproved,
+			SACType:              &sacType,
+			StorageFacility:      &storageFacility,
+			ServiceOrderNumber:   &serviceOrderNumber,
+		},
+		Move: move,
+	})
+
+	// Create Releasing Agent
+	testdatagen.MakeMTOAgent(appCtx.DB(), testdatagen.Assertions{
+		MTOAgent: models.MTOAgent{
+			ID:            uuid.Must(uuid.NewV4()),
+			MTOShipment:   ntsrShipment,
+			MTOShipmentID: ntsrShipment.ID,
+			FirstName:     swag.String("Test"),
+			LastName:      swag.String("Agent"),
+			Email:         swag.String("test@test.email.com"),
+			MTOAgentType:  models.MTOAgentReleasing,
+		},
+	})
+
+	// Create Payment Request
+	paymentRequest := testdatagen.MakePaymentRequest(appCtx.DB(), testdatagen.Assertions{
+		PaymentRequest: models.PaymentRequest{
+			ID:              uuid.Must(uuid.NewV4()),
+			MoveTaskOrder:   move,
+			IsFinal:         false,
+			Status:          models.PaymentRequestStatusPending,
+			RejectionReason: nil,
+		},
+		Move: move,
+	})
+
+	// Create Domestic linehaul service item
+	dlCost := unit.Cents(80000)
+	dlItemParams := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameContractCode,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   testdatagen.DefaultContractCode,
+		},
+		{
+			Key:     models.ServiceItemParamNameReferenceDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameServicesScheduleDest,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: "DL Test Year",
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: strconv.FormatFloat(1.01, 'f', 5, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameIsPeak,
+			KeyType: models.ServiceItemParamTypeBoolean,
+			Value:   strconv.FormatBool(false),
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "21",
+		},
+		{
+			Key:     models.ServiceItemParamNameServiceAreaDest,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   strconv.Itoa(144),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightOriginal,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1400",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightEstimated,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1500",
+		},
+
+		{
+			Key:     models.ServiceItemParamNameActualPickupDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameDistanceZip3,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   fmt.Sprintf("%d", int(354)),
+		},
+
+		{
+			Key:     models.ServiceItemParamNameWeightBilled,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1400),
+		},
+		{
+			Key:     models.ServiceItemParamNameFSCWeightBasedDistanceMultiplier,
+			KeyType: models.ServiceItemParamTypeDecimal,
+			Value:   strconv.FormatFloat(0.000417, 'f', 7, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameEIAFuelPrice,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   fmt.Sprintf("%d", int(unit.Millicents(281400))),
+		},
+		{
+			Key:     models.ServiceItemParamNameZipPickupAddress,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "80301",
+		},
+		{
+			Key:     models.ServiceItemParamNameZipDestAddress,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "80501",
+		},
+		{
+			Key:     models.ServiceItemParamNameServiceAreaOrigin,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   strconv.Itoa(144),
+		},
+	}
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeDLH,
+		dlItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &dlCost,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+
+	// Create Fuel surcharge service item
+	fsCost := unit.Cents(10700)
+	fsItemParams := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameContractCode,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   testdatagen.DefaultContractCode,
+		},
+		{
+			Key:     models.ServiceItemParamNameReferenceDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameServicesScheduleDest,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: "FS Test Year",
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: strconv.FormatFloat(1.01, 'f', 5, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameIsPeak,
+			KeyType: models.ServiceItemParamTypeBoolean,
+			Value:   strconv.FormatBool(false),
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "21",
+		},
+		{
+			Key:     models.ServiceItemParamNameServiceAreaDest,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   strconv.Itoa(144),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightOriginal,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1400",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightEstimated,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1500",
+		},
+
+		{
+			Key:     models.ServiceItemParamNameActualPickupDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameDistanceZip3,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   fmt.Sprintf("%d", int(354)),
+		},
+
+		{
+			Key:     models.ServiceItemParamNameWeightBilled,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1400),
+		},
+		{
+			Key:     models.ServiceItemParamNameFSCWeightBasedDistanceMultiplier,
+			KeyType: models.ServiceItemParamTypeDecimal,
+			Value:   strconv.FormatFloat(0.000417, 'f', 7, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameEIAFuelPrice,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   fmt.Sprintf("%d", int(unit.Millicents(281400))),
+		},
+		{
+			Key:     models.ServiceItemParamNameZipPickupAddress,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "80301",
+		},
+		{
+			Key:     models.ServiceItemParamNameZipDestAddress,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "80501",
+		},
+	}
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeFSC,
+		fsItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &fsCost,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+
+	// Create Domestic origin price service item
+	doCost := unit.Cents(15000)
+	doItemParams := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameContractCode,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   testdatagen.DefaultContractCode,
+		},
+		{
+			Key:     models.ServiceItemParamNameReferenceDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameServicesScheduleDest,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightBilled,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(4300),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: "DO Test Year",
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: strconv.FormatFloat(1.04071, 'f', 5, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameIsPeak,
+			KeyType: models.ServiceItemParamTypeBoolean,
+			Value:   strconv.FormatBool(false),
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "6.25",
+		},
+		{
+			Key:     models.ServiceItemParamNameServiceAreaOrigin,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   strconv.Itoa(144),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightOriginal,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1400",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightEstimated,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1500",
+		},
+	}
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeDOP,
+		doItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &doCost,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+
+	// Create Domestic destination price service item
+	ddpCost := unit.Cents(15000)
+	ddpItemParams := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameContractCode,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   testdatagen.DefaultContractCode,
+		},
+		{
+			Key:     models.ServiceItemParamNameReferenceDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameServicesScheduleDest,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightBilled,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(4300),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: "DDP Test Year",
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: strconv.FormatFloat(1.04071, 'f', 5, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameIsPeak,
+			KeyType: models.ServiceItemParamTypeBoolean,
+			Value:   strconv.FormatBool(false),
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "6.25",
+		},
+		{
+			Key:     models.ServiceItemParamNameServiceAreaDest,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   strconv.Itoa(144),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightOriginal,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1400",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightEstimated,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1500",
+		},
+	}
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeDDP,
+		ddpItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &ddpCost,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+
+	// Create Domestic unpacking service item
+	duCost := unit.Cents(45900)
+	duItemParams := []testdatagen.CreatePaymentServiceItemParams{
+		{
+			Key:     models.ServiceItemParamNameContractCode,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   testdatagen.DefaultContractCode,
+		},
+		{
+			Key:     models.ServiceItemParamNameReferenceDate,
+			KeyType: models.ServiceItemParamTypeDate,
+			Value:   currentTime.Format("2006-01-02"),
+		},
+		{
+			Key:     models.ServiceItemParamNameServicesScheduleDest,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(1),
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightBilled,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   strconv.Itoa(4300),
+		},
+		{
+			Key:   models.ServiceItemParamNameContractYearName,
+			Value: "DUPK Test Year",
+		},
+		{
+			Key:   models.ServiceItemParamNameEscalationCompounded,
+			Value: strconv.FormatFloat(1.04071, 'f', 5, 64),
+		},
+		{
+			Key:     models.ServiceItemParamNameIsPeak,
+			KeyType: models.ServiceItemParamTypeBoolean,
+			Value:   strconv.FormatBool(false),
+		},
+		{
+			Key:     models.ServiceItemParamNamePriceRateOrFactor,
+			KeyType: models.ServiceItemParamTypeString,
+			Value:   "5.79",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightOriginal,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1400",
+		},
+		{
+			Key:     models.ServiceItemParamNameWeightEstimated,
+			KeyType: models.ServiceItemParamTypeInteger,
+			Value:   "1500",
+		},
+	}
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeDUPK,
+		duItemParams,
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &duCost,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+
+}
+
+/*
+ * Create a NTS-R move with a single payment request and service item
+ */
+func createNTSRMoveWithPaymentRequest(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, locator string) {
+	currentTime := time.Now()
+	tac := "1111"
+
+	// Create Customer
+	customer := testdatagen.MakeServiceMember(appCtx.DB(), testdatagen.Assertions{})
+
+	// Create Orders
+	orders := testdatagen.MakeOrder(appCtx.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			ServiceMemberID: customer.ID,
+			ServiceMember:   customer,
+			TAC:             &tac,
+		},
+		UserUploader: userUploader,
+	})
+
+	// Create Move
+	selectedMoveType := models.SelectedMoveTypeNTSR
+	move := testdatagen.MakeMove(appCtx.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Locator:            locator,
+			OrdersID:           orders.ID,
+			AvailableToPrimeAt: swag.Time(time.Now()),
+			SelectedMoveType:   &selectedMoveType,
+			SubmittedAt:        &currentTime,
+		},
+		Order: orders,
+	})
+
+	// Create Pickup Address
+	shipmentPickupAddress := testdatagen.MakeAddress(appCtx.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			// KKFA GBLOC
+			PostalCode: "85004",
+		},
+	})
+
+	// Create Storage Facility
+	storageFacility := testdatagen.MakeStorageFacility(appCtx.DB(), testdatagen.Assertions{
+		Address: models.Address{
+			// KKFA GBLOC
+			PostalCode: "85004",
+		},
+	})
+
+	// Create NTS-R Shipment
+	tacType := models.LOATypeHHG
+	serviceOrderNumber := "1234"
+	ntsrShipment := testdatagen.MakeNTSRShipment(appCtx.DB(), testdatagen.Assertions{
+		MTOShipment: models.MTOShipment{
+			PrimeEstimatedWeight: &estimatedWeight,
+			PrimeActualWeight:    &actualWeight,
+			ApprovedDate:         swag.Time(time.Now()),
+			PickupAddress:        &shipmentPickupAddress,
+			TACType:              &tacType,
+			Status:               models.MTOShipmentStatusApproved,
+			StorageFacility:      &storageFacility,
+			ServiceOrderNumber:   &serviceOrderNumber,
+			UsesExternalVendor:   true,
+		},
+		Move: move,
+	})
+
+	// Create Releasing Agent
+	testdatagen.MakeMTOAgent(appCtx.DB(), testdatagen.Assertions{
+		MTOAgent: models.MTOAgent{
+			ID:            uuid.Must(uuid.NewV4()),
+			MTOShipment:   ntsrShipment,
+			MTOShipmentID: ntsrShipment.ID,
+			FirstName:     swag.String("Test"),
+			LastName:      swag.String("Agent"),
+			Email:         swag.String("test@test.email.com"),
+			MTOAgentType:  models.MTOAgentReleasing,
+		},
+	})
+
+	// Create Payment Request
+	paymentRequest := testdatagen.MakePaymentRequest(appCtx.DB(), testdatagen.Assertions{
+		PaymentRequest: models.PaymentRequest{
+			ID:              uuid.Must(uuid.NewV4()),
+			MoveTaskOrder:   move,
+			IsFinal:         false,
+			Status:          models.PaymentRequestStatusPending,
+			RejectionReason: nil,
+		},
+		Move: move,
+	})
+
+	// create service item
+	msCostcos := unit.Cents(32400)
+	testdatagen.MakePaymentServiceItemWithParams(
+		appCtx.DB(),
+		models.ReServiceCodeCS,
+		[]testdatagen.CreatePaymentServiceItemParams{
+			{
+				Key:     models.ServiceItemParamNameContractCode,
+				KeyType: models.ServiceItemParamTypeString,
+				Value:   testdatagen.DefaultContractCode,
+			}},
+		testdatagen.Assertions{
+			PaymentServiceItem: models.PaymentServiceItem{
+				PriceCents: &msCostcos,
+			},
+			Move:           move,
+			MTOShipment:    ntsrShipment,
+			PaymentRequest: paymentRequest,
+		},
+	)
+}
+
 // Run does that data load thing
 func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *uploader.UserUploader, primeUploader *uploader.PrimeUploader) {
 	moveRouter := moverouter.NewMoveRouter()
@@ -3165,6 +3799,11 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	createPrimeSimulatorMoveNeedsShipmentUpdate(appCtx, userUploader)
 	createUnsubmittedMoveWithPPMShipmentThroughEstimatedWeights(appCtx, userUploader)
 	createUnsubmittedMoveWithMinimumPPMShipment(appCtx, userUploader)
+
+	// TIO
+	createNTSRMoveWithServiceItemsAndPaymentRequest(appCtx, userUploader, "NTSRT1")
+	createNTSRMoveWithPaymentRequest(appCtx, userUploader, "NTSRT2")
+	createNTSRMoveWithPaymentRequest(appCtx, userUploader, "NTSRT3")
 
 	//Retiree, HOR, HHG
 	createMoveWithOptions(appCtx, testdatagen.Assertions{


### PR DESCRIPTION
## [MB-11962](https://dp3.atlassian.net/browse/MB-11962) for this change

## Summary

This PR adds 3 TIO cypress tests and related e2e seed data.  The tests are all from the perspective of a TIO reviewing a move with a NTS-R. 

Overview of new Tests:

-  **Rejection Flow:** A test that goes through rejecting all service items and the request itself
- **Review/Approval Flow:** A test that approves a payment request and does more general validation along the way (payment request info, external vendor shipment, ect)
- **Calculations:** A test to verify calculation info in both places it appears (when reviewing individual service items and in the payment request)

## Setup to Run Your Code
Note: Changes were only make to Cypress tests and seed data. No changes were made to the application itself.  

This PR includes new data, you should be sure to update and use fresh data every-time before running the cypress tests. 

Re-generate e2e seed data and run the e2e tests. There are several ways to do this, the most simplistic being:
```make e2e_test```

You could aslo run in docker with:
```make e2e_test_docker```

For reference, the 3 move locators used for these tests in the seed data are: `NTSRT1`, `NTSRT2`, `NTSRT3`. 