### PR TITLE
MB-12618 convert services/order and services/event tests

### DIFF
--- a/pkg/services/event/notification_test.go
+++ b/pkg/services/event/notification_test.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -15,101 +14,20 @@ import (
 func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 	now := time.Now()
 
-	mtoServiceItemDOFSIT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDOFSIT,
-			Name: "Destination 1st Day SIT",
-		},
-	})
-
-	mtoServiceItemDDFSIT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDDFSIT,
-			Name: "Destination 1st Day SIT",
-		},
-	})
-
-	customerContact1 := testdatagen.MakeMTOServiceItemCustomerContact(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemCustomerContact: models.MTOServiceItemCustomerContact{
-			MTOServiceItemID:           mtoServiceItemDDFSIT.ID,
-			Type:                       models.CustomerContactTypeFirst,
-			TimeMilitary:               "0800Z",
-			FirstAvailableDeliveryDate: time.Now(),
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDDFSIT,
-			Name: "Destination 1st Day SIT",
-		},
-	})
-
-	customerContact2 := testdatagen.MakeMTOServiceItemCustomerContact(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemCustomerContact: models.MTOServiceItemCustomerContact{
-			MTOServiceItemID:           mtoServiceItemDDFSIT.ID,
-			Type:                       models.CustomerContactTypeSecond,
-			TimeMilitary:               "0400Z",
-			FirstAvailableDeliveryDate: time.Now(),
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDDFSIT,
-		},
-	})
-
-	mtoServiceItemDCRT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDCRT,
-			Name: "Dom. Crating",
-		},
-	})
-
-	itemDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			Type:      models.DimensionTypeItem,
-			Length:    900,
-			Height:    900,
-			Width:     900,
-			CreatedAt: time.Time{},
-			UpdatedAt: time.Time{},
-		},
-		MTOServiceItem: mtoServiceItemDCRT,
-	})
-
-	crateDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
-		MTOServiceItemDimension: models.MTOServiceItemDimension{
-			MTOServiceItemID: mtoServiceItemDCRT.ID,
-			Type:             models.DimensionTypeCrate,
-			Length:           2000,
-			Height:           2000,
-			Width:            2000,
-			CreatedAt:        time.Time{},
-			UpdatedAt:        time.Time{},
-		},
-	})
-
-	testString := "Lorem ipsum"
-
-	mtoServiceItemDOSHUT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &now,
-		},
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDOSHUT,
-		},
-		MTOServiceItem: models.MTOServiceItem{
-			Description: &testString,
-			Reason:      &testString,
-		},
-	})
-
-	suite.T().Run("Success with MTOServiceItemDOFSIT", func(t *testing.T) {
+	suite.Run("Success with MTOServiceItemDOFSIT", func() {
+		// Under test: assembleMTOServiceItemPayload
+		// Mocked:     None
+		// Set up:     Create a DOFSIT in the db, assemble the webhook notification payload
+		// Expected outcome: Payload should contain the DOFSIT details
+		mtoServiceItemDOFSIT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOFSIT,
+				Name: "Destination 1st Day SIT",
+			},
+		})
 		data := &primemessages.MTOServiceItemOriginSIT{}
 
 		payload, assemblePayloadErr := assembleMTOServiceItemPayload(suite.AppContextForTest(), mtoServiceItemDOFSIT.ID)
@@ -124,7 +42,42 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 		suite.Equal(mtoServiceItemDOFSIT.Reason, data.Reason)
 	})
 
-	suite.T().Run("Success with MTOServiceItemDDFSIT", func(t *testing.T) {
+	suite.Run("Success with MTOServiceItemDDFSIT", func() {
+		// Under test: assembleMTOServiceItemPayload
+		// Set up:     Create a DDFSIT in the db, assemble the webhook notification payload
+		// Expected outcome: Payload should contain the DDFSIT details
+		mtoServiceItemDDFSIT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDFSIT,
+				Name: "Destination 1st Day SIT",
+			},
+		})
+		customerContact1 := testdatagen.MakeMTOServiceItemCustomerContact(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemCustomerContact: models.MTOServiceItemCustomerContact{
+				MTOServiceItemID:           mtoServiceItemDDFSIT.ID,
+				Type:                       models.CustomerContactTypeFirst,
+				TimeMilitary:               "0800Z",
+				FirstAvailableDeliveryDate: time.Now(),
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDFSIT,
+				Name: "Destination 1st Day SIT",
+			},
+		})
+		customerContact2 := testdatagen.MakeMTOServiceItemCustomerContact(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemCustomerContact: models.MTOServiceItemCustomerContact{
+				MTOServiceItemID:           mtoServiceItemDDFSIT.ID,
+				Type:                       models.CustomerContactTypeSecond,
+				TimeMilitary:               "0400Z",
+				FirstAvailableDeliveryDate: time.Now(),
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDDFSIT,
+			},
+		})
 		data := &primemessages.MTOServiceItemDestSIT{}
 
 		payload, assemblePayloadErr := assembleMTOServiceItemPayload(suite.AppContextForTest(), mtoServiceItemDDFSIT.ID)
