### PR TITLE
MB-12275: circleci speedups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -936,8 +936,8 @@ jobs:
       - announce_failure
 
   integration_tests_milmove:
-    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 4 files here
-    parallelism: 4
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 6 files here
+    parallelism: 6
     executor: milmove_integration_tester
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,10 +688,6 @@ jobs:
       - run: rm -rf pkg/assets/assets.go && make pkg/assets/assets.go
       - run: make server_generate mocks_generate
       - run: scripts/check-generated-code pkg/gen/ $(find . -type d -name "*mocks" -exec echo -n '{} ' \;)
-      - save_cache:
-          key: go-mod-sources-v3-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
-          paths:
-            - '~/go'
       - announce_failure
 
   # `anti_virus` uses virus detection software to scan the source code
@@ -1143,10 +1139,10 @@ jobs:
       # see https://www.npmjs.com/package/terser-webpack-plugin/v/1.4.4#cache
       - restore_cache:
           keys:
-            - v1-node-modules-cache
+            - v2-node-modules-cache-{{ checksum "yarn.lock" }}
       - run: make client_build
       - save_cache:
-          key: v1-node-modules-cache
+          key: v2-node-modules-cache-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules/.cache
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,8 +871,8 @@ jobs:
       - announce_failure
 
   integration_tests_office:
-    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 8 files here
-    parallelism: 8
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 12 files here
+    parallelism: 12
     executor: milmove_integration_tester
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,18 @@ executors:
         environment:
           GOPATH: /home/circleci/go
 
+  mymove_compiler_xlarge:
+    # large and no ram disk
+    resource_class: xlarge
+    working_directory: ~/transcom/mymove
+    docker:
+      - image: *circleci-docker
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          GOPATH: /home/circleci/go
+
   mymove_ramdisk_compiler:
     # large and no ram disk
     resource_class: large
@@ -1097,14 +1109,18 @@ jobs:
   # items are in the workspace, we don't even have to checkout the
   # code again
   #
-  # the babel/terser cache below takes the compile from ~6-7m to ~4-5m !!
+  # the babel/terser cache below takes the compile step from ~6-7m to ~4-5m !!
   compile_app_client:
-    executor: mymove_ramdisk_compiler
-    working_directory: /mnt/ramdisk
+    # ahobson tested this and saw 75% of the 16GB being used
+    # (according to the resources tab on CircleCI)
+    # if it starts running out of memory, we should move away from
+    # using a ramdisk
+    #
+    # This entire step takes ~6 minutes with xlarge ramdisk
+    # This entire step takes ~7 minutes without xlarge ramdisk
+    executor: mymove_ramdisk_compiler_xlarge
     steps:
       - checkout
-      # use the yarn.lock as a key so that PRs with the same
-      # dependencies will use the same cache
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
@@ -1118,6 +1134,9 @@ jobs:
       # cacheDirectory
       #
       # see https://www.npmjs.com/package/terser-webpack-plugin/v/1.4.4#cache
+      #
+      # use the yarn.lock as a key so that PRs with the same
+      # dependencies will use the same cache
       - restore_cache:
           keys:
             - v2-node-modules-cache-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,15 +726,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run:
-          name: Output processes and resource usage every 5 seconds while job is running
-          command: |
-            while true; do
-              sleep 5
-              ps auxwwf
-              echo "======"
-            done
-          background: true
       - run: echo 'export PATH=${PATH}:${GOPATH}/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run:
           name: Install Frozen YARN dependencies
@@ -767,10 +758,6 @@ jobs:
           name: Run DangerJS checks
           command: yarn danger ci --failOnErrors
       # `v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}` is used to cache pre-commit plugins.
-      - run:
-          name: Output maximum memory usage in Bytes
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-          when: always
       - save_cache:
           key: v1-pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1110,7 +1110,8 @@ jobs:
   #
   # the babel/terser cache below takes the compile from ~6-7m to ~4-5m !!
   compile_app_client:
