### PR TITLE
Removed unneeded imports from tools.go and cleaned up go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,6 @@ require (
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/go-openapi/swag v0.21.1
 	github.com/go-openapi/validate v0.21.0
-	github.com/go-playground/locales v0.14.0
-	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/gobuffalo/envy v1.10.1
 	github.com/gobuffalo/fizz v1.14.0
@@ -45,7 +43,6 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/jstemmer/go-junit-report v1.0.0
 	github.com/jung-kurt/gofpdf v1.16.2
-	github.com/leodido/go-urn v1.2.1
 	github.com/lib/pq v1.10.5
 	github.com/luna-duclos/instrumentedsql v1.1.3
 	github.com/markbates/goth v1.71.1
@@ -60,7 +57,6 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.11.0
-	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	github.com/tealeg/xlsx/v3 v3.2.4
@@ -68,20 +64,6 @@ require (
 	github.com/trussworks/otelhttp v0.0.0-20220428162739-458ecc428855
 	github.com/vektra/mockery/v2 v2.12.1
 	go.mozilla.org/pkcs7 v0.0.0-20181213175627-3cffc6fbfe83
-	go.uber.org/zap v1.21.0
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
-	golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	golang.org/x/text v0.3.7
-	golang.org/x/tools v0.1.10
-	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
-	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
-	pault.ag/go/pksigner v1.0.2
-)
-
-require (
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.7.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.32.0
@@ -97,7 +79,14 @@ require (
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/sdk/metric v0.30.0
 	go.opentelemetry.io/otel/trace v1.7.0
+	go.uber.org/zap v1.21.0
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	golang.org/x/text v0.3.7
+	golang.org/x/tools v0.1.10
 	gotest.tools/gotestsum v1.8.0
+	pault.ag/go/pksigner v1.0.2
 )
 
 require (
@@ -123,6 +112,8 @@ require (
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gobuffalo/attrs v1.0.1 // indirect
@@ -166,6 +157,7 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/markbates/oncer v1.0.0 // indirect
@@ -196,6 +188,7 @@ require (
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	go.mongodb.org/mongo-driver v1.8.3 // indirect
@@ -206,13 +199,17 @@ require (
 	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	pault.ag/go/fasc v0.0.0-20190505145209-c337c3c0bbf0 // indirect

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -12,22 +12,10 @@ import (
 	_ "github.com/codegangsta/gin"
 	// Install for managing the database
 	_ "github.com/gobuffalo/pop/v6/soda"
-
+	// Install go-junit-report for CircleCI test result report generation
+	_ "github.com/jstemmer/go-junit-report"
 	// Install for autogenerating mocks
 	_ "github.com/vektra/mockery/v2"
-
-	// Test packages
-	_ "github.com/go-playground/locales"
-	_ "github.com/go-playground/universal-translator"
-	_ "github.com/go-playground/validator/v10"
-	_ "github.com/imdario/mergo"
-	_ "github.com/leodido/go-urn"
-	_ "github.com/namsral/flag"
-	_ "github.com/stretchr/objx"
-
-	// Install go-junit-report for CirclCI test result report generation
-	_ "github.com/jstemmer/go-junit-report"
-
 	// Possible replacement for go-junit-report
 	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
## Summary

I was trying to run a tool to make our import order consistent (which I may try to do in a later PR) but I noticed a couple of things in doing so which I'm addressing here:
- Our `tools.go` has some imports labeled "test packages" for things that don't look like tools to me.  Am I missing something?  I removed them and everything built fine.
- The `go.mod` file had been fixed a while back (I thought) to have just two `require` sections -- one for direct dependencies and one for indirect ones.  But we had regressed back to the three sections we had before with mixed indirect/direct dependencies.  I combined all `require` sections together and ran `go mod tidy` and got the two sections back.

### Additional steps

Does everything still seem to build OK?  Am I missing something about these files?
