### PR TITLE
Moved context to array of objects

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -4574,9 +4574,12 @@ func init() {
           "x-nullable": true
         },
         "context": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "x-nullable": true
         },
@@ -11563,9 +11566,12 @@ func init() {
           "x-nullable": true
         },
         "context": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "x-nullable": true
         },

--- a/pkg/gen/ghcmessages/move_audit_history.go
+++ b/pkg/gen/ghcmessages/move_audit_history.go
@@ -41,7 +41,7 @@ type MoveAuditHistory struct {
 	ClientQuery *string `json:"clientQuery,omitempty"`
 
 	// context
-	Context map[string]string `json:"context,omitempty"`
+	Context []map[string]string `json:"context"`
 
 	// id column for the context table the record belongs to
 	// Example: 1f2270c7-7166-40ae-981e-b200ebdf3054

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -88,8 +88,8 @@ func MoveAuditHistory(auditHistory models.AuditHistory) *ghcmessages.MoveAuditHi
 		ActionTstampClk:      strfmt.DateTime(auditHistory.ActionTstampClk),
 		ActionTstampStm:      strfmt.DateTime(auditHistory.ActionTstampStm),
 		ActionTstampTx:       strfmt.DateTime(auditHistory.ActionTstampTx),
-		ChangedValues:        removeEscapeJSON(auditHistory.ChangedData),
-		OldValues:            removeEscapeJSON(auditHistory.OldData),
+		ChangedValues:        removeEscapeJSONtoObject(auditHistory.ChangedData),
+		OldValues:            removeEscapeJSONtoObject(auditHistory.OldData),
 		ClientQuery:          auditHistory.ClientQuery,
 		EventName:            auditHistory.EventName,
 		ID:                   strfmt.UUID(auditHistory.ID.String()),
@@ -100,7 +100,7 @@ func MoveAuditHistory(auditHistory models.AuditHistory) *ghcmessages.MoveAuditHi
 		SessionUserLastName:  auditHistory.SessionUserLastName,
 		SessionUserEmail:     auditHistory.SessionUserEmail,
 		SessionUserTelephone: auditHistory.SessionUserTelephone,
-		Context:              removeEscapeJSON(auditHistory.Context),
+		Context:              removeEscapeJSONtoArray(auditHistory.Context),
 		ContextID:            auditHistory.ContextID,
 		StatementOnly:        auditHistory.StatementOnly,
 		TableName:            auditHistory.TableName,
@@ -111,7 +111,7 @@ func MoveAuditHistory(auditHistory models.AuditHistory) *ghcmessages.MoveAuditHi
 	return payload
 }
 
