### PR TITLE
MB-11319 add shipment type

### DIFF
--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -127,7 +127,7 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 			audit_history.*,
 			json_agg(
 				json_build_object(
-					'addressType', 'pickupAddress'::TEXT,
+					'address_type', 'pickupAddress'::TEXT,
 					'shipment_type', shipments.shipment_type
 				)
 				)::TEXT AS context,
@@ -144,7 +144,7 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 			audit_history.*,
 			json_agg(
 				json_build_object(
-					'addressType', 'destinationAddress'::TEXT,
+					'address_type', 'destinationAddress'::TEXT,
 					'shipment_type', shipments.shipment_type
 				)
 			)::TEXT AS context,

--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -125,8 +125,12 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 	pickup_address_logs AS (
 		SELECT
 			audit_history.*,
-			json_agg(json_build_object('addressType',
-					'pickupAddress'::TEXT))::TEXT AS context,
+			json_agg(
+				json_build_object(
+					'addressType', 'pickupAddress'::TEXT,
+					'shipment_type', shipments.shipment_type
+				)
+				)::TEXT AS context,
 			shipments.id::text AS context_id
 		FROM
 			audit_history
@@ -138,8 +142,12 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 	destination_address_logs AS (
 		SELECT
 			audit_history.*,
-			json_agg(json_build_object('addressType',
-					'destinationAddress'::TEXT))::TEXT AS context,
+			json_agg(
+				json_build_object(
+					'addressType', 'destinationAddress'::TEXT,
+					'shipment_type', shipments.shipment_type
+				)
+			)::TEXT AS context,
 			shipments.id::text AS context_id
 		FROM
 			audit_history

--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -217,15 +217,25 @@ func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, param
 		FROM
 			mto_agents
 		JOIN shipments ON mto_agents.mto_shipment_id = shipments.id
+
+
 	),
 	agents_logs AS (
-		SELECT audit_history.*,
-			NULL AS context,
+		SELECT
+			audit_history.*,
+			json_agg(
+				json_build_object(
+					'shipment_type', shipments.shipment_type
+				)
+			)::TEXT AS context,
 			NULL AS context_id
 		FROM
 			audit_history
+		JOIN shipments ON shipments.id = audit_history.object_id
 		JOIN agents ON agents.id = audit_history.object_id
 			AND audit_history."table_name" = 'mto_agents'
+		GROUP BY
+			shipments.id, audit_history.id
 	),
 	reweighs AS (
 		SELECT

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -318,7 +318,7 @@ export const updateMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
   tableName: 'addresses',
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
-  getDetailsLabeledDetails: ({ changedValues, oldValues, context }) => {
+  getDetailsLabeledDetails: ({ oldValues, changedValues, context }) => {
     let newChangedValues = {
       street_address_1: oldValues.street_address_1,
       street_address_2: oldValues.street_address_2,
@@ -340,6 +340,7 @@ export const updateMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
     }
 
     newChangedValues = {
+      shipment_type: context[0]?.shipment_type,
       ...changedValues,
     };
 
@@ -355,7 +356,7 @@ export const updateMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
   tableName: 'mto_agents',
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
-  getDetailsLabeledDetails: ({ changedValues, oldValues }) => {
+  getDetailsLabeledDetails: ({ oldValues, changedValues, context }) => {
     let newChangedValues = {
       email: oldValues.email,
       first_name: oldValues.first_name,
@@ -376,6 +377,7 @@ export const updateMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
     }
 
     newChangedValues = {
+      shipment_type: context[0].shipment_type,
       ...changedValues,
     };
 

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -115,7 +115,7 @@ export const createMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
   getDetailsLabeledDetails: ({ changedValues, context }) => {
     const address = formatMoveHistoryFullAddress(changedValues);
 
-    const { addressType } = context.filter((contextObject) => contextObject.addressType)[0];
+    const addressType = context.filter((contextObject) => contextObject.address_type)[0].address_type;
 
     let addressLabel = '';
     if (addressType === 'pickupAddress') {
@@ -332,7 +332,7 @@ export const updateMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
 
     const address = formatMoveHistoryFullAddress(newChangedValues);
 
-    const { addressType } = context.filter((contextObject) => contextObject.addressType)[0];
+    const addressType = context.filter((contextObject) => contextObject.address_type)[0].address_type;
 
     let addressLabel = '';
     if (addressType === 'pickupAddress') {

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -125,6 +125,7 @@ export const createMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
     }
 
     const newChangedValues = {
+      shipment_type: context[0]?.shipment_type,
       ...changedValues,
     };
 
@@ -140,7 +141,7 @@ export const createMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
   tableName: 'mto_agents',
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
-  getDetailsLabeledDetails: ({ changedValues, oldValues }) => {
+  getDetailsLabeledDetails: ({ changedValues, oldValues, context }) => {
     const agent = formatMoveHistoryAgent(changedValues);
 
     const agentType = changedValues.agent_type ?? oldValues.agent_type;
@@ -153,6 +154,7 @@ export const createMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
     }
 
     const newChangedValues = {
+      shipment_type: context[0]?.shipment_type,
       ...changedValues,
     };
 

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -287,7 +287,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
       },
-      context: [{ shipment_type: 'HHG', addressType: 'pickupAddress' }],
+      context: [{ shipment_type: 'HHG', address_type: 'pickupAddress' }],
     };
 
     it('correctly matches the Update mto shipment address event for pickup addresses', () => {
@@ -318,7 +318,7 @@ describe('moveHistoryEventTemplate', () => {
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
           oldValues: item.oldValues,
-          context: [{ shipment_type: 'HHG', addressType: 'destinationAddress' }],
+          context: [{ shipment_type: 'HHG', address_type: 'destinationAddress' }],
         }),
       ).toEqual({
         destination_address: '12 Any Street, P.O. Box 1234, Beverly Hills, CA 90211',
@@ -344,7 +344,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_2: 'P.O. Box 1234',
         state: 'CA',
       },
-      context: [{ shipment_type: 'HHG', addressType: 'pickupAddress' }],
+      context: [{ shipment_type: 'HHG', address_type: 'pickupAddress' }],
     };
 
     it('correctly matches the insert mto shipment address event for pickup addresses', () => {
@@ -374,7 +374,7 @@ describe('moveHistoryEventTemplate', () => {
       expect(
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
-          context: [{ shipment_type: 'HHG', addressType: 'destinationAddress' }],
+          context: [{ shipment_type: 'HHG', address_type: 'destinationAddress' }],
         }),
       ).toEqual({
         destination_address: '12 Any Street, P.O. Box 1234, Beverly Hills, CA 90211',

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -287,7 +287,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
       },
-      context: [{ addressType: 'pickupAddress' }],
+      context: [{ shipment_type: 'HHG', addressType: 'pickupAddress' }],
     };
 
     it('correctly matches the Update mto shipment address event for pickup addresses', () => {
@@ -306,6 +306,7 @@ describe('moveHistoryEventTemplate', () => {
         postal_code: '90211',
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
+        shipment_type: 'HHG',
       });
     });
 
@@ -317,7 +318,7 @@ describe('moveHistoryEventTemplate', () => {
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
           oldValues: item.oldValues,
-          context: [{ addressType: 'destinationAddress' }],
+          context: [{ shipment_type: 'HHG', addressType: 'destinationAddress' }],
         }),
       ).toEqual({
         destination_address: '12 Any Street, P.O. Box 1234, Beverly Hills, CA 90211',
@@ -325,6 +326,7 @@ describe('moveHistoryEventTemplate', () => {
         postal_code: '90211',
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
+        shipment_type: 'HHG',
       });
     });
   });
@@ -342,7 +344,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_2: 'P.O. Box 1234',
         state: 'CA',
       },
-      context: [{ addressType: 'pickupAddress' }],
+      context: [{ shipment_type: 'HHG', addressType: 'pickupAddress' }],
     };
 
     it('correctly matches the insert mto shipment address event for pickup addresses', () => {
@@ -361,6 +363,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
         state: 'CA',
+        shipment_type: 'HHG',
       });
     });
 
@@ -371,7 +374,7 @@ describe('moveHistoryEventTemplate', () => {
       expect(
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
-          context: [{ addressType: 'destinationAddress' }],
+          context: [{ shipment_type: 'HHG', addressType: 'destinationAddress' }],
         }),
       ).toEqual({
         destination_address: '12 Any Street, P.O. Box 1234, Beverly Hills, CA 90211',
@@ -380,6 +383,7 @@ describe('moveHistoryEventTemplate', () => {
         street_address_1: '12 Any Street',
         street_address_2: 'P.O. Box 1234',
         state: 'CA',
+        shipment_type: 'HHG',
       });
     });
   });
@@ -402,6 +406,7 @@ describe('moveHistoryEventTemplate', () => {
         last_name: 'Griffin',
         phone: '555-555-5551',
       },
+      context: [{ shipment_type: 'HHG' }],
     };
 
     it('correctly matches the Update mto shipment agent event for releasing agents', () => {
@@ -412,12 +417,14 @@ describe('moveHistoryEventTemplate', () => {
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
           oldValues: item.oldValues,
+          context: item.context,
         }),
       ).toEqual({
         releasing_agent: 'Grace Griffin, 555-555-5555, grace@email.com',
         email: 'grace@email.com',
         first_name: 'Grace',
         phone: '555-555-5555',
+        shipment_type: 'HHG',
       });
     });
 
