### PR TITLE
MB-11321 - Add 'create standard service item' move history event

### DIFF
--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -56,9 +56,9 @@ export const acknowledgeExcessWeightRiskEvent = buildMoveHistoryEventTemplate({
 });
 
 export const approveShipmentEvent = buildMoveHistoryEventTemplate({
-  action: '*',
+  action: 'UPDATE',
   eventName: moveHistoryOperations.approveShipment,
-  tableName: '*',
+  tableName: 'mto_shipments',
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved shipment',
   getDetailsPlainText: (historyRecord) => {
@@ -93,6 +93,17 @@ export const createOrdersEvent = buildMoveHistoryEventTemplate({
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Submitted orders',
   getDetailsPlainText: () => '-',
+});
+
+export const createServiceItemEvent = buildMoveHistoryEventTemplate({
+  action: 'INSERT',
+  eventName: '*',
+  tableName: 'mto_service_items',
+  detailsType: detailsTypes.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Approved service item',
+  getDetailsPlainText: (historyRecord) => {
+    return `${shipmentTypes[historyRecord.context?.shipment_type]} shipment, ${historyRecord.context?.name}`;
+  },
 });
 
 export const requestShipmentCancellationEvent = buildMoveHistoryEventTemplate({
@@ -165,7 +176,7 @@ export const updateMoveTaskOrderStatusEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateServiceItemStatusEvent = buildMoveHistoryEventTemplate({
-  action: '*',
+  action: 'UPDATE',
   eventName: moveHistoryOperations.updateServiceItemStatus,
   tableName: 'mto_service_items',
   detailsType: detailsTypes.PLAIN_TEXT,
@@ -212,6 +223,7 @@ const allMoveHistoryEventTemplates = [
   approveShipmentDiversionEvent,
   createMTOShipmentEvent,
   createOrdersEvent,
+  createServiceItemEvent,
   requestShipmentCancellationEvent,
   requestShipmentDiversionEvent,
   setFinancialReviewFlagEvent,

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -97,7 +97,7 @@ export const createOrdersEvent = buildMoveHistoryEventTemplate({
 
 export const createStandardServiceItemEvent = buildMoveHistoryEventTemplate({
   action: 'INSERT',
-  eventName: 'approveShipment',
+  eventName: moveHistoryOperations.approveShipment,
   tableName: 'mto_service_items',
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -95,9 +95,9 @@ export const createOrdersEvent = buildMoveHistoryEventTemplate({
   getDetailsPlainText: () => '-',
 });
 
-export const createServiceItemEvent = buildMoveHistoryEventTemplate({
+export const createStandardServiceItemEvent = buildMoveHistoryEventTemplate({
   action: 'INSERT',
-  eventName: '*',
+  eventName: 'approveShipment',
   tableName: 'mto_service_items',
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',
@@ -223,7 +223,7 @@ const allMoveHistoryEventTemplates = [
   approveShipmentDiversionEvent,
   createMTOShipmentEvent,
   createOrdersEvent,
-  createServiceItemEvent,
+  createStandardServiceItemEvent,
   requestShipmentCancellationEvent,
   requestShipmentDiversionEvent,
   setFinancialReviewFlagEvent,

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -8,6 +8,7 @@ const {
   updateMoveTaskOrderStatusEvent,
   updateServiceItemStatusEvent,
   acknowledgeExcessWeightRiskEvent,
+  createServiceItemEvent,
 } = require('./moveHistoryEventTemplate');
 
 describe('moveHistoryEventTemplate', () => {
@@ -26,6 +27,7 @@ describe('moveHistoryEventTemplate', () => {
 
   describe('when given an Approved shipment history record', () => {
     const item = {
+      action: 'UPDATE',
       changedValues: { status: 'APPROVED' },
       eventName: 'approveShipment',
       oldValues: { shipment_type: 'HHG' },
@@ -63,6 +65,24 @@ describe('moveHistoryEventTemplate', () => {
     it('correctly matches the Submitted orders event', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(createOrdersEvent);
+    });
+  });
+
+  describe('when given a Create service item history record', () => {
+    const item = {
+      action: 'INSERT',
+      context: {
+        shipment_type: 'HHG',
+        name: 'Domestic linehaul',
+      },
+      eventName: 'approveShipment',
+      tableName: 'mto_service_items',
+    };
+    it('correctly matches the Create service item event', () => {
+      const result = getMoveHistoryEventTemplate(item);
+      expect(result).toEqual(createServiceItemEvent);
+      expect(result.getEventNameDisplay(result)).toEqual('Approved service item');
+      expect(result.getDetailsPlainText(item)).toEqual('HHG shipment, Domestic linehaul');
     });
   });
 
@@ -113,6 +133,7 @@ describe('moveHistoryEventTemplate', () => {
 
   describe('when given an Approved service item history record', () => {
     const item = {
+      action: 'UPDATE',
       changedValues: { status: 'APPROVED' },
       context: { name: 'Domestic origin price', shipment_type: 'HHG_INTO_NTS_DOMESTIC' },
       eventName: 'updateMTOServiceItemStatus',

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -8,7 +8,7 @@ const {
   updateMoveTaskOrderStatusEvent,
   updateServiceItemStatusEvent,
   acknowledgeExcessWeightRiskEvent,
-  createServiceItemEvent,
+  createStandardServiceItemEvent,
 } = require('./moveHistoryEventTemplate');
 
 describe('moveHistoryEventTemplate', () => {
@@ -68,7 +68,7 @@ describe('moveHistoryEventTemplate', () => {
     });
   });
 
-  describe('when given a Create service item history record', () => {
+  describe('when given a Create standard service item history record', () => {
     const item = {
       action: 'INSERT',
       context: {
@@ -78,9 +78,9 @@ describe('moveHistoryEventTemplate', () => {
       eventName: 'approveShipment',
       tableName: 'mto_service_items',
     };
-    it('correctly matches the Create service item event', () => {
+    it('correctly matches the Create standard service item event', () => {
       const result = getMoveHistoryEventTemplate(item);
-      expect(result).toEqual(createServiceItemEvent);
+      expect(result).toEqual(createStandardServiceItemEvent);
       expect(result.getEventNameDisplay(result)).toEqual('Approved service item');
       expect(result.getDetailsPlainText(item)).toEqual('HHG shipment, Domestic linehaul');
     });

--- a/src/pages/Office/MoveHistory/MoveHistory.test.jsx
+++ b/src/pages/Office/MoveHistory/MoveHistory.test.jsx
@@ -108,6 +108,7 @@ jest.mock('hooks/queries', () => ({
               tac_type: '',
               uses_external_vendor: '',
             },
+            tableName: 'mto_shipments',
           },
         ],
       },


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11321) for this change

## Summary

This PR should add support for displaying approved **standard** service items in the move history.
Since these **standard** service items are created in the approved status when a shipment is approved, the move history event template should cover all service items created in the 'approveShipment' event.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app as a TOO
2. Navigate to a move that is not yet approved (ex. locator 7MKYDR)
3. Approve the move with standard service items
4. Navigate to the move history page and verify that the standard service item approvals are displayed per the requirements in the story.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
<img width="1291" alt="image" src="https://user-images.githubusercontent.com/97245917/164302705-d8be7601-2163-4782-b5ae-e2def9c24832.png">
