### PR TITLE
Convert pkg/edi/segment tests

### DIFF
--- a/pkg/edi/edi824/parser_test.go
+++ b/pkg/edi/edi824/parser_test.go
@@ -22,7 +22,7 @@ func TestEDI824(t *testing.T) {
 }
 
 func (suite *EDI824Suite) TestParse() {
-	suite.T().Run("successfully parse simple 824 string", func(t *testing.T) {
+	suite.Run("successfully parse simple 824 string", func() {
 		sample824EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -142,7 +142,7 @@ IEA*1*000000001
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse simple 824 string with missing optional TED", func(t *testing.T) {
+	suite.Run("successfully parse simple 824 string with missing optional TED", func() {
 		sample824EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -214,7 +214,7 @@ IEA*1*000000001
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse complex 824 with loops", func(t *testing.T) {
+	suite.Run("successfully parse complex 824 with loops", func() {
 		sample824EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -620,7 +620,7 @@ IEA*1*000000001
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse sample real 824", func(t *testing.T) {
+	suite.Run("successfully parse sample real 824", func() {
 		sample824EDIString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|\rGS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010\rST*824*000000001\rBGN*11*1126-9404*20210217\rOTI*TR*BM*1126-9404*MILMOVE*8004171844*20210217**100001251*0001\rSE*5*000000001\rGE*1*1\rIEA*1*000000001\r"
 		edi824 := EDI{}
 		err := edi824.Parse(sample824EDIString)
@@ -682,7 +682,7 @@ IEA*1*000000001
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("fail to parse 824 with unknown segment", func(t *testing.T) {
+	suite.Run("fail to parse 824 with unknown segment", func() {
 		sample824EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010
@@ -700,7 +700,7 @@ IEA*1*000000001
 		suite.Contains(err.Error(), "unexpected row for EDI 824")
 	})
 
-	suite.T().Run("fail to parse 824 with bad format", func(t *testing.T) {
+	suite.Run("fail to parse 824 with bad format", func() {
 		sample824EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1544*U*00401*000000001*0*T*|
 GS*AG*8004171844*MILMOVE*20210217*1544*1*X*004010

--- a/pkg/edi/edi997/parser_test.go
+++ b/pkg/edi/edi997/parser_test.go
@@ -24,7 +24,7 @@ func TestEDI997Suite(t *testing.T) {
 
 func (suite *EDI997Suite) TestParse() {
 
-	suite.T().Run("successfully parse simple 997 string", func(t *testing.T) {
+	suite.Run("successfully parse simple 997 string", func() {
 		sample997EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
 GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
@@ -152,7 +152,7 @@ IEA*1*000000022
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse simple 997 string with AK4 and AK5 present", func(t *testing.T) {
+	suite.Run("successfully parse simple 997 string with AK4 and AK5 present", func() {
 		sample997EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
 GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
@@ -247,7 +247,7 @@ IEA*1*000000022
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse simple 997 string with carriage returns instead of newlines", func(t *testing.T) {
+	suite.Run("successfully parse simple 997 string with carriage returns instead of newlines", func() {
 		sample997EDIString := "ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:\rGS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010\rST*997*0001\rAK1*SI*100001251\rAK2*858*0001\rAK3*ab*123\rAK4*1*2*3*4*MM*bad data goes here 89\rAK5*A\rAK9*A*1*1*1\rSE*6*0001\rGE*1*220001\rIEA*1*000000022\r"
 		edi997 := EDI{}
 		err := edi997.Parse(sample997EDIString)
@@ -329,7 +329,7 @@ IEA*1*000000022
 		suite.validateIEA(ieaString, iea)
 	})
 
-	suite.T().Run("successfully parse complex 997 with loops", func(t *testing.T) {
+	suite.Run("successfully parse complex 997 with loops", func() {
 		sample997EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
 GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
@@ -638,7 +638,7 @@ IEA*1*000000022
 
 	})
 
-	suite.T().Run("fail to parse 997 with unknown segment", func(t *testing.T) {
+	suite.Run("fail to parse 997 with unknown segment", func() {
 		sample997EDIString := `
 ISA*00*          *00*          *12*8004171844     *ZZ*MILMOVE        *210217*1530*U*00401*000000022*0*T*:
 GS*FA*8004171844*MILMOVE*20210217*152945*220001*X*004010
@@ -659,7 +659,7 @@ IEA*1*000000022
 		suite.Contains(err.Error(), "unexpected row for EDI 997")
 	})
 
-	suite.T().Run("fail to parse 997 with bad format", func(t *testing.T) {
+	suite.Run("fail to parse 997 with bad format", func() {
 		sample997EDIString := `
 ISA*00
 GS

--- a/pkg/edi/edi_test.go
+++ b/pkg/edi/edi_test.go
@@ -39,7 +39,7 @@ func (suite *EDISuite) TestNewScanLine() {
 		"line 4",
 	}
 
-	suite.T().Run("successfully read lines broken by newline \\n", func(t *testing.T) {
+	suite.Run("successfully read lines broken by newline \\n", func() {
 		scanner := bufio.NewScanner(strings.NewReader(strings.Join(expected, "\n")))
 		scanner.Split(SplitLines)
 		idx := 0
@@ -50,7 +50,7 @@ func (suite *EDISuite) TestNewScanLine() {
 		suite.Equal(len(expected), idx, "Processed less lines than expected")
 	})
 
-	suite.T().Run("successfully read lines broken by carriage return and newline \\r\\n", func(t *testing.T) {
+	suite.Run("successfully read lines broken by carriage return and newline \\r\\n", func() {
 		scanner := bufio.NewScanner(strings.NewReader(strings.Join(expected, "\r\n")))
 		scanner.Split(SplitLines)
 		idx := 0
@@ -61,7 +61,7 @@ func (suite *EDISuite) TestNewScanLine() {
 		suite.Equal(len(expected), idx, "Processed less lines than expected")
 	})
 
-	suite.T().Run("successfully read lines broken by only carriage return \\r", func(t *testing.T) {
+	suite.Run("successfully read lines broken by only carriage return \\r", func() {
 		scanner := bufio.NewScanner(strings.NewReader(strings.Join(expected, "\r")))
 		scanner.Split(SplitLines)
 		idx := 0

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -51,7 +51,7 @@ func TestInvoiceSuite(t *testing.T) {
 }
 
 func (suite *InvoiceSuite) TestEDIString() {
-	suite.T().Run("full EDI string is expected", func(t *testing.T) {
+	suite.Run("full EDI string is expected", func() {
 		invoice := MakeValidEdi()
 		ediString, err := invoice.EDIString(suite.Logger())
 		suite.NoError(err)
@@ -89,7 +89,7 @@ IEA*1*000009999
 }
 
 func (suite *InvoiceSuite) TestValidate() {
-	suite.T().Run("everything validates successfully", func(t *testing.T) {
+	suite.Run("everything validates successfully", func() {
 		invoice := MakeValidEdi()
 		err := invoice.Validate()
 		suite.NoError(err, "Failed to get invoice 858C as EDI string")

--- a/pkg/edi/segment/ak1_test.go
+++ b/pkg/edi/segment/ak1_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateAK1() {
 	validAK1 := AK1{
 		FunctionalIdentifierCode: "SI",
 		GroupControlNumber:       1234567,
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validAK1)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		ak1 := AK1{
 			FunctionalIdentifierCode: "XX", // eq
 			GroupControlNumber:       0,    // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateAK1() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		ak1 := AK1{
 			FunctionalIdentifierCode: "SI",
 			GroupControlNumber:       999999999999999, // max

--- a/pkg/edi/segment/ak2_test.go
+++ b/pkg/edi/segment/ak2_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateAK2() {
 	validAK2 := AK2{
 		TransactionSetIdentifierCode: "858",
 		TransactionSetControlNumber:  "ABCDE",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validAK2)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		ak2 := AK2{
 			TransactionSetIdentifierCode: "123", // eq
 			TransactionSetControlNumber:  "123", // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateAK2() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		ak2 := validAK2
 		ak2.TransactionSetControlNumber = "1234567890" // max
 

--- a/pkg/edi/segment/ak3_test.go
+++ b/pkg/edi/segment/ak3_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateAK3() {
 	validAK3 := AK3{
 		SegmentIDCode:                   "ID",
@@ -12,7 +8,7 @@ func (suite *SegmentSuite) TestValidateAK3() {
 		SegmentSyntaxErrorCode:          "ERR",
 	}
 
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		err := suite.validator.Struct(validAK3)
 		suite.NoError(err)
 	})
@@ -22,12 +18,12 @@ func (suite *SegmentSuite) TestValidateAK3() {
 		SegmentPositionInTransactionSet: 12345,
 	}
 
-	suite.T().Run("validate success with only required fields", func(t *testing.T) {
+	suite.Run("validate success with only required fields", func() {
 		err := suite.validator.Struct(altValidAK3)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure for min", func(t *testing.T) {
+	suite.Run("validate failure for min", func() {
 		ak3 := AK3{
 			SegmentIDCode:                   "", // min
 			SegmentPositionInTransactionSet: 0,  // min
@@ -39,7 +35,7 @@ func (suite *SegmentSuite) TestValidateAK3() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure for max", func(t *testing.T) {
+	suite.Run("validate failure for max", func() {
 		ak3 := AK3{
 			SegmentIDCode:                   "XXXX",    // max
 			SegmentPositionInTransactionSet: 9999999,   // max
@@ -57,7 +53,7 @@ func (suite *SegmentSuite) TestValidateAK3() {
 }
 
 func (suite *SegmentSuite) TestStringArrayAK3() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validAK3 := AK3{
 			SegmentIDCode:                   "ID",
 			SegmentPositionInTransactionSet: 12345,
@@ -68,7 +64,7 @@ func (suite *SegmentSuite) TestStringArrayAK3() {
 		suite.Equal(arrayValidAK3, validAK3.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validAK3 := AK3{
 			SegmentIDCode:                   "ID",
 			SegmentPositionInTransactionSet: 12345,
@@ -79,7 +75,7 @@ func (suite *SegmentSuite) TestStringArrayAK3() {
 }
 
 func (suite *SegmentSuite) TestParseAK3() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidAK3 := []string{"ID", "12345", "CODE", "ERR"}
 
 		expectedAK3 := AK3{
@@ -96,7 +92,7 @@ func (suite *SegmentSuite) TestParseAK3() {
 		}
 	})
 
-	suite.T().Run("parse success on required fields", func(t *testing.T) {
+	suite.Run("parse success on required fields", func() {
 		arrayValidAK3 := []string{"ID", "12345", "", ""}
 
 		expectedAK3 := AK3{
@@ -111,7 +107,7 @@ func (suite *SegmentSuite) TestParseAK3() {
 		}
 	})
 
-	suite.T().Run("wrong number of elements", func(t *testing.T) {
+	suite.Run("wrong number of elements", func() {
 		badArrayAK3 := []string{"11"}
 		var badAK3 AK3
 		err := badAK3.Parse(badArrayAK3)
@@ -120,7 +116,7 @@ func (suite *SegmentSuite) TestParseAK3() {
 		}
 	})
 
-	suite.T().Run("wrong number of elements greater than max", func(t *testing.T) {
+	suite.Run("wrong number of elements greater than max", func() {
 		badArrayAK3 := []string{"11", "12", "by", "goo", "fooz"}
 		var badAK3 AK3
 		err := badAK3.Parse(badArrayAK3)
@@ -129,7 +125,7 @@ func (suite *SegmentSuite) TestParseAK3() {
 		}
 	})
 
-	suite.T().Run("fail when SegmentPositionInTransactionSet not a valid int", func(t *testing.T) {
+	suite.Run("fail when SegmentPositionInTransactionSet not a valid int", func() {
 		badArrayAK3 := []string{"ID", "12345.4", "", ""}
 
 		var badAK3 AK3

--- a/pkg/edi/segment/ak4_test.go
+++ b/pkg/edi/segment/ak4_test.go
@@ -1,11 +1,7 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateAK4() {
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		validAK4 := AK4{
 			PositionInSegment:                       1,
 			ElementPositionInSegment:                1,
@@ -18,7 +14,7 @@ func (suite *SegmentSuite) TestValidateAK4() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success only required fields", func(t *testing.T) {
+	suite.Run("validate success only required fields", func() {
 		validOptionalAK4 := AK4{
 			PositionInSegment:          1,
 			ElementPositionInSegment:   1,
@@ -28,7 +24,7 @@ func (suite *SegmentSuite) TestValidateAK4() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		ak4 := AK4{
 			PositionInSegment:                       -1, // min
 			ElementPositionInSegment:                -1, // min
@@ -46,7 +42,7 @@ func (suite *SegmentSuite) TestValidateAK4() {
 		suite.ValidateErrorLen(err, 5)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		ak4 := AK4{
 			PositionInSegment:                       100,                                                                                                    // max
 			ElementPositionInSegment:                100,                                                                                                    // max
@@ -68,7 +64,7 @@ func (suite *SegmentSuite) TestValidateAK4() {
 }
 
 func (suite *SegmentSuite) TestStringArrayAK4() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validAK4 := AK4{
 			PositionInSegment:                       1,
 			ElementPositionInSegment:                1,
@@ -81,7 +77,7 @@ func (suite *SegmentSuite) TestStringArrayAK4() {
 		suite.Equal(arrayValidAK4, validAK4.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validOptionalAK4 := AK4{
 			PositionInSegment:          1,
 			ElementPositionInSegment:   1,
@@ -93,7 +89,7 @@ func (suite *SegmentSuite) TestStringArrayAK4() {
 }
 
 func (suite *SegmentSuite) TestParseAK4() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidAK4 := []string{"1", "1", "11", "1111", "ABC", "Bad data element"}
 		expectedAK4 := AK4{
 			PositionInSegment:                       1,
@@ -111,7 +107,7 @@ func (suite *SegmentSuite) TestParseAK4() {
 		}
 	})
 
-	suite.T().Run("parse success only required fields", func(t *testing.T) {
+	suite.Run("parse success only required fields", func() {
 		arrayValidOptionalAK4 := []string{"1", "1", "", "", "ABC", ""}
 		expectedOptionalAK4 := AK4{
 			PositionInSegment:          1,
@@ -126,7 +122,7 @@ func (suite *SegmentSuite) TestParseAK4() {
 		}
 	})
 
-	suite.T().Run("wrong number of fields", func(t *testing.T) {
+	suite.Run("wrong number of fields", func() {
 		badArrayAK4 := []string{"1", "1"}
 		var badAK4 AK4
 		err := badAK4.Parse(badArrayAK4)
@@ -135,7 +131,7 @@ func (suite *SegmentSuite) TestParseAK4() {
 		}
 	})
 
-	suite.T().Run("invalid integers", func(t *testing.T) {
+	suite.Run("invalid integers", func() {
 		// First four fields are integers that could fail conversion
 		for i := 0; i < 4; i++ {
 			badArrayAK4 := []string{"1", "1", "11", "1111", "ABC", "Bad data element"}

--- a/pkg/edi/segment/ak5_test.go
+++ b/pkg/edi/segment/ak5_test.go
@@ -1,11 +1,7 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateAK5() {
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		validAK5 := AK5{
 			TransactionSetAcknowledgmentCode:   "A",
 			TransactionSetSyntaxErrorCodeAK502: "abc",
@@ -18,7 +14,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success only required fields", func(t *testing.T) {
+	suite.Run("validate success only required fields", func() {
 		validAK5 := AK5{
 			TransactionSetAcknowledgmentCode: "A",
 		}
@@ -26,7 +22,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("failure due to missing required fields", func(t *testing.T) {
+	suite.Run("failure due to missing required fields", func() {
 
 		ak5 := AK5{
 			TransactionSetSyntaxErrorCodeAK502: "abc",
@@ -39,7 +35,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.ValidateError(err, "TransactionSetAcknowledgmentCode", "len")
 	})
 
-	suite.T().Run("validate failure max", func(t *testing.T) {
+	suite.Run("validate failure max", func() {
 		// length of characters are more than max
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "AAAAA",
@@ -60,7 +56,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 		suite.ValidateErrorLen(err, 6)
 	})
 
-	suite.T().Run("validate failure min", func(t *testing.T) {
+	suite.Run("validate failure min", func() {
 		// length of characters are less than min
 		ak5 := AK5{
 			TransactionSetAcknowledgmentCode:   "",
@@ -78,7 +74,7 @@ func (suite *SegmentSuite) TestValidateAK5() {
 }
 
 func (suite *SegmentSuite) TestStringArrayAK5() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validAK5 := AK5{
 			TransactionSetAcknowledgmentCode:   "A",
 			TransactionSetSyntaxErrorCodeAK502: "abc",
@@ -91,7 +87,7 @@ func (suite *SegmentSuite) TestStringArrayAK5() {
 		suite.Equal(arrayValidAK5, validAK5.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validOptionalAK5 := AK5{
 			TransactionSetAcknowledgmentCode: "A",
 		}
@@ -101,7 +97,7 @@ func (suite *SegmentSuite) TestStringArrayAK5() {
 }
 
 func (suite *SegmentSuite) TestParseAK5() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidAK5 := []string{"A", "abc", "def", "ghi", "jkl", "mno"}
 		expectedAK5 := AK5{
 			TransactionSetAcknowledgmentCode:   "A",
@@ -119,7 +115,7 @@ func (suite *SegmentSuite) TestParseAK5() {
 		}
 	})
 
-	suite.T().Run("parse success only required fields", func(t *testing.T) {
+	suite.Run("parse success only required fields", func() {
 		arrayValidOptionalAK5 := []string{"A", "", "", "", "", ""}
 		expectedOptionalAK5 := AK5{
 			TransactionSetAcknowledgmentCode: "A",
@@ -132,7 +128,7 @@ func (suite *SegmentSuite) TestParseAK5() {
 		}
 	})
 
-	suite.T().Run("wrong number of fields", func(t *testing.T) {
+	suite.Run("wrong number of fields", func() {
 		badArrayAK5 := []string{"A", "abc", "def", "ghi", "jkl", "mno", "zzz"}
 		var badAK5 AK5
 		err := badAK5.Parse(badArrayAK5)

--- a/pkg/edi/segment/ak9_test.go
+++ b/pkg/edi/segment/ak9_test.go
@@ -2,11 +2,10 @@ package edisegment
 
 import (
 	"fmt"
-	"testing"
 )
 
 func (suite *SegmentSuite) TestValidateAK9() {
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		validAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:      "A",
 			NumberOfTransactionSetsIncluded:     1,
@@ -22,7 +21,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success only required fields", func(t *testing.T) {
+	suite.Run("validate success only required fields", func() {
 		validAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "E",
 			NumberOfTransactionSetsIncluded: 1,
@@ -33,7 +32,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success for all valid FunctionalGroupAcknowledgeCode values", func(t *testing.T) {
+	suite.Run("validate success for all valid FunctionalGroupAcknowledgeCode values", func() {
 		validAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "A",
 			NumberOfTransactionSetsIncluded: 1,
@@ -48,7 +47,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		}
 	})
 
-	suite.T().Run("validate failure for invalid FunctionalGroupAcknowledgeCode", func(t *testing.T) {
+	suite.Run("validate failure for invalid FunctionalGroupAcknowledgeCode", func() {
 		validAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "B",
 			NumberOfTransactionSetsIncluded: 1,
@@ -59,7 +58,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateError(err, "FunctionalGroupAcknowledgeCode", "oneof")
 	})
 
-	suite.T().Run("failure due to missing required fields", func(t *testing.T) {
+	suite.Run("failure due to missing required fields", func() {
 
 		ak9 := AK9{
 			FunctionalGroupSyntaxErrorCodeAK905: "AAA",
@@ -76,7 +75,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
-	suite.T().Run("validate failure max", func(t *testing.T) {
+	suite.Run("validate failure max", func() {
 		// length of characters are more than max
 		ak9 := AK9{
 			FunctionalGroupAcknowledgeCode:      "AA",
@@ -103,7 +102,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 		suite.ValidateErrorLen(err, 9)
 	})
 
-	suite.T().Run("validate failure min", func(t *testing.T) {
+	suite.Run("validate failure min", func() {
 		// length of characters are less than min
 		ak9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "",
@@ -122,7 +121,7 @@ func (suite *SegmentSuite) TestValidateAK9() {
 }
 
 func (suite *SegmentSuite) TestStringArrayAK9() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:      "A",
 			NumberOfTransactionSetsIncluded:     1,
@@ -138,7 +137,7 @@ func (suite *SegmentSuite) TestStringArrayAK9() {
 		suite.Equal(arrayValidAK9, validAK9.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validOptionalAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "A",
 			NumberOfTransactionSetsIncluded: 1,
@@ -151,7 +150,7 @@ func (suite *SegmentSuite) TestStringArrayAK9() {
 }
 
 func (suite *SegmentSuite) TestParseAK9() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidAK9 := []string{"A", "1", "2", "3", "AAA", "BBB", "CCC", "DDD", "EEE"}
 		expectedAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:      "A",
@@ -172,7 +171,7 @@ func (suite *SegmentSuite) TestParseAK9() {
 		}
 	})
 
-	suite.T().Run("parse success only required fields", func(t *testing.T) {
+	suite.Run("parse success only required fields", func() {
 		arrayValidOptionalAK9 := []string{"A", "1", "2", "3", "", "", "", "", ""}
 		expectedOptionalAK9 := AK9{
 			FunctionalGroupAcknowledgeCode:  "A",
@@ -188,7 +187,7 @@ func (suite *SegmentSuite) TestParseAK9() {
 		}
 	})
 
-	suite.T().Run("wrong number of elements", func(t *testing.T) {
+	suite.Run("wrong number of elements", func() {
 		badArrayAK9 := []string{"A", "abc"}
 		var badAK9 AK9
 		err := badAK9.Parse(badArrayAK9)
@@ -197,7 +196,7 @@ func (suite *SegmentSuite) TestParseAK9() {
 		}
 	})
 
-	suite.T().Run("parse fails for invalid ints", func(t *testing.T) {
+	suite.Run("parse fails for invalid ints", func() {
 		var validOptionalAK9 AK9
 		arrayInvalidIntsAK9 := []string{"A", "g", "2", "3", "", "", "", "", ""}
 

--- a/pkg/edi/segment/bgn_test.go
+++ b/pkg/edi/segment/bgn_test.go
@@ -1,11 +1,7 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateBGN() {
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		validBGN := BGN{
 			TransactionSetPurposeCode: "11",
 			ReferenceIdentification:   "hello",
@@ -15,7 +11,7 @@ func (suite *SegmentSuite) TestValidateBGN() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		bgn := BGN{
 			TransactionSetPurposeCode: "10",       // eq
 			ReferenceIdentification:   "",         // min
@@ -29,7 +25,7 @@ func (suite *SegmentSuite) TestValidateBGN() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		bgn := BGN{
 			TransactionSetPurposeCode: "11",
 			ReferenceIdentification:   "long string that exceeds max length", // max
@@ -43,7 +39,7 @@ func (suite *SegmentSuite) TestValidateBGN() {
 }
 
 func (suite *SegmentSuite) TestStringArrayBGN() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validBGN := BGN{
 			TransactionSetPurposeCode: "11",
 			ReferenceIdentification:   "hello",
@@ -55,7 +51,7 @@ func (suite *SegmentSuite) TestStringArrayBGN() {
 }
 
 func (suite *SegmentSuite) TestParseBGN() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidBGN := []string{"11", "hello", "20210310"}
 		expectedBGN := BGN{
 			TransactionSetPurposeCode: "11",
@@ -70,7 +66,7 @@ func (suite *SegmentSuite) TestParseBGN() {
 		}
 	})
 
-	suite.T().Run("wrong number of fields", func(t *testing.T) {
+	suite.Run("wrong number of fields", func() {
 		badArrayBGN := []string{"11", "hello"}
 		var badBGN BGN
 		err := badBGN.Parse(badArrayBGN)

--- a/pkg/edi/segment/bx_test.go
+++ b/pkg/edi/segment/bx_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateBX() {
 	validBX := BX{
 		TransactionSetPurposeCode:    "00",
@@ -14,12 +10,12 @@ func (suite *SegmentSuite) TestValidateBX() {
 		ShipmentQualifier:            "4",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validBX)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		bx := BX{
 			TransactionSetPurposeCode:    "01",    // eq
 			TransactionMethodTypeCode:    "K",     // eq
@@ -41,7 +37,7 @@ func (suite *SegmentSuite) TestValidateBX() {
 		suite.ValidateErrorLen(err, 7)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		bx := validBX
 		bx.StandardCarrierAlphaCode = "T" // min
 
@@ -50,7 +46,7 @@ func (suite *SegmentSuite) TestValidateBX() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		bx := validBX
 		bx.ShipmentIdentificationNumber = "A123456789012345678901234567890" // max
 		bx.StandardCarrierAlphaCode = "TESTING"                             // max

--- a/pkg/edi/segment/c3_test.go
+++ b/pkg/edi/segment/c3_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateC3() {
 	validC3 := C3{
 		CurrencyCodeC301: "USD",
@@ -12,12 +8,12 @@ func (suite *SegmentSuite) TestValidateC3() {
 		CurrencyCodeC304: "EUR",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validC3)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		c3 := C3{
 			CurrencyCodeC301: "TTTT", // max
 			ExchangeRate:     "K",    // none

--- a/pkg/edi/segment/fa1_test.go
+++ b/pkg/edi/segment/fa1_test.go
@@ -1,20 +1,16 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateFA1() {
 	validFA1 := FA1{
 		AgencyQualifierCode: "DF",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validFA1)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure", func(t *testing.T) {
+	suite.Run("validate failure", func() {
 		fa1 := FA1{
 			AgencyQualifierCode: "XX", // oneof
 		}

--- a/pkg/edi/segment/fa2_test.go
+++ b/pkg/edi/segment/fa2_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateFA2() {
 	validFA2 := FA2{
 		BreakdownStructureDetailCode: "TA",
 		FinancialInformationCode:     "307",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validFA2)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		fa2 := FA2{
 			BreakdownStructureDetailCode: "XX", // eq
 			FinancialInformationCode:     "",   // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateFA2() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		fa2 := validFA2
 		fa2.FinancialInformationCode = "123456789012345678901234567890123456789012345678901234567890123456789012345678901" // max
 

--- a/pkg/edi/segment/g62_test.go
+++ b/pkg/edi/segment/g62_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateG62() {
 	validG62ActualPickupDateTime := G62{
 		DateQualifier: 86,
@@ -22,7 +18,7 @@ func (suite *SegmentSuite) TestValidateG62() {
 		Date:          "20200909",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validG62ActualPickupDateTime)
 		suite.NoError(err)
 		err = suite.validator.Struct(validG62RequestedPickupDateTime)
@@ -31,7 +27,7 @@ func (suite *SegmentSuite) TestValidateG62() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		g62 := G62{
 			DateQualifier: 42,         // oneof
 			Date:          "20190945", // datetime

--- a/pkg/edi/segment/ge_test.go
+++ b/pkg/edi/segment/ge_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateGE() {
 	validGE := GE{
 		NumberOfTransactionSetsIncluded: 1,
 		GroupControlNumber:              1234567,
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validGE)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		ge := GE{
 			NumberOfTransactionSetsIncluded: 2, // eq
 			GroupControlNumber:              0, // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateGE() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		ge := validGE
 		ge.GroupControlNumber = 1000000000 // max
 

--- a/pkg/edi/segment/gs_test.go
+++ b/pkg/edi/segment/gs_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateGS() {
 	validGS := GS{
 		FunctionalIdentifierCode: "SI",
@@ -16,7 +12,7 @@ func (suite *SegmentSuite) TestValidateGS() {
 		Version:                  "004010",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validGS)
 		suite.NoError(err)
 	})
@@ -32,12 +28,12 @@ func (suite *SegmentSuite) TestValidateGS() {
 		Version:                  "004010",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(altValidGS)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		gs := GS{
 			FunctionalIdentifierCode: "XX",        // oneof
 			ApplicationSendersCode:   "XXXXX",     // oneof
@@ -61,7 +57,7 @@ func (suite *SegmentSuite) TestValidateGS() {
 		suite.ValidateErrorLen(err, 8)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		gs := validGS
 		gs.GroupControlNumber = 1000000000 // max
 

--- a/pkg/edi/segment/hl_test.go
+++ b/pkg/edi/segment/hl_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateHL() {
 	validHL := HL{
 		HierarchicalIDNumber:  "303",
 		HierarchicalLevelCode: "SS",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validHL)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure", func(t *testing.T) {
+	suite.Run("validate failure", func() {
 		hl := HL{
 			HierarchicalIDNumber:       "A-123", // alphanum
 			HierarchicalParentIDNumber: "1",     // isdefault
@@ -29,7 +25,7 @@ func (suite *SegmentSuite) TestValidateHL() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		hl := validHL
 		hl.HierarchicalIDNumber = "" // alphanum takes precidence over min
 
@@ -38,7 +34,7 @@ func (suite *SegmentSuite) TestValidateHL() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		hl := validHL
 		hl.HierarchicalIDNumber = "0123456789ABCDF" // max
 

--- a/pkg/edi/segment/iea_test.go
+++ b/pkg/edi/segment/iea_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateIEA() {
 	validIEA := IEA{
 		NumberOfIncludedFunctionalGroups: 1,
 		InterchangeControlNumber:         1,
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validIEA)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		iea := IEA{
 			NumberOfIncludedFunctionalGroups: 2, // eq
 			InterchangeControlNumber:         0, // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateIEA() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		iea := validIEA
 		iea.InterchangeControlNumber = 1000000000 // max
 

--- a/pkg/edi/segment/isa_test.go
+++ b/pkg/edi/segment/isa_test.go
@@ -2,7 +2,6 @@ package edisegment
 
 import (
 	"fmt"
-	"testing"
 )
 
 func (suite *SegmentSuite) TestValidateISA() {
@@ -25,7 +24,7 @@ func (suite *SegmentSuite) TestValidateISA() {
 		ComponentElementSeparator:         "|",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validISA)
 		suite.NoError(err)
 	})
@@ -47,12 +46,12 @@ func (suite *SegmentSuite) TestValidateISA() {
 		ComponentElementSeparator:         "|",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(altValidISA)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		isa := ISA{
 			AuthorizationInformationQualifier: "11",                           // eq
 			AuthorizationInformation:          "1111111111",                   // eq
@@ -92,7 +91,7 @@ func (suite *SegmentSuite) TestValidateISA() {
 		suite.ValidateErrorLen(err, 16)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		isa := validISA
 		isa.InterchangeControlNumber = 1000000000 // max
 

--- a/pkg/edi/segment/l0_test.go
+++ b/pkg/edi/segment/l0_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL0() {
 	validBilledL0 := L0{
 		LadingLineItemNumber:   1,
@@ -18,17 +14,17 @@ func (suite *SegmentSuite) TestValidateL0() {
 		WeightUnitCode:       "L",
 	}
 
-	suite.T().Run("validate success billed", func(t *testing.T) {
+	suite.Run("validate success billed", func() {
 		err := suite.validator.Struct(validBilledL0)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success weight", func(t *testing.T) {
+	suite.Run("validate success weight", func() {
 		err := suite.validator.Struct(validWeightL0)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		l0 := L0{
 			LadingLineItemNumber:  2000, // max
 			BilledRatedAsQuantity: 3.0,  // required_with
@@ -40,7 +36,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		l0 := L0{
 			LadingLineItemNumber: 0,     // min
 			Weight:               300.0, // required_with
@@ -53,7 +49,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		l0 := validBilledL0
 		l0.BilledRatedAsQualifier = "ABC" // len
 
@@ -62,7 +58,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 4", func(t *testing.T) {
+	suite.Run("validate failure 4", func() {
 		l0 := validWeightL0
 		l0.WeightQualifier = "X" // eq
 		l0.WeightUnitCode = "X"  // eq
@@ -73,7 +69,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 5", func(t *testing.T) {
+	suite.Run("validate failure 5", func() {
 		l0 := L0{
 			LadingLineItemNumber: 1,
 			Volume:               144.0, // required_with
@@ -86,7 +82,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 6", func(t *testing.T) {
+	suite.Run("validate failure 6", func() {
 		l0 := L0{
 			LadingLineItemNumber: 1,
 			Volume:               144.0,
@@ -102,7 +98,7 @@ func (suite *SegmentSuite) TestValidateL0() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 7", func(t *testing.T) {
+	suite.Run("validate failure 7", func() {
 		l0 := L0{
 			LadingLineItemNumber: 1,
 			LadingQuantity:       10000000, // max

--- a/pkg/edi/segment/l10_test.go
+++ b/pkg/edi/segment/l10_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL10() {
 	validL10 := L10{
 		Weight:          100.0,
@@ -11,12 +7,12 @@ func (suite *SegmentSuite) TestValidateL10() {
 		WeightUnitCode:  "L",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validL10)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure", func(t *testing.T) {
+	suite.Run("validate failure", func() {
 		l10 := L10{
 			// Weight required
 			WeightQualifier: "X",

--- a/pkg/edi/segment/l1_test.go
+++ b/pkg/edi/segment/l1_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL1() {
 	freightRate := float64(0)
 	validL1 := L1{
@@ -18,19 +14,19 @@ func (suite *SegmentSuite) TestValidateL1() {
 		Charge:               10000,
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validL1)
 		suite.NoError(err)
 		suite.Equal([]string{"L1", "1", "0.00", "LB", "10000"}, validL1.StringArray())
 	})
 
-	suite.T().Run("validate alt success", func(t *testing.T) {
+	suite.Run("validate alt success", func() {
 		err := suite.validator.Struct(altValidL1)
 		suite.NoError(err)
 		suite.Equal([]string{"L1", "12", "", "", "10000"}, altValidL1.StringArray())
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		freightRate := float64(-1)
 		l1 := L1{
 			// LadingLineItemNumber:          // required
@@ -47,7 +43,7 @@ func (suite *SegmentSuite) TestValidateL1() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		l1 := validL1
 		l1.LadingLineItemNumber = 1000 // max
 		l1.Charge = 1000000000000      // max
@@ -58,7 +54,7 @@ func (suite *SegmentSuite) TestValidateL1() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		l1 := validL1
 		l1.LadingLineItemNumber = -3 // min
 		l1.RateValueQualifier = ""   // required_with

--- a/pkg/edi/segment/l3_test.go
+++ b/pkg/edi/segment/l3_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL3() {
 	validWeightL3 := L3{
 		Weight:          300.0,
@@ -11,12 +7,12 @@ func (suite *SegmentSuite) TestValidateL3() {
 		PriceCents:      100,
 	}
 
-	suite.T().Run("validate success weight", func(t *testing.T) {
+	suite.Run("validate success weight", func() {
 		err := suite.validator.Struct(validWeightL3)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		l3 := L3{
 			Weight:     300.0,
 			PriceCents: 100,
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateL3() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		l3 := L3{
 			Weight:          300.0,
 			WeightQualifier: "INVALID",
@@ -39,7 +35,7 @@ func (suite *SegmentSuite) TestValidateL3() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		l3 := L3{
 			Weight:          99999999999, // 10 digits
 			WeightQualifier: "B",
@@ -52,7 +48,7 @@ func (suite *SegmentSuite) TestValidateL3() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		l3 := L3{
 			Weight:     -1,
 			PriceCents: -9999999999999, // 13 digits

--- a/pkg/edi/segment/l5_test.go
+++ b/pkg/edi/segment/l5_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL5() {
 	validL5 := L5{
 		LadingLineItemNumber:   1,
@@ -12,12 +8,12 @@ func (suite *SegmentSuite) TestValidateL5() {
 		CommodityCodeQualifier: "D",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validL5)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure of lading description", func(t *testing.T) {
+	suite.Run("validate failure of lading description", func() {
 		l5 := L5{
 			LadingLineItemNumber: 1,
 		}
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateL5() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure of missing CommodityCodeQualifier", func(t *testing.T) {
+	suite.Run("validate failure of missing CommodityCodeQualifier", func() {
 		l5 := L5{
 			LadingLineItemNumber: 1,
 			LadingDescription:    "DLH - Domestic Line Haul",
@@ -39,7 +35,7 @@ func (suite *SegmentSuite) TestValidateL5() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure of missing CommodityCode ", func(t *testing.T) {
+	suite.Run("validate failure of missing CommodityCode ", func() {
 		l5 := L5{
 			LadingLineItemNumber:   1,
 			LadingDescription:      "DLH - Domestic Line Haul",

--- a/pkg/edi/segment/l7_test.go
+++ b/pkg/edi/segment/l7_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateL7() {
 	validL7Default := L7{}
 	validL7WithValues := L7{
@@ -13,17 +9,17 @@ func (suite *SegmentSuite) TestValidateL7() {
 		TariffDistance:       1,
 	}
 
-	suite.T().Run("validate success default", func(t *testing.T) {
+	suite.Run("validate success default", func() {
 		err := suite.validator.Struct(validL7Default)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success with values", func(t *testing.T) {
+	suite.Run("validate success with values", func() {
 		err := suite.validator.Struct(validL7WithValues)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		l7 := L7{
 			LadingLineItemNumber: -3,                  // min
 			TariffNumber:         "XXXXXXXX",          // max
@@ -39,7 +35,7 @@ func (suite *SegmentSuite) TestValidateL7() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		l7 := L7{
 			LadingLineItemNumber: 1000,   // max
 			TariffDistance:       100000, // max

--- a/pkg/edi/segment/lx_test.go
+++ b/pkg/edi/segment/lx_test.go
@@ -1,20 +1,16 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateLX() {
 	validLX := LX{
 		AssignedNumber: 1,
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validLX)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		lx := LX{
 			AssignedNumber: 0, // min
 		}
@@ -24,7 +20,7 @@ func (suite *SegmentSuite) TestValidateLX() {
 		suite.ValidateErrorLen(err, 1)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		lx := LX{
 			AssignedNumber: 1000000, // max
 		}

--- a/pkg/edi/segment/mea_test.go
+++ b/pkg/edi/segment/mea_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateMEA() {
 	validMEADefault := MEA{
 		MeasurementValue: 100.0,
@@ -15,17 +11,17 @@ func (suite *SegmentSuite) TestValidateMEA() {
 		MeasurementValue:           100.0,
 	}
 
-	suite.T().Run("validate success default", func(t *testing.T) {
+	suite.Run("validate success default", func() {
 		err := suite.validator.Struct(validMEADefault)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success with values", func(t *testing.T) {
+	suite.Run("validate success with values", func() {
 		err := suite.validator.Struct(validMEAWithValues)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure", func(t *testing.T) {
+	suite.Run("validate failure", func() {
 		mea := MEA{
 			MeasurementReferenceIDCode: "ABC", // len
 			MeasurementQualifier:       "XX",  // oneof

--- a/pkg/edi/segment/n1_test.go
+++ b/pkg/edi/segment/n1_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateN1() {
 	validN1 := N1{
 		EntityIdentifierCode:        "SF",
@@ -12,12 +8,12 @@ func (suite *SegmentSuite) TestValidateN1() {
 		IdentificationCode:          "XX",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validN1)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		n1 := N1{
 			EntityIdentifierCode:        "XX", // oneof
 			Name:                        "",   // min
@@ -31,7 +27,7 @@ func (suite *SegmentSuite) TestValidateN1() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		n1 := validN1
 		n1.Name = "1234567890123456789012345678901234567890123456789012345678901" // max
 		n1.IdentificationCodeQualifier = "19"                                     // oneof
@@ -44,7 +40,7 @@ func (suite *SegmentSuite) TestValidateN1() {
 		suite.ValidateErrorLen(err, 3)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		n1 := validN1
 		n1.IdentificationCode = "123456789012345678901234567890123456789012345678901234567890123456789012345678901" // max
 

--- a/pkg/edi/segment/n3_test.go
+++ b/pkg/edi/segment/n3_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateN3() {
 	validN3Line1Only := N3{
 		AddressInformation1: "ABC",
@@ -14,17 +10,17 @@ func (suite *SegmentSuite) TestValidateN3() {
 		AddressInformation2: "XYZ",
 	}
 
-	suite.T().Run("validate success line 1 only", func(t *testing.T) {
+	suite.Run("validate success line 1 only", func() {
 		err := suite.validator.Struct(validN3Line1Only)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success both lines", func(t *testing.T) {
+	suite.Run("validate success both lines", func() {
 		err := suite.validator.Struct(validN3BothLines)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		n3 := N3{
 			AddressInformation1: "",                                                         // min
 			AddressInformation2: "12345678901234567890123456789012345678901234567890123456", // max
@@ -36,7 +32,7 @@ func (suite *SegmentSuite) TestValidateN3() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		n3 := N3{
 			AddressInformation1: "12345678901234567890123456789012345678901234567890123456", // max
 		}

--- a/pkg/edi/segment/n4_test.go
+++ b/pkg/edi/segment/n4_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateN4() {
 	validN4 := N4{
 		CityName:            "Augusta",
@@ -11,12 +7,12 @@ func (suite *SegmentSuite) TestValidateN4() {
 		PostalCode:          "30907",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validN4)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		n4 := N4{
 			CityName:            "A",       // min
 			StateOrProvinceCode: "Georgia", // len
@@ -36,7 +32,7 @@ func (suite *SegmentSuite) TestValidateN4() {
 		suite.ValidateErrorLen(err, 6)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		n4 := validN4
 		n4.CityName = "1234567890123456789012345678901" // max
 		n4.PostalCode = "01234567890123456"             // max

--- a/pkg/edi/segment/n9_test.go
+++ b/pkg/edi/segment/n9_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateN9() {
 	validN9Default := N9{
 		ReferenceIdentificationQualifier: "DY",
@@ -17,17 +13,17 @@ func (suite *SegmentSuite) TestValidateN9() {
 		Date:                             "20190903",
 	}
 
-	suite.T().Run("validate success default", func(t *testing.T) {
+	suite.Run("validate success default", func() {
 		err := suite.validator.Struct(validN9Default)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success all", func(t *testing.T) {
+	suite.Run("validate success all", func() {
 		err := suite.validator.Struct(validN9All)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		n9 := N9{
 			ReferenceIdentificationQualifier: "XX",                                             // oneof
 			ReferenceIdentification:          "",                                               // min
@@ -43,7 +39,7 @@ func (suite *SegmentSuite) TestValidateN9() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		n9 := validN9All
 		n9.ReferenceIdentification = "1234567890123456789012345678901" // max
 

--- a/pkg/edi/segment/nte_test.go
+++ b/pkg/edi/segment/nte_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateNTE() {
 	validNTEDefault := NTE{
 		Description: "Something",
@@ -14,17 +10,17 @@ func (suite *SegmentSuite) TestValidateNTE() {
 		Description:       "Something Else",
 	}
 
-	suite.T().Run("validate success default", func(t *testing.T) {
+	suite.Run("validate success default", func() {
 		err := suite.validator.Struct(validNTEDefault)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success all", func(t *testing.T) {
+	suite.Run("validate success all", func() {
 		err := suite.validator.Struct(validNTEAll)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		nte := NTE{
 			NoteReferenceCode: "XX", // len
 			Description:       "",   // min
@@ -36,7 +32,7 @@ func (suite *SegmentSuite) TestValidateNTE() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		nte := validNTEAll
 		nte.Description = "123456789012345678901234567890123456789012345678901234567890123456789012345678901" // max
 

--- a/pkg/edi/segment/oti_test.go
+++ b/pkg/edi/segment/oti_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateOTI() {
 	validOTI := OTI{
 		ApplicationAcknowledgementCode:   "TA",
@@ -17,12 +13,12 @@ func (suite *SegmentSuite) TestValidateOTI() {
 		TransactionSetControlNumber:      "ABCDE",
 	}
 
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		err := suite.validator.Struct(validOTI)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success only required fields", func(t *testing.T) {
+	suite.Run("validate success only required fields", func() {
 		validOptionalOTI := OTI{
 			ApplicationAcknowledgementCode:   "TA",
 			ReferenceIdentificationQualifier: "BM",
@@ -32,7 +28,7 @@ func (suite *SegmentSuite) TestValidateOTI() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		oti := OTI{
 			ApplicationAcknowledgementCode:   "XX",       // oneof
 			ReferenceIdentificationQualifier: "XX",       // oneof
@@ -58,7 +54,7 @@ func (suite *SegmentSuite) TestValidateOTI() {
 		suite.ValidateErrorLen(err, 9)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		oti := validOTI
 		oti.ReferenceIdentification = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" // max
 		oti.ApplicationSendersCode = "MILMOVEMILMOVEMILMOVE"            // max
@@ -75,7 +71,7 @@ func (suite *SegmentSuite) TestValidateOTI() {
 		suite.ValidateErrorLen(err, 5)
 	})
 
-	suite.T().Run("validate failure 3", func(t *testing.T) {
+	suite.Run("validate failure 3", func() {
 		oti := validOTI
 		oti.GroupControlNumber = 0 // required_with
 
@@ -86,7 +82,7 @@ func (suite *SegmentSuite) TestValidateOTI() {
 }
 
 func (suite *SegmentSuite) TestStringArrayOTI() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validOTI := OTI{
 			ApplicationAcknowledgementCode:   "TA",
 			ReferenceIdentificationQualifier: "BM",
@@ -102,7 +98,7 @@ func (suite *SegmentSuite) TestStringArrayOTI() {
 		suite.Equal(arrayValidOTI, validOTI.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validOptionalOTI := OTI{
 			ApplicationAcknowledgementCode:   "TA",
 			ReferenceIdentificationQualifier: "BM",
@@ -114,7 +110,7 @@ func (suite *SegmentSuite) TestStringArrayOTI() {
 }
 
 func (suite *SegmentSuite) TestParseOTI() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidOTI := []string{"TA", "BM", "ABC", "MILMOVE", "RECEIVER", "20210311", "1057", "12345", "ABCDE"}
 		expectedOTI := OTI{
 			ApplicationAcknowledgementCode:   "TA",
@@ -135,7 +131,7 @@ func (suite *SegmentSuite) TestParseOTI() {
 		}
 	})
 
-	suite.T().Run("parse success only required fields", func(t *testing.T) {
+	suite.Run("parse success only required fields", func() {
 		arrayValidOptionalOTI := []string{"TA", "BM", "ABC", "", "", "", "", "", ""}
 		expectedOptionalOTI := OTI{
 			ApplicationAcknowledgementCode:   "TA",
@@ -150,7 +146,7 @@ func (suite *SegmentSuite) TestParseOTI() {
 		}
 	})
 
-	suite.T().Run("wrong number of fields", func(t *testing.T) {
+	suite.Run("wrong number of fields", func() {
 		badArrayOTI := []string{"TA", "BM"}
 		var badOTI OTI
 		err := badOTI.Parse(badArrayOTI)
@@ -159,7 +155,7 @@ func (suite *SegmentSuite) TestParseOTI() {
 		}
 	})
 
-	suite.T().Run("invalid integers", func(t *testing.T) {
+	suite.Run("invalid integers", func() {
 		badArrayOTI := []string{"TA", "BM", "ABC", "MILMOVE", "RECEIVER", "20210311", "1057", "A12345", "ABCDE"}
 		var badOTI OTI
 		err := badOTI.Parse(badArrayOTI)

--- a/pkg/edi/segment/per_test.go
+++ b/pkg/edi/segment/per_test.go
@@ -1,9 +1,5 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidatePER() {
 	validPERDefault := PER{
 		ContactFunctionCode: "IC",
@@ -16,17 +12,17 @@ func (suite *SegmentSuite) TestValidatePER() {
 		CommunicationNumber:          "5551234567",
 	}
 
-	suite.T().Run("validate success default", func(t *testing.T) {
+	suite.Run("validate success default", func() {
 		err := suite.validator.Struct(validPERDefault)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success all", func(t *testing.T) {
+	suite.Run("validate success all", func() {
 		err := suite.validator.Struct(validPERAll)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		per := PER{
 			Name:                         "Cross Dock Testing With Too Long a Name Cross Dock Testing With Too Long a Name",
 			CommunicationNumberQualifier: "BX",
@@ -41,7 +37,7 @@ func (suite *SegmentSuite) TestValidatePER() {
 		suite.ValidateErrorLen(err, 4)
 	})
 
-	suite.T().Run("validate segment is parsed correctly", func(t *testing.T) {
+	suite.Run("validate segment is parsed correctly", func() {
 		values := []string{"IC", "Cross Dock", "TE", "5551234567"}
 		per := PER{
 			ContactFunctionCode:          "IC",

--- a/pkg/edi/segment/se_test.go
+++ b/pkg/edi/segment/se_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateSE() {
 	validSE := SE{
 		NumberOfIncludedSegments:    12345,
 		TransactionSetControlNumber: "ABCDE",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validSE)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		se := SE{
 			NumberOfIncludedSegments:    0,     // min
 			TransactionSetControlNumber: "ABC", // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateSE() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		se := SE{
 			NumberOfIncludedSegments:    10000000000,  // max
 			TransactionSetControlNumber: "1234567890", // max

--- a/pkg/edi/segment/st_test.go
+++ b/pkg/edi/segment/st_test.go
@@ -1,21 +1,17 @@
 package edisegment
 
-import (
-	"testing"
-)
-
 func (suite *SegmentSuite) TestValidateST() {
 	validST := ST{
 		TransactionSetIdentifierCode: "858",
 		TransactionSetControlNumber:  "ABCDE",
 	}
 
-	suite.T().Run("validate success", func(t *testing.T) {
+	suite.Run("validate success", func() {
 		err := suite.validator.Struct(validST)
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure 1", func(t *testing.T) {
+	suite.Run("validate failure 1", func() {
 		st := ST{
 			TransactionSetIdentifierCode: "123", // eq
 			TransactionSetControlNumber:  "123", // min
@@ -27,7 +23,7 @@ func (suite *SegmentSuite) TestValidateST() {
 		suite.ValidateErrorLen(err, 2)
 	})
 
-	suite.T().Run("validate failure 2", func(t *testing.T) {
+	suite.Run("validate failure 2", func() {
 		st := validST
 		st.TransactionSetControlNumber = "1234567890" // max
 

--- a/pkg/edi/segment/ted_test.go
+++ b/pkg/edi/segment/ted_test.go
@@ -2,11 +2,10 @@ package edisegment
 
 import (
 	"strings"
-	"testing"
 )
 
 func (suite *SegmentSuite) TestValidateTED() {
-	suite.T().Run("validate success all fields", func(t *testing.T) {
+	suite.Run("validate success all fields", func() {
 		validTED := TED{
 			ApplicationErrorConditionCode: "007",
 			FreeFormMessage:               "free form message",
@@ -15,7 +14,7 @@ func (suite *SegmentSuite) TestValidateTED() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate success only required fields", func(t *testing.T) {
+	suite.Run("validate success only required fields", func() {
 		validOptionalTED := TED{
 			ApplicationErrorConditionCode: "007",
 		}
@@ -23,7 +22,7 @@ func (suite *SegmentSuite) TestValidateTED() {
 		suite.NoError(err)
 	})
 
-	suite.T().Run("validate failure", func(t *testing.T) {
+	suite.Run("validate failure", func() {
 		ted := TED{
 			ApplicationErrorConditionCode: "123",                   // oneof
 			FreeFormMessage:               strings.Repeat("x", 61), // max
@@ -37,7 +36,7 @@ func (suite *SegmentSuite) TestValidateTED() {
 }
 
 func (suite *SegmentSuite) TestStringArrayTED() {
-	suite.T().Run("string array all fields", func(t *testing.T) {
+	suite.Run("string array all fields", func() {
 		validTED := TED{
 			ApplicationErrorConditionCode: "007",
 			FreeFormMessage:               "free form message",
@@ -46,7 +45,7 @@ func (suite *SegmentSuite) TestStringArrayTED() {
 		suite.Equal(arrayValidTED, validTED.StringArray())
 	})
 
-	suite.T().Run("string array only required fields", func(t *testing.T) {
+	suite.Run("string array only required fields", func() {
 		validOptionalTED := TED{
 			ApplicationErrorConditionCode: "007",
 		}
@@ -56,7 +55,7 @@ func (suite *SegmentSuite) TestStringArrayTED() {
 }
 
 func (suite *SegmentSuite) TestParseTED() {
-	suite.T().Run("parse success all fields", func(t *testing.T) {
+	suite.Run("parse success all fields", func() {
 		arrayValidTED := []string{"007", "free form message"}
 		expectedTED := TED{
 			ApplicationErrorConditionCode: "007",
@@ -70,7 +69,7 @@ func (suite *SegmentSuite) TestParseTED() {
 		}
 	})
 
-	suite.T().Run("parse success only required fields", func(t *testing.T) {
+	suite.Run("parse success only required fields", func() {
 		arrayValidOptionalTED := []string{"007", ""}
 		expectedOptionalTED := TED{
 			ApplicationErrorConditionCode: "007",
@@ -83,7 +82,7 @@ func (suite *SegmentSuite) TestParseTED() {
 		}
 	})
 
-	suite.T().Run("wrong number of fields", func(t *testing.T) {
+	suite.Run("wrong number of fields", func() {
 		badArrayTED := []string{"007", "hello", "world"}
 		var badTED TED
 		err := badTED.Parse(badArrayTED)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12824) for this change

## Summary

Converts the package and tests in `./pkg/edi/segment` to use transactions.
These tests don't actually use the db but by converting the call to `suite.Run()` that allows us to have consistency and later introduce a linter that catches calles to `suite.T().Run`.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)