-func removeEscapeJSON(data *string) map[string]string {
+func removeEscapeJSONtoObject(data *string) map[string]string {
 	var result map[string]string
 	if data == nil || *data == "" {
 		return result
@@ -121,6 +121,17 @@ func removeEscapeJSON(data *string) map[string]string {
 	_ = json.Unmarshal(byteData, &result)
 	return result
 
+}
+
+func removeEscapeJSONtoArray(data *string) []map[string]string {
+	var result []map[string]string
+	if data == nil || *data == "" {
+		return result
+	}
+	var byteData = []byte(*data)
+
+	_ = json.Unmarshal(byteData, &result)
+	return result
 }
 
 func moveHistoryRecords(auditHistories models.AuditHistories) ghcmessages.MoveAuditHistories {

--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -76,22 +76,33 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 	),
 	service_items AS (
 		SELECT
-			mto_service_items.*, re_services.name, mto_shipments.shipment_type
+			mto_service_items.id,
+			json_agg(json_build_object('name',
+					re_services.name,
+					'shipment_type',
+					mto_shipments.shipment_type))::TEXT AS context
 		FROM
 			mto_service_items
 		JOIN re_services ON mto_service_items.re_service_id = re_services.id
 		JOIN mto_shipments ON mto_service_items.mto_shipment_id = mto_shipments.id
-		WHERE mto_shipments.move_id = (SELECT moves.id FROM moves)
+	WHERE
+		mto_shipments.move_id = (
+			SELECT
+				moves.id
+			FROM
+				moves)
+		GROUP BY
+			mto_service_items.id
 	),
 	service_item_logs AS (
 		SELECT
 			audit_history.*,
-			json_build_object('name', service_items.name, 'shipment_type', service_items.shipment_type)::TEXT AS context,
+			context,
 			NULL AS context_id
 		FROM
 			audit_history
-		JOIN service_items ON service_items.id = audit_history.object_id
-			AND audit_history."table_name" = 'mto_service_items'
+			JOIN service_items ON service_items.id = audit_history.object_id
+				AND audit_history. "table_name" = 'mto_service_items'
 	),
 	pickup_address_logs AS (
 		SELECT

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -78,13 +78,13 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 			if h.TableName == "addresses" {
 				if *h.ObjectID == updateAddress.ID {
 					if h.OldData != nil {
-						oldData := removeEscapeJSON(h.OldData)
+						oldData := removeEscapeJSONtoObject(h.OldData)
 						if oldData["city"] == oldAddress.City && oldData["state"] == oldAddress.State && oldData["postal_code"] == oldAddress.PostalCode {
 							verifyOldPickupAddress = true
 						}
 					}
 					if h.ChangedData != nil {
-						changedData := removeEscapeJSON(h.ChangedData)
+						changedData := removeEscapeJSONtoObject(h.ChangedData)
 						if changedData["city"] == updateAddress.City && changedData["state"] == updateAddress.State && changedData["postal_code"] == updateAddress.PostalCode {
 							verifyNewPickupAddress = true
 						}
@@ -93,13 +93,13 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 			} else if h.TableName == "orders" {
 				if *h.ObjectID == approvedMove.Orders.ID {
 					if h.OldData != nil {
-						oldData := removeEscapeJSON(h.OldData)
+						oldData := removeEscapeJSONtoObject(h.OldData)
 						if len(oldData["sac"]) == 0 {
 							verifyOldSAC = true
 						}
 					}
 					if h.ChangedData != nil {
-						changedData := removeEscapeJSON(h.ChangedData)
+						changedData := removeEscapeJSONtoObject(h.ChangedData)
 						if changedData["sac"] == updateSAC {
 							verifyNewSAC = true
 						}
@@ -107,21 +107,21 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 				}
 			} else if h.TableName == "entitlements" {
 				if h.ChangedData != nil {
-					oldData := removeEscapeJSON(h.OldData)
+					oldData := removeEscapeJSONtoObject(h.OldData)
 					if len(oldData["authorized_weight"]) == 0 {
 						verifyDBAuthorizedWeight = true
 					}
 				}
 			} else if h.TableName == "moves" {
 				if h.OldData != nil {
-					oldData := removeEscapeJSON(h.OldData)
+					oldData := removeEscapeJSONtoObject(h.OldData)
 					if len(oldData["tio_remarks"]) == 0 {
 						verifyOldTIORemarks = true
 					}
 				}
 				if *h.ObjectID == approvedMove.ID {
 					if h.ChangedData != nil {
-						changedData := removeEscapeJSON(h.ChangedData)
+						changedData := removeEscapeJSONtoObject(h.ChangedData)
 						if changedData["tio_remarks"] == tioRemarks {
 							verifyTIORemarks = true
 						}
@@ -159,8 +159,19 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {
 
 }
 
-func removeEscapeJSON(data *string) map[string]string {
+func removeEscapeJSONtoObject(data *string) map[string]string {
 	var result map[string]string
+	if data == nil || *data == "" {
+		return result
+	}
+	var byteData = []byte(*data)
+
+	_ = json.Unmarshal(byteData, &result)
+	return result
+}
+
+func removeEscapeJSONtoArray(data *string) []map[string]string {
+	var result []map[string]string
 	if data == nil || *data == "" {
 		return result
 	}
@@ -293,8 +304,8 @@ func (suite *MoveHistoryServiceSuite) TestMoveFetcherWithFakeData() {
 			if h.TableName == "mto_service_items" {
 				if *h.ObjectID == updatedServiceItem.ID {
 					if h.Context != nil {
-						context := removeEscapeJSON(h.Context)
-						if context != nil && context["name"] == serviceItem.ReService.Name && context["shipment_type"] == string(serviceItem.MTOShipment.ShipmentType) {
+						context := removeEscapeJSONtoArray(h.Context)
+						if context != nil && context[0]["name"] == serviceItem.ReService.Name && context[0]["shipment_type"] == string(serviceItem.MTOShipment.ShipmentType) {
 							verifyServiceItemStatusContext = true
 						}
 					}

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -102,7 +102,7 @@ export const createStandardServiceItemEvent = buildMoveHistoryEventTemplate({
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',
   getDetailsPlainText: (historyRecord) => {
-    return `${shipmentTypes[historyRecord.context?.shipment_type]} shipment, ${historyRecord.context?.name}`;
+    return `${shipmentTypes[historyRecord.context[0]?.shipment_type]} shipment, ${historyRecord.context[0]?.name}`;
   },
 });
 
@@ -191,7 +191,7 @@ export const updateServiceItemStatusEvent = buildMoveHistoryEventTemplate({
     }
   },
   getDetailsPlainText: (historyRecord) => {
-    return `${shipmentTypes[historyRecord.context?.shipment_type]} shipment, ${historyRecord.context?.name}`;
+    return `${shipmentTypes[historyRecord.context[0]?.shipment_type]} shipment, ${historyRecord.context[0]?.name}`;
   },
 });
 

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -71,10 +71,12 @@ describe('moveHistoryEventTemplate', () => {
   describe('when given a Create standard service item history record', () => {
     const item = {
       action: 'INSERT',
-      context: {
-        shipment_type: 'HHG',
-        name: 'Domestic linehaul',
-      },
+      context: [
+        {
+          shipment_type: 'HHG',
+          name: 'Domestic linehaul',
+        },
+      ],
       eventName: 'approveShipment',
       tableName: 'mto_service_items',
     };
@@ -135,7 +137,7 @@ describe('moveHistoryEventTemplate', () => {
     const item = {
       action: 'UPDATE',
       changedValues: { status: 'APPROVED' },
-      context: { name: 'Domestic origin price', shipment_type: 'HHG_INTO_NTS_DOMESTIC' },
+      context: [{ name: 'Domestic origin price', shipment_type: 'HHG_INTO_NTS_DOMESTIC' }],
       eventName: 'updateMTOServiceItemStatus',
       tableName: 'mto_service_items',
     };

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -2463,9 +2463,11 @@ definitions:
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         x-nullable: true
       context:
-        type: object
-        additionalProperties:
-          type: string
+        type: array
+        items:
+          type: object
+          additionalProperties:
+            type: string
         x-nullable: true
       contextId:
         description: id column for the context table the record belongs to

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -2562,9 +2562,11 @@ definitions:
         pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
         x-nullable: true
       context:
-        type: object
-        additionalProperties:
-          type: string
+        type: array
+        items:
+          type: object
+          additionalProperties:
+            type: string
         x-nullable: true
       contextId:
         description: id column for the context table the record belongs to


### PR DESCRIPTION
## Summary

Because of two different types of context data objects being used, it was causing an issue for the payment_requests ticket. These changes aim to fix it

## How to run the code
1. Go to officelocal:3000/
2. Login as a user 
3. Choose a move with service items to approve
4. Approve them 
5. Make sure the details match the image below

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/84801109/164542007-29d2c559-55d1-4ac4-aede-c2026f3f9af1.png">
