### PR TITLE
MB-12037: Add scroll to top and clean up navigation

### DIFF
--- a/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
@@ -12,6 +12,7 @@ import { getResponseError, patchMTOShipment } from 'services/internalApi';
 import { updateMTOShipment } from 'store/entities/actions';
 import { selectMTOShipmentById } from 'store/entities/selectors';
 import { setFlashMessage } from 'store/flash/actions';
+import ScrollToTop from 'components/ScrollToTop';
 
 const Advance = () => {
   const [errorMessage, setErrorMessage] = useState();
@@ -21,7 +22,7 @@ const Advance = () => {
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
 
   const handleBack = () => {
-    history.push(generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, { moveId, mtoShipmentId }));
+    history.goBack();
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {
@@ -60,6 +61,7 @@ const Advance = () => {
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
+      <ScrollToTop />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
@@ -22,7 +22,7 @@ const Advance = () => {
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
 
   const handleBack = () => {
-    history.goBack();
+    history.push(generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, { moveId, mtoShipmentId }));
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {

--- a/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
@@ -61,7 +61,7 @@ const Advance = () => {
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
-      <ScrollToTop />
+      <ScrollToTop otherDep={errorMessage} />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/Advance/Advance.test.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.test.jsx
@@ -14,12 +14,16 @@ import { selectMTOShipmentById } from 'store/entities/selectors';
 import { MockProviders } from 'testUtils';
 
 const mockPush = jest.fn();
-const mockGoBack = jest.fn();
 
 const mockMoveId = uuidv4();
 const mockMTOShipmentId = uuidv4();
 
 const reviewPath = generatePath(customerRoutes.MOVE_REVIEW_PATH, {
+  moveId: mockMoveId,
+  mtoShipmentId: mockMTOShipmentId,
+});
+
+const estimatedIncentivePath = generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, {
   moveId: mockMoveId,
   mtoShipmentId: mockMTOShipmentId,
 });
@@ -66,7 +70,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
-    goBack: mockGoBack,
   }),
   useParams: () => ({
     moveId: mockMoveId,
@@ -162,7 +165,7 @@ describe('Advance page', () => {
 
     userEvent.click(backButton);
 
-    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(estimatedIncentivePath);
   });
 
   it('calls the patch shipment endpoint when save & continue is clicked', async () => {

--- a/src/pages/MyMove/PPMBooking/Advance/Advance.test.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.test.jsx
@@ -23,10 +23,6 @@ const reviewPath = generatePath(customerRoutes.MOVE_REVIEW_PATH, {
   moveId: mockMoveId,
   mtoShipmentId: mockMTOShipmentId,
 });
-const estimatedIncentivePath = generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, {
-  moveId: mockMoveId,
-  mtoShipmentId: mockMTOShipmentId,
-});
 
 const mockMTOShipment = {
   id: mockMTOShipmentId,
@@ -166,7 +162,7 @@ describe('Advance page', () => {
 
     userEvent.click(backButton);
 
-    expect(mockPush).toHaveBeenCalledWith(estimatedIncentivePath);
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
   it('calls the patch shipment endpoint when save & continue is clicked', async () => {

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
@@ -95,7 +95,7 @@ const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
-      <ScrollToTop />
+      <ScrollToTop otherDep={errorMessage} />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
@@ -8,7 +8,7 @@ import { MtoShipmentShape, ServiceMemberShape } from 'types/customerShapes';
 import { DutyLocationShape } from 'types';
 import DateAndLocationForm from 'components/Customer/PPMBooking/DateAndLocationForm/DateAndLocationForm';
 import { validatePostalCode } from 'utils/validation';
-import { customerRoutes } from 'constants/routes';
+import { customerRoutes, generalRoutes } from 'constants/routes';
 import { createMTOShipment, patchMTOShipment } from 'services/internalApi';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
@@ -24,9 +24,12 @@ const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }
   const dispatch = useDispatch();
 
   const isNewShipment = !mtoShipment?.id;
-
   const handleBack = () => {
-    history.goBack();
+    if (isNewShipment) {
+      history.push(generatePath(customerRoutes.SHIPMENT_SELECT_TYPE_PATH, { moveId }));
+    } else {
+      history.push(generalRoutes.HOME_PATH);
+    }
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
@@ -8,13 +8,14 @@ import { MtoShipmentShape, ServiceMemberShape } from 'types/customerShapes';
 import { DutyLocationShape } from 'types';
 import DateAndLocationForm from 'components/Customer/PPMBooking/DateAndLocationForm/DateAndLocationForm';
 import { validatePostalCode } from 'utils/validation';
-import { customerRoutes, generalRoutes } from 'constants/routes';
+import { customerRoutes } from 'constants/routes';
 import { createMTOShipment, patchMTOShipment } from 'services/internalApi';
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { shipmentTypes } from 'constants/shipments';
 import { formatDateForSwagger } from 'shared/dates';
 import { updateMTOShipment } from 'store/entities/actions';
+import ScrollToTop from 'components/ScrollToTop';
 
 const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }) => {
   const [errorMessage, setErrorMessage] = useState();
@@ -25,11 +26,7 @@ const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }
   const isNewShipment = !mtoShipment?.id;
 
   const handleBack = () => {
-    if (isNewShipment) {
-      history.push(generatePath(customerRoutes.SHIPMENT_SELECT_TYPE_PATH, { moveId }));
-    }
-
-    history.push(generalRoutes.HOME_PATH);
+    history.goBack();
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {
@@ -95,6 +92,7 @@ const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
+      <ScrollToTop />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.test.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.test.jsx
@@ -1,20 +1,23 @@
 import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { generatePath } from 'react-router';
+import { generatePath, MemoryRouter } from 'react-router';
 
 import DateAndLocation from 'pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation';
-import { customerRoutes, generalRoutes } from 'constants/routes';
+import { customerRoutes } from 'constants/routes';
 import { createMTOShipment, patchMTOShipment } from 'services/internalApi';
 import { updateMTOShipment } from 'store/entities/actions';
 
 const mockPush = jest.fn();
+const mockGoBack = jest.fn();
+
 const mockMoveId = 'move123';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
+    goBack: mockGoBack,
   }),
   useParams: () => ({
     moveId: mockMoveId,
@@ -81,28 +84,24 @@ beforeEach(() => {
 describe('DateAndLocation component', () => {
   describe('creating a new PPM shipment', () => {
     it('renders the heading and empty form', () => {
-      render(<DateAndLocation {...defaultProps} />);
+      render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('PPM date & location');
     });
 
     it('routes back to the new shipment type screen when back is clicked', async () => {
-      const selectShipmentType = generatePath(customerRoutes.SHIPMENT_SELECT_TYPE_PATH, {
-        moveId: mockMoveId,
-      });
-
-      render(<DateAndLocation {...defaultProps} />);
+      render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
       const backButton = await screen.getByRole('button', { name: 'Back' });
       userEvent.click(backButton);
 
-      expect(mockPush).toHaveBeenCalledWith(selectShipmentType);
+      expect(mockGoBack).toHaveBeenCalled();
     });
 
     it('calls create shipment endpoint and formats required payload values', async () => {
       createMTOShipment.mockResolvedValueOnce({ id: mockNewShipmentId });
 
-      render(<DateAndLocation {...defaultProps} />);
+      render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
       const primaryPostalCodes = screen.getAllByLabelText('ZIP');
       userEvent.type(primaryPostalCodes[0], '10001');
@@ -141,7 +140,7 @@ describe('DateAndLocation component', () => {
     it('displays an error alert when the create shipment fails', async () => {
       createMTOShipment.mockRejectedValueOnce('fatal error');
 
-      render(<DateAndLocation {...defaultProps} />);
+      render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
       const primaryPostalCodes = screen.getAllByLabelText('ZIP');
       userEvent.type(primaryPostalCodes[0], '10001');
@@ -174,7 +173,7 @@ describe('DateAndLocation component', () => {
     it('calls create shipment endpoint and formats optional payload values', async () => {
       createMTOShipment.mockResolvedValueOnce({ id: mockNewShipmentId });
 
-      render(<DateAndLocation {...defaultProps} />);
+      render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
       const primaryPostalCodes = screen.getAllByLabelText('ZIP');
       userEvent.type(primaryPostalCodes[0], '10001');
@@ -223,7 +222,7 @@ describe('DateAndLocation component', () => {
 
   describe('editing an existing PPM shipment', () => {
     it('renders the heading and form with shipment values', async () => {
-      render(<DateAndLocation {...fullShipmentProps} />);
+      render(<DateAndLocation {...fullShipmentProps} />, { wrapper: MemoryRouter });
 
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('PPM date & location');
 
@@ -242,19 +241,17 @@ describe('DateAndLocation component', () => {
     });
 
     it('routes back to the home page screen when back is clicked', async () => {
-      const selectShipmentType = generatePath(generalRoutes.HOME_PATH);
-
-      render(<DateAndLocation {...defaultProps} {...fullShipmentProps} />);
+      render(<DateAndLocation {...defaultProps} {...fullShipmentProps} />, { wrapper: MemoryRouter });
 
       userEvent.click(screen.getByRole('button', { name: 'Back' }));
 
-      expect(mockPush).toHaveBeenCalledWith(selectShipmentType);
+      expect(mockGoBack).toHaveBeenCalled();
     });
 
     it('displays an error alert when the update shipment fails', async () => {
       patchMTOShipment.mockRejectedValueOnce('fatal error');
 
-      render(<DateAndLocation {...fullShipmentProps} />);
+      render(<DateAndLocation {...fullShipmentProps} />, { wrapper: MemoryRouter });
 
       userEvent.click(screen.getByRole('button', { name: 'Save & Continue' }));
 
@@ -287,7 +284,7 @@ describe('DateAndLocation component', () => {
     it('calls update shipment endpoint and formats optional payload values', async () => {
       patchMTOShipment.mockResolvedValueOnce({ id: fullShipmentProps.mtoShipment.id });
 
-      render(<DateAndLocation {...fullShipmentProps} />);
+      render(<DateAndLocation {...fullShipmentProps} />, { wrapper: MemoryRouter });
 
       const primaryPostalCodes = screen.getAllByLabelText('ZIP');
       userEvent.clear(primaryPostalCodes[0]);

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.test.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.test.jsx
@@ -4,12 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { generatePath, MemoryRouter } from 'react-router';
 
 import DateAndLocation from 'pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation';
-import { customerRoutes } from 'constants/routes';
+import { customerRoutes, generalRoutes } from 'constants/routes';
 import { createMTOShipment, patchMTOShipment } from 'services/internalApi';
 import { updateMTOShipment } from 'store/entities/actions';
 
 const mockPush = jest.fn();
-const mockGoBack = jest.fn();
 
 const mockMoveId = 'move123';
 
@@ -17,7 +16,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
-    goBack: mockGoBack,
   }),
   useParams: () => ({
     moveId: mockMoveId,
@@ -92,10 +90,14 @@ describe('DateAndLocation component', () => {
     it('routes back to the new shipment type screen when back is clicked', async () => {
       render(<DateAndLocation {...defaultProps} />, { wrapper: MemoryRouter });
 
+      const selectShipmentType = generatePath(customerRoutes.SHIPMENT_SELECT_TYPE_PATH, {
+        moveId: mockMoveId,
+      });
+
       const backButton = await screen.getByRole('button', { name: 'Back' });
       userEvent.click(backButton);
 
-      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith(selectShipmentType);
     });
 
     it('calls create shipment endpoint and formats required payload values', async () => {
@@ -243,9 +245,11 @@ describe('DateAndLocation component', () => {
     it('routes back to the home page screen when back is clicked', async () => {
       render(<DateAndLocation {...defaultProps} {...fullShipmentProps} />, { wrapper: MemoryRouter });
 
+      const selectShipmentType = generatePath(generalRoutes.HOME_PATH);
+
       userEvent.click(screen.getByRole('button', { name: 'Back' }));
 
-      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith(selectShipmentType);
     });
 
     it('displays an error alert when the update shipment fails', async () => {

--- a/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.jsx
@@ -20,7 +20,7 @@ const EstimatedIncentive = () => {
   const { moveId, mtoShipmentId, shipmentNumber } = useParams();
   const shipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
   const handleBack = () => {
-    history.goBack();
+    history.push(generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_WEIGHT_PATH, { moveId, mtoShipmentId }));
   };
 
   const handleNext = () => {

--- a/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.jsx
@@ -13,6 +13,7 @@ import ShipmentTag from 'components/ShipmentTag/ShipmentTag';
 import { selectMTOShipmentById } from 'store/entities/selectors';
 import { customerRoutes } from 'constants/routes';
 import EstimatedIncentiveDetails from 'components/Customer/PPMBooking/EstimatedIncentiveDetails/EstimatedIncentiveDetails';
+import ScrollToTop from 'components/ScrollToTop';
 
 const EstimatedIncentive = () => {
   const history = useHistory();
@@ -28,6 +29,7 @@ const EstimatedIncentive = () => {
 
   return (
     <div className={classnames(ppmBookingPageStyles.PPMBookingPage, styles.EstimatedIncentive)}>
+      <ScrollToTop />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.test.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedIncentive/EstimatedIncentive.test.jsx
@@ -9,7 +9,6 @@ import { MockProviders } from 'testUtils';
 import { customerRoutes } from 'constants/routes';
 
 const mockPush = jest.fn();
-const mockBack = jest.fn();
 const mockMoveId = 'move123';
 const mockShipmentId = 'shipment123';
 
@@ -17,7 +16,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
-    goBack: mockBack,
   }),
   useParams: () => ({
     moveId: mockMoveId,
@@ -74,17 +72,17 @@ describe('EstimatedIncentive component', () => {
       </MockProviders>,
     );
 
-    userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    const shipmentInfo = {
+      moveId: mockMoveId,
+      mtoShipmentId: mockShipmentId,
+    };
 
-    expect(mockBack).toHaveBeenCalled();
+    userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(mockPush).toHaveBeenCalledWith(
+      generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_WEIGHT_PATH, shipmentInfo),
+    );
 
     userEvent.click(screen.getByRole('button', { name: 'Next' }));
-
-    expect(mockPush).toHaveBeenCalledWith(
-      generatePath(customerRoutes.SHIPMENT_PPM_ADVANCES_PATH, {
-        moveId: mockMoveId,
-        mtoShipmentId: mockShipmentId,
-      }),
-    );
+    expect(mockPush).toHaveBeenCalledWith(generatePath(customerRoutes.SHIPMENT_PPM_ADVANCES_PATH, shipmentInfo));
   });
 });

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
@@ -15,6 +15,7 @@ import {
   selectMTOShipmentById,
   selectServiceMemberFromLoggedInUser,
 } from 'store/entities/selectors';
+import ScrollToTop from 'components/ScrollToTop';
 
 const EstimatedWeightsProGear = () => {
   const [errorMessage, setErrorMessage] = useState();
@@ -27,7 +28,7 @@ const EstimatedWeightsProGear = () => {
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
 
   const handleBack = () => {
-    history.push(generatePath(customerRoutes.SHIPMENT_EDIT_PATH, { moveId, mtoShipmentId }));
+    history.goBack();
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {
@@ -60,6 +61,7 @@ const EstimatedWeightsProGear = () => {
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
+      <ScrollToTop />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
@@ -28,7 +28,7 @@ const EstimatedWeightsProGear = () => {
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
 
   const handleBack = () => {
-    history.goBack();
+    history.push(generatePath(customerRoutes.SHIPMENT_EDIT_PATH, { moveId, mtoShipmentId }));
   };
 
   const handleSubmit = async (values, { setSubmitting }) => {

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
@@ -61,7 +61,7 @@ const EstimatedWeightsProGear = () => {
 
   return (
     <div className={ppmBookingPageStyles.PPMBookingPage}>
-      <ScrollToTop />
+      <ScrollToTop otherDep={errorMessage} />
       <GridContainer>
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
@@ -18,10 +18,6 @@ const mockGoBack = jest.fn();
 const mockMoveId = uuidv4();
 const mockMTOShipmentId = uuidv4();
 
-const shipmentEditPath = generatePath(customerRoutes.SHIPMENT_EDIT_PATH, {
-  moveId: mockMoveId,
-  mtoShipmentId: mockMTOShipmentId,
-});
 const estimatedIncentivePath = generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, {
   moveId: mockMoveId,
   mtoShipmentId: mockMTOShipmentId,
@@ -207,7 +203,7 @@ describe('EstimatedWeightsProGear page', () => {
 
     userEvent.click(backButton);
 
-    expect(mockPush).toHaveBeenCalledWith(shipmentEditPath);
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
   it('calls the patch shipment endpoint when save & continue is clicked', async () => {

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
@@ -13,11 +13,14 @@ import { selectMTOShipmentById } from 'store/entities/selectors';
 import { MockProviders } from 'testUtils';
 
 const mockPush = jest.fn();
-const mockGoBack = jest.fn();
 
 const mockMoveId = uuidv4();
 const mockMTOShipmentId = uuidv4();
 
+const shipmentEditPath = generatePath(customerRoutes.SHIPMENT_EDIT_PATH, {
+  moveId: mockMoveId,
+  mtoShipmentId: mockMTOShipmentId,
+});
 const estimatedIncentivePath = generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATED_INCENTIVE_PATH, {
   moveId: mockMoveId,
   mtoShipmentId: mockMTOShipmentId,
@@ -87,7 +90,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: mockPush,
-    goBack: mockGoBack,
   }),
   useParams: () => ({
     moveId: mockMoveId,
@@ -203,7 +205,7 @@ describe('EstimatedWeightsProGear page', () => {
 
     userEvent.click(backButton);
 
-    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith(shipmentEditPath);
   });
 
   it('calls the patch shipment endpoint when save & continue is clicked', async () => {


### PR DESCRIPTION
## [MB-12037](https://dp3.atlassian.net/browse/MB-12037) for this change

## Summary

This adds the `ScrollToTop` component on each of our PPM pages. 

There was also an existing bug where if we navigate to the Advances pages from the estimated incentives page, the back button perpetually loops you between the two pages (see video below). This was a result of us using a combination of `history.push()` and `history.goBack()`. 

https://user-images.githubusercontent.com/84742904/165785544-010a639a-d93c-4b12-aae3-b58d101b9db9.mov

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