@@ -141,7 +94,43 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 
 	})
 
-	suite.T().Run("Success with MTOServiceItemDCRT", func(t *testing.T) {
+	suite.Run("Success with MTOServiceItemDCRT", func() {
+		// Under test: assembleMTOServiceItemPayload
+		// Set up:     Create a DCRT in the db, assemble the webhook notification payload
+		// Expected outcome: Payload should contain the DCRT details
+		mtoServiceItemDCRT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDCRT,
+				Name: "Dom. Crating",
+			},
+		})
+
+		itemDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				Type:      models.DimensionTypeItem,
+				Length:    900,
+				Height:    900,
+				Width:     900,
+				CreatedAt: time.Time{},
+				UpdatedAt: time.Time{},
+			},
+			MTOServiceItem: mtoServiceItemDCRT,
+		})
+
+		crateDimension1 := testdatagen.MakeMTOServiceItemDimension(suite.DB(), testdatagen.Assertions{
+			MTOServiceItemDimension: models.MTOServiceItemDimension{
+				MTOServiceItemID: mtoServiceItemDCRT.ID,
+				Type:             models.DimensionTypeCrate,
+				Length:           2000,
+				Height:           2000,
+				Width:            2000,
+				CreatedAt:        time.Time{},
+				UpdatedAt:        time.Time{},
+			},
+		})
 		data := &primemessages.MTOServiceItemDomesticCrating{}
 
 		payload, assemblePayloadErr := assembleMTOServiceItemPayload(suite.AppContextForTest(), mtoServiceItemDCRT.ID)
@@ -158,7 +147,21 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 
 	})
 
