### PR TITLE
[MB-11929] remove expired 2017 RDS cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certi
 
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove
 
 COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -8,7 +8,6 @@ COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/d
 
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove
 COPY bin/generate-test-data /bin/generate-test-data
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -12,7 +12,6 @@ WORKDIR /home/circleci/project
 RUN make clean
 RUN make bin/rds-ca-rsa4096-g1.pem
 RUN make bin/rds-ca-2019-root.pem
-RUN make bin/rds-ca-us-gov-west-1-2017-root.pem
 RUN rm -f pkg/assets/assets.go && make pkg/assets/assets.go
 RUN make server_generate
 RUN rm -f bin/milmove && make bin/milmove
@@ -26,7 +25,6 @@ FROM gcr.io/distroless/base:latest
 
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY --from=builder --chown=root:root /home/circleci/project/bin/milmove /bin/milmove
 
 COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -8,7 +8,6 @@ COPY config/tls/dod-wcf-intermediate-ca-1.pem /usr/local/share/ca-certificates/d
 
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove /bin/milmove
 
 COPY migrations/app/schema /migrate/schema

--- a/Dockerfile.tasks
+++ b/Dockerfile.tasks
@@ -14,7 +14,6 @@ COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certi
 COPY config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b /config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 COPY bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/milmove-tasks /bin/milmove-tasks
 
 WORKDIR /bin

--- a/Dockerfile.webhook_client
+++ b/Dockerfile.webhook_client
@@ -23,7 +23,6 @@ FROM gcr.io/distroless/static:latest
 COPY --from=builder --chown=root:root /etc/ssl/certs /etc/ssl/certs
 
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
-COPY bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 COPY bin/webhook-client /bin/webhook-client
 
 CMD ["/bin/webhook-client", "webhook-notify"]

--- a/Dockerfile.webhook_client_local
+++ b/Dockerfile.webhook_client_local
@@ -17,7 +17,6 @@ COPY --chown=circleci:circleci . /home/circleci/project
 WORKDIR /home/circleci/project
 
 RUN make clean
-RUN make bin/rds-ca-us-gov-west-1-2017-root.pem
 RUN make bin/rds-ca-rsa4096-g1.pem
 
 RUN make bin/webhook-client
@@ -38,7 +37,6 @@ COPY --from=builder --chown=root:root /home/circleci/project/config/tls/devlocal
 
 # Public root certificate for RDS in us-gov-west-1.
 COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
-COPY --from=builder --chown=root:root /home/circleci/project/bin/rds-ca-us-gov-west-1-2017-root.pem /bin/rds-ca-us-gov-west-1-2017-root.pem
 
 # The main webhook-client binary.
 COPY --from=builder --chown=root:root /home/circleci/project/bin/webhook-client /bin/webhook-client

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ setup:
 deps_nix: install_pre_commit deps_shared ## Nix equivalent (kind of) of `deps` target.
 
 .PHONY: deps_shared
-deps_shared: client_deps bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem bin/rds-ca-rsa4096-g1.pem ## install dependencies
+deps_shared: client_deps bin/rds-ca-2019-root.pem bin/rds-ca-rsa4096-g1.pem ## install dependencies
 
 .PHONY: test
 test: client_test server_test e2e_test ## Run all tests
@@ -230,10 +230,6 @@ bin/rds-ca-rsa4096-g1.pem:
 bin/rds-ca-2019-root.pem:
 	mkdir -p bin/
 	curl -sSo bin/rds-ca-2019-root.pem https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem
-
-bin/rds-ca-us-gov-west-1-2017-root.pem:
-	mkdir -p bin/
-	curl -sSo bin/rds-ca-us-gov-west-1-2017-root.pem https://s3.us-gov-west-1.amazonaws.com/rds-downloads/rds-ca-us-gov-west-1-2017-root.pem
 
 ### MilMove Targets
 
@@ -370,7 +366,6 @@ build_tools: bin/gin \
 	bin/mockery \
 	bin/rds-ca-rsa4096-g1.pem \
 	bin/rds-ca-2019-root.pem \
-	bin/rds-ca-us-gov-west-1-2017-root.pem \
 	bin/big-cat \
 	bin/generate-deploy-notes \
 	bin/ecs-deploy \
@@ -396,7 +391,7 @@ build: server_build build_tools client_build ## Build the server, tools, and cli
 # acceptance_test runs a few acceptance tests against a local or remote environment.
 # This can help identify potential errors before deploying a container.
 .PHONY: acceptance_test
-acceptance_test: bin/rds-ca-2019-root.pem bin/rds-ca-us-gov-west-1-2017-root.pem bin/rds-ca-rsa4096-g1.pem ## Run acceptance tests
+acceptance_test: bin/rds-ca-2019-root.pem bin/rds-ca-rsa4096-g1.pem ## Run acceptance tests
 ifndef TEST_ACC_ENV
 	@echo "Running acceptance tests for webserver using local environment."
 	@echo "* Use environment XYZ by setting environment variable to TEST_ACC_ENV=XYZ."

--- a/cmd/milmove/main_test.go
+++ b/cmd/milmove/main_test.go
@@ -149,7 +149,7 @@ func (suite *webServerSuite) patchContext(ctx map[string]string) map[string]stri
 	}
 
 	// Always set the root cert to something on the local system.
-	newValue := filepath.Join(os.Getenv("TEST_ACC_CWD"), "bin/rds-ca-us-gov-west-1-2017-root.pem")
+	newValue := filepath.Join(os.Getenv("TEST_ACC_CWD"), "bin/rds-ca-rsa4096-g1.pem")
 	ctx["DB_SSL_ROOT_CERT"] = newValue
 
 	// Always set the migration path to something on the local system.

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -41,7 +41,6 @@ docker run \
        server_build \
        bin/generate-test-data \
        bin/rds-ca-2019-root.pem \
-       bin/rds-ca-us-gov-west-1-2017-root.pem \
        bin/rds-ca-rsa4096-g1.pem
 docker build -t milmove_e2e:local -f Dockerfile.e2e .
 


### PR DESCRIPTION

## [MB-11929]
## Summary
This is the final step in updating the RDS certificates. This removes all references to the expired 2017 RDS cert. This includes the dockerfiles as well as the main_test.go file. 

[MB-11929]: https://dp3.atlassian.net/browse/MB-11929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