### PR TITLE
MB-11943 - Add 'create basic service item' move history event

### DIFF
--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -80,8 +80,8 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 		FROM
 			mto_service_items
 		JOIN re_services ON mto_service_items.re_service_id = re_services.id
-		JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipments.id
-		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves)
+		JOIN moves ON moves.id = mto_service_items.move_id
+		LEFT JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipments.id
 	),
 	service_item_logs AS (
 		SELECT

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -95,6 +95,17 @@ export const createOrdersEvent = buildMoveHistoryEventTemplate({
   getDetailsPlainText: () => '-',
 });
 
+export const createBasicServiceItemEvent = buildMoveHistoryEventTemplate({
+  action: 'INSERT',
+  eventName: moveHistoryOperations.updateMoveTaskOrderStatus,
+  tableName: 'mto_service_items',
+  detailsType: detailsTypes.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Approved service item',
+  getDetailsPlainText: (historyRecord) => {
+    return `${historyRecord.context?.name}`;
+  },
+});
+
 export const createStandardServiceItemEvent = buildMoveHistoryEventTemplate({
   action: 'INSERT',
   eventName: moveHistoryOperations.approveShipment,
@@ -223,6 +234,7 @@ const allMoveHistoryEventTemplates = [
   approveShipmentDiversionEvent,
   createMTOShipmentEvent,
   createOrdersEvent,
+  createBasicServiceItemEvent,
   createStandardServiceItemEvent,
   requestShipmentCancellationEvent,
   requestShipmentDiversionEvent,

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -9,6 +9,7 @@ const {
   updateServiceItemStatusEvent,
   acknowledgeExcessWeightRiskEvent,
   createStandardServiceItemEvent,
+  createBasicServiceItemEvent,
 } = require('./moveHistoryEventTemplate');
 
 describe('moveHistoryEventTemplate', () => {
@@ -65,6 +66,23 @@ describe('moveHistoryEventTemplate', () => {
     it('correctly matches the Submitted orders event', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(createOrdersEvent);
+    });
+  });
+
+  describe('when given a Create basic service item history record', () => {
+    const item = {
+      action: 'INSERT',
+      context: {
+        name: 'Domestic linehaul',
+      },
+      eventName: 'updateMoveTaskOrderStatus',
+      tableName: 'mto_service_items',
+    };
+    it('correctly matches the Create basic service item event', () => {
+      const result = getMoveHistoryEventTemplate(item);
+      expect(result).toEqual(createBasicServiceItemEvent);
+      expect(result.getEventNameDisplay(result)).toEqual('Approved service item');
+      expect(result.getDetailsPlainText(item)).toEqual('Domestic linehaul');
     });
   });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11943) for this change

## Summary

This PR should add support for displaying approved **basic** service items in the move history.
Since these **basic** service items are created in the approved status when an MTO is created, the move history event template should cover all service items created in the 'updateMoveTaskOrderStatus' event.

One thing to pay a little more attention to is the change in the fetch query, which is now including _all_ service items tied to a move, and not just the ones tied to that move's shipments. A 'where' condition was also removed because it may have been unnecessary.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app as a TOO
2. Navigate to a move that is not yet approved (e.g. locator 7MKYDR)
3. Address any required TOO to-do items as enumerated in the left nav 
4. Approve shipments and add any basic service items (e.g. Move management) to the move
5. Navigate to the move history page and verify that the basic service item approvals are displayed per the requirements in the story.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/97245917/164314721-985542ae-ba26-4102-8fd7-c3965d3fbcf1.png">
