### PR TITLE
MB-11864 SC can delete PPM

### DIFF
--- a/pkg/services/mto_shipment/validation.go
+++ b/pkg/services/mto_shipment/validation.go
@@ -130,3 +130,15 @@ func checkUpdateAllowed() validator {
 		return err
 	})
 }
+
+// Checks if a shipment can be deleted
+func checkDeleteAllowed() validator {
+	return validatorFunc(func(appCtx appcontext.AppContext, _ *models.MTOShipment, older *models.MTOShipment) error {
+		move := older.MoveTaskOrder
+		if move.Status != models.MoveStatusDRAFT && move.Status != models.MoveStatusNeedsServiceCounseling {
+			return apperror.NewForbiddenError("A shipment can only be deleted if the move is in Draft or NeedsServiceCounseling")
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11864) for this change

## Summary
There wasn't any additional work needed for an SC to delete a PPM, but I did do a small refactor to the delete shipment service object so that it follows our validator pattern

[this article](https://transcom.github.io/mymove-docs/docs/backend/guides/service-validation#the-pattern) explains more about the approach used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->
A clean run of make server_test should be sufficient, but below are additional instructions to verify that an SC can delete a PPM

1. Access the office app
2. Login as a service counselor
3. Look at move `PPMSC1`
4. Delete the ppm shipment
5. Once you're back on the Move details page, there shouldn't be any visible shipments 

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.
