### PR TITLE
MB-12208 refactor payment request validation per new pattern

### DIFF
--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -83,7 +83,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 				return paymentrequestop.NewCreatePaymentRequestUnprocessableEntity().WithPayload(errPayload), err
 			}
 
-			createdPaymentRequest, err := h.PaymentRequestCreator.CreatePaymentRequest(appCtx, &paymentRequest)
+			createdPaymentRequest, err := h.PaymentRequestCreator.CreatePaymentRequestCheck(appCtx, &paymentRequest)
 			if err != nil {
 				appCtx.Logger().Error("Error creating payment request", zap.Error(err))
 				switch e := err.(type) {

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -101,7 +101,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		req = suite.AuthenticateUserRequest(req, subtestData.requestUser)
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.MatchedBy(func(paymentRequest *models.PaymentRequest) bool {
 				// Making sure the service items are ordered by priority regardless of the order in which they come in through the payment request parameters
@@ -160,7 +160,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		}
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
@@ -210,7 +210,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		}
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&returnedPaymentRequest, nil).Once()
 
@@ -249,7 +249,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
@@ -273,7 +273,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		subtestData := suite.makeCreatePaymentRequestHandlerSubtestData()
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, errors.New("creator failed")).Once()
 
@@ -306,7 +306,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		subtestData := suite.makeCreatePaymentRequestHandlerSubtestData()
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
@@ -335,7 +335,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		subtestData := suite.makeCreatePaymentRequestHandlerSubtestData()
 
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(&models.PaymentRequest{}, nil).Once()
 
@@ -377,7 +377,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		err := apperror.NewInvalidCreateInputError(verrs, "can't create payment request for MTO ID 1234")
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
 
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
@@ -416,7 +416,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 		ordersID, _ := uuid.FromString("2b8b141a-7c44-45f2-9114-bb0831cc5db3")
 		err := apperror.NewConflictError(ordersID, "incomplete orders")
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 
@@ -454,7 +454,7 @@ func (suite *HandlerSuite) TestCreatePaymentRequestHandler() {
 
 		err := apperror.NewBadDataError("sent some bad data, foo!")
 		paymentRequestCreator := &mocks.PaymentRequestCreator{}
-		paymentRequestCreator.On("CreatePaymentRequest",
+		paymentRequestCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest")).Return(nil, err).Once()
 

--- a/pkg/services/mocks/PaymentRequestCreator.go
+++ b/pkg/services/mocks/PaymentRequestCreator.go
@@ -15,7 +15,7 @@ type PaymentRequestCreator struct {
 }
 
 // CreatePaymentRequest provides a mock function with given fields: appCtx, paymentRequest
-func (_m *PaymentRequestCreator) CreatePaymentRequest(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest) (*models.PaymentRequest, error) {
+func (_m *PaymentRequestCreator) CreatePaymentRequestCheck(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest) (*models.PaymentRequest, error) {
 	ret := _m.Called(appCtx, paymentRequest)
 
 	var r0 *models.PaymentRequest

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -13,7 +13,7 @@ import (
 // PaymentRequestCreator is the exported interface for creating a payment request
 //go:generate mockery --name PaymentRequestCreator --disable-version-string
 type PaymentRequestCreator interface {
-	CreatePaymentRequest(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest) (*models.PaymentRequest, error)
+	CreatePaymentRequestCheck(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest) (*models.PaymentRequest, error)
 }
 
 // PaymentRequestRecalculator is the exported interface for recalculating a payment request

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -237,7 +237,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		paymentRequestReturn, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		paymentRequestReturn, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.FatalNoError(err)
 
 		expectedSequenceNumber := 1
@@ -305,7 +305,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.FatalNoError(err)
 
 		// Verify some of the data that came back
@@ -351,7 +351,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		paymentRequestResult, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		paymentRequestResult, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.FatalNoError(err)
 
 		// Verify some of the data that came back
@@ -403,7 +403,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		paymentRequestResult, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		paymentRequestResult, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.Error(err)
 		suite.IsType(apperror.ConflictError{}, err)
 		suite.Contains(err.Error(), "paymentRequestCreator.validShipment: Shipment uses external vendor for MTOShipmentID")
@@ -443,7 +443,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 		).Return(0, nil)
 		failingCreator := NewPaymentRequestCreator(planner, failingServiceItemPricer)
 
-		_, err := failingCreator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		_, err := failingCreator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.Error(err)
 		wrappedErr := errors.Unwrap(err)
 		suite.Equal(errMsg, wrappedErr.Error())
@@ -455,7 +455,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			MoveTaskOrderID: badID,
 			IsFinal:         false,
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &invalidPaymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &invalidPaymentRequest)
 
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
@@ -467,7 +467,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			MoveTaskOrderID: uuid.Nil,
 			IsFinal:         false,
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &invalidPaymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &invalidPaymentRequest)
 
 		suite.Error(err)
 		suite.IsType(apperror.InvalidCreateInputError{}, err)
@@ -540,7 +540,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			paymentRequest := models.PaymentRequest{
 				MoveTaskOrderID: mtoInvalid.ID,
 			}
-			_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+			_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 
 			suite.Error(err)
 			suite.IsType(testData.ExpectedError, err)
@@ -694,7 +694,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			paymentRequest := models.PaymentRequest{
 				MoveTaskOrderID: mtoInvalid.ID,
 			}
-			_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+			_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 
 			suite.Error(err)
 			suite.IsType(testData.ExpectedError, err)
@@ -713,7 +713,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &invalidPaymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &invalidPaymentRequest)
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
 		suite.Equal(fmt.Sprintf("ID: %s not found for MTO Service Item", badID), err.Error())
@@ -737,7 +737,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &invalidPaymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &invalidPaymentRequest)
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
 		suite.Equal(fmt.Sprintf("ID: %s not found Service Item Param Key ID", badID), err.Error())
