### PR TITLE
Use testing.T#Cleanup to simplify running tests in transactions

### DIFF
--- a/pkg/handlers/ordersapi/post_revision_test.go
+++ b/pkg/handlers/ordersapi/post_revision_test.go
@@ -59,8 +59,8 @@ func (suite *HandlerSuite) TestPostRevision() {
 		Revision:    &rev,
 	}
 
-	handler := PostRevisionHandler{handlers.NewHandlerConfig(suite.DB(), suite.Logger())}
 	suite.T().Run("NewSuccess", func(t *testing.T) {
+		handler := PostRevisionHandler{handlers.NewHandlerConfig(suite.DB(), suite.Logger())}
 		response := handler.Handle(params)
 
 		suite.IsType(&ordersoperations.PostRevisionCreated{}, response)
@@ -99,6 +99,7 @@ func (suite *HandlerSuite) TestPostRevision() {
 
 	suite.T().Run("AmendmentSuccess", func(t *testing.T) {
 		seqNum = int64(1)
+		handler := PostRevisionHandler{handlers.NewHandlerConfig(suite.DB(), suite.Logger())}
 		response := handler.Handle(params)
 
 		suite.IsType(&ordersoperations.PostRevisionCreated{}, response)
@@ -136,8 +137,14 @@ func (suite *HandlerSuite) TestPostRevision() {
 	})
 
 	suite.T().Run("SeqNumConflict", func(t *testing.T) {
-		// Sending the amendment again should result in a conflict because the SeqNum will be taken
+		seqNum = int64(1)
+		handler := PostRevisionHandler{handlers.NewHandlerConfig(suite.DB(), suite.Logger())}
 		response := handler.Handle(params)
+
+		suite.IsType(&ordersoperations.PostRevisionCreated{}, response)
+
+		// Sending the amendment again should result in a conflict because the SeqNum will be taken
+		response = handler.Handle(params)
 		suite.IsType(&handlers.ErrResponse{}, response)
 		errResponse, ok := response.(*handlers.ErrResponse)
 		if !ok {
@@ -149,6 +156,7 @@ func (suite *HandlerSuite) TestPostRevision() {
 	suite.T().Run("EdipiConflict", func(t *testing.T) {
 		params.MemberID = "9999999999"
 		seqNum = int64(99999)
+		handler := PostRevisionHandler{handlers.NewHandlerConfig(suite.DB(), suite.Logger())}
 		response := handler.Handle(params)
 		suite.IsType(&handlers.ErrResponse{}, response)
 		errResponse, ok := response.(*handlers.ErrResponse)

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -72,11 +72,10 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 	params := move_task_order.HideNonFakeMoveTaskOrdersParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
 
 	suite.Run("successfully hide fake moves", func() {
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
 			movetaskorder.NewMoveTaskOrderHider(),
 		}
 		var moves models.Moves
@@ -111,7 +110,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		}
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
 			mockHider,
 		}
 
@@ -139,7 +138,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
 			mockHider,
 		}
 		mockHider.On("Hide",

--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -14,17 +14,19 @@ import (
 )
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
-	availableMTO := testdatagen.MakeAvailableMove(suite.DB())
-	notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 	mtoChecker := NewMoveTaskOrderChecker()
 
-	suite.RunWithRollback("MTO is available and visible - success", func() {
+	suite.Run("MTO is available and visible - success", func() {
+		availableMTO := testdatagen.MakeAvailableMove(suite.DB())
+		testdatagen.MakeDefaultMove(suite.DB())
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), availableMTO.ID)
 		suite.Equal(availableToPrime, true)
 		suite.NoError(err)
 	})
 
-	suite.RunWithRollback("MTO is available but hidden - failure", func() {
+	suite.Run("MTO is available but hidden - failure", func() {
+		testdatagen.MakeAvailableMove(suite.DB())
+		testdatagen.MakeDefaultMove(suite.DB())
 		now := time.Now()
 		hide := false
 		availableHiddenMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
@@ -41,13 +43,17 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 		suite.Equal(availableToPrime, false)
 	})
 
-	suite.RunWithRollback("MTO is not available - no failure, but returns false", func() {
+	suite.Run("MTO is not available - no failure, but returns false", func() {
+		testdatagen.MakeAvailableMove(suite.DB())
+		notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), notAvailableMTO.ID)
 		suite.Equal(availableToPrime, false)
 		suite.NoError(err)
 	})
 
-	suite.RunWithRollback("MTO ID is not valid - failure", func() {
+	suite.Run("MTO ID is not valid - failure", func() {
+		testdatagen.MakeAvailableMove(suite.DB())
+		testdatagen.MakeDefaultMove(suite.DB())
 		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), badUUID)
 		suite.Error(err)

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -31,7 +31,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		moveRouter,
 	)
 
-	suite.RunWithRollback("Move status is updated successfully (with HHG shipment)", func() {
+	suite.Run("Move status is updated successfully (with HHG shipment)", func() {
 		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -47,7 +47,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Equal(models.MoveStatusServiceCounselingCompleted, actualMTO.Status)
 	})
 
-	suite.RunWithRollback("Move/shipment/PPM statuses are updated successfully (with PPM shipment)", func() {
+	suite.Run("Move/shipment/PPM statuses are updated successfully (with PPM shipment)", func() {
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -71,7 +71,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		}
 	})
 
-	suite.RunWithRollback("MTO status is updated successfully with facility info", func() {
+	suite.Run("MTO status is updated successfully with facility info", func() {
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			StorageFacility: models.StorageFacility{
 				Address: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -86,19 +86,20 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 				Email: swag.String("old@email.com"),
 			},
 		})
-		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			MTOShipment: models.MTOShipment{
-				StorageFacility: &storageFacility,
-			},
-		})
-		var mtoShipments []models.MTOShipment
-		mtoShipments = append(mtoShipments, shipment)
 		expectedMTOWithFacility := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
-				Status:       models.MoveStatusNeedsServiceCounseling,
-				MTOShipments: mtoShipments,
+				Status: models.MoveStatusNeedsServiceCounseling,
 			},
 		})
+		testdatagen.MakeMTOShipmentWithMove(suite.DB(), &expectedMTOWithFacility,
+			testdatagen.Assertions{
+				MTOShipment: models.MTOShipment{
+					StorageFacility: &storageFacility,
+				},
+			})
+
+		suite.NoError(suite.DB().Reload(&expectedMTOWithFacility))
+
 		eTag := etag.GenerateEtag(expectedMTOWithFacility.UpdatedAt)
 
 		actualMTO, err := mtoUpdater.UpdateStatusServiceCounselingCompleted(suite.AppContextForTest(), expectedMTOWithFacility.ID, eTag)
@@ -109,7 +110,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Equal(actualMTO.Status, models.MoveStatusServiceCounselingCompleted)
 	})
 
-	suite.RunWithRollback("Invalid input error when there is no facility information on NTS-r shipment", func() {
+	suite.Run("Invalid input error when there is no facility information on NTS-r shipment", func() {
 		noFacilityInfoMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -135,7 +136,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "NTS-release shipment must include facility info")
 	})
 
-	suite.RunWithRollback("No shipments on move", func() {
+	suite.Run("No shipments on move", func() {
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -150,7 +151,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "No shipments associated with move")
 	})
 
-	suite.RunWithRollback("MTO status is in a conflicted state", func() {
+	suite.Run("MTO status is in a conflicted state", func() {
 		draftMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusDRAFT,
@@ -168,7 +169,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "The status for the Move")
 	})
 
-	suite.RunWithRollback("Etag is stale", func() {
+	suite.Run("Etag is stale", func() {
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -183,8 +184,6 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCounselingInfo() {
-	expectedMTO := testdatagen.MakeDefaultMove(suite.DB())
-
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := moverouter.NewMoveRouter()
 	mtoUpdater := NewMoveTaskOrderUpdater(
@@ -193,7 +192,9 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		moveRouter,
 	)
 
-	suite.RunWithRollback("MTO post counseling information is updated successfully", func() {
+	suite.Run("MTO post counseling information is updated successfully", func() {
+		expectedMTO := testdatagen.MakeDefaultMove(suite.DB())
+
 		// Make a couple of shipments for the move; one prime, one external
 		primeShipment := testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: expectedMTO,
@@ -248,7 +249,9 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		suite.Equal(models.PPMShipmentStatusWaitingOnCustomer, actualMTO.MTOShipments[0].PPMShipment.Status)
 	})
 
-	suite.RunWithRollback("Counseling isn't an approved service item", func() {
+	suite.Run("Counseling isn't an approved service item", func() {
+		expectedMTO := testdatagen.MakeDefaultMove(suite.DB())
+
 		testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: expectedMTO,
 			MTOShipment: models.MTOShipment{
@@ -262,7 +265,9 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		suite.IsType(apperror.ConflictError{}, err)
 	})
 
-	suite.RunWithRollback("Etag is stale", func() {
+	suite.Run("Etag is stale", func() {
+		expectedMTO := testdatagen.MakeDefaultMove(suite.DB())
+
 		testdatagen.MakeMTOServiceItemBasic(suite.DB(), testdatagen.Assertions{
 			MTOServiceItem: models.MTOServiceItem{
 				Status: models.MTOServiceItemStatusApproved,
@@ -284,11 +289,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	// Set up a default move:
 	show := true
-	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Show: &show,
-		},
-	})
+	setupTestData := func() models.Move {
+		return testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				Show: &show,
+			},
+		})
+	}
 
 	// Set up the necessary updater objects:
 	queryBuilder := query.NewQueryBuilder()
@@ -300,8 +307,9 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	)
 
 	// Case: Move successfully deactivated
-	suite.RunWithRollback("Success - Set show field to false", func() {
+	suite.Run("Success - Set show field to false", func() {
 		show = false
+		move := setupTestData()
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, &show)
 
 		suite.NotNil(updatedMove)
@@ -311,8 +319,9 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Move successfully activated
-	suite.RunWithRollback("Success - Set show field to true", func() {
+	suite.Run("Success - Set show field to true", func() {
 		show = true
+		move := setupTestData()
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, &show)
 
 		suite.NotNil(updatedMove)
@@ -333,7 +342,8 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Show input value is nil, not True or False
-	suite.RunWithRollback("Fail - Nil value in show field", func() {
+	suite.Run("Fail - Nil value in show field", func() {
+		move := setupTestData()
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, nil)
 
 		suite.Nil(updatedMove)
@@ -344,7 +354,8 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 
 	// Case: Invalid input found while updating the move
 	// TODO: Is there a way to mock ValidateUpdate so that these tests actually mean something?
-	suite.RunWithRollback("Fail - Invalid input found on move", func() {
+	suite.Run("Fail - Invalid input found on move", func() {
+		move := setupTestData()
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mockUpdater.On("ShowHide",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -360,7 +371,8 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Query error encountered while updating the move
-	suite.RunWithRollback("Fail - Query error", func() {
+	suite.Run("Fail - Query error", func() {
+		move := setupTestData()
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mockUpdater.On("ShowHide",
 			mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -125,14 +125,13 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
 
-			err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusSubmitted, shipment.Status)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusSubmitted, shipment.Status, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -147,16 +146,15 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 		{"Submitted", models.MTOShipmentStatusSubmitted},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
 
-			err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status 'SUBMITTED' from [\"DRAFT\"]", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status 'SUBMITTED' from [\"DRAFT\"]", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }
 
@@ -171,14 +169,13 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 		{"Cancellation Requested", models.MTOShipmentStatusCancellationRequested},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
 
-			err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusCanceled, shipment.Status)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusCanceled, shipment.Status, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -193,16 +190,15 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
 
-			err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }
 
@@ -218,15 +214,14 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 		{"Submitted", models.MTOShipmentStatusSubmitted},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
 
-			err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
+		err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusRejected, shipment.Status)
-			suite.Equal(&rejectionReason, shipment.RejectionReason)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusRejected, shipment.Status, subname)
+		suite.Equal(&rejectionReason, shipment.RejectionReason, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -241,16 +236,15 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
 
-			err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
+		err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }
 
@@ -265,14 +259,13 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 		{"Approved", models.MTOShipmentStatusApproved},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
 
-			err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusDiversionRequested, shipment.Status)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusDiversionRequested, shipment.Status, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -287,16 +280,15 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
 
-			err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }
 
@@ -304,13 +296,12 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 	shipment := testdatagen.MakeStubbedShipment(suite.DB())
 	shipmentRouter := NewShipmentRouter()
 
-	suite.Run("fails when the Diversion field is false", func() {
-		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
+	subname := "fails when the Diversion field is false"
+	err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
-		suite.Error(err)
-		suite.IsType(apperror.ConflictError{}, err)
-		suite.Contains(err.Error(), "Cannot approve the diversion")
-	})
+	suite.Error(err, subname)
+	suite.IsType(apperror.ConflictError{}, err, subname)
+	suite.Contains(err.Error(), "Cannot approve the diversion", subname)
 
 	validStatuses := []struct {
 		desc   string
@@ -319,15 +310,14 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 		{"Approved", models.MTOShipmentStatusSubmitted},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
-			shipment.Diversion = true
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
+		shipment.Diversion = true
 
-			err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusApproved, shipment.Status)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusApproved, shipment.Status, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -342,17 +332,16 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
-			shipment.Diversion = true
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
+		shipment.Diversion = true
 
-			err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }
 
@@ -362,13 +351,12 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversionUsesExternal() {
 	shipment.UsesExternalVendor = true
 	shipment.Diversion = true
 
-	suite.Run("fails when the UsesExternal field is true", func() {
-		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
+	subname := "fails when the UsesExternal field is true"
+	err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
-		suite.Error(err)
-		suite.IsType(apperror.ConflictError{}, err)
-		suite.Contains(err.Error(), "has the UsesExternalVendor field set to true")
-	})
+	suite.Error(err, subname)
+	suite.IsType(apperror.ConflictError{}, err, subname)
+	suite.Contains(err.Error(), "has the UsesExternalVendor field set to true", subname)
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
@@ -382,14 +370,13 @@ func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 		{"Approved", models.MTOShipmentStatusApproved},
 	}
 	for _, validStatus := range validStatuses {
-		suite.Run("from valid status: "+string(validStatus.status), func() {
-			shipment.Status = validStatus.status
+		subname := "from valid status: " + string(validStatus.status)
+		shipment.Status = validStatus.status
 
-			err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)
 
-			suite.NoError(err)
-			suite.Equal(models.MTOShipmentStatusCancellationRequested, shipment.Status)
-		})
+		suite.NoError(err, subname)
+		suite.Equal(models.MTOShipmentStatusCancellationRequested, shipment.Status, subname)
 	}
 
 	invalidStatuses := []struct {
@@ -404,15 +391,14 @@ func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 		{"Draft", models.MTOShipmentStatusDraft},
 	}
 	for _, invalidStatus := range invalidStatuses {
-		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
-			shipment.Status = invalidStatus.status
+		subname := "from invalid status: " + string(invalidStatus.status)
+		shipment.Status = invalidStatus.status
 
-			err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)
+		err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)
 
-			suite.Error(err)
-			suite.IsType(ConflictStatusError{}, err)
-			suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID))
-			suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status))
-		})
+		suite.Error(err, subname)
+		suite.IsType(ConflictStatusError{}, err, subname)
+		suite.Contains(err.Error(), fmt.Sprintf("Shipment with id '%s' can only transition to status", shipment.ID), subname)
+		suite.Contains(err.Error(), fmt.Sprintf("but its current status is '%s'", invalidStatus.status), subname)
 	}
 }

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -404,13 +404,16 @@ func (suite *PopTestSuite) DB() *pop.Connection {
 		// cannot accidentally share a transaction
 		_, ok := suite.perTestTxnConn[t]
 		if !ok {
+			if len(suite.perTestTxnConn) > 0 {
+				suite.FailNow("Opening more than one db connection in transactional test")
+			}
 			suite.perTestTxnConn[t] = suite.openTxnPopConnection()
 
 			// Any time a database connection is established, make sure we
 			// close it at the end of the test so that the transaction
 			// is rolled back. See txdb for more info
 			t.Cleanup(func() {
-				suite.tearDownTxnTest()
+				suite.tearDownTxnTest(t)
 			})
 		}
 		return suite.perTestTxnConn[t]
@@ -518,7 +521,7 @@ func (suite *PopTestSuite) NilOrNoVerrs(err error) {
 // TearDownTest runs the teardown per test. It will only do something
 // useful if per test transactions are enabled
 func (suite *PopTestSuite) TearDownTest() {
-	suite.tearDownTxnTest()
+	suite.tearDownAllTxnTest()
 }
 
 // TearDown runs the teardown for step for the suite

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"testing"
 
 	"github.com/DATA-DOG/go-txdb"
 	"github.com/gobuffalo/pop/v6"
@@ -141,14 +142,25 @@ func (suite *PopTestSuite) openTxnPopConnection() *pop.Connection {
 	return popConn
 }
 
+// tearDownAllTxnTest ensures all open connections for this test are
+// torn down
+func (suite *PopTestSuite) tearDownAllTxnTest() {
+	if !suite.usePerTestTransaction {
+		return
+	}
+	suite.Logger().Warn("Tearing Down all Connections")
+	for t := range suite.perTestTxnConn {
+		suite.tearDownTxnTest(t)
+	}
+}
+
 // tearDownTxnTest closes the db connection established for this test
-func (suite *PopTestSuite) tearDownTxnTest() {
+func (suite *PopTestSuite) tearDownTxnTest(t *testing.T) {
 	if !suite.usePerTestTransaction {
 		return
 	}
 	suite.perTestTxnMutex.Lock()
 	defer suite.perTestTxnMutex.Unlock()
-	t := suite.T()
 	db, ok := suite.perTestTxnConn[t]
 	if ok {
 		delete(suite.perTestTxnConn, t)

--- a/pkg/testingsuite/pop_suite_txn.go
+++ b/pkg/testingsuite/pop_suite_txn.go
@@ -146,12 +146,16 @@ func (suite *PopTestSuite) tearDownTxnTest() {
 	if !suite.usePerTestTransaction {
 		return
 	}
-	if suite.lowPrivConn == nil {
-		return
+	suite.perTestTxnMutex.Lock()
+	defer suite.perTestTxnMutex.Unlock()
+	t := suite.T()
+	db, ok := suite.perTestTxnConn[t]
+	if ok {
+		delete(suite.perTestTxnConn, t)
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("Closing Subtest DB Failed!: %v", err)
+		}
 	}
-	err := suite.lowPrivConn.Close()
-	if err != nil {
-		log.Panicf("Error closing lowPrivConn: %v", err)
-	}
-	suite.lowPrivConn = nil
+
 }


### PR DESCRIPTION
## Summary

By using the [Cleanup](https://pkg.go.dev/testing#T.Cleanup) function whenever a database connection is established for per test transaction, we can ensure it is closed and the transaction is rolled back. We no longer need to convert suite.T().Run to suite.Run!

The docs for how to convert/write transaction tests needs to be updated if we like this approach

## Setup to Run Your Code

```sh
make server_test
```

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.

