### PR TITLE
Adding prime actual weight 

### DIFF
--- a/src/constants/MoveHistory/Database/FieldMappings.js
+++ b/src/constants/MoveHistory/Database/FieldMappings.js
@@ -9,7 +9,7 @@ export default {
   status: 'Status',
   customer_remarks: 'Customer remarks',
   approved_date: 'Approved date',
-  actual_pickup_date: 'Actual pickup date',
+  actual_pickup_date: 'Departure date',
   prime_estimated_weight: 'Prime estimated weight',
   counselor_remarks: 'Counselor remarks',
   service_order_number: 'Service order number',
@@ -43,5 +43,5 @@ export default {
   receiving_agent: 'Receiving agent',
   releasing_agent: 'Releasing agent',
   tio_remarks: 'Max billable weight remark',
-  prime_actual_weight: 'Prime actual weight',
+  prime_actual_weight: 'Shipment weight',
 };

--- a/src/constants/MoveHistory/Database/FieldMappings.js
+++ b/src/constants/MoveHistory/Database/FieldMappings.js
@@ -43,4 +43,5 @@ export default {
   receiving_agent: 'Receiving agent',
   releasing_agent: 'Releasing agent',
   tio_remarks: 'Max billable weight remark',
+  prime_actual_weight: 'Prime actual weight',
 };

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -34,6 +34,8 @@ describe('LabeledDetails', () => {
         nts_sac: '5555',
         department_indicator: 'AIR_FORCE',
         grade: 'E_1',
+        actual_pickup_date: '01-01-2022',
+        prime_actual_weight: '100',
       },
     };
     it.each([
@@ -60,6 +62,8 @@ describe('LabeledDetails', () => {
       ['HHG SAC', ': 4444'],
       ['NTS SAC', ': 5555'],
       ['Dept. indicator', ': Air Force'],
+      ['Departure date', ': 01 Jan 2022'],
+      ['Shipment weight', ': 100'],
     ])('it renders %s%s', (displayName, value) => {
       render(<LabeledDetails historyRecord={historyRecord} />);
 


### PR DESCRIPTION
[Jira Ticket](https://dp3.atlassian.net/browse/MB-11344)

## Summary

Added one line to accommodate the prime actual weight. Writing this PR and probably the writing the ticket probably took longer than making the change haha

## Setup to Run Your Code

1. Log in as a prime user
2. Navigate to move PENDNG
3. Click update shipment
4. Edit the actual pickup date and actual weight
5. Click save
6. Sign out 
7. Sign in as TIO user
8. Navigate to move PENDNG
9. Navigate to the move history tab
10. Observe that both actual pickup date and actual weight are created
