### PR TITLE
MB-12621: Limit recalculation of ZipTransitDistance to PPMs

### DIFF
--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
@@ -52,6 +52,11 @@ func (r DistanceZipLookup) lookup(appCtx appcontext.AppContext, keyData *Service
 	if len(destinationZip) < 5 {
 		return "", apperror.NewInvalidInputError(*mtoShipmentID, fmt.Errorf(errorMsgForDestinationZip), nil, errorMsgForDestinationZip)
 	}
+
+	if mtoShipment.Distance != nil && mtoShipment.ShipmentType != models.MTOShipmentTypePPM {
+		return strconv.Itoa(mtoShipment.Distance.Int()), nil
+	}
+
 	distanceMiles, err := planner.ZipTransitDistance(appCtx, pickupZip, destinationZip)
 	if err != nil {
 		return "", err

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1992,7 +1992,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 		"90210", "90211").Return(3, nil).Times(7)
 
 	// called for domestic shorthaul service item
-	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(12)
+	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(10)
 
 	// called for domestic origin SIT pickup service item
 	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "94535").Return(348, nil).Once()

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1992,7 +1992,7 @@ func createHHGWithPaymentServiceItems(appCtx appcontext.AppContext, primeUploade
 		"90210", "90211").Return(3, nil).Times(7)
 
 	// called for domestic shorthaul service item
-	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(10)
+	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "90211").Return(348, nil).Times(12)
 
 	// called for domestic origin SIT pickup service item
 	planner.On("ZipTransitDistance", mock.AnythingOfType("*appcontext.appContext"), "90210", "94535").Return(348, nil).Once()


### PR DESCRIPTION
[Jira ticket](tbd) for this change

## Summary

Recent changes to the `DistanceZipLookup` function removed the restriction to not recalculate distance if the shipment had the distance field set. This can expectedly result in additional calls for service items that rely on distance: DLH, DSH, and FSC. This PR limits the previous change to only apply to PPMs since the `ppm_estimator` is explicitly setting the shipment distance and running with new zips wasn't resulting in distance recalculation 

Without this PR the `db_dev_fresh` and was failing, and tT(https://ustcdp3.slack.com/archives/CP6PTUPQF/p1655329802041779?thread_ts=1655328463.425639&cid=CP6PTUPQF)

## Setup to Run Your Code

1. `make db_dev_fresh` and `make_dev_dev_e2e_populate` should run without error