-    executor: mymove_ramdisk_compiler_xlarge
+    executor: mymove_ramdisk_compiler
+    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,10 +614,21 @@ commands:
             docker cp cypress:/home/circleci/cypress/videos cypress/ 2>/dev/null || echo "No cypress videos copied"
             docker cp cypress:/home/circleci/cypress/reports cypress/ 2>/dev/null || echo "No cypress reports copied"
 
+  # this custom step has some duplication with
+  # scripts/run-e2e-mtls-test-docker because we want to run some of the
+  # steps below in parallel
   e2e_tests_mtls:
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
       - run:
-          name: make e2e_mtls_test_docker
+          name: setup docker for server
+          command: |
+            docker network create e2e_mtls
+            docker build -t milmove_mtls:local -f Dockerfile.e2e .
+      - run:
+          background: true
+          name: run server
           command: |
             echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
             echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
@@ -626,16 +637,15 @@ commands:
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
             source $BASH_ENV
-            make e2e_mtls_test_docker
-          environment:
-            # Env vars needed for the webserver to run inside docker
-            APPLICATION: app
-            LOGIN_GOV_CALLBACK_PROTOCOL: http
-            LOGIN_GOV_MY_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal
-            LOGIN_GOV_OFFICE_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:officemovemillocal
-            LOGIN_GOV_ADMIN_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:adminmovemillocal
-            LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
-            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+            docker-compose -f docker-compose.mtls.yml up
+      - run:
+          name: run e2e mtls tests
+          command: |
+            docker run \
+            --name prime_api_client \
+            --network e2e_mtls \
+            --entrypoint /scripts/run-e2e-mtls-test \
+            milmove_mtls:local
 
 jobs:
   # `pre_deps_golang` is used for caching Go module sources
@@ -946,34 +956,12 @@ jobs:
   # `integration_tests_mtls` runs integration tests using
   # prime-api-client.
   #
-  # This could almost certainly be sped up in a manner similar to the
-  # integration_tests, but this test is short enough it isn't urgent
-  # right now
   integration_tests_mtls:
     executor: mymove_compiler
     steps:
-      - aws_vars_transcom_gov_dev
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - restore_cache:
-          keys:
-            - go-mod-sources-v3-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
-      - restore_cache:
-          keys:
-            - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
       - attach_workspace:
-          at: /home/circleci/transcom/mymove/bin
-      - run: rm -f pkg/assets/assets.go && make pkg/assets/assets.go
-      - run: make server_generate
-      - run: rm -f bin/generate-test-data && make bin/generate-test-data
-      - run: rm -f bin/prime-api-client && make bin/prime-api-client
-      - run:
-          name: Install Frozen YARN dependencies
-          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+          at: .
       - e2e_tests_mtls
-      - store_test_results:
-          path: cypress/results
       - announce_failure
 
   # `server_test` runs the server side Go tests
@@ -1092,6 +1080,7 @@ jobs:
             - Dockerfile.webhook_client
             - Dockerfile.webhook_client_dp3
             - docker-compose.e2e.yml
+            - docker-compose.mtls.yml
             - bin
             - config
             - migrations
@@ -1711,13 +1700,11 @@ workflows:
               ignore: *integration-ignore-branch
 
       - integration_tests_mtls:
+          # mtls integration tests use the same server image as the
+          # e2e cypress tests and so needs the client build
           requires:
-            - pre_deps_golang
-            - check_generated_code
-            - push_app_gov_dev
-            - push_app_stg
-            - push_migrations_gov_dev
-            - push_migrations_stg
+            - compile_app_server
+            - compile_app_client
           # See comments at the top of this file for configuring/using
           # this branch config
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1103,6 +1103,8 @@ jobs:
     working_directory: /mnt/ramdisk
     steps:
       - checkout
+      # use the yarn.lock as a key so that PRs with the same
+      # dependencies will use the same cache
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
@@ -1120,10 +1122,16 @@ jobs:
           keys:
             - v2-node-modules-cache-{{ checksum "yarn.lock" }}
       - run: make client_build
