### PR TITLE
[MB-11997] Update placeholder text for duty location input retiree/separatee

### DIFF
--- a/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.jsx
+++ b/src/components/Customer/CurrentDutyLocationForm/CurrentDutyLocationForm.jsx
@@ -32,6 +32,7 @@ const CurrentDutyLocationForm = ({ initialValues, onBack, onSubmit, newDutyLocat
                 label="What is your current duty location?"
                 name="current_location"
                 id="current_location"
+                placeholder="Start typing a duty location..."
                 required
               />
             </SectionWrapper>

--- a/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
+++ b/src/components/Customer/EditOrdersForm/EditOrdersForm.jsx
@@ -151,10 +151,16 @@ const EditOrdersForm = ({
                     label="HOR, PLEAD or HOS"
                     displayAddress={false}
                     hint="Enter the option closest to your destination. Your move counselor will identify if there might be a cost to you."
+                    placeholder="Enter a city or ZIP"
                   />
                 </>
               ) : (
-                <DutyLocationInput name="new_duty_location" label="New duty location" displayAddress={false} />
+                <DutyLocationInput
+                  name="new_duty_location"
+                  label="New duty location"
+                  displayAddress={false}
+                  placeholder="Start typing a duty location..."
+                />
               )}
               <p>Uploads:</p>
               <UploadsTable uploads={initialValues.uploaded_orders} onDelete={onDelete} />

--- a/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
+++ b/src/components/Customer/OrdersInfoForm/OrdersInfoForm.jsx
@@ -116,10 +116,16 @@ const OrdersInfoForm = ({ currentDutyLocation, ordersTypeOptions, initialValues,
                     label="HOR, PLEAD or HOS"
                     displayAddress={false}
                     hint="Enter the option closest to your destination. Your move counselor will identify if there might be a cost to you."
+                    placeholder="Enter a city or ZIP"
                   />
                 </>
               ) : (
-                <DutyLocationInput name="new_duty_location" label="New duty location" displayAddress={false} />
+                <DutyLocationInput
+                  name="new_duty_location"
+                  label="New duty location"
+                  displayAddress={false}
+                  placeholder="Start typing a duty location..."
+                />
               )}
             </SectionWrapper>
 

--- a/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
+++ b/src/components/Customer/ServiceInfoForm/ServiceInfoForm.jsx
@@ -96,7 +96,13 @@ const ServiceInfoForm = ({ initialValues, onSubmit, onCancel, newDutyLocation })
                 </Grid>
               </Grid>
 
-              <DutyLocationInput label="Current duty location" name="current_location" id="current_location" required />
+              <DutyLocationInput
+                label="Current duty location"
+                name="current_location"
+                id="current_location"
+                placeholder="Start typing a duty location..."
+                required
+              />
             </SectionWrapper>
 
             <div className={formStyles.formActions}>

--- a/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
+++ b/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
@@ -77,7 +77,7 @@ const customStyles = {
 };
 
 export const DutyLocationSearchBoxComponent = (props) => {
-  const { searchDutyLocations, showAddress, title, input, name, errorMsg, displayAddress, hint } = props;
+  const { searchDutyLocations, showAddress, title, input, name, errorMsg, displayAddress, hint, placeholder } = props;
   const { value, onChange, name: inputName } = input;
 
   const [inputValue, setInputValue] = useState('');
@@ -148,7 +148,7 @@ export const DutyLocationSearchBoxComponent = (props) => {
           loadOptions={loadOptions}
           onChange={selectOption}
           onInputChange={changeInputText}
-          placeholder="Start typing a duty location..."
+          placeholder={placeholder}
           value={hasDutyLocation ? value : null}
           noOptionsMessage={noOptionsMessage}
           styles={customStyles}
@@ -181,6 +181,7 @@ DutyLocationSearchBoxContainer.propTypes = {
     value: DutyLocationShape,
   }),
   hint: PropTypes.node,
+  placeholder: PropTypes.string,
 };
 
 DutyLocationSearchBoxContainer.defaultProps = {
@@ -193,6 +194,7 @@ DutyLocationSearchBoxContainer.defaultProps = {
     value: undefined,
   },
   hint: '',
+  placeholder: '',
 };
 
 DutyLocationSearchBoxComponent.propTypes = {

--- a/src/components/DutyLocationSearchBox/DutyLocationSearchBox.stories.jsx
+++ b/src/components/DutyLocationSearchBox/DutyLocationSearchBox.stories.jsx
@@ -151,6 +151,7 @@ export const Standard = () => {
       name="test_component"
       searchDutyLocations={mockSearchDutyLocations}
       showAddress={mockShowAddress}
+      placeholder="Start typing a duty location..."
     />
   );
 };
@@ -169,6 +170,7 @@ export const WithValue = () => {
       displayAddress={false}
       searchDutyLocations={mockSearchDutyLocations}
       showAddress={mockShowAddress}
+      placeholder="Start typing a duty location..."
     />
   );
 };
@@ -186,6 +188,7 @@ export const WithValueAndAddress = () => {
       title="Test Component"
       searchDutyLocations={mockSearchDutyLocations}
       showAddress={mockShowAddress}
+      placeholder="Start typing a duty location..."
     />
   );
 };
