### PR TITLE
[ MB-12368 ] Add Cypress test for Max Billable Weight updates

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -1,9 +1,8 @@
 {
-  "plugins": ["cypress", "prettier", "security", "no-only-tests"],
-  "extends": ["react-app", "plugin:cypress/recommended", "plugin:prettier/recommended", "plugin:security/recommended"],
+  "plugins": ["prettier", "security", "no-only-tests"],
+  "extends": ["react-app", "plugin:prettier/recommended", "plugin:security/recommended"],
   "rules": {
     "consistent-return": "error",
-    "cypress/require-data-selectors": "warn",
     "react/no-access-state-in-setstate": "error",
     "prettier/prettier": "error",
     "no-only-tests/no-only-tests": "error",

--- a/cypress/integration/office/txo/tio-update-max-billable-weight.js
+++ b/cypress/integration/office/txo/tio-update-max-billable-weight.js
@@ -12,7 +12,10 @@ describe('TIO user', () => {
       'getSortedPaymentRequests',
     );
     cy.intercept('**/ghc/v1/moves/**/payment-requests').as('getMovePaymentRequests');
-    cy.intercept('**/ghc/v1/moves/**/billable-weight').as('getBillableWeight');
+    cy.intercept('**/ghc/v1/move-task-orders/**/billable-weights-reviewed-at').as('getBillableWeight');
+    cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/orders/**/update-max-billable-weight/tio').as('updateBillableWeight');
 
     const userId = '3b2cc1b0-31a2-4d1b-874f-0591f9127374';
     cy.apiSignInAsUser(userId, TIOOfficeUserType);
@@ -34,6 +37,21 @@ describe('TIO user', () => {
 
     cy.wait(['@getBillableWeight']);
 
-    cy.get('[data-testid="maxBillableWeightEdit"]').contains('Edit').click();
+    cy.get('[data-testid="button"]').contains('Edit').click();
+
+    cy.wait(['@getMoves']);
+    cy.wait(250);
+
+    cy.get('fieldset').within((/* $form */) => {
+      cy.get('input#billableWeight').click().clear().type('7400');
+      cy.get('textarea#billableWeightJustification').click().clear().type('Some basic remarks.');
+    });
+
+    cy.get('button').contains('Save changes').click();
+
+    cy.wait(['@updateBillableWeight']);
+
+    cy.get('[data-testid="billableWeightValue"]').contains('7,400 lbs');
+    cy.get('[data-testid="billableWeightRemarks"]').contains('Some basic remarks.');
   });
 });

--- a/cypress/integration/office/txo/tio-update-max-billable-weight.js
+++ b/cypress/integration/office/txo/tio-update-max-billable-weight.js
@@ -15,6 +15,7 @@ describe('TIO user', () => {
     cy.intercept('**/ghc/v1/move-task-orders/**/billable-weights-reviewed-at').as('getBillableWeight');
     cy.intercept('**/ghc/v1/move/**').as('getMoves');
     cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/storage/user/**/uploads/**?contentType=application%2Fpdf').as('getUpload');
     cy.intercept('**/ghc/v1/orders/**/update-max-billable-weight/tio').as('updateBillableWeight');
 
     const userId = '3b2cc1b0-31a2-4d1b-874f-0591f9127374';
@@ -39,8 +40,7 @@ describe('TIO user', () => {
 
     cy.get('[data-testid="button"]').contains('Edit').click();
 
-    cy.wait(['@getMoves']);
-    cy.wait(250);
+    cy.wait(['@getMoves', '@getUpload']);
 
     cy.get('fieldset').within((/* $form */) => {
       cy.get('input#billableWeight').click().clear().type('7400');

--- a/cypress/integration/office/txo/tio-update-max-billable-weight.js
+++ b/cypress/integration/office/txo/tio-update-max-billable-weight.js
@@ -1,0 +1,38 @@
+import { TIOOfficeUserType } from '../../../support/constants';
+
+describe('TIO user', () => {
+  before(() => {
+    cy.prepareOfficeApp();
+  });
+
+  beforeEach(() => {
+    cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
+    cy.intercept('**/ghc/v1/queues/payment-requests?**').as('getPaymentRequests');
+    cy.intercept('**/ghc/v1/queues/payment-requests?sort=age&order=desc&page=1&perPage=20').as(
+      'getSortedPaymentRequests',
+    );
+    cy.intercept('**/ghc/v1/moves/**/payment-requests').as('getMovePaymentRequests');
+    cy.intercept('**/ghc/v1/moves/**/billable-weight').as('getBillableWeight');
+
+    const userId = '3b2cc1b0-31a2-4d1b-874f-0591f9127374';
+    cy.apiSignInAsUser(userId, TIOOfficeUserType);
+  });
+
+  // This test performs a mutation so it can only succeed on a fresh DB.
+  it('can update max billable weight', () => {
+    const paymentRequestId = 'ea945ab7-099a-4819-82de-6968efe131dc';
+
+    // TIO Payment Requests queue
+    cy.wait(['@getGHCClient', '@getPaymentRequests', '@getSortedPaymentRequests']);
+    cy.get('[data-uuid="' + paymentRequestId + '"]').click();
+
+    // Payment Requests page
+    cy.wait(['@getMovePaymentRequests']);
+
+    cy.get('#billable-weights').contains('Review weights').click();
+
+    cy.wait(['@getBillableWeight']);
+
+    cy.get('[data-testid="maxBillableWeightEdit"]').contains('Edit').click();
+  });
+});

--- a/cypress/integration/office/txo/tio-update-max-billable-weight.js
+++ b/cypress/integration/office/txo/tio-update-max-billable-weight.js
@@ -36,11 +36,9 @@ describe('TIO user', () => {
 
     cy.get('#billable-weights').contains('Review weights').click();
 
-    cy.wait(['@getBillableWeight']);
+    cy.wait(['@getBillableWeight', '@getMoves', '@getUpload']);
 
     cy.get('[data-testid="button"]').contains('Edit').click();
-
-    cy.wait(['@getMoves', '@getUpload']);
 
     cy.get('fieldset').within((/* $form */) => {
       cy.get('input#billableWeight').click().clear().type('7400');

--- a/cypress/integration/office/txo/tio-update-max-billable-weight.js
+++ b/cypress/integration/office/txo/tio-update-max-billable-weight.js
@@ -20,14 +20,15 @@ describe('TIO user', () => {
 
   // This test performs a mutation so it can only succeed on a fresh DB.
   it('can update max billable weight', () => {
-    const paymentRequestId = 'ea945ab7-099a-4819-82de-6968efe131dc';
+    // Go to known NTS-R move
+    cy.get('#locator').type('NTSRT2');
+    cy.get('th[data-testid="locator"]').first().click();
+    cy.get('[data-testid="locator-0"]').click();
 
-    // TIO Payment Requests queue
-    cy.wait(['@getGHCClient', '@getPaymentRequests', '@getSortedPaymentRequests']);
-    cy.get('[data-uuid="' + paymentRequestId + '"]').click();
-
-    // Payment Requests page
-    cy.wait(['@getMovePaymentRequests']);
+    // Verify we are on the Payment Requests page
+    cy.url().should('include', `/payment-requests`);
+    cy.wait(['@getMovePaymentRequests', '@getMoves', '@getOrders']);
+    cy.get('[data-testid="MovePaymentRequests"]');
 
     cy.get('#billable-weights').contains('Review weights').click();
 

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -126,11 +126,15 @@ export default function EditBillableWeight({
       <h4 className={styles.header}>{title}</h4>
       {!showFields ? (
         <>
-          <span>{billableWeight ? formatWeight(billableWeight) : formatWeight(maxBillableWeight)}</span>
+          <span data-testid="billableWeightValue">
+            {billableWeight ? formatWeight(billableWeight) : formatWeight(maxBillableWeight)}
+          </span>
           {billableWeightJustification && (
             <>
               <h5 className={styles.remarksHeader}>Remarks</h5>
-              <p className={styles.remarks}>{billableWeightJustification}</p>
+              <p data-testid="billableWeightRemarks" className={styles.remarks}>
+                {billableWeightJustification}
+              </p>
             </>
           )}
           <Button className={styles.editBtn} onClick={toggleEdit}>

--- a/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
+++ b/src/components/Office/BillableWeight/EditBillableWeight/EditBillableWeight.jsx
@@ -122,7 +122,7 @@ export default function EditBillableWeight({
   };
 
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} data-testid="maxBillableWeightEdit">
       <h4 className={styles.header}>{title}</h4>
       {!showFields ? (
         <>


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12368) for this change

## Summary

When working on #8529, I discussed adding tests. That other PR was merged in before I could add tests. This PR is adding tests for that previous PR.

## Setup to Run Your Code

💻 You will need to use three separate terminals to test this locally.

##### Terminal 1

Start the Cypress UI locally.

```sh
make db_e2e_up e2e_test
```

## Additional Steps

1. Click on `cypress/integration/office/txo/tio-update-max-billable-weight.js` in the Cypress UI.
1. See a passing test.