### PR TITLE
MB-12697 Adjust createPaymentRequest event to catch more cases

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/createPaymentRequest.js
+++ b/src/constants/MoveHistory/EventTemplates/createPaymentRequest.js
@@ -1,11 +1,10 @@
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
 import a from 'constants/MoveHistory/Database/Actions';
 import t from 'constants/MoveHistory/Database/Tables';
 
 export default {
   action: a.INSERT,
-  eventName: o.createPaymentRequest,
+  eventName: '*',
   tableName: t.payment_requests,
   detailsType: d.LABELED_PAYMENT_REQUEST,
   getEventNameDisplay: ({ changedValues }) => `Submitted payment request ${changedValues?.payment_request_number}`,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12697) for this change

## Summary
I've made the `createPaymentRequest` event catch eventNames more generically.

Are there any cases that I might be missing or not thinking of that these changes would affect? 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office application
2. Login as a TIO
3.

## Verification Steps for Author

These are to be checked by the author.
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/6477059/173429659-aa1eb20b-fca5-4512-9d09-b1e203b57aa1.png">
