### PR TITLE
MB-12001 FileUpload component to accept file types as a prop

### DIFF
--- a/src/components/FileUpload/FileUpload.jsx
+++ b/src/components/FileUpload/FileUpload.jsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import PropTypes from 'prop-types';
+import { func, string, arrayOf } from 'prop-types';
 import isMobile from 'is-mobile';
 import { FilePond, registerPlugin } from 'react-filepond';
 import 'filepond-polyfill/dist/filepond-polyfill';
@@ -20,73 +20,82 @@ registerPlugin(
   FilePondImagePreview,
 );
 
-const FileUpload = forwardRef(({ name, createUpload, onChange, labelIdle, labelIdleMobile, onAddFile }, ref) => {
-  const handleOnChange = () => {
-    if (onChange) onChange();
-  };
+const FileUpload = forwardRef(
+  ({ name, createUpload, onChange, labelIdle, labelIdleMobile, onAddFile, acceptedFileTypes }, ref) => {
+    const handleOnChange = () => {
+      if (onChange) onChange();
+    };
 
-  const processFile = (fieldName, file, metadata, load, error, progress, abort) => {
-    createUpload(file)
-      .then((response) => {
-        load(response.id);
-      })
-      .catch(error);
+    const processFile = (fieldName, file, metadata, load, error, progress, abort) => {
+      createUpload(file)
+        .then((response) => {
+          load(response);
+        })
+        .catch(error);
 
-    // TODO - in order to handle abort, we need to pass an AbortController to SwaggerRequest, implement this as a future story (it's not working as-is)
-    // https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#browser
-    return { abort };
-  };
+      // TODO - in order to handle abort, we need to pass an AbortController to SwaggerRequest, implement this as a future story (it's not working as-is)
+      // https://github.com/swagger-api/swagger-js/blob/master/docs/usage/http-client.md#browser
+      return { abort };
+    };
 
-  const revertFile = (uploadId, load, error) => {
-    deleteUpload(uploadId)
-      .then(() => {
-        load();
-        handleOnChange();
-      })
-      .catch(error);
-  };
+    const revertFile = (uploadId, load, error) => {
+      deleteUpload(uploadId)
+        .then(() => {
+          load();
+          handleOnChange();
+        })
+        .catch(error);
+    };
 
-  const handleProcessFile = () => {
-    handleOnChange();
-  };
+    const handleProcessFile = () => {
+      handleOnChange();
+    };
 
-  const serverConfig = {
-    url: '/internal',
-    process: processFile,
-    fetch: null,
-    revert: revertFile,
-  };
+    const serverConfig = {
+      url: '/internal',
+      process: processFile,
+      fetch: null,
+      revert: revertFile,
+    };
 
-  /**
-   * Default FilePond instance props
-   * If these need to be overwritten, they can be exposed as a prop on this
-   * component and passed through (like labelIdle)
-   */
-  const filePondProps = {
-    allowMultiple: true,
-    server: serverConfig,
-    imagePreviewMaxHeight: 100,
-    labelIdle: isMobile() ? labelIdleMobile : labelIdle,
-    acceptedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
-    maxFileSize: '25MB',
-    credits: false,
-  };
+    /**
+     * Default FilePond instance props
+     * If these need to be overwritten, they can be exposed as a prop on this
+     * component and passed through (like labelIdle)
+     */
+    const filePondProps = {
+      allowMultiple: true,
+      server: serverConfig,
+      imagePreviewMaxHeight: 100,
+      labelIdle: isMobile() ? labelIdleMobile : labelIdle,
+      maxFileSize: '25MB',
+      credits: false,
+    };
 
-  /* eslint-disable react/jsx-props-no-spreading */
-  return (
-    <FilePond ref={ref} {...filePondProps} name={name} onprocessfile={handleProcessFile} onaddfilestart={onAddFile} />
-  );
-  /* eslint-enable react/jsx-props-no-spreading */
-});
+    /* eslint-disable react/jsx-props-no-spreading */
+    return (
+      <FilePond
+        ref={ref}
+        {...filePondProps}
+        acceptedFileTypes={acceptedFileTypes}
+        name={name}
+        onprocessfile={handleProcessFile}
+        onaddfilestart={onAddFile}
+      />
+    );
+    /* eslint-enable react/jsx-props-no-spreading */
+  },
+);
 
 FileUpload.propTypes = {
-  name: PropTypes.string,
-  createUpload: PropTypes.func,
-  onChange: PropTypes.func,
-  onAddFile: PropTypes.func,
+  name: string,
+  createUpload: func,
+  onChange: func,
+  onAddFile: func,
+  acceptedFileTypes: arrayOf(string),
   // FilePond instance props
-  labelIdle: PropTypes.string,
-  labelIdleMobile: PropTypes.string,
+  labelIdle: string,
+  labelIdleMobile: string,
 };
 
 FileUpload.defaultProps = {
@@ -94,6 +103,7 @@ FileUpload.defaultProps = {
   createUpload: createUploadApi,
   onChange: undefined,
   onAddFile: undefined,
+  acceptedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
   labelIdle: 'Drag & drop or <span class="filepond--label-action">click to upload</span>',
   labelIdleMobile: '<span class="filepond--label-action">Upload</span>',
 };

--- a/src/components/FileUpload/FileUpload.stories.jsx
+++ b/src/components/FileUpload/FileUpload.stories.jsx
@@ -8,13 +8,33 @@ export default {
 };
 
 const mockCreateUploadSuccess = () => {
-  return Promise.resolve();
+  return Promise.resolve({ id: '1234' });
 };
 
 const mockCreateUploadError = () => {
   return Promise.reject();
 };
+const Template = (args) => <FileUpload {...args} />;
 
-export const fileUploadSuccess = () => <FileUpload createUpload={mockCreateUploadSuccess} />;
+export const FileUploadSuccess = Template.bind({});
+FileUploadSuccess.args = {
+  createUpload: mockCreateUploadSuccess,
+};
 
-export const fileUploadError = () => <FileUpload createUpload={mockCreateUploadError} />;
+export const FileUploadWithExtendedAcceptedFileTypes = Template.bind({});
+FileUploadWithExtendedAcceptedFileTypes.args = {
+  createUpload: mockCreateUploadSuccess,
+  acceptedFileTypes: [
+    'image/jpeg',
+    'image/png',
+    'application/pdf',
+    '.csv',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-excel',
+  ],
+};
+
+export const FileUploadError = Template.bind({});
+FileUploadError.args = {
+  createUpload: mockCreateUploadError,
+};


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12001) for this change

## Summary

This PR refactored the fileupload component to have an acceptedFileTypes prop so that this component can be used with different file types in other places throughout the app.

This PR was tested in Chrome, FF and Safari 

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Run using storybook
2. Navigate to the Components/FileUpload stories
3. Upload an excel spreadsheet 

## Screenshots
<img width="1049" alt="Screen Shot 2022-06-14 at 1 39 26 PM" src="https://user-images.githubusercontent.com/67110378/173642447-9b071e12-ebac-48f7-81dd-7ab58bbf0c50.png">
