### PR TITLE
MB-12617 Convert handlers/primeapi tests

### DIFF
--- a/pkg/handlers/primeapi/allowed_payment_service_item_params_test.go
+++ b/pkg/handlers/primeapi/allowed_payment_service_item_params_test.go
@@ -2,7 +2,6 @@ package primeapi
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -31,7 +30,7 @@ var invalidParamsTestCases = []paramTestCase{
 
 func (suite *HandlerSuite) TestAllowedParams() {
 	for _, tc := range allowedParamsTestCases {
-		suite.T().Run(fmt.Sprintf("param %s should be allowed for service code %s", tc.paramKeyName, string(tc.reServiceCode)), func(t *testing.T) {
+		suite.Run(fmt.Sprintf("param %s should be allowed for service code %s", tc.paramKeyName, string(tc.reServiceCode)), func() {
 			suite.True(AllowedParamKeysPaymentRequest.Contains(tc.reServiceCode, tc.paramKeyName))
 		})
 	}
@@ -39,7 +38,7 @@ func (suite *HandlerSuite) TestAllowedParams() {
 
 func (suite *HandlerSuite) TestNotAllowedParams() {
 	for _, tc := range invalidParamsTestCases {
-		suite.T().Run(fmt.Sprintf("param %s should not be allowed for service code %s", tc.paramKeyName, string(tc.reServiceCode)), func(t *testing.T) {
+		suite.Run(fmt.Sprintf("param %s should not be allowed for service code %s", tc.paramKeyName, string(tc.reServiceCode)), func() {
 			suite.False(AllowedParamKeysPaymentRequest.Contains(tc.reServiceCode, tc.paramKeyName))
 		})
 	}

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -1,12 +1,13 @@
 package primeapi
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/http/httptest"
-	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 
 	"github.com/go-openapi/swag"
@@ -73,12 +74,13 @@ func (suite *HandlerSuite) TestListMovesHandlerReturnsUpdated() {
 
 func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	request := httptest.NewRequest("GET", "/move-task-orders/{moveTaskOrderID}", nil)
-	handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
-	handler := GetMoveTaskOrderHandler{handlerConfig,
-		movetaskorder.NewMoveTaskOrderFetcher(),
-	}
 
-	suite.T().Run("Success with Prime-available move by ID", func(t *testing.T) {
+	suite.Run("Success with Prime-available move by ID", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
+
 		successMove := testdatagen.MakeAvailableMove(suite.DB())
 		params := movetaskorderops.GetMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -96,7 +98,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.NotEmpty(movePayload.AvailableToPrimeAt) // checks that the date is not 0001-01-01
 	})
 
-	suite.T().Run("Success with Prime-available move by Locator", func(t *testing.T) {
+	suite.Run("Success with Prime-available move by Locator", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		successMove := testdatagen.MakeAvailableMove(suite.DB())
 		params := movetaskorderops.GetMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -114,7 +120,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.NotEmpty(movePayload.AvailableToPrimeAt) // checks that the date is not 0001-01-01
 	})
 
-	suite.T().Run("Returns the destination address type for a shipment on a move if it exists", func(t *testing.T) {
+	suite.Run("Returns the destination address type for a shipment on a move if it exists", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		successMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				AvailableToPrimeAt: swag.Time(time.Now()),
@@ -150,7 +160,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 	})
 
-	suite.T().Run("Success returns reweighs on shipments if they exist", func(t *testing.T) {
+	suite.Run("Success returns reweighs on shipments if they exist", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		successMove := testdatagen.MakeAvailableMove(suite.DB())
 		params := movetaskorderops.GetMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -175,7 +189,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.Equal(strfmt.UUID(reweigh.ID.String()), reweighPayload.ID)
 	})
 
-	suite.T().Run("Success - returns sit extensions on shipments if they exist", func(t *testing.T) {
+	suite.Run("Success - returns sit extensions on shipments if they exist", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		successMove := testdatagen.MakeAvailableMove(suite.DB())
 		params := movetaskorderops.GetMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -201,7 +219,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.Equal(strfmt.UUID(sitExtension.ID.String()), reweighPayload.ID)
 	})
 
-	suite.T().Run("Success - filters shipments handled by an external vendor", func(t *testing.T) {
+	suite.Run("Success - filters shipments handled by an external vendor", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		move := testdatagen.MakeAvailableMove(suite.DB())
 
 		// Create two shipments, one prime, one external.  Only prime one should be returned.
@@ -237,7 +259,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		}
 	})
 
-	suite.T().Run("Success - returns shipment with attached PpmShipment", func(t *testing.T) {
+	suite.Run("Success - returns shipment with attached PpmShipment", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		move := testdatagen.MakeAvailableMove(suite.DB())
 		ppmShipment := testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -261,7 +287,11 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 		suite.Equal(ppmShipment.ID.String(), movePayload.MtoShipments[0].PpmShipment.ID.String())
 	})
 
-	suite.T().Run("Failure 'Not Found' for non-available move", func(t *testing.T) {
+	suite.Run("Failure 'Not Found' for non-available move", func() {
+		handler := GetMoveTaskOrderHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			movetaskorder.NewMoveTaskOrderFetcher(),
+		}
 		failureMove := testdatagen.MakeDefaultMove(suite.DB()) // default is not available to Prime
 		params := movetaskorderops.GetMoveTaskOrderParams{
 			HTTPRequest: request,
@@ -280,16 +310,16 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 
 func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 	request := httptest.NewRequest("POST", "/move-task-orders/{moveTaskOrderID}", nil)
-	handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
 	fakeS3 := storageTest.NewFakeS3Storage(true)
-	handlerConfig.SetFileStorer(fakeS3)
-	handler := CreateExcessWeightRecordHandler{
-		handlerConfig,
-		// Must use the Prime service object in particular:
-		moverouter.NewPrimeMoveExcessWeightUploader(upload.NewUploadCreator(handlerConfig.FileStorer())),
-	}
 
-	suite.T().Run("Success - Created an excess weight record", func(t *testing.T) {
+	suite.Run("Success - Created an excess weight record", func() {
+		handler := CreateExcessWeightRecordHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			// Must use the Prime service object in particular:
+			moverouter.NewPrimeMoveExcessWeightUploader(upload.NewUploadCreator(fakeS3)),
+		}
+		handler.HandlerConfig.SetFileStorer(fakeS3)
+
 		now := time.Now()
 		availableMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
@@ -316,7 +346,14 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 		suite.NotEmpty(okResponse.Payload.ID)
 	})
 
-	suite.T().Run("Fail - Move not found - 404", func(t *testing.T) {
+	suite.Run("Fail - Move not found - 404", func() {
+		handler := CreateExcessWeightRecordHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			// Must use the Prime service object in particular:
+			moverouter.NewPrimeMoveExcessWeightUploader(upload.NewUploadCreator(fakeS3)),
+		}
+		handler.HandlerConfig.SetFileStorer(fakeS3)
+
 		params := movetaskorderops.CreateExcessWeightRecordParams{
 			HTTPRequest:     request,
 			File:            suite.Fixture("test.pdf"),
@@ -331,7 +368,14 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 		suite.Contains(*notFoundResponse.Payload.Detail, params.MoveTaskOrderID.String())
 	})
 
-	suite.T().Run("Fail - Move not Prime-available - 404", func(t *testing.T) {
+	suite.Run("Fail - Move not Prime-available - 404", func() {
+		handler := CreateExcessWeightRecordHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			// Must use the Prime service object in particular:
+			moverouter.NewPrimeMoveExcessWeightUploader(upload.NewUploadCreator(fakeS3)),
+		}
+		handler.HandlerConfig.SetFileStorer(fakeS3)
+
 		unavailableMove := testdatagen.MakeDefaultMove(suite.DB()) // default move is not available to Prime
 		params := movetaskorderops.CreateExcessWeightRecordParams{
 			HTTPRequest:     request,
@@ -350,21 +394,20 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 }
 
 func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
-	mto := testdatagen.MakeAvailableMove(suite.DB())
 
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
-	eTag := base64.StdEncoding.EncodeToString([]byte(mto.UpdatedAt.Format(time.RFC3339Nano)))
 
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
+	suite.Run("Successful patch - Integration Test", func() {
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+		eTag := etag.GenerateEtag(mto.UpdatedAt)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
 
-	params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
-		HTTPRequest:     req,
-		MoveTaskOrderID: mto.ID.String(),
-		IfMatch:         eTag,
-	}
-
-	suite.T().Run("Successful patch - Integration Test", func(t *testing.T) {
+		params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
+			HTTPRequest:     req,
+			MoveTaskOrderID: mto.ID.String(),
+			IfMatch:         eTag,
+		}
 		// Create two shipments, one prime, one external.  Only prime one should be returned.
 		primeShipment := testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: mto,
@@ -422,12 +465,9 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		suite.Equal(primemessages.PPMShipmentStatusWAITINGONCUSTOMER, okPayload.MtoShipments[0].PpmShipment.Status)
 	})
 
-	suite.T().Run("Unsuccessful patch - Integration Test - patch fail MTO not available", func(t *testing.T) {
+	suite.Run("Unsuccessful patch - Integration Test - patch fail MTO not available", func() {
 		defaultMTO := testdatagen.MakeDefaultMove(suite.DB())
-
-		requestUser := testdatagen.MakeStubbedUser(suite.DB())
-		eTag := base64.StdEncoding.EncodeToString([]byte(defaultMTO.UpdatedAt.Format(time.RFC3339Nano)))
-
+		eTag := etag.GenerateEtag(defaultMTO.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", defaultMTO.ID.String()), nil)
 		req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -454,7 +494,12 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		suite.IsType(&movetaskorderops.UpdateMTOPostCounselingInformationNotFound{}, response)
 	})
 
-	suite.T().Run("Patch failure - 500", func(t *testing.T) {
+	suite.Run("Patch failure - 500", func() {
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+		eTag := etag.GenerateEtag(mto.UpdatedAt)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
@@ -467,19 +512,28 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 		}
 
 		internalServerErr := errors.New("ServerError")
+		params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
+			HTTPRequest:     req,
+			MoveTaskOrderID: mto.ID.String(),
+			IfMatch:         eTag,
+		}
 
 		mockUpdater.On("UpdatePostCounselingInfo",
 			mock.AnythingOfType("*appcontext.appContext"),
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
+			mto.ID,
+			eTag,
 		).Return(nil, internalServerErr)
 
 		response := handler.Handle(params)
 		suite.IsType(&movetaskorderops.UpdateMTOPostCounselingInformationInternalServerError{}, response)
 	})
 
-	suite.T().Run("Patch failure - 404", func(t *testing.T) {
+	suite.Run("Patch failure - 404", func() {
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+		eTag := etag.GenerateEtag(mto.UpdatedAt)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
@@ -490,19 +544,28 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 			&mockUpdater,
 			mtoChecker,
 		}
+		params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
+			HTTPRequest:     req,
+			MoveTaskOrderID: mto.ID.String(),
+			IfMatch:         eTag,
+		}
 
 		mockUpdater.On("UpdatePostCounselingInfo",
 			mock.AnythingOfType("*appcontext.appContext"),
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
+			mto.ID,
+			eTag,
 		).Return(nil, apperror.NotFoundError{})
 
 		response := handler.Handle(params)
 		suite.IsType(&movetaskorderops.UpdateMTOPostCounselingInformationNotFound{}, response)
 	})
 
-	suite.T().Run("Patch failure - 409", func(t *testing.T) {
+	suite.Run("Patch failure - 409", func() {
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+		eTag := etag.GenerateEtag(mto.UpdatedAt)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
@@ -513,19 +576,27 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 			&mockUpdater,
 			mtoChecker,
 		}
-
+		params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
+			HTTPRequest:     req,
+			MoveTaskOrderID: mto.ID.String(),
+			IfMatch:         eTag,
+		}
 		mockUpdater.On("UpdatePostCounselingInfo",
 			mock.AnythingOfType("*appcontext.appContext"),
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
+			mto.ID,
+			eTag,
 		).Return(nil, apperror.ConflictError{})
 
 		response := handler.Handle(params)
 		suite.IsType(&movetaskorderops.UpdateMTOPostCounselingInformationConflict{}, response)
 	})
 
-	suite.T().Run("Patch failure - 422", func(t *testing.T) {
+	suite.Run("Patch failure - 422", func() {
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+		eTag := etag.GenerateEtag(mto.UpdatedAt)
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+
 		mockFetcher := mocks.Fetcher{}
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
@@ -539,11 +610,14 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 
 		mockUpdater.On("UpdatePostCounselingInfo",
 			mock.AnythingOfType("*appcontext.appContext"),
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-		).Return(nil, apperror.NewInvalidInputError(mto.ID, nil, validate.NewErrors(), ""))
-
+			mto.ID,
+			eTag,
+		).Return(nil, apperror.NewInvalidInputError(uuid.Nil, nil, validate.NewErrors(), ""))
+		params := movetaskorderops.UpdateMTOPostCounselingInformationParams{
+			HTTPRequest:     req,
+			MoveTaskOrderID: mto.ID.String(),
+			IfMatch:         eTag,
+		}
 		response := handler.Handle(params)
 		suite.IsType(&movetaskorderops.UpdateMTOPostCounselingInformationUnprocessableEntity{}, response)
 	})

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -1,7 +1,6 @@
 package payloads
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/etag"
@@ -51,7 +50,7 @@ func (suite *PayloadsSuite) TestMoveTaskOrder() {
 		ExcessWeightUploadID:       &excessWeightUploadID,
 	}
 
-	suite.T().Run("Success - Returns a basic move payload with no payment requests, service items or shipments", func(t *testing.T) {
+	suite.Run("Success - Returns a basic move payload with no payment requests, service items or shipments", func() {
 		returnedModel := MoveTaskOrder(&basicMove)
 
 		suite.IsType(&primemessages.MoveTaskOrder{}, returnedModel)
@@ -86,7 +85,7 @@ func (suite *PayloadsSuite) TestReweigh() {
 		UpdatedAt:   updatedAt,
 	}
 
-	suite.T().Run("Success - Returns a reweigh payload without optional fields", func(t *testing.T) {
+	suite.Run("Success - Returns a reweigh payload without optional fields", func() {
 		returnedPayload := Reweigh(&reweigh)
 
 		suite.IsType(&primemessages.Reweigh{}, returnedPayload)
@@ -103,7 +102,7 @@ func (suite *PayloadsSuite) TestReweigh() {
 
 	})
 
-	suite.T().Run("Success - Returns a reweigh payload with optional fields", func(t *testing.T) {
+	suite.Run("Success - Returns a reweigh payload with optional fields", func() {
 		// Set optional fields
 		weight := int64(2000)
 		reweigh.Weight = handlers.PoundPtrFromInt64Ptr(&weight)
@@ -139,7 +138,7 @@ func (suite *PayloadsSuite) TestExcessWeightRecord() {
 	fakeFileStorer := test.NewFakeS3Storage(true)
 	upload := testdatagen.MakeStubbedUpload(suite.DB(), testdatagen.Assertions{})
 
-	suite.T().Run("Success - all data populated", func(t *testing.T) {
+	suite.Run("Success - all data populated", func() {
 		move := models.Move{
 			ID:                         id,
 			ExcessWeightQualifiedAt:    &now,
@@ -157,7 +156,7 @@ func (suite *PayloadsSuite) TestExcessWeightRecord() {
 		suite.Equal(move.ExcessWeightUpload.ID.String(), excessWeightRecord.ID.String())
 	})
 
-	suite.T().Run("Success - some nil data, but no errors", func(t *testing.T) {
+	suite.Run("Success - some nil data, but no errors", func() {
 		move := models.Move{ID: id}
 
 		excessWeightRecord := ExcessWeightRecord(suite.AppContextForTest(), fakeFileStorer, &move)
@@ -204,7 +203,7 @@ func (suite *PayloadsSuite) TestSitExtension() {
 		Status:        models.SITExtensionStatusPending,
 	}
 
-	suite.T().Run("Success - Returns a sitextension payload without optional fields", func(t *testing.T) {
+	suite.Run("Success - Returns a sitextension payload without optional fields", func() {
 		returnedPayload := SITExtension(&sitExtension)
 
 		suite.IsType(&primemessages.SITExtension{}, returnedPayload)
@@ -220,7 +219,7 @@ func (suite *PayloadsSuite) TestSitExtension() {
 
 	})
 
-	suite.T().Run("Success - Returns a sit extension payload with optional fields", func(t *testing.T) {
+	suite.Run("Success - Returns a sit extension payload with optional fields", func() {
 		// Set optional fields
 		approvedDays := int(30)
 		sitExtension.ApprovedDays = &approvedDays
@@ -253,7 +252,7 @@ func (suite *PayloadsSuite) TestSitExtension() {
 
 func (suite *PayloadsSuite) TestEntitlement() {
 
-	suite.T().Run("Success - Returns the entitlement payload with only required fields", func(t *testing.T) {
+	suite.Run("Success - Returns the entitlement payload with only required fields", func() {
 		entitlement := models.Entitlement{
 			ID:                             uuid.Must(uuid.NewV4()),
 			DependentsAuthorized:           nil,
@@ -291,7 +290,7 @@ func (suite *PayloadsSuite) TestEntitlement() {
 		suite.Equal(int64(0), payload.TotalWeight)
 	})
 
-	suite.T().Run("Success - Returns the entitlement payload with all optional fields populated", func(t *testing.T) {
+	suite.Run("Success - Returns the entitlement payload with all optional fields populated", func() {
 		entitlement := models.Entitlement{
 			ID:                             uuid.Must(uuid.NewV4()),
 			DependentsAuthorized:           handlers.FmtBool(true),
@@ -330,7 +329,7 @@ func (suite *PayloadsSuite) TestEntitlement() {
 		suite.Equal(etag.GenerateEtag(entitlement.UpdatedAt), payload.ETag)
 	})
 
-	suite.T().Run("Success - Returns the entitlement payload with total weight self when dependents are not authorized", func(t *testing.T) {
+	suite.Run("Success - Returns the entitlement payload with total weight self when dependents are not authorized", func() {
 		entitlement := models.Entitlement{
 			ID:                             uuid.Must(uuid.NewV4()),
 			DependentsAuthorized:           handlers.FmtBool(false),

--- a/pkg/handlers/primeapi/payloads/payload_to_model_test.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model_test.go
@@ -2,7 +2,6 @@ package payloads
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -55,7 +54,7 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 	DCRTServiceItem.SetMoveTaskOrderID(handlers.FmtUUID(moveTaskOrderIDField))
 	DCRTServiceItem.SetMtoShipmentID(*mtoShipmentIDString)
 
-	suite.T().Run("Success - Returns a basic service item model", func(t *testing.T) {
+	suite.Run("Success - Returns a basic service item model", func() {
 		returnedModel, verrs := MTOServiceItemModel(basicServieItem)
 
 		suite.NoVerrs(verrs)
@@ -64,7 +63,7 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 		suite.Equal(models.ReServiceCodeFSC, returnedModel.ReService.Code)
 	})
 
-	suite.T().Run("Success - Returns a DCRT service item model", func(t *testing.T) {
+	suite.Run("Success - Returns a DCRT service item model", func() {
 		returnedModel, verrs := MTOServiceItemModel(DCRTServiceItem)
 
 		var returnedItem, returnedCrate models.MTOServiceItemDimension
@@ -86,7 +85,7 @@ func (suite *PayloadsSuite) TestMTOServiceItemModel() {
 		suite.Equal(unit.ThousandthInches(*DCRTServiceItem.Crate.Length), returnedCrate.Length)
 	})
 
-	suite.T().Run("Fail -  Returns error for DCRT service item because of validation error", func(t *testing.T) {
+	suite.Run("Fail -  Returns error for DCRT service item because of validation error", func() {
 		badCrateMeasurement := int32(200)
 		badCrate := &primemessages.MTOServiceItemDimension{
 			Height: &badCrateMeasurement,
@@ -128,7 +127,7 @@ func (suite *PayloadsSuite) TestReweighModelFromUpdate() {
 		Weight:             &weight,
 	}
 
-	suite.T().Run("Success - Returns a reweigh model", func(t *testing.T) {
+	suite.Run("Success - Returns a reweigh model", func() {
 		returnedModel := ReweighModelFromUpdate(reweigh, *idString, *mtoShipmentIDString)
 
 		suite.Equal(idField.String(), returnedModel.ID.String())
@@ -153,7 +152,7 @@ func (suite *PayloadsSuite) TestSITExtensionModel() {
 		RequestReason:     &reason,
 	}
 
-	suite.T().Run("Success - Returns a sit extension model", func(t *testing.T) {
+	suite.Run("Success - Returns a sit extension model", func() {
 		returnedModel := SITExtensionModel(sitExtension, *mtoShipmentIDString)
 
 		suite.Equal(mtoShipmentIDField, returnedModel.MTOShipmentID)

--- a/pkg/handlers/primeapi/reweigh_test.go
+++ b/pkg/handlers/primeapi/reweigh_test.go
@@ -3,9 +3,9 @@ package primeapi
 import (
 	"fmt"
 	"net/http/httptest"
-	"testing"
 	"time"
 
+	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
@@ -31,20 +31,6 @@ const (
 )
 
 func (suite *HandlerSuite) TestUpdateReweighHandler() {
-	// Make an available MTO
-	mto := testdatagen.MakeAvailableMove(suite.DB())
-
-	// Make a shipment on the available MTO
-	mtoShipment1 := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: mto,
-	})
-
-	// Make Reweigh Request
-	reweigh := testdatagen.MakeReweighWithNoWeightForShipment(
-		suite.DB(),
-		testdatagen.Assertions{},
-		mtoShipment1,
-	)
 
 	// Mock out a planner.
 	mockPlanner := &routemocks.Planner{}
@@ -59,17 +45,34 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 	recalculator := paymentrequest.NewPaymentRequestRecalculator(creator, statusUpdater)
 	paymentRequestShipmentRecalculator := paymentrequest.NewPaymentRequestShipmentRecalculator(recalculator)
 
-	// Create handler
-	handler := UpdateReweighHandler{
-		handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
-		reweighservice.NewReweighUpdater(movetaskorder.NewMoveTaskOrderChecker(), paymentRequestShipmentRecalculator),
+	setupTestData := func() (UpdateReweighHandler, models.Reweigh) {
+
+		// Create handler
+		handler := UpdateReweighHandler{
+			handlers.NewHandlerConfig(suite.DB(), suite.Logger()),
+			reweighservice.NewReweighUpdater(movetaskorder.NewMoveTaskOrderChecker(), paymentRequestShipmentRecalculator),
+		}
+		// Make an available MTO
+		mto := testdatagen.MakeAvailableMove(suite.DB())
+
+		// Make a shipment on the available MTO
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: mto,
+		})
+
+		// Make Reweigh Request
+		reweigh := testdatagen.MakeReweighWithNoWeightForShipment(
+			suite.DB(),
+			testdatagen.Assertions{},
+			shipment,
+		)
+		return handler, reweigh
 	}
 
-	var updatedETag string
-
-	suite.T().Run("Success 200 - Update reweigh weight", func(t *testing.T) {
+	suite.Run("Success 200 - Update reweigh weight", func() {
 		// Testcase:   reweigh us updated with the new weight of the shipment
 		// Expected:   Success response 200
+		handler, reweigh := setupTestData()
 
 		// Update with weights
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s/rewighs/%s", reweigh.ShipmentID.String(), reweigh.ID.String()), nil)
@@ -83,25 +86,22 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 				Weight: &weight,
 			},
 		}
-
 		// Run swagger validations
 		suite.NoError(params.Body.Validate(strfmt.Default))
 
 		// Run handler and check response
 		response := handler.Handle(params)
-		// fmt.
 		suite.IsType(&mtoshipmentops.UpdateReweighOK{}, response)
 
 		// Check values
 		reweighOk := response.(*mtoshipmentops.UpdateReweighOK)
-		updatedETag = reweighOk.Payload.ETag
-
 		suite.Equal(&weight, reweighOk.Payload.Weight)
 	})
 
-	suite.T().Run("Success 200 - Update reweigh verification reason", func(t *testing.T) {
+	suite.Run("Success 200 - Update reweigh verification reason", func() {
 		// Testcase:   reweigh is updated with the verification reason
 		// Expected:   Success response 200
+		handler, reweigh := setupTestData()
 
 		// Update with verification reason
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s/rewighs/%s", reweigh.ShipmentID.String(), reweigh.ID.String()), nil)
@@ -110,7 +110,7 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 			HTTPRequest:   req,
 			ReweighID:     *handlers.FmtUUID(reweigh.ID),
 			MtoShipmentID: *handlers.FmtUUID(reweigh.ShipmentID),
-			IfMatch:       updatedETag,
+			IfMatch:       etag.GenerateEtag(reweigh.UpdatedAt),
 			Body: &primemessages.UpdateReweigh{
 				VerificationReason: &reason,
 			},
@@ -125,14 +125,14 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 
 		// Check values
 		reweighOk := response.(*mtoshipmentops.UpdateReweighOK)
-		updatedETag = reweighOk.Payload.ETag
 
 		suite.Equal(&reason, reweighOk.Payload.VerificationReason)
 	})
 
-	suite.T().Run("Failure 422 - Failed to update reweigh weight due to bad request - zero reweigh value", func(t *testing.T) {
+	suite.Run("Failure 422 - Failed to update reweigh weight due to bad request - zero reweigh value", func() {
 		// Testcase:   reweigh us updated with the new weight of the shipment
 		// Expected:   Failure 422
+		_, reweigh := setupTestData()
 
 		// Update with weights
 
@@ -143,7 +143,7 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 			HTTPRequest:   req,
 			ReweighID:     *handlers.FmtUUID(reweigh.ID),
 			MtoShipmentID: *handlers.FmtUUID(reweigh.ShipmentID),
-			IfMatch:       updatedETag,
+			IfMatch:       etag.GenerateEtag(reweigh.UpdatedAt),
 			Body: &primemessages.UpdateReweigh{
 				Weight: &weight,
 			},
@@ -154,9 +154,10 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 		suite.Equal("validation failure list:\nweight in body should be greater than or equal to 1", err.Error())
 	})
 
-	suite.T().Run("Failure 422 - Failed to update reweigh weight due to bad request - negative reweigh value", func(t *testing.T) {
+	suite.Run("Failure 422 - Failed to update reweigh weight due to bad request - negative reweigh value", func() {
 		// Testcase:   reweigh us updated with the new weight of the shipment
 		// Expected:   Failure response 422
+		_, reweigh := setupTestData()
 
 		// Update with weights
 
@@ -167,7 +168,7 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 			HTTPRequest:   req,
 			ReweighID:     *handlers.FmtUUID(reweigh.ID),
 			MtoShipmentID: *handlers.FmtUUID(reweigh.ShipmentID),
-			IfMatch:       updatedETag,
+			IfMatch:       etag.GenerateEtag(reweigh.UpdatedAt),
 			Body: &primemessages.UpdateReweigh{
 				Weight: &weight,
 			},
@@ -178,11 +179,12 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 		suite.Equal("validation failure list:\nweight in body should be greater than or equal to 1", err.Error())
 	})
 
-	suite.T().Run("Failure 404 - Reweigh not found", func(t *testing.T) {
+	suite.Run("Failure 404 - Reweigh not found", func() {
 		// Testcase:   Reweigh ID is not found
 		// Expected:   Failure response 404
+		handler, reweigh := setupTestData()
 
-		// Update with verification reason\
+		// Update with verification reason
 		badID, _ := uuid.NewV4()
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/mto-shipments/%s/rewighs/%s", reweigh.ShipmentID.String(), badID.String()), nil)
 		reason := "The shipment was already delivered."
@@ -190,7 +192,7 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 			HTTPRequest:   req,
 			ReweighID:     *handlers.FmtUUID(badID),
 			MtoShipmentID: *handlers.FmtUUID(reweigh.ShipmentID),
-			IfMatch:       updatedETag,
+			IfMatch:       etag.GenerateEtag(reweigh.UpdatedAt),
 			Body: &primemessages.UpdateReweigh{
 				VerificationReason: &reason,
 			},
@@ -204,9 +206,10 @@ func (suite *HandlerSuite) TestUpdateReweighHandler() {
 		suite.IsType(&mtoshipmentops.UpdateReweighNotFound{}, response)
 	})
 
-	suite.T().Run("Fail - PreconditionFailed due to wrong etag", func(t *testing.T) {
+	suite.Run("Fail - PreconditionFailed due to wrong etag", func() {
 		// Testcase:   etag for reweigh is wrong
 		// Expected:   PreconditionFailed error is returned
+		handler, reweigh := setupTestData()
 
 		// Update with reweigh with a bad etag
 		// Testcase:   Reweigh updated with incorrect etag


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12617) for this change

## Summary

Converts the package and tests in `./pkg/handlers/primeapi` to use transactions.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)