### PR TITLE
MB-12178 - Handle unidentified move history events (round 2)

### DIFF
--- a/src/constants/historyLogUIDisplayName.js
+++ b/src/constants/historyLogUIDisplayName.js
@@ -25,8 +25,16 @@ export const dbActions = {
   DELETE: 'DELETE',
 };
 
-export const formatTableName = (tableName) => {
-  return typeof tableName === 'string' ? tableName.toLowerCase().replace(/_/g, ' ') : 'database';
+export const dbTables = {
+  moves: 'moves',
+  mto_shipments: 'mto_shipments',
+  orders: 'orders',
+  mto_service_items: 'mto_service_items',
+  entitlements: 'entitlements',
+  payment_requests: 'payment_requests',
+  mto_agents: 'mto_agents',
+  reweighs: 'reweighs',
+  addresses: 'addresses',
 };
 
 export const dbFieldToDisplayName = {

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -2,7 +2,7 @@ import moveHistoryOperations from './moveHistoryOperations';
 import { shipmentTypes } from './shipments';
 
 import { formatMoveHistoryFullAddress, formatMoveHistoryAgent } from 'utils/formatters';
-import { dbActions, formatTableName } from 'constants/historyLogUIDisplayName';
+import { dbActions, dbTables } from 'constants/historyLogUIDisplayName';
 
 function propertiesMatch(p1, p2) {
   return p1 === '*' || p2 === '*' || p1 === p2;
@@ -57,18 +57,18 @@ const buildMoveHistoryEventTemplate = ({
 };
 
 export const acknowledgeExcessWeightRiskEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.acknowledgeExcessWeightRisk,
-  tableName: 'moves',
+  tableName: dbTables.moves,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Updated move',
   getDetailsPlainText: () => 'Dismissed excess weight alert',
 });
 
 export const approveShipmentEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.approveShipment,
-  tableName: 'mto_shipments',
+  tableName: dbTables.mto_shipments,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved shipment',
   getDetailsPlainText: (historyRecord) => {
@@ -88,9 +88,9 @@ export const approveShipmentDiversionEvent = buildMoveHistoryEventTemplate({
 });
 
 export const createBasicServiceItemEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.updateMoveTaskOrderStatus,
-  tableName: 'mto_service_items',
+  tableName: dbTables.mto_service_items,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',
   getDetailsPlainText: (historyRecord) => {
@@ -99,18 +99,18 @@ export const createBasicServiceItemEvent = buildMoveHistoryEventTemplate({
 });
 
 export const createMTOShipmentEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.createMTOShipment,
-  tableName: 'mto_shipments',
+  tableName: dbTables.mto_shipments,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Submitted/Requested shipments',
   getDetailsPlainText: () => '-',
 });
 
 export const createMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: '',
-  tableName: 'addresses',
+  tableName: dbTables.addresses,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
   getDetailsLabeledDetails: ({ changedValues, context }) => {
@@ -137,9 +137,9 @@ export const createMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
 });
 
 export const createMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  action: dbActions.INSERT,
   eventName: moveHistoryOperations.updateMTOShipment,
-  tableName: 'mto_agents',
+  tableName: dbTables.mto_agents,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
   getDetailsLabeledDetails: ({ changedValues, oldValues, context }) => {
@@ -166,18 +166,18 @@ export const createMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
 });
 
 export const createOrdersEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  action: dbActions.INSERT,
   eventName: moveHistoryOperations.createOrders,
-  tableName: 'orders',
+  tableName: dbTables.orders,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Submitted orders',
   getDetailsPlainText: () => '-',
 });
 
 export const createPaymentRequestReweighUpdate = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.updateReweigh,
