### PR TITLE
MB-12018 Create new proof of service document upload event

### DIFF
--- a/src/constants/MoveHistory/Database/Tables.js
+++ b/src/constants/MoveHistory/Database/Tables.js
@@ -8,4 +8,5 @@ export default {
   mto_agents: 'mto_agents',
   reweighs: 'reweighs',
   addresses: 'addresses',
+  proof_of_service_docs: 'proof_of_service_docs',
 };

--- a/src/constants/MoveHistory/EventTemplates/index.js
+++ b/src/constants/MoveHistory/EventTemplates/index.js
@@ -9,6 +9,7 @@ export { default as createOrders } from './createOrders';
 export { default as createPaymentRequestReweighUpdate } from './createPaymentRequestReweighUpdate';
 export { default as createPaymentRequestShipmentUpdate } from './createPaymentRequestShipmentUpdate';
 export { default as createStandardServiceItem } from './createStandardServiceItem';
+export { default as proofOfServiceDocUpload } from './proofOfServiceDocUpload';
 export { default as requestShipmentCancellation } from './requestShipmentCancellation';
 export { default as requestShipmentDiversion } from './requestShipmentDiversion';
 export { default as requestShipmentReweigh } from './requestShipmentReweigh';

--- a/src/constants/MoveHistory/EventTemplates/proofOfServiceDocUpload.js
+++ b/src/constants/MoveHistory/EventTemplates/proofOfServiceDocUpload.js
@@ -1,0 +1,14 @@
+import a from 'constants/MoveHistory/Database/Actions';
+import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
+import t from 'constants/MoveHistory/Database/Tables';
+
+export default {
+  action: a.INSERT,
+  eventName: 'createUpload',
+  tableName: t.proof_of_service_docs,
+  detailsType: d.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Uploaded document',
+  getDetailsPlainText: ({ context }) => {
+    return `Proof of service document uploaded for payment request ${context[0].payment_request_number}`;
+  },
+};

--- a/src/constants/MoveHistory/EventTemplates/proofOfServiceDocUpload.test.js
+++ b/src/constants/MoveHistory/EventTemplates/proofOfServiceDocUpload.test.js
@@ -1,0 +1,20 @@
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import e from 'constants/MoveHistory/EventTemplates/proofOfServiceDocUpload';
+import a from 'constants/MoveHistory/Database/Actions';
+import t from 'constants/MoveHistory/Database/Tables';
+
+describe('when given a proof of service document upload history record', () => {
+  const item = {
+    action: a.INSERT,
+    eventName: 'createUpload',
+    tableName: t.proof_of_service_docs,
+    context: [{ payment_request_number: '1234-5678-1' }],
+  };
+  it('correctly matches the proof of service document upload event', () => {
+    const result = getTemplate(item);
+    expect(result).toMatchObject(e);
+    expect(result.getDetailsPlainText(item)).toEqual(
+      'Proof of service document uploaded for payment request 1234-5678-1',
+    );
+  });
+});


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12018) for this change

## Summary

Created a new event for the proof of service document upload.
The backend changes were done in #8641.


## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office application.
2. Login as a prime simulator.
3. Select a move and remember the move code.
4. Upload a document in the Payment Requests section and save.
5. Login as a TIO.
6. Select the same move as the one where you uploaded the documents.
7. Go to the move history tab.
8. The first history item should be the proof of service document upload 

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/6477059/169915862-2535dace-e110-4b8b-9db9-dbed5258aae3.png">