@@ -760,7 +760,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &invalidPaymentRequest)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &invalidPaymentRequest)
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
 		suite.Equal("Not found Service Item Param Key bogus: FETCH_NOT_FOUND", err.Error())
@@ -789,7 +789,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err = creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest1)
+		_, err = creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest1)
 		suite.FatalNoError(err)
 
 		paymentRequest2 := models.PaymentRequest{
@@ -808,7 +808,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err = creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest2)
+		_, err = creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest2)
 		suite.FatalNoError(err)
 
 		// Verify expected payment request numbers
@@ -846,7 +846,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest1)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest1)
 		suite.Contains(err.Error(), "has missing ReferenceID")
 
 		moveTaskOrder.ReferenceID = &saveReferenceID
@@ -884,7 +884,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest1)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest1)
 		suite.FatalNoError(err)
 		paymentRequest2 := models.PaymentRequest{
 			MoveTaskOrderID: moveTaskOrder.ID,
@@ -917,7 +917,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		_, err = creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest2)
+		_, err = creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest2)
 		suite.Error(err)
 		suite.IsType(apperror.InvalidInputError{}, err)
 		suite.Contains(err.Error(), "final PaymentRequest has already been submitted")
@@ -959,7 +959,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest1)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest1)
 		suite.FatalNoError(err)
 
 		paymentRequest1.Status = models.PaymentRequestStatusReviewedAllRejected
@@ -996,7 +996,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		_, err = creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest2)
+		_, err = creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest2)
 		suite.NoError(err)
 
 		paymentRequest1.IsFinal = false
@@ -1027,7 +1027,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 				},
 			},
 		}
-		_, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest1)
+		_, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest1)
 		suite.Contains(err.Error(), "has missing ReferenceID")
 
 		moveTaskOrder.ReferenceID = &saveReferenceID
@@ -1046,7 +1046,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 			},
 		}
 
-		paymentRequestReturn, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequest)
+		paymentRequestReturn, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequest)
 		suite.FatalNoError(err)
 		suite.NotEqual(paymentRequestReturn.ID, uuid.Nil)
 		suite.Equal(1, len(paymentRequestReturn.PaymentServiceItems), "PaymentServiceItems expect 1")
@@ -1060,7 +1060,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequest() {
 	})
 }
 
-func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequestOnNTSRelease() {
+func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequestCheckOnNTSRelease() {
 	testStorageFacilityZip := "30907"
 	testDestinationZip := "78234"
 	testEscalationCompounded := 1.04071
@@ -1171,7 +1171,7 @@ func (suite *PaymentRequestServiceSuite) TestCreatePaymentRequestOnNTSRelease() 
 
 	// Create an initial payment request.
 	creator := NewPaymentRequestCreator(mockPlanner, ghcrateengine.NewServiceItemPricer())
-	paymentRequest, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequestArg)
+	paymentRequest, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequestArg)
 	suite.FatalNoError(err)
 
 	// Make sure we have just the DLH payment service item