-  tableName: 'payment_requests',
+  tableName: dbTables.payment_requests,
   detailsType: detailsTypes.STATUS,
   getEventNameDisplay: () => 'Created payment request',
   getStatusDetails: () => {
@@ -186,9 +186,9 @@ export const createPaymentRequestReweighUpdate = buildMoveHistoryEventTemplate({
 });
 
 export const createPaymentRequestShipmentUpdate = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.updateMTOShipment,
-  tableName: 'payment_requests',
+  tableName: dbTables.payment_requests,
   detailsType: detailsTypes.STATUS,
   getEventNameDisplay: () => 'Created payment request',
   getStatusDetails: () => {
@@ -197,9 +197,9 @@ export const createPaymentRequestShipmentUpdate = buildMoveHistoryEventTemplate(
 });
 
 export const createStandardServiceItemEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.approveShipment,
-  tableName: 'mto_service_items',
+  tableName: dbTables.mto_service_items,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Approved service item',
   getDetailsPlainText: (historyRecord) => {
@@ -230,7 +230,7 @@ export const requestShipmentDiversionEvent = buildMoveHistoryEventTemplate({
 });
 
 export const requestShipmentReweighEvent = buildMoveHistoryEventTemplate({
-  action: 'INSERT',
+  actions: dbActions.INSERT,
   eventName: moveHistoryOperations.requestShipmentReweigh,
   tableName: 'reweighs',
   detailsType: detailsTypes.PLAIN_TEXT,
@@ -241,9 +241,9 @@ export const requestShipmentReweighEvent = buildMoveHistoryEventTemplate({
 });
 
 export const setFinancialReviewFlagEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.setFinancialReviewFlag,
-  tableName: 'moves',
+  tableName: dbTables.moves,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => {
     return 'Flagged move';
@@ -265,33 +265,33 @@ export const submitMoveForApprovalEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateAllowanceEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateAllowance,
-  tableName: 'entitlements',
+  tableName: dbTables.entitlements,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated allowances',
 });
 
 export const updateBillableWeightEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateBillableWeight,
-  tableName: 'entitlements',
+  tableName: dbTables.entitlements,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated move',
 });
 
 export const updateMoveTaskOrderEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMoveTaskOrder,
-  tableName: 'moves',
+  tableName: dbTables.moves,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated move',
 });
 
 export const updateMoveTaskOrderStatusEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMoveTaskOrderStatus,
