### PR TITLE
MB-12339 QAE/CSR payment request read only

### DIFF
--- a/pkg/auth/authentication/permissions.go
+++ b/pkg/auth/authentication/permissions.go
@@ -28,7 +28,7 @@ var TOO = RolePermissions{
 var TIO = RolePermissions{
 	RoleType: roles.RoleTypeTIO,
 	Permissions: []string{"create.serviceItem", "read.paymentRequest", "update.paymentServiceItemStatus",
-		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
+		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances", "update.maxBillableWeight"},
 }
 
 var ServicesCounselor = RolePermissions{

--- a/pkg/auth/authentication/permissions.go
+++ b/pkg/auth/authentication/permissions.go
@@ -21,13 +21,14 @@ type RolePermissions struct {
 
 var TOO = RolePermissions{
 	RoleType: roles.RoleTypeTOO,
-	Permissions: []string{"update.move", "create.serviceItem",
+	Permissions: []string{"update.move", "create.serviceItem", "update.paymentServiceItemStatus",
 		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
 }
 
 var TIO = RolePermissions{
-	RoleType:    roles.RoleTypeTIO,
-	Permissions: []string{"create.serviceItem", "read.paymentRequest", "update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
+	RoleType: roles.RoleTypeTIO,
+	Permissions: []string{"create.serviceItem", "read.paymentRequest", "update.paymentServiceItemStatus",
+		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
 }
 
 var ServicesCounselor = RolePermissions{

--- a/pkg/auth/authentication/permissions.go
+++ b/pkg/auth/authentication/permissions.go
@@ -27,7 +27,7 @@ var TOO = RolePermissions{
 
 var TIO = RolePermissions{
 	RoleType:    roles.RoleTypeTIO,
-	Permissions: []string{"create.serviceItem", "update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
+	Permissions: []string{"create.serviceItem", "read.paymentRequest", "update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances"},
 }
 
 var ServicesCounselor = RolePermissions{
@@ -37,7 +37,7 @@ var ServicesCounselor = RolePermissions{
 
 var QAECSR = RolePermissions{
 	RoleType:    roles.RoleTypeQaeCsr,
-	Permissions: []string{"read.move"},
+	Permissions: []string{"read.paymentRequest"},
 }
 
 var AllRolesPermissions = []RolePermissions{TOO, TIO, ServicesCounselor, QAECSR}

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1483,7 +1483,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "read.paymentRequest"
+        ]
       },
       "parameters": [
         {
@@ -8892,7 +8895,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "read.paymentRequest"
+        ]
       },
       "parameters": [
         {

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1969,7 +1969,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "update.maxBillableWeight"
+        ]
       },
       "parameters": [
         {
@@ -9508,7 +9511,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "update.maxBillableWeight"
+        ]
       },
       "parameters": [
         {

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -39,14 +39,6 @@ func (h GetPaymentRequestForMoveHandler) Handle(
 ) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) {
-				forbiddenErr := apperror.NewForbiddenError(
-					"user is not authenticated with TIO office role",
-				)
-				appCtx.Logger().Error(forbiddenErr.Error())
-				return paymentrequestop.NewGetPaymentRequestsForMoveForbidden(), forbiddenErr
-			}
 
 			locator := params.Locator
 

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -225,31 +225,6 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 		suite.Assertions.IsType(&paymentrequestop.GetPaymentRequestNotFound{}, response)
 	})
 
-	suite.Run("Failed list fetch - Forbidden", func() {
-		paymentServiceItemParam, _ := setupTestData()
-		paymentRequests := models.PaymentRequests{paymentServiceItemParam.PaymentServiceItem.PaymentRequest}
-
-		officeUserTOO := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-
-		paymentRequestListFetcher := &mocks.PaymentRequestListFetcher{}
-		paymentRequestListFetcher.On("FetchPaymentRequestListByMove", mock.AnythingOfType("*appcontext.appContext"),
-			mock.Anything,
-			mock.Anything).Return(&paymentRequests, nil).Once()
-
-		request := httptest.NewRequest("GET", fmt.Sprintf("/moves/%s/payment-requests/", "ABC123"), nil)
-		request = suite.AuthenticateOfficeRequest(request, officeUserTOO)
-		params := paymentrequestop.GetPaymentRequestsForMoveParams{
-			HTTPRequest: request,
-			Locator:     "ABC123",
-		}
-		handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
-		handler := GetPaymentRequestForMoveHandler{
-			HandlerConfig:             handlerConfig,
-			PaymentRequestListFetcher: paymentRequestListFetcher,
-		}
-		response := handler.Handle(params)
-		suite.Assertions.IsType(&paymentrequestop.GetPaymentRequestsForMoveForbidden{}, response)
-	})
 }
 
 func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {

--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.jsx
@@ -9,6 +9,8 @@ import styles from './BillableWeightCard.module.scss';
 import ExternalVendorWeightSummary from 'components/Office/ExternalVendorWeightSummary/ExternalVendorWeightSummary';
 import ShipmentList from 'components/ShipmentList/ShipmentList';
 import { formatWeight } from 'utils/formatters';
+import Restricted from 'components/Restricted/Restricted';
+import { permissionTypes } from 'constants/permissions';
 
 export default function BillableWeightCard({
   maxBillableWeight,
@@ -36,9 +38,11 @@ export default function BillableWeightCard({
             </div>
           )}
         </div>
-        <Button onClick={onReviewWeights} secondary={secondaryReviewWeightsBtn} style={{ maxWidth: '160px' }}>
-          Review weights
-        </Button>
+        <Restricted to={permissionTypes.updateMaxBillableWeight}>
+          <Button onClick={onReviewWeights} secondary={secondaryReviewWeightsBtn} style={{ maxWidth: '160px' }}>
+            Review weights
+          </Button>
+        </Restricted>
       </div>
       <div className={styles.spaceBetween}>
         <div>

--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.stories.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 import BillableWeightCard from './BillableWeightCard';
 
+import { MockProviders } from 'testUtils';
+import { permissionTypes } from 'constants/permissions';
+
 export default {
   title: 'Office Components/BillableWeightCard',
   component: BillableWeightCard,
@@ -10,7 +13,7 @@ export default {
   },
 };
 
-export const Card = (argTypes) => (
+const BasicCard = (argTypes) => (
   <div style={{ background: '#f9f9f9', width: '100%', minWidth: '1000px', height: '100%', paddingTop: 20 }}>
     <BillableWeightCard
       maxBillableWeight={13750}
@@ -39,3 +42,11 @@ export const Card = (argTypes) => (
     />
   </div>
 );
+
+export const Card = (argTypes) => (
+  <MockProviders permissions={[permissionTypes.updateMaxBillableWeight]}>
+    <BasicCard argTypes={argTypes} />
+  </MockProviders>
+);
+
+export const CardReadOnly = (argTypes) => <BasicCard argTypes={argTypes} />;

--- a/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.test.jsx
+++ b/src/components/Office/BillableWeight/BillableWeightCard/BillableWeightCard.test.jsx
@@ -6,6 +6,7 @@ import BillableWeightCard from './BillableWeightCard';
 
 import { formatWeight } from 'utils/formatters';
 import { MockProviders } from 'testUtils';
+import { permissionTypes } from 'constants/permissions';
 
 describe('BillableWeightCard', () => {
   const defaultProps = {
@@ -15,6 +16,14 @@ describe('BillableWeightCard', () => {
     weightAllowance: 8000,
     onReviewWeights: jest.fn(),
     secondaryReviewWeightsBtn: false,
+  };
+
+  const renderWithPermission = (props) => {
+    render(
+      <MockProviders permissions={[permissionTypes.updateMaxBillableWeight]}>
+        <BillableWeightCard {...defaultProps} {...props} />
+      </MockProviders>,
+    );
   };
 
   it('renders maximum billable weight, total billable weight, weight requested and weight allowance', () => {
@@ -45,7 +54,7 @@ describe('BillableWeightCard', () => {
       },
     ];
 
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+    renderWithPermission({ shipments });
 
     // labels
     expect(screen.getByText('Maximum billable weight')).toBeInTheDocument();
@@ -76,7 +85,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 40 },
       },
     ];
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+    renderWithPermission({ shipments });
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
 
@@ -98,7 +107,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 40 },
       },
     ];
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} secondaryReviewWeightsBtn />);
+    renderWithPermission({ shipments, secondaryReviewWeightsBtn: true });
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
     expect(reviewWeights).toHaveClass('usa-button--secondary');
@@ -114,7 +123,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 40 },
       },
     ];
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+    renderWithPermission({ shipments });
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
     expect(reviewWeights).not.toHaveClass('usa-button--secondary');
@@ -130,7 +139,11 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234' },
       },
     ];
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+    render(
+      <MockProviders permissions={[permissionTypes.updateMaxBillableWeight]}>
+        <BillableWeightCard {...defaultProps} shipments={shipments} />
+      </MockProviders>,
+    );
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
     expect(reviewWeights).not.toHaveClass('usa-button--secondary');
@@ -146,7 +159,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 2344 },
       },
     ];
-    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+    renderWithPermission({ shipments });
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
     expect(reviewWeights).not.toHaveClass('usa-button--secondary');
@@ -171,7 +184,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 2344 },
       },
     ];
-    render(<BillableWeightCard {...props} shipments={shipments} />);
+    renderWithPermission({ ...props, shipments });
 
     const reviewWeights = screen.getByRole('button', { name: 'Review weights' });
     expect(reviewWeights).not.toHaveClass('usa-button--secondary');
@@ -204,11 +217,7 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 500 },
       },
     ];
