### PR TITLE
MB-12807 convert pkg/services tests

### DIFF
--- a/pkg/services/admin_user/admin_user_fetcher_test.go
+++ b/pkg/services/admin_user/admin_user_fetcher_test.go
@@ -3,7 +3,6 @@ package adminuser
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gobuffalo/validate/v3"
 
@@ -35,7 +34,7 @@ func (t *testAdminUserQueryBuilder) UpdateOne(appConfig appcontext.AppContext, m
 }
 
 func (suite *AdminUserServiceSuite) TestFetchAdminUser() {
-	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the user is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchOne := func(appConfig appcontext.AppContext, model interface{}) error {
@@ -56,7 +55,7 @@ func (suite *AdminUserServiceSuite) TestFetchAdminUser() {
 		suite.Equal(id, adminUser.ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with zero admin user", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with zero admin user", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/admin_user/admin_user_list_fetcher_test.go
+++ b/pkg/services/admin_user/admin_user_list_fetcher_test.go
@@ -3,7 +3,6 @@ package adminuser
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -43,7 +42,7 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *AdminUserServiceSuite) TestFetchAdminUserList() {
-	suite.T().Run("if the users are successfully fetched, they should be returned", func(t *testing.T) {
+	suite.Run("if the users are successfully fetched, they should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -66,7 +65,7 @@ func (suite *AdminUserServiceSuite) TestFetchAdminUserList() {
 		suite.Equal(id, adminUsers[0].ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no admin users", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no admin users", func() {
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/admin_user/admin_user_updater_test.go
+++ b/pkg/services/admin_user/admin_user_updater_test.go
@@ -1,8 +1,6 @@
 package adminuser
 
 import (
-	"testing"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
@@ -20,7 +18,7 @@ func (suite *AdminUserServiceSuite) TestUpdateAdminUser() {
 	}
 
 	// Happy path
-	suite.T().Run("If the user is updated successfully it should be returned", func(t *testing.T) {
+	suite.Run("If the user is updated successfully it should be returned", func() {
 		fakeUpdateOne := func(appcontext.AppContext, interface{}, *string) (*validate.Errors, error) {
 			return nil, nil
 		}
@@ -41,7 +39,7 @@ func (suite *AdminUserServiceSuite) TestUpdateAdminUser() {
 	})
 
 	// Bad organization ID
-	suite.T().Run("If we are provided a organization that doesn't exist, the create should fail", func(t *testing.T) {
+	suite.Run("If we are provided a organization that doesn't exist, the create should fail", func() {
 		fakeUpdateOne := func(appCtx appcontext.AppContext, model interface{}, eTag *string) (*validate.Errors, error) {
 			return nil, nil
 		}

--- a/pkg/services/dbtools/table_from_slice_creator_test.go
+++ b/pkg/services/dbtools/table_from_slice_creator_test.go
@@ -1,8 +1,6 @@
 package dbtools
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/appcontext"
 )
 
@@ -34,19 +32,19 @@ var validSlice = []TestStruct{
 func (suite *DBToolsServiceSuite) TestCreateTableFromSlice() {
 	tableFromSliceCreator := NewTableFromSliceCreator(true, false)
 
-	suite.T().Run("passing in a non-slice", func(t *testing.T) {
+	suite.Run("passing in a non-slice", func() {
 		err := tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), 1)
 		suite.Error(err)
 		suite.Equal("Parameter must be slice or array, but got int", err.Error())
 	})
 
-	suite.T().Run("passing in a slice, but not a slice of structs", func(t *testing.T) {
+	suite.Run("passing in a slice, but not a slice of structs", func() {
 		err := tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), []int{1, 2, 3})
 		suite.Error(err)
 		suite.Equal("Elements of slice must be type struct, but got int", err.Error())
 	})
 
-	suite.T().Run("passing in a slice of structs, but with a non-string field", func(t *testing.T) {
+	suite.Run("passing in a slice of structs, but with a non-string field", func() {
 		var invalidStructSlice []struct {
 			field1 string
 			field2 int
@@ -56,7 +54,7 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSlice() {
 		suite.Equal("All fields of struct must be string, but field field2 is int", err.Error())
 	})
 
-	suite.T().Run("valid slice of structs", func(t *testing.T) {
+	suite.Run("valid slice of structs", func() {
 		err := tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), validSlice)
 		suite.NoError(err)
 
@@ -69,8 +67,10 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSlice() {
 		}
 	})
 
-	suite.T().Run("errors out when table exists", func(t *testing.T) {
+	suite.Run("errors out when table exists", func() {
 		err := tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), validSlice)
+		suite.NoError(err)
+		err = tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), validSlice)
 		suite.Error(err)
 		// TODO: Fix this DB error string literal comparison when we move the COPY-related functionality to jackc/pgx.
 		if err != nil {
@@ -82,7 +82,7 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSlice() {
 func (suite *DBToolsServiceSuite) TestCreateTableFromSlicePermTable() {
 	tableFromSliceCreator := NewTableFromSliceCreator(true, true)
 
-	suite.T().Run("two runs no error when drop flag is true", func(t *testing.T) {
+	suite.Run("two runs no error when drop flag is true", func() {
 		err := tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), validSlice)
 		suite.NoError(err)
 		err = tableFromSliceCreator.CreateTableFromSlice(suite.AppContextForTest(), validSlice)
@@ -99,13 +99,13 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSlicePermTable() {
 }
 
 func (suite *DBToolsServiceSuite) TestCreateTableFromSliceWithinTransaction() {
-	suite.T().Run("create table from slice in a transaction", func(t *testing.T) {
+	var testStructs []TestStruct
+	suite.Run("create table from slice in a transaction", func() {
 		txnErr := suite.AppContextForTest().NewTransaction(func(txnAppCtx appcontext.AppContext) error {
 			tableFromSliceCreator := NewTableFromSliceCreator(true, true)
 			err := tableFromSliceCreator.CreateTableFromSlice(txnAppCtx, validSlice)
 			suite.NoError(err)
 
-			var testStructs []TestStruct
 			err = txnAppCtx.DB().Order("name").All(&testStructs)
 			suite.NoError(err)
 			suite.Len(testStructs, 3)
@@ -116,10 +116,7 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSliceWithinTransaction() {
 		})
 		suite.NoError(txnErr)
 
-	})
-
-	suite.T().Run("verify data still in database after transaction", func(t *testing.T) {
-		var testStructs []TestStruct
+		// Verify data still in table after transaction
 		err := suite.DB().Order("name").All(&testStructs)
 		suite.NoError(err)
 		suite.Len(testStructs, 3)

--- a/pkg/services/electronic_order/electronic_order_category_count_fetcher_test.go
+++ b/pkg/services/electronic_order/electronic_order_category_count_fetcher_test.go
@@ -2,7 +2,6 @@ package electronicorder
 
 import (
 	"errors"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
@@ -20,7 +19,7 @@ func (t *testElectronicOrderCategoricalCountQueryBuilder) FetchCategoricalCounts
 }
 
 func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderCategoricalCounts() {
-	suite.T().Run("If we get a match on the category we should get a map with the count", func(t *testing.T) {
+	suite.Run("If we get a match on the category we should get a map with the count", func() {
 
 		fakeFetchCategoricalCountsFromOneModel := func(appCtx appcontext.AppContext, model interface{}) (map[interface{}]int, error) {
 			value := map[interface{}]int{
@@ -43,7 +42,7 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderCategoricalCou
 		suite.Equal(3, counts[models.IssuerArmy])
 	})
 
-	suite.T().Run("If there's an error, we get it without counts", func(t *testing.T) {
+	suite.Run("If there's an error, we get it without counts", func() {
 		fakeFetchCategoricalCountsFromOneModel := func(appCtx appcontext.AppContext, model interface{}) (map[interface{}]int, error) {
 			return nil, errors.New("Fetch error")
 		}

--- a/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
@@ -3,7 +3,6 @@ package electronicorder
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -43,7 +42,7 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
-	suite.T().Run("if the transportation order is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the transportation order is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -66,7 +65,7 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 		suite.Equal(id, electronicOrders[0].ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no electronic orders", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no electronic orders", func() {
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/fetch/fetcher_test.go
+++ b/pkg/services/fetch/fetcher_test.go
@@ -3,7 +3,6 @@ package fetch
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -23,7 +22,7 @@ func (t *testFetcherQueryBuilder) FetchOne(appCtx appcontext.AppContext, model i
 }
 
 func (suite *FetchServiceSuite) TestFetchRecord() {
-	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the user is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetch := func(appCtx appcontext.AppContext, model interface{}, filters []services.QueryFilter) error {
@@ -47,7 +46,7 @@ func (suite *FetchServiceSuite) TestFetchRecord() {
 		suite.Equal(id, officeUser.ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no office user", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no office user", func() {
 		fakeFetch := func(appCtx appcontext.AppContext, model interface{}, filters []services.QueryFilter) error {
 			return errors.New("Fetch error")
 		}
@@ -65,7 +64,7 @@ func (suite *FetchServiceSuite) TestFetchRecord() {
 		suite.Equal(models.OfficeUser{}, *officeUser)
 	})
 
-	suite.T().Run("reflection error", func(t *testing.T) {
+	suite.Run("reflection error", func() {
 		fakeFetch := func(appCtx appcontext.AppContext, model interface{}, filters []services.QueryFilter) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/fetch/list_fetcher_test.go
+++ b/pkg/services/fetch/list_fetcher_test.go
@@ -3,7 +3,6 @@ package fetch
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -43,7 +42,7 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *FetchServiceSuite) TestFetchRecordList() {
-	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the user is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -67,7 +66,7 @@ func (suite *FetchServiceSuite) TestFetchRecordList() {
 		suite.Equal(id, officeUsers[0].ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no office users", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no office users", func() {
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/move/financial_review_flag_setter_test.go
+++ b/pkg/services/move/financial_review_flag_setter_test.go
@@ -2,7 +2,6 @@ package move
 
 import (
 	"errors"
-	"testing"
 
 	"github.com/go-openapi/swag"
 
@@ -19,7 +18,7 @@ func (suite *MoveServiceSuite) TestFinancialReviewFlagSetter() {
 	flagCreator := NewFinancialReviewFlagSetter()
 	defaultFlagReason := "destination address is far from duty location"
 
-	suite.T().Run("flag can be set", func(t *testing.T) {
+	suite.Run("flag can be set", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(move.UpdatedAt)
 
@@ -35,7 +34,7 @@ func (suite *MoveServiceSuite) TestFinancialReviewFlagSetter() {
 		suite.Require().Equal(defaultFlagReason, *move.FinancialReviewRemarks)
 	})
 
-	suite.T().Run("Wrong moveID should result in error", func(t *testing.T) {
+	suite.Run("Wrong moveID should result in error", func() {
 		wrongUUID := uuid.Must(uuid.NewV4())
 
 		_, err := flagCreator.SetFinancialReviewFlag(suite.AppContextForTest(), wrongUUID, "", true, &defaultFlagReason)
@@ -43,7 +42,7 @@ func (suite *MoveServiceSuite) TestFinancialReviewFlagSetter() {
 		suite.Require().True(errors.As(err, &apperror.NotFoundError{}))
 	})
 
-	suite.T().Run("Empty remarks param should result in error", func(t *testing.T) {
+	suite.Run("Empty remarks param should result in error", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(move.UpdatedAt)
 
@@ -52,7 +51,7 @@ func (suite *MoveServiceSuite) TestFinancialReviewFlagSetter() {
 		suite.Require().True(errors.As(err, &apperror.InvalidInputError{}))
 	})
 
-	suite.T().Run("setting flag after it has already been set should have no effect", func(t *testing.T) {
+	suite.Run("setting flag after it has already been set should have no effect", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(move.UpdatedAt)
 		// Make sure move starts out as we expect it to
@@ -70,7 +69,7 @@ func (suite *MoveServiceSuite) TestFinancialReviewFlagSetter() {
 
 	})
 	// If we set the flag to false, the timestamp and remarks fields should be nilled out
-	suite.T().Run("when flag is set to false we nil out FinancialReviewFlagSetAt and FinancialReviewRemarks", func(t *testing.T) {
+	suite.Run("when flag is set to false we nil out FinancialReviewFlagSetAt and FinancialReviewRemarks", func() {
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(move.UpdatedAt)
 

--- a/pkg/services/move/move_fetcher_test.go
+++ b/pkg/services/move/move_fetcher_test.go
@@ -1,7 +1,6 @@
 package move
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -14,7 +13,7 @@ func (suite *MoveServiceSuite) TestMoveFetcher() {
 	moveFetcher := NewMoveFetcher()
 	defaultSearchParams := services.MoveFetcherParams{}
 
-	suite.T().Run("successfully returns default draft move", func(t *testing.T) {
+	suite.Run("successfully returns default draft move", func() {
 		expectedMove := testdatagen.MakeDefaultMove(suite.DB())
 
 		actualMove, err := moveFetcher.FetchMove(suite.AppContextForTest(), expectedMove.Locator, &defaultSearchParams)
@@ -32,7 +31,7 @@ func (suite *MoveServiceSuite) TestMoveFetcher() {
 		suite.Equal(expectedMove.ReferenceID, actualMove.ReferenceID)
 	})
 
-	suite.T().Run("successfully returns submitted move available to prime", func(t *testing.T) {
+	suite.Run("successfully returns submitted move available to prime", func() {
 		expectedMove := testdatagen.MakeAvailableMove(suite.DB())
 
 		actualMove, err := moveFetcher.FetchMove(suite.AppContextForTest(), expectedMove.Locator, &defaultSearchParams)
@@ -50,7 +49,7 @@ func (suite *MoveServiceSuite) TestMoveFetcher() {
 		suite.Equal(expectedMove.ReferenceID, actualMove.ReferenceID)
 	})
 
-	suite.T().Run("returns not found error for unknown locator", func(t *testing.T) {
+	suite.Run("returns not found error for unknown locator", func() {
 		_ = testdatagen.MakeAvailableMove(suite.DB())
 
 		_, err := moveFetcher.FetchMove(suite.AppContextForTest(), "QX97UY", &defaultSearchParams)
@@ -58,7 +57,7 @@ func (suite *MoveServiceSuite) TestMoveFetcher() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns not found for a move that is marked hidden in the db", func(t *testing.T) {
+	suite.Run("Returns not found for a move that is marked hidden in the db", func() {
 		hide := false
 		hiddenMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
@@ -76,7 +75,7 @@ func (suite *MoveServiceSuite) TestMoveFetcher() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Returns hidden move if explicit param is passed in", func(t *testing.T) {
+	suite.Run("Returns hidden move if explicit param is passed in", func() {
 		hide := false
 		actualMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{

--- a/pkg/services/move/move_list_fetcher_test.go
+++ b/pkg/services/move/move_list_fetcher_test.go
@@ -3,7 +3,6 @@ package move
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -43,7 +42,7 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *MoveServiceSuite) TestFetchMoveList() {
-	suite.T().Run("if the move is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the move is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -66,7 +65,7 @@ func (suite *MoveServiceSuite) TestFetchMoveList() {
 		suite.Equal(id, moves[0].ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no moves", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no moves", func() {
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/move/validation_test.go
+++ b/pkg/services/move/validation_test.go
@@ -1,7 +1,6 @@
 package move
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -53,7 +52,7 @@ func (suite *MoveServiceSuite) TestMoveValidation() {
 			},
 		}
 		for name, test := range testCases {
-			suite.T().Run(name, func(t *testing.T) {
+			suite.Run(name, func() {
 				err := checkMoveVisibility().Validate(appCtx, test.move, test.delta)
 				suite.IsType(test.result, err)
 			})
@@ -101,7 +100,7 @@ func (suite *MoveServiceSuite) TestMoveValidation() {
 			},
 		}
 		for name, test := range testCases {
-			suite.T().Run(name, func(t *testing.T) {
+			suite.Run(name, func() {
 				err := checkPrimeAvailability().Validate(appCtx, test.move, test.delta)
 				suite.IsType(test.result, err)
 			})

--- a/pkg/services/move_documents/weight_ticket_updater_test.go
+++ b/pkg/services/move_documents/weight_ticket_updater_test.go
@@ -571,7 +571,7 @@ func (suite *MoveDocumentServiceSuite) TestValueForEitherMakeOrModelFails() {
 	suite.NoVerrs(verrs)
 	suite.NoError(err)
 
-	suite.T().Run("weight ticket set has model but not make fails", func(t *testing.T) {
+	suite.Run("weight ticket set has model but not make fails", func() {
 		vehicleModel := "Wagon"
 		emptyWeight := (int64)(1000)
 		fullWeight := (int64)(2500)
@@ -600,7 +600,7 @@ func (suite *MoveDocumentServiceSuite) TestValueForEitherMakeOrModelFails() {
 		suite.NotEmpty(verrs)
 	})
 
-	suite.T().Run("weight ticket set has make but not model fails", func(t *testing.T) {
+	suite.Run("weight ticket set has make but not model fails", func() {
 		vehicleMake := "Radio Flyer"
 		emptyWeight := (int64)(1000)
 		fullWeight := (int64)(2500)

--- a/pkg/services/office/office_fetcher_test.go
+++ b/pkg/services/office/office_fetcher_test.go
@@ -3,7 +3,6 @@ package office
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -23,7 +22,7 @@ func (t *testOfficeQueryBuilder) FetchOne(appCtx appcontext.AppContext, model in
 }
 
 func (suite *OfficeServiceSuite) TestFetchOffice() {
-	suite.T().Run("if the transportation office is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the transportation office is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -43,7 +42,7 @@ func (suite *OfficeServiceSuite) TestFetchOffice() {
 		suite.Equal(id, office.ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with zero office", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with zero office", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/office/office_list_fetcher_test.go
+++ b/pkg/services/office/office_list_fetcher_test.go
@@ -3,7 +3,6 @@ package office
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gofrs/uuid"
 
@@ -43,7 +42,7 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *OfficeServiceSuite) TestFetchOfficeList() {
-	suite.T().Run("if the transportation office is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the transportation office is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -66,7 +65,7 @@ func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 		suite.Equal(id, offices[0].ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with no offices", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with no offices", func() {
 		fakeFetchMany := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/office_user/customer/customer_updater_test.go
+++ b/pkg/services/office_user/customer/customer_updater_test.go
@@ -1,7 +1,6 @@
 package customer
 
 import (
-	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -18,19 +17,19 @@ func (suite *CustomerServiceSuite) TestCustomerUpdater() {
 
 	customerUpdater := NewCustomerUpdater()
 
-	suite.T().Run("NewNotFoundError when customer if doesn't exist", func(t *testing.T) {
+	suite.Run("NewNotFoundError when customer if doesn't exist", func() {
 		_, err := customerUpdater.UpdateCustomer(suite.AppContextForTest(), "", models.ServiceMember{})
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("PreconditionsError when etag is stale", func(t *testing.T) {
+	suite.Run("PreconditionsError when etag is stale", func() {
 		staleEtag := etag.GenerateEtag(expectedCustomer.UpdatedAt.Add(-1 * time.Minute))
 		_, err := customerUpdater.UpdateCustomer(suite.AppContextForTest(), staleEtag, models.ServiceMember{ID: expectedCustomer.ID})
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Customer fields are updated", func(t *testing.T) {
+	suite.Run("Customer fields are updated", func() {
 		defaultCustomer := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 
 		var backupContacts []models.BackupContact

--- a/pkg/services/office_user/customer/customer_updater_test.go
+++ b/pkg/services/office_user/customer/customer_updater_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func (suite *CustomerServiceSuite) TestCustomerUpdater() {
-	expectedCustomer := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 
 	customerUpdater := NewCustomerUpdater()
 
@@ -24,6 +23,7 @@ func (suite *CustomerServiceSuite) TestCustomerUpdater() {
 	})
 
 	suite.Run("PreconditionsError when etag is stale", func() {
+		expectedCustomer := testdatagen.MakeExtendedServiceMember(suite.DB(), testdatagen.Assertions{})
 		staleEtag := etag.GenerateEtag(expectedCustomer.UpdatedAt.Add(-1 * time.Minute))
 		_, err := customerUpdater.UpdateCustomer(suite.AppContextForTest(), staleEtag, models.ServiceMember{ID: expectedCustomer.ID})
 		suite.IsType(apperror.PreconditionFailedError{}, err)

--- a/pkg/services/office_user/office_user_creator_test.go
+++ b/pkg/services/office_user/office_user_creator_test.go
@@ -3,7 +3,6 @@ package officeuser
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/notifications"
 
@@ -59,7 +58,7 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 	}
 
 	// Happy path - creates a new User as well
-	suite.T().Run("If the user is created successfully it should be returned", func(t *testing.T) {
+	suite.Run("If the user is created successfully it should be returned", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			switch model.(type) {
 			case *models.TransportationOffice:
@@ -89,11 +88,11 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 		suite.NotNil(officeUser.User)
 		suite.Equal(officeUser.User.ID, *officeUser.UserID)
 		suite.Equal(userInfo.Email, officeUser.User.LoginGovEmail)
-		mockSender.(*mocks.NotificationSender).AssertNumberOfCalls(t, "SendNotification", 1)
+		mockSender.(*mocks.NotificationSender).AssertNumberOfCalls(suite.T(), "SendNotification", 1)
 	})
 
 	// Reuses existing user if it's already been created for an admin or service member
-	suite.T().Run("Finds existing user by email and associates with office user", func(t *testing.T) {
+	suite.Run("Finds existing user by email and associates with office user", func() {
 		existingUserInfo := models.OfficeUser{
 			LastName:               "Spaceman",
 			FirstName:              "Leo",
@@ -129,11 +128,11 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 		suite.Nil(verrs)
 		suite.NotNil(officeUser.User)
 		suite.Equal(officeUser.User.ID, *officeUser.UserID)
-		mockSender.(*mocks.NotificationSender).AssertNumberOfCalls(t, "SendNotification", 0)
+		mockSender.(*mocks.NotificationSender).AssertNumberOfCalls(suite.T(), "SendNotification", 0)
 	})
 
 	// Bad transportation office ID
-	suite.T().Run("If we are provided a transportation office that doesn't exist, the create should fail", func(t *testing.T) {
+	suite.Run("If we are provided a transportation office that doesn't exist, the create should fail", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			return models.ErrFetchNotFound
 		}
@@ -150,7 +149,7 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 	})
 
 	// Transaction rollback on createOne validation failure
-	suite.T().Run("CreateOne validation error should rollback transaction", func(t *testing.T) {
+	suite.Run("CreateOne validation error should rollback transaction", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			switch model.(type) {
 			case *models.TransportationOffice:
@@ -194,7 +193,7 @@ func (suite *OfficeUserServiceSuite) TestCreateOfficeUser() {
 	})
 
 	// Transaction rollback on createOne error failure
-	suite.T().Run("CreateOne error should rollback transaction", func(t *testing.T) {
+	suite.Run("CreateOne error should rollback transaction", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			switch model.(type) {
 			case *models.TransportationOffice:

--- a/pkg/services/office_user/office_user_fetcher_test.go
+++ b/pkg/services/office_user/office_user_fetcher_test.go
@@ -3,7 +3,6 @@ package officeuser
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
@@ -42,7 +41,7 @@ func (t *testOfficeUserQueryBuilder) QueryForAssociations(appCtx appcontext.AppC
 }
 
 func (suite *OfficeUserServiceSuite) TestFetchOfficeUser() {
-	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the user is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -68,7 +67,7 @@ func (suite *OfficeUserServiceSuite) TestFetchOfficeUser() {
 		suite.Equal(id, officeUser.ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with zero office user", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with zero office user", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}
@@ -86,7 +85,7 @@ func (suite *OfficeUserServiceSuite) TestFetchOfficeUser() {
 }
 
 func (suite *OfficeUserServiceSuite) TestFetchOfficeUserPop() {
-	suite.T().Run("returns office user on success", func(t *testing.T) {
+	suite.Run("returns office user on success", func() {
 		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 		fetcher := NewOfficeUserFetcherPop()
 
@@ -96,7 +95,7 @@ func (suite *OfficeUserServiceSuite) TestFetchOfficeUserPop() {
 		suite.Equal(officeUser.ID, fetchedUser.ID)
 	})
 
-	suite.T().Run("returns zero value office user on error", func(t *testing.T) {
+	suite.Run("returns zero value office user on error", func() {
 		fetcher := NewOfficeUserFetcherPop()
 		officeUser, err := fetcher.FetchOfficeUserByID(suite.AppContextForTest(), uuid.Nil)
 

--- a/pkg/services/office_user/office_user_updater_test.go
+++ b/pkg/services/office_user/office_user_updater_test.go
@@ -2,7 +2,6 @@ package officeuser
 
 import (
 	"database/sql"
-	"testing"
 
 	"github.com/go-openapi/strfmt"
 
@@ -18,17 +17,22 @@ import (
 func (suite *OfficeUserServiceSuite) TestUpdateOfficeUser() {
 	queryBuilder := query.NewQueryBuilder()
 	updater := NewOfficeUserUpdater(queryBuilder)
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
-		OfficeUser: models.OfficeUser{
-			TransportationOffice: models.TransportationOffice{
-				Name: "Random Office",
+	setupTestData := func() models.OfficeUser {
+		officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
+			OfficeUser: models.OfficeUser{
+				TransportationOffice: models.TransportationOffice{
+					Name: "Random Office",
+				},
 			},
-		},
-	})
-	transportationOffice := testdatagen.MakeDefaultTransportationOffice(suite.DB())
+		})
+		return officeUser
+	}
 
 	// Happy path
-	suite.T().Run("If the user is updated successfully it should be returned", func(t *testing.T) {
+	suite.Run("If the user is updated successfully it should be returned", func() {
+		officeUser := setupTestData()
+		transportationOffice := testdatagen.MakeDefaultTransportationOffice(suite.DB())
+
 		firstName := "Lea"
 		payload := &adminmessages.OfficeUserUpdatePayload{
 			FirstName:              &firstName,
@@ -45,7 +49,7 @@ func (suite *OfficeUserServiceSuite) TestUpdateOfficeUser() {
 	})
 
 	// Bad office user ID
-	suite.T().Run("If we are provided an office user that doesn't exist, the create should fail", func(t *testing.T) {
+	suite.Run("If we are provided an office user that doesn't exist, the create should fail", func() {
 		payload := &adminmessages.OfficeUserUpdatePayload{}
 
 		_, _, err := updater.UpdateOfficeUser(suite.AppContextForTest(), uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001"), payload)
@@ -54,7 +58,8 @@ func (suite *OfficeUserServiceSuite) TestUpdateOfficeUser() {
 	})
 
 	// Bad transportation office ID
-	suite.T().Run("If we are provided a transportation office that doesn't exist, the create should fail", func(t *testing.T) {
+	suite.Run("If we are provided a transportation office that doesn't exist, the create should fail", func() {
+		officeUser := setupTestData()
 		payload := &adminmessages.OfficeUserUpdatePayload{
 			TransportationOfficeID: strfmt.UUID("00000000-0000-0000-0000-000000000001"),
 		}

--- a/pkg/services/pagination/pagination_test.go
+++ b/pkg/services/pagination/pagination_test.go
@@ -1,9 +1,7 @@
 package pagination
 
-import "testing"
-
 func (suite *PaginationServiceSuite) TestOffset() {
-	suite.T().Run("should return the correct offset for a given page", func(t *testing.T) {
+	suite.Run("should return the correct offset for a given page", func() {
 		page, perPage := int64(4), int64(25)
 		pagination := NewPagination(&page, &perPage)
 

--- a/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
+++ b/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
@@ -1,8 +1,6 @@
 package paymentserviceitem
 
 import (
-	"testing"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
@@ -14,7 +12,7 @@ import (
 )
 
 func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
-	suite.T().Run("Successfully approves a payment service item", func(t *testing.T) {
+	suite.Run("Successfully approves a payment service item", func() {
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 		eTag := etag.GenerateEtag(paymentServiceItem.UpdatedAt)
 		updater := NewPaymentServiceItemStatusUpdater()
@@ -32,7 +30,7 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 
 	})
 
-	suite.T().Run("Successfully rejects a payment service item", func(t *testing.T) {
+	suite.Run("Successfully rejects a payment service item", func() {
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 		eTag := etag.GenerateEtag(paymentServiceItem.UpdatedAt)
 		updater := NewPaymentServiceItemStatusUpdater()
@@ -50,7 +48,7 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 
 	})
 
-	suite.T().Run("Fails if we can't find an existing paymentServiceItem", func(t *testing.T) {
+	suite.Run("Fails if we can't find an existing paymentServiceItem", func() {
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 		eTag := etag.GenerateEtag(paymentServiceItem.UpdatedAt)
 		updater := NewPaymentServiceItemStatusUpdater()
@@ -63,7 +61,7 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Fails if we have a stale eTag", func(t *testing.T) {
+	suite.Run("Fails if we have a stale eTag", func() {
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 		// Arbitrary date time that isn't the record updatedAt used here
 		badETag := etag.GenerateEtag(testdatagen.DateInsidePerformancePeriod)
@@ -76,7 +74,7 @@ func (suite *PaymentServiceItemSuite) TestUpdatePaymentServiceItemStatus() {
 		suite.IsType(apperror.PreconditionFailedError{}, err)
 	})
 
-	suite.T().Run("Fails if we attempt to reject without a rejection reason", func(t *testing.T) {
+	suite.Run("Fails if we attempt to reject without a rejection reason", func() {
 		paymentServiceItem := testdatagen.MakeDefaultPaymentServiceItem(suite.DB())
 		eTag := etag.GenerateEtag(paymentServiceItem.UpdatedAt)
 		updater := NewPaymentServiceItemStatusUpdater()

--- a/pkg/services/reweigh/reweigh_creator_test.go
+++ b/pkg/services/reweigh/reweigh_creator_test.go
@@ -1,7 +1,6 @@
 package reweigh
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -14,19 +13,19 @@ import (
 
 func (suite *ReweighSuite) TestReweighCreator() {
 	// Create new mtoShipment
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{})
 
-	// Create a valid reweigh for the move
-	newReweigh := &models.Reweigh{
-		RequestedAt: time.Now(),
-		RequestedBy: models.ReweighRequesterPrime,
-		ShipmentID:  mtoShipment.ID,
-	}
-
-	suite.T().Run("CreateReweigh - Success", func(t *testing.T) {
+	suite.Run("CreateReweigh - Success", func() {
 		// Under test:	CreateReweigh
 		// Set up:		Established valid shipment and valid reweigh
 		// Expected:	New reweigh successfully created
+		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{})
+
+		// Create a valid reweigh for the move
+		newReweigh := &models.Reweigh{
+			RequestedAt: time.Now(),
+			RequestedBy: models.ReweighRequesterPrime,
+			ShipmentID:  mtoShipment.ID,
+		}
 		reweighCreator := NewReweighCreator()
 		createdReweigh, err := reweighCreator.CreateReweighCheck(suite.AppContextForTest(), newReweigh)
 
@@ -37,9 +36,15 @@ func (suite *ReweighSuite) TestReweighCreator() {
 	})
 
 	// InvalidInputError
-	suite.T().Run("Reweigh with validation errors returns an InvalidInputError", func(t *testing.T) {
-		badRequestedby := models.ReweighRequester("not requested by anyone")
-		newReweigh.RequestedBy = badRequestedby
+	suite.Run("Reweigh with validation errors returns an InvalidInputError", func() {
+		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{})
+
+		// Create a reweigh with a bad requester
+		newReweigh := &models.Reweigh{
+			RequestedAt: time.Now(),
+			RequestedBy: models.ReweighRequester("not requested by anyone"),
+			ShipmentID:  mtoShipment.ID,
+		}
 		reweighCreator := NewReweighCreator()
 		createReweigh, err := reweighCreator.CreateReweighCheck(suite.AppContextForTest(), newReweigh)
 
@@ -48,9 +53,14 @@ func (suite *ReweighSuite) TestReweighCreator() {
 		suite.IsType(apperror.InvalidInputError{}, err)
 	})
 
-	suite.T().Run("Not Found Error", func(t *testing.T) {
-		notFoundUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
-		newReweigh.ShipmentID = notFoundUUID
+	suite.Run("Not Found Error", func() {
+
+		// Create a reweigh with a shipment that doesn't exist
+		newReweigh := &models.Reweigh{
+			RequestedAt: time.Now(),
+			RequestedBy: models.ReweighRequesterPrime,
+			ShipmentID:  uuid.Must(uuid.NewV4()),
+		}
 		reweighCreator := NewReweighCreator()
 		createdReweigh, err := reweighCreator.CreateReweighCheck(suite.AppContextForTest(), newReweigh)
 

--- a/pkg/services/reweigh/reweigh_updater_test.go
+++ b/pkg/services/reweigh/reweigh_updater_test.go
@@ -1,7 +1,6 @@
 package reweigh
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -42,19 +41,20 @@ func (suite *ReweighSuite) TestReweighUpdater() {
 
 	reweighUpdater := NewReweighUpdater(movetaskorder.NewMoveTaskOrderChecker(), paymentRequestShipmentRecalculator)
 	currentTime := time.Now()
-	shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			AvailableToPrimeAt: &currentTime,
-		},
-	})
-	oldReweigh := testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{
-		MTOShipment: shipment,
-	})
-	eTag := etag.GenerateEtag(oldReweigh.UpdatedAt)
-	newReweigh := oldReweigh
 
 	// Test Success - Reweigh updated
-	suite.T().Run("Updated reweigh - Success", func(t *testing.T) {
+	suite.Run("Updated reweigh - Success", func() {
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &currentTime,
+			},
+		})
+		oldReweigh := testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{
+			MTOShipment: shipment,
+		})
+		eTag := etag.GenerateEtag(oldReweigh.UpdatedAt)
+
+		newReweigh := oldReweigh
 		newWeight := unit.Pound(200)
 		newReweigh.Weight = &newWeight
 		updatedReweigh, err := reweighUpdater.UpdateReweighCheck(suite.AppContextForTest(), &newReweigh, eTag)
@@ -62,24 +62,39 @@ func (suite *ReweighSuite) TestReweighUpdater() {
 		suite.NoError(err)
 		suite.NotNil(updatedReweigh)
 		suite.Equal(newWeight, *updatedReweigh.Weight)
-		eTag = etag.GenerateEtag(updatedReweigh.UpdatedAt)
 	})
 	// Test NotFoundError
-	suite.T().Run("Not Found Error", func(t *testing.T) {
-		notFoundUUID := "00000000-0000-0000-0000-000000000001"
-		notFoundReweigh := newReweigh
-		notFoundReweigh.ID = uuid.FromStringOrNil(notFoundUUID)
+	suite.Run("Not Found Error", func() {
+		notFoundReweigh := testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{
+			Stub: true,
+			Reweigh: models.Reweigh{
+				ID: uuid.Must(uuid.NewV4()),
+			},
+		})
+		eTag := etag.GenerateEtag(time.Now())
 
 		updatedReweigh, err := reweighUpdater.UpdateReweighCheck(suite.AppContextForTest(), &notFoundReweigh, eTag)
 
 		suite.Nil(updatedReweigh)
 		suite.Error(err)
 		suite.IsType(apperror.NotFoundError{}, err)
-		suite.Contains(err.Error(), notFoundUUID)
+		suite.Contains(err.Error(), notFoundReweigh.ID.String())
 	})
 	// PreconditionFailedError
-	suite.T().Run("Precondition Failed", func(t *testing.T) {
-		updatedReweigh, err := reweighUpdater.UpdateReweighCheck(suite.AppContextForTest(), &newReweigh, "nada") // base validation
+	suite.Run("Precondition Failed", func() {
+		shipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				AvailableToPrimeAt: &currentTime,
+			},
+		})
+		oldReweigh := testdatagen.MakeReweigh(suite.DB(), testdatagen.Assertions{
+			MTOShipment: shipment,
+		})
+		// bad etag value
+		eTag := etag.GenerateEtag(time.Now())
+		newReweigh := oldReweigh
+
+		updatedReweigh, err := reweighUpdater.UpdateReweighCheck(suite.AppContextForTest(), &newReweigh, eTag) // base validation
 
 		suite.Nil(updatedReweigh)
 		suite.Error(err)

--- a/pkg/services/sit_extension/sit_extension_creator_test.go
+++ b/pkg/services/sit_extension/sit_extension_creator_test.go
@@ -1,8 +1,6 @@
 package sitextension
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
@@ -15,18 +13,18 @@ import (
 )
 
 func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
-	move := testdatagen.MakeAvailableMove(suite.DB())
 
 	// Create move router for SitExtension Createor
 	moveRouter := moverouter.NewMoveRouter()
 	sitExtensionCreator := NewSitExtensionCreator(moveRouter)
 	movefetcher := movefetcher.NewMoveTaskOrderFetcher()
 
-	suite.T().Run("Success - CreateSITExtension with no status passed in", func(t *testing.T) {
+	suite.Run("Success - CreateSITExtension with no status passed in", func() {
 		// Under test:	CreateSITExtension
 		// Set up:		Established valid shipment and valid SIT extension
 		// Expected:	New sit successfully created
 		// Create new mtoShipment
+		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &move, testdatagen.Assertions{})
 
 		// Create a valid SIT Extension for the move
@@ -57,7 +55,8 @@ func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
 	})
 
 	// InvalidInputError
-	suite.T().Run("Failure - SIT Extension with validation errors returns an InvalidInputError", func(t *testing.T) {
+	suite.Run("Failure - SIT Extension with validation errors returns an InvalidInputError", func() {
+		move := testdatagen.MakeAvailableMove(suite.DB())
 		shipment := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &move, testdatagen.Assertions{})
 
 		// Create a SIT Extension for the move
@@ -74,7 +73,7 @@ func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
 		suite.IsType(apperror.InvalidInputError{}, err)
 	})
 
-	suite.T().Run("Failure - Not Found Error because shipment not found", func(t *testing.T) {
+	suite.Run("Failure - Not Found Error because shipment not found", func() {
 		// Create a SIT Extension for the move
 		sit := &models.SITExtension{
 			MTOShipmentID: uuid.Must(uuid.NewV4()),
@@ -86,7 +85,8 @@ func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Failure - Not Found Error because shipment uses external vendor", func(t *testing.T) {
+	suite.Run("Failure - Not Found Error because shipment uses external vendor", func() {
+		move := testdatagen.MakeAvailableMove(suite.DB())
 		externalShipment := testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
 			MTOShipment: models.MTOShipment{
@@ -106,8 +106,9 @@ func (suite *SitExtensionServiceSuite) TestSITExtensionCreator() {
 		suite.IsType(apperror.NotFoundError{}, err)
 	})
 
-	suite.T().Run("Success - CreateSITExtension with status passed in ", func(t *testing.T) {
+	suite.Run("Success - CreateSITExtension with status passed in ", func() {
 		// Create new mtoShipment
+		move := testdatagen.MakeAvailableMove(suite.DB())
 		move2 := testdatagen.MakeAvailableMove(suite.DB())
 		shipment2 := testdatagen.MakeMTOShipmentWithMove(suite.DB(), &move, testdatagen.Assertions{})
 

--- a/pkg/services/upload/upload_creator_test.go
+++ b/pkg/services/upload/upload_creator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage/test"
@@ -19,7 +18,7 @@ func (suite *UploadServiceSuite) TestCreateUpload() {
 	testFile, fileErr := os.Open("../../testdatagen/testdata/test.pdf")
 	suite.Require().NoError(fileErr)
 
-	suite.T().Run("Success - Upload is created", func(t *testing.T) {
+	suite.Run("Success - Upload is created", func() {
 		upload, err := uploadCreator.CreateUpload(suite.AppContextForTest(), testFile, testFileName, models.UploadTypePRIME)
 		suite.NoError(err)
 		suite.Require().NotNil(upload)
@@ -30,7 +29,7 @@ func (suite *UploadServiceSuite) TestCreateUpload() {
 		suite.Equal(upload.Filename, upload.StorageKey)
 	})
 
-	suite.T().Run("Fail - Upload with invalid type causes an error", func(t *testing.T) {
+	suite.Run("Fail - Upload with invalid type causes an error", func() {
 		upload, err := uploadCreator.CreateUpload(suite.AppContextForTest(), testFile, testFileName, "INVALID")
 		suite.Nil(upload)
 		suite.Require().Error(err)

--- a/pkg/services/upload/upload_information_fetcher_test.go
+++ b/pkg/services/upload/upload_information_fetcher_test.go
@@ -1,8 +1,6 @@
 package upload
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *UploadServiceSuite) TestFetchUploadInformation() {
-	suite.T().Run("fetch office user upload", func(t *testing.T) {
+	suite.Run("fetch office user upload", func() {
 		email := "officeuser1@example.com"
 		ou := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 			User: models.User{
@@ -43,7 +41,7 @@ func (suite *UploadServiceSuite) TestFetchUploadInformation() {
 		suite.Equal(ou.Telephone, *ui.OfficeUserPhone)
 	})
 
-	suite.T().Run("fetch service member upload", func(t *testing.T) {
+	suite.Run("fetch service member upload", func() {
 		uu := testdatagen.MakeDefaultUserUpload(suite.DB())
 		uif := NewUploadInformationFetcher()
 		suite.NotNil(uu.UploadID)

--- a/pkg/services/user/user_fetcher_test.go
+++ b/pkg/services/user/user_fetcher_test.go
@@ -3,7 +3,6 @@ package user
 import (
 	"errors"
 	"reflect"
-	"testing"
 
 	"github.com/gobuffalo/validate/v3"
 
@@ -30,7 +29,7 @@ func (t *testUserQueryBuilder) UpdateOne(appCtx appcontext.AppContext, model int
 }
 
 func (suite *UserServiceSuite) TestFetchUser() {
-	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
+	suite.Run("if the user is fetched, it should be returned", func() {
 		id, err := uuid.NewV4()
 		suite.NoError(err)
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
@@ -51,7 +50,7 @@ func (suite *UserServiceSuite) TestFetchUser() {
 		suite.Equal(id, user.ID)
 	})
 
-	suite.T().Run("if there is an error, we get it with zero user", func(t *testing.T) {
+	suite.Run("if there is an error, we get it with zero user", func() {
 		fakeFetchOne := func(appCtx appcontext.AppContext, model interface{}) error {
 			return errors.New("Fetch error")
 		}

--- a/pkg/services/user/user_session_revocation_test.go
+++ b/pkg/services/user/user_session_revocation_test.go
@@ -11,7 +11,6 @@ package user
 
 import (
 	"reflect"
-	"testing"
 	"time"
 
 	"github.com/alexedwards/scs/v2/memstore"
@@ -47,7 +46,7 @@ func (suite *UserServiceSuite) TestRevokeMilUserSession() {
 		RevokeMilSession: &boolean,
 	}
 
-	suite.T().Run("Key is removed from Redis when boolean is true", func(t *testing.T) {
+	suite.Run("Key is removed from Redis when boolean is true", func() {
 		_, existsBefore, _ := sessionStore.Find(sessionID)
 
 		suite.Equal(existsBefore, true)
@@ -60,7 +59,7 @@ func (suite *UserServiceSuite) TestRevokeMilUserSession() {
 		suite.Equal(existsAfter, false)
 	})
 
-	suite.T().Run("Key is not removed from Redis when boolean is false", func(t *testing.T) {
+	suite.Run("Key is not removed from Redis when boolean is false", func() {
 		sessionStore.Commit(sessionID, []byte("encoded_data"), time.Now().Add(time.Minute))
 		boolean = false
 		payload = &adminmessages.UserUpdatePayload{
@@ -75,7 +74,7 @@ func (suite *UserServiceSuite) TestRevokeMilUserSession() {
 		suite.Equal(exists, true)
 	})
 
-	suite.T().Run("Returns an error if user is not found", func(t *testing.T) {
+	suite.Run("Returns an error if user is not found", func() {
 		fakeUpdateOne := func(appCtx appcontext.AppContext, model interface{}, eTag *string) (*validate.Errors, error) {
 			return nil, nil
 		}
@@ -121,7 +120,7 @@ func (suite *UserServiceSuite) TestRevokeAdminUserSession() {
 		RevokeAdminSession: &boolean,
 	}
 
-	suite.T().Run("Key is removed from Redis when boolean is true", func(t *testing.T) {
+	suite.Run("Key is removed from Redis when boolean is true", func() {
 		_, existsBefore, _ := sessionStore.Find(sessionID)
 
 		suite.Equal(existsBefore, true)
@@ -134,7 +133,7 @@ func (suite *UserServiceSuite) TestRevokeAdminUserSession() {
 		suite.Equal(existsAfter, false)
 	})
 
-	suite.T().Run("Key is not removed from Redis when boolean is false", func(t *testing.T) {
+	suite.Run("Key is not removed from Redis when boolean is false", func() {
 		sessionStore.Commit(sessionID, []byte("encoded_data"), time.Now().Add(time.Minute))
 		boolean = false
 		payload = &adminmessages.UserUpdatePayload{
@@ -174,7 +173,7 @@ func (suite *UserServiceSuite) TestRevokeOfficeUserSession() {
 		RevokeOfficeSession: &boolean,
 	}
 
-	suite.T().Run("Key is removed from Redis when boolean is true", func(t *testing.T) {
+	suite.Run("Key is removed from Redis when boolean is true", func() {
 		_, existsBefore, _ := sessionStore.Find(sessionID)
 
 		suite.Equal(existsBefore, true)
@@ -187,7 +186,7 @@ func (suite *UserServiceSuite) TestRevokeOfficeUserSession() {
 		suite.Equal(existsAfter, false)
 	})
 
-	suite.T().Run("Key is not removed from Redis when boolean is false", func(t *testing.T) {
+	suite.Run("Key is not removed from Redis when boolean is false", func() {
 		sessionStore.Commit(sessionID, []byte("encoded_data"), time.Now().Add(time.Minute))
 		boolean = false
 		payload = &adminmessages.UserUpdatePayload{
@@ -235,7 +234,7 @@ func (suite *UserServiceSuite) TestRevokeMultipleSessions() {
 		RevokeMilSession:    &boolean,
 	}
 
-	suite.T().Run("All keys are removed from Redis when boolean is true", func(t *testing.T) {
+	suite.Run("All keys are removed from Redis when boolean is true", func() {
 		_, adminExistsBefore, _ := sessionStore.Find(adminSessionID)
 		_, officeExistsBefore, _ := sessionStore.Find(officeSessionID)
 		_, milExistsBefore, _ := sessionStore.Find(milSessionID)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12807) for this change

## Summary

Converts the package and tests in a number of `./pkg/services/` to use transactions. See ticket for full list.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)