-  tableName: 'moves',
+  tableName: dbTables.moves,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: (historyRecord) => {
     return historyRecord.changedValues?.available_to_prime_at ? 'Approved move' : 'Move status updated';
@@ -302,9 +302,9 @@ export const updateMoveTaskOrderStatusEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateMTOShipmentEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMTOShipment,
-  tableName: 'mto_shipments',
+  tableName: dbTables.mto_shipments,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
   getDetailsLabeledDetails: (historyRecord) => {
@@ -316,9 +316,9 @@ export const updateMTOShipmentEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMTOShipment,
-  tableName: 'addresses',
+  tableName: dbTables.addresses,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
   getDetailsLabeledDetails: ({ oldValues, changedValues, context }) => {
@@ -354,9 +354,9 @@ export const updateMTOShipmentAddressesEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMTOShipment,
-  tableName: 'mto_agents',
+  tableName: dbTables.mto_agents,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated shipment',
   getDetailsLabeledDetails: ({ oldValues, changedValues, context }) => {
@@ -391,17 +391,17 @@ export const updateMTOShipmentAgentEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updatePaymentRequestStatus = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updatePaymentRequestStatus,
-  tableName: 'payment_requests',
+  tableName: dbTables.payment_requests,
   detailsType: detailsTypes.PAYMENT,
   getEventNameDisplay: () => 'Submitted payment request',
 });
 
 export const updateServiceItemStatusEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateServiceItemStatus,
-  tableName: 'mto_service_items',
+  tableName: dbTables.mto_service_items,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: (historyRecord) => {
     switch (historyRecord.changedValues?.status) {
@@ -419,7 +419,7 @@ export const updateServiceItemStatusEvent = buildMoveHistoryEventTemplate({
 });
 
 export const uploadAmendedOrdersEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: moveHistoryOperations.uploadAmendedOrders,
   tableName: 'orders',
   detailsType: detailsTypes.PLAIN_TEXT,
@@ -428,9 +428,9 @@ export const uploadAmendedOrdersEvent = buildMoveHistoryEventTemplate({
 });
 
 export const updateOrderEvent = buildMoveHistoryEventTemplate({
-  action: 'UPDATE',
+  actions: dbActions.UPDATE,
   eventName: '*',
-  tableName: 'orders',
+  tableName: dbTables.orders,
   detailsType: detailsTypes.LABELED,
   getEventNameDisplay: () => 'Updated orders',
   getDetailsLabeledDetails: (historyRecord) => {
@@ -451,19 +451,27 @@ export const updateOrderEvent = buildMoveHistoryEventTemplate({
 });
 
 export const undefinedEvent = buildMoveHistoryEventTemplate({
-  action: '*',
-  eventName: '*',
-  tableName: '*',
+  action: null,
+  eventName: null,
+  tableName: null,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: (historyRecord) => {
-    switch (historyRecord.action) {
-      case dbActions.INSERT:
-        return `Created new item in ${formatTableName(historyRecord.tableName)}`;
-      case dbActions.DELETE:
-        return `Deleted item in ${formatTableName(historyRecord.tableName)}`;
-      case dbActions.UPDATE:
+    switch (historyRecord?.tableName) {
+      case dbTables.orders:
+        return 'Updated order';
+      case dbTables.mto_service_items:
+        return 'Updated service item';
+      case dbTables.entitlements:
+        return 'Updated allowances';
+      case dbTables.payment_requests:
+        return 'Updated payment request';
+      case dbTables.mto_shipments:
+      case dbTables.mto_agents:
+      case dbTables.addresses:
+        return 'Updated shipment';
+      case dbTables.moves:
       default:
-        return `Updated item in ${formatTableName(historyRecord.tableName)}`;
+        return 'Updated move';
     }
   },
   getDetailsPlainText: () => {

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -455,8 +455,8 @@ export const undefinedEvent = buildMoveHistoryEventTemplate({
   eventName: null,
   tableName: null,
   detailsType: detailsTypes.PLAIN_TEXT,
-  getEventNameDisplay: (historyRecord) => {
-    switch (historyRecord?.tableName) {
+  getEventNameDisplay: ({ tableName }) => {
+    switch (tableName) {
       case dbTables.orders:
         return 'Updated order';
       case dbTables.mto_service_items:

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -537,11 +537,11 @@ describe('when given an unidentifiable move history record', () => {
   const item = {
     action: 'UPDATE',
     eventName: 'testEventName',
-    tableName: 'imaginary_test_objects',
+    tableName: 'mto_agents',
   };
   it('correctly matches the Undefined move history event', () => {
     const result = getMoveHistoryEventTemplate(item);
     expect(result).toEqual(undefinedEvent);
-    expect(result.getEventNameDisplay(item)).toEqual('Updated item in imaginary test objects');
+    expect(result.getEventNameDisplay(item)).toEqual('Updated shipment');
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12178) for this change

## Summary

This is round 2 of PRs for this ticket! See the previous PR, #8554 
These changes should provide a simple way to show basic information about an event in the move history that can't be identified.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->
*Note: testing this change requires testing an event that is yet unknown to the front end. Since new events are being supported with each sprint, it may be difficult to identify the steps to take in order to test this properly. The steps below describe testing a TIO update weight event that is not supported yet, but it may be supported soon.

1. Access the office app
2. Login as a TIO
3. Navigate to a move (e.g. locator WTSTAT)
4. Navigate to the payments requests tab and click "review weights"
5. Update the max billable weight and click "save"
6. Navigate to the Move history tab and verify that there are one or more generic entries for the unidentified weight update event

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.



## Screenshots
<img width="1532" alt="image" src="https://user-images.githubusercontent.com/97245917/167460803-aab1ecd6-0c26-4bfc-a450-0d95bc199178.png">

