### PR TITLE
MB-12143 Document when MTO/basic service items are approved

### DIFF
--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -118,7 +118,7 @@ export const createBasicServiceItemEvent = buildMoveHistoryEventTemplate({
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',
   getDetailsPlainText: (historyRecord) => {
-    return `${historyRecord.context?.name}`;
+    return `${historyRecord.context[0]?.name}`;
   },
 });
 

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -72,9 +72,11 @@ describe('moveHistoryEventTemplate', () => {
   describe('when given a Create basic service item history record', () => {
     const item = {
       action: 'INSERT',
-      context: {
-        name: 'Domestic linehaul',
-      },
+      context: [
+        {
+          name: 'Move management',
+        },
+      ],
       eventName: 'updateMoveTaskOrderStatus',
       tableName: 'mto_service_items',
     };
@@ -82,7 +84,7 @@ describe('moveHistoryEventTemplate', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(createBasicServiceItemEvent);
       expect(result.getEventNameDisplay(result)).toEqual('Approved service item');
-      expect(result.getDetailsPlainText(item)).toEqual('Domestic linehaul');
+      expect(result.getDetailsPlainText(item)).toEqual('Move management');
     });
   });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12143) for this change

## Summary

This PR addresses mto/basic service times to be shown in the move history log page after approving a shipment and mto/basic service item(s).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app http://officelocal:3000
2. Login as a TOO role
3. Filter moves by status column using `New move`
4. Click on any new move
5. Select a shipment and mto/basic service items (Move management and Counseling)
6. Approve selected items. You may have to update fields on the orders before being able to approve.
7. Check move history page
8. Should be able to see that mto/basic service items have been approved 🎉 

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
<img width="1456" alt="Screen Shot 2022-04-25 at 2 17 24 PM" src="https://user-images.githubusercontent.com/1522549/165176625-e6b59477-98d0-48a6-973c-65d0367641d8.png">
