### PR TITLE
Added filter for mto_service_items

### DIFF
--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -63,7 +63,7 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 			mto_service_items
 		JOIN re_services ON mto_service_items.re_service_id = re_services.id
 		JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipment_id
-		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves)
+		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves) AND mto_service_items.move_id = (SELECT moves.id FROM moves)
 	),
 	service_item_logs AS (
 		SELECT

--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -62,8 +62,8 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 		FROM
 			mto_service_items
 		JOIN re_services ON mto_service_items.re_service_id = re_services.id
-		JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipment_id
-		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves) AND mto_service_items.move_id = (SELECT moves.id FROM moves)
+		JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipments.id
+		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves)
 	),
 	service_item_logs AS (
 		SELECT


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12171) for this change

## Summary

Ali was seeing an issue where he was seeing service items that weren't related to his current move. This is because there is a missing filter on the where clause of the mto_service items query. 

## Setup to Run Your Code

1. Go to officelocal:3000/
2. Sign is a TOO user
3. Go to http://officelocal:3000/moves/WTSTAT/history
4. Approve a move
5. Go to the history page
6. Observe that the service items are there
7. Go to a different move's history page
8. Observe that the service items that were on WTSTAT are not on your current page. 

