### PR TITLE
MB-12224 - Refactor history updateMoveTaskOrderStatusEvent

### DIFF
--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -206,12 +206,10 @@ export const updateMoveTaskOrderStatusEvent = buildMoveHistoryEventTemplate({
   tableName: 'moves',
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: (historyRecord) => {
-    return historyRecord.changedValues?.status === 'APPROVED' ? 'Approved move' : 'Rejected move';
+    return historyRecord.changedValues?.available_to_prime_at ? 'Approved move' : 'Move status updated';
   },
   getDetailsPlainText: (historyRecord) => {
-    return historyRecord.changedValues?.status === 'APPROVED'
-      ? 'Created Move Task Order (MTO)'
-      : 'Rejected Move Task Order (MTO)';
+    return historyRecord.changedValues?.available_to_prime_at ? 'Created Move Task Order (MTO)' : '-';
   },
 });
 

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -190,6 +190,7 @@ describe('moveHistoryEventTemplate', () => {
     const item = {
       action: 'UPDATE',
       changedValues: {
+        available_to_prime_at: '2022-04-13T15:21:31.746028+00:00',
         status: 'APPROVED',
       },
       eventName: 'updateMoveTaskOrderStatus',
@@ -198,21 +199,23 @@ describe('moveHistoryEventTemplate', () => {
     it('correctly matches the Update move task order status event', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(updateMoveTaskOrderStatusEvent);
+      expect(result.getEventNameDisplay(item)).toEqual('Approved move');
       expect(result.getDetailsPlainText(item)).toEqual('Created Move Task Order (MTO)');
     });
   });
 
-  describe('when given a Move rejected history record', () => {
+  describe('when given a Move status update history record', () => {
     const item = {
       action: 'UPDATE',
-      changedValues: { status: 'REJECTED' },
+      changedValues: { status: 'CANCELED' },
       eventName: 'updateMoveTaskOrderStatus',
       tableName: 'moves',
     };
     it('correctly matches the Update move task order status event', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(updateMoveTaskOrderStatusEvent);
-      expect(result.getDetailsPlainText(item)).toEqual('Rejected Move Task Order (MTO)');
+      expect(result.getEventNameDisplay(item)).toEqual('Move status updated');
+      expect(result.getDetailsPlainText(item)).toEqual('-');
     });
   });
 


### PR DESCRIPTION
The event that corresponds to an update to a move's status is now
informed by the available_to_prime_at field. Since at this point we only
expect to track the change to the 'Approved' status, this seems like a
the most reasonable way to do that. A default case is also there and can
be expanded upon if necessary in future work.

## [Jira ticket](https://dp3.atlassian.net/browse/MB-12224) for this change

## Summary

This change probably won't immediately change any behavior in your local environment, but it should address the issue found with a move in staging (which probably was caught in a weird database state due to a past bug). 
Regardless, the code can be reviewed to determine whether the new logic is an improvement, and the move approval can still be tested to ensure that it's still working.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a TOO
3. Navigate to a move that hasn't yet been approved (perhaps move code REQINF)
4. Address any outstanding TOO items and approve the shipments
5. Navigate to the move history tab and ensure that the entry corresponding to the move approval matches the acceptance criteria

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/97245917/166557895-87c6977b-290e-4178-8003-36b3fbe9d212.png">
