### PR TITLE
[MB-12760] Fix TOO approval of PPM shipment by adding missing PPM payload

### DIFF
--- a/pkg/services/mto_shipment/shipment_approver.go
+++ b/pkg/services/mto_shipment/shipment_approver.go
@@ -101,6 +101,14 @@ func (f *shipmentApprover) findShipment(appCtx appcontext.AppContext, shipmentID
 		return nil, apperror.NewQueryError("MTOShipment", err, "")
 	}
 
+	if shipment.ShipmentType == models.MTOShipmentTypePPM {
+		err = appCtx.DB().Load(shipment, "PPMShipment")
+	}
+
+	if err != nil {
+		return nil, apperror.NewQueryError("MTOShipment", err, "")
+	}
+
 	return shipment, nil
 }
 

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -24,7 +24,7 @@ const PPMShipmentInfoList = ({ className, shipment, warnIfMissing, errorIfMissin
     secondaryPickupPostalCode,
     sitExpected,
     spouseProGearWeight,
-  } = shipment.ppmShipment;
+  } = shipment.ppmShipment || {};
 
   setFlagStyles({
     row: styles.row,

--- a/src/pages/MyMove/EditOrders.jsx
+++ b/src/pages/MyMove/EditOrders.jsx
@@ -27,6 +27,7 @@ import { OrdersShape, ServiceMemberShape } from 'types/customerShapes';
 import { formatWeight, formatYesNoInputValue, dropdownInputOptions } from 'utils/formatters';
 import { ORDERS_TYPE_OPTIONS } from 'constants/orders';
 import { ExistingUploadsShape } from 'types';
+import { formatDateForSwagger } from 'shared/dates';
 
 export const EditOrders = ({
   serviceMember,
@@ -96,6 +97,8 @@ export const EditOrders = ({
       service_member_id: serviceMember.id,
       has_dependents: hasDependents,
       new_duty_location_id: newDutyLocationId,
+      issue_date: formatDateForSwagger(fieldValues.issue_date),
+      report_by_date: formatDateForSwagger(fieldValues.report_by_date),
       // spouse_has_pro_gear is not updated by this form but is a required value because the endpoint is shared with the
       // ppm office edit orders
       spouse_has_pro_gear: currentOrders.spouse_has_pro_gear,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12760) for this change

## Summary

This addresses a bug in a prime counseled PPM shipment seeing a Something Went Wrong error on the office side when the TOO approved a PPM shipment along with the move.  

The response to the approve shipment mutation did not load the PPM Shipment association on the MTO Shipment so when the react query updated the query cache and components re-rendered we tried to access PPM data to display it and got an undefined error.  The page tries to redirect you to the Move Task Order page but this bad cache invalidation causes the page to crash.

These are normally integration bugs that would be caught during Cypress tests where we lack coverage.

I would have been more thorough but this is a big demo blocker issue for us on Thursday so it's a bit rushed ❤️ 

## Setup to Run Your Code

💻 You will need to use three separate terminals to test this locally.

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make db_dev_e2e_populate && make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Sign in to the customer app with a user like `ppm.test.user1@example.com` and use the pre-filled postal codes, which will go to the TOO for approval and then the prime for counseling.
2. Login as the TOO to the default KKFA GBLOC and approve the shipment and a basic service item
3. There should no longer be a Something Went Wrong failure because the approve shipment response has the ppm shipment data loaded in the payload so it doesn't cause any undefined errors when destructuring the shipment props in any component.
4. You should be redirected to the Move Task Order page and the PPM shipment is shown

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

![Screen Shot 2022-06-14 at 9 48 13 AM](https://user-images.githubusercontent.com/52669884/173702236-0b6a733f-eebd-434c-9c5c-d552eaa70773.png)
