### PR TITLE
[ MB-9033 ] ADR for using React-App-Rewired

### DIFF
--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -18,42 +18,65 @@ will remove the single build dependency from your project._ This is not an
 option currently on MilMove as ejecting would add some maintainability overhead
 that the development team may address at a later time or a later ADR.
 
+## Decision drivers
 
+Some of the issues we've seen is that in order to best control our build
+toolchain there are certain configurations that need to be updated. For
+instance, Webpack 5 removed the Node Polyfills that are used by the MilMove
+client application. This causes our client application to break in unique ways
+around `process` not being defined. Refactoring our client application is a
+possible solution, but there are ways to have Webpack 5 use Node Polyfills that
+we need by defining it in a Webpack configuration file. The issue here is that
+Create-React-App and React-Scripts prevent us from modifying these scripts as
+they are not exposed to engineers.
 
-*[context and problem statement]*
-*[context and problem statement]*
-*[decision drivers | forces]* <!-- optional -->
+This is true for other tools such as ESLint as well and has been an issue
+previously on the client application for the project. Sometimes the
+React-Scripts and Create-React-App tools update and support some level of
+customization but it leaves the MilMove engineering team in a holding pattern
+without a clear path forward besides following contributions upstream or
+contributing upstream to the Create-React-App project.
+
+It's also true that Facebook's Create-React-App development team is notorious
+for denying any changes for specific configuration updates. As stated above,
+their own documentation states that `ejecting` or maintaining a fork of
+Create-React-App are the only viable solutions for customization using their
+build toolchain.
 
 ## Considered Alternatives
 
-* *[alternative 1]*
-* *[alternative 2]*
-* *[alternative 3]*
-* *[...]* <!-- numbers of alternatives can vary -->
+> **bold denotes chosen**
+
+* *Do nothing*
+* *Eject the Create-React-App configuration*
+* **Dynamically patch the configurations**
 
 ## Decision Outcome
 
-* Chosen Alternative: *[alternative 1]*
-* *[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force force | ... | comes out best (see below)]*
-* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+* Chosen Alternative: *Dynamically patch the configurations*
+
+We can leverage React-App-Rewired in order to perform dynamic patching of the
+Webpack configuration, and other configurations as needed, in order to bring
+back these Node Polyfills for supporting the `process` object that the client
+application currently relies on.
 
 ## Pros and Cons of the Alternatives <!-- optional -->
 
-### *[alternative 1]*
+### *Do nothing*
 
 * `+` *[argument 1 pro]*
 * `+` *[argument 2 pro]*
 * `-` *[argument 1 con]*
 * *[...]* <!-- numbers of pros and cons can vary -->
 
-### *[alternative 2]*
+### *Eject the Create-React-App configuration*
 
 * `+` *[argument 1 pro]*
 * `+` *[argument 2 pro]*
 * `-` *[argument 1 con]*
 * *[...]* <!-- numbers of pros and cons can vary -->
 
-### *[alternative 3]*
+### *Dynamically patch the configurations*
 
 * `+` *[argument 1 pro]*
 * `+` *[argument 2 pro]*

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -83,8 +83,17 @@ in the future. The **React-App-Rewired** library supports modifying **webpack**
 * `+` *Allows engineering team to take ownership of the configuration for the
   client application.*
 * `-` *No wide-support from engineering team to maintain the build toolchain.*
+  * Without wide-support from engineering, the lack of configuration is a safer
+  space to exist in for the project regardless of the benefits or
+  responsibilities to leverage the build toolchain manually.
+* `-` *Removes the reliance on **Create-React-App** and **React-Scripts** to
+  incorporate security fixes which have much larger teams dedicated to this.*
 * `-` *Breaks out of the update cycle for **Create-React-App** and
   **React-Scripts**.*
