### PR TITLE
MB-12326: Service counselor can navigate to create a PPM

### DIFF
--- a/src/components/Customer/MtoShipmentForm/getShipmentOptions.js
+++ b/src/components/Customer/MtoShipmentForm/getShipmentOptions.js
@@ -59,6 +59,10 @@ const ntsReleaseShipmentTOOSchema = Yup.object().shape({
   storageFacility: StorageFacilityAddressSchema,
 });
 
+const ppmSchema = Yup.object().shape({
+  // todo
+});
+
 function getShipmentOptions(shipmentType, userRole) {
   switch (shipmentType) {
     case SHIPMENT_OPTIONS.HHG:
@@ -117,6 +121,11 @@ function getShipmentOptions(shipmentType, userRole) {
           throw new Error('unrecognized user role type');
         }
       }
+
+    case SHIPMENT_OPTIONS.PPM:
+      return {
+        schema: ppmSchema,
+      };
 
     default:
       throw new Error('unrecognized move type');

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -103,6 +103,8 @@ const ShipmentForm = ({
   const isHHG = shipmentType === SHIPMENT_OPTIONS.HHG;
   const isNTS = shipmentType === SHIPMENT_OPTIONS.NTS;
   const isNTSR = shipmentType === SHIPMENT_OPTIONS.NTSR;
+  const isPPM = shipmentType === SHIPMENT_OPTIONS.PPM;
+
   const showAccountingCodes = isNTS || isNTSR;
 
   const isTOO = userRole === roleTypes.TOO;
@@ -140,6 +142,11 @@ const ShipmentForm = ({
     usesExternalVendor,
     destinationType,
   }) => {
+    if (isPPM) {
+      // todo
+      return;
+    }
+
     const deliveryDetails = delivery;
     if (hasDeliveryAddress === 'no' && shipmentType !== SHIPMENT_OPTIONS.NTSR) {
       delete deliveryDetails.address;
@@ -455,14 +462,16 @@ const ShipmentForm = ({
                 )}
 
                 <div className={`${formStyles.formActions} ${styles.buttonGroup}`}>
-                  <Button
-                    data-testid="submitForm"
-                    disabled={isSubmitting || !isValid}
-                    type="submit"
-                    onClick={handleSubmit}
-                  >
-                    Save
-                  </Button>
+                  {!isPPM && (
+                    <Button
+                      data-testid="submitForm"
+                      disabled={isSubmitting || !isValid}
+                      type="submit"
+                      onClick={handleSubmit}
+                    >
+                      Save
+                    </Button>
+                  )}
                   <Button
                     type="button"
                     secondary
@@ -472,6 +481,16 @@ const ShipmentForm = ({
                   >
                     Cancel
                   </Button>
+                  {isPPM && (
+                    <Button
+                      data-testid="submitForm"
+                      disabled={isSubmitting || !isValid}
+                      type="submit"
+                      onClick={handleSubmit}
+                    >
+                      Save and Continue
+                    </Button>
+                  )}
                 </div>
               </Form>
             </div>

--- a/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
@@ -185,3 +185,9 @@ export const ExternalVendorShipment = () => {
     />
   );
 };
+
+export const PPMShipment = () => {
+  return (
+    <ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.PPM} userRole={roleTypes.SERVICES_COUNSELOR} />
+  );
+};

--- a/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
@@ -692,4 +692,20 @@ describe('ShipmentForm component', () => {
       });
     });
   });
+
+  describe('creating a new PPM shipment', () => {
+    it('displays PPM content', async () => {
+      render(
+        <ShipmentForm
+          {...defaultProps}
+          selectedMoveType={SHIPMENT_OPTIONS.PPM}
+          isCreatePage
+          userRole={roleTypes.SERVICES_COUNSELOR}
+          mtoShipment={mockMtoShipment}
+        />,
+      );
+
+      expect(await screen.findByTestId('tag')).toHaveTextContent('PPM');
+    });
+  });
 });

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -339,6 +339,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
                     </option>
                     <option value={SHIPMENT_OPTIONS_URL.NTS}>NTS</option>
                     <option value={SHIPMENT_OPTIONS_URL.NTSrelease}>NTS-release</option>
+                    <option value={SHIPMENT_OPTIONS_URL.PPM}>PPM</option>
                   </ButtonDropdown>
                 )
               }


### PR DESCRIPTION
## Jira ticket for this change: [MB-12326](https://dp3.atlassian.net/browse/MB-12326), sub-task of [MB-11865](https://dp3.atlassian.net/browse/MB-11865)

## Summary

This pull request adds the ability to use the "Add New Shipment" dropdown (available on the Move Details page for Service Counselors) to navigate to the page where a new PPM will be created. The Add Shipment page for creating a PPM has a minimum of content right now, which will be added as sub-components are completed. The "Cancel" button returns the user to the Move Details page.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. In Storybook, in the `Office Components` -> `Forms` -> `ShipmentForm` component, view the `PPM Shipment` story, and verify that it displays with just the weight allowance, the remarks component, and the "Cancel" and "Save and Continue" buttons.
2. Login to the application locally as a service counselor user and view any move that's in a state where a shipment can be added.
3. Click the "Add New Shipment" dropdown. Verify that "PPM" is an option, and select it.
4. In the Add Shipment page, verify that the PPM content displays (and not everything else).

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
