### PR TITLE
[ MB-9033 ] Add heading level props to components for ReactUSWDS

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -203,7 +203,7 @@ class MtoShipmentForm extends Component {
               <Grid row>
                 <Grid col desktop={{ col: 8, offset: 2 }}>
                   {errorMessage && (
-                    <Alert type="error" heading="An error occurred">
+                    <Alert type="error" headingLevel="h2" heading="An error occurred">
                       {errorMessage}
                     </Alert>
                   )}

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -213,7 +213,7 @@ class MtoShipmentForm extends Component {
 
                     <h1>{shipmentForm.header[`${shipmentType}`]}</h1>
 
-                    <Alert type="info" noIcon>
+                    <Alert headingLevel="h4" type="info" noIcon>
                       Remember: You can move{' '}
                       {orders.has_dependents
                         ? formatWeight(serviceMember.weight_allotment?.total_weight_self_plus_dependents)

--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.jsx
@@ -203,7 +203,7 @@ class MtoShipmentForm extends Component {
               <Grid row>
                 <Grid col desktop={{ col: 8, offset: 2 }}>
                   {errorMessage && (
-                    <Alert type="error" headingLevel="h2" heading="An error occurred">
+                    <Alert type="error" headingLevel="h4" heading="An error occurred">
                       {errorMessage}
                     </Alert>
                   )}

--- a/src/components/Customer/PPM/Booking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
+++ b/src/components/Customer/PPM/Booking/EstimatedWeightsProGearForm/EstimatedWeightsProGearForm.jsx
@@ -52,7 +52,9 @@ const EstimatedWeightsProGearForm = ({ orders, serviceMember, mtoShipment, onSub
         return (
           <div className={classnames(styles.EstimatedWeightsProGearForm, ppmStyles.formContainer)}>
             <Form className={(formStyles.form, ppmStyles.form)}>
-              <Alert type="info">{`Total weight allowance for your move: ${formatWeight(authorizedWeight)}`}</Alert>
+              <Alert headingLevel="h4" type="info">{`Total weight allowance for your move: ${formatWeight(
+                authorizedWeight,
+              )}`}</Alert>
               <SectionWrapper className={classnames(ppmStyles.sectionWrapper, formStyles.formSection)}>
                 <h2>Full PPM</h2>
                 <p>

--- a/src/components/Customer/SubmitMoveForm/SubmitMoveForm.jsx
+++ b/src/components/Customer/SubmitMoveForm/SubmitMoveForm.jsx
@@ -75,7 +75,7 @@ const SubmitMoveForm = (props) => {
               </div>
 
               {error && (
-                <Alert type="error" heading="Server Error">
+                <Alert type="error" headingLevel="h4" heading="Server Error">
                   There was a problem saving your signature.
                 </Alert>
               )}

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -255,7 +255,7 @@ const ShipmentForm = ({
               onSubmit={handleDeleteShipment}
             />
             {errorMessage && (
-              <Alert type="error" heading="An error occurred">
+              <Alert type="error" headingLevel="h4" heading="An error occurred">
                 {errorMessage}
               </Alert>
             )}

--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -260,7 +260,7 @@ const ShipmentForm = ({
               </Alert>
             )}
             {isTOO && mtoShipment.usesExternalVendor && (
-              <Alert type="warning">
+              <Alert headingLevel="h4" type="warning">
                 The GHC prime contractor is not handling the shipment. Information will not be automatically shared with
                 the movers handling it.
               </Alert>

--- a/src/components/TabNav/index.jsx
+++ b/src/components/TabNav/index.jsx
@@ -8,8 +8,8 @@ const TabNav = ({ items, role }) => (
   <nav className={classNames(styles.tabNav)} role={role}>
     <div>
       <ul className={classNames(styles.tabList)}>
-        {items.map((item, index) => (
-          <li key={index.toString()} className={classNames(styles.tabItem)}>
+        {items.map((item /* , index */) => (
+          <li key={item.id} className={classNames(styles.tabItem)}>
             {item}
           </li>
         ))}

--- a/src/components/Table/Filters/SelectFilter.jsx
+++ b/src/components/Table/Filters/SelectFilter.jsx
@@ -21,9 +21,11 @@ const SelectFilter = ({ options, column: { filterValue, setFilter } }) => {
   );
 };
 
+const OptionsShape = PropTypes.object;
+
 // Values come from react-table
 SelectFilter.propTypes = {
-  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+  options: PropTypes.arrayOf(OptionsShape).isRequired,
   column: PropTypes.shape({
     filterValue: PropTypes.node,
     setFilter: PropTypes.func,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -153,6 +153,11 @@ const Table = ({
   );
 };
 
+// TODO Refactor this to be an actual shape for a Row given the code above.
+const RowShape = PropTypes.object;
+// TODO Refactor this to be an actual shape for a HeaderGroup given the code above.
+const HeaderGroupShape = PropTypes.object;
+
 Table.propTypes = {
   handleClick: PropTypes.func,
   showFilters: PropTypes.bool,
@@ -164,8 +169,8 @@ Table.propTypes = {
   // below are props from useTable() hook
   getTableProps: PropTypes.func.isRequired,
   getTableBodyProps: PropTypes.func.isRequired,
-  headerGroups: PropTypes.arrayOf(PropTypes.object).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  headerGroups: PropTypes.arrayOf(HeaderGroupShape).isRequired,
+  rows: PropTypes.arrayOf(RowShape).isRequired,
   prepareRow: PropTypes.func.isRequired,
   canPreviousPage: PropTypes.bool,
   canNextPage: PropTypes.bool,

--- a/src/components/Table/TableQueue.jsx
+++ b/src/components/Table/TableQueue.jsx
@@ -141,6 +141,8 @@ const TableQueue = ({
   );
 };
 
+const ColumnShape = PropTypes.object;
+
 TableQueue.propTypes = {
   // handleClick is the handler to handle functionality to click on a row
   handleClick: PropTypes.func.isRequired,
@@ -149,7 +151,7 @@ TableQueue.propTypes = {
   // title is the table title
   title: PropTypes.string.isRequired,
   // columns is the columns to show in the table
-  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  columns: PropTypes.arrayOf(ColumnShape).isRequired,
   // showFilters is bool value to show filters or not
   showFilters: PropTypes.bool,
   // showPagination is bool value to show pagination or not

--- a/src/components/form/IconButtons.jsx
+++ b/src/components/form/IconButtons.jsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const EditButton = ({ label, ...props }) => (
   /* eslint-disable-next-line react/jsx-props-no-spreading */
-  <Button icon {...props}>
+  <Button {...props}>
     <span className="icon">
       <FontAwesomeIcon icon="pen" />
     </span>
@@ -23,7 +23,7 @@ EditButton.propTypes = {
 
 export const DocsButton = ({ label, ...props }) => (
   /* eslint-disable-next-line react/jsx-props-no-spreading */
-  <Button icon {...props}>
+  <Button {...props}>
     <span className="icon">
       <FontAwesomeIcon icon="file" />
     </span>

--- a/src/components/form/IconButtons.test.jsx
+++ b/src/components/form/IconButtons.test.jsx
@@ -9,7 +9,7 @@ describe('DocsButton', () => {
     const wrapper = shallow(<DocsButton label="my docs button" />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="file" class="svg-inline--fa fa-file fa-w-12 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg></span><span>my docs button</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="file" class="svg-inline--fa fa-file " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M0 64C0 28.65 28.65 0 64 0H224V128C224 145.7 238.3 160 256 160H384V448C384 483.3 355.3 512 320 512H64C28.65 512 0 483.3 0 448V64zM256 128V0L384 128H256z"></path></svg></span><span>my docs button</span></button>',
     );
   });
   it('should pass props down', () => {
@@ -32,14 +32,14 @@ describe('EditButton', () => {
     const wrapper = shallow(<EditButton />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen fa-w-16 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"></path></svg></span><span>Edit</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M362.7 19.32C387.7-5.678 428.3-5.678 453.3 19.32L492.7 58.75C517.7 83.74 517.7 124.3 492.7 149.3L444.3 197.7L314.3 67.72L362.7 19.32zM421.7 220.3L188.5 453.4C178.1 463.8 165.2 471.5 151.1 475.6L30.77 511C22.35 513.5 13.24 511.2 7.03 504.1C.8198 498.8-1.502 489.7 .976 481.2L36.37 360.9C40.53 346.8 48.16 333.9 58.57 323.5L291.7 90.34L421.7 220.3z"></path></svg></span><span>Edit</span></button>',
     );
   });
   it('should render the button with custom label', () => {
     const wrapper = shallow(<EditButton label="my custom edit" />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen fa-w-16 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"></path></svg></span><span>my custom edit</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M362.7 19.32C387.7-5.678 428.3-5.678 453.3 19.32L492.7 58.75C517.7 83.74 517.7 124.3 492.7 149.3L444.3 197.7L314.3 67.72L362.7 19.32zM421.7 220.3L188.5 453.4C178.1 463.8 165.2 471.5 151.1 475.6L30.77 511C22.35 513.5 13.24 511.2 7.03 504.1C.8198 498.8-1.502 489.7 .976 481.2L36.37 360.9C40.53 346.8 48.16 333.9 58.57 323.5L291.7 90.34L421.7 220.3z"></path></svg></span><span>my custom edit</span></button>',
     );
   });
   it('should pass props down', () => {

--- a/src/components/form/IconButtons.test.jsx
+++ b/src/components/form/IconButtons.test.jsx
@@ -9,7 +9,7 @@ describe('DocsButton', () => {
     const wrapper = shallow(<DocsButton label="my docs button" />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button usa-button--icon" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="file" class="svg-inline--fa fa-file " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M0 64C0 28.65 28.65 0 64 0H224V128C224 145.7 238.3 160 256 160H384V448C384 483.3 355.3 512 320 512H64C28.65 512 0 483.3 0 448V64zM256 128V0L384 128H256z"></path></svg></span><span>my docs button</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="file" class="svg-inline--fa fa-file fa-w-12 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"></path></svg></span><span>my docs button</span></button>',
     );
   });
   it('should pass props down', () => {
@@ -32,14 +32,14 @@ describe('EditButton', () => {
     const wrapper = shallow(<EditButton />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button usa-button--icon" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M362.7 19.32C387.7-5.678 428.3-5.678 453.3 19.32L492.7 58.75C517.7 83.74 517.7 124.3 492.7 149.3L444.3 197.7L314.3 67.72L362.7 19.32zM421.7 220.3L188.5 453.4C178.1 463.8 165.2 471.5 151.1 475.6L30.77 511C22.35 513.5 13.24 511.2 7.03 504.1C.8198 498.8-1.502 489.7 .976 481.2L36.37 360.9C40.53 346.8 48.16 333.9 58.57 323.5L291.7 90.34L421.7 220.3z"></path></svg></span><span>Edit</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen fa-w-16 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"></path></svg></span><span>Edit</span></button>',
     );
   });
   it('should render the button with custom label', () => {
     const wrapper = shallow(<EditButton label="my custom edit" />);
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).html()).toBe(
-      '<button class="usa-button usa-button--icon" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M362.7 19.32C387.7-5.678 428.3-5.678 453.3 19.32L492.7 58.75C517.7 83.74 517.7 124.3 492.7 149.3L444.3 197.7L314.3 67.72L362.7 19.32zM421.7 220.3L188.5 453.4C178.1 463.8 165.2 471.5 151.1 475.6L30.77 511C22.35 513.5 13.24 511.2 7.03 504.1C.8198 498.8-1.502 489.7 .976 481.2L36.37 360.9C40.53 346.8 48.16 333.9 58.57 323.5L291.7 90.34L421.7 220.3z"></path></svg></span><span>my custom edit</span></button>',
+      '<button class="usa-button" data-testid="button"><span class="icon"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="pen" class="svg-inline--fa fa-pen fa-w-16 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"></path></svg></span><span>my custom edit</span></button>',
     );
   });
   it('should pass props down', () => {

--- a/src/containers/FlashMessage/FlashMessage.jsx
+++ b/src/containers/FlashMessage/FlashMessage.jsx
@@ -19,7 +19,7 @@ export const FlashMessage = ({ flash, clearFlashMessage }) => {
   return (
     // We use {title || undefined} here because an empty string as the title will render a blank header in Firefox,
     // so we must pass in undefined if we want to see no header at all.
-    <Alert slim={slim} type={type} heading={title || undefined}>
+    <Alert slim={slim} type={type} headingLevel="h4" heading={title || undefined}>
       {message}
     </Alert>
   );

--- a/src/pages/MyMove/AmendOrders/AmendOrders.jsx
+++ b/src/pages/MyMove/AmendOrders/AmendOrders.jsx
@@ -97,7 +97,7 @@ export const AmendOrders = ({ uploads, updateOrders, serviceMemberId, currentOrd
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Home/index.jsx
+++ b/src/pages/MyMove/Home/index.jsx
@@ -161,7 +161,7 @@ export class Home extends Component {
   renderAlert = () => {
     if (this.hasUnapprovedAmendedOrders) {
       return (
-        <Alert type="success" slim data-testid="unapproved-amended-orders-alert">
+        <Alert headingLevel="h4" type="success" slim data-testid="unapproved-amended-orders-alert">
           <span className={styles.alertMessageFirstLine}>
             The transportation office will review your new documents and update your move info. Contact your movers to
             coordinate any changes to your move.
@@ -358,12 +358,12 @@ export class Home extends Component {
           </header>
           <div className={`usa-prose grid-container ${styles['grid-container']}`}>
             {showDeleteSuccessAlert && (
-              <Alert slim type="success">
+              <Alert headingLevel="h4" slim type="success">
                 The shipment was deleted.
               </Alert>
             )}
             {showDeleteErrorAlert && (
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 Something went wrong, and your changes were not saved. Please try again later or contact your counselor.
               </Alert>
             )}

--- a/src/pages/MyMove/Orders.jsx
+++ b/src/pages/MyMove/Orders.jsx
@@ -127,7 +127,7 @@ export class Orders extends Component {
         {serverError && (
           <Grid row>
             <Grid col desktop={{ col: 8, offset: 2 }}>
-              <Alert type="error" heading="An error occurred">
+              <Alert type="error" headingLevel="h4" heading="An error occurred">
                 {serverError}
               </Alert>
             </Grid>

--- a/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
+++ b/src/pages/MyMove/PPMBooking/Advance/Advance.jsx
@@ -74,7 +74,7 @@ const Advance = () => {
             <ShipmentTag shipmentType={shipmentTypes.PPM} shipmentNumber={shipmentNumber} />
             <h1>Advances</h1>
             {errorMessage && (
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 {errorMessage}
               </Alert>
             )}

--- a/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
+++ b/src/pages/MyMove/PPMBooking/DateAndLocation/DateAndLocation.jsx
@@ -102,7 +102,7 @@ const DateAndLocation = ({ mtoShipment, serviceMember, destinationDutyLocation }
             <ShipmentTag shipmentType={shipmentTypes.PPM} shipmentNumber={shipmentNumber} />
             <h1>PPM date & location</h1>
             {errorMessage && (
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 {errorMessage}
               </Alert>
             )}

--- a/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
+++ b/src/pages/MyMove/PPMBooking/EstimatedWeightsProGear/EstimatedWeightsProGear.jsx
@@ -73,7 +73,7 @@ const EstimatedWeightsProGear = () => {
             <ShipmentTag shipmentType={shipmentTypes.PPM} shipmentNumber={shipmentNumber} />
             <h1>Estimated weight</h1>
             {errorMessage && (
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 {errorMessage}
               </Alert>
             )}

--- a/src/pages/MyMove/Profile/BackupContact.jsx
+++ b/src/pages/MyMove/Profile/BackupContact.jsx
@@ -102,7 +102,7 @@ export const BackupContact = ({
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/BackupMailingAddress.jsx
+++ b/src/pages/MyMove/Profile/BackupMailingAddress.jsx
@@ -62,7 +62,7 @@ export const BackupMailingAddress = ({ serviceMember, updateServiceMember, push 
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/ContactInfo.jsx
+++ b/src/pages/MyMove/Profile/ContactInfo.jsx
@@ -65,7 +65,7 @@ export const ContactInfo = ({ serviceMember, updateServiceMember, userEmail, pus
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/DodInfo.jsx
+++ b/src/pages/MyMove/Profile/DodInfo.jsx
@@ -57,7 +57,7 @@ export const DodInfo = ({ updateServiceMember, serviceMember, push }) => {
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/DutyLocation.jsx
+++ b/src/pages/MyMove/Profile/DutyLocation.jsx
@@ -55,7 +55,7 @@ export const DutyLocation = ({ serviceMember, existingDutyLocation, newDutyLocat
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/EditContactInfo.jsx
+++ b/src/pages/MyMove/Profile/EditContactInfo.jsx
@@ -136,7 +136,7 @@ export const EditContactInfo = ({
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/EditServiceInfo.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.jsx
@@ -97,7 +97,7 @@ export const EditServiceInfo = ({
     <GridContainer>
       <ScrollToTop />
       {serverError && (
-        <Alert type="error" heading="An error occurred">
+        <Alert type="error" headingLevel="h4" heading="An error occurred">
           {serverError}
         </Alert>
       )}

--- a/src/pages/MyMove/Profile/EditServiceInfo.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.jsx
@@ -97,7 +97,7 @@ export const EditServiceInfo = ({
     <GridContainer>
       <ScrollToTop />
       {serverError && (
-        <Alert type="error" headingLevel="h4" heading="An error occurred">
+        <Alert type="error" headingLevel="h2" heading="An error occurred">
           {serverError}
         </Alert>
       )}

--- a/src/pages/MyMove/Profile/EditServiceInfo.jsx
+++ b/src/pages/MyMove/Profile/EditServiceInfo.jsx
@@ -97,7 +97,7 @@ export const EditServiceInfo = ({
     <GridContainer>
       <ScrollToTop />
       {serverError && (
-        <Alert type="error" headingLevel="h2" heading="An error occurred">
+        <Alert type="error" headingLevel="h4" heading="An error occurred">
           {serverError}
         </Alert>
       )}

--- a/src/pages/MyMove/Profile/Name.jsx
+++ b/src/pages/MyMove/Profile/Name.jsx
@@ -59,7 +59,7 @@ export const Name = ({ serviceMember, push, updateServiceMember }) => {
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Profile/Profile.jsx
+++ b/src/pages/MyMove/Profile/Profile.jsx
@@ -36,7 +36,11 @@ const Profile = ({ serviceMember, currentOrders, currentBackupContacts, moveIsIn
       <div className="grid-row">
         <div className="grid-col-12">
           <h1>Profile</h1>
-          {showMessages && <Alert type="info">Contact your movers if you need to make changes to your move.</Alert>}
+          {showMessages && (
+            <Alert headingLevel="h4" type="info">
+              Contact your movers if you need to make changes to your move.
+            </Alert>
+          )}
           <SectionWrapper className={formStyles.formSection}>
             <ContactInfoDisplay
               telephone={serviceMember?.telephone || ''}

--- a/src/pages/MyMove/Profile/ResidentialAddress.jsx
+++ b/src/pages/MyMove/Profile/ResidentialAddress.jsx
@@ -81,7 +81,7 @@ export const ResidentialAddress = ({ serviceMember, updateServiceMember, push })
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>

--- a/src/pages/MyMove/Review/Review.test.jsx
+++ b/src/pages/MyMove/Review/Review.test.jsx
@@ -213,7 +213,7 @@ describe('Review page', () => {
       </MockProviders>,
     );
 
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Details saved');
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Details saved');
     expect(
       screen.getByText('Review your info and submit your move request now, or come back and finish later.'),
     ).toBeInTheDocument();

--- a/src/pages/MyMove/Review/Review.test.jsx
+++ b/src/pages/MyMove/Review/Review.test.jsx
@@ -213,7 +213,7 @@ describe('Review page', () => {
       </MockProviders>,
     );
 
-    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent('Details saved');
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Details saved');
     expect(
       screen.getByText('Review your info and submit your move request now, or come back and finish later.'),
     ).toBeInTheDocument();

--- a/src/pages/MyMove/SelectShipmentType.jsx
+++ b/src/pages/MyMove/SelectShipmentType.jsx
@@ -118,7 +118,7 @@ export class SelectShipmentType extends Component {
           <Grid row>
             <Grid col desktop={{ col: 8, offset: 2 }}>
               {errorMessage && (
-                <Alert type="error" heading="An error occurred">
+                <Alert type="error" headingLevel="h4" heading="An error occurred">
                   {errorMessage}
                 </Alert>
               )}

--- a/src/pages/MyMove/UploadOrders.jsx
+++ b/src/pages/MyMove/UploadOrders.jsx
@@ -93,7 +93,7 @@ export class UploadOrders extends Component {
         {serverError && (
           <Grid row>
             <Grid col desktop={{ col: 8, offset: 2 }}>
-              <Alert type="error" heading="An error occurred">
+              <Alert type="error" headingLevel="h4" heading="An error occurred">
                 {serverError}
               </Alert>
             </Grid>

--- a/src/pages/Office/MoveDetails/MoveDetails.jsx
+++ b/src/pages/Office/MoveDetails/MoveDetails.jsx
@@ -315,7 +315,7 @@ const MoveDetails = ({
           <Grid row className={styles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={styles.alertContainer}>
-                <Alert slim type={alertType}>
+                <Alert headingLevel="h4" slim type={alertType}>
                   {alertMessage}
                 </Alert>
               </Grid>

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.jsx
@@ -240,7 +240,7 @@ const MovePaymentRequests = ({
           <Grid row className={txoStyles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={txoStyles.alertContainer}>
-                <Alert slim type={alertType}>
+                <Alert headingLevel="h4" slim type={alertType}>
                   {alertMessage}
                 </Alert>
               </Grid>

--- a/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
+++ b/src/pages/Office/MoveTaskOrder/MoveTaskOrder.jsx
@@ -634,14 +634,20 @@ export const MoveTaskOrder = ({ match, ...props }) => {
           <Grid row className={styles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={styles.alertContainer}>
-                <Alert slim type={alertType}>
+                <Alert headingLevel="h4" slim type={alertType}>
                   {alertMessage}
                 </Alert>
               </Grid>
             )}
           </Grid>
           {isWeightAlertVisible && (
-            <Alert slim type="warning" cta={excessWeightAlertControl} className={styles.alertWithButton}>
+            <Alert
+              headingLevel="h4"
+              slim
+              type="warning"
+              cta={excessWeightAlertControl}
+              className={styles.alertWithButton}
+            >
               <span>
                 This move is at risk for excess weight.{' '}
                 <span className={styles.rightAlignButtonWrapper}>
@@ -653,7 +659,7 @@ export const MoveTaskOrder = ({ match, ...props }) => {
             </Alert>
           )}
           {isSuccessAlertVisible && (
-            <Alert slim type="success">
+            <Alert headingLevel="h4" slim type="success">
               Your changes were saved
             </Alert>
           )}

--- a/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
+++ b/src/pages/Office/ReviewBillableWeight/ReviewBillableWeight.jsx
@@ -172,12 +172,12 @@ export default function ReviewBillableWeight() {
           <DocumentViewerSidebar title="Review weights" subtitle="Edit max billable weight" onClose={handleClose}>
             <DocumentViewerSidebar.Content>
               {totalBillableWeight > maxBillableWeight && (
-                <Alert slim type="error" data-testid="maxBillableWeightAlert">
+                <Alert headingLevel="h4" slim type="error" data-testid="maxBillableWeightAlert">
                   {`Max billable weight exceeded. \nPlease resolve.`}
                 </Alert>
               )}
               {shipmentsMissingInformation?.length > 0 && (
-                <Alert slim type="warning" data-testid="maxBillableWeightMissingShipmentWeightAlert">
+                <Alert headingLevel="h4" slim type="warning" data-testid="maxBillableWeightMissingShipmentWeightAlert">
                   Missing shipment weights may impact max billable weight.
                 </Alert>
               )}
@@ -221,13 +221,13 @@ export default function ReviewBillableWeight() {
             <DocumentViewerSidebar.Content>
               <div className={reviewBillableWeightStyles.contentContainer}>
                 {totalBillableWeight > maxBillableWeight && (
-                  <Alert slim type="error" data-testid="maxBillableWeightAlert">
+                  <Alert headingLevel="h4" slim type="error" data-testid="maxBillableWeightAlert">
                     {`Max billable weight exceeded. \nPlease resolve.`}
                   </Alert>
                 )}
                 {((!selectedShipment?.reweigh?.weight && selectedShipment?.reweigh?.requestedAt) ||
                   !selectedShipment.primeEstimatedWeight) && (
-                  <Alert slim type="warning" data-testid="shipmentMissingInformation">
+                  <Alert headingLevel="h4" slim type="warning" data-testid="shipmentMissingInformation">
                     Shipment missing information
                   </Alert>
                 )}
@@ -236,7 +236,12 @@ export default function ReviewBillableWeight() {
                   selectedShipment.calculatedBillableWeight,
                 ) &&
                   selectedShipment.shipmentType !== SHIPMENT_OPTIONS.NTSR && (
-                    <Alert slim type="warning" data-testid="shipmentBillableWeightExceeds110OfEstimated">
+                    <Alert
+                      headingLevel="h4"
+                      slim
+                      type="warning"
+                      data-testid="shipmentBillableWeightExceeds110OfEstimated"
+                    >
                       Shipment exceeds 110% of estimated weight.
                     </Alert>
                   )}

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -298,14 +298,14 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
           <Grid row className={scMoveDetailsStyles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={scMoveDetailsStyles.alertContainer}>
-                <Alert slim type={alertType}>
+                <Alert headingLevel="h4" slim type={alertType}>
                   {alertMessage}
                 </Alert>
               </Grid>
             )}
             {infoSavedAlert && (
               <Grid col={12} className={scMoveDetailsStyles.alertContainer}>
-                <Alert slim type={infoSavedAlert.alertType}>
+                <Alert headingLevel="h4" slim type={infoSavedAlert.alertType}>
                   {infoSavedAlert.message}
                 </Alert>
               </Grid>

--- a/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
+++ b/src/pages/PrimeUI/CreatePaymentRequest/CreatePaymentRequest.jsx
@@ -188,7 +188,7 @@ const CreatePaymentRequest = ({ setFlashMessage }) => {
         <div className="grid-col-12">
           {errorMessage?.detail && (
             <div className={primeStyles.errorContainer}>
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 <span className={primeStyles.errorTitle}>{errorMessage.title}</span>
                 <span className={primeStyles.errorDetail}>{errorMessage.detail}</span>
               </Alert>

--- a/src/pages/PrimeUI/CreateServiceItem/CreateServiceItem.jsx
+++ b/src/pages/PrimeUI/CreateServiceItem/CreateServiceItem.jsx
@@ -75,7 +75,7 @@ const CreateServiceItem = ({ setFlashMessage }) => {
           <h1>Create Shipment Service Item</h1>
           {errorMessage?.detail && (
             <div className={primeStyles.errorContainer}>
-              <Alert slim type="error">
+              <Alert headingLevel="h4" slim type="error">
                 <span className={primeStyles.errorTitle}>{errorMessage.title}</span>
                 <span className={primeStyles.errorDetail}>{errorMessage.detail}</span>
               </Alert>

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdate.jsx
@@ -151,7 +151,7 @@ const PrimeUIShipmentUpdate = ({ setFlashMessage }) => {
             <Grid col desktop={{ col: 8, offset: 2 }}>
               {errorMessage?.detail && (
                 <div className={primeStyles.errorContainer}>
-                  <Alert type="error">
+                  <Alert headingLevel="h4" type="error">
                     <span className={primeStyles.errorTitle}>{errorMessage.title}</span>
                     <span className={primeStyles.errorDetail}>{errorMessage.detail}</span>
                   </Alert>

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateAddress.jsx
@@ -148,7 +148,7 @@ const PrimeUIShipmentUpdateAddress = () => {
             <Grid col desktop={{ col: 8, offset: 2 }}>
               {errorMessage?.detail && (
                 <div className={primeStyles.errorContainer}>
-                  <Alert type="error">
+                  <Alert headingLevel="h4" type="error">
                     <span className={primeStyles.errorTitle}>{errorMessage.title}</span>
                     <span className={primeStyles.errorDetail}>{errorMessage.detail}</span>
                   </Alert>

--- a/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateReweigh.jsx
+++ b/src/pages/PrimeUI/Shipment/PrimeUIShipmentUpdateReweigh.jsx
@@ -99,7 +99,7 @@ const PrimeUIShipmentUpdateReweigh = ({ setFlashMessage }) => {
             <Grid col desktop={{ col: 8, offset: 2 }}>
               {errorMessage?.detail && (
                 <div className={primeStyles.errorContainer}>
-                  <Alert type="error">
+                  <Alert headingLevel="h4" type="error">
                     <span className={primeStyles.errorTitle}>{errorMessage.title}</span>
                     <span className={primeStyles.errorDetail}>{errorMessage.detail}</span>
                   </Alert>

--- a/src/pages/PrimeUI/UploadPaymentRequestDocuments/UploadPaymentRequestDocuments.jsx
+++ b/src/pages/PrimeUI/UploadPaymentRequestDocuments/UploadPaymentRequestDocuments.jsx
@@ -75,7 +75,7 @@ const UploadPaymentRequest = ({ setFlashMessage }) => {
       {serverError && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="error" heading="An error occurred">
+            <Alert type="error" headingLevel="h4" heading="An error occurred">
               {serverError}
             </Alert>
           </Grid>
@@ -85,7 +85,9 @@ const UploadPaymentRequest = ({ setFlashMessage }) => {
       {uploadSuccess && (
         <Grid row>
           <Grid col desktop={{ col: 8, offset: 2 }}>
-            <Alert type="success">Upload saved successfully</Alert>
+            <Alert headingLevel="h4" type="success">
+              Upload saved successfully
+            </Alert>
           </Grid>
         </Grid>
       )}

--- a/src/stories/alerts.stories.jsx
+++ b/src/stories/alerts.stories.jsx
@@ -12,7 +12,7 @@ export default {
 
 export const success = () => (
   <div>
-    <Alert heading="Success status" type="success">
+    <Alert headingLevel="h4" heading="Success status" type="success">
       This is a succinct, helpful success message. This is a <a href="#">link</a>.
     </Alert>
     <Alert slim type="success">
@@ -23,10 +23,10 @@ export const success = () => (
 
 export const warning = () => (
   <div>
-    <Alert heading="Warning status" type="warning">
+    <Alert headingLevel="h4" heading="Warning status" type="warning">
       This is a succinct, helpful warning message. This is a <a href="#">link</a>.
     </Alert>
-    <Alert slim type="warning">
+    <Alert headingLevel="h4" slim type="warning">
       This is a succinct, helpful warning message. This is a <a href="#">link</a>.
     </Alert>
   </div>
@@ -34,10 +34,10 @@ export const warning = () => (
 
 export const error = () => (
   <div>
-    <Alert heading="Error status" type="error">
+    <Alert headingLevel="h4" heading="Error status" type="error">
       This is a succinct, helpful error message. This is a <a href="#">link</a>.
     </Alert>
-    <Alert slim type="error">
+    <Alert headingLevel="h4" slim type="error">
       This is a succinct, helpful error message. This is a <a href="#">link</a>.
     </Alert>
   </div>
@@ -45,10 +45,10 @@ export const error = () => (
 
 export const info = () => (
   <div>
-    <Alert heading="Informative status" type="info">
+    <Alert headingLevel="h4" heading="Informative status" type="info">
       This is a succinct, helpful info message. This is a <a href="#">link</a>.
     </Alert>
-    <Alert slim type="info">
+    <Alert headingLevel="h4" slim type="info">
       This is a succinct, helpful info message. This is a <a href="#">link</a>.
     </Alert>
   </div>


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-9033) for this change

## Summary

In preparation of the ReactUSWDS upgrade https://github.com/transcom/mymove/pull/8662, we want to add the headingLevel prop to components since they require it.

⚠️ Noticing that there's a spacing issue for the buttons. ReactUSWDS will take care of this issue once the PR is merged in! Let's wait until the ReactUSWDS upgrade is done. ⚠️

## Setup to Run Your Code

<details>
<summary>💻 You will need to use a terminal to test this locally.</summary>

##### Terminal 1

Start the client tests locally.

```sh
make client_tests
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.