### PR TITLE
MB-12600: Ensure client and server test coverage only increases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -985,15 +985,37 @@ jobs:
           keys:
             - go-mod-sources-v3-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run: echo 'export PATH=${PATH}:${GOPATH}/bin:~/transcom/mymove/bin' >> $BASH_ENV
+      - restore_cache:
+          keys:
+            - server-tests-coverage
+      - run:
+          name: Save Baseline Test Coverage
+          command: |
+            [ -r ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ] && cp ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt /tmp/coverage_baseline.txt || echo "Skipping saving baseline"
+            rm -rf ~/transcom/mymove/tmp/test-results
       # make -j 2 tells make to run 2 simultaneous builds
       - run: make -j 2 bin/milmove bin/go-junit-report
       - server_tests_step:
           application: app
+      - run:
+          name: Ensure Test Coverage Increasing
+          command: |
+            ./scripts/ensure-go-test-coverage /tmp/coverage_baseline.txt tmp/test-results/gotest/app/go-coverage.txt
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results
       - store_test_results:
           path: ~/transcom/mymove/tmp/test-results
+      # only save the cache on master builds because we only want to
+      # change the baseline of test results on master builds
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >>]
+          steps:
+            save_cache:
+              key: server-tests-coverage
+              paths:
+                - ~/transcom/mymove/tmp/test-results
       - announce_failure
 
   # `client_test` runs the client side Javascript tests
@@ -1004,15 +1026,37 @@ jobs:
       - restore_cache:
           keys:
             - v3-cache-yarn-v3-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - client-tests-coverage
+      - run:
+          name: Save Baseline Test Coverage
+          command: |
+            [ -r ~/transcom/mymove/coverage/clover.xml ] && cp ~/transcom/mymove/coverage/clover.xml /tmp/clover_baseline.xml || echo "Skipping saving baseline"
+            rm -rf ~/transcom/mymove/coverage
       - run:
           name: Install Frozen YARN dependencies
           command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - run: make client_test_coverage
+      - run:
+          name: Ensure Test Coverage Increasing
+          command: |
+            ./scripts/ensure-js-test-coverage /tmp/clover_baseline.xml coverage/clover.xml
       - store_artifacts:
           path: ~/transcom/mymove/coverage
           destination: coverage
       - store_test_results:
           path: ~/transcom/mymove
+      # only save the cache on master builds because we only want to
+      # change the baseline of test results on master builds
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >>]
+          steps:
+            save_cache:
+              key: client-tests-coverage
+              paths:
+                - ~/transcom/mymove/coverage
       - announce_failure
 
   # `webhook_client_test` runs the webhook client Go tests

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -149,6 +149,8 @@ This subset of development scripts is used for testing
 
 | Script Name                           | Description                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `ensure-go-test-coverage`              | Parse the go test coverage to ensure coverage increases                                                          |
+| `ensure-js-test-coverage`              | Parse the js test coverage to ensure coverage increases                                                          |
 | `run-e2e-test`                        | Runs cypress tests with interactive GUI                                                          |
 | `run-e2e-test-docker`                 | Runs cypress tests entirely inside docker containers like in CircleCI                            |
 | `run-e2e-mtls-test-docker`            | Runs integration tests for mtls endpoints inside docker containers like in CircleCI              |

--- a/scripts/ensure-go-test-coverage
+++ b/scripts/ensure-go-test-coverage
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os.path
+import sys
+
+if len(sys.argv) != 3:
+  print(f"Usage: {sys.argv[0]} baseline_coverage.txt new_coverage.txt")
+  sys.exit(1)
+
+def total_coverage_percent(filename):
+  """parse out the total coverage percentage which is on the line
+   with (statements) and strip off the % sign
+  """
+  with open(filename) as f:
+    for line in f:
+      if "(statements)" in line:
+        percent = line.split()[-1]
+        return float(percent.rstrip('%'))
+
+baseline_file = sys.argv[1]
+new_file = sys.argv[2]
+
+baseline_percent = 0.0
+# we can remove this conditional once the baselines are being saved on master
+if not os.path.exists(baseline_file):
+  print(f"Baseline file '{baseline_file}' does not exist, assuming 0")
+else:
+  baseline_percent = total_coverage_percent(baseline_file)
+
+new_percent = total_coverage_percent(new_file)
+
+print(f"Baseline test coverage: {baseline_percent}")
+print(f"New test coverage: {new_percent}")
+
+if new_percent < baseline_percent:
+  print("Test Coverage has decreased")
+  sys.exit(1)

--- a/scripts/ensure-js-test-coverage
+++ b/scripts/ensure-js-test-coverage
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import os.path
+import sys
+import xml.etree.ElementTree as ET
+
+if len(sys.argv) != 3:
+  print(f"Usage: {sys.argv[0]} baseline_coverage.xml new_coverage.xml")
+  sys.exit(1)
+
+def total_coverage_percent(filename):
+  """parse out the total coverage percentage from the junit xml
+  """
+  root = ET.parse(filename).getroot()
+  attrs = root.find("./project/metrics").attrib
+  # use statements as our percentage, round to 1 decimal place
+  return round(int(attrs["coveredstatements"]) / int(attrs["statements"]) * 100, 1)
+
+baseline_file = sys.argv[1]
+new_file = sys.argv[2]
+
+baseline_percent = 0.0
+# we can remove this conditional once the baselines are being saved on master
+if not os.path.exists(baseline_file):
+  print(f"Baseline file '{baseline_file}' does not exist, assuming 0")
+else:
+  baseline_percent = total_coverage_percent(baseline_file)
+
+new_percent = total_coverage_percent(new_file)
+
+print(f"Baseline test coverage: {baseline_percent}")
+print(f"New test coverage: {new_percent}")
+
+if new_percent < baseline_percent:
+  print("Test Coverage has decreased")
+  sys.exit(1)


### PR DESCRIPTION
## [MB-12600](https://dp3.atlassian.net/browse/MB-12600) for this change

## Summary

Add some scripts to make it easier to extract code coverage info.

## Setup to Run Your Code

The real test is running in CI and seeing the new steps.

* [server_test](https://app.circleci.com/pipelines/github/transcom/mymove/42258/workflows/6de2561a-383d-4996-844b-185c36c8a7ce/jobs/660291/parallel-runs/0/steps/0-109)
* [client_test](https://app.circleci.com/pipelines/github/transcom/mymove/42258/workflows/6de2561a-383d-4996-844b-185c36c8a7ce/jobs/660272/parallel-runs/0/steps/0-106)


You can run the following to generate the coverage files for go and then run the script manually to see it print out the coverage info.

```
make server_test_setup
NO_DB=1 SERVER_REPORT=1 COVERAGE=1 ./scripts/run-server-test
./scripts/ensure-go-test-coverage  tmp/test-results/gotest/app/go-coverage.txt  tmp/test-results/gotest/app/go-coverage.txt
```

For the client tests, you can do this simulation
```
yarn test:coverage
./scripts/ensure-js-test-coverage coverage/clover.xml coverage/clover.xml
```

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?



