### PR TITLE
MB-12324: Adds ShipmentIncentiveAdvance sub-component

### DIFF
--- a/src/components/Office/ShipmentForm/ShipmentForm.module.scss
+++ b/src/components/Office/ShipmentForm/ShipmentForm.module.scss
@@ -40,6 +40,11 @@
     @include u-margin-bottom(3);
   }
 
+  .AdvanceText {
+    @include u-font-size('body', 'xs');
+    @include u-margin-top(2.5);
+  }
+
   .weightAllowance {
     padding-top: 9px;
     padding-bottom: 9px;

--- a/src/components/Office/ShipmentForm/ShipmentForm.module.scss
+++ b/src/components/Office/ShipmentForm/ShipmentForm.module.scss
@@ -40,6 +40,10 @@
     @include u-margin-bottom(3);
   }
 
+  .NoSpacing {
+    @include u-margin-bottom(0);
+  }
+
   .AdvanceText {
     @include u-font-size('body', 'xs');
     @include u-margin-top(2.5);

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -9,15 +9,18 @@ import SectionWrapper from 'components/Customer/SectionWrapper';
 import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
 
 const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
-  const [inputProps, , helperProps] = useField('advanceRequested');
-  const advanceRequested = !!inputProps.value;
+  const [advanceInput, , advanceHelper] = useField('advanceRequested');
+  const advanceRequested = !!advanceInput.value;
+  const [amountInput] = useField('amountRequested');
+  const amountRequested = Number(amountInput.value || '0');
 
   const formattedIncentive = ((estimatedIncentive || 0) / 100).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
     maximumFractionDigits: 0,
   });
