### PR TITLE
MB-11663 update support api handlers

### DIFF
--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_service_item"
@@ -25,33 +26,36 @@ type UpdateMTOServiceItemStatusHandler struct {
 
 // Handle updates mto server item statuses
 func (h UpdateMTOServiceItemStatusHandler) Handle(params mtoserviceitemops.UpdateMTOServiceItemStatusParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-	mtoServiceItemID := uuid.FromStringOrNil(params.MtoServiceItemID)
-	status := models.MTOServiceItemStatus(params.Body.Status)
-	eTag := params.IfMatch
-	reason := params.Body.RejectionReason
+			mtoServiceItemID := uuid.FromStringOrNil(params.MtoServiceItemID)
+			status := models.MTOServiceItemStatus(params.Body.Status)
+			eTag := params.IfMatch
+			reason := params.Body.RejectionReason
 
-	mtoServiceItem, err := h.ApproveOrRejectServiceItem(appCtx, mtoServiceItemID, status, reason, eTag)
+			mtoServiceItem, err := h.ApproveOrRejectServiceItem(appCtx, mtoServiceItemID, status, reason, eTag)
 
-	if err != nil {
-		appCtx.Logger().Error("ApproveOrRejectServiceItem error: ", zap.Error(err))
+			if err != nil {
+				appCtx.Logger().Error("ApproveOrRejectServiceItem error: ", zap.Error(err))
 
-		switch e := err.(type) {
-		case apperror.NotFoundError:
-			payload := payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusNotFound().WithPayload(payload)
-		case apperror.InvalidInputError:
-			payload := payloads.ValidationError("The information you provided is invalid", h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusUnprocessableEntity().WithPayload(payload)
-		case apperror.PreconditionFailedError:
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusPreconditionFailed().WithPayload(
-				payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		default:
-			return mtoserviceitemops.NewUpdateMTOServiceItemStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-	}
+				switch e := err.(type) {
+				case apperror.NotFoundError:
+					payload := payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))
+					return mtoserviceitemops.NewUpdateMTOServiceItemStatusNotFound().WithPayload(payload), err
+				case apperror.InvalidInputError:
+					payload := payloads.ValidationError("The information you provided is invalid", h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)
+					return mtoserviceitemops.NewUpdateMTOServiceItemStatusUnprocessableEntity().WithPayload(payload), err
+				case apperror.PreconditionFailedError:
+					return mtoserviceitemops.NewUpdateMTOServiceItemStatusPreconditionFailed().WithPayload(
+						payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				default:
+					return mtoserviceitemops.NewUpdateMTOServiceItemStatusInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
+			}
 
-	payload := payloads.MTOServiceItem(mtoServiceItem)
-	return mtoserviceitemops.NewUpdateMTOServiceItemStatusOK().WithPayload(payload)
+			payload := payloads.MTOServiceItem(mtoServiceItem)
+			return mtoserviceitemops.NewUpdateMTOServiceItemStatusOK().WithPayload(payload), nil
+		})
 }

--- a/pkg/handlers/supportapi/mto_shipment.go
+++ b/pkg/handlers/supportapi/mto_shipment.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -27,33 +28,39 @@ type UpdateMTOShipmentStatusHandlerFunc struct {
 
 // Handle updates the status of a MTO Shipment
 func (h UpdateMTOShipmentStatusHandlerFunc) Handle(params mtoshipmentops.UpdateMTOShipmentStatusParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-	shipmentID := uuid.FromStringOrNil(params.MtoShipmentID.String())
-	status := models.MTOShipmentStatus(params.Body.Status)
-	rejectionReason := params.Body.RejectionReason
-	eTag := params.IfMatch
+			shipmentID := uuid.FromStringOrNil(params.MtoShipmentID.String())
+			status := models.MTOShipmentStatus(params.Body.Status)
+			rejectionReason := params.Body.RejectionReason
+			eTag := params.IfMatch
 
-	shipment, err := h.UpdateMTOShipmentStatus(appCtx, shipmentID, status, rejectionReason, eTag)
+			shipment, err := h.UpdateMTOShipmentStatus(appCtx, shipmentID, status, rejectionReason, eTag)
 
-	if err != nil {
-		appCtx.Logger().Error("UpdateMTOShipmentStatus error: ", zap.Error(err))
+			if err != nil {
+				appCtx.Logger().Error("UpdateMTOShipmentStatus error: ", zap.Error(err))
 
-		switch e := err.(type) {
-		case apperror.NotFoundError:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.InvalidInputError:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusUnprocessableEntity().WithPayload(
-				payloads.ValidationError("The input provided did not pass validation.", h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors))
-		case apperror.PreconditionFailedError:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case mtoshipment.ConflictStatusError:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		default:
-			return mtoshipmentops.NewUpdateMTOShipmentStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-	}
+				switch e := err.(type) {
+				case apperror.NotFoundError:
+					return mtoshipmentops.NewUpdateMTOShipmentStatusNotFound().WithPayload(
+						payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.InvalidInputError:
+					return mtoshipmentops.NewUpdateMTOShipmentStatusUnprocessableEntity().WithPayload(
+						payloads.ValidationError("The input provided did not pass validation.", h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)), err
+				case apperror.PreconditionFailedError:
+					return mtoshipmentops.NewUpdateMTOShipmentStatusPreconditionFailed().WithPayload(
+						payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case mtoshipment.ConflictStatusError:
+					return mtoshipmentops.NewUpdateMTOShipmentStatusConflict().WithPayload(
+						payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				default:
+					return mtoshipmentops.NewUpdateMTOShipmentStatusInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
+			}
 
-	payload := payloads.MTOShipment(shipment)
-	return mtoshipmentops.NewUpdateMTOShipmentStatusOK().WithPayload(payload)
+			payload := payloads.MTOShipment(shipment)
+			return mtoshipmentops.NewUpdateMTOShipmentStatusOK().WithPayload(payload), nil
+		})
 }

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 
 	"github.com/spf13/viper"
@@ -35,120 +36,128 @@ type UpdatePaymentRequestStatusHandler struct {
 
 // Handle updates payment requests status
 func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
-	paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
 
-	if err != nil {
-		appCtx.Logger().Error(fmt.Sprintf("Error parsing payment request id: %s", params.PaymentRequestID.String()), zap.Error(err))
-		return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
+			if err != nil {
+				appCtx.Logger().Error(fmt.Sprintf("Error parsing payment request id: %s", params.PaymentRequestID.String()), zap.Error(err))
+				return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(
+					payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+			}
 
-	// Let's fetch the existing payment request using the PaymentRequestFetcher service object
-	existingPaymentRequest, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
+			// Let's fetch the existing payment request using the PaymentRequestFetcher service object
+			existingPaymentRequest, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
 
-	if err != nil {
-		msg := fmt.Sprintf("Error finding Payment Request for status update with ID: %s", params.PaymentRequestID.String())
-		appCtx.Logger().Error(msg, zap.Error(err))
-		return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
+			if err != nil {
+				msg := fmt.Sprintf("Error finding Payment Request for status update with ID: %s", params.PaymentRequestID.String())
+				appCtx.Logger().Error(msg, zap.Error(err))
+				return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(
+					payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest))), err
+			}
 
-	status := existingPaymentRequest.Status
-	mtoID := existingPaymentRequest.MoveTaskOrderID
+			status := existingPaymentRequest.Status
+			mtoID := existingPaymentRequest.MoveTaskOrderID
 
-	var reviewedDate time.Time
-	var recGexDate time.Time
-	var sentGexDate time.Time
-	var paidAtDate time.Time
+			var reviewedDate time.Time
+			var recGexDate time.Time
+			var sentGexDate time.Time
+			var paidAtDate time.Time
 
-	if existingPaymentRequest.ReviewedAt != nil {
-		reviewedDate = *existingPaymentRequest.ReviewedAt
-	}
-	if existingPaymentRequest.ReceivedByGexAt != nil {
-		recGexDate = *existingPaymentRequest.ReceivedByGexAt
-	}
-	if existingPaymentRequest.SentToGexAt != nil {
-		sentGexDate = *existingPaymentRequest.SentToGexAt
-	}
-	if existingPaymentRequest.PaidAt != nil {
-		paidAtDate = *existingPaymentRequest.PaidAt
-	}
+			if existingPaymentRequest.ReviewedAt != nil {
+				reviewedDate = *existingPaymentRequest.ReviewedAt
+			}
+			if existingPaymentRequest.ReceivedByGexAt != nil {
+				recGexDate = *existingPaymentRequest.ReceivedByGexAt
+			}
+			if existingPaymentRequest.SentToGexAt != nil {
+				sentGexDate = *existingPaymentRequest.SentToGexAt
+			}
+			if existingPaymentRequest.PaidAt != nil {
+				paidAtDate = *existingPaymentRequest.PaidAt
+			}
 
-	// Let's map the incoming status to our enumeration type
-	switch params.Body.Status {
-	case supportmessages.PaymentRequestStatusPENDING:
-		status = models.PaymentRequestStatusPending
-	case supportmessages.PaymentRequestStatusREVIEWED:
-		status = models.PaymentRequestStatusReviewed
-		reviewedDate = time.Now()
-	case supportmessages.PaymentRequestStatusSENTTOGEX:
-		status = models.PaymentRequestStatusSentToGex
-		sentGexDate = time.Now()
-	case supportmessages.PaymentRequestStatusRECEIVEDBYGEX:
-		status = models.PaymentRequestStatusReceivedByGex
-		recGexDate = time.Now()
-	case supportmessages.PaymentRequestStatusPAID:
-		status = models.PaymentRequestStatusPaid
-		paidAtDate = time.Now()
-	case supportmessages.PaymentRequestStatusEDIERROR:
-		status = models.PaymentRequestStatusEDIError
-	case supportmessages.PaymentRequestStatusDEPRECATED:
-		status = models.PaymentRequestStatusDeprecated
-	}
+			// Let's map the incoming status to our enumeration type
+			switch params.Body.Status {
+			case supportmessages.PaymentRequestStatusPENDING:
+				status = models.PaymentRequestStatusPending
+			case supportmessages.PaymentRequestStatusREVIEWED:
+				status = models.PaymentRequestStatusReviewed
+				reviewedDate = time.Now()
+			case supportmessages.PaymentRequestStatusSENTTOGEX:
+				status = models.PaymentRequestStatusSentToGex
+				sentGexDate = time.Now()
+			case supportmessages.PaymentRequestStatusRECEIVEDBYGEX:
+				status = models.PaymentRequestStatusReceivedByGex
+				recGexDate = time.Now()
+			case supportmessages.PaymentRequestStatusPAID:
+				status = models.PaymentRequestStatusPaid
+				paidAtDate = time.Now()
+			case supportmessages.PaymentRequestStatusEDIERROR:
+				status = models.PaymentRequestStatusEDIError
+			case supportmessages.PaymentRequestStatusDEPRECATED:
+				status = models.PaymentRequestStatusDeprecated
+			}
 
-	// If we got a rejection reason let's use it
-	rejectionReason := existingPaymentRequest.RejectionReason
-	if params.Body.RejectionReason != nil {
-		rejectionReason = params.Body.RejectionReason
-	}
+			// If we got a rejection reason let's use it
+			rejectionReason := existingPaymentRequest.RejectionReason
+			if params.Body.RejectionReason != nil {
+				rejectionReason = params.Body.RejectionReason
+			}
 
-	paymentRequestForUpdate := models.PaymentRequest{
-		ID:                              existingPaymentRequest.ID,
-		MoveTaskOrder:                   existingPaymentRequest.MoveTaskOrder,
-		MoveTaskOrderID:                 existingPaymentRequest.MoveTaskOrderID,
-		IsFinal:                         existingPaymentRequest.IsFinal,
-		Status:                          status,
-		RejectionReason:                 rejectionReason,
-		RequestedAt:                     existingPaymentRequest.RequestedAt,
-		ReviewedAt:                      &reviewedDate,
-		SentToGexAt:                     &sentGexDate,
-		ReceivedByGexAt:                 &recGexDate,
-		PaidAt:                          &paidAtDate,
-		PaymentRequestNumber:            existingPaymentRequest.PaymentRequestNumber,
-		RecalculationOfPaymentRequestID: existingPaymentRequest.RecalculationOfPaymentRequestID,
-		SequenceNumber:                  existingPaymentRequest.SequenceNumber,
-	}
+			paymentRequestForUpdate := models.PaymentRequest{
+				ID:                              existingPaymentRequest.ID,
+				MoveTaskOrder:                   existingPaymentRequest.MoveTaskOrder,
+				MoveTaskOrderID:                 existingPaymentRequest.MoveTaskOrderID,
+				IsFinal:                         existingPaymentRequest.IsFinal,
+				Status:                          status,
+				RejectionReason:                 rejectionReason,
+				RequestedAt:                     existingPaymentRequest.RequestedAt,
+				ReviewedAt:                      &reviewedDate,
+				SentToGexAt:                     &sentGexDate,
+				ReceivedByGexAt:                 &recGexDate,
+				PaidAt:                          &paidAtDate,
+				PaymentRequestNumber:            existingPaymentRequest.PaymentRequestNumber,
+				RecalculationOfPaymentRequestID: existingPaymentRequest.RecalculationOfPaymentRequestID,
+				SequenceNumber:                  existingPaymentRequest.SequenceNumber,
+			}
 
-	// And now let's save our updated model object using the PaymentRequestUpdater service object.
-	updatedPaymentRequest, err := h.PaymentRequestStatusUpdater.UpdatePaymentRequestStatus(appCtx, &paymentRequestForUpdate, params.IfMatch)
+			// And now let's save our updated model object using the PaymentRequestUpdater service object.
+			updatedPaymentRequest, err := h.PaymentRequestStatusUpdater.UpdatePaymentRequestStatus(appCtx, &paymentRequestForUpdate, params.IfMatch)
 
-	if err != nil {
-		switch err.(type) {
-		case apperror.NotFoundError:
-			return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.PreconditionFailedError:
-			return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.ConflictError:
-			return paymentrequestop.NewUpdatePaymentRequestStatusConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		default:
-			appCtx.Logger().Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
-			return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-	}
+			if err != nil {
+				switch err.(type) {
+				case apperror.NotFoundError:
+					return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(
+						payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.PreconditionFailedError:
+					return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(
+						payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.ConflictError:
+					return paymentrequestop.NewUpdatePaymentRequestStatusConflict().WithPayload(
+						payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				default:
+					appCtx.Logger().Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
+					return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
+			}
 
-	_, err = event.TriggerEvent(event.Event{
-		EventKey:        event.PaymentRequestUpdateEventKey,
-		MtoID:           mtoID,
-		UpdatedObjectID: updatedPaymentRequest.ID,
-		EndpointKey:     event.SupportUpdatePaymentRequestStatusEndpointKey,
-		AppContext:      appCtx,
-		TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
-	})
-	if err != nil {
-		appCtx.Logger().Error("supportapi.UpdatePaymentRequestStatusHandler could not generate the event")
-	}
+			_, err = event.TriggerEvent(event.Event{
+				EventKey:        event.PaymentRequestUpdateEventKey,
+				MtoID:           mtoID,
+				UpdatedObjectID: updatedPaymentRequest.ID,
+				EndpointKey:     event.SupportUpdatePaymentRequestStatusEndpointKey,
+				AppContext:      appCtx,
+				TraceID:         h.GetTraceIDFromRequest(params.HTTPRequest),
+			})
+			if err != nil {
+				appCtx.Logger().Error("supportapi.UpdatePaymentRequestStatusHandler could not generate the event")
+			}
 
-	returnPayload := payloads.PaymentRequest(updatedPaymentRequest)
-	return paymentrequestop.NewUpdatePaymentRequestStatusOK().WithPayload(returnPayload)
+			returnPayload := payloads.PaymentRequest(updatedPaymentRequest)
+			return paymentrequestop.NewUpdatePaymentRequestStatusOK().WithPayload(returnPayload), err
+		})
 }
 
 // ListMTOPaymentRequestsHandler gets all payment requests for a given MTO
@@ -158,28 +167,30 @@ type ListMTOPaymentRequestsHandler struct {
 
 // Handle getting payment requests for a given MTO
 func (h ListMTOPaymentRequestsHandler) Handle(params paymentrequestop.ListMTOPaymentRequestsParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
-	mtoID, err := uuid.FromString(params.MoveTaskOrderID.String())
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			mtoID, err := uuid.FromString(params.MoveTaskOrderID.String())
 
-	if err != nil {
-		appCtx.Logger().Error(fmt.Sprintf("Error parsing move task order id: %s", params.MoveTaskOrderID.String()), zap.Error(err))
-		return paymentrequestop.NewListMTOPaymentRequestsInternalServerError()
-	}
+			if err != nil {
+				appCtx.Logger().Error(fmt.Sprintf("Error parsing move task order id: %s", params.MoveTaskOrderID.String()), zap.Error(err))
+				return paymentrequestop.NewListMTOPaymentRequestsInternalServerError(), err
+			}
 
-	var paymentRequests models.PaymentRequests
+			var paymentRequests models.PaymentRequests
 
-	query := appCtx.DB().Where("move_id = ?", mtoID)
+			query := appCtx.DB().Where("move_id = ?", mtoID)
 
-	err = query.All(&paymentRequests)
+			err = query.All(&paymentRequests)
 
-	if err != nil {
-		appCtx.Logger().Error("Unable to fetch records:", zap.Error(err))
-		return paymentrequestop.NewListMTOPaymentRequestsInternalServerError()
-	}
+			if err != nil {
+				appCtx.Logger().Error("Unable to fetch records:", zap.Error(err))
+				return paymentrequestop.NewListMTOPaymentRequestsInternalServerError(), err
+			}
 
-	payload := payloads.PaymentRequests(&paymentRequests)
+			payload := payloads.PaymentRequests(&paymentRequests)
 
-	return paymentrequestop.NewListMTOPaymentRequestsOK().WithPayload(*payload)
+			return paymentrequestop.NewListMTOPaymentRequestsOK().WithPayload(*payload), nil
+		})
 }
 
 // GetPaymentRequestEDIHandler returns the EDI for a given payment request
@@ -191,59 +202,62 @@ type GetPaymentRequestEDIHandler struct {
 
 // Handle getting the EDI for a given payment request
 func (h GetPaymentRequestEDIHandler) Handle(params paymentrequestop.GetPaymentRequestEDIParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-	paymentRequestID := uuid.FromStringOrNil(params.PaymentRequestID.String())
-	paymentRequest, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
-	if err != nil {
-		msg := fmt.Sprintf("Error finding Payment Request for EDI generation with ID: %s", params.PaymentRequestID.String())
-		appCtx.Logger().Error(msg, zap.Error(err))
-		return paymentrequestop.NewGetPaymentRequestEDINotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
-
-	var payload supportmessages.PaymentRequestEDI
-	payload.ID = *handlers.FmtUUID(paymentRequestID)
-
-	edi858c, err := h.GHCPaymentRequestInvoiceGenerator.Generate(appCtx, paymentRequest, false)
-	if err == nil {
-		payload.Edi, err = edi858c.EDIString(appCtx.Logger())
-	}
-	if err != nil {
-		appCtx.Logger().Error(fmt.Sprintf("Error generating EDI string for payment request ID: %s: %s", paymentRequestID, err))
-		switch e := err.(type) {
-
-		// NotFoundError -> Not Found response
-		case apperror.NotFoundError:
-			return paymentrequestop.NewGetPaymentRequestEDINotFound().
-				WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-
-		// InvalidInputError -> Unprocessable Entity response
-		case apperror.InvalidInputError:
-			return paymentrequestop.NewGetPaymentRequestEDIUnprocessableEntity().
-				WithPayload(payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors))
-
-		// ConflictError -> Conflict Error response
-		case apperror.ConflictError:
-			return paymentrequestop.NewGetPaymentRequestEDIConflict().
-				WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-
-		// QueryError -> Internal Server error
-		case apperror.QueryError:
-			if e.Unwrap() != nil {
-				// If you can unwrap, log the internal error (usually a pq error) for better debugging
-				// Note we do not expose this detail in the payload
-				appCtx.Logger().Error("Error retrieving an EDI for the payment request", zap.Error(e.Unwrap()))
+			paymentRequestID := uuid.FromStringOrNil(params.PaymentRequestID.String())
+			paymentRequest, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
+			if err != nil {
+				msg := fmt.Sprintf("Error finding Payment Request for EDI generation with ID: %s", params.PaymentRequestID.String())
+				appCtx.Logger().Error(msg, zap.Error(err))
+				return paymentrequestop.NewGetPaymentRequestEDINotFound().WithPayload(
+					payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest))), err
 			}
-			return paymentrequestop.NewGetPaymentRequestEDIInternalServerError().
-				WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		// Unknown -> Internal Server Error
-		default:
-			return paymentrequestop.NewGetPaymentRequestEDIInternalServerError().
-				WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-	}
 
-	return paymentrequestop.NewGetPaymentRequestEDIOK().WithPayload(&payload)
+			var payload supportmessages.PaymentRequestEDI
+			payload.ID = *handlers.FmtUUID(paymentRequestID)
+
+			edi858c, err := h.GHCPaymentRequestInvoiceGenerator.Generate(appCtx, paymentRequest, false)
+			if err == nil {
+				payload.Edi, err = edi858c.EDIString(appCtx.Logger())
+			}
+			if err != nil {
+				appCtx.Logger().Error(fmt.Sprintf("Error generating EDI string for payment request ID: %s: %s", paymentRequestID, err))
+				switch e := err.(type) {
+
+				// NotFoundError -> Not Found response
+				case apperror.NotFoundError:
+					return paymentrequestop.NewGetPaymentRequestEDINotFound().WithPayload(
+						payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+
+				// InvalidInputError -> Unprocessable Entity response
+				case apperror.InvalidInputError:
+					return paymentrequestop.NewGetPaymentRequestEDIUnprocessableEntity().WithPayload(
+						payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)), err
+
+				// ConflictError -> Conflict Error response
+				case apperror.ConflictError:
+					return paymentrequestop.NewGetPaymentRequestEDIConflict().WithPayload(
+						payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+
+				// QueryError -> Internal Server error
+				case apperror.QueryError:
+					if e.Unwrap() != nil {
+						// If you can unwrap, log the internal error (usually a pq error) for better debugging
+						// Note we do not expose this detail in the payload
+						appCtx.Logger().Error("Error retrieving an EDI for the payment request", zap.Error(e.Unwrap()))
+					}
+					return paymentrequestop.NewGetPaymentRequestEDIInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				// Unknown -> Internal Server Error
+				default:
+					return paymentrequestop.NewGetPaymentRequestEDIInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
+			}
+
+			return paymentrequestop.NewGetPaymentRequestEDIOK().WithPayload(&payload), nil
+		})
 }
 
 // ProcessReviewedPaymentRequestsHandler returns the EDI for a given payment request
@@ -264,154 +278,170 @@ type ProcessReviewedPaymentRequestsHandler struct {
 
 // Handle getting the EDI for a given payment request
 func (h ProcessReviewedPaymentRequestsHandler) Handle(params paymentrequestop.ProcessReviewedPaymentRequestsParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
 
-	paymentRequestID := uuid.FromStringOrNil(params.Body.PaymentRequestID.String())
-	sendToSyncada := params.Body.SendToSyncada
-	readFromSyncada := params.Body.ReadFromSyncada
-	deleteFromSyncada := params.Body.DeleteFromSyncada
-	paymentRequestStatus := params.Body.Status
-	var paymentRequests models.PaymentRequests
-	var updatedPaymentRequests models.PaymentRequests
+			paymentRequestID := uuid.FromStringOrNil(params.Body.PaymentRequestID.String())
+			sendToSyncada := params.Body.SendToSyncada
+			readFromSyncada := params.Body.ReadFromSyncada
+			deleteFromSyncada := params.Body.DeleteFromSyncada
+			paymentRequestStatus := params.Body.Status
+			var paymentRequests models.PaymentRequests
+			var updatedPaymentRequests models.PaymentRequests
 
-	if sendToSyncada == nil {
-		return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, sendToSyncada flag required", h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
-	if readFromSyncada == nil {
-		return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, readFromSyncada flag required", h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
-	if deleteFromSyncada == nil {
-		return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, deleteFromSyncada flag required", h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
-
-	if *sendToSyncada {
-		reviewedPaymentRequestProcessor, err := paymentrequest.InitNewPaymentRequestReviewedProcessor(appCtx, true, h.ICNSequencer(), h.GexSender())
-		if err != nil {
-			msg := "failed to initialize InitNewPaymentRequestReviewedProcessor"
-			appCtx.Logger().Error(msg, zap.Error(err))
-			return paymentrequestop.NewProcessReviewedPaymentRequestsInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-		reviewedPaymentRequestProcessor.ProcessReviewedPaymentRequest(appCtx)
-	} else {
-		if paymentRequestID != uuid.Nil {
-			pr, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
-			if err != nil {
-				msg := fmt.Sprintf("Error finding Payment Request with ID: %s", params.Body.PaymentRequestID.String())
-				appCtx.Logger().Error(msg, zap.Error(err))
-				return paymentrequestop.NewProcessReviewedPaymentRequestsNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest)))
+			if sendToSyncada == nil {
+				syncadaErr := apperror.NewBadDataError("bad request, sendToSyncada flag required")
+				return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(
+					payloads.ClientError(handlers.BadRequestErrMessage, syncadaErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), syncadaErr
 			}
-			paymentRequests = append(paymentRequests, pr)
-		} else {
-			reviewedPaymentRequests, err := h.PaymentRequestReviewedFetcher.FetchReviewedPaymentRequest(appCtx)
-			if err != nil {
-				msg := "function ProcessReviewedPaymentRequest failed call to FetchReviewedPaymentRequest"
-				appCtx.Logger().Error(msg, zap.Error(err))
-				return paymentrequestop.NewProcessReviewedPaymentRequestsInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
+			if readFromSyncada == nil {
+				syncadaErr := apperror.NewBadDataError("bad request, readFromSyncada flag required")
+				return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(
+					payloads.ClientError(handlers.BadRequestErrMessage, syncadaErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), syncadaErr
 			}
-			paymentRequests = append(paymentRequests, reviewedPaymentRequests...)
-		}
-
-		// Update each payment request to have the given status
-		for _, pr := range paymentRequests {
-			switch paymentRequestStatus {
-			case supportmessages.PaymentRequestStatusPENDING:
-				pr.Status = models.PaymentRequestStatusPending
-			case supportmessages.PaymentRequestStatusREVIEWED:
-				reviewedAt := time.Now()
-				pr.Status = models.PaymentRequestStatusReviewed
-				pr.ReviewedAt = &reviewedAt
-			case supportmessages.PaymentRequestStatusSENTTOGEX:
-				sentToGex := time.Now()
-				pr.Status = models.PaymentRequestStatusSentToGex
-				pr.SentToGexAt = &sentToGex
-			case supportmessages.PaymentRequestStatusRECEIVEDBYGEX:
-				recByGex := time.Now()
-				pr.Status = models.PaymentRequestStatusReceivedByGex
-				pr.ReceivedByGexAt = &recByGex
-			case supportmessages.PaymentRequestStatusPAID:
-				paidAt := time.Now()
-				pr.Status = models.PaymentRequestStatusPaid
-				pr.PaidAt = &paidAt
-			case supportmessages.PaymentRequestStatusEDIERROR:
-				pr.Status = models.PaymentRequestStatusEDIError
-			case supportmessages.PaymentRequestStatusDEPRECATED:
-				pr.Status = models.PaymentRequestStatusDeprecated
-			case "":
-				sentToGex := time.Now()
-				pr.Status = models.PaymentRequestStatusSentToGex
-				pr.SentToGexAt = &sentToGex
-			default:
-				return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, "bad request, an invalid status type was used", h.GetTraceIDFromRequest(params.HTTPRequest)))
+			if deleteFromSyncada == nil {
+				syncadaErr := apperror.NewBadDataError("bad request, deleteFromSyncada flag required")
+				return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(
+					payloads.ClientError(handlers.BadRequestErrMessage, syncadaErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), syncadaErr
 			}
 
-			newPr := pr
-			var nilEtag string
-			updatedPaymentRequest, err := h.PaymentRequestStatusUpdater.UpdatePaymentRequestStatus(appCtx, &newPr, nilEtag)
+			if *sendToSyncada {
+				reviewedPaymentRequestProcessor, err := paymentrequest.InitNewPaymentRequestReviewedProcessor(appCtx, true, h.ICNSequencer(), h.GexSender())
+				if err != nil {
+					msg := "failed to initialize InitNewPaymentRequestReviewedProcessor"
+					appCtx.Logger().Error(msg, zap.Error(err))
+					return paymentrequestop.NewProcessReviewedPaymentRequestsInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
+				reviewedPaymentRequestProcessor.ProcessReviewedPaymentRequest(appCtx)
+			} else {
+				if paymentRequestID != uuid.Nil {
+					pr, err := h.PaymentRequestFetcher.FetchPaymentRequest(appCtx, paymentRequestID)
+					if err != nil {
+						msg := fmt.Sprintf("Error finding Payment Request with ID: %s", params.Body.PaymentRequestID.String())
+						appCtx.Logger().Error(msg, zap.Error(err))
+						return paymentrequestop.NewProcessReviewedPaymentRequestsNotFound().WithPayload(
+							payloads.ClientError(handlers.NotFoundMessage, msg, h.GetTraceIDFromRequest(params.HTTPRequest))), err
+					}
+					paymentRequests = append(paymentRequests, pr)
+				} else {
+					reviewedPaymentRequests, err := h.PaymentRequestReviewedFetcher.FetchReviewedPaymentRequest(appCtx)
+					if err != nil {
+						msg := "function ProcessReviewedPaymentRequest failed call to FetchReviewedPaymentRequest"
+						appCtx.Logger().Error(msg, zap.Error(err))
+						return paymentrequestop.NewProcessReviewedPaymentRequestsInternalServerError().WithPayload(
+							payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+					}
+					paymentRequests = append(paymentRequests, reviewedPaymentRequests...)
+				}
 
-			if err != nil {
-				switch err.(type) {
-				case apperror.NotFoundError:
-					return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-				case apperror.PreconditionFailedError:
-					return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-				default:
-					appCtx.Logger().Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
-					return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
+				// Update each payment request to have the given status
+				for _, pr := range paymentRequests {
+					switch paymentRequestStatus {
+					case supportmessages.PaymentRequestStatusPENDING:
+						pr.Status = models.PaymentRequestStatusPending
+					case supportmessages.PaymentRequestStatusREVIEWED:
+						reviewedAt := time.Now()
+						pr.Status = models.PaymentRequestStatusReviewed
+						pr.ReviewedAt = &reviewedAt
+					case supportmessages.PaymentRequestStatusSENTTOGEX:
+						sentToGex := time.Now()
+						pr.Status = models.PaymentRequestStatusSentToGex
+						pr.SentToGexAt = &sentToGex
+					case supportmessages.PaymentRequestStatusRECEIVEDBYGEX:
+						recByGex := time.Now()
+						pr.Status = models.PaymentRequestStatusReceivedByGex
+						pr.ReceivedByGexAt = &recByGex
+					case supportmessages.PaymentRequestStatusPAID:
+						paidAt := time.Now()
+						pr.Status = models.PaymentRequestStatusPaid
+						pr.PaidAt = &paidAt
+					case supportmessages.PaymentRequestStatusEDIERROR:
+						pr.Status = models.PaymentRequestStatusEDIError
+					case supportmessages.PaymentRequestStatusDEPRECATED:
+						pr.Status = models.PaymentRequestStatusDeprecated
+					case "":
+						sentToGex := time.Now()
+						pr.Status = models.PaymentRequestStatusSentToGex
+						pr.SentToGexAt = &sentToGex
+					default:
+						statusErr := apperror.NewBadDataError("bad request, an invalid status type was used")
+						return paymentrequestop.NewProcessReviewedPaymentRequestsBadRequest().WithPayload(
+							payloads.ClientError(handlers.BadRequestErrMessage, statusErr.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), statusErr
+					}
+
+					newPr := pr
+					var nilEtag string
+					updatedPaymentRequest, err := h.PaymentRequestStatusUpdater.UpdatePaymentRequestStatus(appCtx, &newPr, nilEtag)
+
+					if err != nil {
+						switch err.(type) {
+						case apperror.NotFoundError:
+							return paymentrequestop.NewUpdatePaymentRequestStatusNotFound().WithPayload(
+								payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+						case apperror.PreconditionFailedError:
+							return paymentrequestop.NewUpdatePaymentRequestStatusPreconditionFailed().WithPayload(
+								payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+						default:
+							appCtx.Logger().Error(fmt.Sprintf("Error saving payment request status for ID: %s: %s", paymentRequestID, err))
+							return paymentrequestop.NewUpdatePaymentRequestStatusInternalServerError().WithPayload(
+								payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+						}
+					}
+					updatedPaymentRequests = append(updatedPaymentRequests, *updatedPaymentRequest)
 				}
 			}
-			updatedPaymentRequests = append(updatedPaymentRequests, *updatedPaymentRequest)
-		}
-	}
 
-	if *readFromSyncada {
-		// Set up viper to read environment variables
-		v := viper.New()
-		v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-		v.AutomaticEnv()
-		path997 := v.GetString(cli.GEXSFTP997PickupDirectory)
-		path824 := v.GetString(cli.GEXSFTP824PickupDirectory)
+			if *readFromSyncada {
+				// Set up viper to read environment variables
+				v := viper.New()
+				v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+				v.AutomaticEnv()
+				path997 := v.GetString(cli.GEXSFTP997PickupDirectory)
+				path824 := v.GetString(cli.GEXSFTP824PickupDirectory)
 
-		sshClient, err := cli.InitGEXSSH(appCtx, v)
-		if err != nil {
-			appCtx.Logger().Fatal("couldn't initialize SSH client", zap.Error(err))
-		}
-		defer func() {
-			if closeErr := sshClient.Close(); closeErr != nil {
-				appCtx.Logger().Fatal("could not close SFTP client", zap.Error(closeErr))
+				sshClient, err := cli.InitGEXSSH(appCtx, v)
+				if err != nil {
+					appCtx.Logger().Fatal("couldn't initialize SSH client", zap.Error(err))
+				}
+				defer func() {
+					if closeErr := sshClient.Close(); closeErr != nil {
+						appCtx.Logger().Fatal("could not close SFTP client", zap.Error(closeErr))
+					}
+				}()
+
+				sftpClient, err := cli.InitGEXSFTP(appCtx, sshClient)
+				if err != nil {
+					appCtx.Logger().Fatal("couldn't initialize SFTP client", zap.Error(err))
+				}
+				defer func() {
+					if closeErr := sftpClient.Close(); closeErr != nil {
+						appCtx.Logger().Fatal("could not close SFTP client", zap.Error(closeErr))
+					}
+				}()
+
+				wrappedSFTPClient := invoice.NewSFTPClientWrapper(sftpClient)
+				syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, *deleteFromSyncada)
+
+				_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(appCtx, path997, time.Time{}, invoice.NewEDI997Processor())
+				if err != nil {
+					appCtx.Logger().Error("Error reading 997 responses", zap.Error(err))
+				} else {
+					appCtx.Logger().Info("Successfully processed 997 responses")
+				}
+				_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(appCtx, path824, time.Time{}, invoice.NewEDI824Processor())
+				if err != nil {
+					appCtx.Logger().Error("Error reading 824 responses", zap.Error(err))
+				} else {
+					appCtx.Logger().Info("Successfully processed 824 responses")
+				}
+			} else {
+				appCtx.Logger().Info("Skipping reading from Syncada")
 			}
-		}()
+			payload := payloads.PaymentRequests(&updatedPaymentRequests)
 
-		sftpClient, err := cli.InitGEXSFTP(appCtx, sshClient)
-		if err != nil {
-			appCtx.Logger().Fatal("couldn't initialize SFTP client", zap.Error(err))
-		}
-		defer func() {
-			if closeErr := sftpClient.Close(); closeErr != nil {
-				appCtx.Logger().Fatal("could not close SFTP client", zap.Error(closeErr))
-			}
-		}()
-
-		wrappedSFTPClient := invoice.NewSFTPClientWrapper(sftpClient)
-		syncadaSFTPSession := invoice.NewSyncadaSFTPReaderSession(wrappedSFTPClient, *deleteFromSyncada)
-
-		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(appCtx, path997, time.Time{}, invoice.NewEDI997Processor())
-		if err != nil {
-			appCtx.Logger().Error("Error reading 997 responses", zap.Error(err))
-		} else {
-			appCtx.Logger().Info("Successfully processed 997 responses")
-		}
-		_, err = syncadaSFTPSession.FetchAndProcessSyncadaFiles(appCtx, path824, time.Time{}, invoice.NewEDI824Processor())
-		if err != nil {
-			appCtx.Logger().Error("Error reading 824 responses", zap.Error(err))
-		} else {
-			appCtx.Logger().Info("Successfully processed 824 responses")
-		}
-	} else {
-		appCtx.Logger().Info("Skipping reading from Syncada")
-	}
-	payload := payloads.PaymentRequests(&updatedPaymentRequests)
-
-	return paymentrequestop.NewProcessReviewedPaymentRequestsOK().WithPayload(*payload)
+			return paymentrequestop.NewProcessReviewedPaymentRequestsOK().WithPayload(*payload), nil
+		})
 }
 
 // RecalculatePaymentRequestHandler recalculates a payment request
@@ -422,39 +452,49 @@ type RecalculatePaymentRequestHandler struct {
 
 // Handle getting the EDI for a given payment request
 func (h RecalculatePaymentRequestHandler) Handle(params paymentrequestop.RecalculatePaymentRequestParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
-	paymentRequestID := uuid.FromStringOrNil(params.PaymentRequestID.String())
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			paymentRequestID := uuid.FromStringOrNil(params.PaymentRequestID.String())
 
-	newPaymentRequest, err := h.PaymentRequestRecalculator.RecalculatePaymentRequest(appCtx, paymentRequestID)
+			newPaymentRequest, err := h.PaymentRequestRecalculator.RecalculatePaymentRequest(appCtx, paymentRequestID)
 
-	if err != nil {
-		switch e := err.(type) {
-		case *apperror.BadDataError:
-			return paymentrequestop.NewRecalculatePaymentRequestBadRequest().WithPayload(payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.NotFoundError:
-			return paymentrequestop.NewRecalculatePaymentRequestNotFound().WithPayload(payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.ConflictError:
-			return paymentrequestop.NewRecalculatePaymentRequestConflict().WithPayload(payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.PreconditionFailedError:
-			return paymentrequestop.NewRecalculatePaymentRequestPreconditionFailed().WithPayload(payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		case apperror.InvalidInputError:
-			return paymentrequestop.NewRecalculatePaymentRequestUnprocessableEntity().WithPayload(payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors))
-		case apperror.InvalidCreateInputError:
-			return paymentrequestop.NewRecalculatePaymentRequestUnprocessableEntity().WithPayload(payloads.ValidationError(err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors))
-		case apperror.QueryError:
-			if e.Unwrap() != nil {
-				// If you can unwrap, log the internal error (usually a pq error) for better debugging
-				// Note we do not expose this detail in the payload
-				appCtx.Logger().Error("Error recalculating payment request", zap.Error(e.Unwrap()))
+			if err != nil {
+				switch e := err.(type) {
+				case *apperror.BadDataError:
+					return paymentrequestop.NewRecalculatePaymentRequestBadRequest().WithPayload(
+						payloads.ClientError(handlers.BadRequestErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.NotFoundError:
+					return paymentrequestop.NewRecalculatePaymentRequestNotFound().WithPayload(
+						payloads.ClientError(handlers.NotFoundMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.ConflictError:
+					return paymentrequestop.NewRecalculatePaymentRequestConflict().WithPayload(
+						payloads.ClientError(handlers.ConflictErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.PreconditionFailedError:
+					return paymentrequestop.NewRecalculatePaymentRequestPreconditionFailed().WithPayload(
+						payloads.ClientError(handlers.PreconditionErrMessage, err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				case apperror.InvalidInputError:
+					return paymentrequestop.NewRecalculatePaymentRequestUnprocessableEntity().WithPayload(
+						payloads.ValidationError(handlers.ValidationErrMessage, h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)), err
+				case apperror.InvalidCreateInputError:
+					return paymentrequestop.NewRecalculatePaymentRequestUnprocessableEntity().WithPayload(
+						payloads.ValidationError(err.Error(), h.GetTraceIDFromRequest(params.HTTPRequest), e.ValidationErrors)), err
+				case apperror.QueryError:
+					if e.Unwrap() != nil {
+						// If you can unwrap, log the internal error (usually a pq error) for better debugging
+						// Note we do not expose this detail in the payload
+						appCtx.Logger().Error("Error recalculating payment request", zap.Error(e.Unwrap()))
+					}
+					return paymentrequestop.NewRecalculatePaymentRequestInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				default:
+					appCtx.Logger().Error(fmt.Sprintf("Error recalculating payment request for ID: %s: %s", paymentRequestID, err))
+					return paymentrequestop.NewRecalculatePaymentRequestInternalServerError().WithPayload(
+						payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+				}
 			}
-			return paymentrequestop.NewRecalculatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		default:
-			appCtx.Logger().Error(fmt.Sprintf("Error recalculating payment request for ID: %s: %s", paymentRequestID, err))
-			return paymentrequestop.NewRecalculatePaymentRequestInternalServerError().WithPayload(payloads.InternalServerError(handlers.FmtString(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-		}
-	}
 
-	returnPayload := payloads.PaymentRequest(newPaymentRequest)
+			returnPayload := payloads.PaymentRequest(newPaymentRequest)
 
-	return paymentrequestop.NewRecalculatePaymentRequestCreated().WithPayload(returnPayload)
+			return paymentrequestop.NewRecalculatePaymentRequestCreated().WithPayload(returnPayload), nil
+		})
 }

--- a/pkg/handlers/supportapi/webhook_notification.go
+++ b/pkg/handlers/supportapi/webhook_notification.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-openapi/swag"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/services/event"
 
@@ -20,26 +21,28 @@ type ReceiveWebhookNotificationHandler struct {
 
 // Handle receipt of message
 func (h ReceiveWebhookNotificationHandler) Handle(params webhookops.ReceiveWebhookNotificationParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
-	notif := params.Body
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			notif := params.Body
 
-	objectID := "<empty>"
-	if notif.ObjectID != nil {
-		objectID = notif.ObjectID.String()
-	}
-	mtoID := "<empty>"
-	if notif.MoveTaskOrderID != nil {
-		mtoID = notif.MoveTaskOrderID.String()
-	}
+			objectID := "<empty>"
+			if notif.ObjectID != nil {
+				objectID = notif.ObjectID.String()
+			}
+			mtoID := "<empty>"
+			if notif.MoveTaskOrderID != nil {
+				mtoID = notif.MoveTaskOrderID.String()
+			}
 
-	appCtx.Logger().Info("Received Webhook Notification: ",
-		zap.String("id", notif.ID.String()),
-		zap.String("eventKey", notif.EventKey),
-		zap.String("createdAt", notif.CreatedAt.String()),
-		zap.String("traceID", notif.TraceID.String()),
-		zap.String("moveID", mtoID),
-		zap.String("objectID", objectID))
-	return webhookops.NewReceiveWebhookNotificationOK().WithPayload(notif)
+			appCtx.Logger().Info("Received Webhook Notification: ",
+				zap.String("id", notif.ID.String()),
+				zap.String("eventKey", notif.EventKey),
+				zap.String("createdAt", notif.CreatedAt.String()),
+				zap.String("traceID", notif.TraceID.String()),
+				zap.String("moveID", mtoID),
+				zap.String("objectID", objectID))
+			return webhookops.NewReceiveWebhookNotificationOK().WithPayload(notif), nil
+		})
 }
 
 // CreateWebhookNotificationHandler is the interface to handle the createWebhookNotification
@@ -49,36 +52,39 @@ type CreateWebhookNotificationHandler struct {
 
 // Handle handles the endpoint request to the createWebhookNotification handler
 func (h CreateWebhookNotificationHandler) Handle(params webhookops.CreateWebhookNotificationParams) middleware.Responder {
-	appCtx := h.AppContextFromRequest(params.HTTPRequest)
-	payload := params.Body
+	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
+		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
+			payload := params.Body
 
-	var err error
-	if payload == nil {
-		// create a default notification payload
-		message := "{ \"message\": \"This is a test notification\" }"
-		payload = &supportmessages.WebhookNotification{
-			EventKey: string(event.TestCreateEventKey),
-			TraceID:  *handlers.FmtUUID(h.GetTraceIDFromRequest(params.HTTPRequest)),
-			Object:   swag.String(message),
-			Status:   supportmessages.WebhookNotificationStatusPENDING,
-		}
-	}
-	// Convert to model and create in DB
-	notification, verrs := payloads.WebhookNotificationModel(payload, h.GetTraceIDFromRequest(params.HTTPRequest))
-	if verrs == nil {
-		verrs, err = appCtx.DB().ValidateAndCreate(notification)
-	}
-	if verrs != nil && verrs.HasAny() {
-		appCtx.Logger().Error("Error validating WebhookNotification: ", zap.Error(verrs))
+			var err error
+			if payload == nil {
+				// create a default notification payload
+				message := "{ \"message\": \"This is a test notification\" }"
+				payload = &supportmessages.WebhookNotification{
+					EventKey: string(event.TestCreateEventKey),
+					TraceID:  *handlers.FmtUUID(h.GetTraceIDFromRequest(params.HTTPRequest)),
+					Object:   swag.String(message),
+					Status:   supportmessages.WebhookNotificationStatusPENDING,
+				}
+			}
+			// Convert to model and create in DB
+			notification, verrs := payloads.WebhookNotificationModel(payload, h.GetTraceIDFromRequest(params.HTTPRequest))
+			if verrs == nil {
+				verrs, err = appCtx.DB().ValidateAndCreate(notification)
+			}
+			if verrs != nil && verrs.HasAny() {
+				appCtx.Logger().Error("Error validating WebhookNotification: ", zap.Error(verrs))
 
-		return webhookops.NewCreateWebhookNotificationUnprocessableEntity().WithPayload(payloads.ValidationError(
-			"The notification definition is invalid.", h.GetTraceIDFromRequest(params.HTTPRequest), verrs))
-	}
-	if err != nil {
-		appCtx.Logger().Error("Error creating WebhookNotification: ", zap.Error(err))
-		return webhookops.NewCreateWebhookNotificationInternalServerError().WithPayload(payloads.InternalServerError(swag.String(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest)))
-	}
+				return webhookops.NewCreateWebhookNotificationUnprocessableEntity().WithPayload(payloads.ValidationError(
+					"The notification definition is invalid.", h.GetTraceIDFromRequest(params.HTTPRequest), verrs)), verrs
+			}
+			if err != nil {
+				appCtx.Logger().Error("Error creating WebhookNotification: ", zap.Error(err))
+				return webhookops.NewCreateWebhookNotificationInternalServerError().WithPayload(
+					payloads.InternalServerError(swag.String(err.Error()), h.GetTraceIDFromRequest(params.HTTPRequest))), err
+			}
 
-	payload = payloads.WebhookNotification(notification)
-	return webhookops.NewCreateWebhookNotificationCreated().WithPayload(payload)
+			payload = payloads.WebhookNotification(notification)
+			return webhookops.NewCreateWebhookNotificationCreated().WithPayload(payload), nil
+		})
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11663) for this change

## Summary
This PR should refactor the support api handlers such that they now use the AuditableAppContextFromRequestWithErrors method instead of AppContextFromRequest. This should allow the handler methods to be audited and return errors usefully.

Please refer to to the other Pull Requests around this:
- #8348 
- #8341 
- #8351
- #8358 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminal to test this locally.</summary>

##### Terminal 1

Run the server tests to make sure they are still passing

```sh
make server_test
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.