### PR TITLE
[MB-12131] add new gov RDS cert to all dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN update-ca-certificates
 FROM gcr.io/distroless/base:latest
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -6,6 +6,7 @@ RUN apk upgrade --no-cache busybox
 COPY config/tls/dod-wcf-root-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-root-ca-1.pem.crt
 COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/dod-wcf-intermediate-ca-1.pem.crt
 
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -10,6 +10,7 @@ COPY --chown=circleci:circleci . /home/circleci/project
 WORKDIR /home/circleci/project
 
 RUN make clean
+RUN make bin/rds-ca-rsa4096-g1.pem
 RUN make bin/rds-ca-2019-root.pem
 RUN make bin/rds-ca-us-gov-west-1-2017-root.pem
 RUN rm -f pkg/assets/assets.go && make pkg/assets/assets.go
@@ -23,6 +24,7 @@ RUN rm -f bin/milmove && make bin/milmove
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base:latest
 
+COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/milmove /bin/milmove

--- a/Dockerfile.tasks
+++ b/Dockerfile.tasks
@@ -12,6 +12,7 @@ FROM gcr.io/distroless/base:latest
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove-tasks /bin/milmove-tasks

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -22,6 +22,7 @@ FROM gcr.io/distroless/static:latest
 # Copy DOD certs from the builder.
 COPY --from=builder --chown=root:root /etc/ssl/certs /etc/ssl/certs
 
+COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/webhook-client /bin/webhook-client
 

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -18,6 +18,8 @@ WORKDIR /home/circleci/project
 
 RUN make clean
 RUN make bin/rds-ca-us-gov-west-1-2017-root.pem
+RUN make bin/rds-ca-rsa4096-g1.pem
+
 RUN make bin/webhook-client
 
 #########
@@ -35,6 +37,7 @@ COPY --from=builder --chown=root:root /home/circleci/project/config/tls/devlocal
 COPY --from=builder --chown=root:root /home/circleci/project/config/tls/devlocal-mtls.key /config/tls/devlocal-mtls.key
 
 # Public root certificate for RDS in us-gov-west-1.
+COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 
 # The main webhook-client binary.


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary
This PR adds the new RDS certificate for AWS GovCloud to all the dockerfiles that currently have the 2017 RDS cert, which is expiring soon.

This PR does not remove old certs yet. 