### PR TITLE
MB-10401 - Update financial liability paragraph for correct PPM Info

### DIFF
--- a/src/scenes/Legalese/legaleseText.js
+++ b/src/scenes/Legalese/legaleseText.js
@@ -61,7 +61,7 @@ For a HHG shipment, I am entitled to move a certain amount of HHG by weight, kno
 the continental United States, or beyond).  If I move more HHG weight than my maximum weight allowance, I will be \
 subject to excess cost for exceeding my weight allowance or entitlement.
 
-For a PPM shipment, I understand I will be paid 95% of what the government would have paid to move my belongings. My \
+For a PPM shipment, I understand I will be paid 100% of what the government would have paid to move my belongings. My \
 final payment will be calculated using documented weight and distance, up to my maximum weight allowance. I will not \
 be paid for moving any extra weight beyond my weight allowance.
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-10401) for this change

## Summary

This PR updates the PPM section of the legal text to replace "95%" with "100%"

A/C

Given that I’m on the Signature Page

When I read through the “Financial Liability” Section

Then I will see I will be paid 100% of the government cost

## Setup to Run Your Code
- Run the customer app locally or access through the [ephemeral deploy](https://my-milmove-pr-8552.mymove.sandbox.truss.coffee/) 
- Choose any unsubmitted user, I recommend using `advance_requested@ppm.unsubmitted` because that user has all of the required fields already added you would only need to click through the review page to get to the post submission page which is were legal text affect by this PR is


## Screenshots
[Previously showed 95%]
<img width="608" alt="Screen Shot 2022-05-04 at 11 09 06 AM" src="https://user-images.githubusercontent.com/67110378/166932307-052af1f5-12d4-42ca-b310-03fc7edb73f0.png">
