### PR TITLE
[MB-10956] part 5: Remove sort by destination duty station in backend

### DIFF
--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -379,7 +379,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 		subtestData := suite.makeUpdateOrderHandlerSubtestData()
 		move := subtestData.move
 		order := subtestData.move.Orders
-		destinationDutyStation := order.NewDutyLocation
+		destinationDutyLocation := order.NewDutyLocation
 		originDutyStation := order.OriginDutyLocation
 
 		requestUser := testdatagen.MakeOfficeUserWithMultipleRoles(suite.DB(), testdatagen.Assertions{Stub: true})
@@ -393,7 +393,7 @@ func (suite *HandlerSuite) TestUpdateOrderHandlerWithAmendedUploads() {
 			OrdersType:            ghcmessages.NewOrdersType(ghcmessages.OrdersTypeRETIREMENT),
 			OrdersTypeDetail:      &ordersTypeDetail,
 			OrdersNumber:          handlers.FmtString("ORDER100"),
-			NewDutyLocationID:     handlers.FmtUUID(destinationDutyStation.ID),
+			NewDutyLocationID:     handlers.FmtUUID(destinationDutyLocation.ID),
 			OriginDutyLocationID:  handlers.FmtUUID(originDutyStation.ID),
 			Tac:                   handlers.FmtString("E19A"),
 			Sac:                   nullable.NewString("987654321"),

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -131,7 +131,7 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 	var groupByColumms []string
 	groupByColumms = append(groupByColumms, "service_members.id", "orders.id", "origin_dl.id")
 
-	if params.Sort != nil && *params.Sort == "destinationDutyStation" {
+	if params.Sort != nil && *params.Sort == "destinationDutyLocation" {
 		groupByColumms = append(groupByColumms, "dest_dl.name")
 	}
 
@@ -334,16 +334,16 @@ func gblocFilterForTOO(gbloc *string) QueryOption {
 
 func sortOrder(sort *string, order *string) QueryOption {
 	parameters := map[string]string{
-		"lastName":               "service_members.last_name",
-		"dodID":                  "service_members.edipi",
-		"branch":                 "service_members.affiliation",
-		"locator":                "moves.locator",
-		"status":                 "moves.status",
-		"submittedAt":            "moves.submitted_at",
-		"destinationDutyStation": "dest_dl.name",
-		"originDutyLocation":     "origin_dl.name",
-		"requestedMoveDate":      "min(mto_shipments.requested_pickup_date)",
-		"originGBLOC":            "origin_to.gbloc",
+		"lastName":                "service_members.last_name",
+		"dodID":                   "service_members.edipi",
+		"branch":                  "service_members.affiliation",
+		"locator":                 "moves.locator",
+		"status":                  "moves.status",
+		"submittedAt":             "moves.submitted_at",
+		"destinationDutyLocation": "dest_dl.name",
+		"originDutyLocation":      "origin_dl.name",
+		"requestedMoveDate":       "min(mto_shipments.requested_pickup_date)",
+		"originGBLOC":             "origin_to.gbloc",
 	}
 
 	return func(query *pop.Query) {

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -81,14 +81,13 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 	locatorQuery := locatorFilter(params.Locator)
 	dodIDQuery := dodIDFilter(params.DodID)
 	lastNameQuery := lastNameFilter(params.LastName)
-	dutyLocationQuery := destinationDutyLocationFilter(params.DestinationDutyLocation)
 	originDutyLocationQuery := originDutyLocationFilter(params.OriginDutyLocation)
 	moveStatusQuery := moveStatusFilter(params.Status)
 	submittedAtQuery := submittedAtFilter(params.SubmittedAt)
 	requestedMoveDateQuery := requestedMoveDateFilter(params.RequestedMoveDate)
 	sortOrderQuery := sortOrder(params.Sort, params.Order)
 	// Adding to an array so we can iterate over them and apply the filters after the query structure is set below
-	options := [11]QueryOption{branchQuery, locatorQuery, dodIDQuery, lastNameQuery, dutyLocationQuery, originDutyLocationQuery, moveStatusQuery, gblocQuery, submittedAtQuery, requestedMoveDateQuery, sortOrderQuery}
+	options := [11]QueryOption{branchQuery, locatorQuery, dodIDQuery, lastNameQuery, originDutyLocationQuery, moveStatusQuery, gblocQuery, submittedAtQuery, requestedMoveDateQuery, sortOrderQuery}
 
 	query := appCtx.DB().Q().EagerPreload(
 		"Orders.ServiceMember",
@@ -130,10 +129,6 @@ func (f orderFetcher) ListOrders(appCtx appcontext.AppContext, officeUserID uuid
 
 	var groupByColumms []string
 	groupByColumms = append(groupByColumms, "service_members.id", "orders.id", "origin_dl.id")
-
-	if params.Sort != nil && *params.Sort == "destinationDutyLocation" {
-		groupByColumms = append(groupByColumms, "dest_dl.name")
-	}
 
 	if params.Sort != nil && *params.Sort == "originDutyLocation" {
 		groupByColumms = append(groupByColumms, "origin_dl.name")
@@ -253,15 +248,6 @@ func locatorFilter(locator *string) QueryOption {
 	}
 }
 
-func destinationDutyLocationFilter(destinationDutyLocation *string) QueryOption {
-	return func(query *pop.Query) {
-		if destinationDutyLocation != nil {
-			nameSearch := fmt.Sprintf("%s%%", *destinationDutyLocation)
-			query.Where("dest_dl.name ILIKE ?", nameSearch)
-		}
-	}
-}
-
 func originDutyLocationFilter(originDutyLocation *string) QueryOption {
 	return func(query *pop.Query) {
 		if originDutyLocation != nil {
@@ -334,16 +320,15 @@ func gblocFilterForTOO(gbloc *string) QueryOption {
 
 func sortOrder(sort *string, order *string) QueryOption {
 	parameters := map[string]string{
-		"lastName":                "service_members.last_name",
-		"dodID":                   "service_members.edipi",
-		"branch":                  "service_members.affiliation",
-		"locator":                 "moves.locator",
-		"status":                  "moves.status",
-		"submittedAt":             "moves.submitted_at",
-		"destinationDutyLocation": "dest_dl.name",
-		"originDutyLocation":      "origin_dl.name",
-		"requestedMoveDate":       "min(mto_shipments.requested_pickup_date)",
-		"originGBLOC":             "origin_to.gbloc",
+		"lastName":           "service_members.last_name",
+		"dodID":              "service_members.edipi",
+		"branch":             "service_members.affiliation",
+		"locator":            "moves.locator",
+		"status":             "moves.status",
+		"submittedAt":        "moves.submitted_at",
+		"originDutyLocation": "origin_dl.name",
+		"requestedMoveDate":  "min(mto_shipments.requested_pickup_date)",
+		"originGBLOC":        "origin_to.gbloc",
 	}
 
 	return func(query *pop.Query) {

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -347,14 +347,6 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 	affiliation := models.AffiliationNAVY
 	edipi := "9999999999"
 
-	// SET UP: New Duty Location for sorting by destination duty location
-	newDutyLocationName := "Ze Duty Location"
-	newDutyLocation2 := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
-		DutyLocation: models.DutyLocation{
-			Name: newDutyLocationName,
-		},
-	})
-
 	// CREATE EXPECTED MOVES
 	expectedMove1 := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
 		// Default New Duty Location name is Fort Gordon
@@ -372,10 +364,6 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		},
 		// Lea Spacemen
 		ServiceMember: models.ServiceMember{Affiliation: &affiliation, FirstName: &serviceMemberFirstName, Edipi: &edipi},
-		Order: models.Order{
-			NewDutyLocation:   newDutyLocation2,
-			NewDutyLocationID: newDutyLocation2.ID,
-		},
 		MTOShipment: models.MTOShipment{
 			RequestedPickupDate: &requestedMoveDate2,
 		},
@@ -438,22 +426,6 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 		suite.Equal(2, len(moves))
 		suite.Equal(*expectedMove2.Orders.ServiceMember.Affiliation, *moves[0].Orders.ServiceMember.Affiliation)
 		suite.Equal(*expectedMove1.Orders.ServiceMember.Affiliation, *moves[1].Orders.ServiceMember.Affiliation)
-	})
-
-	suite.T().Run("Sort by destination duty location", func(t *testing.T) {
-		params := services.ListOrderParams{Sort: swag.String("destinationDutyLocation"), Order: swag.String("asc")}
-		moves, _, err := orderFetcher.ListOrders(suite.AppContextForTest(), officeUser.ID, &params)
-		suite.NoError(err)
-		suite.Equal(2, len(moves))
-		suite.Equal(expectedMove1.Orders.NewDutyLocation.Name, moves[0].Orders.NewDutyLocation.Name)
-		suite.Equal(expectedMove2.Orders.NewDutyLocation.Name, moves[1].Orders.NewDutyLocation.Name)
-
-		params = services.ListOrderParams{Sort: swag.String("destinationDutyLocation"), Order: swag.String("desc")}
-		moves, _, err = orderFetcher.ListOrders(suite.AppContextForTest(), officeUser.ID, &params)
-		suite.NoError(err)
-		suite.Equal(2, len(moves))
-		suite.Equal(expectedMove2.Orders.NewDutyLocation.Name, moves[0].Orders.NewDutyLocation.Name)
-		suite.Equal(expectedMove1.Orders.NewDutyLocation.Name, moves[1].Orders.NewDutyLocation.Name)
 	})
 
 	suite.T().Run("Sort by request move date", func(t *testing.T) {

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -441,14 +441,14 @@ func (suite *OrderServiceSuite) TestListOrdersWithSortOrder() {
 	})
 
 	suite.T().Run("Sort by destination duty location", func(t *testing.T) {
-		params := services.ListOrderParams{Sort: swag.String("destinationDutyStation"), Order: swag.String("asc")}
+		params := services.ListOrderParams{Sort: swag.String("destinationDutyLocation"), Order: swag.String("asc")}
 		moves, _, err := orderFetcher.ListOrders(suite.AppContextForTest(), officeUser.ID, &params)
 		suite.NoError(err)
 		suite.Equal(2, len(moves))
 		suite.Equal(expectedMove1.Orders.NewDutyLocation.Name, moves[0].Orders.NewDutyLocation.Name)
 		suite.Equal(expectedMove2.Orders.NewDutyLocation.Name, moves[1].Orders.NewDutyLocation.Name)
 
-		params = services.ListOrderParams{Sort: swag.String("destinationDutyStation"), Order: swag.String("desc")}
+		params = services.ListOrderParams{Sort: swag.String("destinationDutyLocation"), Order: swag.String("desc")}
 		moves, _, err = orderFetcher.ListOrders(suite.AppContextForTest(), officeUser.ID, &params)
 		suite.NoError(err)
 		suite.Equal(2, len(moves))


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10956) for this change
I started to rename this, and then realized that we don't use sort by destination duty location anywhere.
All of the office queues have been switched over to sorting by origin duty location.
So I deleted this dead code instead of renaming the parameter.

## Setup to Run Your Code
Open up the TOO, TIO, and Service Counselor queues and make sure there are no errors.