--- a/pkg/services/payment_request/payment_request_recalculator.go
+++ b/pkg/services/payment_request/payment_request_recalculator.go
@@ -85,7 +85,7 @@ func (p *paymentRequestRecalculator) doRecalculate(appCtx appcontext.AppContext,
 	if err != nil {
 		return nil, err
 	}
-	newPaymentRequest, err := p.paymentRequestCreator.CreatePaymentRequest(appCtx, &inputPaymentRequest)
+	newPaymentRequest, err := p.paymentRequestCreator.CreatePaymentRequestCheck(appCtx, &inputPaymentRequest)
 	if err != nil {
 		return nil, err // Just pass the error type from the PaymentRequestCreator.
 	}

--- a/pkg/services/payment_request/payment_request_recalculator_test.go
+++ b/pkg/services/payment_request/payment_request_recalculator_test.go
@@ -62,7 +62,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestSuccess() 
 
 	// Create an initial payment request.
 	creator := NewPaymentRequestCreator(mockPlanner, ghcrateengine.NewServiceItemPricer())
-	paymentRequest, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequestArg)
+	paymentRequest, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequestArg)
 	suite.FatalNoError(err)
 
 	// Add a few proof of service docs and prime uploads.
@@ -335,7 +335,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculatePaymentRequestErrors() {
 		// Mock out a creator.
 		errString := "mock creator test error"
 		mockCreator := &mocks.PaymentRequestCreator{}
-		mockCreator.On("CreatePaymentRequest",
+		mockCreator.On("CreatePaymentRequestCheck",
 			mock.AnythingOfType("*appcontext.appContext"),
 			mock.AnythingOfType("*models.PaymentRequest"),
 		).Return(nil, errors.New(errString))

--- a/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
+++ b/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
@@ -36,7 +36,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculateShipmentPaymentRequestSu
 	creator := NewPaymentRequestCreator(mockPlanner, ghcrateengine.NewServiceItemPricer())
 
 	// Payment Request 1
-	paymentRequest1, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequestArg)
+	paymentRequest1, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequestArg)
 	suite.FatalNoError(err)
 
 	// Add a couple of proof of service docs and prime uploads.
@@ -64,7 +64,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculateShipmentPaymentRequestSu
 	// Create additional payment request for same shipment
 	// Payment Request 2
 	var paymentRequest2 *models.PaymentRequest
-	paymentRequest2, err = creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequestArg2)
+	paymentRequest2, err = creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequestArg2)
 	suite.FatalNoError(err)
 
 	// Add a couple of proof of service docs and prime uploads.
@@ -148,7 +148,7 @@ func (suite *PaymentRequestServiceSuite) TestRecalculateShipmentPaymentRequestEr
 	// Setup baseline move/shipment/service items data along with needed rate data.
 	_ /*move*/, paymentRequestArg := suite.setupRecalculateData1()
 
