### PR TITLE
MB-12019 create move history record for too reweigh request

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -721,3 +721,4 @@
 20220412203950_create_move_history_trigger_for_entitlements.up.sql
 20220418182209_remove_access_code.up.sql
 20220420162556_create_indexes_for_mto_shipments_deleted_at.up.sql
+20220425211936_create_move_history_triggers_for_reweighs.up.sql

--- a/migrations/app/schema/20220425211936_create_move_history_triggers_for_reweighs.up.sql
+++ b/migrations/app/schema/20220425211936_create_move_history_triggers_for_reweighs.up.sql
@@ -1,0 +1,1 @@
+SELECT add_audit_history_table(target_table := 'reweighs', audit_rows := BOOLEAN 't', audit_query_text := BOOLEAN 't', ignored_cols := ARRAY['created_at', 'updated_at']);

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -157,6 +157,17 @@ export const requestShipmentDiversionEvent = buildMoveHistoryEventTemplate({
   },
 });
 
+export const requestShipmentReweighEvent = buildMoveHistoryEventTemplate({
+  action: 'INSERT',
+  eventName: moveHistoryOperations.requestShipmentReweigh,
+  tableName: 'reweighs',
+  detailsType: detailsTypes.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Updated shipment',
+  getDetailsPlainText: (historyRecord) => {
+    return `${shipmentTypes[historyRecord.context[0]?.shipment_type]} shipment, reweigh requested`;
+  },
+});
+
 export const setFinancialReviewFlagEvent = buildMoveHistoryEventTemplate({
   action: 'UPDATE',
   eventName: moveHistoryOperations.setFinancialReviewFlag,
@@ -279,6 +290,7 @@ const allMoveHistoryEventTemplates = [
   createStandardServiceItemEvent,
   requestShipmentCancellationEvent,
   requestShipmentDiversionEvent,
+  requestShipmentReweighEvent,
   setFinancialReviewFlagEvent,
   submitMoveForApprovalEvent,
   updateMoveTaskOrderEvent,

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -11,6 +11,7 @@ const {
   createStandardServiceItemEvent,
   createBasicServiceItemEvent,
   updateOrderEvent,
+  requestShipmentReweighEvent,
 } = require('./moveHistoryEventTemplate');
 
 const { detailsTypes } = require('constants/moveHistoryEventTemplate');
@@ -125,6 +126,20 @@ describe('moveHistoryEventTemplate', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(requestShipmentCancellationEvent);
       expect(result.getDetailsPlainText(item)).toEqual('Requested cancellation for PPM shipment');
+    });
+  });
+
+  describe('when given a Request shipment reweigh history record', () => {
+    const item = {
+      action: 'INSERT',
+      context: [{ shipment_type: 'HHG' }],
+      eventName: 'requestShipmentReweigh',
+      tableName: 'reweighs',
+    };
+    it('correctly matches the Request shipment reweigh event', () => {
+      const result = getMoveHistoryEventTemplate(item);
+      expect(result).toEqual(requestShipmentReweighEvent);
+      expect(result.getDetailsPlainText(item)).toEqual('HHG shipment, reweigh requested');
     });
   });
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12019) for this change

## Summary

This PR should introduce support for displaying TOO reweigh request events in the move history.
This includes a database migration to add triggers to the reweighs table, an update to the move_history_fetcher to include the reweigh records, and a front end event template to support identifying and displaying reweigh request events.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a TOO
3. Find a move that has the option for a reweigh request (e.g. locator PENDNG)
4. Navigate to the 'Move task order' tab and click the 'Request reweigh' button located in the 'Shipment weight' section
5. Navigate to the 'Move history' tab and verify that a record is created for the reweigh request and that it is displayed per the story requirements.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [x] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/97245917/165398030-41585d8a-b21f-4cad-a577-95e487f95b39.png">
