### PR TITLE
Add bin/prime-api-client to the e2e Dockerfile

### DIFF
--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -40,6 +40,7 @@ docker run \
        make pkg/assets/assets.go \
        server_build \
        bin/generate-test-data \
+       bin/prime-api-client \
        bin/rds-ca-2019-root.pem \
        bin/rds-ca-rsa4096-g1.pem
 docker build -t milmove_e2e:local -f Dockerfile.e2e .


### PR DESCRIPTION
## Summary

It was reported in Slack that running `make e2e_test_docker` locally was failing locally due to not being able to find the `bin/prime-api-client` binary. This patch fixes it according to the solutions brought up in the thread.

[=> Slack thread 🔒 ](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1654098479031039)

## Setup to Run Your Code

You can test this by running `make e2e_test_docker` and successfully running the Cypress test suite locally within a Docker container.