### PR TITLE
MB-12178 - Add generic handling for unknown history events

### DIFF
--- a/src/constants/historyLogUIDisplayName.js
+++ b/src/constants/historyLogUIDisplayName.js
@@ -19,6 +19,16 @@ export const HistoryLogRecordShape = PropTypes.shape({
   tableName: PropTypes.string,
 });
 
+export const dbActions = {
+  UPDATE: 'UPDATE',
+  INSERT: 'INSERT',
+  DELETE: 'DELETE',
+};
+
+export const formatTableName = (tableName) => {
+  return typeof tableName === 'string' ? tableName.toLowerCase().replace(/_/g, ' ') : 'database';
+};
+
 export const dbFieldToDisplayName = {
   updated_at: 'Updated at',
   diversion: 'Diversion',

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -2,6 +2,7 @@ import moveHistoryOperations from './moveHistoryOperations';
 import { shipmentTypes } from './shipments';
 
 import { formatMoveHistoryFullAddress, formatMoveHistoryAgent } from 'utils/formatters';
+import { dbActions, formatTableName } from 'constants/historyLogUIDisplayName';
 
 function propertiesMatch(p1, p2) {
   return p1 === '*' || p2 === '*' || p1 === p2;
@@ -450,11 +451,19 @@ export const undefinedEvent = buildMoveHistoryEventTemplate({
   eventName: '*',
   tableName: '*',
   detailsType: detailsTypes.PLAIN_TEXT,
-  getEventNameDisplay: () => {
-    return 'Undefined event type';
+  getEventNameDisplay: (historyRecord) => {
+    switch (historyRecord.action) {
+      case dbActions.INSERT:
+        return `Created new item in ${formatTableName(historyRecord.tableName)}`;
+      case dbActions.DELETE:
+        return `Deleted item in ${formatTableName(historyRecord.tableName)}`;
+      case dbActions.UPDATE:
+      default:
+        return `Updated item in ${formatTableName(historyRecord.tableName)}`;
+    }
   },
   getDetailsPlainText: () => {
-    return 'Undefined event details';
+    return '-';
   },
 });
 

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -21,6 +21,7 @@ const {
   requestShipmentReweighEvent,
   createPaymentRequestReweighUpdate,
   createPaymentRequestShipmentUpdate,
+  undefinedEvent,
 } = require('./moveHistoryEventTemplate');
 
 const { detailsTypes } = require('constants/moveHistoryEventTemplate');
@@ -515,5 +516,18 @@ describe('moveHistoryEventTemplate', () => {
       expect(result).toEqual(createPaymentRequestShipmentUpdate);
       expect(result.getStatusDetails(item)).toEqual('Pending');
     });
+  });
+});
+
+describe('when given an unidentifiable move history record', () => {
+  const item = {
+    action: 'UPDATE',
+    eventName: 'testEventName',
+    tableName: 'imaginary_test_objects',
+  };
+  it('correctly matches the Undefined move history event', () => {
+    const result = getMoveHistoryEventTemplate(item);
+    expect(result).toEqual(undefinedEvent);
+    expect(result.getEventNameDisplay(item)).toEqual('Updated item in imaginary test objects');
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12178) for this change

## Summary

These changes should provide a simple way to show basic information about an event in the move history that can't be identified.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->
*Note: testing this change requires testing an event that is yet unknown to the front end. Since new events are being supported with each sprint, it may be difficult to identify the steps to take in order to test this properly. The steps below describe testing a TIO update weight event that is not supported yet, but it may be supported soon.

1. Access the office app
2. Login as a TIO
3. Navigate to a move (e.g. locator WTSTAT)
4. Navigate to the payments requests tab and click "review weights"
5. Update the max billable weight and click "save"
6. Navigate to the Move history tab and verify that there are one or more generic entries for the unidentified weight update event

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.



## Screenshots
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/97245917/166827487-6bc250aa-cd00-4b84-ba4e-040041f2494d.png">
