### PR TITLE
MB-11316 document when a too cancels a shipment

### DIFF
--- a/src/constants/historyLogUIDisplayName.js
+++ b/src/constants/historyLogUIDisplayName.js
@@ -73,7 +73,7 @@ export const eventNamePlainTextToDisplay = {
       ? 'Move flagged for financial review'
       : 'Move unflagged for financial review';
   },
-  requestShipmentCancellation: () => 'Shipment cancelled',
+  requestShipmentCancellation: (_, oldValues) => `Requested cancellation for ${oldValues.shipment_type} shipment`,
   updateMoveTaskOrderStatus: (changedValues) => {
     return changedValues.status === 'APPROVED' ? 'Created Move Task Order (MTO)' : 'Rejected Move Task Order (MTO)';
   },

--- a/src/constants/historyLogUIDisplayName.js
+++ b/src/constants/historyLogUIDisplayName.js
@@ -64,6 +64,14 @@ export const eventNamesWithEmptyDetails = {
   createMTOShipment: 'Submitted/Requested shipments', // internal.yaml prime.yaml
 };
 
+export const shipmentOptionToDisplay = {
+  HHG_OUTOF_NTS_DOMESTIC: 'NTS-release',
+  HHG_INTO_NTS_DOMESTIC: 'NTS',
+  HHG: 'HHG',
+  PPM: 'PPM',
+  HHG_SHORTHAUL_DOMESTIC: 'HHG_SHORTHAUL_DOMESTIC',
+};
+
 export const eventNamePlainTextToDisplay = {
   approveShipment: () => 'Approved shipment',
   updateMTOServiceItemStatus: () => 'Service item status', // ghc.yaml Need to check status as well
@@ -73,7 +81,8 @@ export const eventNamePlainTextToDisplay = {
       ? 'Move flagged for financial review'
       : 'Move unflagged for financial review';
   },
-  requestShipmentCancellation: (_, oldValues) => `Requested cancellation for ${oldValues.shipment_type} shipment`,
+  requestShipmentCancellation: (_, oldValues) =>
+    `Requested cancellation for ${shipmentOptionToDisplay[oldValues.shipment_type]} shipment`,
   updateMoveTaskOrderStatus: (changedValues) => {
     return changedValues.status === 'APPROVED' ? 'Created Move Task Order (MTO)' : 'Rejected Move Task Order (MTO)';
   },

--- a/src/constants/historyLogUIDisplayName.test.js
+++ b/src/constants/historyLogUIDisplayName.test.js
@@ -1,4 +1,8 @@
-import { getHistoryLogEventNameDisplay } from './historyLogUIDisplayName';
+import {
+  getHistoryLogEventNameDisplay,
+  eventNamePlainTextToDisplay,
+  shipmentOptionToDisplay,
+} from './historyLogUIDisplayName';
 
 describe('historyLogUIDisplay', () => {
   describe('display Submitted orders', () => {
@@ -49,6 +53,51 @@ describe('historyLogUIDisplay', () => {
       it('should be string Approved service item', () => {
         expect(result).toEqual('Move rejected');
       });
+    });
+  });
+
+  describe('displays the correct plain text when each eventNamePlainTextToDisplay is called', () => {
+    it.each([
+      ['approveShipment', 'Approved shipment', {}, {}],
+      ['requestShipmentDiversion', 'Requested diversion', {}, {}],
+      ['updateMTOServiceItemStatus', 'Service item status', {}, {}],
+      ['setFinancialReviewFlag', 'Move flagged for financial review', {}, { financial_review_flag: 'true' }],
+      ['setFinancialReviewFlag', 'Move unflagged for financial review', {}, { financial_review_flag: 'false' }],
+      [
+        'requestShipmentCancellation',
+        `Requested cancellation for ${shipmentOptionToDisplay.HHG} shipment`,
+        { shipment_type: 'HHG' },
+        {},
+      ],
+      [
+        'requestShipmentCancellation',
+        `Requested cancellation for ${shipmentOptionToDisplay.HHG_OUTOF_NTS_DOMESTIC} shipment`,
+        { shipment_type: 'HHG_OUTOF_NTS_DOMESTIC' },
+        {},
+      ],
+      [
+        'requestShipmentCancellation',
+        `Requested cancellation for ${shipmentOptionToDisplay.HHG_INTO_NTS_DOMESTIC} shipment`,
+        { shipment_type: 'HHG_INTO_NTS_DOMESTIC' },
+        {},
+      ],
+      [
+        'requestShipmentCancellation',
+        `Requested cancellation for ${shipmentOptionToDisplay.PPM} shipment`,
+        { shipment_type: 'PPM' },
+        {},
+      ],
+      [
+        'requestShipmentCancellation',
+        `Requested cancellation for ${shipmentOptionToDisplay.HHG_SHORTHAUL_DOMESTIC} shipment`,
+        { shipment_type: 'HHG_SHORTHAUL_DOMESTIC' },
+        {},
+      ],
+      ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', {}, { status: 'APPROVED' }],
+      ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', {}, { status: 'REJECTED' }],
+    ])('for event name %s it returns %s', (eventName, text, oldValues, changedValues) => {
+      const displayText = eventNamePlainTextToDisplay[eventName](changedValues, oldValues);
+      expect(displayText).toEqual(text);
     });
   });
 });

--- a/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.jsx
+++ b/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.jsx
@@ -42,7 +42,7 @@ const MoveHistoryDetailsSelector = ({ eventName, oldValues, changedValues }) => 
   }
 
   if (eventNamesWithPlainTextDetails[eventName]) {
-    return <PlainTextDetails eventName={eventName} changedValues={changedValues} />;
+    return <PlainTextDetails eventName={eventName} oldValues={oldValues} changedValues={changedValues} />;
   }
 
   return (

--- a/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.test.jsx
+++ b/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.test.jsx
@@ -39,6 +39,6 @@ describe('MoveHistoryDetailsSelector', () => {
   ])('for event name %s it renders %s', (eventName, text, oldValues, changedValues) => {
     render(<MoveHistoryDetailsSelector eventName={eventName} oldValues={oldValues} changedValues={changedValues} />);
 
-    expect(screen.getByText(text, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(text)).toBeInTheDocument();
   });
 });