@@ -204,6 +207,7 @@ export const WithErrorMessage = () => {
       errorMsg="Something went wrong"
       searchDutyLocations={mockSearchDutyLocations}
       showAddress={mockShowAddress}
+      placeholder="Start typing a duty location..."
     />
   );
 };
@@ -225,6 +229,7 @@ export const WithLocalError = () => {
       title="Test Component"
       searchDutyLocations={brokenSearchDutyLocations}
       showAddress={mockShowAddress}
+      placeholder="Start typing a duty location..."
     />
   );
 };

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -35,10 +35,24 @@ const OrdersDetailForm = ({
     ? 'HOR, HOS or PLEAD'
     : 'New duty location';
 
+  const newDutyLocationPlaceholder = ['RETIREMENT', 'SEPARATION'].includes(formOrdersType)
+    ? 'Enter a city or ZIP'
+    : 'Start typing a duty location...';
+
   return (
     <div className={styles.OrdersDetailForm}>
-      <DutyLocationInput name="originDutyLocation" label="Current duty location" displayAddress={false} />
-      <DutyLocationInput name="newDutyLocation" label={newDutyLocationLabel} displayAddress={false} />
+      <DutyLocationInput
+        name="originDutyLocation"
+        label="Current duty location"
+        displayAddress={false}
+        placeholder="Start typing a duty location..."
+      />
+      <DutyLocationInput
+        name="newDutyLocation"
+        label={newDutyLocationLabel}
+        displayAddress={false}
+        placeholder={newDutyLocationPlaceholder}
+      />
       <DatePickerInput name="issueDate" label="Date issued" />
       <DatePickerInput name="reportByDate" label={reportDateRowLabel} />
       {showDepartmentIndicator && (

--- a/src/components/form/fields/DutyLocationInput.jsx
+++ b/src/components/form/fields/DutyLocationInput.jsx
@@ -6,7 +6,7 @@ import DutyLocationSearchBox from 'components/DutyLocationSearchBox/DutyLocation
 
 // TODO: refactor component when we can to make it more user friendly with Formik
 export const DutyLocationInput = (props) => {
-  const { label, name, displayAddress, hint } = props;
+  const { label, name, displayAddress, hint, placeholder } = props;
   const [field, meta, helpers] = useField(props);
 
   const errorString = meta.value?.name ? meta.error?.name || meta.error : '';
@@ -23,6 +23,7 @@ export const DutyLocationInput = (props) => {
       errorMsg={errorString}
       displayAddress={displayAddress}
       hint={hint}
+      placeholder={placeholder}
     />
   );
 };
@@ -34,11 +35,13 @@ DutyLocationInput.propTypes = {
   name: PropTypes.string.isRequired,
   displayAddress: PropTypes.bool,
   hint: PropTypes.node,
+  placeholder: PropTypes.string,
 };
 
 DutyLocationInput.defaultProps = {
   displayAddress: true,
   hint: '',
+  placeholder: '',
 };
 
 export default DutyLocationInput;

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -120,7 +120,7 @@ const OrdersEdit = (props) => {
             <Field
               name="current_location"
               component={DutyLocationSearchBox}
-              props={{ title: 'Current Duty Location' }}
+              props={{ title: 'Current Duty Location', placeholder: 'Start typing a duty location...' }}
             />
           </div>
         </FormSection>


### PR DESCRIPTION
## [MB-11997](https://dp3.atlassian.net/browse/MB-11997) for this change

## Summary

This PR updates the placeholder text in the duty location input field for retirees and separatees. This mainly affects the duty location input when adding a retirement/separation order. This PR also updates the edit form, but practically, the input can never be nulled out, which reveals the placeholder text. **All other placeholders should still display `Starting typing a duty location...`**

## Technical Notes
The `placeholder` is hardcoded in `src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx`. To accommodate the change, I needed to add a `placeholder` prop and drill it all the way down. This way we can update the placeholder text depending on the location.


## Setup to Run Your Code

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>
