### PR TITLE
Add sort-imports rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,16 @@ module.exports = {
     'react/jsx-curly-brace-presence': 'error',
     'react/require-default-props': 'warn',
     'no-unused-vars': 'warn',
+    'sort-imports': [
+      'error',
+      {
+        ignoreCase: false,
+        ignoreDeclarationSort: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['single', 'multiple', 'all', 'none'],
+        allowSeparatedGroups: false,
+      },
+    ],
     'import/order': [
       'error',
       {


### PR DESCRIPTION
## [Confluence discussion](https://dp3.atlassian.net/wiki/spaces/MT/pages/1725038635/2022-04-28+Front+End+Check-In?focusedCommentId=1733034029#comment-1733034029) for this change 🔒 

## Summary

This change adds the `sort-imports` rule to ESLint to help mitigate some of the issues that @YanZ777 brought up in our Confluence discussion. I have copied over the defaults from the documentation, but I reordered the `memberSyntaxSortOrder` by reversing it. Please feel free to change it while reviewing this.

[=> The documentation on _sort-imports_](https://eslint.org/docs/rules/sort-imports)


## Setup to Run Your Code

Load up a file, and test that `sort-imports` is correctly showing errors on `jsx` files.