### PR TITLE
Convert remaining package tests to transactions

### DIFF
--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -97,13 +97,6 @@ func (aq *AwardQueue) assignPerformanceBandsForTSPPerformanceGroup(appCtx appcon
 	return nil
 }
 
-// waitForLock MUST be called within a transaction!
-func waitForLock(appCtx appcontext.AppContext, id int) error {
-
-	// obtain transaction-level advisory-lock
-	return appCtx.DB().RawQuery("SELECT pg_advisory_xact_lock($1)", id).Exec()
-}
-
 // NewAwardQueue creates a new AwardQueue
 func NewAwardQueue() *AwardQueue {
 	return &AwardQueue{}

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -11,9 +11,7 @@ package awardqueue
 
 import (
 	"testing"
-	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/testingsuite"
 	"github.com/transcom/mymove/pkg/unit"
 
@@ -106,35 +104,6 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	}
 }
 
-func (suite *AwardQueueSuite) Test_waitForLock() {
-	ret := make(chan int)
-	lockID := 1
-
-	go func() {
-		suite.AppContextForTest().NewTransaction(func(txnAppCtx appcontext.AppContext) error {
-			suite.Nil(waitForLock(txnAppCtx, lockID))
-			time.Sleep(time.Second)
-			ret <- 1
-			return nil
-		})
-	}()
-
-	go func() {
-		suite.AppContextForTest().NewTransaction(func(txnAppCtx appcontext.AppContext) error {
-			time.Sleep(time.Millisecond * 500)
-			suite.Nil(waitForLock(txnAppCtx, lockID))
-			ret <- 2
-			return nil
-		})
-	}()
-
-	first := <-ret
-	second := <-ret
-
-	suite.Equal(1, first)
-	suite.Equal(2, second)
-}
-
 func equalSlice(a []int, b []int) bool {
 	if len(a) != len(b) {
 		return false
@@ -153,7 +122,9 @@ type AwardQueueSuite struct {
 
 func TestAwardQueueSuite(t *testing.T) {
 	hs := &AwardQueueSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction(),
+		),
 	}
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()

--- a/pkg/handlers/dpsapi/api_test.go
+++ b/pkg/handlers/dpsapi/api_test.go
@@ -19,7 +19,8 @@ type HandlerSuite struct {
 // TestHandlerSuite creates our test suite
 func TestHandlerSuite(t *testing.T) {
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/primeapi/payloads/payloads_test.go
+++ b/pkg/handlers/primeapi/payloads/payloads_test.go
@@ -19,7 +19,8 @@ type PayloadsSuite struct {
 // TestHandlerSuite creates our test suite
 func TestHandlerSuite(t *testing.T) {
 	hs := &PayloadsSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage()),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -12,11 +12,12 @@ type MigrateSuite struct {
 	testingsuite.PopTestSuite
 }
 
+// This suite uses the high privileged role.
 func TestMigrateSuite(t *testing.T) {
 	ms := &MigrateSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(
 			"migrate",
-			testingsuite.WithHighPrivPSQLRole(),
+			testingsuite.WithHighPrivPSQLRole(), // WithPerTestTransaction cannot be used in conjunction with the HighPrivPSQLRole
 		),
 	}
 	suite.Run(t, ms)

--- a/pkg/paperwork/paperwork_test.go
+++ b/pkg/paperwork/paperwork_test.go
@@ -64,7 +64,7 @@ func (suite *PaperworkSuite) openLocalFile(path string, fs *afero.Afero) (afero.
 func TestPaperworkSuite(t *testing.T) {
 	storer := storageTest.NewFakeS3Storage(true)
 
-	popSuite := testingsuite.NewPopTestSuite(testingsuite.CurrentPackage())
+	popSuite := testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction())
 	newUploader, err := uploader.NewUserUploader(storer, uploader.MaxCustomerUserUploadFileSizeLimit)
 	if err != nil {
 		log.Panic(err)

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -98,50 +98,58 @@ func (suite *PaperworkSuite) TestComputeObligations() {
 	pickupPostalCode := "85369"
 	destinationPostalCode := "31905"
 	cents := unit.Cents(1000)
-	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			OriginalMoveDate:      &origMoveDate,
-			ActualMoveDate:        &actualDate,
-			PickupPostalCode:      &pickupPostalCode,
-			DestinationPostalCode: &destinationPostalCode,
-			TotalSITCost:          &cents,
-		},
-	})
 
-	address := models.Address{
-		StreetAddress1: "some address",
-		City:           "city",
-		State:          "state",
-		PostalCode:     "31905",
+	setupTestData := func() (models.PersonallyProcuredMove, models.Order, models.DutyLocation) {
+		ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+			PersonallyProcuredMove: models.PersonallyProcuredMove{
+				OriginalMoveDate:      &origMoveDate,
+				ActualMoveDate:        &actualDate,
+				PickupPostalCode:      &pickupPostalCode,
+				DestinationPostalCode: &destinationPostalCode,
+				TotalSITCost:          &cents,
+			},
+		})
+
+		address := models.Address{
+			StreetAddress1: "some address",
+			City:           "city",
+			State:          "state",
+			PostalCode:     "31905",
+		}
+		suite.MustSave(&address)
+
+		locationName := "New Duty Location"
+		location := models.DutyLocation{
+			Name:      locationName,
+			AddressID: address.ID,
+			Address:   address,
+		}
+		suite.MustSave(&location)
+
+		orderID := uuid.Must(uuid.NewV4())
+		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
+			Order: models.Order{
+				ID:                orderID,
+				NewDutyLocationID: location.ID,
+				NewDutyLocation:   location,
+			},
+		})
+
+		currentDutyLocation := testdatagen.FetchOrMakeDefaultCurrentDutyLocation(suite.DB())
+		return ppm, order, currentDutyLocation
 	}
-	suite.MustSave(&address)
 
-	locationName := "New Duty Location"
-	location := models.DutyLocation{
-		Name:      locationName,
-		AddressID: address.ID,
-		Address:   address,
-	}
-	suite.MustSave(&location)
-
-	orderID := uuid.Must(uuid.NewV4())
-	order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
-		Order: models.Order{
-			ID:                orderID,
-			NewDutyLocationID: location.ID,
-			NewDutyLocation:   location,
-		},
-	})
-
-	currentDutyLocation := testdatagen.FetchOrMakeDefaultCurrentDutyLocation(suite.DB())
-	params := models.ShipmentSummaryFormData{
-		PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm},
-		WeightAllotment:         models.SSWMaxWeightEntitlement{TotalWeight: totalWeightEntitlement},
-		PPMRemainingEntitlement: ppmRemainingEntitlement,
-		CurrentDutyLocation:     currentDutyLocation,
-		Order:                   order,
-	}
 	suite.Run("TestComputeObligations", func() {
+		ppm, order, currentDutyLocation := setupTestData()
+
+		params := models.ShipmentSummaryFormData{
+			PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm},
+			WeightAllotment:         models.SSWMaxWeightEntitlement{TotalWeight: totalWeightEntitlement},
+			PPMRemainingEntitlement: ppmRemainingEntitlement,
+			CurrentDutyLocation:     currentDutyLocation,
+			Order:                   order,
+		}
+
 		var costDetails = make(rateengine.CostDetails)
 		costDetails["pickupLocation"] = &rateengine.CostDetail{
 			Cost:      rateengine.CostComputation{GCC: 100, SITMax: 20000},
@@ -186,6 +194,15 @@ func (suite *PaperworkSuite) TestComputeObligations() {
 	})
 
 	suite.Run("TestComputeObligations when actual PPM SIT exceeds MaxSIT", func() {
+		ppm, order, currentDutyLocation := setupTestData()
+
+		params := models.ShipmentSummaryFormData{
+			PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm},
+			WeightAllotment:         models.SSWMaxWeightEntitlement{TotalWeight: totalWeightEntitlement},
+			PPMRemainingEntitlement: ppmRemainingEntitlement,
+			CurrentDutyLocation:     currentDutyLocation,
+			Order:                   order,
+		}
 		var costDetails = make(rateengine.CostDetails)
 		costDetails["pickupLocation"] = &rateengine.CostDetail{
 			Cost:      rateengine.CostComputation{SITMax: unit.Cents(500)},
@@ -206,6 +223,8 @@ func (suite *PaperworkSuite) TestComputeObligations() {
 	})
 
 	suite.Run("TestComputeObligations when there is no actual PPM SIT", func() {
+		_, order, _ := setupTestData()
+
 		var costDetails = make(rateengine.CostDetails)
 		costDetails["pickupLocation"] = &rateengine.CostDetail{
 			Cost:      rateengine.CostComputation{SITMax: unit.Cents(500)},
@@ -242,6 +261,15 @@ func (suite *PaperworkSuite) TestComputeObligations() {
 	})
 
 	suite.Run("TestCalcError", func() {
+		ppm, order, currentDutyLocation := setupTestData()
+
+		params := models.ShipmentSummaryFormData{
+			PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm},
+			WeightAllotment:         models.SSWMaxWeightEntitlement{TotalWeight: totalWeightEntitlement},
+			PPMRemainingEntitlement: ppmRemainingEntitlement,
+			CurrentDutyLocation:     currentDutyLocation,
+			Order:                   order,
+		}
 		mockComputer := mockPPMComputer{err: errors.New("ERROR")}
 		ppmComputer := SSWPPMComputer{&mockComputer}
 		_, err := ppmComputer.ComputeObligations(suite.AppContextForTest(), params, planner)

--- a/pkg/services/invoice/gex_sender_http_test.go
+++ b/pkg/services/invoice/gex_sender_http_test.go
@@ -19,7 +19,8 @@ type GexSuite struct {
 func TestGexSuite(t *testing.T) {
 
 	ts := &GexSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("gex")),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("gex"),
+			testingsuite.WithPerTestTransaction()),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -2,7 +2,6 @@ package invoice
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"testing"
 	"time"
@@ -31,16 +30,10 @@ type GHCInvoiceSuite struct {
 	icnSequencer sequence.Sequencer
 }
 
-func (suite *GHCInvoiceSuite) SetupTest() {
-	errTruncateAll := suite.TruncateAll()
-	if errTruncateAll != nil {
-		log.Panicf("failed to truncate database: %#v", errTruncateAll)
-	}
-}
-
 func TestGHCInvoiceSuite(t *testing.T) {
 	ts := &GHCInvoiceSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("ghcinvoice")),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("ghcinvoice"),
+			testingsuite.WithPerTestTransaction()),
 	}
 	ts.icnSequencer = sequence.NewDatabaseSequencer(ediinvoice.ICNSequenceName)
 

--- a/pkg/services/invoice/invoice_service_test.go
+++ b/pkg/services/invoice/invoice_service_test.go
@@ -18,8 +18,9 @@ type InvoiceServiceSuite struct {
 func TestInvoiceSuite(t *testing.T) {
 
 	ts := &InvoiceServiceSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("invoice_service")),
-		storer:       storageTest.NewFakeS3Storage(true),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("invoice_service"),
+			testingsuite.WithPerTestTransaction()),
+		storer: storageTest.NewFakeS3Storage(true),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()

--- a/pkg/services/invoice/process_edi824_test.go
+++ b/pkg/services/invoice/process_edi824_test.go
@@ -2,7 +2,6 @@ package invoice
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 
@@ -19,16 +18,10 @@ type ProcessEDI824Suite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *ProcessEDI824Suite) SetupTest() {
-	errTruncateAll := suite.TruncateAll()
-	if errTruncateAll != nil {
-		log.Panicf("failed to truncate database: %#v", errTruncateAll)
-	}
-}
-
 func TestProcessEDI824Suite(t *testing.T) {
 	ts := &ProcessEDI824Suite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, ts)

--- a/pkg/services/invoice/process_edi997_test.go
+++ b/pkg/services/invoice/process_edi997_test.go
@@ -1,7 +1,6 @@
 package invoice
 
 import (
-	"log"
 	"strings"
 	"testing"
 
@@ -17,16 +16,10 @@ type ProcessEDI997Suite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *ProcessEDI997Suite) SetupTest() {
-	errTruncateAll := suite.TruncateAll()
-	if errTruncateAll != nil {
-		log.Panicf("failed to truncate database: %#v", errTruncateAll)
-	}
-}
-
 func TestProcessEDI997Suite(t *testing.T) {
 	ts := &ProcessEDI997Suite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction()),
 	}
 
 	suite.Run(t, ts)

--- a/pkg/services/invoice/syncada_sftp_reader_test.go
+++ b/pkg/services/invoice/syncada_sftp_reader_test.go
@@ -24,7 +24,8 @@ type SyncadaSftpReaderSuite struct {
 func TestSyncadaSftpReaderSuite(t *testing.T) {
 
 	ts := &SyncadaSftpReaderSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("syncada_sftp_reader")),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("syncada_sftp_reader"),
+			testingsuite.WithPerTestTransaction()),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()

--- a/pkg/services/invoice/syncada_sftp_sender_test.go
+++ b/pkg/services/invoice/syncada_sftp_sender_test.go
@@ -25,7 +25,8 @@ type SyncadaSftpSenderSuite struct {
 func TestSyncadaSftpSenderSuite(t *testing.T) {
 
 	ts := &SyncadaSftpSenderSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("syncada_sftp_sender")),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("syncada_sftp_sender"),
+			testingsuite.WithPerTestTransaction()),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()

--- a/pkg/services/postal_codes/postal_code_validator_test.go
+++ b/pkg/services/postal_codes/postal_code_validator_test.go
@@ -15,7 +15,8 @@ type ValidatePostalCodeTestSuite struct {
 
 func TestValidatePostalCodeTestSuite(t *testing.T) {
 	ts := &ValidatePostalCodeTestSuite{
-		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage(),
+			testingsuite.WithPerTestTransaction()),
 	}
 	suite.Run(t, ts)
 	ts.PopTestSuite.TearDown()


### PR DESCRIPTION
## [MB-12316 Convert remaining packages to transactions](https://dp3.atlassian.net/browse/MB-12316)

### Summary 

All packages that were found to clone the database converted, except those that needed substantial changes. Those were written into separate tickets and added to the epic. 

### Testing

Running all server tests should suffice

For more about the changes, please see https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/