-    render(
-      <MockProviders>
-        <BillableWeightCard {...defaultProps} shipments={shipments} />
-      </MockProviders>,
-    );
+    renderWithPermission({ shipments });
 
     expect(screen.getByText('1 other shipment:')).toBeInTheDocument();
     expect(screen.getByText('1,234 lbs')).toBeInTheDocument();
@@ -241,13 +250,26 @@ describe('BillableWeightCard', () => {
         reweigh: { id: '1234', weight: 500 },
       },
     ];
-    render(
-      <MockProviders>
-        <BillableWeightCard {...defaultProps} shipments={shipments} />
-      </MockProviders>,
-    );
+    renderWithPermission({ shipments });
 
     expect(screen.getByText('2 other shipments:')).toBeInTheDocument();
     expect(screen.getByText('4,500 lbs')).toBeInTheDocument();
+  });
+
+  it('does not show the review weights button with no permission', () => {
+    const shipments = [
+      {
+        id: '0001',
+        shipmentType: 'HHG',
+        calculatedBillableWeight: 6161,
+        estimatedWeight: 5600,
+        primeEstimatedWeight: 100,
+        reweigh: { id: '1234', weight: 40 },
+      },
+    ];
+    render(<BillableWeightCard {...defaultProps} shipments={shipments} />);
+
+    const reviewWeights = screen.queryByRole('button', { name: 'Review weights' });
+    expect(reviewWeights).not.toBeInTheDocument();
   });
 });

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.jsx
@@ -15,6 +15,8 @@ import { toDollarString, formatDateFromIso, formatCents } from 'utils/formatters
 import PaymentRequestDetails from 'components/Office/PaymentRequestDetails/PaymentRequestDetails';
 import ConnectedAcountingCodesModal from 'components/Office/AccountingCodesModal/AccountingCodesModal';
 import { groupByShipment } from 'utils/serviceItems';