@@ -429,12 +436,14 @@ describe('moveHistoryEventTemplate', () => {
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
           oldValues: { ...item.oldValues, agent_type: 'RECEIVING_AGENT' },
+          context: item.context,
         }),
       ).toEqual({
         receiving_agent: 'Grace Griffin, 555-555-5555, grace@email.com',
         email: 'grace@email.com',
         first_name: 'Grace',
         phone: '555-555-5555',
+        shipment_type: 'HHG',
       });
     });
   });
@@ -452,6 +461,7 @@ describe('moveHistoryEventTemplate', () => {
         phone: '555-555-5555',
         agent_type: 'RELEASING_AGENT',
       },
+      context: [{ shipment_type: 'HHG' }],
     };
 
     it('correctly matches the insert mto shipment agent event for releasing agents', () => {
@@ -461,6 +471,7 @@ describe('moveHistoryEventTemplate', () => {
       expect(
         result.getDetailsLabeledDetails({
           changedValues: item.changedValues,
+          context: item.context,
         }),
       ).toEqual({
         releasing_agent: 'Grace Griffin, 555-555-5555, grace@email.com',
@@ -469,6 +480,7 @@ describe('moveHistoryEventTemplate', () => {
         last_name: 'Griffin',
         phone: '555-555-5555',
         agent_type: 'RELEASING_AGENT',
+        shipment_type: 'HHG',
       });
     });
 
@@ -479,6 +491,7 @@ describe('moveHistoryEventTemplate', () => {
       expect(
         result.getDetailsLabeledDetails({
           changedValues: { ...item.changedValues, agent_type: 'RECEIVING_AGENT' },
+          context: item.context,
         }),
       ).toEqual({
         receiving_agent: 'Grace Griffin, 555-555-5555, grace@email.com',
@@ -487,6 +500,7 @@ describe('moveHistoryEventTemplate', () => {
         last_name: 'Griffin',
         phone: '555-555-5555',
         agent_type: 'RECEIVING_AGENT',
+        shipment_type: 'HHG',
       });
     });
   });

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -69,7 +69,7 @@ describe('LabeledDetails', () => {
     });
   });
 
-  it('renderes shipment_type as a header', async () => {
+  it('renders shipment_type as a header', async () => {
     const historyRecord = {
       changedValues: {
         billable_weight_cap: '200',


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11319) for this change

## Summary

Adding the shipment type was missed in [the previous PR](https://github.com/transcom/mymove/pull/8483). 
This one should add it in. 
Context was used (thank you @rogeruiz for the pairing help) to retrieve the needed data.
Tests were adjusted to handle the new context.

I've also changed the context for the pickup and destination addresses to have `address_type` instead of `addressType` to keep them all consistent. @michaelvaldes-truss

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office application
2. Login as a TOO
3. Select a move
4. On the move details page, select a shipment to edit.
5. Edit as many or as little fields as you desire and save.
6. Go to the move history tab and see the updates to the shipments.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.


## Screenshots
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/6477059/167056280-f211fa83-28ba-44fb-9718-185a82036857.png">