--- a/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.test.jsx
+++ b/src/pages/Office/MoveHistory/MoveHistoryDetailsSelector.test.jsx
@@ -15,7 +15,6 @@ describe('MoveHistoryDetailsSelector', () => {
     ['requestShipmentDiversion', 'Requested diversion'],
     ['updateMTOServiceItem', 'Service Items'],
     ['updateMTOServiceItemStatus', 'Service item status'],
-    ['requestShipmentCancellation', 'Shipment cancelled'],
     ['createOrders', '-'],
     ['updateOrders', 'Labeled'],
     ['uploadAmendedOrders', '-'],
@@ -32,12 +31,13 @@ describe('MoveHistoryDetailsSelector', () => {
   });
 
   it.each([
-    ['setFinancialReviewFlag', 'Move flagged for financial review', { financial_review_flag: 'true' }],
-    ['setFinancialReviewFlag', 'Move unflagged for financial review', { financial_review_flag: 'false' }],
-    ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', { status: 'APPROVED' }],
-    ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', { status: 'Rejected' }],
-  ])('for event name %s it renders %s', (eventName, text, changedValues) => {
-    render(<MoveHistoryDetailsSelector eventName={eventName} changedValues={changedValues} />);
+    ['setFinancialReviewFlag', 'Move flagged for financial review', {}, { financial_review_flag: 'true' }],
+    ['setFinancialReviewFlag', 'Move unflagged for financial review', {}, { financial_review_flag: 'false' }],
+    ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', {}, { status: 'APPROVED' }],
+    ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', {}, { status: 'Rejected' }],
+    ['requestShipmentCancellation', 'Requested cancellation for HHG shipment', { shipment_type: 'HHG' }, {}],
+  ])('for event name %s it renders %s', (eventName, text, oldValues, changedValues) => {
+    render(<MoveHistoryDetailsSelector eventName={eventName} oldValues={oldValues} changedValues={changedValues} />);
 
     expect(screen.getByText(text, { exact: false })).toBeInTheDocument();
   });

--- a/src/pages/Office/MoveHistory/PlainTextDetails.jsx
+++ b/src/pages/Office/MoveHistory/PlainTextDetails.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 
 import { HistoryLogValuesShape, eventNamePlainTextToDisplay } from 'constants/historyLogUIDisplayName';
 
-const PlainTextDetails = ({ eventName, changedValues }) => {
+const PlainTextDetails = ({ eventName, oldValues, changedValues }) => {
   let textToDisplay = '';
   if (eventNamePlainTextToDisplay[eventName]) {
-    textToDisplay = eventNamePlainTextToDisplay[eventName](changedValues);
+    textToDisplay = eventNamePlainTextToDisplay[eventName](changedValues, oldValues);
   }
   return <div>{textToDisplay}</div>;
 };
@@ -14,11 +14,13 @@ const PlainTextDetails = ({ eventName, changedValues }) => {
 PlainTextDetails.propTypes = {
   eventName: PropTypes.string,
   changedValues: HistoryLogValuesShape,
+  oldValues: HistoryLogValuesShape,
 };
 
 PlainTextDetails.defaultProps = {
   eventName: '',
   changedValues: {},
+  oldValues: {},
 };
 
 export default PlainTextDetails;

--- a/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 
 import PlainTextDetails from './PlainTextDetails';
 
+import { shipmentOptionToDisplay } from 'constants/historyLogUIDisplayName';
+
 describe('PlainTextDetails', () => {
   it.each([
     ['approveShipment', 'Approved shipment', {}, {}],
@@ -10,7 +12,36 @@ describe('PlainTextDetails', () => {
     ['updateMTOServiceItemStatus', 'Service item status', {}, {}],
     ['setFinancialReviewFlag', 'Move flagged for financial review', {}, { financial_review_flag: 'true' }],
     ['setFinancialReviewFlag', 'Move unflagged for financial review', {}, { financial_review_flag: 'false' }],
-    ['requestShipmentCancellation', 'Requested cancellation for HHG Shipment', { shipment_type: 'HHG' }, {}],
+    [
+      'requestShipmentCancellation',
+      `Requested cancellation for ${shipmentOptionToDisplay.HHG} shipment`,
+      { shipment_type: 'HHG' },
+      {},
+    ],
+    [
+      'requestShipmentCancellation',
+      `Requested cancellation for ${shipmentOptionToDisplay.HHG_OUTOF_NTS_DOMESTIC} shipment`,
+      { shipment_type: 'HHG_OUTOF_NTS_DOMESTIC' },
+      {},
+    ],
+    [
+      'requestShipmentCancellation',
+      `Requested cancellation for ${shipmentOptionToDisplay.HHG_INTO_NTS_DOMESTIC} shipment`,
+      { shipment_type: 'HHG_INTO_NTS_DOMESTIC' },
+      {},
+    ],
+    [
+      'requestShipmentCancellation',
+      `Requested cancellation for ${shipmentOptionToDisplay.PPM} shipment`,
+      { shipment_type: 'PPM' },
+      {},
+    ],
+    [
+      'requestShipmentCancellation',
+      `Requested cancellation for ${shipmentOptionToDisplay.HHG_SHORTHAUL_DOMESTIC} shipment`,
+      { shipment_type: 'HHG_SHORTHAUL_DOMESTIC' },
+      {},
+    ],
     ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', {}, { status: 'APPROVED' }],
     ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', {}, { status: 'REJECTED' }],
   ])('for event name %s it renders %s', (eventName, text, oldValues, changedValues) => {

--- a/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
@@ -18,35 +18,11 @@ describe('PlainTextDetails', () => {
       { shipment_type: 'HHG' },
       {},
     ],
-    [
-      'requestShipmentCancellation',
-      `Requested cancellation for ${shipmentOptionToDisplay.HHG_OUTOF_NTS_DOMESTIC} shipment`,
-      { shipment_type: 'HHG_OUTOF_NTS_DOMESTIC' },
-      {},
-    ],
-    [
-      'requestShipmentCancellation',
-      `Requested cancellation for ${shipmentOptionToDisplay.HHG_INTO_NTS_DOMESTIC} shipment`,
-      { shipment_type: 'HHG_INTO_NTS_DOMESTIC' },
-      {},
-    ],
-    [
-      'requestShipmentCancellation',
-      `Requested cancellation for ${shipmentOptionToDisplay.PPM} shipment`,
-      { shipment_type: 'PPM' },
-      {},
-    ],
-    [
-      'requestShipmentCancellation',
-      `Requested cancellation for ${shipmentOptionToDisplay.HHG_SHORTHAUL_DOMESTIC} shipment`,
-      { shipment_type: 'HHG_SHORTHAUL_DOMESTIC' },
-      {},
-    ],
     ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', {}, { status: 'APPROVED' }],
     ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', {}, { status: 'REJECTED' }],
   ])('for event name %s it renders %s', (eventName, text, oldValues, changedValues) => {
     render(<PlainTextDetails eventName={eventName} oldValues={oldValues} changedValues={changedValues} />);
 
-    expect(screen.getByText(text, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(text)).toBeInTheDocument();
   });
 });

--- a/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/PlainTextDetails.test.jsx
@@ -5,16 +5,16 @@ import PlainTextDetails from './PlainTextDetails';
 
 describe('PlainTextDetails', () => {
   it.each([
-    ['approveShipment', 'Approved shipment', {}],
-    ['requestShipmentDiversion', 'Requested diversion', {}],
-    ['updateMTOServiceItemStatus', 'Service item status', {}],
-    ['setFinancialReviewFlag', 'Move flagged for financial review', { financial_review_flag: 'true' }],
-    ['setFinancialReviewFlag', 'Move unflagged for financial review', { financial_review_flag: 'false' }],
-    ['requestShipmentCancellation', 'Shipment cancelled', {}],
-    ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', { status: 'APPROVED' }],
-    ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', { status: 'REJECTED' }],
-  ])('for event name %s it renders %s', (eventName, text, changedValues) => {
-    render(<PlainTextDetails eventName={eventName} changedValues={changedValues} />);
+    ['approveShipment', 'Approved shipment', {}, {}],
+    ['requestShipmentDiversion', 'Requested diversion', {}, {}],
+    ['updateMTOServiceItemStatus', 'Service item status', {}, {}],
+    ['setFinancialReviewFlag', 'Move flagged for financial review', {}, { financial_review_flag: 'true' }],
+    ['setFinancialReviewFlag', 'Move unflagged for financial review', {}, { financial_review_flag: 'false' }],
+    ['requestShipmentCancellation', 'Requested cancellation for HHG Shipment', { shipment_type: 'HHG' }, {}],
+    ['updateMoveTaskOrderStatus', 'Created Move Task Order (MTO)', {}, { status: 'APPROVED' }],
+    ['updateMoveTaskOrderStatus', 'Rejected Move Task Order (MTO)', {}, { status: 'REJECTED' }],
+  ])('for event name %s it renders %s', (eventName, text, oldValues, changedValues) => {
+    render(<PlainTextDetails eventName={eventName} oldValues={oldValues} changedValues={changedValues} />);
 
     expect(screen.getByText(text, { exact: false })).toBeInTheDocument();
   });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11316) for this change

## Summary

I added support for formatting when a TOO cancels a shipment. 
I've also added some tests for the `historyLogUIDisplayName`. They're a bit redundant with `PlainTextDetails`, but I wanted to have them both around since one is testing a pure function and the other is testing a component.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a TOO
3. Find a move with shipments you can cancel (you can use move locator `HGNTSR`
4. Cancel the shipment by going to the Move task order tab and canceling the shipment
5. Go to the Move history tab
6. The text saying what shipment type has been canceled should now be visible

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/6477059/161611258-5ed75a94-75e7-4f7e-995b-e24604e023fc.png">
