### PR TITLE
MB-12307 Convert supportapi tests to run within a transaction

### DIFF
--- a/pkg/handlers/supportapi/api_test.go
+++ b/pkg/handlers/supportapi/api_test.go
@@ -17,8 +17,8 @@ type HandlerSuite struct {
 }
 
 // AfterTest completes tests by trying to close open files
-func (suite *HandlerSuite) AfterTest() {
-	for _, file := range suite.TestFilesToClose() {
+func (hs *HandlerSuite) AfterTest() {
+	for _, file := range hs.TestFilesToClose() {
 		//RA Summary: gosec - errcheck - Unchecked return value
 		//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
 		//RA: Functions with unchecked return values in the file are used to close a local server connection to ensure a unit test server is not left running indefinitely

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -2,7 +2,6 @@ package supportapi
 
 import (
 	"net/http/httptest"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -66,7 +65,6 @@ func (suite *HandlerSuite) TestListMTOsHandler() {
 	listMTOsPayload := listMTOsResponse.Payload
 
 	suite.Equal(2, len(listMTOsPayload))
-
 }
 
 func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
@@ -76,7 +74,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.Logger())
 
-	suite.T().Run("successfully hide fake moves", func(t *testing.T) {
+	suite.Run("successfully hide fake moves", func() {
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
 			context,
 			movetaskorder.NewMoveTaskOrderHider(),
@@ -99,7 +97,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		}
 	})
 
-	suite.T().Run("unsuccessfully hide fake moves", func(t *testing.T) {
+	suite.Run("unsuccessfully hide fake moves", func() {
 		var moves models.Moves
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 		moves = append(moves, move)
@@ -125,7 +123,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		suite.IsType(movetaskorderops.NewHideNonFakeMoveTaskOrdersInternalServerError(), response)
 	})
 
-	suite.T().Run("Do not include mto in payload when it's missing a contractor id", func(t *testing.T) {
+	suite.Run("Do not include mto in payload when it's missing a contractor id", func() {
 		var moves models.Moves
 		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 		mto.ContractorID = nil
@@ -231,55 +229,62 @@ func (suite *HandlerSuite) moveTaskOrderPopulated(response *movetaskorderops.Cre
 }
 
 func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
+	setupTestData := func() (models.DutyLocation, models.DutyLocation, models.ServiceMember, *supportmessages.MoveTaskOrder) {
+		// Create the objects that are already in the db
+		destinationDutyLocation := testdatagen.MakeDefaultDutyLocation(suite.DB())
+		originDutyLocation := testdatagen.MakeDefaultDutyLocation(suite.DB())
+		customer := testdatagen.MakeDefaultServiceMember(suite.DB())
+		contractor := testdatagen.MakeDefaultContractor(suite.DB())
+		document := testdatagen.MakeDefaultDocument(suite.DB())
 
-	// Create the objects that are already in the db
-	destinationDutyLocation := testdatagen.MakeDefaultDutyLocation(suite.DB())
-	originDutyLocation := testdatagen.MakeDefaultDutyLocation(suite.DB())
-	dbCustomer := testdatagen.MakeDefaultServiceMember(suite.DB())
-	contractor := testdatagen.MakeDefaultContractor(suite.DB())
-	document := testdatagen.MakeDefaultDocument(suite.DB())
+		// Create the mto payload we will be requesting to create
+		issueDate := swag.Time(time.Now())
+		reportByDate := swag.Time(time.Now().AddDate(0, 0, -1))
+		ordersTypedetail := supportmessages.OrdersTypeDetailHHGPERMITTED
+		deptIndicator := supportmessages.DeptIndicatorAIRFORCE
+		selectedMoveType := supportmessages.SelectedMoveTypeHHG
 
-	// Create the mto payload we will be requesting to create
-	issueDate := swag.Time(time.Now())
-	reportByDate := swag.Time(time.Now().AddDate(0, 0, -1))
-	ordersTypedetail := supportmessages.OrdersTypeDetailHHGPERMITTED
-	deptIndicator := supportmessages.DeptIndicatorAIRFORCE
-	selectedMoveType := supportmessages.SelectedMoveTypeHHG
-
-	rank := (supportmessages.Rank)("E_6")
-	mtoPayload := &supportmessages.MoveTaskOrder{
-		PpmType:          "FULL",
-		SelectedMoveType: &selectedMoveType,
-		ContractorID:     handlers.FmtUUID(contractor.ID),
-		Order: &supportmessages.Order{
-			Rank:                      &rank,
-			OrderNumber:               swag.String("4554"),
-			DestinationDutyLocationID: handlers.FmtUUID(destinationDutyLocation.ID),
-			OriginDutyLocationID:      handlers.FmtUUID(originDutyLocation.ID),
-			Entitlement: &supportmessages.Entitlement{
-				DependentsAuthorized: swag.Bool(true),
-				TotalDependents:      5,
-				NonTemporaryStorage:  swag.Bool(false),
+		rank := (supportmessages.Rank)("E_6")
+		mtoPayload := &supportmessages.MoveTaskOrder{
+			PpmType:          "FULL",
+			SelectedMoveType: &selectedMoveType,
+			ContractorID:     handlers.FmtUUID(contractor.ID),
+			Order: &supportmessages.Order{
+				Rank:                      &rank,
+				OrderNumber:               swag.String("4554"),
+				DestinationDutyLocationID: handlers.FmtUUID(destinationDutyLocation.ID),
+				OriginDutyLocationID:      handlers.FmtUUID(originDutyLocation.ID),
+				Entitlement: &supportmessages.Entitlement{
+					DependentsAuthorized: swag.Bool(true),
+					TotalDependents:      5,
+					NonTemporaryStorage:  swag.Bool(false),
+				},
+				IssueDate:           handlers.FmtDatePtr(issueDate),
+				ReportByDate:        handlers.FmtDatePtr(reportByDate),
+				OrdersType:          supportmessages.NewOrdersType("PERMANENT_CHANGE_OF_STATION"),
+				OrdersTypeDetail:    &ordersTypedetail,
+				UploadedOrdersID:    handlers.FmtUUID(document.ID),
+				Status:              supportmessages.NewOrdersStatus(supportmessages.OrdersStatusDRAFT),
+				Tac:                 swag.String("E19A"),
+				DepartmentIndicator: &deptIndicator,
 			},
-			IssueDate:           handlers.FmtDatePtr(issueDate),
-			ReportByDate:        handlers.FmtDatePtr(reportByDate),
-			OrdersType:          supportmessages.NewOrdersType("PERMANENT_CHANGE_OF_STATION"),
-			OrdersTypeDetail:    &ordersTypedetail,
-			UploadedOrdersID:    handlers.FmtUUID(document.ID),
-			Status:              supportmessages.NewOrdersStatus(supportmessages.OrdersStatusDRAFT),
-			Tac:                 swag.String("E19A"),
-			DepartmentIndicator: &deptIndicator,
-		},
+		}
+		// We only provide an existing customerID not the whole object.
+		// We expect the handler to link the correct objects
+		mtoPayload.Order.CustomerID = handlers.FmtUUID(customer.ID)
+		return destinationDutyLocation, originDutyLocation, customer, mtoPayload
 	}
 
-	// Create the handler object
+	setupHandler := func() CreateMoveTaskOrderHandler {
+		return CreateMoveTaskOrderHandler{
+			handlers.NewHandlerContext(suite.DB(), suite.Logger()),
+			internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
+		}
+	}
+
 	request := httptest.NewRequest("POST", "/move-task-orders", nil)
-	context := handlers.NewHandlerContext(suite.DB(), suite.Logger())
-	handler := CreateMoveTaskOrderHandler{context,
-		internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
-	}
 
-	suite.T().Run("Successful createMoveTaskOrder 201", func(t *testing.T) {
+	suite.Run("Successful createMoveTaskOrder 201", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Mocked:     None
@@ -288,10 +293,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Expected outcome:
 		//             New MTO and orders are created. Customer data and duty location data are pulled in.
 		//			   Status should be default value which is DRAFT
-
-		// We only provide an existing customerID not the whole object.
-		// We expect the handler to link the correct objects
-		mtoPayload.Order.CustomerID = handlers.FmtUUID(dbCustomer.ID)
+		destinationDutyLocation, originDutyLocation, customer, mtoPayload := setupTestData()
 
 		params := movetaskorderops.CreateMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -299,7 +301,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		}
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
@@ -311,40 +313,34 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Check that moveTaskOrder was populated, including nested objects
 		suite.moveTaskOrderPopulated(moveTaskOrdersResponse, &destinationDutyLocation, &originDutyLocation)
 		// Check that customer name matches the DB
-		suite.Equal(dbCustomer.FirstName, responsePayload.Order.Customer.FirstName)
+		suite.Equal(customer.FirstName, responsePayload.Order.Customer.FirstName)
 		// Check that status has defaulted to DRAFT
 		suite.Equal(models.MoveStatusDRAFT, (models.MoveStatus)(responsePayload.Status))
 		// Check that SelectedMoveType was set
 		suite.Equal(string(models.SelectedMoveTypeHHG), string(*responsePayload.SelectedMoveType))
 	})
 
-	suite.T().Run("Successful integration test with createMoveTaskOrder", func(t *testing.T) {
+	suite.Run("Successful integration test with createMoveTaskOrder", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Mocked:     None
 		// Set up:     We successfully create a new MTO, and then test that this move can be successfully approved.
 		// Expected outcome:
 		//             New MTO and orders are created. MTO can be approved and marked as available to Prime.
-
-		// Let's copy the default mtoPayload so we don't affect the other tests:
-		integrationMTO := *mtoPayload
+		_, _, _, integrationMTO := setupTestData()
 
 		// We have to set the status for the orders to APPROVED and the move to SUBMITTED so that we can try to approve
 		// this move later on. We can't approve a DRAFT move.
 		integrationMTO.Status = supportmessages.MoveStatusSUBMITTED
 		integrationMTO.Order.Status = supportmessages.NewOrdersStatus(supportmessages.OrdersStatusAPPROVED)
 
-		// We only provide an existing customerID not the whole object.
-		// We expect the handler to link the correct objects
-		integrationMTO.Order.CustomerID = handlers.FmtUUID(dbCustomer.ID)
-
 		params := movetaskorderops.CreateMoveTaskOrderParams{
 			HTTPRequest: request,
-			Body:        &integrationMTO,
+			Body:        integrationMTO,
 		}
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
@@ -366,7 +362,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		siCreator := mtoserviceitem.NewMTOServiceItemCreator(queryBuilder, moveRouter)
 
 		// Submit the request to approve the MTO
-		approvalHandler := MakeMoveTaskOrderAvailableHandlerFunc{context,
+		approvalHandler := MakeMoveTaskOrderAvailableHandlerFunc{handlers.NewHandlerContext(suite.DB(), suite.Logger()),
 			movetaskorder.NewMoveTaskOrderUpdater(queryBuilder, siCreator, moveRouter),
 		}
 		approvalResponse := approvalHandler.Handle(approvalParams)
@@ -382,7 +378,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		suite.Equal(string(approvedMTO.Status), string(models.MoveStatusAPPROVED))
 	})
 
-	suite.T().Run("Successful createMoveTaskOrder 201 with canceled status", func(t *testing.T) {
+	suite.Run("Successful createMoveTaskOrder 201 with canceled status", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Mocked:     None
@@ -392,9 +388,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Expected outcome:
 		//             New MTO and orders are created. Customer data and duty location data are pulled in.
 		//             Status is canceled.
-
-		// We only provide an existing customerID not the whole object.
-		mtoPayload.Order.CustomerID = handlers.FmtUUID(dbCustomer.ID)
+		destinationDutyLocation, originDutyLocation, customer, mtoPayload := setupTestData()
 
 		// Set the status to CANCELED
 		mtoPayload.Status = supportmessages.MoveStatusCANCELED
@@ -405,7 +399,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		}
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
@@ -417,12 +411,12 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Check that moveTaskOrder was populated, including nested objects
 		suite.moveTaskOrderPopulated(moveTaskOrdersResponse, &destinationDutyLocation, &originDutyLocation)
 		// Check that customer name matches the DB
-		suite.Equal(dbCustomer.FirstName, responsePayload.Order.Customer.FirstName)
+		suite.Equal(customer.FirstName, responsePayload.Order.Customer.FirstName)
 		// Check that status has been set to CANCELED
 		suite.Equal((models.MoveStatus)(responsePayload.Status), models.MoveStatusCANCELED)
 	})
 
-	suite.T().Run("Successful createMoveTaskOrder 201 with customer creation", func(t *testing.T) {
+	suite.Run("Successful createMoveTaskOrder 201 with customer creation", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Mocked:     None
@@ -430,6 +424,10 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		//             The order is associated with existing duty locations.
 		// Expected outcome:
 		//             New MTO, orders and customer are created.
+		destinationDutyLocation, originDutyLocation, _, mtoPayload := setupTestData()
+
+		// Set the status to CANCELED
+		mtoPayload.Status = supportmessages.MoveStatusCANCELED
 
 		// This time we provide customer details to create
 		newCustomerFirstName := "Grace"
@@ -449,7 +447,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
@@ -466,7 +464,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		suite.Equal((models.MoveStatus)(responsePayload.Status), models.MoveStatusCANCELED)
 
 	})
-	suite.T().Run("Success createMoveTaskOrder discarded readOnly referenceID", func(t *testing.T) {
+	suite.Run("Success createMoveTaskOrder discarded readOnly referenceID", func() {
 
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
@@ -476,6 +474,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Expected outcome:
 		//             A new referenceID is generated.
 		//             Default status is draft.
+		destinationDutyLocation, originDutyLocation, _, mtoPayload := setupTestData()
 
 		// Running the same request should result in the same reference id
 		mtoPayload.ReferenceID = "some terrible reference id"
@@ -486,7 +485,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderCreated{}, response)
@@ -499,7 +498,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		suite.moveTaskOrderPopulated(moveTaskOrdersResponse, &destinationDutyLocation, &originDutyLocation)
 	})
 
-	suite.T().Run("Failed createMoveTaskOrder 422 UnprocessableEntity due to no customer", func(t *testing.T) {
+	suite.Run("Failed createMoveTaskOrder 422 UnprocessableEntity due to no customer", func() {
 
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
@@ -507,6 +506,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		// Set up:     We pass in a new moveTaskOrder, order, but no customer info
 		// Expected outcome:
 		//             Failure due to no customer info, so unprocessableEntity
+		_, _, _, mtoPayload := setupTestData()
 
 		mtoPayload.Order.Customer = nil
 		mtoPayload.Order.CustomerID = nil
@@ -519,21 +519,23 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 		// CALL FUNCTION UNDER TEST
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 
 		// VERIFY RESULTS
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderUnprocessableEntity{}, response)
 	})
 
-	suite.T().Run("Failed createMoveTaskOrder 404 NotFound", func(t *testing.T) {
+	suite.Run("Failed createMoveTaskOrder 404 NotFound", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle
 		// Mocked:     MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Set up:     We call the handler but force the mocked service object to return a notFoundError
 		// Expected outcome:
 		//             NotFound Response
+		_, _, _, mtoPayload := setupTestData()
 
 		mockCreator := supportMocks.InternalMoveTaskOrderCreator{}
+		handler := setupHandler()
 		handler.moveTaskOrderCreator = &mockCreator
 
 		// Set expectation that a call to InternalCreateMoveTaskOrder will return a notFoundError
@@ -554,7 +556,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		suite.IsType(&movetaskorderops.CreateMoveTaskOrderNotFound{}, response)
 	})
 
-	suite.T().Run("Failed createMoveTaskOrder 404 NotFound Bad DutyLocation", func(t *testing.T) {
+	suite.Run("Failed createMoveTaskOrder 404 NotFound Bad DutyLocation", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateMoveTaskOrderHandler.Handle and MoveTaskOrderCreator.CreateMoveTaskOrder
 		// Mocked:     None
@@ -562,9 +564,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 		//             The order has a bad duty location ID.
 		// Expected outcome:
 		//             Failure of 404 Not Found since the dutyLocation is not found.
-
-		// We only provide an existing customerID not the whole object.
-		mtoPayload.Order.CustomerID = handlers.FmtUUID(dbCustomer.ID)
+		_, _, _, mtoPayload := setupTestData()
 
 		// Using a randomID as a dutyLocationID should cause a query error
 		mtoPayload.Order.OriginDutyLocationID = handlers.FmtUUID(uuid.Must(uuid.NewV4()))
@@ -574,7 +574,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 			Body:        mtoPayload,
 		}
 
-		handler := CreateMoveTaskOrderHandler{context,
+		handler := CreateMoveTaskOrderHandler{handlers.NewHandlerContext(suite.DB(), suite.Logger()),
 			internalmovetaskorder.NewInternalMoveTaskOrderCreator(),
 		}
 

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -3,7 +3,6 @@ package supportapi
 import (
 	"fmt"
 	"net/http/httptest"
-	"testing"
 	"time"
 
 	moverouter "github.com/transcom/mymove/pkg/services/move"
@@ -28,46 +27,61 @@ import (
 )
 
 func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
-	mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-		MTOShipment: models.MTOShipment{
-			Status:       models.MTOShipmentStatusSubmitted,
-			ShipmentType: models.MTOShipmentTypeHHGLongHaulDom,
-		},
-	})
-	// Populate the reServices table with codes needed by the
-	// HHG_LONGHAUL_DOMESTIC shipment type
-	reServiceCodes := []models.ReServiceCode{
-		models.ReServiceCodeDLH,
-		models.ReServiceCodeFSC,
-		models.ReServiceCodeDOP,
-		models.ReServiceCodeDDP,
-		models.ReServiceCodeDPK,
-		models.ReServiceCodeDUPK,
-	}
-	for _, serviceCode := range reServiceCodes {
-		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-			ReService: models.ReService{
-				Code:      serviceCode,
-				Name:      "test",
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
+	setupTestData := func() models.MTOShipment {
+		ghcDomesticTransitTime := models.GHCDomesticTransitTime{
+			MaxDaysTransitTime: 12,
+			WeightLbsLower:     0,
+			WeightLbsUpper:     10000,
+			DistanceMilesLower: 0,
+			DistanceMilesUpper: 10000,
+		}
+		_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
+
+		mto := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Move: models.Move{Status: models.MoveStatusAPPROVED}})
+		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+			MTOShipment: models.MTOShipment{
+				Status:       models.MTOShipmentStatusSubmitted,
+				ShipmentType: models.MTOShipmentTypeHHGLongHaulDom,
 			},
 		})
+		// Populate the reServices table with codes needed by the
+		// HHG_LONGHAUL_DOMESTIC shipment type
+		reServiceCodes := []models.ReServiceCode{
+			models.ReServiceCodeDLH,
+			models.ReServiceCodeFSC,
+			models.ReServiceCodeDOP,
+			models.ReServiceCodeDDP,
+			models.ReServiceCodeDPK,
+			models.ReServiceCodeDUPK,
+		}
+		for _, serviceCode := range reServiceCodes {
+			testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+				ReService: models.ReService{
+					Code:      serviceCode,
+					Name:      "test",
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+			})
+		}
+
+		return mtoShipment
 	}
 
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
-	eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
+	setupParams := func(shipment models.MTOShipment) mtoshipmentops.UpdateMTOShipmentStatusParams {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
+		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s", mtoShipment.ID.String()), nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s", shipment.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
 
-	params := mtoshipmentops.UpdateMTOShipmentStatusParams{
-		HTTPRequest:   req,
-		MtoShipmentID: *handlers.FmtUUID(mtoShipment.ID),
-		Body:          &supportmessages.UpdateMTOShipmentStatus{Status: "APPROVED"},
-		IfMatch:       eTag,
+		return mtoshipmentops.UpdateMTOShipmentStatusParams{
+			HTTPRequest:   req,
+			MtoShipmentID: *handlers.FmtUUID(shipment.ID),
+			Body:          &supportmessages.UpdateMTOShipmentStatus{Status: "APPROVED"},
+			IfMatch:       eTag,
+		}
 	}
 
 	// Used for all tests except 500 error:
@@ -86,24 +100,17 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 		mock.Anything,
 		mock.Anything,
 	).Return(1000, nil)
-
-	ghcDomesticTransitTime := models.GHCDomesticTransitTime{
-		MaxDaysTransitTime: 12,
-		WeightLbsLower:     0,
-		WeightLbsUpper:     10000,
-		DistanceMilesLower: 0,
-		DistanceMilesUpper: 10000,
-	}
-	_, _ = suite.DB().ValidateAndCreate(&ghcDomesticTransitTime)
-
 	updater := mtoshipment.NewMTOShipmentStatusUpdater(queryBuilder, siCreator, planner)
-	handler := UpdateMTOShipmentStatusHandlerFunc{
-		handlers.NewHandlerContext(suite.DB(), suite.Logger()),
-		fetcher,
-		updater,
+
+	setupHandler := func() UpdateMTOShipmentStatusHandlerFunc {
+		return UpdateMTOShipmentStatusHandlerFunc{
+			handlers.NewHandlerContext(suite.DB(), suite.Logger()),
+			fetcher,
+			updater,
+		}
 	}
 
-	suite.T().Run("Patch failure - 500", func(t *testing.T) {
+	suite.Run("Patch failure - 500", func() {
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MTOShipmentStatusUpdater{}
 		mockHandler := UpdateMTOShipmentStatusHandlerFunc{
@@ -122,7 +129,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 			mock.Anything,
 		).Return(nil, internalServerErr)
 
-		response := mockHandler.Handle(params)
+		response := mockHandler.Handle(setupParams(setupTestData()))
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusInternalServerError{}, response)
 
 		errResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusInternalServerError)
@@ -130,29 +137,32 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 
 	})
 
-	suite.T().Run("Patch failure - 404", func(t *testing.T) {
+	suite.Run("Patch failure - 404", func() {
+		params := setupParams(setupTestData())
 		notFoundParams := mtoshipmentops.UpdateMTOShipmentStatusParams{
 			HTTPRequest:   params.HTTPRequest,
 			MtoShipmentID: strfmt.UUID(uuid.Nil.String()),
 			Body:          params.Body,
 			IfMatch:       params.IfMatch,
 		}
-		response := handler.Handle(notFoundParams)
+		response := setupHandler().Handle(notFoundParams)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusNotFound{}, response)
 	})
 
-	suite.T().Run("Patch failure - 412", func(t *testing.T) {
+	suite.Run("Patch failure - 412", func() {
+		params := setupParams(setupTestData())
 		preconditionParams := mtoshipmentops.UpdateMTOShipmentStatusParams{
 			HTTPRequest:   params.HTTPRequest,
 			MtoShipmentID: params.MtoShipmentID,
 			Body:          params.Body,
 			IfMatch:       "eTag",
 		}
-		response := handler.Handle(preconditionParams)
+		response := setupHandler().Handle(preconditionParams)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusPreconditionFailed{}, response)
 	})
 
-	suite.T().Run("Patch failure - 422", func(t *testing.T) {
+	suite.Run("Patch failure - 422", func() {
+		params := setupParams(setupTestData())
 		invalidInputParams := mtoshipmentops.UpdateMTOShipmentStatusParams{
 			HTTPRequest:   params.HTTPRequest,
 			MtoShipmentID: params.MtoShipmentID,
@@ -165,11 +175,14 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 
 	// Second to last because many of the above tests fail because of a conflict error with APPROVED/REJECTED shipments
 	// first:
-	suite.T().Run("Successful patch - Integration Test", func(t *testing.T) {
+	suite.Run("Successful patch - Integration Test", func() {
+		mtoShipment := setupTestData()
 		move := mtoShipment.MoveTaskOrder
 		move.Status = models.MoveStatusAPPROVED
 		_ = suite.DB().Save(&move)
-		response := handler.Handle(params)
+
+		params := setupParams(mtoShipment)
+		response := setupHandler().Handle(params)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusOK{}, response)
 
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusOK)
@@ -178,19 +191,20 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 	})
 
 	// Last because the shipment has to be either APPROVED or REJECTED before triggering this conflict:
-	suite.T().Run("Patch failure - 409", func(t *testing.T) {
+	suite.Run("Patch failure - 409", func() {
+		params := setupParams(setupTestData())
 		conflictParams := mtoshipmentops.UpdateMTOShipmentStatusParams{
 			HTTPRequest:   params.HTTPRequest,
 			MtoShipmentID: params.MtoShipmentID,
 			Body:          &supportmessages.UpdateMTOShipmentStatus{Status: "SUBMITTED"},
 			IfMatch:       params.IfMatch,
 		}
-		response := handler.Handle(conflictParams)
+		response := setupHandler().Handle(conflictParams)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusConflict{}, response)
 	})
 
 	// Test Successful Cancellation Request
-	suite.T().Run("Successful patch - Integration Test for CANCELLATION_REQUESTED", func(t *testing.T) {
+	suite.Run("Successful patch - Integration Test for CANCELLATION_REQUESTED", func() {
 		// Under test: updateMTOShipmentHandler function
 		// Mocked:     none
 		// Setup: We create a new mtoShipment, then try to update the status from Approved to Cancellation_Requested
@@ -205,15 +219,17 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 			},
 		})
 		eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
+
+		baseParams := setupParams(mtoShipment)
 		params := mtoshipmentops.UpdateMTOShipmentStatusParams{
-			HTTPRequest:   req,
+			HTTPRequest:   baseParams.HTTPRequest,
 			MtoShipmentID: *handlers.FmtUUID(mtoShipment.ID),
 			Body:          &supportmessages.UpdateMTOShipmentStatus{Status: "CANCELLATION_REQUESTED"},
 			IfMatch:       eTag,
 		}
 
 		suite.NoError(params.Body.Validate(strfmt.Default))
-		response := handler.Handle(params)
+		response := setupHandler().Handle(params)
 		suite.IsType(&mtoshipmentops.UpdateMTOShipmentStatusOK{}, response)
 
 		okResponse := response.(*mtoshipmentops.UpdateMTOShipmentStatusOK)

--- a/pkg/handlers/supportapi/webhook_notification_test.go
+++ b/pkg/handlers/supportapi/webhook_notification_test.go
@@ -2,7 +2,6 @@ package supportapi
 
 import (
 	"net/http/httptest"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -19,7 +18,7 @@ import (
 
 func (suite *HandlerSuite) TestCreateWebhookNotification() {
 
-	suite.T().Run("Success createWebhookNotification 201 Created", func(t *testing.T) {
+	suite.Run("Success createWebhookNotification 201 Created", func() {
 
 		// TESTCASE SCENARIO
 		// Under test: CreateWebhookNotificationHandler
@@ -63,7 +62,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 		suite.NotNil(responsePayload.UpdatedAt)
 	})
 
-	suite.T().Run("Success createWebhookNotification 201 Created from empty payload", func(t *testing.T) {
+	suite.Run("Success createWebhookNotification 201 Created from empty payload", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateWebhookNotificationHandler
 		// Mocked:     None
@@ -99,7 +98,7 @@ func (suite *HandlerSuite) TestCreateWebhookNotification() {
 		suite.NotNil(responsePayload.UpdatedAt)
 	})
 
-	suite.T().Run("Failed createWebhookNotification 500 Failed due to non-existent MTO id", func(t *testing.T) {
+	suite.Run("Failed createWebhookNotification 500 Failed due to non-existent MTO id", func() {
 		// TESTCASE SCENARIO
 		// Under test: CreateWebhookNotificationHandler
 		// Mocked:     None


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12307) for this change

## Summary

Converts all remaining tests in `/pkg/handlers/supportapi` to use transactions.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [ ] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [ ] There is no unjustified usage of `Truncate` in the tests
- [ ] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [ ] `Fatalf` is deprecated in favor of other assertions/checks
- [ ] Go's `testing` package is only imported in the setup test file