+import Restricted from 'components/Restricted/Restricted';
+import { permissionTypes } from 'constants/permissions';
 
 const paymentRequestStatusLabel = (status) => {
   switch (status) {
@@ -167,24 +169,26 @@ const PaymentRequestCard = ({
               )}
             </>
           )}
-          {paymentRequest.status === 'PENDING' && (
-            <div className={styles.reviewButton}>
-              <Button
-                style={{ maxWidth: '225px' }}
-                onClick={handleClick}
-                disabled={hasBillableWeightIssues}
-                test-dataid="reviewBtn"
-              >
-                <FontAwesomeIcon icon="copy" className={`${styles['docs-icon']} fas fa-copy`} />
-                Review service items
-              </Button>
-              {hasBillableWeightIssues && (
-                <span className={styles.errorText} test-dataid="errorTxt">
-                  Resolve billable weight before reviewing service items.
-                </span>
-              )}
-            </div>
-          )}
+          <Restricted to={permissionTypes.updatePaymentServiceItemStatus}>
+            {paymentRequest.status === 'PENDING' && (
+              <div className={styles.reviewButton}>
+                <Button
+                  style={{ maxWidth: '225px' }}
+                  onClick={handleClick}
+                  disabled={hasBillableWeightIssues}
+                  test-dataid="reviewBtn"
+                >
+                  <FontAwesomeIcon icon="copy" className={`${styles['docs-icon']} fas fa-copy`} />
+                  Review service items
+                </Button>
+                {hasBillableWeightIssues && (
+                  <span className={styles.errorText} test-dataid="errorTxt">
+                    Resolve billable weight before reviewing service items.
+                  </span>
+                )}
+              </div>
+            )}
+          </Restricted>
         </div>
         <div className={styles.footer}>
           <dl>

--- a/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
+++ b/src/components/Office/PaymentRequestCard/PaymentRequestCard.stories.jsx
@@ -11,6 +11,7 @@ import PaymentRequestCard from './PaymentRequestCard';
 import { MockProviders } from 'testUtils';
 import { serviceItemCodes } from 'content/serviceItems';
 import { formatPaymentRequestAddressString } from 'utils/shipmentDisplay';
+import { permissionTypes } from 'constants/permissions';
 
 const mockedDate = '2020-12-08T00:00:00.000Z';
 
