### PR TITLE
MB-12100 services counselor move history

### DIFF
--- a/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.jsx
+++ b/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { Tag } from '@trussworks/react-uswds';
+import PropTypes from 'prop-types';
+
+import 'styles/office.scss';
+import TabNav from 'components/TabNav';
+
+const ServicesCounselingTabNav = ({ unapprovedShipmentCount = 0, moveCode }) => {
+  return (
+    <header className="nav-header">
+      <div className="grid-container-desktop-lg">
+        <TabNav
+          items={[
+            <NavLink
+              exact
+              activeClassName="usa-current"
+              to={`/counseling/moves/${moveCode}/details`}
+              data-testid="MoveDetails-Tab"
+            >
+              <span className="tab-title">Move details</span>
+              {unapprovedShipmentCount > 0 && <Tag>{unapprovedShipmentCount}</Tag>}
+            </NavLink>,
+            <NavLink
+              exact
+              activeClassName="usa-current"
+              to={`/counseling/moves/${moveCode}/history`}
+              data-testid="MoveHistory-Tab"
+            >
+              <span className="tab-title">Move history</span>
+            </NavLink>,
+          ]}
+        />
+      </div>
+    </header>
+  );
+};
+
+ServicesCounselingTabNav.defaultProps = {
+  unapprovedShipmentCount: 0,
+};
+
+ServicesCounselingTabNav.propTypes = {
+  unapprovedShipmentCount: PropTypes.number,
+  moveCode: PropTypes.string.isRequired,
+};
+
+export default ServicesCounselingTabNav;

--- a/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.stories.jsx
+++ b/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.stories.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import ServicesCounselingTabNav from './ServicesCounselingTabNav';
+
+export default {
+  title: 'components/Services Counseling Tab Navigation',
+  component: ServicesCounselingTabNav,
+  decorators: [
+    (Story) => {
+      return (
+        <MemoryRouter initialEntries={['/']}>
+          <div style={{ padding: '20px' }}>
+            <Story />
+          </div>
+        </MemoryRouter>
+      );
+    },
+  ],
+};
+
+const basicNavProps = {
+  moveCode: 'TESTCO',
+};
+
+const moveWithUnapprovedShipments = {
+  ...basicNavProps,
+  unapprovedShipmentCount: 6,
+};
+
+export const Default = () => <ServicesCounselingTabNav {...basicNavProps} />;
+
+export const withMoveDetailsTag = () => <ServicesCounselingTabNav {...moveWithUnapprovedShipments} />;

