### PR TITLE
[MB-11923] clean dp3 dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch mb-11923-clean-dp3-docker
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -40,22 +40,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch mb-11923-clean-dp3-docker
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch mb-11923-clean-dp3-docker
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch mb-11923-clean-dp3-docker
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch mb-11923-clean-dp3-docker
 
 executors:
   av_medium:

--- a/Dockerfile.dp3
+++ b/Dockerfile.dp3
@@ -1,9 +1,9 @@
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base:latest
 
+#AWS GovCloud RDS cert
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
-COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+
 COPY bin/milmove /bin/milmove
 
 # Demo Environment certs

--- a/Dockerfile.tasks_dp3
+++ b/Dockerfile.tasks_dp3
@@ -10,9 +10,9 @@ COPY config/tls/api.loadtest.dp3.us.chain.der.p7b /config/tls/api.loadtest.dp3.u
 # Exp Environment Certs
 COPY config/tls/api.exp.dp3.us.chain.der.p7b /config/tls/api.exp.dp3.us.chain.der.p7b
 
+#AWS GovCloud RDS cert
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
-COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
+
 COPY bin/milmove-tasks /bin/milmove-tasks
 
 WORKDIR /bin

--- a/Dockerfile.webhook_client_dp3
+++ b/Dockerfile.webhook_client_dp3
@@ -30,9 +30,9 @@ FROM gcr.io/distroless/static:latest
 # Copy DOD certs from the builder.
 COPY --from=builder --chown=root:root /etc/ssl/certs /etc/ssl/certs
 
+#AWS GovCloud RDS cert
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/webhook-client /bin/webhook-client
 
 CMD ["/bin/webhook-client", "webhook-notify"]


### PR DESCRIPTION
## [MB-11923]

## Summary

Now that we've rolled out the RDS cert updates in the dp3 environments, the old certs need to be removed. This PR cleans those certs from the dp3 specific dockerfiles. 