### PR TITLE
[ MB-12420 ] Add the UpdateMTOReviewedBillableWeightsAt event

### DIFF
--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -492,6 +492,15 @@ export const undefinedEvent = buildMoveHistoryEventTemplate({
   },
 });
 
+export const updateMTOSReviewedBillableWeightsAt = buildMoveHistoryEventTemplate({
+  action: dbActions.UPDATE,
+  eventName: moveHistoryOperations.updateMTOReviewedBillableWeightsAt,
+  tableName: 'moves',
+  detailsType: detailsTypes.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Updated move',
+  getDetailsPlainText: () => 'Reviewed weights',
+});
+
 const allMoveHistoryEventTemplates = [
   acknowledgeExcessWeightRiskEvent,
   approveShipmentEvent,
@@ -523,6 +532,7 @@ const allMoveHistoryEventTemplates = [
   updateServiceItemStatusEvent,
   updateBillableWeightEvent,
   updateAllowanceEvent,
+  updateMTOSReviewedBillableWeightsAt,
 ];
 
 const getMoveHistoryEventTemplate = (historyRecord) => {

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -492,7 +492,7 @@ export const undefinedEvent = buildMoveHistoryEventTemplate({
   },
 });
 
-export const updateMTOSReviewedBillableWeightsAt = buildMoveHistoryEventTemplate({
+export const updateMTOReviewedBillableWeightsAt = buildMoveHistoryEventTemplate({
   action: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMTOReviewedBillableWeightsAt,
   tableName: 'moves',
@@ -532,7 +532,7 @@ const allMoveHistoryEventTemplates = [
   updateServiceItemStatusEvent,
   updateBillableWeightEvent,
   updateAllowanceEvent,
-  updateMTOSReviewedBillableWeightsAt,
+  updateMTOReviewedBillableWeightsAt,
 ];
 
 const getMoveHistoryEventTemplate = (historyRecord) => {

--- a/src/constants/moveHistoryEventTemplate.js
+++ b/src/constants/moveHistoryEventTemplate.js
@@ -495,7 +495,7 @@ export const undefinedEvent = buildMoveHistoryEventTemplate({
 export const updateMTOReviewedBillableWeightsAt = buildMoveHistoryEventTemplate({
   action: dbActions.UPDATE,
   eventName: moveHistoryOperations.updateMTOReviewedBillableWeightsAt,
-  tableName: 'moves',
+  tableName: dbTables.moves,
   detailsType: detailsTypes.PLAIN_TEXT,
   getEventNameDisplay: () => 'Updated move',
   getDetailsPlainText: () => 'Reviewed weights',

--- a/src/constants/moveHistoryEventTemplate.test.js
+++ b/src/constants/moveHistoryEventTemplate.test.js
@@ -22,6 +22,7 @@ const {
   requestShipmentReweighEvent,
   createPaymentRequestReweighUpdate,
   createPaymentRequestShipmentUpdate,
+  updateMTOReviewedBillableWeightsAt,
   undefinedEvent,
 } = require('./moveHistoryEventTemplate');
 
@@ -38,6 +39,19 @@ describe('moveHistoryEventTemplate', () => {
       const result = getMoveHistoryEventTemplate(item);
       expect(result).toEqual(acknowledgeExcessWeightRiskEvent);
       expect(result.getDetailsPlainText(item)).toEqual('Dismissed excess weight alert');
+    });
+  });
+
+  describe('when given an MTO Reviewed Billable Weight At event', () => {
+    const item = {
+      action: 'UPDATE',
+      eventName: 'UpdateMTOReviewedBillableWeightsAt',
+      tableName: 'moves',
+    };
+    it('correctly matches the MTO Reviewed Billable Weight At event', () => {
+      const result = getMoveHistoryEventTemplate(item);
+      expect(result).toEqual(updateMTOReviewedBillableWeightsAt);
+      expect(result.getDetailsPlainText(item)).toEqual('Reviewed weights');
     });
   });
 

--- a/src/constants/moveHistoryOperations.js
+++ b/src/constants/moveHistoryOperations.js
@@ -25,6 +25,7 @@ const moveHistoryOperations = {
   updateBillableWeight: 'updateBillableWeight', // ghc.yaml
   updatePaymentRequestStatus: 'updatePaymentRequestStatus',
   updateReweigh: 'updateReweigh',
+  updateMTOReviewedBillableWeightsAt: 'UpdateMTOReviewedBillableWeightsAt',
 };
 
 export default moveHistoryOperations;


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12420) for this change

## Summary

As an office user, I want to have the ability to see when a TIO clicks on the review weights button max  so that the office users can easily see if the TIO has reviewed the weights. 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Run the client tests locally

```sh
make client_test
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Make sure that client tests are passing. Specifically tests found in `src/constants/moveHistoryEventTemplate.test.js`
2. Login as a TIO and click on the **Review weights** button.
3. Check the history log for an event that matches **Updated move: Reviewed weights**