-      - save_cache:
-          key: v2-node-modules-cache-{{ checksum "yarn.lock" }}
-          paths:
-            - ./node_modules/.cache
+      # only save the cache on master builds so that PRs don't pollute
+      # the cache
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >>]
+          steps:
+            save_cache:
+              key: v2-node-modules-cache-{{ checksum "yarn.lock" }}
+              paths:
+                - ./node_modules/.cache
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ executors:
           GOPATH: /home/circleci/go
 
   mymove_compiler_xlarge:
-    # large and no ram disk
+    # xlarge and no ram disk
     resource_class: xlarge
     working_directory: ~/transcom/mymove
     docker:
@@ -112,7 +112,7 @@ executors:
           GOPATH: /home/circleci/go
 
   mymove_ramdisk_compiler:
-    # large and no ram disk
+    # large with ram disk
     resource_class: large
     working_directory: /mnt/ramdisk
     docker:
@@ -124,7 +124,7 @@ executors:
           GOPATH: /home/circleci/go
 
   mymove_ramdisk_compiler_xlarge:
-    # large and no ram disk
+    # xlarge with ram disk
     resource_class: xlarge
     working_directory: /mnt/ramdisk
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -840,8 +840,8 @@ jobs:
   # separate the integration tests by site so that if there is a flaky
   # test, we only have to re-run part of the integration tests
   integration_tests_admin:
-    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 2 files here
-    parallelism: 2
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 4 files here
+    parallelism: 4
     executor: milmove_integration_tester
     steps:
       - attach_workspace:
@@ -862,8 +862,8 @@ jobs:
       - announce_failure
 
   integration_tests_office:
-    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 4 files here
-    parallelism: 4
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 8 files here
+    parallelism: 8
     executor: milmove_integration_tester
     steps:
       - attach_workspace:
@@ -905,8 +905,8 @@ jobs:
 
   # reads integration tests in mymove dir, should eventually be removed when tests are in milmove dir
   integration_tests_mymove:
-    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 4 files here
-    parallelism: 4
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 8 files here
+    parallelism: 8
     executor: milmove_integration_tester
     steps:
       - attach_workspace:
@@ -927,6 +927,8 @@ jobs:
       - announce_failure
 
   integration_tests_milmove:
+    # parallelism requires enough files to divide by the # of parallel threads. So you need at least 4 files here
+    parallelism: 4
     executor: milmove_integration_tester
     steps:
       - attach_workspace:

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -10,6 +10,7 @@ COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY bin/milmove /bin/milmove
 COPY bin/generate-test-data /bin/generate-test-data
+COPY bin/prime-api-client /bin/prime-api-client
 
 COPY migrations/app/schema /migrate/schema
 COPY migrations/app/secure /migrate/secure
@@ -19,10 +20,11 @@ COPY build /build
 COPY config /config
 COPY swagger /swagger
 COPY pkg/testdatagen/testdata /pkg/testdatagen/testdata
+COPY scripts /scripts
 
 # Install tools needed in container
 # hadolint ignore=DL3018