-  const maximumAdvance = (((estimatedIncentive || 0) * 0.6) / 100).toLocaleString('en-US', {
+  const maximumAdvance = ((estimatedIncentive || 0) * 0.6) / 100;
+  const formattedMaximumAdvance = maximumAdvance.toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
     maximumFractionDigits: 2,
@@ -26,16 +29,16 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
 
   const handleAdvanceRequestedChange = (event) => {
     const selected = event.target.value;
-    helperProps.setValue(selected === 'Yes');
+    advanceHelper.setValue(selected === 'Yes');
   };
 
   return (
     <SectionWrapper className={formStyles.formSection}>
       <Fieldset className={styles.Fieldset}>
         <h2 className={styles.SectionHeader}>Incentive &amp; advance</h2>
-        <h3>Estimated incentive: {formattedIncentive}</h3>
+        <h3 className={styles.NoSpacing}>Estimated incentive: {formattedIncentive}</h3>
 
-        <Grid row gap>
+        <Grid row>
           <Grid col={12}>
             <FormGroup>
               <Label className={styles.Label}>Advance (AOA) requested?</Label>
@@ -62,7 +65,6 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
             {advanceRequested && (
               <>
                 <FormGroup>
-                  <Label>Amount requested</Label>
                   <MaskedTextField
                     defaultValue="0"
                     name="amountRequested"
@@ -74,9 +76,14 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
                     thousandsSeparator=","
                     lazy={false} // immediate masking evaluation
                     prefix="$"
+                    warning={
+                      amountRequested > maximumAdvance
+                        ? `Reminder: your advance can not be more than ${formattedMaximumAdvance}`
+                        : ''
+                    }
                   />
                 </FormGroup>
-                Maximum advance: {maximumAdvance}
+                <div className={styles.AdvanceText}>Maximum advance: {formattedMaximumAdvance}</div>
               </>
             )}
           </Grid>

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -76,14 +76,17 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
                     thousandsSeparator=","
                     lazy={false} // immediate masking evaluation
                     prefix="$"
-                    warning={
+                    error={
                       amountRequested > maximumAdvance
                         ? `Reminder: your advance can not be more than ${formattedMaximumAdvance}`
                         : ''
                     }
                   />
                 </FormGroup>
-                <div className={styles.AdvanceText}>Maximum advance: {formattedMaximumAdvance}</div>
+
+                <FormGroup>
+                  <div className={styles.AdvanceText}>Maximum advance: {formattedMaximumAdvance}</div>
+                </FormGroup>
               </>
             )}
           </Grid>

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Fieldset, FormGroup, Radio, Grid, Label } from '@trussworks/react-uswds';
+import { useField } from 'formik';
+import PropTypes from 'prop-types';
+
+import formStyles from 'styles/form.module.scss';
+import styles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
+import SectionWrapper from 'components/Customer/SectionWrapper';
+import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextField';
+
+const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
+  const [inputProps, , helperProps] = useField('advanceRequested');
+  const advanceRequested = !!inputProps.value;
+
+  const formattedIncentive = ((estimatedIncentive || 0) / 100).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+  const maximumAdvance = (((estimatedIncentive || 0) * 0.6) / 100).toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+
+  const handleAdvanceRequestedChange = (event) => {
+    const selected = event.target.value;
+    helperProps.setValue(selected === 'Yes');
+  };
+
+  return (
+    <SectionWrapper className={formStyles.formSection}>
+      <Fieldset className={styles.Fieldset}>
+        <h2 className={styles.SectionHeader}>Incentive &amp; advance</h2>
+        <h3>Estimated incentive: {formattedIncentive}</h3>
+
+        <Grid row gap>
+          <Grid col={12}>
+            <FormGroup>
+              <Label className={styles.Label}>Advance (AOA) requested?</Label>
+              <Radio
+                id="advanceRequestedYes"
+                label="Yes"
+                name="advanceRequested"
+                value="Yes"
+                title="Yes"
+                checked={advanceRequested}
+                onChange={handleAdvanceRequestedChange}
+              />
+              <Radio
+                id="advanceRequestedNo"
+                label="No"
+                name="advanceRequested"
+                value="No"
+                title="No"
+                checked={!advanceRequested}
+                onChange={handleAdvanceRequestedChange}
+              />
+            </FormGroup>
+
+            {advanceRequested && (
+              <>
+                <FormGroup>
+                  <Label>Amount requested</Label>
+                  <MaskedTextField
+                    defaultValue="0"
+                    name="amountRequested"
+                    label="Amount requested"
+                    id="amountRequested"
+                    mask={Number}
+                    scale={0} // digits after point, 0 for integers
+                    signed={false} // disallow negative
+                    thousandsSeparator=","
+                    lazy={false} // immediate masking evaluation
+                    prefix="$"
+                  />
+                </FormGroup>
+                Maximum advance: {maximumAdvance}
+              </>
+            )}
+          </Grid>
+        </Grid>
+      </Fieldset>
+    </SectionWrapper>
+  );
+};
+
+export default ShipmentIncentiveAdvance;
+
+ShipmentIncentiveAdvance.propTypes = {
+  estimatedIncentive: PropTypes.number,
+};
+
+ShipmentIncentiveAdvance.defaultProps = {
+  estimatedIncentive: 0,
+};

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.jsx
@@ -17,6 +17,7 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
   const formattedIncentive = ((estimatedIncentive || 0) / 100).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
+    minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
   const maximumAdvance = ((estimatedIncentive || 0) * 0.6) / 100;
