### PR TITLE
MB-12621: update distance zip lookup

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
@@ -41,10 +41,6 @@ func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *Service
 		}
 	}
 
-	if mtoShipment.Distance != nil {
-		return strconv.Itoa(mtoShipment.Distance.Int()), nil
-	}
-
 	// Now calculate the distance between zips
 	pickupZip := r.PickupAddress.PostalCode
 	destinationZip := r.DestinationAddress.PostalCode

--- a/pkg/services/ppmshipment/ppm_estimator_test.go
+++ b/pkg/services/ppmshipment/ppm_estimator_test.go
@@ -300,7 +300,7 @@ func (suite *PPMShipmentSuite) TestEstimatedIncentive() {
 			mock.AnythingOfType("[]models.MTOServiceItem")).Return(serviceParams, nil)
 
 		mockedPlanner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"),
-			"90210", "30813").Return(2361, nil).Once()
+			"90210", "30813").Return(2361, nil)
 
 		ppmEstimate, err := ppmEstimator.EstimateIncentiveWithDefaultChecks(suite.AppContextForTest(), oldPPMShipment, &newPPM)
 		suite.NilOrNoVerrs(err)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12621) for this change

## Summary

The PPM estimator sets the `distance` field on the `mtoShipment` the first time an incentive is estimated. This causes an issue if you go back to update the pickup or destination zip codes since previously the distance zip lookup was not calling the planner if the shipment had an existing distance. 

This PR removes the logic in the distance lookup so that the planner is called even if there's an existing distance on the shipment 

## Note
To best test this PR, go through the instructions below _without_ switching users, or refreshing the database or coming back to the app later

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Sign in as a milmove user
2. Go through the flow to the estimated incentive page
3. Press back to get back to the Dates and Location page
4. Update the zips and navigate back to the estimated incentive page

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
<img width="709" alt="Screen Shot 2022-06-13 at 11 22 06 AM" src="https://user-images.githubusercontent.com/67110378/173389920-d5588978-9da5-49db-a0d9-fe8784d744e6.png">
<img width="694" alt="Screen Shot 2022-06-13 at 11 29 02 AM" src="https://user-images.githubusercontent.com/67110378/173389924-bd3361d9-b3a7-4a34-896e-b9dca472c6db.png">
