### PR TITLE
Rely on browser btoa over node to keep FE code separated from BE

### DIFF
--- a/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
+++ b/src/components/Customer/MtoShipmentForm/MtoShipmentForm.test.jsx
@@ -310,7 +310,7 @@ describe('MtoShipmentForm component', () => {
       const expectedCreateResponse = {
         createdAt: '2021-06-11T18:12:11.918Z',
         customerRemarks: '',
-        eTag: btoa(updatedAt),
+        eTag: window.btoa(updatedAt),
         id: uuidv4(),
         moveTaskOrderID: moveId,
         pickupAddress: { ...shipmentInfo.pickupAddress, id: uuidv4() },
@@ -422,7 +422,7 @@ describe('MtoShipmentForm component', () => {
 
     const mockMtoShipment = {
       id: uuidv4(),
-      eTag: btoa(updatedAt),
+      eTag: window.btoa(updatedAt),
       createdAt: '2021-06-11T18:12:11.918Z',
       updatedAt,
       moveTaskOrderId: moveId,
@@ -677,7 +677,7 @@ describe('MtoShipmentForm component', () => {
         ...mockMtoShipment,
         pickupAddress: { ...shipmentInfo.pickupAddress },
         shipmentType: SHIPMENT_OPTIONS.HHG,
-        eTag: btoa(newUpdatedAt),
+        eTag: window.btoa(newUpdatedAt),
         status: 'SUBMITTED',
       };
 

--- a/src/pages/MyMove/PPM/Booking/Advance/Advance.test.jsx
+++ b/src/pages/MyMove/PPM/Booking/Advance/Advance.test.jsx
@@ -30,8 +30,8 @@ const estimatedIncentivePath = generatePath(customerRoutes.SHIPMENT_PPM_ESTIMATE
   mtoShipmentId: mockMTOShipmentId,
 });
 
-const mockShipmentETag = Buffer.from(new Date()).toString('base64');
-const mockPPMShipmentETag = Buffer.from(new Date()).toString('base64');
+const mockShipmentETag = window.btoa(new Date());
+const mockPPMShipmentETag = window.btoa(new Date());
 
 const mockMTOShipment = {
   id: mockMTOShipmentId,

--- a/src/pages/MyMove/PPM/Booking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
+++ b/src/pages/MyMove/PPM/Booking/EstimatedWeightsProGear/EstimatedWeightsProGear.test.jsx
@@ -51,9 +51,9 @@ const mockMTOShipment = {
     destinationPostalCode: '20004',
     sitExpected: false,
     expectedDepartureDate: '2022-12-31',
-    eTag: btoa(new Date()),
+    eTag: window.btoa(new Date()),
   },
-  eTag: btoa(new Date()),
+  eTag: window.btoa(new Date()),
 };
 
 const mockPreExistingShipment = {
@@ -64,9 +64,9 @@ const mockPreExistingShipment = {
     hasProGear: false,
     proGearWeight: null,
     spouseProGearWeight: null,
-    eTag: btoa(new Date()),
+    eTag: window.btoa(new Date()),
   },
-  eTag: btoa(new Date()),
+  eTag: window.btoa(new Date()),
 };
 
 const mockPreExistingShipmentWithProGear = {
@@ -76,9 +76,9 @@ const mockPreExistingShipmentWithProGear = {
     hasProGear: true,
     proGearWeight: 1000,
     spouseProGearWeight: 100,
-    eTag: btoa(new Date()),
+    eTag: window.btoa(new Date()),
   },
-  eTag: btoa(new Date()),
+  eTag: window.btoa(new Date()),
 };
 
 const mockDispatch = jest.fn();


### PR DESCRIPTION
## Summary

We were previously using the `btoa` or `Buffer.from` functions that are provided by the nodeJS backend. Since we are calling these on the FE we should utilize the FE versions of these. This change aligns with the decision of Webpack 5 to remove the node builtins from the bundle. 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. You can then run `yarn test` to run and verify the changes have caused no breakages

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
