### PR TITLE
[MB-12077] Make ServiceItem fields that are unused in responses optional

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -3984,11 +3984,7 @@ func init() {
         "moveTaskOrderID",
         "reServiceID",
         "reServiceCode",
-        "reServiceName",
-        "mtoShipmentID",
-        "reason",
-        "pickupPostalCode",
-        "description"
+        "reServiceName"
       ],
       "properties": {
         "SITPostalCode": {
@@ -4013,7 +4009,8 @@ func init() {
           "format": "date"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "dimensions": {
           "$ref": "#/definitions/MTOServiceItemDimensions"
@@ -4050,10 +4047,12 @@ func init() {
         "mtoShipmentID": {
           "type": "string",
           "format": "uuid",
+          "x-nullable": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "pickupPostalCode": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "quantity": {
           "type": "integer"
@@ -4073,7 +4072,8 @@ func init() {
           "type": "string"
         },
         "reason": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "rejectedAt": {
           "type": "string",
@@ -10960,11 +10960,7 @@ func init() {
         "moveTaskOrderID",
         "reServiceID",
         "reServiceCode",
-        "reServiceName",
-        "mtoShipmentID",
-        "reason",
-        "pickupPostalCode",
-        "description"
+        "reServiceName"
       ],
       "properties": {
         "SITPostalCode": {
@@ -10989,7 +10985,8 @@ func init() {
           "format": "date"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "dimensions": {
           "$ref": "#/definitions/MTOServiceItemDimensions"
@@ -11026,10 +11023,12 @@ func init() {
         "mtoShipmentID": {
           "type": "string",
           "format": "uuid",
+          "x-nullable": true,
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
         "pickupPostalCode": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "quantity": {
           "type": "integer"
@@ -11049,7 +11048,8 @@ func init() {
           "type": "string"
         },
         "reason": {
-          "type": "string"
+          "type": "string",
+          "x-nullable": true
         },
         "rejectedAt": {
           "type": "string",

--- a/pkg/gen/ghcmessages/m_t_o_service_item.go
+++ b/pkg/gen/ghcmessages/m_t_o_service_item.go
@@ -40,8 +40,7 @@ type MTOServiceItem struct {
 	DeletedAt strfmt.Date `json:"deletedAt,omitempty"`
 
 	// description
-	// Required: true
-	Description *string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// dimensions
 	Dimensions MTOServiceItemDimensions `json:"dimensions,omitempty"`
@@ -71,13 +70,11 @@ type MTOServiceItem struct {
 
 	// mto shipment ID
 	// Example: 1f2270c7-7166-40ae-981e-b200ebdf3054
-	// Required: true
 	// Format: uuid
-	MtoShipmentID *strfmt.UUID `json:"mtoShipmentID"`
+	MtoShipmentID *strfmt.UUID `json:"mtoShipmentID,omitempty"`
 
 	// pickup postal code
-	// Required: true
-	PickupPostalCode *string `json:"pickupPostalCode"`
+	PickupPostalCode *string `json:"pickupPostalCode,omitempty"`
 
 	// quantity
 	Quantity int64 `json:"quantity,omitempty"`
@@ -100,8 +97,7 @@ type MTOServiceItem struct {
 	ReServiceName *string `json:"reServiceName"`
 
 	// reason
-	// Required: true
-	Reason *string `json:"reason"`
+	Reason *string `json:"reason,omitempty"`
 
 	// rejected at
 	// Format: date-time
@@ -153,10 +149,6 @@ func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDescription(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateDimensions(formats); err != nil {
 		res = append(res, err)
 	}
@@ -177,10 +169,6 @@ func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validatePickupPostalCode(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateReServiceCode(formats); err != nil {
 		res = append(res, err)
 	}
@@ -190,10 +178,6 @@ func (m *MTOServiceItem) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReServiceName(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -274,15 +258,6 @@ func (m *MTOServiceItem) validateDeletedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("deletedAt", "body", "date", m.DeletedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateDescription(formats strfmt.Registry) error {
-
-	if err := validate.Required("description", "body", m.Description); err != nil {
 		return err
 	}
 
@@ -381,21 +356,11 @@ func (m *MTOServiceItem) validateMoveTaskOrderID(formats strfmt.Registry) error 
 }
 
 func (m *MTOServiceItem) validateMtoShipmentID(formats strfmt.Registry) error {
-
-	if err := validate.Required("mtoShipmentID", "body", m.MtoShipmentID); err != nil {
-		return err
+	if swag.IsZero(m.MtoShipmentID) { // not required
+		return nil
 	}
 
 	if err := validate.FormatOf("mtoShipmentID", "body", "uuid", m.MtoShipmentID.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validatePickupPostalCode(formats strfmt.Registry) error {
-
-	if err := validate.Required("pickupPostalCode", "body", m.PickupPostalCode); err != nil {
 		return err
 	}
 
@@ -427,15 +392,6 @@ func (m *MTOServiceItem) validateReServiceID(formats strfmt.Registry) error {
 func (m *MTOServiceItem) validateReServiceName(formats strfmt.Registry) error {
 
 	if err := validate.Required("reServiceName", "body", m.ReServiceName); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *MTOServiceItem) validateReason(formats strfmt.Registry) error {
-
-	if err := validate.Required("reason", "body", m.Reason); err != nil {
 		return err
 	}
 

--- a/swagger-def/definitions/MTOServiceItem.yaml
+++ b/swagger-def/definitions/MTOServiceItem.yaml
@@ -5,10 +5,6 @@ required:
   - reServiceID
   - reServiceCode
   - reServiceName
-  - mtoShipmentID
-  - reason
-  - pickupPostalCode
-  - description
 properties:
   moveTaskOrderID:
     example: 1f2270c7-7166-40ae-981e-b200ebdf3054
@@ -18,6 +14,7 @@ properties:
     example: 1f2270c7-7166-40ae-981e-b200ebdf3054
     format: uuid
     type: string
+    x-nullable: true
   reServiceID:
     example: 1f2270c7-7166-40ae-981e-b200ebdf3054
     format: uuid
@@ -36,15 +33,18 @@ properties:
     type: string
   description:
     type: string
+    x-nullable: true
   dimensions:
     $ref: 'MTOServiceItemDimensions.yaml'
   reason:
     type: string
+    x-nullable: true
   rejectionReason:
     type: string
     x-nullable: true
   pickupPostalCode:
     type: string
+    x-nullable: true
   SITPostalCode:
     type: string
     readOnly: true

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4006,10 +4006,6 @@ definitions:
       - reServiceID
       - reServiceCode
       - reServiceName
-      - mtoShipmentID
-      - reason
-      - pickupPostalCode
-      - description
     properties:
       moveTaskOrderID:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
@@ -4019,6 +4015,7 @@ definitions:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
         type: string
+        x-nullable: true
       reServiceID:
         example: 1f2270c7-7166-40ae-981e-b200ebdf3054
         format: uuid
@@ -4037,15 +4034,18 @@ definitions:
         type: string
       description:
         type: string
+        x-nullable: true
       dimensions:
         $ref: '#/definitions/MTOServiceItemDimensions'
       reason:
         type: string
+        x-nullable: true
       rejectionReason:
         type: string
         x-nullable: true
       pickupPostalCode:
         type: string
+        x-nullable: true
       SITPostalCode:
         type: string
         readOnly: true


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12077) for this change
These API changes will unblock writing load tests for payment requests.

These service item fields were not always being used in responses, even though they were marked as required in the swagger definition.
The Go app doesn't check response types against their swagger definitions, so inconsistencies like this only come to light when you're working on load tests, which do check response types against the spec.

An alternative way to go about this would be to create another service item type that is just used for responses, instead of having the definition shared. I didn't do this because it seems like we generally tend to err on the side of sharing code vs having super tight definitions.


## Setup to Run Your Code

<details>
<summary>💻 You will need to use 2 separate terminals to test this locally.</summary>

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps
I think this should be pretty well covered by automated tests.
To exercise the affected API requests pretty thoroughly you can:
1. create a customer
2. approve as TOO
3. Create additional service items with the prime simulator
4. Approve those service items as a TOO

## Verification Steps for Author

These are to be checked by the author.
- [ ] Have the Jira acceptance criteria been met for this change?

