### PR TITLE
MB-12225 cypress complete ppm entry

### DIFF
--- a/cypress/integration/milmove/ppms/entireShipment.js
+++ b/cypress/integration/milmove/ppms/entireShipment.js
@@ -69,6 +69,7 @@ function navigateHappyPathWithDelete(userId, isMobile = false) {
   submitsAdvancePage(true, isMobile);
   navigateToAgreementAndSign();
   submitMove('@signedCertifications');
+  verifyStep5ExistsAndBtnIsDisabled();
 }
 
 function navigateHappyPathWithEditsAndBacks(userId, isMobile = false) {
@@ -85,7 +86,9 @@ function navigateHappyPathWithEditsAndBacks(userId, isMobile = false) {
   submitsAdvancePage(true, isMobile);
 
   navigateToAgreementAndSign();
+
   submitMove('@signedCertifications');
+  verifyStep5ExistsAndBtnIsDisabled();
 }
 
 // update the form values by submitting and then return to the page to verify if the values persist and then return to the next page
@@ -136,4 +139,11 @@ function verifyShipmentSpecificInfoOnEstimatedIncentivePage() {
 function customerDeletesExistingShipment() {
   cy.get('[data-testid="shipment-list-item-container"]').as('shipmentListContainer');
   deleteShipment('@shipmentListContainer', 0);
+}
+
+function verifyStep5ExistsAndBtnIsDisabled() {
+  cy.get('[data-testid="stepContainer5"]').within(() => {
+    cy.get('button').contains('Upload PPM Documents').should('be.disabled');
+    cy.get('p').contains('After a counselor approves your PPM, you will be able to:');
+  });
 }

--- a/cypress/integration/milmove/ppms/navigateToUploadDocs.js
+++ b/cypress/integration/milmove/ppms/navigateToUploadDocs.js
@@ -33,7 +33,7 @@ describe('PPM Request Payment - Begin providing documents flow', () => {
 function verifyHomePageAfterCounseling() {
   cy.get('h3').should('contain', 'Your move is in progress.');
   cy.get('[data-testid="stepContainer5"]').within(() => {
-    cy.get('p').contains('25 Apr 2022');
+    cy.get('p').contains('15 Apr 2022');
     cy.get('button').contains('Upload PPM Documents').should('be.enabled').click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/shipments\/[^/]+\/about/);

--- a/cypress/integration/milmove/ppms/navigateToUploadDocs.js
+++ b/cypress/integration/milmove/ppms/navigateToUploadDocs.js
@@ -1,0 +1,42 @@
+import { setMobileViewport } from '../../../support/ppmShared';
+
+describe('PPM Request Payment - Begin providing documents flow', () => {
+  before(() => {
+    cy.prepareCustomerApp();
+  });
+
+  beforeEach(() => {
+    cy.intercept('GET', '**/internal/moves/**/mto_shipments').as('getShipment');
+  });
+
+  const viewportType = [
+    { viewport: 'desktop', isMobile: false },
+    { viewport: 'mobile', isMobile: true },
+  ];
+
+  viewportType.forEach(({ viewport, isMobile }) => {
+    it(`has upload documents button enabled - ${viewport}`, () => {
+      if (isMobile) {
+        setMobileViewport();
+      }
+
+      // readyToFinish@ppm.approved
+      const userId = 'cde987a1-a717-4a61-98b5-1f05e2e0844d';
+      cy.apiSignInAsUser(userId);
+      cy.wait('@getShipment');
+
+      verifyHomePageAfterCounseling();
+    });
+  });
+});
+
+function verifyHomePageAfterCounseling() {
+  cy.get('h3').should('contain', 'Your move is in progress.');
+  cy.get('[data-testid="stepContainer5"]').within(() => {
+    cy.get('p').contains('25 Apr 2022');
+    cy.get('button').contains('Upload PPM Documents').should('be.enabled').click();
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/shipments\/[^/]+\/about/);
+    });
+  });
+}

--- a/cypress/integration/mymove/utilities/customer.js
+++ b/cypress/integration/mymove/utilities/customer.js
@@ -146,9 +146,9 @@ export function submitMove(actionToWaitOn) {
     cy.wait(actionToWaitOn);
   }
 
-  cy.get('.usa-alert--success').within(() => {
-    cy.contains('You’ve submitted your move request.');
-  });
+  cy.get('.usa-alert--success').contains('You’ve submitted your move request.');
+
+  cy.get('h3').contains('Next step: Your move gets approved');
 
   // ensure that shipment list doesn't have a button to edit or delete
   cy.get('[data-testid="shipment-list-item-container"] button').should('not.exist');

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -4080,6 +4080,7 @@ func (e e2eBasicScenario) Run(appCtx appcontext.AppContext, userUploader *upload
 	createUnSubmittedMoveWithFullPPMShipment2(appCtx, userUploader)
 	createUnSubmittedMoveWithFullPPMShipment3(appCtx, userUploader)
 	createSubmittedMoveWithPPMShipment(appCtx, userUploader, moveRouter)
+	createApprovedMoveWithPPM(appCtx, userUploader)
 	createNTSMoveWithServiceItemsandPaymentRequests(appCtx, userUploader)
 
 	// TIO

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -850,7 +850,7 @@ func createApprovedMoveWithPPM(appCtx appcontext.AppContext, userUploader *uploa
 		moveLocator: "REAFIN",
 	}
 
-	approvedAt := time.Now()
+	approvedAt := time.Date(2022, 4, 15, 12, 30, 0, 0, time.UTC)
 
 	assertions := testdatagen.Assertions{
 		UserUploader: userUploader,

--- a/src/components/PPMSummaryList/PPMSummaryList.test.jsx
+++ b/src/components/PPMSummaryList/PPMSummaryList.test.jsx
@@ -53,7 +53,6 @@ describe('PPMSummaryList component', () => {
       render(<PPMSummaryList {...props} />);
       expect(screen.queryByText(`PPM approved: 15 Apr 2022.`)).toBeInTheDocument();
     });
-    // QQQQ: Add test for AOA
   });
 
   describe('there is only one shipment', () => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11128) for this change

## Summary

These changes add cypress tests for step 5 (starting the complete PPM flow after service counseling). 

`navigateToUploadDocs.js` starts with a move that has been approved by a counselor.
Minor changes have been made to the `review.js` and `entireShipment.js` flows.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the server locally.

```sh
make server_run
```

##### Terminal 2

Start cypress locally.

```sh
make e2e_test_fresh
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots
![image](https://user-images.githubusercontent.com/84742904/165168587-6b4895e4-e38a-42cd-b945-55000ec9f326.png)
