### PR TITLE
Update move_history_fetcher.go

### DIFF
--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -34,6 +34,7 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 			mto_shipments.*
 		FROM
 			mto_shipments
+		WHERE move_id = (SELECT moves.id FROM moves) 
 	),
 	shipment_logs AS (
 		SELECT


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

Move history page was returning all logs no matter what page you were on. Added a `WHERE` clause to filter by move code 

## Setup to Run Your Code

1. Go to officelocal:3000/
2. Log in as an office user
3. Click on a move that has a shipment you can edit
4. Edit the shipment
5. Look at the history page for that same move and see that the log is there
6. Go back to the move table page
7. Click on a different move
8. Click on history
9. Observe that the earlier change does not appear

