### PR TITLE
MB-12621: Fix failing migration for payment service param

### DIFF
--- a/migrations/app/schema/20220526183214_consolidate_distanceZip3_and_distanceZip5_service_item_params.up.sql
+++ b/migrations/app/schema/20220526183214_consolidate_distanceZip3_and_distanceZip5_service_item_params.up.sql
@@ -17,9 +17,3 @@ VALUES
 
 DELETE FROM service_params WHERE service_item_param_key_id = '7a99efc3-df2b-401f-ae56-f293517afbde';
 DELETE FROM service_params WHERE service_item_param_key_id = '60b0d960-eb2e-4597-846b-d97720493799';
-
--- For any existing payment service item params, replace references to DistanceZip3 and DistanceZip5 with the new DistanceZip param
-INSERT INTO payment_service_item_params(id, payment_service_item_id, service_item_param_key_id, value, created_at, updated_at)
-	SELECT uuid_generate_v4(), payment_service_item_id, '2cbc2251-eb7d-4c69-a120-9a83785c994b', value, now(), now()
-    FROM payment_service_item_params
-    WHERE service_item_param_key_id = '7a99efc3-df2b-401f-ae56-f293517afbde' OR service_item_param_key_id = '60b0d960-eb2e-4597-846b-d97720493799';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12621) for this change

## Summary

This PR removes an insert in a migration that was added that violates a duplicate key rule with some of data present in staging. I removed the insert statement since it was a 'nice to have' in a [previous PR ](https://github.com/transcom/mymove/pull/8699#issuecomment-1151531447).

I'm not entirely sure if editing an existing migration is okay? Please let me know if I should create a new one

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. `make db_dev_migrate` passes without errors

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

