### PR TITLE
Rely on Cypress to get Assertions correct

### DIFF
--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -184,11 +184,7 @@ describe('Services counselor user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button')
-        .contains('Save')
-        .should('be.enabled')
-        .click()
-        .then(() => cy.get('button').should('be.disabled'));
+      cy.get('button').contains('Save').should('be.enabled').click().should('be.disabled');
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -184,7 +184,7 @@ describe('Services counselor user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button').contains('Save').should('be.enabled').click().should('be.disabled');
+      cy.get('[data-testid="scAllowancesSave"]').should('be.enabled').click().should('be.disabled');
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -318,11 +318,7 @@ describe('TOO user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button')
-        .contains('Save')
-        .should('be.enabled')
-        .click()
-        .then(() => cy.get('button').should('be.disabled'));
+      cy.get('button').contains('Save').should('be.enabled').click().should('be.disabled');
     });
 
     cy.wait(['@patchAllowances']);

--- a/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.jsx
+++ b/src/pages/Office/ServicesCounselingMoveAllowances/ServicesCounselingMoveAllowances.jsx
@@ -105,7 +105,7 @@ const ServicesCounselingMoveAllowances = () => {
       storageInTransit: Number(storageInTransit),
       organizationalClothingAndIndividualEquipment,
     };
-    mutateOrders({ orderID: orderId, ifMatchETag: order.eTag, body });
+    return mutateOrders({ orderID: orderId, ifMatchETag: order.eTag, body });
   };
 
   const { entitlement, grade, agency } = order;


### PR DESCRIPTION
This attempts to remove the .then() and rather rely on the Assertions
that Cypress uses to block, wait, and retry while things change state.
