### PR TITLE
MB-11939 - Ignore columns in move history triggers

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -715,3 +715,4 @@
 20220321142756_remove_cac_jacquelineio_jaynawallacetruss.up.sql
 20220321233308_add_advance_requested.up.sql
 20220323190113_add_comment_for_audit_history_client_query_column.up.sql
+20220331190115_create_move_history_triggers_with_ignored_columns.up.sql

--- a/migrations/app/schema/20220331190115_create_move_history_triggers_with_ignored_columns.up.sql
+++ b/migrations/app/schema/20220331190115_create_move_history_triggers_with_ignored_columns.up.sql
@@ -1,0 +1,8 @@
+SELECT add_audit_history_table(target_table := 'addresses', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'mto_shipments', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'storage_facilities', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'moves', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'orders', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'mto_service_items', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'service_members', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);
+SELECT add_audit_history_table(target_table := 'payment_requests', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);


### PR DESCRIPTION
There are triggers for certain tables that will help to populate the
move history table. This migration will overwrite those triggers with
new triggers that ignore certain columns in those tables that produce
superfluous data.

## [Jira ticket](https://dp3.atlassian.net/browse/MB-11939) for this change

## Summary

I chose to ignore both the updated_at and created_at columns for each table. Should we not ignore the created_at columns? Are there any more columns that we should obviously ignore?

[this article](tbd) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Run the migrations on your local database 

```sh
make db_dev_migrate
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Access the client site and log in as a too
2. Make empty updates to the shipment and other parts of any move (save them without making any changes)
3. Note that no more extra rows are created for the "updated_at" data in move history

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
