### PR TITLE
MB-12347 Display Required Delivery Date

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -4432,6 +4432,11 @@ func init() {
           "type": "string",
           "format": "date"
         },
+        "requiredDeliveryDate": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true
+        },
         "reweigh": {
           "x-nullable": true,
           "x-omitempty": true,
@@ -11709,6 +11714,11 @@ func init() {
         "requestedPickupDate": {
           "type": "string",
           "format": "date"
+        },
+        "requiredDeliveryDate": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true
         },
         "reweigh": {
           "x-nullable": true,

--- a/pkg/gen/ghcmessages/m_t_o_shipment.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment.go
@@ -121,6 +121,10 @@ type MTOShipment struct {
 	// Format: date
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
 
+	// required delivery date
+	// Format: date
+	RequiredDeliveryDate *strfmt.Date `json:"requiredDeliveryDate,omitempty"`
+
 	// reweigh
 	Reweigh *Reweigh `json:"reweigh,omitempty"`
 
@@ -227,6 +231,10 @@ func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRequestedPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRequiredDeliveryDate(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -484,6 +492,18 @@ func (m *MTOShipment) validateRequestedPickupDate(formats strfmt.Registry) error
 	}
 
 	if err := validate.FormatOf("requestedPickupDate", "body", "date", m.RequestedPickupDate.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) validateRequiredDeliveryDate(formats strfmt.Registry) error {
+	if swag.IsZero(m.RequiredDeliveryDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("requiredDeliveryDate", "body", "date", m.RequiredDeliveryDate.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -590,6 +590,10 @@ func MTOShipment(mtoShipment *models.MTOShipment, sitStatusPayload *ghcmessages.
 		payload.RequestedDeliveryDate = *handlers.FmtDatePtr(mtoShipment.RequestedDeliveryDate)
 	}
 
+	if mtoShipment.RequiredDeliveryDate != nil && !mtoShipment.RequiredDeliveryDate.IsZero() {
+		payload.RequiredDeliveryDate = handlers.FmtDatePtr(mtoShipment.RequiredDeliveryDate)
+	}
+
 	if mtoShipment.ScheduledPickupDate != nil {
 		payload.ScheduledPickupDate = handlers.FmtDatePtr(mtoShipment.ScheduledPickupDate)
 	}

--- a/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.jsx
+++ b/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.jsx
@@ -7,13 +7,15 @@ import styles from './importantShipmentDates.module.scss';
 import DataTable from 'components/DataTable/index';
 import DataTableWrapper from 'components/DataTableWrapper/index';
 
-const ImportantShipmentDates = ({ requestedPickupDate, scheduledPickupDate }) => {
+const ImportantShipmentDates = ({ requestedPickupDate, scheduledPickupDate, requiredDeliveryDate }) => {
+  const emDash = '\u2014';
   return (
     <div className={classnames('maxw-tablet', styles.shipmentDatesContainer)}>
       <DataTableWrapper className="table--data-point-group">
+        <DataTable columnHeaders={['Customer requested pick up date']} dataRow={[requestedPickupDate || emDash]} />
         <DataTable
-          columnHeaders={['Customer requested pick up date', 'Scheduled pick up date']}
-          dataRow={[requestedPickupDate, scheduledPickupDate]}
+          columnHeaders={['Scheduled pick up date', 'Required delivery date']}
+          dataRow={[scheduledPickupDate || emDash, requiredDeliveryDate || emDash]}
         />
       </DataTableWrapper>
     </div>
@@ -23,11 +25,13 @@ const ImportantShipmentDates = ({ requestedPickupDate, scheduledPickupDate }) =>
 ImportantShipmentDates.defaultProps = {
   requestedPickupDate: '',
   scheduledPickupDate: '',
+  requiredDeliveryDate: '',
 };
 
 ImportantShipmentDates.propTypes = {
   requestedPickupDate: PropTypes.string,
   scheduledPickupDate: PropTypes.string,
+  requiredDeliveryDate: PropTypes.string,
 };
 
 export default ImportantShipmentDates;

--- a/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.test.jsx
+++ b/src/components/Office/ImportantShipmentDates/ImportantShipmentDates.test.jsx
@@ -6,12 +6,26 @@ import ImportantShipmentDates from './ImportantShipmentDates';
 describe('ImportantShipmentDates', () => {
   const requestedPickupDate = 'Thursday, 26 Mar 2020';
   const scheduledPickupDate = 'Friday, 27 Mar 2020';
+  const requiredDeliveryDate = 'Monday, 30 Mar 2020';
 
   it('should render the shipment dates we pass in', () => {
     const wrapper = mount(
-      <ImportantShipmentDates requestedPickupDate={requestedPickupDate} scheduledPickupDate={scheduledPickupDate} />,
+      <ImportantShipmentDates
+        requestedPickupDate={requestedPickupDate}
+        scheduledPickupDate={scheduledPickupDate}
+        requiredDeliveryDate={requiredDeliveryDate}
+      />,
     );
     expect(wrapper.find('td').at(0).text()).toEqual(requestedPickupDate);
     expect(wrapper.find('td').at(1).text()).toEqual(scheduledPickupDate);
+    expect(wrapper.find('td').at(2).text()).toEqual(requiredDeliveryDate);
+  });
+
+  it('should render an em-dash when no date is provided', () => {
+    const emDash = '\u2014';
+    const wrapper = mount(<ImportantShipmentDates />);
+    expect(wrapper.find('td').at(0).text()).toEqual(emDash);
+    expect(wrapper.find('td').at(1).text()).toEqual(emDash);
+    expect(wrapper.find('td').at(2).text()).toEqual(emDash);
   });
 });

--- a/src/components/Office/ImportantShipmentDates/importantShipmentDates.stories.jsx
+++ b/src/components/Office/ImportantShipmentDates/importantShipmentDates.stories.jsx
@@ -7,5 +7,11 @@ export default {
 };
 
 export const Default = () => (
-  <ImportantShipmentDates requestedPickupDate="Thursday, 26 Mar 2020" scheduledPickupDate="Friday, 27 Mar 2020" />
+  <ImportantShipmentDates
+    requestedPickupDate="Thursday, 26 Mar 2020"
+    scheduledPickupDate="Friday, 27 Mar 2020"
+    requiredDeliveryDate="Monday, 30 Mar 2020"
+  />
 );
+
+export const EmptyState = () => <ImportantShipmentDates />;

--- a/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
+++ b/src/components/Office/ShipmentDetails/ShipmentDetailsMain.jsx
@@ -29,6 +29,7 @@ const ShipmentDetailsMain = ({
   const {
     requestedPickupDate,
     scheduledPickupDate,
+    requiredDeliveryDate,
     pickupAddress,
     destinationAddress,
     primeEstimatedWeight,
@@ -131,6 +132,7 @@ const ShipmentDetailsMain = ({
       <ImportantShipmentDates
         requestedPickupDate={formatDate(requestedPickupDate)}
         scheduledPickupDate={scheduledPickupDate ? formatDate(scheduledPickupDate) : null}
+        requiredDeliveryDate={requiredDeliveryDate ? formatDate(requiredDeliveryDate) : null}
       />
       <ShipmentAddresses
         pickupAddress={displayedPickupAddress}

--- a/swagger-def/definitions/MTOShipment.yaml
+++ b/swagger-def/definitions/MTOShipment.yaml
@@ -50,6 +50,10 @@ properties:
   requestedDeliveryDate:
     format: date
     type: string
+  requiredDeliveryDate:
+    x-nullable: true
+    format: date
+    type: string
   approvedDate:
     format: date-time
     type: string

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4600,6 +4600,10 @@ definitions:
       requestedDeliveryDate:
         format: date
         type: string
+      requiredDeliveryDate:
+        x-nullable: true
+        format: date
+        type: string
       approvedDate:
         format: date-time
         type: string


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12347) for this change

## Summary
This PR adds displaying of the Required Delivery Date to the Shipment Details dates. This field was already in the database but was not being included with returned shipment payloads. This PR includes it with shipment payload responses and displays it on the MTO page in the shipment details. It also updates the 3 shipment date fields to display an [em-dash](https://en.wikipedia.org/wiki/Dash#Em_dash) when no date is present in the data. 

Moves with a required delivery date in generated data:
* RDY4PY
* PARAMS

Designs: https://www.figma.com/file/5AhuEkaH3bJVrtffU3wp22/Milmove-Office-App?node-id=595%3A13294

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Verification Steps for Reviewers

- [ ] The `ImportantShipmentDates` component in storybook includes the Required Delivery Date
<img width="1104" alt="Screen Shot 2022-05-13 at 10 04 20 AM" src="https://user-images.githubusercontent.com/62263329/168329573-a77a7e07-96c7-4fe2-baf3-af3bc7bf17bc.png">

- [ ] The empty state of the `ImportantShipmentDates` component is added to storybook 
<img width="1120" alt="Screen Shot 2022-05-13 at 10 04 37 AM" src="https://user-images.githubusercontent.com/62263329/168329706-a6dbbf9a-b328-4d27-8d5e-490c88be4f78.png">

- [ ] The Required Delivery Date is shown in the shipment dates section of the MTO page
<img width="988" alt="Screen Shot 2022-05-13 at 10 49 05 AM" src="https://user-images.githubusercontent.com/62263329/168331037-c6add869-86b8-4975-abb1-c3f089d09c89.png">

- [ ] When theRequired Delivery Date (or any of the 3 shipment dates) is null, an em-dash is displayed
<img width="990" alt="Screen Shot 2022-05-13 at 10 52 46 AM" src="https://user-images.githubusercontent.com/62263329/168331633-d319c2c7-a027-4f9d-a553-52ffd491e54e.png">
