### PR TITLE
MB-12048: (WIP) Service Counselor users can approve PPM (front-end)

### DIFF
--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.jsx
@@ -5,7 +5,7 @@ import { Button } from '@trussworks/react-uswds';
 import { ModalContainer, Overlay } from 'components/MigratedModal/MigratedModal';
 import Modal, { connectModal, ModalActions, ModalClose, ModalTitle } from 'components/Modal/Modal';
 
-export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
+export const SubmitMoveConfirmationModal = ({ onClose, onSubmit, bodyText }) => (
   <div data-testid="SubmitMoveConfirmationModal">
     <Overlay />
     <ModalContainer>
@@ -14,7 +14,7 @@ export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
         <ModalTitle>
           <h2>Are you sure?</h2>
         </ModalTitle>
-        <p>You can’t make changes after you submit the move.</p>
+        <p>{bodyText}</p>
         <ModalActions>
           <Button className="usa-button--submit" type="submit" onClick={() => onSubmit()}>
             Yes, submit
@@ -36,6 +36,11 @@ export const SubmitMoveConfirmationModal = ({ onClose, onSubmit }) => (
 SubmitMoveConfirmationModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  bodyText: PropTypes.string,
+};
+
+SubmitMoveConfirmationModal.defaultProps = {
+  bodyText: "You can't make changes after you submit the move.",
 };
 
 SubmitMoveConfirmationModal.displayName = 'SubmitMoveConfirmationModal';

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.stories.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.stories.jsx
@@ -8,3 +8,11 @@ export default {
 };
 
 export const Basic = () => <SubmitMoveConfirmationModal onClose={() => {}} onSubmit={() => {}} />;
+
+export const AsApprovePPM = () => (
+  <SubmitMoveConfirmationModal
+    onClose={() => {}}
+    onSubmit={() => {}}
+    bodyText="You can't make changes after you approve the PPM."
+  />
+);

--- a/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
+++ b/src/components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { SubmitMoveConfirmationModal } from 'components/Office/SubmitMoveConfirmationModal/SubmitMoveConfirmationModal';
 
@@ -12,36 +13,36 @@ beforeEach(() => {
 
 describe('SubmitMoveConfirmationModal', () => {
   it('renders the component', () => {
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
-    expect(wrapper.find('SubmitMoveConfirmationModal').exists()).toBe(true);
-    expect(wrapper.find('ModalTitle').exists()).toBe(true);
-    expect(wrapper.find('ModalActions').exists()).toBe(true);
-    expect(wrapper.find('ModalClose').exists()).toBe(true);
-    expect(wrapper.find('button[data-testid="modalCancelButton"]').exists()).toBe(true);
-    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+    render(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+    expect(screen.getByRole('heading', { level: 2, name: 'Are you sure?' })).toBeInTheDocument();
+    expect(screen.getByText("You can't make changes after you submit the move.")).toBeInTheDocument();
   });
 
   it('closes the modal when close icon is clicked', () => {
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
-
-    wrapper.find('button[data-testid="modalCloseButton"]').simulate('click');
-
-    expect(onClose.mock.calls.length).toBe(1);
-  });
-
-  it('closes the modal when the cancel button is clicked', () => {
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
-
-    wrapper.find('button[data-testid="modalCancelButton"]').simulate('click');
+    render(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+    userEvent.click(screen.getByTestId('modalCloseButton'));
 
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('calls the submit function when submit button is clicked', async () => {
-    const wrapper = mount(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+  it('closes the modal when the cancel button is clicked', () => {
+    render(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+    userEvent.click(screen.getByTestId('modalCancelButton'));
 
-    wrapper.find('button[type="submit"]').simulate('click');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls the submit function when submit button is clicked', () => {
+    render(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} />);
+    userEvent.click(screen.getByRole('button', { name: 'Yes, submit' }));
 
     expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('accepts an optional bodyText prop', () => {
+    render(<SubmitMoveConfirmationModal onSubmit={onSubmit} onClose={onClose} bodyText="test text goes here" />);
+    expect(screen.getByRole('heading', { level: 2, name: 'Are you sure?' })).toBeInTheDocument();
+    expect(screen.queryByText("You can't make changes after you submit the move.")).not.toBeInTheDocument();
+    expect(screen.getByText('test text goes here')).toBeInTheDocument();
   });
 });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -13,7 +13,10 @@ import { SHIPMENT_OPTIONS_URL } from 'shared/constants';
 import { useMoveDetailsQueries } from 'hooks/queries';
 import { formatDate } from 'shared/dates';
 import { MockProviders, renderWithRouter } from 'testUtils';
-import { updateMoveStatusServiceCounselingCompleted } from 'services/ghcApi';
+import {
+  updateMoveStatusServiceCounselingCompleted,
+  updateMoveStatusServiceCounselingPPMApproved,
+} from 'services/ghcApi';
 
 const mockRequestedMoveCode = 'LR4T8V';
 
@@ -29,6 +32,7 @@ jest.mock('hooks/queries', () => ({
 jest.mock('services/ghcApi', () => ({
   ...jest.requireActual('services/ghcApi'),
   updateMoveStatusServiceCounselingCompleted: jest.fn(),
+  updateMoveStatusServiceCounselingPPMApproved: jest.fn(),
 }));
 
 const mtoShipments = [
@@ -230,6 +234,24 @@ const newMoveDetailsQuery = {
   isLoading: false,
   isError: false,
   isSuccess: true,
+};
+
+const newPPMMoveDetailsQuery = {
+  ...newMoveDetailsQuery,
+  mtoShipments: [
+    {
+      createdAt: '2022-04-07T19:00:01.681Z',
+      eTag: 'MjAyMi0wNC0wN1QxOTowMDozNy40OTY1ODRa',
+      id: '11793d13-f3b3-473d-8eec-f969d5c350d9',
+      moveTaskOrderID: '1af43f14-9921-4723-a8ad-57477ee0b99f',
+      requestedDeliveryDate: '0001-01-01',
+      requestedPickupDate: '0001-01-01',
+      shipmentType: 'PPM',
+      sitDaysAllowance: 90,
+      status: 'DRAFT',
+      updatedAt: '2022-04-07T19:00:37.496Z',
+    },
+  ],
 };
 
 const counselingCompletedMoveDetailsQuery = {
@@ -551,6 +573,27 @@ describe('MoveDetails page', () => {
         render(mockedComponent);
 
         const submitButton = await screen.findByRole('button', { name: 'Submit move details' });
+
+        userEvent.click(submitButton);
+
+        expect(await screen.findByRole('heading', { name: 'Are you sure?', level: 2 })).toBeInTheDocument();
+
+        const modalSubmitButton = screen.getByRole('button', { name: 'Yes, submit' });
+
+        userEvent.click(modalSubmitButton);
+
+        await waitFor(() => {
+          expect(screen.queryByRole('heading', { name: 'Are you sure?', level: 2 })).not.toBeInTheDocument();
+        });
+      });
+
+      it('allows the service counselor to approve a PPM with the modal', async () => {
+        useMoveDetailsQueries.mockReturnValue(newPPMMoveDetailsQuery);
+        updateMoveStatusServiceCounselingPPMApproved.mockImplementation(() => Promise.resolve({}));
+
+        render(mockedComponent);
+
+        const submitButton = await screen.findByRole('button', { name: 'Approve PPM' });
 
         userEvent.click(submitButton);
 

--- a/src/services/ghcApi.js
+++ b/src/services/ghcApi.js
@@ -189,6 +189,18 @@ export function updateMoveStatusServiceCounselingCompleted({ moveTaskOrderID, if
   );
 }
 
+export function updateMoveStatusServiceCounselingPPMApproved({ moveTaskOrderID, ifMatchETag, normalize = false }) {
+  const operationPath = 'moveTaskOrder.updateMTOStatusServiceCounselingPPMApproved';
+  return makeGHCRequest(
+    operationPath,
+    {
+      moveTaskOrderID,
+      'If-Match': ifMatchETag,
+    },
+    { normalize },
+  );
+}
+
 export function updateMTOShipmentStatus({
   shipmentID,
   operationPath,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12048) for this change

## Summary

This pull request wires up the service counselor's view of the move details page, and allows moves that only contain a PPM shipment(s) to be approved, so that customers can subsequently submit claims for reimbursement. 

PPM-only moves will have the text of the button in the top right of the page changed to "Approve PPM"; the body text of the modal, when clicked, will display appropriate text; if the user clicks confirm on the modal, it will make a request to a separate (currently, partially-implemented) endpoint. The post-submission alert success/error text values have updated in this case as well.

**This pull request is essentially blocked** until [MB-10787](https://dp3.atlassian.net/browse/MB-10787) is completed; in order properly track whether or not the PPM has been approved, the endpoint that the front end work in this PR is calling needs to set an attribute on the shipment which indicates its status, and that work is still not yet implemented. As a result, this pull request is set up as a draft to gather comment.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. As a customer, submit a move with a PPM-only shipment.
2. Log in locally as a service counselor user, and view that move from the queue.
3. Verify that the button in the top right reads "Approve PPM."
4. Click that button, then verify that the resulting modal displays the text "You can't make changes after you approve the PPM."
5. // TODO additional instructions once PR isn't blocked

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

* [Service counselor move details page with PPM-only move](https://user-images.githubusercontent.com/83614364/163008809-9cd93cfa-0466-47be-a267-26ab9697e3e5.png)
* [PPM approval modal](https://user-images.githubusercontent.com/83614364/163008891-be7088ac-b354-4ad5-8c30-34c02bef03e2.png)
* [Post-approval error alert text](https://user-images.githubusercontent.com/83614364/163008941-e89dc4e2-40b2-4b12-adc9-50627f57ca9a.png)
 