### PR TITLE
MB-12058 Remove usages of AuditableAppContextFromRequest

### DIFF
--- a/pkg/handlers/mocks/HandlerContext.go
+++ b/pkg/handlers/mocks/HandlerContext.go
@@ -68,22 +68,6 @@ func (_m *HandlerContext) AppNames() auth.ApplicationServername {
 	return r0
 }
 
-// AuditableAppContextFromRequest provides a mock function with given fields: _a0, _a1
-func (_m *HandlerContext) AuditableAppContextFromRequest(_a0 *http.Request, _a1 func(appcontext.AppContext) middleware.Responder) middleware.Responder {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 middleware.Responder
-	if rf, ok := ret.Get(0).(func(*http.Request, func(appcontext.AppContext) middleware.Responder) middleware.Responder); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(middleware.Responder)
-		}
-	}
-
-	return r0
-}
-
 // AuditableAppContextFromRequestWithErrors provides a mock function with given fields: _a0, _a1
 func (_m *HandlerContext) AuditableAppContextFromRequestWithErrors(_a0 *http.Request, _a1 func(appcontext.AppContext) (middleware.Responder, error)) middleware.Responder {
 	ret := _m.Called(_a0, _a1)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12058) for this change

## Summary
`AuditableAppContextFromRequest` is no longer being used, so it is being removed.

I didn't touch `AppContextFromRequest` since I saw it was being used inside of `AuditableAppContextFromRequestWithErrors`.

Did I remove the correct thing? 
Did I update the comment correctly?

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

Login to both the customer and the office app and make sure things work. 
I would also check that the server tests pass ok for this PR.

## Verification Steps for Author

These are to be checked by the author.
- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?