@@ -76,7 +77,7 @@ const ShipmentIncentiveAdvance = ({ estimatedIncentive }) => {
                     thousandsSeparator=","
                     lazy={false} // immediate masking evaluation
                     prefix="$"
-                    error={
+                    warning={
                       amountRequested > maximumAdvance
                         ? `Reminder: your advance can not be more than ${formattedMaximumAdvance}`
                         : ''

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.stories.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.stories.jsx
@@ -44,7 +44,19 @@ export const advanceRequested = () => (
     {() => {
       return (
         <Form className={formStyles.form} style={{ maxWidth: 'none' }}>
-          <ShipmentIncentiveAdvance estimatedIncentive={600000} />
+          <ShipmentIncentiveAdvance estimatedIncentive={1000000} />
+        </Form>
+      );
+    }}
+  </Formik>
+);
+
+export const advanceRequestedWithWarning = () => (
+  <Formik initialValues={{ advanceRequested: true, amountRequested: '7000' }}>
+    {() => {
+      return (
+        <Form className={formStyles.form} style={{ maxWidth: 'none' }}>
+          <ShipmentIncentiveAdvance estimatedIncentive={1111111} />
         </Form>
       );
     }}

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.stories.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.stories.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+import { Formik } from 'formik';
+
+import ShipmentIncentiveAdvance from './ShipmentIncentiveAdvance';
+
+import styles from 'pages/Office/ServicesCounselingMoveInfo/ServicesCounselingTab.module.scss';
+import shipmentFormStyles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
+import { Form } from 'components/form/Form';
+import formStyles from 'styles/form.module.scss';
+
+export default {
+  title: 'Office Components / Forms / ShipmentForm / ShipmentIncentiveAdvance',
+  component: ShipmentIncentiveAdvance,
+  decorators: [
+    (Story) => (
+      <GridContainer className={styles.gridContainer}>
+        <Grid row>
+          <Grid col desktop={{ col: 8, offset: 2 }}>
+            <div className={shipmentFormStyles.ShipmentForm}>
+              <Story />
+            </div>
+          </Grid>
+        </Grid>
+      </GridContainer>
+    ),
+  ],
+};
+
+export const advanceNotRequested = () => (
+  <Formik initialValues={{ advanceRequested: false }}>
+    {() => {
+      return (
+        <Form className={formStyles.form} style={{ maxWidth: 'none' }}>
+          <ShipmentIncentiveAdvance />
+        </Form>
+      );
+    }}
+  </Formik>
+);
+
+export const advanceRequested = () => (
+  <Formik initialValues={{ advanceRequested: true, amountRequested: '5000' }}>
+    {() => {
+      return (
+        <Form className={formStyles.form} style={{ maxWidth: 'none' }}>
+          <ShipmentIncentiveAdvance estimatedIncentive={600000} />
+        </Form>
+      );
+    }}
+  </Formik>
+);

--- a/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.test.jsx
+++ b/src/components/Office/ShipmentIncentiveAdvance/ShipmentIncentiveAdvance.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
+
+import ShipmentIncentiveAdvance from './ShipmentIncentiveAdvance';
+
+describe('components/Office/ShipmentIncentiveAdvance', () => {
+  it('should display content without props', () => {
+    render(
+      <Formik initialValues={{}}>
+        <ShipmentIncentiveAdvance />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Incentive & advance');
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Estimated incentive: $0');
+    expect(screen.getByLabelText('No')).toBeChecked();
+    expect(screen.getByLabelText('Yes')).not.toBeChecked();
+
+    expect(screen.queryByLabelText('Amount requested')).not.toBeInTheDocument();
+  });
+
+  it('should respond to user radio button input', async () => {
+    render(
+      <Formik initialValues={{}}>
+        <ShipmentIncentiveAdvance />
+      </Formik>,
+    );
+
+    userEvent.click(screen.getByLabelText('Yes'));
+
+    expect(await screen.findByLabelText('Amount requested')).toBeInTheDocument();
+  });
+
+  it('should respond to props and form values', async () => {
+    render(
+      <Formik initialValues={{ advanceRequested: true, amountRequested: '7000' }}>
+        <ShipmentIncentiveAdvance estimatedIncentive={1111111} />
+      </Formik>,
+    );
+
+    expect(await screen.findByLabelText('Amount requested')).toHaveValue('7,000');
+    expect(screen.getByText('Reminder: your advance can not be more than $6,666.67')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Jira ticket for this change: [MB-12324](https://dp3.atlassian.net/browse/MB-12324), a sub-task of [MB-11865](https://dp3.atlassian.net/browse/MB-11865)

## Summary

This pull request adds the `ShipmentIncentiveAdvance` component, which will be used by the second "page" of the `ShipmentForm` when adding/editing PPM shipments as a service counselor. 

The component is only added in Storybook for now, so no UI or behavior changes should be made to the existing application.

## Setup to Run Your Code

Start the Storybook locally.

```sh
make storybook
```

### Additional steps

1. In Storybook, view 'Office Components' -> 'Forms' -> 'Shipment Form' -> 'ShipmentIncentiveAdvance'.
2. Validate that each state of the component look and behave correctly.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

* [Customer is not requesting an advance](https://user-images.githubusercontent.com/83614364/167725459-eee0c253-db44-497e-91b2-97746fe3685f.png)
* [Customer is requesting an advance](https://user-images.githubusercontent.com/83614364/167725557-14ae642a-ddd4-4542-961c-0eb4a1598d76.png)
* [Customer is requesting an invalid advance amount](https://user-images.githubusercontent.com/83614364/167725647-32f3ffe7-9c38-46ef-ba8e-699d07a0f1cc.png) 