-	paidPaymentRequest, err := creator.CreatePaymentRequest(suite.AppContextForTest(), &paymentRequestArg)
+	paidPaymentRequest, err := creator.CreatePaymentRequestCheck(suite.AppContextForTest(), &paymentRequestArg)
 	suite.FatalNoError(err)
 
 	suite.T().Run("Fail to find shipment ID", func(t *testing.T) {

--- a/pkg/services/payment_request/rules.go
+++ b/pkg/services/payment_request/rules.go
@@ -1,0 +1,22 @@
+package paymentrequest
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// verify that the MoveTaskOrderID on the payment request is not a nil uuid
+func checkMTOIDField() paymentRequestValidator {
+	return paymentRequestValidatorFunc(func(_ appcontext.AppContext, paymentRequest models.PaymentRequest, oldPaymentRequest *models.PaymentRequest) error {
+		// Verify that the MTO ID exists
+		if paymentRequest.MoveTaskOrderID == uuid.Nil {
+			return apperror.NewInvalidCreateInputError(nil, "Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create")
+		}
+
+		return nil
+	})
+}

--- a/pkg/services/payment_request/rules_test.go
+++ b/pkg/services/payment_request/rules_test.go
@@ -1,0 +1,43 @@
+package paymentrequest
+
+import (
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *PaymentRequestServiceSuite) TestValidationRules() {
+
+	suite.Run("checkMTOIDField", func() {
+
+		suite.Run("success", func() {
+
+			move := testdatagen.MakeDefaultMove(suite.DB())
+			paymentRequest := models.PaymentRequest{
+				MoveTaskOrderID: move.ID,
+			}
+
+			err := checkMTOIDField().Validate(suite.AppContextForTest(), paymentRequest, nil)
+			suite.NoError(err)
+		})
+
+		suite.Run("failure", func() {
+
+			paymentRequest := models.PaymentRequest{
+				MoveTaskOrderID: uuid.Must(uuid.FromString("00000000-0000-0000-0000-000000000000")),
+			}
+
+			err := checkMTOIDField().Validate(suite.AppContextForTest(), paymentRequest, nil)
+			switch err.(type) {
+			case apperror.InvalidCreateInputError:
+				suite.Equal(err.Error(), "Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create")
+			default:
+				suite.Failf("expected *apperror.InvalidCreateInputError", "%v", err)
+			}
+		})
+
+	})
+
+}

--- a/pkg/services/payment_request/validation.go
+++ b/pkg/services/payment_request/validation.go
@@ -1,0 +1,42 @@
+package paymentrequest
+
+import (
+	"github.com/gobuffalo/validate/v3"
+
+	"github.com/transcom/mymove/pkg/apperror"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+type paymentRequestValidator interface {
+	Validate(appCtx appcontext.AppContext, newPaymentRequest models.PaymentRequest, oldPaymentRequest *models.PaymentRequest) error
+}
+
+func validatePaymentRequest(appCtx appcontext.AppContext, newPaymentRequest models.PaymentRequest, oldPaymentRequest *models.PaymentRequest, checks ...paymentRequestValidator) (result error) {
+	verrs := validate.NewErrors()
+	for _, checker := range checks {
+		if err := checker.Validate(appCtx, newPaymentRequest, oldPaymentRequest); err != nil {
+			switch e := err.(type) {
+			case *validate.Errors:
+				// accumulate validation errors
+				verrs.Append(e)
+			default:
+				// non-validation errors have priority,
+				// and short-circuit doing any further checks
+				return err
+			}
+		}
+	}
+	if verrs.HasAny() {
+		result = apperror.NewInvalidInputError(newPaymentRequest.ID, nil, verrs, "Invalid input found while validating the payment request.")
+	}
+	return result
+}
+
+type paymentRequestValidatorFunc func(appcontext.AppContext, models.PaymentRequest, *models.PaymentRequest) error
+
+func (fn paymentRequestValidatorFunc) Validate(appCtx appcontext.AppContext, newPaymentRequest models.PaymentRequest, oldPaymentRequest *models.PaymentRequest) error {
+	return fn(appCtx, newPaymentRequest, oldPaymentRequest)
+}

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -2114,7 +2114,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 	}
 
 	paymentRequest.PaymentServiceItems = paymentServiceItems
-	newPaymentRequest, createErr := paymentRequestCreator.CreatePaymentRequest(appCtx, &paymentRequest)
+	newPaymentRequest, createErr := paymentRequestCreator.CreatePaymentRequestCheck(appCtx, &paymentRequest)
 
 	if createErr != nil {
 		logger.Fatal("Error creating payment request", zap.Error(createErr))


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12208) for this change

## Summary

This change done in this PR is very minor and a bit silly, it simply refactors out a single validation check from the payment request service. However, I think this change is still worthwhile as it sets up our [preferred validation pattern](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/service-validation/#the-pattern) for the payment requests service. If we ever add additional validation we have all the files (rules.go, validation.go) and patterns in place to just drop in more validation. Also, it let me write tests to explicitly test the validation that was being done for a payment request (checking the MTOID was not a null uuid). 

Note: There are other types of validation done in payment request that are not validation the payment request itself. I flirted with pulling these out into rules.go as well but it ended up being pretty gross and required abusing the intent of the new validation pattern a bit.

This is the pattern that was put into place: https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/service-validation/#the-pattern


## Verification Steps for Reviewers

These are to be checked by a reviewer.

- [ ] The payment-requests endpoint works as expected when a valid moveTaskOrderID is provided:
```
{
    "moveTaskOrderID": "91086334-b9a4-457e-8314-bad944531713",
    "serviceItems": [
        {
            "id": "3f1d996d-816d-4f29-9c4c-343b73393eb3"
        }
    ]
}
```
<img width="1296" alt="Screen Shot 2022-04-27 at 8 05 17 AM" src="https://user-images.githubusercontent.com/62263329/165537174-a239bd8a-a115-4f95-a9b2-d1878bcde830.png">

- [ ] The payment-requests endpoint returns an error when the nil uuid is provided:
```
{
    "moveTaskOrderID": "00000000-0000-0000-0000-000000000000",
    "serviceItems": [
        {
            "id": "3f1d996d-816d-4f29-9c4c-343b73393eb3"
        }
    ]
}
```
Error should have message: "Invalid Create Input Error: MoveTaskOrderID is required on PaymentRequest create"