+  * The update cycle of **Create-React-App** and **React-Scripts** is one that
+  is owned by their upstream development team. This cycle is a benefit to the
+  MilMove engineering team as there are less dependencies that need to be
+  managed by us.
 
 ### *Dynamically patch the configurations*
 

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -1,0 +1,61 @@
+# Using React-App-Rewired
+
+**User Story:** *[MB-9033](https://dp3.atlassian.net/browse/MB-9033)* <!-- optional -->
+
+## Background
+
+The MilMove client application uses Create-React-App and React-Scripts for its
+build toolchain. This build toolchain has many benefits to developing the client
+application, but also has limitations when it comes to updating the
+configuration of various build tools that are used in the development of the
+client application. These tools such as webpack, ESlint, and Babel are
+configured with pre-determined configurations that are in-accessible without
+_ejecting_ from the Create-React-App toolchain.
+
+Facebook's own documentation mentions that _If you aren't satisfied with the
+build tool and configuration choices, you can `eject` at any time. This command
+will remove the single build dependency from your project._ This is not an
+option currently on MilMove as ejecting would add some maintainability overhead
+that the development team may address at a later time or a later ADR.
+
+
+
+*[context and problem statement]*
+*[context and problem statement]*
+*[decision drivers | forces]* <!-- optional -->
+
+## Considered Alternatives
+
+* *[alternative 1]*
+* *[alternative 2]*
+* *[alternative 3]*
+* *[...]* <!-- numbers of alternatives can vary -->
+
+## Decision Outcome
+
+* Chosen Alternative: *[alternative 1]*
+* *[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force force | ... | comes out best (see below)]*
+* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### *[alternative 1]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 2]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 3]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -52,7 +52,7 @@ build toolchain.
 > **bold denotes chosen**
 
 * *Do nothing*
-* *Eject the Create-React-App configuration*
+* *Eject the **Create-React-App** configuration*
 * **Dynamically patch the configurations**
 
 ## Decision Outcome

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -1,6 +1,6 @@
 # Using React-App-Rewired
 
-**User Story:** *[MB-9033](https://dp3.atlassian.net/browse/MB-9033)* <!-- optional -->
+**User Story:** *[MB-9033](https://dp3.atlassian.net/browse/MB-9033)* :lock:
 
 ## Background
 

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -69,25 +69,26 @@ in the future. The **React-App-Rewired** library supports modifying **webpack**
 
 [gh-rar]: https://github.com/timarney/react-app-rewired
 
-## Pros and Cons of the Alternatives <!-- optional -->
+## Pros and Cons of the Alternatives
 
 ### *Do nothing*
 
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
+* `+` *There's no work to be done so teams can focus on other work.*
+* `-` *Leaves dependencies out of date due to not being able to update to the
+  latest versions of NPM packages.*
 
-### *Eject the Create-React-App configuration*
+### *Eject the **Create-React-App** configuration*
 
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
+* `+` *Reduces the dependency on **Create-React-App**.*
+* `+` *Allows engineering team to take ownership of the configuration for the
+  client application.*
+* `-` *No wide-support from engineering team to maintain the build toolchain.*
+* `-` *Breaks out of the update cycle for **Create-React-App** and
+  **React-Scripts**.*
 
 ### *Dynamically patch the configurations*
 
-* `+` *[argument 1 pro]*
-* `+` *[argument 2 pro]*
-* `-` *[argument 1 con]*
-* *[...]* <!-- numbers of pros and cons can vary -->
+* `+` *Allows for control of extending or modifying build toolchain
+  configurations.*
+* `+` *Removes the need to `eject` from the **Create-React-App** ecosystem.*
+* `-` *Changes the build toolchain commands due to dynamic patching.*

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -59,10 +59,15 @@ build toolchain.
 
 * Chosen Alternative: *Dynamically patch the configurations*
 
-We can leverage React-App-Rewired in order to perform dynamic patching of the
-Webpack configuration, and other configurations as needed, in order to bring
-back these Node Polyfills for supporting the `process` object that the client
-application currently relies on.
+We can leverage [**React-App-Rewired** in order to perform dynamic patching of
+the **webpack** configuration][gh-rar], and other configurations as needed, in
+order to bring back these Node polyfills for supporting the `process` object
+that the client application currently relies on. This is also useful in case
+there are other configuration options that would like to be modified or extended
+in the future. The **React-App-Rewired** library supports modifying **webpack**
+& **Jest** configurations.
+
+[gh-rar]: https://github.com/timarney/react-app-rewired
 
 ## Pros and Cons of the Alternatives <!-- optional -->
 

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -4,17 +4,17 @@
 
 ## Background
 
-The MilMove client application uses Create-React-App and React-Scripts for its
-build toolchain. This build toolchain has many benefits to developing the client
-application, but also has limitations when it comes to updating the
-configuration of various build tools that are used in the development of the
-client application. These tools such as webpack, ESlint, and Babel are
-configured with pre-determined configurations that are in-accessible without
-_ejecting_ from the Create-React-App toolchain.
+The MilMove client application uses **Create-React-App** and **React-Scripts**
+for its build toolchain. This build toolchain has many benefits to developing
+the client application, but also has limitations when it comes to updating
+the configuration of various build tools that are used in the development of
+the client application. These tools such as **webpack**, **ESLint**, and
+**Babel** are configured with pre-determined configurations that are
+in-accessible without *ejecting* from the **Create-React-App** toolchain.
 
-Facebook's own documentation mentions that _If you aren't satisfied with the
+Facebook's own documentation mentions that *If you aren't satisfied with the
 build tool and configuration choices, you can `eject` at any time. This command
-will remove the single build dependency from your project._ This is not an
+will remove the single build dependency from your project.* This is not an
 option currently on MilMove as ejecting would add some maintainability overhead
 that the development team may address at a later time or a later ADR.
 

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -83,14 +83,14 @@ in the future. The **React-App-Rewired** library supports modifying **webpack**
 * `+` *Allows engineering team to take ownership of the configuration for the
   client application.*
 * `-` *No wide-support from engineering team to maintain the build toolchain.*
-  * Without wide-support from engineering, the lack of configuration is a safer
+  * `+` Without wide-support from engineering, the lack of configuration is a safer
   space to exist in for the project regardless of the benefits or
   responsibilities to leverage the build toolchain manually.
 * `-` *Removes the reliance on **Create-React-App** and **React-Scripts** to
   incorporate security fixes which have much larger teams dedicated to this.*
 * `-` *Breaks out of the update cycle for **Create-React-App** and
   **React-Scripts**.*
-  * The update cycle of **Create-React-App** and **React-Scripts** is one that
+  * `+` The update cycle of **Create-React-App** and **React-Scripts** is one that
   is owned by their upstream development team. This cycle is a benefit to the
   MilMove engineering team as there are less dependencies that need to be
   managed by us.

--- a/docs/adr/0072-using-react-app-rewired.md
+++ b/docs/adr/0072-using-react-app-rewired.md
@@ -22,25 +22,29 @@ that the development team may address at a later time or a later ADR.
 
 Some of the issues we've seen is that in order to best control our build
 toolchain there are certain configurations that need to be updated. For
-instance, Webpack 5 removed the Node Polyfills that are used by the MilMove
-client application. This causes our client application to break in unique ways
-around `process` not being defined. Refactoring our client application is a
-possible solution, but there are ways to have Webpack 5 use Node Polyfills that
-we need by defining it in a Webpack configuration file. The issue here is that
-Create-React-App and React-Scripts prevent us from modifying these scripts as
-they are not exposed to engineers.
+instance, [**webpack** 5 removed the Node polyfills][wp5-migrate] that are used
+by the MilMove client application. This causes our client application to break
+in unique ways around `process` not being defined. Refactoring our client
+application is a possible solution, but there are ways to have **webpack** 5 use
+the Node polyfills that we need by defining it in a **webpack** configuration
+file. Our issue here is that **Create-React-App** and **React-Scripts** prevent
+us from modifying these scripts as they are not exposed to users of those
+libraries.
 
-This is true for other tools such as ESLint as well and has been an issue
+[wp5-migrate]:
+https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
+
+This is true for other tools such as **ESLint** as well and has been an issue
 previously on the client application for the project. Sometimes the
-React-Scripts and Create-React-App tools update and support some level of
-customization but it leaves the MilMove engineering team in a holding pattern
+**React-Scripts** and **Create-React-App** tools update and support some level
+of customization but it leaves the MilMove engineering team in a holding pattern
 without a clear path forward besides following contributions upstream or
-contributing upstream to the Create-React-App project.
+contributing upstream to the **Create-React-App** project.
 
-It's also true that Facebook's Create-React-App development team is notorious
-for denying any changes for specific configuration updates. As stated above,
-their own documentation states that `ejecting` or maintaining a fork of
-Create-React-App are the only viable solutions for customization using their
+It's also true that Facebook's **Create-React-App** development team is
+notorious for denying any changes for specific configuration updates. As stated
+above, their own documentation states that `ejecting` or maintaining a fork of
+**Create-React-App** are the only viable solutions for customization using their
 build toolchain.
 
 ## Considered Alternatives

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -76,6 +76,7 @@ This log lists the architectural decisions for DP3 Infrastructure.
 - [ADR-0069](0069-use-orchestrator-service-objects.md) - Use orchestrator service objects
 - [ADR-0070](0070-cypress-tests-file-layout.md) - Use a consistent file structure for cypress tests
 - [ADR-0071](0071-move-history-events.md) - Introduce Move History Events
+- [ADR-0072](0072-using-react-app-rewired.md) - Using React-App-Rewired
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-9033) for this change

## Summary

When working on updating React-USWDS to the latest version, there were a number of upgrades that needed to be done to the underlying dependencies. This work resulted in the application needing to use a new library called React-App-Rewired in order to apply changes to the configuration for tools used in React-Scripts. This ADR's purpose is to document the decision to not eject the Create-React-App and instead leverage the React-App-Rewired library to modify the webpack configuration.

- #8713 
- #8724 