-RUN apk update && apk add ca-certificates --no-cache
+RUN apk update && apk add ca-certificates --no-cache && apk add jq bash --no-cache
 RUN update-ca-certificates
 
 WORKDIR /

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -25,7 +25,7 @@ func initRootFlags(flag *pflag.FlagSet) {
 	flag.Bool(utils.InsecureFlag, false, "Skip TLS verification and validation")
 	flag.String(utils.FilenameFlag, "", "The name of the file being passed in")
 	flag.String(utils.IDFlag, "", "The UUID of the object being retrieved or updated")
-	flag.Duration(utils.WaitFlag, time.Second*60, "duration to wait for server to respond")
+	flag.Duration(utils.WaitFlag, time.Second*30, "duration to wait for server to respond")
 }
 
 func main() {

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -24,6 +25,7 @@ func initRootFlags(flag *pflag.FlagSet) {
 	flag.Bool(utils.InsecureFlag, false, "Skip TLS verification and validation")
 	flag.String(utils.FilenameFlag, "", "The name of the file being passed in")
 	flag.String(utils.IDFlag, "", "The UUID of the object being retrieved or updated")
+	flag.Duration(utils.WaitFlag, time.Second*60, "duration to wait for server to respond")
 }
 
 func main() {

--- a/cmd/prime-api-client/utils/shared.go
+++ b/cmd/prime-api-client/utils/shared.go
@@ -39,7 +39,8 @@ const (
 	PortFlag string = "port"
 	// InsecureFlag indicates that TLS verification and validation can be skipped
 	InsecureFlag string = "insecure"
-	// WaitFlat is how long to wait for the server to respond
+	// WaitFlag is how long to wait for the server to respond. The
+	// string is parsed by https://pkg.go.dev/time#ParseDuration
 	WaitFlag string = "wait"
 )
 

--- a/cmd/prime-api-client/utils/shared.go
+++ b/cmd/prime-api-client/utils/shared.go
@@ -39,6 +39,8 @@ const (
 	PortFlag string = "port"
 	// InsecureFlag indicates that TLS verification and validation can be skipped
 	InsecureFlag string = "insecure"
+	// WaitFlat is how long to wait for the server to respond
+	WaitFlag string = "wait"
 )
 
 // ParseFlags parses the command line flags

--- a/docker-compose.mtls.yml
+++ b/docker-compose.mtls.yml
@@ -4,45 +4,25 @@ services:
   database:
     image: postgres:12.7
     restart: always
-    ports:
-      - '6432:5432'
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_DB=dev_db
-
-  milmove_migrate:
-    depends_on:
-      - database
-    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app-migrations:git-branch-placeholder_branch_name
-    links:
-      - database
-    environment:
-      - DB_ENV=development
-      - DB_HOST=database
-      - DB_NAME=dev_db
-      - DB_PASSWORD=mysecretpassword
-      - DB_PORT=5432
-      - DB_SSL_MODE=disable
-      - DB_USER=postgres
-      - ENVIRONMENT=test
-      - MIGRATION_PATH=file:///migrate/schema;file:///migrate/secure
-      - MIGRATION_MANIFEST=/migrate/migrations_manifest.txt
-    entrypoint:
-      - '/bin/milmove'
-      - 'migrate'
-    volumes:
-      - ./migrations/app/secure:/migrate/secure
+    tmpfs:
+      - /var/lib/postgresql/data
 
   milmove:
     depends_on:
       - database
-      - milmove_migrate
-    image: 021081706899.dkr.ecr.us-gov-west-1.amazonaws.com/app:git-branch-placeholder_branch_name
-    links:
-      - database
-    ports:
-      - '9443:9443'
+    networks:
+      default:
+        aliases:
+          - primelocal
+    image: ${MILMOVE_MTLS_IMAGE:-milmove_mtls:local}
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "/bin/milmove migrate && /bin/generate-test-data --named-scenario='e2e_basic' && /bin/milmove serve"
     environment:
       - CLIENT_AUTH_SECRET_KEY
       - CSRF_AUTH_KEY
@@ -77,6 +57,8 @@ services:
       - LOGIN_GOV_MY_CLIENT_ID
       - LOGIN_GOV_OFFICE_CLIENT_ID
       - LOGIN_GOV_SECRET_KEY
+      - MIGRATION_PATH=file:///migrate/schema;file:///migrate/secure
+      - MIGRATION_MANIFEST=/migrate/migrations_manifest.txt
       - MOVE_MIL_DOD_CA_CERT
       - MOVE_MIL_DOD_TLS_CERT
       - MOVE_MIL_DOD_TLS_KEY
@@ -87,7 +69,10 @@ services:
       - SERVE_API_SUPPORT=true
       - STORAGE_BACKEND=local
       - TZ=UTC
-    extra_hosts:
-      - "primelocal:127.0.0.1"
-    volumes:
-      - ./tmp:/tmp
+
+# use a custom external network to ensure consistent naming in
+# circleci and locally
+networks:
+  default:
+    external: true
+    name: e2e_mtls

--- a/scripts/run-e2e-mtls-test
+++ b/scripts/run-e2e-mtls-test
@@ -6,6 +6,9 @@ set -eux -o pipefail
 # INTEGRATION TESTS START
 #
 
+# The prime-api-client is mostly deprecated, but we haven't updated
+# the mtls e2e tests with an alternative, so keep using it for now
+
 ##Integration test for Prime API
 ##Return moves from the list-moves endpoint where is_available_for_prime is true
 function prime_api_client () {
@@ -20,13 +23,18 @@ function prime_api_client () {
 
 
 # wait for 5 minutes for the server to be ready
+# don't try to parse the output with jq because
+# 1. the first attempt will also include logs of the client retrying
+# 2. it is helpful to see the raw json returned from the first request
+#    if debugging is necessary
 prime_api_client --wait 5m list-moves
+
 # now that the server is ready, actually run the tests and parse the JSON response
 
 # Integration test/health check for Prime API
 # Return moves from the list-moves endpoint where available_to_prime_at
 # is NOT NULL
-moves=$(prime_api_client --wait 5m list-moves)
+moves=$(prime_api_client list-moves)
 #Returns move IDs from the list-moves response (this would fail if API returns 500/400)
 moveID=$(echo "$moves" | jq '.[0] | .id')
 echo "$moveID"

--- a/scripts/run-e2e-mtls-test
+++ b/scripts/run-e2e-mtls-test
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+#
+# INTEGRATION TESTS START
+#
+
+##Integration test for Prime API
+##Return moves from the list-moves endpoint where is_available_for_prime is true
+function prime_api_client () {
+    bin/prime-api-client \
+    --certpath config/tls/devlocal-mtls.cer \
+    --keypath config/tls/devlocal-mtls.key \
+    --insecure \
+    --hostname primelocal \
+    --port 9443 \
+    "$@"
+}
+
+
+# wait for 5 minutes for the server to be ready
+prime_api_client --wait 5m list-moves
+# now that the server is ready, actually run the tests and parse the JSON response
+
+# Integration test/health check for Prime API
+# Return moves from the list-moves endpoint where available_to_prime_at
+# is NOT NULL
+moves=$(prime_api_client --wait 5m list-moves)
+#Returns move IDs from the list-moves response (this would fail if API returns 500/400)
+moveID=$(echo "$moves" | jq '.[0] | .id')
+echo "$moveID"
+
+#Integration test/health check for Support API
+#Return all mtos regardless of whether or not they have been made available to prime at some point
+list_mtos=$(prime_api_client support-list-mtos)
+#Returns mtoShipments from the support-list-mtos response (this would fail if API returns 500/400)
+supportMtoShipments=$(echo "$list_mtos" | jq '.[0] | .mtoShipments')
+echo "$supportMtoShipments"
+
+#
+# INTEGRATION TESTS END
+#
+
+exit 0

--- a/scripts/run-e2e-mtls-test-docker
+++ b/scripts/run-e2e-mtls-test-docker
@@ -1,160 +1,59 @@
 #! /usr/bin/env bash
 
+circleci_build_image=milmove/circleci-docker:milmove-app-3d4d7c108724ebcbe7d986d63dcd6fb8a4246633
+
 set -eux -o pipefail
 
-scripts/ensure-application app
-
-# Set Defaults
-NETWORK="mymove_default" # Docker network
-
-# When running locally enable TTY
-DOCKER_RUN="docker run -t"
+# This script is no longer used in circleci because in CI we want some
+# of the steps below to run in parallel and that's hard to integration
+# with circleci config, so there's some duplication in .circleci/config.yml
 if [ -n "${CIRCLECI+x}" ]; then
-  echo "RUNNING IN CIRCLECI"
-  DOCKER_RUN="docker run"
+  echo "This script is only for running mtls tests locally"
+  exit 1
 fi
 
 # Check that the docker process is running first
 docker system info >> /dev/null
 
-if [[ -n "${CIRCLECI+x}" ]]; then
-  # CI/CD allows us to use pre-built images using the branch name
-  scripts/update-docker-compose docker-compose.mtls.yml
+# ensure we nuke anything from a prior run
+docker-compose -f docker-compose.mtls.yml down
+docker rm -f prime_api_client || true
+docker network rm e2e_mtls || true
 
-  # Let's clean things up before starting
-  # This may show an error locally but can be safely ignored, its only for CircleCI
-  docker-compose -f docker-compose.mtls.yml down --rmi all || true
+# in CI, we can copy in the artifacts built in CI, but locally we have
+# to compile inside docker first
+rm -rf bin pkg/assets/assets.go
+mkdir bin
+# set GOPATH if not already set
+: "${GOPATH:=$HOME/.gopath}"
+docker run \
+       --rm \
+       -v "${GOPATH}:${GOPATH}" \
+       -v "${PWD}:${PWD}" \
+       -w "${PWD}" \
+       -e GOPATH \
+       -e CIRCLECI=1 \
+       ${circleci_build_image} \
+      make pkg/assets/assets.go \
+       server_build \
+       bin/prime-api-client \
+       bin/generate-test-data \
+       bin/rds-ca-2019-root.pem \
+       bin/rds-ca-us-gov-west-1-2017-root.pem \
+       bin/rds-ca-rsa4096-g1.pem
+docker build -t milmove_mtls:local -f Dockerfile.e2e .
 
-  # Docker Compose Setup
-  aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+# clean up the generated files that are now for linux instead of macOS
+rm -rf bin
 
-  # If you don't pull and CircleCI has cached previous images then you won't see any changes from AWS ECR
-  docker-compose -f docker-compose.mtls.yml pull
+docker network create e2e_mtls
+docker-compose -f docker-compose.mtls.yml up -d
 
-  # Bring these containers up but don't start them so they can be manipulated first
-  docker-compose -f docker-compose.mtls.yml up --no-start
-
-  # Can't mount folders in CircleCI so copy this data in
-  # https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
-  docker cp ./migrations/app/secure mymove_milmove_migrate_1:/migrate/
-  # Copy the certificate authority into the container.
-  docker cp ./config/tls/devlocal-ca.key mymove_milmove_1:/config/tls/devlocal-ca.key
-  docker cp ./config/tls/devlocal-ca.pem mymove_milmove_1:/config/tls/devlocal-ca.pem
-
-  # Start everything up
-  docker-compose -f docker-compose.mtls.yml up -d --no-recreate --remove-orphans
-
-  # Build a small e2e dockerfile
-  docker build -f Dockerfile.tools --tag tools:latest .
-
-  # Following the logs should block any more actions until migrations are completed and the container exits
-  docker-compose -f docker-compose.mtls.yml logs -f milmove_migrate
-else
-  # Locally development requires that we build the container
-
-  # Let's clean things up before starting
-  docker-compose -f docker-compose.mtls_local.yml down --remove-orphans || true
-
-  # Build images and start everything up
-  docker-compose -f docker-compose.mtls_local.yml up --remove-orphans -d --build
-
-  # Build a small tools dockerfile
-  docker build -f Dockerfile.tools_local --tag tools:latest .
-
-  # Following the logs should block any more actions until migrations are completed and the container exits
-  docker-compose -f docker-compose.mtls_local.yml logs -f milmove_migrate
-fi
-
-# Need to wait not just for DB but also migrations to finish
-while true; do
-  MIGRATE_EXIT=$(docker ps --filter="name=mymove_milmove_migrate_1" --filter="status=exited" -q)
-  if [[ -n "${MIGRATE_EXIT}" ]]; then
-    break
-  else
-    echo
-    echo "Waiting 5 seconds for migrations to complete"
-    sleep 5
-  fi
-done
-
-MIGRATE_EXIT_CODE=$(docker inspect --format='{{.State.ExitCode}}' mymove_milmove_migrate_1)
-if [[ "${MIGRATE_EXIT_CODE}" != "0" ]]; then
-  echo
-  echo "Migration exited with exit code ${MIGRATE_EXIT_CODE}"
-  exit 1
-fi
-
-# Truncate the DB
-$DOCKER_RUN \
-  --link="database" \
-  --net "${NETWORK}" \
-  --rm \
-  --entrypoint psql \
-  tools:latest \
-  postgres://postgres:mysecretpassword@database:5432/dev_db?sslmode=disable -c 'TRUNCATE users CASCADE;'
-
-# Generate Test Data
-$DOCKER_RUN \
-  -e DB_NAME=dev_db \
-  -e DB_HOST=database \
-  -e DB_PORT=5432 \
-  -e DB_USER=postgres \
-  -e DB_PASSWORD=mysecretpassword \
-  -e LOCAL_STORAGE_ROOT=/tmp \
-  -e LOCAL_STORAGE_WEB_ROOT=storage \
-  --link="database" \
-  --net "${NETWORK}" \
-  -v "$(pwd)"/tmp:/tmp \
-  --rm \
-  --entrypoint generate-test-data \
-  tools:latest \
-  --named-scenario e2e_basic
-
-#
-# INTEGRATION TESTS START
-#
-
-##Integration test for Prime API
-##Return moves from the list-moves endpoint where is_available_for_prime is true
-function prime_api_client () {
-  # Cannot mount directories in CircleCI so certificates and data are built into the container
-  $DOCKER_RUN \
-    --link="mymove_milmove_1:primelocal" \
-    --net "${NETWORK}" \
-    --rm \
-    --entrypoint prime-api-client \
-    tools:latest \
-    --certpath ./config/tls/devlocal-mtls.cer \
-    --keypath ./config/tls/devlocal-mtls.key \
-    --insecure \
-    --hostname primelocal \
-    --port 9443 \
-    "$@"
-}
-
-
-#Integration test/health check for Prime API
-#Return moves from the list-moves endpoint where available_to_prime_at is NOT NULL
-moves=$(prime_api_client list-moves)
-#Returns move IDs from the list-moves response (this would fail if API returns 500/400)
-moveID=$(echo "$moves" | jq '.[0] | .id')
-echo "$moveID"
-
-#Integration test/health check for Support API
-#Return all mtos regardless of whether or not they have been made available to prime at some point
-list_mtos=$(prime_api_client support-list-mtos)
-#Returns mtoShipments from the support-list-mtos response (this would fail if API returns 500/400)
-supportMtoShipments=$(echo "$list_mtos" | jq '.[0] | .mtoShipments')
-echo "$supportMtoShipments"
-
-#
-# INTEGRATION TESTS END
-#
+docker run \
+       --name prime_api_client \
+       --network e2e_mtls \
+       --entrypoint /scripts/run-e2e-mtls-test \
+       milmove_mtls:local
 
 # Stop the app container to release the DB connection
-if [[ -n "${CIRCLECI+x}" ]]; then
-  docker-compose -f docker-compose.branch.yml down --remove-orphans || true
-  git checkout docker-compose.mtls.yml
-else
-  docker-compose -f docker-compose.local.yml down --remove-orphans || true
-fi
+docker-compose -f docker-compose.mtls.yml down


### PR DESCRIPTION
## Summary

This PR has 4 main changes

1. It ensures that the babel and terser cache is saved in CI only on builds on the master branch. Using the cache can chop 1-2 minutes off the client build
2. Builds the client code on a xlarge instance with a ramdisk. This saves another 1 minute or so
3. Maximizes the parallelism for every integration test. Every integration test finishes in less than ~6 minutes
4. Reworks the mtls e2e test to work in a manner similar to the other e2e tests. It now finishes in ~2 minutes.

The most recent PR run finishes in just under 14 minutes.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.