@@ -18,14 +19,15 @@ export default {
   title: 'Office Components/PaymentRequestCard',
   component: PaymentRequestCard,
   decorators: [
-    (Story) => {
+    (Story, context) => {
       if (isHappoRun()) {
         MockDate.set(mockedDate);
         addons.getChannel().on('storyRendered', MockDate.reset);
       }
+      const permissions = context.name.includes('Read Only') ? [] : [permissionTypes.updatePaymentServiceItemStatus];
       return (
         <div style={{ padding: '1em', backgroundColor: '#f9f9f9', minWidth: '1200px' }}>
-          <MockProviders initialEntries={['/moves/L0CATR/payment-requests']}>
+          <MockProviders initialEntries={['/moves/L0CATR/payment-requests']} permissions={permissions}>
             <Story />
           </MockProviders>
         </div>
@@ -243,3 +245,30 @@ export const Rejected = () => (
     onEditAccountingCodes={onEditAccountingCodes}
   />
 );
+
+export const ReadOnly = () => {
+  const [modifiedShipments, setModifiedShipments] = React.useState(shipmentsInfo);
+  const handleEditAccountingCodes = (id, values) => {
+    const updatedShipments = modifiedShipments.map((s) => {
+      if (s.mtoShipmentID !== id) {
+        return s;
+      }
+
+      return {
+        ...s,
+        tacType: values.tacType,
+        sacType: values.sacType,
+      };
+    });
+
+    setModifiedShipments(updatedShipments);
+  };
+
+  return (
+    <PaymentRequestCard
+      paymentRequest={pendingPaymentRequest}
+      shipmentsInfo={modifiedShipments}
+      onEditAccountingCodes={handleEditAccountingCodes}
+    />
+  );
+};

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -3,5 +3,6 @@ export const permissionTypes = {
   updateAllowances: 'update.allowances',
   updateFinancialReviewFlag: 'update.financialReviewFlag',
   updateOrders: 'update.orders',
+  updatePaymentServiceItemStatus: 'update.paymentServiceItemStatus',
   updateShipment: 'update.shipment',
 };

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -2,6 +2,7 @@
 export const permissionTypes = {
   updateAllowances: 'update.allowances',
   updateFinancialReviewFlag: 'update.financialReviewFlag',
+  updateMaxBillableWeight: 'update.maxBillableWeight',
   updateOrders: 'update.orders',
   updatePaymentServiceItemStatus: 'update.paymentServiceItemStatus',
   updateShipment: 'update.shipment',

--- a/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
+++ b/src/pages/Office/MovePaymentRequests/MovePaymentRequests.test.jsx
@@ -424,7 +424,10 @@ const errorReturnValue = {
 
 function renderMovePaymentRequests(props) {
   return render(
-    <MockProviders initialEntries={[`/moves/L2BKD6/payment-requests`]}>
+    <MockProviders
+      initialEntries={[`/moves/L2BKD6/payment-requests`]}
+      permissions={[permissionTypes.updateMaxBillableWeight]}
+    >
       <MovePaymentRequests {...props} />
     </MockProviders>,
   );

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -445,6 +445,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.maxBillableWeight
   '/counseling/orders/{orderID}/allowances':
     parameters:
       - description: ID of order to use

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -1694,6 +1694,8 @@ paths:
       description: Fetches payment requests for a move
       operationId: getPaymentRequestsForMove
       summary: Fetches payment requests using the move code (locator).
+      x-permissions:
+        - read.paymentRequest
   '/moves/{moveID}/financial-review-flag':
     parameters:
       - description: ID of move to flag

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -465,6 +465,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.maxBillableWeight
   /counseling/orders/{orderID}/allowances:
     parameters:
       - description: ID of order to use

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1726,6 +1726,8 @@ paths:
       description: Fetches payment requests for a move
       operationId: getPaymentRequestsForMove
       summary: Fetches payment requests using the move code (locator).
+      x-permissions:
+        - read.paymentRequest
   /moves/{moveID}/financial-review-flag:
     parameters:
       - description: ID of move to flag


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12339) for this change

## Summary

This PR does three things: 

1. Switch the payment request for move endpoint to use the new permissions pattern rather than in-line role checking 
2. Allow QAE/CSR role users to see payment requests
3. Make payment request page read only for QAE/CSR role users

Also included are related storybook and test updates. 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

## Validation
1) Log in as a TIO: The payment request page (and app as a whole) should be unchanged and still include review weights and service items buttons. 
2) Log in as a QAE/CSR: The payment request page can be viewed and is in a read only state (no review weights or service items buttons).
3) Stories and tests are updated to include read only states

## Video

https://user-images.githubusercontent.com/62263329/173089770-0b228d30-5c6b-45e5-a7b7-e5db986cdd6e.mov