-	suite.T().Run("Success with MTOServiceItemDOSHUT", func(t *testing.T) {
+	suite.Run("Success with MTOServiceItemDOSHUT", func() {
+		testString := "Lorem ipsum"
+
+		mtoServiceItemDOSHUT := testdatagen.MakeMTOServiceItem(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &now,
+			},
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOSHUT,
+			},
+			MTOServiceItem: models.MTOServiceItem{
+				Description: &testString,
+				Reason:      &testString,
+			},
+		})
 		data := &primemessages.MTOServiceItemShuttle{}
 
 		payload, assemblePayloadErr := assembleMTOServiceItemPayload(suite.AppContextForTest(), mtoServiceItemDOSHUT.ID)
@@ -176,15 +179,15 @@ func (suite *EventServiceSuite) Test_MTOServiceItemPayload() {
 }
 
 func (suite *EventServiceSuite) TestAssembleOrderPayload() {
-	order := testdatagen.MakeDefaultOrder(suite.DB())
 
-	suite.T().Run("Success with default Order", func(t *testing.T) {
+	suite.Run("Success with default Order", func() {
+		order := testdatagen.MakeDefaultOrder(suite.DB())
 		payload, err := assembleOrderPayload(suite.AppContextForTest(), order.ID)
+		suite.FatalNoError(err)
 
 		data := &primemessages.Order{}
 		unmarshalErr := data.UnmarshalBinary(payload)
 
-		suite.Nil(err)
 		suite.Nil(unmarshalErr)
 		suite.Equal(order.ID.String(), data.ID.String())
 		suite.NotNil(order.ServiceMember)
@@ -202,7 +205,7 @@ func (suite *EventServiceSuite) TestAssembleOrderPayload() {
 }
 
 func (suite *EventServiceSuite) TestAssembleMTOShipmentPayload() {
-	suite.T().Run("Non-external shipment returns payload with all associations", func(t *testing.T) {
+	suite.Run("Non-external shipment returns payload with all associations", func() {
 		// Setup test data
 		pickupAddress := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
 		secondaryPickupAddress := testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
@@ -242,7 +245,7 @@ func (suite *EventServiceSuite) TestAssembleMTOShipmentPayload() {
 		suite.Equal(agent.ID.String(), data.Agents[0].ID.String())
 	})
 
-	suite.T().Run("External shipment reports that it should not notify", func(t *testing.T) {
+	suite.Run("External shipment reports that it should not notify", func() {
 		// Setup test data
 		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
 			MTOShipment: models.MTOShipment{

--- a/pkg/services/order/excess_weight_risk_manager_test.go
+++ b/pkg/services/order/excess_weight_risk_manager_test.go
@@ -1,7 +1,6 @@
 package order
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -19,7 +18,7 @@ import (
 )
 
 func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -32,7 +31,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -46,7 +45,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.Contains(err.Error(), order.ID.String())
 	})
 
-	suite.T().Run("Updates the BillableWeight and approves the move when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the BillableWeight and approves the move when all fields are valid", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		now := time.Now()
@@ -75,7 +74,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the BillableWeight but does not approve the move if unacknowledged amended orders exist", func(t *testing.T) {
+	suite.Run("Updates the BillableWeight but does not approve the move if unacknowledged amended orders exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		storer := storageTest.NewFakeS3Storage(true)
@@ -124,7 +123,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the BillableWeight but does not approve the move if unreviewed service items exist", func(t *testing.T) {
+	suite.Run("Updates the BillableWeight but does not approve the move if unreviewed service items exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 
@@ -151,7 +150,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the BillableWeight but does not acknowledge the risk if there is no excess weight risk", func(t *testing.T) {
+	suite.Run("Updates the BillableWeight but does not acknowledge the risk if there is no excess weight risk", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{})
@@ -176,7 +175,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 		suite.Nil(moveInDB.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Updates the BillableWeight but does not acknowledge the risk if the risk was already acknowledged", func(t *testing.T) {
+	suite.Run("Updates the BillableWeight but does not acknowledge the risk if the risk was already acknowledged", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		now := time.Now()
@@ -208,7 +207,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {
 }
 
 func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -222,7 +221,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -237,7 +236,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.Contains(err.Error(), order.ID.String())
 	})
 
-	suite.T().Run("Updates the MaxBillableWeight and TIO remarks and approves the move when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the MaxBillableWeight and TIO remarks and approves the move when all fields are valid", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		now := time.Now()
@@ -268,7 +267,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the MaxBillableWeight and TIO remarks but does not approve the move if unacknowledged amended orders exist", func(t *testing.T) {
+	suite.Run("Updates the MaxBillableWeight and TIO remarks but does not approve the move if unacknowledged amended orders exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		storer := storageTest.NewFakeS3Storage(true)
@@ -319,7 +318,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the MaxBillableWeight and TIO remarks but does not approve the move if unreviewed service items exist", func(t *testing.T) {
+	suite.Run("Updates the MaxBillableWeight and TIO remarks but does not approve the move if unreviewed service items exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 
@@ -348,7 +347,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.WithinDuration(time.Now(), *acknowledgedAt, 2*time.Second)
 	})
 
-	suite.T().Run("Updates the MaxBillableWeight and TIO remarks but does not acknowledge the risk if there is no excess weight risk", func(t *testing.T) {
+	suite.Run("Updates the MaxBillableWeight and TIO remarks but does not acknowledge the risk if there is no excess weight risk", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{})
@@ -375,7 +374,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 		suite.Nil(moveInDB.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Updates the MaxBillableWeight and TIO remarks but does not acknowledge the risk if the risk was already acknowledged", func(t *testing.T) {
+	suite.Run("Updates the MaxBillableWeight and TIO remarks but does not acknowledge the risk if the risk was already acknowledged", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		now := time.Now()
@@ -409,7 +408,7 @@ func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTIO() {
 }
 
 func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
-	suite.T().Run("Returns an error when move is not found", func(t *testing.T) {
+	suite.Run("Returns an error when move is not found", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -421,7 +420,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		move := testdatagen.MakeDefaultMove(suite.DB())
@@ -435,7 +434,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.Contains(err.Error(), move.ID.String())
 	})
 
-	suite.T().Run("Updates the ExcessWeightAcknowledgedAt field and approves the move when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the ExcessWeightAcknowledgedAt field and approves the move when all fields are valid", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		now := time.Now()
@@ -459,7 +458,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.NotNil(updatedMove.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Updates the ExcessWeightAcknowledgedAt field but does not approve the move if unacknowledged amended orders exist", func(t *testing.T) {
+	suite.Run("Updates the ExcessWeightAcknowledgedAt field but does not approve the move if unacknowledged amended orders exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 		storer := storageTest.NewFakeS3Storage(true)
@@ -501,7 +500,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.NotNil(moveInDB.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Updates the ExcessWeightAcknowledgedAt field but does not approve the move if unreviewed service items exist", func(t *testing.T) {
+	suite.Run("Updates the ExcessWeightAcknowledgedAt field but does not approve the move if unreviewed service items exist", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 
@@ -521,7 +520,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.NotNil(moveInDB.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Does not update the ExcessWeightAcknowledgedAt field if there is no risk of excess weight", func(t *testing.T) {
+	suite.Run("Does not update the ExcessWeightAcknowledgedAt field if there is no risk of excess weight", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 
@@ -542,7 +541,7 @@ func (suite *OrderServiceSuite) TestAcknowledgeExcessWeightRisk() {
 		suite.Nil(updatedMove.ExcessWeightAcknowledgedAt)
 	})
 
-	suite.T().Run("Does not update the ExcessWeightAcknowledgedAt field if the risk was already acknowledged", func(t *testing.T) {
+	suite.Run("Does not update the ExcessWeightAcknowledgedAt field if the risk was already acknowledged", func() {
 		moveRouter := moverouter.NewMoveRouter()
 		excessWeightRiskManager := NewExcessWeightRiskManager(moveRouter)
 

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -2,7 +2,6 @@ package order
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -25,7 +24,7 @@ import (
 )
 
 func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -39,7 +38,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when origin duty location is not found", func(t *testing.T) {
+	suite.Run("Returns an error when origin duty location is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -58,7 +57,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when new duty location is not found", func(t *testing.T) {
+	suite.Run("Returns an error when new duty location is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -77,7 +76,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -91,7 +90,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Updates the order when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the order when all fields are valid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		move := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{})
@@ -150,7 +149,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.Equal(move.Status, moveInDB.Status)
 	})
 
-	suite.T().Run("Rolls back transaction if Order is invalid", func(t *testing.T) {
+	suite.Run("Rolls back transaction if Order is invalid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -184,7 +183,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.InvalidInputError{}, err)
 	})
 
-	suite.T().Run("Allow Order update to have a missing HHG SAC", func(t *testing.T) {
+	suite.Run("Allow Order update to have a missing HHG SAC", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -228,7 +227,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.Nil(updatedOrder.SAC)
 	})
 
-	suite.T().Run("Allow Order update to have a missing NTS SAC", func(t *testing.T) {
+	suite.Run("Allow Order update to have a missing NTS SAC", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -272,7 +271,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.Nil(updatedOrder.NtsSAC)
 	})
 
-	suite.T().Run("Allow Order update to have a missing NTS TAC", func(t *testing.T) {
+	suite.Run("Allow Order update to have a missing NTS TAC", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -316,7 +315,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.Nil(updatedOrder.NtsTAC)
 	})
 
-	suite.T().Run("Rolls back transaction if Order is invalid", func(t *testing.T) {
+	suite.Run("Rolls back transaction if Order is invalid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -351,7 +350,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 		suite.IsType(apperror.InvalidInputError{}, err)
 	})
 
-	suite.T().Run("Rolls back transaction if Order is missing required fields", func(t *testing.T) {
+	suite.Run("Rolls back transaction if Order is missing required fields", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		orderWithoutDefaults := testdatagen.MakeOrderWithoutDefaults(suite.DB(), testdatagen.Assertions{})
@@ -393,7 +392,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsTOO() {
 }
 
 func (suite *OrderServiceSuite) TestUpdateOrderAsCounselor() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -407,7 +406,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsCounselor() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -421,7 +420,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsCounselor() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Updates the order when it is found", func(t *testing.T) {
+	suite.Run("Updates the order when it is found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeNeedsServiceCounselingMove(suite.DB()).Orders
@@ -469,7 +468,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsCounselor() {
 		suite.EqualValues(body.Sac.Value, updatedOrder.SAC)
 	})
 
-	suite.T().Run("Rolls back transaction if Order is invalid", func(t *testing.T) {
+	suite.Run("Rolls back transaction if Order is invalid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeOrderWithoutDefaults(suite.DB(), testdatagen.Assertions{})
@@ -504,7 +503,7 @@ func (suite *OrderServiceSuite) TestUpdateOrderAsCounselor() {
 }
 
 func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -518,7 +517,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -532,7 +531,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Updates the allowance when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the allowance when all fields are valid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeServiceCounselingCompletedMove(suite.DB(), testdatagen.Assertions{}).Orders
@@ -575,7 +574,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsTOO() {
 }
 
 func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -589,7 +588,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns an error when the etag does not match", func(t *testing.T) {
+	suite.Run("Returns an error when the etag does not match", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeDefaultMove(suite.DB()).Orders
@@ -603,7 +602,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Updates the allowance when all fields are valid", func(t *testing.T) {
+	suite.Run("Updates the allowance when all fields are valid", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeNeedsServiceCounselingMove(suite.DB()).Orders
@@ -646,7 +645,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.EqualValues(payload.Agency, fetchedSM.Affiliation)
 	})
 
-	suite.T().Run("Updates the allowance when move needs service counseling and order fields are missing", func(t *testing.T) {
+	suite.Run("Updates the allowance when move needs service counseling and order fields are missing", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		orderWithoutDefaults := testdatagen.MakeOrderWithoutDefaults(suite.DB(), testdatagen.Assertions{})
@@ -704,7 +703,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.Nil(updatedOrder.OrdersTypeDetail)
 	})
 
-	suite.T().Run("Entire update is aborted when ProGearWeight is over max amount", func(t *testing.T) {
+	suite.Run("Entire update is aborted when ProGearWeight is over max amount", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeNeedsServiceCounselingMove(suite.DB()).Orders
@@ -740,7 +739,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 		suite.Nil(updatedOrder)
 	})
 
-	suite.T().Run("Entire update is aborted when ProGearWeightSpouse is over max amount", func(t *testing.T) {
+	suite.Run("Entire update is aborted when ProGearWeightSpouse is over max amount", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		order := testdatagen.MakeNeedsServiceCounselingMove(suite.DB()).Orders
@@ -779,7 +778,7 @@ func (suite *OrderServiceSuite) TestUpdateAllowanceAsCounselor() {
 
 func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 
-	suite.T().Run("Creates and saves new amendedOrder doc when the order.UploadedAmendedOrders is nil", func(t *testing.T) {
+	suite.Run("Creates and saves new amendedOrder doc when the order.UploadedAmendedOrders is nil", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{
@@ -821,7 +820,7 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 
 		expectedChecksum := "nOE6HwzyE4VEDXn67ULeeA=="
 		if upload.Checksum != expectedChecksum {
-			t.Errorf("Did not calculate the correct MD5: expected %s, got %s", expectedChecksum, upload.Checksum)
+			suite.Fail("Did not calculate the correct MD5: expected %s, got %s", expectedChecksum, upload.Checksum)
 		}
 
 		var orderInDB models.Order
@@ -836,13 +835,13 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 		findUpload := models.Upload{}
 		err = suite.DB().Find(&findUpload, upload.ID)
 		if err != nil {
-			t.Fatalf("Couldn't find expected upload.")
+			suite.Fail("Couldn't find expected upload.")
 		}
 		suite.Equal(upload.ID.String(), findUpload.ID.String(), "found upload in db")
 		suite.NotEmpty(url, "URL is populated")
 	})
 
-	suite.T().Run("Returns an error when order is not found", func(t *testing.T) {
+	suite.Run("Returns an error when order is not found", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		nonexistentUUID := uuid.Must(uuid.NewV4())
@@ -869,7 +868,7 @@ func (suite *OrderServiceSuite) TestUploadAmendedOrdersForCustomer() {
 		suite.NoVerrs(verrs)
 	})
 
-	suite.T().Run("Saves userUpload payload to order.UploadedAmendedOrders if the document already exists", func(t *testing.T) {
+	suite.Run("Saves userUpload payload to order.UploadedAmendedOrders if the document already exists", func() {
 		moveRouter := move.NewMoveRouter()
 		orderUpdater := NewOrderUpdater(moveRouter)
 		dutyLocation := testdatagen.MakeDutyLocation(suite.DB(), testdatagen.Assertions{


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12618) for this change

## Summary

Converts the package and tests in `./pkg/services/order` and `./pkg/services/event` to use transactions.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)
