### PR TITLE
MB-12260 - update language of warnings for estimated pro gear weights

### DIFF
--- a/src/components/Customer/PPMBooking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
+++ b/src/components/Customer/PPMBooking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
@@ -28,12 +28,10 @@ const validationSchema = Yup.object().shape({
       then: (schema) =>
         schema
           .required(`Enter a weight into at least one pro-gear field. If you won't have pro-gear, select No above.`)
-          .max(2000, 'Enter a weight less than 2,000 lbs'),
-      otherwise: Yup.number().min(0, 'Enter a weight 0lbs or greater').max(2000, 'Enter a weight less than 2,000 lbs'),
+          .max(2000, 'Enter a weight 2,000 lbs or less'),
+      otherwise: Yup.number().min(0, 'Enter a weight 0lbs or greater').max(2000, 'Enter a weight 2,000 lbs or less'),
     }),
-  spouseProGearWeight: Yup.number()
-    .min(0, 'Enter a weight 0lbs or greater')
-    .max(500, 'Enter a weight less than 500 lbs'),
+  spouseProGearWeight: Yup.number().min(0, 'Enter a weight 0lbs or greater').max(500, 'Enter a weight 500 lbs or less'),
 });
 
 const EstimatedWeightsProGearForm = ({ orders, serviceMember, mtoShipment, onSubmit, onBack }) => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12260) for this change

## Summary

This PR updates the language of the error messages for when the estimated pro gear and spouse progear values are exceeded

- Pro Gear: Enter a weight 2,000 lbs or less
- Spouse Pro Gear: Enter a weight 500 lbs or less

NOTE: this PR addresses the spouse progear language which fulfills the AC for https://dp3.atlassian.net/browse/MB-12261 

## Setup to Run Your Code
You can test this either via storybook
- `make storybook` and navigating to the customer components --> PPM Booking --> Estimated Weights

Or by running locally 
- `make server_run client_run` 
- And selecting a ppm user such as `estimated_weights@ppm.unsubmitted`



## Screenshots
<img width="572" alt="Screen Shot 2022-04-26 at 3 19 43 PM" src="https://user-images.githubusercontent.com/67110378/165377305-aac356e6-3c9e-4fb9-bd20-0ed5ffb45743.png">
<img width="568" alt="Screen Shot 2022-04-26 at 3 19 54 PM" src="https://user-images.githubusercontent.com/67110378/165377308-60aff5a3-4458-47cd-98f9-ad193d9f82ab.png">
<img width="328" alt="Screen Shot 2022-04-26 at 3 20 15 PM" src="https://user-images.githubusercontent.com/67110378/165377313-2e7702ea-67e7-410b-831d-ae061da4b0e6.png">
<img width="300" alt="Screen Shot 2022-04-26 at 3 20 04 PM" src="https://user-images.githubusercontent.com/67110378/165377310-80cf841e-304f-4b89-9528-fc78f89ebcce.png">