--- a/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.test.jsx
+++ b/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.test.jsx
@@ -14,7 +14,7 @@ describe('Move details tag rendering', () => {
     render(<ServicesCounselingTabNav {...basicNavProps} />, { wrapper: MemoryRouter });
 
     const moveDetailsTab = screen.getByTestId('MoveDetails-Tab');
-    expect(within(moveDetailsTab).queryByTestId('tag')).toBeFalsy();
+    expect(within(moveDetailsTab).queryByTestId('tag')).not.toBeInTheDocument();
   });
 
   it('should render the move details tab container with a tag that shows the count of unapproved shipments', () => {
@@ -34,7 +34,7 @@ describe('Move history tab', () => {
     render(<ServicesCounselingTabNav {...basicNavProps} />, { wrapper: MemoryRouter });
 
     const moveTaskOrderTab = screen.getByTestId('MoveHistory-Tab');
-    expect(within(moveTaskOrderTab).queryByTestId('tag')).toBeFalsy();
+    expect(within(moveTaskOrderTab).queryByTestId('tag')).not.toBeInTheDocument();
   });
 
   describe('Tab Links', () => {

--- a/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.test.jsx
+++ b/src/components/Office/ServicesCounselingTabNav/ServicesCounselingTabNav.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import ServicesCounselingTabNav from './ServicesCounselingTabNav';
+
+const basicNavProps = {
+  unapprovedShipmentCount: 0,
+  moveCode: 'TESTCO',
+};
+
+describe('Move details tag rendering', () => {
+  it('should render the move details tab container without a tag', () => {
+    render(<ServicesCounselingTabNav {...basicNavProps} />, { wrapper: MemoryRouter });
+
+    const moveDetailsTab = screen.getByTestId('MoveDetails-Tab');
+    expect(within(moveDetailsTab).queryByTestId('tag')).toBeFalsy();
+  });
+
+  it('should render the move details tab container with a tag that shows the count of unapproved shipments', () => {
+    const moveDetailsShipmentAndAmendedOrders = {
+      ...basicNavProps,
+      unapprovedShipmentCount: 6,
+    };
+    render(<ServicesCounselingTabNav {...moveDetailsShipmentAndAmendedOrders} />, { wrapper: MemoryRouter });
+
+    const moveDetailsTab = screen.getByTestId('MoveDetails-Tab');
+    expect(within(moveDetailsTab).getByTestId('tag')).toHaveTextContent('6');
+  });
+});
+
+describe('Move history tab', () => {
+  it('should render the move history tab container without a tag', () => {
+    render(<ServicesCounselingTabNav {...basicNavProps} />, { wrapper: MemoryRouter });
+
+    const moveTaskOrderTab = screen.getByTestId('MoveHistory-Tab');
+    expect(within(moveTaskOrderTab).queryByTestId('tag')).toBeFalsy();
+  });
+
+  describe('Tab Links', () => {
+    it('should should have the correct hrefs', () => {
+      render(<ServicesCounselingTabNav {...basicNavProps} />, { wrapper: MemoryRouter });
+
+      const moveDetailsTab = screen.getByTestId('MoveDetails-Tab');
+      expect(moveDetailsTab.getAttribute('href')).toBe(`/counseling/moves/${basicNavProps.moveCode}/details`);
+
+      const moveHistoryTab = screen.getByTestId('MoveHistory-Tab');
+      expect(moveHistoryTab.getAttribute('href')).toBe(`/counseling/moves/${basicNavProps.moveCode}/history`);
+    });
+  });
+});

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -45,6 +45,7 @@ export const servicesCounselingRoutes = {
   QUEUE_VIEW_PATH: '/counseling/queue',
   SHIPMENT_ADD_PATH: `${BASE_MOVE_PATH}/new-:shipmentType`,
   SHIPMENT_EDIT_PATH: `${BASE_MOVE_PATH}/shipments/:shipmentId`,
+  MOVE_HISTORY_PATH: `${BASE_MOVE_PATH}/history`,
 };
 
 export const tioRoutes = {

--- a/src/pages/Office/MoveHistory/MoveHistory.test.jsx
+++ b/src/pages/Office/MoveHistory/MoveHistory.test.jsx
@@ -80,26 +80,29 @@ jest.mock('hooks/queries', () => ({
 }));
 
 describe('MoveHistory', () => {
-  render(
-    <MockProviders initialEntries={[`/moves/${testMoveLocator}/history`]}>
-      <MoveHistory moveCode={testMoveLocator} />,
-    </MockProviders>,
+  it.each([['/moves'], ['/counseling/moves']])(
+    'render the different elements of the Move history tab at path %s',
+    async (basePath) => {
+      render(
+        <MockProviders initialEntries={[`${basePath}/${testMoveLocator}/history`]}>
+          <MoveHistory moveCode={testMoveLocator} />,
+        </MockProviders>,
+      );
+
+      expect(screen.getByText('Move history (2)')).toBeInTheDocument();
+      expect(screen.getByRole('table')).toBeInTheDocument();
+
+      expect(screen.getByTestId('move-history-date-time-0')).toHaveTextContent('09 Mar 22 15:33');
+      expect(screen.getByTestId('move-history-event-0')).toHaveTextContent('Updated orders');
+      expect(screen.getByTestId('move-history-details-0')).toBeInTheDocument();
+      expect(screen.getByTestId('move-history-modified-by-0')).toBeInTheDocument();
+
+      expect(screen.getByTestId('move-history-date-time-1')).toHaveTextContent('08 Mar 22 18:28');
+      expect(screen.getByTestId('move-history-event-1')).toBeInTheDocument();
+      expect(screen.getByTestId('move-history-details-1')).toBeInTheDocument();
+      expect(screen.getByTestId('move-history-modified-by-1')).toBeInTheDocument();
+
+      expect(screen.getByTestId('pagination')).toBeInTheDocument();
+    },
   );
-
-  it('renders the different elements of the Move history tab', () => {
-    expect(screen.getByText('Move history (2)')).toBeInTheDocument();
-    expect(screen.getByRole('table')).toBeInTheDocument();
-
-    expect(screen.getByTestId('move-history-date-time-0')).toHaveTextContent('09 Mar 22 15:33');
-    expect(screen.getByTestId('move-history-event-0')).toHaveTextContent('Updated orders');
-    expect(screen.getByTestId('move-history-details-0')).toBeInTheDocument();
-    expect(screen.getByTestId('move-history-modified-by-0')).toBeInTheDocument();
-
-    expect(screen.getByTestId('move-history-date-time-1')).toHaveTextContent('08 Mar 22 18:28');
-    expect(screen.getByTestId('move-history-event-1')).toBeInTheDocument();
-    expect(screen.getByTestId('move-history-details-1')).toBeInTheDocument();
-    expect(screen.getByTestId('move-history-modified-by-1')).toBeInTheDocument();
-
-    expect(screen.getByTestId('pagination')).toBeInTheDocument();
-  });
 });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Link, useParams, useHistory } from 'react-router-dom';
 import { queryCache, useMutation } from 'react-query';
 import { generatePath } from 'react-router';
+import { func } from 'prop-types';
 import classnames from 'classnames';
 import 'styles/office.scss';
 import { Alert, Button, Grid, GridContainer } from '@trussworks/react-uswds';
@@ -34,7 +35,7 @@ import formattedCustomerName from 'utils/formattedCustomerName';
 import { getShipmentTypeLabel } from 'utils/shipmentDisplay';
 import ButtonDropdown from 'components/ButtonDropdown/ButtonDropdown';
 
-const ServicesCounselingMoveDetails = ({ infoSavedAlert }) => {
+const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCount }) => {
   const { moveCode } = useParams();
   const history = useHistory();
   const [alertMessage, setAlertMessage] = useState(null);
@@ -224,6 +225,11 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert }) => {
       setAlertType('error');
     },
   });
+
+  // Keep unapproved shipment count in sync
+  useEffect(() => {
+    setUnapprovedShipmentCount(numberOfErrorIfMissingForAllShipments + numberOfWarnIfMissingForAllShipments);
+  }, [numberOfErrorIfMissingForAllShipments, numberOfWarnIfMissingForAllShipments, setUnapprovedShipmentCount]);
 
   if (isLoading) return <LoadingPlaceholder />;
   if (isError) return <SomethingWentWrong />;
@@ -418,6 +424,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert }) => {
 
 ServicesCounselingMoveDetails.propTypes = {
   infoSavedAlert: AlertStateShape,
+  setUnapprovedShipmentCount: func.isRequired,
 };
 
 ServicesCounselingMoveDetails.defaultProps = {

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.test.jsx
@@ -253,7 +253,7 @@ const renderMockedComponent = (props) => {
 
 const mockedComponent = (
   <MockProviders initialEntries={[detailsURL]}>
-    <ServicesCounselingMoveDetails />
+    <ServicesCounselingMoveDetails setUnapprovedShipmentCount={jest.fn()} />
   </MockProviders>
 );
 
@@ -325,6 +325,22 @@ describe('MoveDetails page', () => {
       // In this case, we would expect 3 since this shipment is missing the storage facility
       // and tac type.
       expect(await screen.findByTestId('requestedShipmentsTag')).toHaveTextContent('3');
+    });
+
+    it('shares the number of missing shipment information', () => {
+      const moveDetailsQuery = {
+        ...newMoveDetailsQuery,
+        mtoShipments: [ntsrShipmentMissingRequiredInfo],
+      };
+
+      useMoveDetailsQueries.mockReturnValue(moveDetailsQuery);
+
+      const mockSetUpapprovedShipmentCount = jest.fn();
+      renderMockedComponent({ setUnapprovedShipmentCount: mockSetUpapprovedShipmentCount });
+
+      // Should have called `setUnapprovedShipmentCount` with 3 missing shipping info
+      expect(mockSetUpapprovedShipmentCount).toHaveBeenCalledTimes(1);
+      expect(mockSetUpapprovedShipmentCount).toHaveBeenCalledWith(3);
     });
 
     /* eslint-disable camelcase */
@@ -460,7 +476,10 @@ describe('MoveDetails page', () => {
     });
 
     it('renders info saved alert', () => {
-      renderMockedComponent({ infoSavedAlert: { alertType: 'success', message: 'great success!' } });
+      renderMockedComponent({
+        infoSavedAlert: { alertType: 'success', message: 'great success!' },
+        setUnapprovedShipmentCount: jest.fn(),
+      });
       expect(screen.getByText('great success!')).toBeInTheDocument();
     });
 
@@ -572,7 +591,9 @@ describe('MoveDetails page', () => {
       ])('shows the "%s" link as expected: %s', async (linkText, route) => {
         useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
 
-        const { history } = renderWithRouter(<ServicesCounselingMoveDetails />, { route: detailsURL });
+        const { history } = renderWithRouter(<ServicesCounselingMoveDetails setUnapprovedShipmentCount={jest.fn()} />, {
+          route: detailsURL,
+        });
 
         const link = await screen.findByRole('link', { name: linkText });
 
@@ -593,7 +614,10 @@ describe('MoveDetails page', () => {
         it.each([[SHIPMENT_OPTIONS_URL.HHG], [SHIPMENT_OPTIONS_URL.NTS], [SHIPMENT_OPTIONS_URL.NTSrelease]])(
           'selects the %s option and navigates to the matching form for that shipment type',
           async (shipmentType) => {
-            const { history } = renderWithRouter(<ServicesCounselingMoveDetails />, { route: detailsURL });
+            const { history } = renderWithRouter(
+              <ServicesCounselingMoveDetails setUnapprovedShipmentCount={jest.fn()} />,
+              { route: detailsURL },
+            );
 
             const path = generatePath(servicesCounselingRoutes.SHIPMENT_ADD_PATH, {
               moveCode: mockRequestedMoveCode,

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.jsx
@@ -25,7 +25,7 @@ const CustomerInfo = lazy(() => import('pages/Office/CustomerInfo/CustomerInfo')
 const MoveHistory = lazy(() => import('pages/Office/MoveHistory/MoveHistory'));
 
 const ServicesCounselingMoveInfo = () => {
-  const [unapprovedShipmentCount, setUnapprovedShipmentCount] = React.useState(0);
+  const [unapprovedShipmentCount, setUnapprovedShipmentCount] = useState(0);
 
   const [infoSavedAlert, setInfoSavedAlert] = useState(null);
   const { hasRecentError, traceId } = useSelector((state) => state.interceptor);

--- a/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
+++ b/src/pages/Office/ServicesCounselingMoveInfo/ServicesCounselingMoveInfo.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, screen, queryByTestId } from '@testing-library/react';
+import { render, screen, queryByTestId, waitForElementToBeRemoved } from '@testing-library/react';
 
 import ServicesCounselingMoveInfo from './ServicesCounselingMoveInfo';
 
 import { MockProviders } from 'testUtils';
-import { useMoveDetailsQueries } from 'hooks/queries';
+import { useMoveDetailsQueries, useGHCGetMoveHistory } from 'hooks/queries';
 import { ORDERS_TYPE, ORDERS_TYPE_DETAILS } from 'constants/orders';
 import MOVE_STATUSES from 'constants/moves';
 
@@ -41,6 +41,7 @@ jest.mock('hooks/queries', () => ({
     };
   },
   useMoveDetailsQueries: jest.fn(),
+  useGHCGetMoveHistory: jest.fn(),
 }));
 
 const newMoveDetailsQuery = {
@@ -166,6 +167,47 @@ const errorReturnValue = {
   isSuccess: false,
 };
 
+const moveHistoryQuery = {
+  isLoading: false,
+  isError: false,
+  queueResult: {
+    totalCount: 1,
+    data: [
+      {
+        action: 'UPDATE',
+        actionTstampClk: '2022-03-09T15:33:38.623Z',
+        actionTstampStm: '2022-03-09T15:33:38.622Z',
+        actionTstampTx: '2022-03-09T15:33:38.579Z',
+        changedValues: { postal_code: '90213', updated_at: '2022-03-08T19:08:44.664709' },
+        clientQuery:
+          'UPDATE "moves" AS moves SET "available_to_prime_at" = $1, "billable_weights_reviewed_at" = $2, "cancel_reason" = $3, "contractor_id" = $4, "excess_weight_acknowledged_at" = $5, "excess_weight_qualified_at" = $6, "excess_weight_upload_id" = $7, "financial_review_flag" = $8, "financial_review_flag_set_at" = $9, "financial_review_remarks" = $10, "locator" = $11, "orders_id" = $12, "ppm_estimated_weight" = $13, "ppm_type" = $14, "reference_id" = $15, "selected_move_type" = $16, "service_counseling_completed_at" = $17, "show" = $18, "status" = $19, "submitted_at" = $20, "tio_remarks" = $21, "updated_at" = $22 WHERE moves.id = $23',
+        eventName: 'updateOrder',
+        id: '7ce7c1ac-a1d7-4caf-858c-09674a00f273',
+        objectId: 'abe92574-53a8-4026-a75c-45ff9eea9bc6',
+        oldValues: {
+          city: 'Beverly Hills',
+          country: 'US',
+          created_at: '2022-02-24T23:45:28.8116',
+          id: '8dd3d021-101e-442f-83d7-1b5b91554e5e',
+          postal_code: '90215',
+          state: 'CA',
+          street_address_1: '123 Any Street',
+          street_address_2: 'P.O. Box 12345',
+          street_address_3: 'c/o Some Person',
+          updated_at: '2022-03-08T19:01:46.151732',
+        },
+        relId: 16592,
+        schemaName: 'public',
+        tableName: 'moves',
+        transactionId: 26993,
+      },
+    ],
+    id: 'abe92574-53a8-4026-a75c-45ff9eea9bc6',
+    locator: 'ABC123',
+    referenceId: '5037-3728',
+  },
+};
+
 describe('Services Counseling Move Info Container', () => {
   describe('check loading and error component states', () => {
     it('renders the Loading Placeholder when the query is still loading', async () => {
@@ -197,6 +239,17 @@ describe('Services Counseling Move Info Container', () => {
 
   describe('Basic rendering', () => {
     useMoveDetailsQueries.mockReturnValue(newMoveDetailsQuery);
+    it('should render the tab container with two tabs, move details and move history', async () => {
+      render(
+        <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+
+      expect(screen.getByTestId('MoveDetails-Tab')).toBeInTheDocument();
+      expect(screen.getByTestId('MoveHistory-Tab')).toBeInTheDocument();
+    });
+
     it('should render the move tab container', () => {
       const wrapper = mount(
         <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/details`]}>
@@ -256,6 +309,22 @@ describe('Services Counseling Move Info Container', () => {
 
       const renderedRoute = wrapper.find('ServicesCounselingMoveDetails');
       expect(renderedRoute).toHaveLength(1);
+    });
+
+    it('should handle the Services Counseling Move History route', async () => {
+      useGHCGetMoveHistory.mockReturnValue(moveHistoryQuery);
+      render(
+        <MockProviders initialEntries={[`/counseling/moves/${testMoveCode}/history`]}>
+          <ServicesCounselingMoveInfo />
+        </MockProviders>,
+      );
+
+      // Wait to finish loading
+      const loadingH2 = await screen.getByRole('heading', { name: 'Loading, please wait...', level: 2 });
+      await waitForElementToBeRemoved(loadingH2);
+
+      // Ensure we are showing the move history
+      expect(await screen.getByRole('heading', { name: 'Move history (1)', level: 1 })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12100) for this change

## Summary

This PR adds 2 tabs to the top of the Services Counselor Move Info page allowing services counselors to access the  paginated Move History. The 'Move Details' tab displays a numeric tag indicating the count of any unapproved/empty shipping fields (similar to what occurs on this tab for the TIO/TOO).   Also included are a number of related test additions/updates. 

## Video of change

https://user-images.githubusercontent.com/62263329/163472104-c9293169-bb3d-4d83-9070-a9fe54f90aeb.mov


