### PR TITLE
MB-12842 Convert pkg/models tests

### DIFF
--- a/pkg/models/contractor_test.go
+++ b/pkg/models/contractor_test.go
@@ -1,13 +1,11 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestContractorValidation() {
-	suite.T().Run("test valid Contractor", func(t *testing.T) {
+	suite.Run("test valid Contractor", func() {
 		newContractor := models.Contractor{
 			Name:           "Contractor 1",
 			Type:           "Prime",
@@ -18,7 +16,7 @@ func (suite *ModelSuite) TestContractorValidation() {
 		suite.verifyValidationErrors(&newContractor, expErrors)
 	})
 
-	suite.T().Run("test empty Contractor", func(t *testing.T) {
+	suite.Run("test empty Contractor", func() {
 		emptyContractor := models.Contractor{}
 		expErrors := map[string][]string{
 			"name":            {"Name can not be blank."},

--- a/pkg/models/customer_support_remarks_test.go
+++ b/pkg/models/customer_support_remarks_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func (suite *ModelSuite) TestCustomerSupportRemarkCreation() {
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	suite.NotNil(move)
-
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-	suite.NotNil(officeUser)
 
 	suite.Run("test valid office remark", func() {
+		move := testdatagen.MakeDefaultMove(suite.DB())
+		suite.NotNil(move)
+
+		officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+		suite.NotNil(officeUser)
 		customerSupportRemark := "This is a note that's saying something about the move."
 		validCustomerSupportRemark := models.CustomerSupportRemark{
 			Content:      customerSupportRemark,

--- a/pkg/models/customer_support_remarks_test.go
+++ b/pkg/models/customer_support_remarks_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -16,7 +14,7 @@ func (suite *ModelSuite) TestCustomerSupportRemarkCreation() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 	suite.NotNil(officeUser)
 
-	suite.T().Run("test valid office remark", func(t *testing.T) {
+	suite.Run("test valid office remark", func() {
 		customerSupportRemark := "This is a note that's saying something about the move."
 		validCustomerSupportRemark := models.CustomerSupportRemark{
 			Content:      customerSupportRemark,

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -48,7 +48,8 @@ func (suite *ModelSuite) TestFetchDocument() {
 
 	verrs, err := suite.DB().ValidateAndSave(&document)
 	if err != nil {
-		t.Fatalf("could not save UserUpload: %v", err)
+		t.Errorf("could not save UserUpload: %v", err)
+		return
 	}
 
 	if verrs.Count() != 0 {
@@ -77,7 +78,8 @@ func (suite *ModelSuite) TestFetchDeletedDocument() {
 
 	verrs, err := suite.DB().ValidateAndSave(&document)
 	if err != nil {
-		t.Fatalf("could not save UserUpload: %v", err)
+		t.Errorf("could not save UserUpload: %v", err)
+		return
 	}
 
 	if verrs.Count() != 0 {

--- a/pkg/models/edi_errors_test.go
+++ b/pkg/models/edi_errors_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -74,7 +72,7 @@ func (suite *ModelSuite) TestEdiErrors() {
 	}
 
 	for name, test := range testCases {
-		suite.T().Run(name, func(t *testing.T) {
+		suite.Run(name, func() {
 			suite.verifyValidationErrors(&test.ediError, test.expectedErrs)
 		})
 	}

--- a/pkg/models/edi_processing_test.go
+++ b/pkg/models/edi_processing_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -48,7 +47,7 @@ func (suite *ModelSuite) TestBasicEDIProcessingInstantiation() {
 	}
 
 	for name, test := range testCases {
-		suite.T().Run(name, func(t *testing.T) {
+		suite.Run(name, func() {
 			suite.verifyValidationErrors(&test.ediProcessing, test.expectedErrs)
 		})
 	}

--- a/pkg/models/entitlements_test.go
+++ b/pkg/models/entitlements_test.go
@@ -1,21 +1,19 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestGetEntitlementWithValidValues() {
 	E1 := models.ServiceMemberRankE1
 
-	suite.T().Run("E1 with dependents", func(t *testing.T) {
+	suite.Run("E1 with dependents", func() {
 		E1FullLoad, err := models.GetEntitlement(E1, true)
 		suite.NoError(err)
 		suite.Assertions.Equal(8000, E1FullLoad)
 	})
 
-	suite.T().Run("E1 without dependents", func(t *testing.T) {
+	suite.Run("E1 without dependents", func() {
 		E1Solo, err := models.GetEntitlement(E1, false)
 		suite.NoError(err)
 		suite.Assertions.Equal(5000, E1Solo)

--- a/pkg/models/fuel_eia_diesel_price_test.go
+++ b/pkg/models/fuel_eia_diesel_price_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -70,7 +69,7 @@ func (suite *ModelSuite) TestBasicFuelEIADieselPriceInstantiation() {
 	}
 
 	for name, test := range testCases {
-		suite.T().Run(name, func(t *testing.T) {
+		suite.Run(name, func() {
 			suite.verifyValidationErrors(&test.fuelEIADP, test.expectedErrs)
 		})
 	}
@@ -81,7 +80,7 @@ func (suite *ModelSuite) TestFuelEIADieselPriceOverlappingDatesConstraint() {
 	now := time.Now()
 	id := uuid.Must(uuid.NewV4())
 
-	suite.T().Run("Overlapping Dates Constraint Test", func(t *testing.T) {
+	suite.Run("Overlapping Dates Constraint Test", func() {
 
 		// Test for overalapping start and end dates
 		newFuelPrice := models.FuelEIADieselPrice{

--- a/pkg/models/ghc_diesel_fuel_price_test.go
+++ b/pkg/models/ghc_diesel_fuel_price_test.go
@@ -25,7 +25,7 @@ func (suite *ModelSuite) TestGHCDieselFuelPriceUniqueness() {
 	}
 
 	if verrs, err := suite.DB().ValidateAndCreate(ghcDieselFuelPrice); err != nil || verrs.HasAny() {
-		t.Fatalf("Didn't create GHC Diesel Fuel Price: %s", err)
+		t.Errorf("Didn't create GHC Diesel Fuel Price: %s", err)
 	}
 
 	anotherGHCDieselFuelPrice := &GHCDieselFuelPrice{

--- a/pkg/models/ghc_entitlements_test.go
+++ b/pkg/models/ghc_entitlements_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -16,14 +14,14 @@ func (suite *ModelSuite) TestAuthorizedWeightWhenExistsInDB() {
 }
 
 func (suite *ModelSuite) TestAuthorizedWeightWhenNotInDBAndHaveWeightAllotment() {
-	suite.T().Run("with no dependents authorized, TotalWeightSelf is AuthorizedWeight", func(t *testing.T) {
+	suite.Run("with no dependents authorized, TotalWeightSelf is AuthorizedWeight", func() {
 		entitlement := models.Entitlement{}
 		entitlement.SetWeightAllotment("E_1")
 
 		suite.Equal(entitlement.WeightAllotment().TotalWeightSelf, *entitlement.AuthorizedWeight())
 	})
 
-	suite.T().Run("with dependents authorized, TotalWeightSelfPlusDependents is AuthorizedWeight", func(t *testing.T) {
+	suite.Run("with dependents authorized, TotalWeightSelfPlusDependents is AuthorizedWeight", func() {
 		dependentsAuthorized := true
 		entitlement := models.Entitlement{DependentsAuthorized: &dependentsAuthorized}
 		entitlement.SetWeightAllotment("E_1")
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestAuthorizedWeightWhenNotInDBAndHaveWeightAllotment()
 }
 
 func (suite *ModelSuite) TestProGearAndProGearSpouseWeight() {
-	suite.T().Run("no validation errors for ProGearWeight and ProGearSpouseWeight", func(t *testing.T) {
+	suite.Run("no validation errors for ProGearWeight and ProGearSpouseWeight", func() {
 		entitlement := models.Entitlement{
 			ProGearWeight:       2000,
 			ProGearWeightSpouse: 500,
@@ -42,7 +40,7 @@ func (suite *ModelSuite) TestProGearAndProGearSpouseWeight() {
 		suite.False(verrs.HasAny(), "Should not have validation errors")
 	})
 
-	suite.T().Run("validation errors for ProGearWeight and ProGearSpouseWeight over max value", func(t *testing.T) {
+	suite.Run("validation errors for ProGearWeight and ProGearSpouseWeight over max value", func() {
 		entitlement := models.Entitlement{
 			ProGearWeight:       2001,
 			ProGearWeightSpouse: 501,
@@ -53,7 +51,7 @@ func (suite *ModelSuite) TestProGearAndProGearSpouseWeight() {
 		suite.NotNil(verrs.Get("pro_gear_weight_spouse"))
 	})
 
-	suite.T().Run("validation errors for ProGearWeight and ProGearSpouseWeight under min value", func(t *testing.T) {
+	suite.Run("validation errors for ProGearWeight and ProGearSpouseWeight under min value", func() {
 		entitlement := models.Entitlement{
 			ProGearWeight:       -1,
 			ProGearWeightSpouse: -1,

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -57,7 +56,7 @@ func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 func (suite *ModelSuite) TestGenerateReferenceID() {
 
 	refID, err := GenerateReferenceID(suite.DB())
-	suite.T().Run("reference id is properly created", func(t *testing.T) {
+	suite.Run("reference id is properly created", func() {
 		suite.NoError(err)
 		suite.NotZero(refID)
 		firstNum, _ := strconv.Atoi(strings.Split(refID, "-")[0])
@@ -119,7 +118,7 @@ func (suite *ModelSuite) TestFetchMove() {
 	_, err = FetchMove(suite.DB(), session, move.ID)
 	suite.Equal(ErrFetchForbidden, err, "Expected to get a Forbidden back.")
 
-	suite.T().Run("Hidden move is not returned", func(t *testing.T) {
+	suite.Run("Hidden move is not returned", func() {
 		// Create a hidden move
 		hiddenMove := testdatagen.MakeHiddenHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{})
 
@@ -128,7 +127,7 @@ func (suite *ModelSuite) TestFetchMove() {
 		suite.Equal(ErrFetchNotFound, err, "Expected to get FetchNotFound.")
 	})
 
-	suite.T().Run("deleted shipments are excluded from the results", func(t *testing.T) {
+	suite.Run("deleted shipments are excluded from the results", func() {
 		mtoShipment := testdatagen.MakeDefaultMTOShipment(suite.DB())
 		mto := mtoShipment.MoveTaskOrder
 		testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{

--- a/pkg/models/mto_agents_test.go
+++ b/pkg/models/mto_agents_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) TestMTOAgentValidation() {
-	suite.T().Run("test valid MTOAgent", func(t *testing.T) {
+	suite.Run("test valid MTOAgent", func() {
 		mtoShipmentID := uuid.Must(uuid.NewV4())
 		mtoAgentID := uuid.Must(uuid.NewV4())
 

--- a/pkg/models/mto_service_item_customer_contacts_test.go
+++ b/pkg/models/mto_service_item_customer_contacts_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -10,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) TestMTOServiceItemCustomerContactValidation() {
-	suite.T().Run("test valid MTOServiceItemCustomerContact", func(t *testing.T) {
+	suite.Run("test valid MTOServiceItemCustomerContact", func() {
 		mtoServiceItemDimensionID := uuid.Must(uuid.NewV4())
 
 		validMTOServiceItemDimension := models.MTOServiceItemCustomerContact{
@@ -23,7 +22,7 @@ func (suite *ModelSuite) TestMTOServiceItemCustomerContactValidation() {
 		suite.verifyValidationErrors(&validMTOServiceItemDimension, expErrors)
 	})
 
-	suite.T().Run("test invalid MTOServiceItemCustomerContact", func(t *testing.T) {
+	suite.Run("test invalid MTOServiceItemCustomerContact", func() {
 		validMTOServiceItemDimension := models.MTOServiceItemCustomerContact{
 			MTOServiceItemID:           uuid.Nil,
 			Type:                       "NOT VALID",

--- a/pkg/models/mto_service_item_dimensions_test.go
+++ b/pkg/models/mto_service_item_dimensions_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/gofrs/uuid"
@@ -11,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) TestMTOServiceItemDimension() {
-	suite.T().Run("test valid MTOServiceItemDimension", func(t *testing.T) {
+	suite.Run("test valid MTOServiceItemDimension", func() {
 		mtoServiceItemDimensionID := uuid.Must(uuid.NewV4())
 
 		validMTOServiceItemDimension := models.MTOServiceItemDimension{
@@ -25,7 +23,7 @@ func (suite *ModelSuite) TestMTOServiceItemDimension() {
 		suite.verifyValidationErrors(&validMTOServiceItemDimension, expErrors)
 	})
 
-	suite.T().Run("test invalid MTOServiceItemDimension", func(t *testing.T) {
+	suite.Run("test invalid MTOServiceItemDimension", func() {
 		validMTOServiceItemDimension := models.MTOServiceItemDimension{
 			MTOServiceItemID: uuid.Nil,
 			Type:             "NOT VALID",
@@ -43,7 +41,7 @@ func (suite *ModelSuite) TestMTOServiceItemDimension() {
 		suite.verifyValidationErrors(&validMTOServiceItemDimension, expErrors)
 	})
 
-	suite.T().Run("correct volume is calculated by Volume function", func(t *testing.T) {
+	suite.Run("correct volume is calculated by Volume function", func() {
 		validMTOServiceItemDimension := models.MTOServiceItemDimension{
 			Length: 6000,
 			Height: 10000,

--- a/pkg/models/mto_service_items_test.go
+++ b/pkg/models/mto_service_items_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestMTOServiceItemValidation() {
-	suite.T().Run("test valid MTOServiceItem", func(t *testing.T) {
+	suite.Run("test valid MTOServiceItem", func() {
 		moveTaskOrderID := uuid.Must(uuid.NewV4())
 		mtoShipmentID := uuid.Must(uuid.NewV4())
 		reServiceID := uuid.Must(uuid.NewV4())

--- a/pkg/models/mto_shipments_test.go
+++ b/pkg/models/mto_shipments_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) TestMTOShipmentValidation() {
-	suite.T().Run("test valid MTOShipment", func(t *testing.T) {
+	suite.Run("test valid MTOShipment", func() {
 		// mock weights
 		estimatedWeight := unit.Pound(1000)
 		actualWeight := unit.Pound(980)
@@ -30,7 +28,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		suite.verifyValidationErrors(&validMTOShipment, expErrors)
 	})
 
-	suite.T().Run("test empty MTOShipment", func(t *testing.T) {
+	suite.Run("test empty MTOShipment", func() {
 		emptyMTOShipment := models.MTOShipment{}
 		expErrors := map[string][]string{
 			"move_task_order_id": {"MoveTaskOrderID can not be blank."},
@@ -39,7 +37,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		suite.verifyValidationErrors(&emptyMTOShipment, expErrors)
 	})
 
-	suite.T().Run("test rejected MTOShipment", func(t *testing.T) {
+	suite.Run("test rejected MTOShipment", func() {
 		rejectionReason := "bad shipment"
 		rejectedMTOShipment := models.MTOShipment{
 			MoveTaskOrderID: uuid.Must(uuid.NewV4()),
@@ -50,7 +48,7 @@ func (suite *ModelSuite) TestMTOShipmentValidation() {
 		suite.verifyValidationErrors(&rejectedMTOShipment, expErrors)
 	})
 
-	suite.T().Run("test validation failures", func(t *testing.T) {
+	suite.Run("test validation failures", func() {
 		// mock weights
 		estimatedWeight := unit.Pound(-1000)
 		actualWeight := unit.Pound(-980)

--- a/pkg/models/notifications_test.go
+++ b/pkg/models/notifications_test.go
@@ -3,13 +3,11 @@ package models_test
 import (
 	"github.com/gofrs/uuid"
 
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestNotificationValidations() {
-	suite.T().Run("test valid Notification", func(t *testing.T) {
+	suite.Run("test valid Notification", func() {
 		validNotification := models.Notification{
 			ServiceMemberID: uuid.Must(uuid.NewV4()),
 		}
@@ -17,7 +15,7 @@ func (suite *ModelSuite) TestNotificationValidations() {
 		suite.verifyValidationErrors(&validNotification, expErrors)
 	})
 
-	suite.T().Run("test empty Notification", func(t *testing.T) {
+	suite.Run("test empty Notification", func() {
 		emptyNotification := models.Notification{}
 		expErrors := map[string][]string{
 			"service_member_id": {"ServiceMemberID can not be blank."},

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -108,83 +108,59 @@ func (suite *ModelSuite) TestTacFormat() {
 }
 
 func (suite *ModelSuite) TestFetchOrderForUser() {
-	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
-	serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	dutyLocation := testdatagen.FetchOrMakeDefaultCurrentDutyLocation(suite.DB())
-	dutyLocation2 := testdatagen.FetchOrMakeDefaultNewOrdersDutyLocation(suite.DB())
-	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
-	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
-	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
-	hasDependents := true
-	spouseHasProGear := true
-	uploadedOrder := Document{
-		ServiceMember:   serviceMember1,
-		ServiceMemberID: serviceMember1.ID,
-	}
-	deptIndicator := testdatagen.DefaultDepartmentIndicator
-	TAC := testdatagen.DefaultTransportationAccountingCode
-	suite.MustSave(&uploadedOrder)
+	suite.Run("successful fetch by authorized user", func() {
+		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{})
 
-	SAC := "N002214CSW32Y9"
-	ordersNumber := "FD4534JFJ"
+		// User is authorized to fetch order
+		session := &auth.Session{
+			ApplicationName: auth.MilApp,
+			UserID:          order.ServiceMember.UserID,
+			ServiceMemberID: order.ServiceMemberID,
+		}
+		goodOrder, err := FetchOrderForUser(suite.DB(), session, order.ID)
 
-	order := Order{
-		ServiceMemberID:      serviceMember1.ID,
-		ServiceMember:        serviceMember1,
-		IssueDate:            issueDate,
-		ReportByDate:         reportByDate,
-		OrdersType:           ordersType,
-		HasDependents:        hasDependents,
-		SpouseHasProGear:     spouseHasProGear,
-		OriginDutyLocationID: &dutyLocation.ID,
-		OriginDutyLocation:   &dutyLocation,
-		NewDutyLocationID:    dutyLocation2.ID,
-		NewDutyLocation:      dutyLocation2,
-		UploadedOrdersID:     uploadedOrder.ID,
-		UploadedOrders:       uploadedOrder,
-		Status:               OrderStatusSUBMITTED,
-		OrdersNumber:         &ordersNumber,
-		TAC:                  &TAC,
-		SAC:                  &SAC,
-		DepartmentIndicator:  &deptIndicator,
-		Grade:                swag.String("E-3"),
-	}
-	suite.MustSave(&order)
+		suite.NoError(err)
+		suite.True(order.IssueDate.Equal(goodOrder.IssueDate))
+		suite.True(order.ReportByDate.Equal(goodOrder.ReportByDate))
+		suite.Equal(order.OrdersType, goodOrder.OrdersType)
+		suite.Equal(order.HasDependents, goodOrder.HasDependents)
+		suite.Equal(order.SpouseHasProGear, goodOrder.SpouseHasProGear)
+		suite.Equal(order.OriginDutyLocation.ID, goodOrder.OriginDutyLocation.ID)
+		suite.Equal(order.NewDutyLocation.ID, goodOrder.NewDutyLocation.ID)
+		suite.Equal(order.Grade, goodOrder.Grade)
+		suite.Equal(order.UploadedOrdersID, goodOrder.UploadedOrdersID)
+	})
 
-	// User is authorized to fetch order
-	session := &auth.Session{
-		ApplicationName: auth.MilApp,
-		UserID:          serviceMember1.UserID,
-		ServiceMemberID: serviceMember1.ID,
-	}
-	goodOrder, err := FetchOrderForUser(suite.DB(), session, order.ID)
+	suite.Run("fetch not found due to bad id", func() {
+		sm := testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{})
+		session := &auth.Session{
+			ApplicationName: auth.MilApp,
+			UserID:          sm.UserID,
+			ServiceMemberID: sm.ID,
+		}
+		// Wrong Order ID
+		wrongID, _ := uuid.NewV4()
+		_, err := FetchOrderForUser(suite.DB(), session, wrongID)
 
-	suite.NoError(err)
-	suite.True(order.IssueDate.Equal(goodOrder.IssueDate))
-	suite.True(order.ReportByDate.Equal(goodOrder.ReportByDate))
-	suite.Equal(order.OrdersType, goodOrder.OrdersType)
-	suite.Equal(order.HasDependents, goodOrder.HasDependents)
-	suite.Equal(order.SpouseHasProGear, goodOrder.SpouseHasProGear)
-	suite.Equal(order.OriginDutyLocation.ID, goodOrder.OriginDutyLocation.ID)
-	suite.Equal(order.NewDutyLocation.ID, goodOrder.NewDutyLocation.ID)
-	suite.Equal(order.Grade, goodOrder.Grade)
-	suite.Equal(order.UploadedOrdersID, goodOrder.UploadedOrdersID)
+		suite.Error(err)
+		suite.Equal(ErrFetchNotFound, err)
+	})
 
-	// Wrong Order ID
-	wrongID, _ := uuid.NewV4()
-	_, err = FetchOrderForUser(suite.DB(), session, wrongID)
+	suite.Run("forbidden user cannot fetch order", func() {
+		order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{})
+		// User is forbidden from fetching order
+		serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
+		session := &auth.Session{
+			ApplicationName: auth.MilApp,
+			UserID:          serviceMember2.UserID,
+			ServiceMemberID: serviceMember2.ID,
+		}
+		_, err := FetchOrderForUser(suite.DB(), session, order.ID)
 
-	suite.Error(err)
-	suite.Equal(ErrFetchNotFound, err)
-
-	// User is forbidden from fetching order
-	session.UserID = serviceMember2.UserID
-	session.ServiceMemberID = serviceMember2.ID
-	_, err = FetchOrderForUser(suite.DB(), session, order.ID)
-
-	suite.Error(err)
-	suite.Equal(ErrFetchForbidden, err)
+		suite.Error(err)
+		suite.Equal(ErrFetchForbidden, err)
+	})
 
 	suite.Run("successfully excludes deleted orders uploads", func() {
 		nonDeletedOrdersUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{})

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -43,7 +42,7 @@ func (suite *ModelSuite) TestMiscValidationsAfterSubmission() {
 	order := move.Orders
 	order.Moves = append(order.Moves, move)
 
-	suite.T().Run("test valid UploadedAmendedOrdersID", func(t *testing.T) {
+	suite.Run("test valid UploadedAmendedOrdersID", func() {
 		testUUID := uuid.Must(uuid.NewV4())
 		order.UploadedAmendedOrdersID = &testUUID
 
@@ -52,7 +51,7 @@ func (suite *ModelSuite) TestMiscValidationsAfterSubmission() {
 		suite.verifyValidationErrors(&order, expErrors)
 	})
 
-	suite.T().Run("test UploadedAmendedOrdersID is not nil UUID", func(t *testing.T) {
+	suite.Run("test UploadedAmendedOrdersID is not nil UUID", func() {
 		order.UploadedAmendedOrdersID = &uuid.Nil
 
 		expErrors := map[string][]string{
@@ -187,7 +186,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 	suite.Error(err)
 	suite.Equal(ErrFetchForbidden, err)
 
-	suite.T().Run("successfully excludes deleted orders uploads", func(t *testing.T) {
+	suite.Run("successfully excludes deleted orders uploads", func() {
 		nonDeletedOrdersUpload := testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{})
 		testdatagen.MakeUserUpload(suite.DB(), testdatagen.Assertions{
 			UserUpload: UserUpload{

--- a/pkg/models/payment_request_test.go
+++ b/pkg/models/payment_request_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestPaymentRequestValidation() {
-	suite.T().Run("test valid PaymentRequest", func(t *testing.T) {
+	suite.Run("test valid PaymentRequest", func() {
 		recalculationOfPaymentRequestID := uuid.Must(uuid.NewV4())
 		validPaymentRequest := models.PaymentRequest{
 			MoveTaskOrderID:                 uuid.Must(uuid.NewV4()),
@@ -22,7 +20,7 @@ func (suite *ModelSuite) TestPaymentRequestValidation() {
 		suite.verifyValidationErrors(&validPaymentRequest, expErrors)
 	})
 
-	suite.T().Run("test empty PaymentServiceItem", func(t *testing.T) {
+	suite.Run("test empty PaymentServiceItem", func() {
 		invalidPaymentRequest := models.PaymentRequest{
 			MoveTaskOrderID: uuid.Must(uuid.NewV4()),
 		}
@@ -36,7 +34,7 @@ func (suite *ModelSuite) TestPaymentRequestValidation() {
 		suite.verifyValidationErrors(&invalidPaymentRequest, expErrors)
 	})
 
-	suite.T().Run("test invalid fields for PaymentRequest", func(t *testing.T) {
+	suite.Run("test invalid fields for PaymentRequest", func() {
 		invalidPaymentRequest := models.PaymentRequest{
 			MoveTaskOrderID:                 uuid.Must(uuid.NewV4()),
 			Status:                          "Sleeping",

--- a/pkg/models/payment_request_to_interchange_control_number_test.go
+++ b/pkg/models/payment_request_to_interchange_control_number_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestPaymentRequestToInterchangeControlNumber() {
-	suite.T().Run("test valid PaymentRequestToInterchangeControlNumber", func(t *testing.T) {
+	suite.Run("test valid PaymentRequestToInterchangeControlNumber", func() {
 		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
 			PaymentRequestID:         uuid.Must(uuid.NewV4()),
 			InterchangeControlNumber: 1,
@@ -19,7 +17,7 @@ func (suite *ModelSuite) TestPaymentRequestToInterchangeControlNumber() {
 		suite.verifyValidationErrors(&validPR2ICN, expErrors)
 	})
 
-	suite.T().Run("test invalid PaymentRequestToInterchangeControlNumber", func(t *testing.T) {
+	suite.Run("test invalid PaymentRequestToInterchangeControlNumber", func() {
 		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
 			PaymentRequestID:         uuid.Nil,
 			InterchangeControlNumber: 0,
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestPaymentRequestToInterchangeControlNumber() {
 		suite.verifyValidationErrors(&validPR2ICN, expErrors)
 	})
 
-	suite.T().Run("test invalid InterchangeControlNumber max", func(t *testing.T) {
+	suite.Run("test invalid InterchangeControlNumber max", func() {
 		validPR2ICN := models.PaymentRequestToInterchangeControlNumber{
 			PaymentRequestID:         uuid.Must(uuid.NewV4()),
 			InterchangeControlNumber: 1000000000,

--- a/pkg/models/payment_service_item_param_test.go
+++ b/pkg/models/payment_service_item_param_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestPaymentServiceItemParamValidation() {
-	suite.T().Run("test valid PaymentServiceItemParam", func(t *testing.T) {
+	suite.Run("test valid PaymentServiceItemParam", func() {
 		validPaymentServiceItemParam := models.PaymentServiceItemParam{
 			PaymentServiceItemID:  uuid.Must(uuid.NewV4()),
 			ServiceItemParamKeyID: uuid.Must(uuid.NewV4()),
@@ -19,7 +17,7 @@ func (suite *ModelSuite) TestPaymentServiceItemParamValidation() {
 		suite.verifyValidationErrors(&validPaymentServiceItemParam, expErrors)
 	})
 
-	suite.T().Run("test empty PaymentServiceItemParam", func(t *testing.T) {
+	suite.Run("test empty PaymentServiceItemParam", func() {
 		invalidPaymentServiceItemParam := models.PaymentServiceItemParam{}
 
 		expErrors := map[string][]string{

--- a/pkg/models/payment_service_item_test.go
+++ b/pkg/models/payment_service_item_test.go
@@ -2,7 +2,6 @@ package models_test
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -16,7 +15,7 @@ import (
 func (suite *ModelSuite) TestPaymentServiceItemValidation() {
 	cents := unit.Cents(1000)
 
-	suite.T().Run("test valid PaymentServiceItem", func(t *testing.T) {
+	suite.Run("test valid PaymentServiceItem", func() {
 		validPaymentServiceItem := models.PaymentServiceItem{
 			PaymentRequestID: uuid.Must(uuid.NewV4()),
 			MTOServiceItemID: uuid.Must(uuid.NewV4()), //MTO Service Item
@@ -28,7 +27,7 @@ func (suite *ModelSuite) TestPaymentServiceItemValidation() {
 		suite.verifyValidationErrors(&validPaymentServiceItem, expErrors)
 	})
 
-	suite.T().Run("test empty PaymentServiceItem", func(t *testing.T) {
+	suite.Run("test empty PaymentServiceItem", func() {
 		invalidPaymentServiceItem := models.PaymentServiceItem{}
 
 		expErrors := map[string][]string{
@@ -41,7 +40,7 @@ func (suite *ModelSuite) TestPaymentServiceItemValidation() {
 		suite.verifyValidationErrors(&invalidPaymentServiceItem, expErrors)
 	})
 
-	suite.T().Run("test invalid status for PaymentServiceItem", func(t *testing.T) {
+	suite.Run("test invalid status for PaymentServiceItem", func() {
 		invalidPaymentServiceItem := models.PaymentServiceItem{
 			PaymentRequestID: uuid.Must(uuid.NewV4()),
 			MTOServiceItemID: uuid.Must(uuid.NewV4()), //MTO Service Item
@@ -63,7 +62,7 @@ func (suite *ModelSuite) TestPSIBeforeCreate() {
 		Move: move,
 	})
 
-	suite.T().Run("test with no ID or Reference ID", func(t *testing.T) {
+	suite.Run("test with no ID or Reference ID", func() {
 		paymentServiceItem := models.PaymentServiceItem{
 			PaymentRequestID: paymentRequest.ID,
 			MTOServiceItemID: serviceItem.ID,
@@ -77,7 +76,7 @@ func (suite *ModelSuite) TestPSIBeforeCreate() {
 		suite.NotEmpty(paymentServiceItem.ReferenceID)
 	})
 
-	suite.T().Run("test with ID and Reference ID already provided", func(t *testing.T) {
+	suite.Run("test with ID and Reference ID already provided", func() {
 		psiID := uuid.FromStringOrNil("8dce708b-58ab-4adc-a243-ae0c53a44a41")
 		referenceID := "1234-5678-8dce708b"
 		filledPaymentServiceItem := models.PaymentServiceItem{
@@ -95,7 +94,7 @@ func (suite *ModelSuite) TestPSIBeforeCreate() {
 		suite.Equal(referenceID, filledPaymentServiceItem.ReferenceID)
 	})
 
-	suite.T().Run("test failure because payment request not found", func(t *testing.T) {
+	suite.Run("test failure because payment request not found", func() {
 		badPaymentServiceItem := models.PaymentServiceItem{
 			PaymentRequestID: uuid.Must(uuid.NewV4()), // new UUID pointing nowhere
 			MTOServiceItemID: serviceItem.ID,
@@ -135,7 +134,7 @@ func (suite *ModelSuite) TestGeneratePSIReferenceID() {
 		RequestedAt:      time.Now(),
 	}
 
-	suite.T().Run("test normal reference ID generation", func(t *testing.T) {
+	suite.Run("test normal reference ID generation", func() {
 		referenceID, err := paymentServiceItem.GeneratePSIReferenceID(suite.DB())
 		suite.NoError(err)
 
@@ -146,7 +145,7 @@ func (suite *ModelSuite) TestGeneratePSIReferenceID() {
 		suite.MustCreate(&paymentServiceItem)
 	})
 
-	suite.T().Run("test another payment request with ID that differs by a digit", func(t *testing.T) {
+	suite.Run("test another payment request with ID that differs by a digit", func() {
 		psiIDDigits := fmt.Sprintf("%x", paymentServiceItem2.ID)
 
 		referenceID, err := paymentServiceItem2.GeneratePSIReferenceID(suite.DB())
@@ -154,7 +153,7 @@ func (suite *ModelSuite) TestGeneratePSIReferenceID() {
 		suite.Equal(*mtoReferenceID+"-"+psiIDDigits[:models.PaymentServiceItemMinReferenceIDSuffixLength+1], referenceID)
 	})
 
-	suite.T().Run("test running out of hex digits", func(t *testing.T) {
+	suite.Run("test running out of hex digits", func() {
 		// Need to create PSIs up to the max hex digits -- we already have the first one from above.
 		start := models.PaymentServiceItemMinReferenceIDSuffixLength + 1
 		end := models.PaymentServiceItemMaxReferenceIDLength - len(*mtoReferenceID) - 1

--- a/pkg/models/prime_upload_test.go
+++ b/pkg/models/prime_upload_test.go
@@ -77,7 +77,7 @@ func (suite *ModelSuite) TestFetchPrimeUpload() {
 
 	verrs, err := suite.DB().ValidateAndSave(&upload)
 	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
+		t.Errorf("could not save PrimeUpload: %v", err)
 	}
 
 	if verrs.Count() != 0 {
@@ -91,7 +91,7 @@ func (suite *ModelSuite) TestFetchPrimeUpload() {
 
 	verrs, err = suite.DB().ValidateAndSave(&primeUpload)
 	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
+		t.Errorf("could not save PrimeUpload: %v", err)
 	}
 
 	if verrs.Count() != 0 {
@@ -120,7 +120,7 @@ func (suite *ModelSuite) TestFetchDeletedPrimeUpload() {
 
 	verrs, err := suite.DB().ValidateAndSave(&upload)
 	if err != nil {
-		t.Fatalf("could not save Upload: %v", err)
+		t.Errorf("could not save Upload: %v", err)
 	}
 
 	if verrs.Count() != 0 {
@@ -136,7 +136,7 @@ func (suite *ModelSuite) TestFetchDeletedPrimeUpload() {
 
 	verrs, err = suite.DB().ValidateAndSave(&primeUpload)
 	if err != nil {
-		t.Fatalf("could not save PrimeUpload: %v", err)
+		t.Errorf("could not save PrimeUpload: %v", err)
 	}
 
 	if verrs.Count() != 0 {

--- a/pkg/models/proof_of_service_doc_test.go
+++ b/pkg/models/proof_of_service_doc_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestProofOfServiceDocValidation() {
-	suite.T().Run("test valid ProofOfServiceDoc", func(t *testing.T) {
+	suite.Run("test valid ProofOfServiceDoc", func() {
 		validProofOfServiceDoc := models.ProofOfServiceDoc{
 			PaymentRequestID: uuid.Must(uuid.NewV4()),
 		}
@@ -17,7 +15,7 @@ func (suite *ModelSuite) TestProofOfServiceDocValidation() {
 		suite.verifyValidationErrors(&validProofOfServiceDoc, expErrors)
 	})
 
-	suite.T().Run("test empty ProofOfServiceDoc", func(t *testing.T) {
+	suite.Run("test empty ProofOfServiceDoc", func() {
 		invalidProofOfServiceDoc := models.ProofOfServiceDoc{}
 
 		expErrors := map[string][]string{

--- a/pkg/models/re_contract_test.go
+++ b/pkg/models/re_contract_test.go
@@ -1,13 +1,11 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReContractValidations() {
-	suite.T().Run("test valid ReContract", func(t *testing.T) {
+	suite.Run("test valid ReContract", func() {
 		validReContract := models.ReContract{
 			Code: "ABC",
 			Name: "ABC, Inc.",
@@ -16,7 +14,7 @@ func (suite *ModelSuite) TestReContractValidations() {
 		suite.verifyValidationErrors(&validReContract, expErrors)
 	})
 
-	suite.T().Run("test empty ReContract", func(t *testing.T) {
+	suite.Run("test empty ReContract", func() {
 		emptyReContract := models.ReContract{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},

--- a/pkg/models/re_contract_year_test.go
+++ b/pkg/models/re_contract_year_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -10,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReContractYearValidations() {
-	suite.T().Run("test valid ReContractYear", func(t *testing.T) {
+	suite.Run("test valid ReContractYear", func() {
 		validReContractYear := models.ReContractYear{
 			ContractID:           uuid.Must(uuid.NewV4()),
 			Name:                 "Base Period Year 1",
@@ -23,7 +22,7 @@ func (suite *ModelSuite) TestReContractYearValidations() {
 		suite.verifyValidationErrors(&validReContractYear, expErrors)
 	})
 
-	suite.T().Run("test empty ReContractYear", func(t *testing.T) {
+	suite.Run("test empty ReContractYear", func() {
 		emptyReContractYear := models.ReContractYear{}
 		expErrors := map[string][]string{
 			"contract_id":           {"ContractID can not be blank."},
@@ -36,7 +35,7 @@ func (suite *ModelSuite) TestReContractYearValidations() {
 		suite.verifyValidationErrors(&emptyReContractYear, expErrors)
 	})
 
-	suite.T().Run("test end date after start date, negative escalation, negative escalation compounded for ReContractYear", func(t *testing.T) {
+	suite.Run("test end date after start date, negative escalation, negative escalation compounded for ReContractYear", func() {
 		badDatesReContractYear := models.ReContractYear{
 			ContractID:           uuid.Must(uuid.NewV4()),
 			Name:                 "Base Period Year 2",

--- a/pkg/models/re_domestic_accessorial_price_test.go
+++ b/pkg/models/re_domestic_accessorial_price_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/gofrs/uuid"
@@ -11,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReDomesticAccessorialPriceValidation() {
-	suite.T().Run("test valid ReDomesticAccessorialPrice", func(t *testing.T) {
+	suite.Run("test valid ReDomesticAccessorialPrice", func() {
 		validReDomesticAccessorialPrice := models.ReDomesticAccessorialPrice{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceID:        uuid.Must(uuid.NewV4()),
@@ -22,7 +20,7 @@ func (suite *ModelSuite) TestReDomesticAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&validReDomesticAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test invalid ReDomesticAccessorialPrice", func(t *testing.T) {
+	suite.Run("test invalid ReDomesticAccessorialPrice", func() {
 		invalidReDomesticAccessorialPrice := models.ReDomesticAccessorialPrice{}
 		expErrors := map[string][]string{
 			"contract_id":       {"ContractID can not be blank."},
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestReDomesticAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&invalidReDomesticAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test service schedule over 3 for ReDomesticAccessorialPrice", func(t *testing.T) {
+	suite.Run("test service schedule over 3 for ReDomesticAccessorialPrice", func() {
 		invalidReDomesticAccessorialPrice := models.ReDomesticAccessorialPrice{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceID:        uuid.Must(uuid.NewV4()),
@@ -46,7 +44,7 @@ func (suite *ModelSuite) TestReDomesticAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&invalidReDomesticAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test per unit cents is not negative ReDomesticAccessorialPrice", func(t *testing.T) {
+	suite.Run("test per unit cents is not negative ReDomesticAccessorialPrice", func() {
 		invalidReDomesticAccessorialPrice := models.ReDomesticAccessorialPrice{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceID:        uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_domestic_linehaul_price_test.go
+++ b/pkg/models/re_domestic_linehaul_price_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReDomesticLinehaulPriceValidations() {
-	suite.T().Run("test valid ReDomesticLinehaulPrice", func(t *testing.T) {
+	suite.Run("test valid ReDomesticLinehaulPrice", func() {
 		validReDomesticLinehaulPrice := models.ReDomesticLinehaulPrice{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			WeightLower:           unit.Pound(5000),
@@ -25,7 +23,7 @@ func (suite *ModelSuite) TestReDomesticLinehaulPriceValidations() {
 		suite.verifyValidationErrors(&validReDomesticLinehaulPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReDomesticLinehaulPrice", func(t *testing.T) {
+	suite.Run("test empty ReDomesticLinehaulPrice", func() {
 		emptyReDomesticLinehaulPrice := models.ReDomesticLinehaulPrice{}
 		expErrors := map[string][]string{
 			"contract_id":              {"ContractID can not be blank."},
@@ -38,7 +36,7 @@ func (suite *ModelSuite) TestReDomesticLinehaulPriceValidations() {
 		suite.verifyValidationErrors(&emptyReDomesticLinehaulPrice, expErrors)
 	})
 
-	suite.T().Run("test negative weight lower for ReDomesticLinehaulPrice", func(t *testing.T) {
+	suite.Run("test negative weight lower for ReDomesticLinehaulPrice", func() {
 		validReDomesticLinehaulPrice := models.ReDomesticLinehaulPrice{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			WeightLower:           unit.Pound(5000),

--- a/pkg/models/re_domestic_other_price_test.go
+++ b/pkg/models/re_domestic_other_price_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReDomesticOtherPriceValidations() {
-	suite.T().Run("test valid ReDomesticOtherPrice", func(t *testing.T) {
+	suite.Run("test valid ReDomesticOtherPrice", func() {
 		validReDomesticOtherPrice := models.ReDomesticOtherPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),
@@ -22,7 +20,7 @@ func (suite *ModelSuite) TestReDomesticOtherPriceValidations() {
 		suite.verifyValidationErrors(&validReDomesticOtherPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReDomesticOtherPrice", func(t *testing.T) {
+	suite.Run("test empty ReDomesticOtherPrice", func() {
 		emptyReDomesticOtherPrice := models.ReDomesticOtherPrice{}
 		expErrors := map[string][]string{
 			"contract_id": {"ContractID can not be blank."},
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestReDomesticOtherPriceValidations() {
 		suite.verifyValidationErrors(&emptyReDomesticOtherPrice, expErrors)
 	})
 
-	suite.T().Run("test ReDomesticOtherPrice with schedule about limit", func(t *testing.T) {
+	suite.Run("test ReDomesticOtherPrice with schedule about limit", func() {
 		badScheduleReDomesticOtherPrice := models.ReDomesticOtherPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_domestic_service_area_price_test.go
+++ b/pkg/models/re_domestic_service_area_price_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -10,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReDomesticServiceAreaPriceValidations() {
-	suite.T().Run("test valid ReDomesticServiceAreaPrice", func(t *testing.T) {
+	suite.Run("test valid ReDomesticServiceAreaPrice", func() {
 		validReDomesticServiceAreaPrice := models.ReDomesticServiceAreaPrice{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			ServiceID:             uuid.Must(uuid.NewV4()),
@@ -22,7 +20,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaPriceValidations() {
 		suite.verifyValidationErrors(&validReDomesticServiceAreaPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReDomesticServiceAreaPrice", func(t *testing.T) {
+	suite.Run("test empty ReDomesticServiceAreaPrice", func() {
 		emptyReDomesticServiceAreaPrice := models.ReDomesticServiceAreaPrice{}
 		expErrors := map[string][]string{
 			"contract_id":              {"ContractID can not be blank."},

--- a/pkg/models/re_domestic_service_area_test.go
+++ b/pkg/models/re_domestic_service_area_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
-	suite.T().Run("test valid ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test valid ReDomesticServiceArea", func() {
 		validReDomesticServiceArea := models.ReDomesticServiceArea{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceArea:      "009",
@@ -20,7 +18,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		suite.verifyValidationErrors(&validReDomesticServiceArea, expErrors)
 	})
 
-	suite.T().Run("test invalid ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test invalid ReDomesticServiceArea", func() {
 		emptyReDomesticServiceArea := models.ReDomesticServiceArea{}
 		expErrors := map[string][]string{
 			"contract_id":       {"ContractID can not be blank."},
@@ -31,7 +29,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		suite.verifyValidationErrors(&emptyReDomesticServiceArea, expErrors)
 	})
 
-	suite.T().Run("test schedules over 3 for ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test schedules over 3 for ReDomesticServiceArea", func() {
 		invalidReDomesticServiceArea := models.ReDomesticServiceArea{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceArea:      "009",
@@ -45,7 +43,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		suite.verifyValidationErrors(&invalidReDomesticServiceArea, expErrors)
 	})
 
-	suite.T().Run("test schedules less than 1 for ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test schedules less than 1 for ReDomesticServiceArea", func() {
 		invalidReDomesticServiceArea := models.ReDomesticServiceArea{
 			ContractID:       uuid.Must(uuid.NewV4()),
 			ServiceArea:      "009",

--- a/pkg/models/re_intl_accessorial_price_test.go
+++ b/pkg/models/re_intl_accessorial_price_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReIntlAccessorialPriceValidation() {
-	suite.T().Run("test valid ReIntlAccessorialPrice", func(t *testing.T) {
+	suite.Run("test valid ReIntlAccessorialPrice", func() {
 		validReIntlAccessorialPrice := models.ReIntlAccessorialPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),
@@ -20,7 +18,7 @@ func (suite *ModelSuite) TestReIntlAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&validReIntlAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test invalid ReIntlAccessorialPrice", func(t *testing.T) {
+	suite.Run("test invalid ReIntlAccessorialPrice", func() {
 		invalidReIntlAccessorialPrice := models.ReIntlAccessorialPrice{}
 		expErrors := map[string][]string{
 			"contract_id":    {"ContractID can not be blank."},
@@ -31,7 +29,7 @@ func (suite *ModelSuite) TestReIntlAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&invalidReIntlAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test invalid market for ReIntlAccessorialPrice", func(t *testing.T) {
+	suite.Run("test invalid market for ReIntlAccessorialPrice", func() {
 		invalidReIntlAccessorialPrice := models.ReIntlAccessorialPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),
@@ -44,7 +42,7 @@ func (suite *ModelSuite) TestReIntlAccessorialPriceValidation() {
 		suite.verifyValidationErrors(&invalidReIntlAccessorialPrice, expErrors)
 	})
 
-	suite.T().Run("test per unit cents less than 1 for ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test per unit cents less than 1 for ReDomesticServiceArea", func() {
 		invalidReIntlAccessorialPrice := models.ReIntlAccessorialPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_intl_other_price_test.go
+++ b/pkg/models/re_intl_other_price_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReIntlOtherPriceValidation() {
-	suite.T().Run("test valid ReIntlOtherPrice", func(t *testing.T) {
+	suite.Run("test valid ReIntlOtherPrice", func() {
 
 		validReIntlOtherPrice := models.ReIntlOtherPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
@@ -22,7 +20,7 @@ func (suite *ModelSuite) TestReIntlOtherPriceValidation() {
 		suite.verifyValidationErrors(&validReIntlOtherPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReIntlOtherPrice", func(t *testing.T) {
+	suite.Run("test empty ReIntlOtherPrice", func() {
 		invalidReIntlOtherPrice := models.ReIntlOtherPrice{}
 		expErrors := map[string][]string{
 			"contract_id":    {"ContractID can not be blank."},
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestReIntlOtherPriceValidation() {
 		suite.verifyValidationErrors(&invalidReIntlOtherPrice, expErrors)
 	})
 
-	suite.T().Run("test negative PerUnitCents value", func(t *testing.T) {
+	suite.Run("test negative PerUnitCents value", func() {
 		intlOtherPrice := models.ReIntlOtherPrice{
 			ContractID:   uuid.Must(uuid.NewV4()),
 			ServiceID:    uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_intl_price_test.go
+++ b/pkg/models/re_intl_price_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReIntlPriceValidation() {
-	suite.T().Run("test valid ReIntlPrice", func(t *testing.T) {
+	suite.Run("test valid ReIntlPrice", func() {
 
 		validReIntlPrice := models.ReIntlPrice{
 			ContractID:            uuid.Must(uuid.NewV4()),
@@ -23,7 +21,7 @@ func (suite *ModelSuite) TestReIntlPriceValidation() {
 		suite.verifyValidationErrors(&validReIntlPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReIntlPrice", func(t *testing.T) {
+	suite.Run("test empty ReIntlPrice", func() {
 		invalidReIntlPrice := models.ReIntlPrice{}
 		expErrors := map[string][]string{
 			"contract_id":              {"ContractID can not be blank."},
@@ -35,7 +33,7 @@ func (suite *ModelSuite) TestReIntlPriceValidation() {
 		suite.verifyValidationErrors(&invalidReIntlPrice, expErrors)
 	})
 
-	suite.T().Run("test empty ReIntlPrice", func(t *testing.T) {
+	suite.Run("test empty ReIntlPrice", func() {
 		reIntlPrice := models.ReIntlPrice{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			ServiceID:             uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_rate_area_test.go
+++ b/pkg/models/re_rate_area_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReRateAreaValidation() {
-	suite.T().Run("test valid ReRateArea", func(t *testing.T) {
+	suite.Run("test valid ReRateArea", func() {
 		validReRateArea := models.ReRateArea{
 			ContractID: uuid.Must(uuid.NewV4()),
 			IsOconus:   true,
@@ -20,7 +18,7 @@ func (suite *ModelSuite) TestReRateAreaValidation() {
 		suite.verifyValidationErrors(&validReRateArea, expErrors)
 	})
 
-	suite.T().Run("test empty ReRateArea", func(t *testing.T) {
+	suite.Run("test empty ReRateArea", func() {
 		emptyReRateArea := models.ReRateArea{}
 		expErrors := map[string][]string{
 			"contract_id": {"ContractID can not be blank."},

--- a/pkg/models/re_service_test.go
+++ b/pkg/models/re_service_test.go
@@ -1,13 +1,11 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReServiceValidation() {
-	suite.T().Run("test valid ReService", func(t *testing.T) {
+	suite.Run("test valid ReService", func() {
 		validReService := models.ReService{
 			Code: "123abc",
 			Name: "California",
@@ -16,7 +14,7 @@ func (suite *ModelSuite) TestReServiceValidation() {
 		suite.verifyValidationErrors(&validReService, expErrors)
 	})
 
-	suite.T().Run("test empty ReService", func(t *testing.T) {
+	suite.Run("test empty ReService", func() {
 		emptyReService := models.ReService{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},

--- a/pkg/models/re_shipment_type_price_test.go
+++ b/pkg/models/re_shipment_type_price_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReShipmentTypePriceValidation() {
-	suite.T().Run("test valid ReShipmentTypePrice", func(t *testing.T) {
+	suite.Run("test valid ReShipmentTypePrice", func() {
 		validReShipmentTypePrice := models.ReShipmentTypePrice{
 			ContractID: uuid.Must(uuid.NewV4()),
 			ServiceID:  uuid.Must(uuid.NewV4()),
@@ -20,7 +18,7 @@ func (suite *ModelSuite) TestReShipmentTypePriceValidation() {
 		suite.verifyValidationErrors(&validReShipmentTypePrice, expErrors)
 	})
 
-	suite.T().Run("test invalid ReShipmentTypePrice", func(t *testing.T) {
+	suite.Run("test invalid ReShipmentTypePrice", func() {
 		invalidReShipmentTypePrice := models.ReShipmentTypePrice{}
 		expErrors := map[string][]string{
 			"contract_id": {"ContractID can not be blank."},
@@ -31,7 +29,7 @@ func (suite *ModelSuite) TestReShipmentTypePriceValidation() {
 		suite.verifyValidationErrors(&invalidReShipmentTypePrice, expErrors)
 	})
 
-	suite.T().Run("test invalid market for ReShipmentTypePrice", func(t *testing.T) {
+	suite.Run("test invalid market for ReShipmentTypePrice", func() {
 		invalidShipmentTypePrice := models.ReShipmentTypePrice{
 			ContractID: uuid.Must(uuid.NewV4()),
 			ServiceID:  uuid.Must(uuid.NewV4()),
@@ -44,7 +42,7 @@ func (suite *ModelSuite) TestReShipmentTypePriceValidation() {
 		suite.verifyValidationErrors(&invalidShipmentTypePrice, expErrors)
 	})
 
-	suite.T().Run("test factor hundredths less than 1 for ReShipmentTypePrice", func(t *testing.T) {
+	suite.Run("test factor hundredths less than 1 for ReShipmentTypePrice", func() {
 		invalidShipmentTypePrice := models.ReShipmentTypePrice{
 			ContractID: uuid.Must(uuid.NewV4()),
 			ServiceID:  uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_task_order_fee_test.go
+++ b/pkg/models/re_task_order_fee_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReTaskOrderFeeValidation() {
-	suite.T().Run("test valid ReTaskOrderFee", func(t *testing.T) {
+	suite.Run("test valid ReTaskOrderFee", func() {
 		validReTaskOrderFee := models.ReTaskOrderFee{
 			ContractYearID: uuid.Must(uuid.NewV4()),
 			ServiceID:      uuid.Must(uuid.NewV4()),
@@ -19,7 +17,7 @@ func (suite *ModelSuite) TestReTaskOrderFeeValidation() {
 		suite.verifyValidationErrors(&validReTaskOrderFee, expErrors)
 	})
 
-	suite.T().Run("test invalid ReTaskOrderFee", func(t *testing.T) {
+	suite.Run("test invalid ReTaskOrderFee", func() {
 		invalidReTaskOrderFee := models.ReTaskOrderFee{}
 		expErrors := map[string][]string{
 			"contract_year_id": {"ContractYearID can not be blank."},
@@ -29,7 +27,7 @@ func (suite *ModelSuite) TestReTaskOrderFeeValidation() {
 		suite.verifyValidationErrors(&invalidReTaskOrderFee, expErrors)
 	})
 
-	suite.T().Run("test price cents less than 1 for ReDomesticServiceArea", func(t *testing.T) {
+	suite.Run("test price cents less than 1 for ReDomesticServiceArea", func() {
 		invalidReTaskOrderFee := models.ReTaskOrderFee{
 			ContractYearID: uuid.Must(uuid.NewV4()),
 			ServiceID:      uuid.Must(uuid.NewV4()),

--- a/pkg/models/re_zip3s_test.go
+++ b/pkg/models/re_zip3s_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReZip3Validations() {
-	suite.T().Run("test valid ReZip3", func(t *testing.T) {
+	suite.Run("test valid ReZip3", func() {
 		validReZip3 := models.ReZip3{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			Zip3:                  "606",
@@ -21,7 +19,7 @@ func (suite *ModelSuite) TestReZip3Validations() {
 		suite.verifyValidationErrors(&validReZip3, expErrors)
 	})
 
-	suite.T().Run("test invalid ReZip3", func(t *testing.T) {
+	suite.Run("test invalid ReZip3", func() {
 		emptyReZip3 := models.ReZip3{}
 		expErrors := map[string][]string{
 			"contract_id":              {"ContractID can not be blank."},
@@ -33,7 +31,7 @@ func (suite *ModelSuite) TestReZip3Validations() {
 		suite.verifyValidationErrors(&emptyReZip3, expErrors)
 	})
 
-	suite.T().Run("test when zip3 is not a length of 3", func(t *testing.T) {
+	suite.Run("test when zip3 is not a length of 3", func() {
 		invalidReZip3 := models.ReZip3{
 			ContractID:            uuid.Must(uuid.NewV4()),
 			Zip3:                  "60",

--- a/pkg/models/re_zip5_rate_areas_test.go
+++ b/pkg/models/re_zip5_rate_areas_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestReZip5RateAreaValidations() {
-	suite.T().Run("test valid ReZip5RateArea", func(t *testing.T) {
+	suite.Run("test valid ReZip5RateArea", func() {
 		validReZip5RateArea := models.ReZip5RateArea{
 			ContractID: uuid.Must(uuid.NewV4()),
 			RateAreaID: uuid.Must(uuid.NewV4()),
@@ -19,7 +17,7 @@ func (suite *ModelSuite) TestReZip5RateAreaValidations() {
 		suite.verifyValidationErrors(&validReZip5RateArea, expErrors)
 	})
 
-	suite.T().Run("test invalid ReZip5RateArea", func(t *testing.T) {
+	suite.Run("test invalid ReZip5RateArea", func() {
 		emptyReZip5RateArea := models.ReZip5RateArea{}
 		expErrors := map[string][]string{
 			"contract_id":  {"ContractID can not be blank."},
@@ -29,7 +27,7 @@ func (suite *ModelSuite) TestReZip5RateAreaValidations() {
 		suite.verifyValidationErrors(&emptyReZip5RateArea, expErrors)
 	})
 
-	suite.T().Run("test when zip5 is not a length of 5", func(t *testing.T) {
+	suite.Run("test when zip5 is not a length of 5", func() {
 		invalidReZip5RateArea := models.ReZip5RateArea{
 			ContractID: uuid.Must(uuid.NewV4()),
 			RateAreaID: uuid.Must(uuid.NewV4()),

--- a/pkg/models/reweigh_test.go
+++ b/pkg/models/reweigh_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -11,7 +10,7 @@ import (
 )
 
 func (suite *ModelSuite) TestReweighValidation() {
-	suite.T().Run("test valid Reweigh", func(t *testing.T) {
+	suite.Run("test valid Reweigh", func() {
 		validReweigh := models.Reweigh{
 			RequestedAt: time.Now(),
 			RequestedBy: models.ReweighRequesterCustomer,
@@ -21,7 +20,7 @@ func (suite *ModelSuite) TestReweighValidation() {
 		suite.verifyValidationErrors(&validReweigh, expErrors)
 	})
 
-	suite.T().Run("test empty reweigh", func(t *testing.T) {
+	suite.Run("test empty reweigh", func() {
 		expErrors := map[string][]string{
 			"requested_at": {"RequestedAt can not be blank."},
 			"requested_by": {"RequestedBy is not in the list [CUSTOMER, PRIME, SYSTEM, TOO]."},
@@ -30,7 +29,7 @@ func (suite *ModelSuite) TestReweighValidation() {
 		suite.verifyValidationErrors(&models.Reweigh{}, expErrors)
 	})
 
-	suite.T().Run("test validation failures", func(t *testing.T) {
+	suite.Run("test validation failures", func() {
 		var verificationReason string
 		weight := unit.Pound(-1)
 		invalidReweigh := models.Reweigh{

--- a/pkg/models/service_item_param_key_test.go
+++ b/pkg/models/service_item_param_key_test.go
@@ -3,7 +3,6 @@ package models_test
 import (
 	"fmt"
 	"strings"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -13,7 +12,7 @@ func (suite *ModelSuite) TestServiceItemParamKeyValidation() {
 	validServiceItemParamTypes := strings.Join(models.ValidServiceItemParamTypes, ", ")
 	validServiceItemParamOrigins := strings.Join(models.ValidServiceItemParamOrigins, ", ")
 
-	suite.T().Run("test valid ServiceItemParamKey", func(t *testing.T) {
+	suite.Run("test valid ServiceItemParamKey", func() {
 		validServiceItemParamKey := models.ServiceItemParamKey{
 			Key:         models.ServiceItemParamNameZipPickupAddress,
 			Description: "Description",
@@ -24,7 +23,7 @@ func (suite *ModelSuite) TestServiceItemParamKeyValidation() {
 		suite.verifyValidationErrors(&validServiceItemParamKey, expErrors)
 	})
 
-	suite.T().Run("test empty ServiceItemParamKey", func(t *testing.T) {
+	suite.Run("test empty ServiceItemParamKey", func() {
 		invalidServiceItemParamKey := models.ServiceItemParamKey{}
 
 		expErrors := map[string][]string{
@@ -37,7 +36,7 @@ func (suite *ModelSuite) TestServiceItemParamKeyValidation() {
 		suite.verifyValidationErrors(&invalidServiceItemParamKey, expErrors)
 	})
 
-	suite.T().Run("test invalid key name for ServiceItemParamKey", func(t *testing.T) {
+	suite.Run("test invalid key name for ServiceItemParamKey", func() {
 		invalidServiceItemParamKey := models.ServiceItemParamKey{
 			Key:         "foo",
 			Description: "Description",
@@ -50,7 +49,7 @@ func (suite *ModelSuite) TestServiceItemParamKeyValidation() {
 		suite.verifyValidationErrors(&invalidServiceItemParamKey, expErrors)
 	})
 
-	suite.T().Run("test invalid type for ServiceItemParamKey", func(t *testing.T) {
+	suite.Run("test invalid type for ServiceItemParamKey", func() {
 		invalidServiceItemParamKey := models.ServiceItemParamKey{
 			Key:         models.ServiceItemParamNameZipPickupAddress,
 			Description: "Description",
@@ -63,7 +62,7 @@ func (suite *ModelSuite) TestServiceItemParamKeyValidation() {
 		suite.verifyValidationErrors(&invalidServiceItemParamKey, expErrors)
 	})
 
-	suite.T().Run("test invalid origin for ServiceItemParamKey", func(t *testing.T) {
+	suite.Run("test invalid origin for ServiceItemParamKey", func() {
 		invalidServiceItemParamKey := models.ServiceItemParamKey{
 			Key:         models.ServiceItemParamNameZipPickupAddress,
 			Description: "Description",

--- a/pkg/models/service_param_test.go
+++ b/pkg/models/service_param_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestServiceParamValidation() {
-	suite.T().Run("test valid ServiceParam", func(t *testing.T) {
+	suite.Run("test valid ServiceParam", func() {
 		validServiceParam := models.ServiceParam{
 			ServiceID:             uuid.Must(uuid.NewV4()),
 			ServiceItemParamKeyID: uuid.Must(uuid.NewV4()),
@@ -19,7 +17,7 @@ func (suite *ModelSuite) TestServiceParamValidation() {
 		suite.verifyValidationErrors(&validServiceParam, expErrors)
 	})
 
-	suite.T().Run("test empty ServiceParam", func(t *testing.T) {
+	suite.Run("test empty ServiceParam", func() {
 		invalidServiceParam := models.ServiceParam{}
 
 		expErrors := map[string][]string{

--- a/pkg/models/sit_extension_test.go
+++ b/pkg/models/sit_extension_test.go
@@ -2,7 +2,6 @@ package models_test
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -17,7 +16,7 @@ func (suite *ModelSuite) TestSITExtensionCreation() {
 	suite.NotNil(shipment)
 	suite.NotEqual(uuid.Nil, shipment.ID)
 
-	suite.T().Run("test valid SITExtension", func(t *testing.T) {
+	suite.Run("test valid SITExtension", func() {
 		approvedDays := 90
 		decisionDate := time.Now()
 		contractorRemarks := "some remarks here from the contractor"
@@ -42,7 +41,7 @@ func (suite *ModelSuite) TestSITExtensionCreation() {
 		suite.NotEqual(time.Time{}, validSITExtension.UpdatedAt)
 	})
 
-	suite.T().Run("test minimal valid SITExtension", func(t *testing.T) {
+	suite.Run("test minimal valid SITExtension", func() {
 		validSITExtension := models.SITExtension{
 			MTOShipment:   shipment,
 			MTOShipmentID: shipment.ID,
@@ -61,7 +60,7 @@ func (suite *ModelSuite) TestSITExtensionCreation() {
 }
 
 func (suite *ModelSuite) TestSITExtensionValidation() {
-	suite.T().Run("test valid SITExtension", func(t *testing.T) {
+	suite.Run("test valid SITExtension", func() {
 		approvedDays := 1
 		decisionDate := time.Now()
 		contractorRemarks := "some remarks here from the contractor"
@@ -91,7 +90,7 @@ func (suite *ModelSuite) TestSITExtensionValidation() {
 	}
 
 	for _, reason := range reasons {
-		suite.T().Run(fmt.Sprintf("test valid SITExtension Reasons (%s)", reason), func(t *testing.T) {
+		suite.Run(fmt.Sprintf("test valid SITExtension Reasons (%s)", reason), func() {
 			validSITExtension := models.SITExtension{
 				MTOShipmentID: uuid.Must(uuid.NewV4()),
 				RequestReason: reason,
@@ -110,7 +109,7 @@ func (suite *ModelSuite) TestSITExtensionValidation() {
 	}
 
 	for _, status := range statuses {
-		suite.T().Run(fmt.Sprintf("test valid SITExtension Status (%s)", status), func(t *testing.T) {
+		suite.Run(fmt.Sprintf("test valid SITExtension Status (%s)", status), func() {
 			validSITExtension := models.SITExtension{
 				MTOShipmentID: uuid.Must(uuid.NewV4()),
 				RequestReason: models.SITExtensionRequestReasonSeriousIllnessMember,
@@ -122,7 +121,7 @@ func (suite *ModelSuite) TestSITExtensionValidation() {
 		})
 	}
 
-	suite.T().Run("test invalid sit extension", func(t *testing.T) {
+	suite.Run("test invalid sit extension", func() {
 		const badReason models.SITExtensionRequestReason = "bad reason"
 		const badStatus models.SITExtensionStatus = "bad status"
 		approvedDays := 0

--- a/pkg/models/sit_extension_test.go
+++ b/pkg/models/sit_extension_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func (suite *ModelSuite) TestSITExtensionCreation() {
-	shipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
-	suite.NotNil(shipment)
-	suite.NotEqual(uuid.Nil, shipment.ID)
 
 	suite.Run("test valid SITExtension", func() {
+		shipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
+		suite.NotNil(shipment)
+		suite.NotEqual(uuid.Nil, shipment.ID)
 		approvedDays := 90
 		decisionDate := time.Now()
 		contractorRemarks := "some remarks here from the contractor"
@@ -42,6 +42,9 @@ func (suite *ModelSuite) TestSITExtensionCreation() {
 	})
 
 	suite.Run("test minimal valid SITExtension", func() {
+		shipment := testdatagen.MakeDefaultMTOShipmentMinimal(suite.DB())
+		suite.NotNil(shipment)
+		suite.NotEqual(uuid.Nil, shipment.ID)
 		validSITExtension := models.SITExtension{
 			MTOShipment:   shipment,
 			MTOShipmentID: shipment.ID,

--- a/pkg/models/storage_facility_test.go
+++ b/pkg/models/storage_facility_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestStorageFacilityValidation() {
-	suite.T().Run("test valid StorageFacility", func(t *testing.T) {
+	suite.Run("test valid StorageFacility", func() {
 		validMTOShipment := models.StorageFacility{
 			FacilityName: "Test Storage Facility",
 			AddressID:    uuid.Must(uuid.NewV4()),
@@ -18,7 +16,7 @@ func (suite *ModelSuite) TestStorageFacilityValidation() {
 		suite.verifyValidationErrors(&validMTOShipment, expErrors)
 	})
 
-	suite.T().Run("test invalid StorageFacility", func(t *testing.T) {
+	suite.Run("test invalid StorageFacility", func() {
 		lotNumber := ""
 		phone := ""
 		email := ""

--- a/pkg/models/tariff400ng_full_pack_rate_test.go
+++ b/pkg/models/tariff400ng_full_pack_rate_test.go
@@ -147,7 +147,7 @@ func (suite *ModelSuite) Test_FetchFullPackRateCents() {
 
 	rate, err := FetchTariff400ngFullPackRateCents(suite.DB(), weight, schedule, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Unable to query full pack rate: %v", err)
+		t.Errorf("Unable to query full pack rate: %v", err)
 	}
 	if rate != rateExpected {
 		t.Errorf("Incorrect full pack rate received. Got: %d. Expected: %d.", rate, rateExpected)

--- a/pkg/models/tariff400ng_full_pack_rate_test.go
+++ b/pkg/models/tariff400ng_full_pack_rate_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -11,7 +10,7 @@ import (
 
 func (suite *ModelSuite) TestTariff400ngFullPackRateValidations() {
 	now := time.Now()
-	suite.T().Run("test valid Tariff400ngFullPackRate", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngFullPackRate", func() {
 		validTariff400ngFullPackRate := Tariff400ngFullPackRate{
 			Schedule:           1,
 			WeightLbsLower:     100,
@@ -24,7 +23,7 @@ func (suite *ModelSuite) TestTariff400ngFullPackRateValidations() {
 		suite.verifyValidationErrors(&validTariff400ngFullPackRate, expErrors)
 	})
 
-	suite.T().Run("test empty Tariff400ngFullPackRate", func(t *testing.T) {
+	suite.Run("test empty Tariff400ngFullPackRate", func() {
 		emptyTariff400ngFullPackRate := Tariff400ngFullPackRate{}
 		expErrors := map[string][]string{
 			"schedule":             {"Schedule can not be blank."},

--- a/pkg/models/tariff400ng_full_unpack_rate_test.go
+++ b/pkg/models/tariff400ng_full_unpack_rate_test.go
@@ -75,7 +75,7 @@ func (suite *ModelSuite) Test_FetchFullUnPackRateCents() {
 
 	rate, err := FetchTariff400ngFullUnpackRateMillicents(suite.DB(), schedule, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Unable to query full unpack rate: %v", err)
+		t.Errorf("Unable to query full unpack rate: %v", err)
 	}
 	if rate != rateExpected {
 		t.Errorf("Incorrect full unpack rate received. Got: %d. Expected: %d.", rate, rateExpected)

--- a/pkg/models/tariff400ng_full_unpack_rate_test.go
+++ b/pkg/models/tariff400ng_full_unpack_rate_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -9,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_Tariff400ngFullUnpackRateValidation() {
-	suite.T().Run("test valid Tariff400ngFullUnpackRate", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngFullUnpackRate", func() {
 		now := time.Now()
 		validTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{
 			Schedule:           1,
@@ -21,7 +20,7 @@ func (suite *ModelSuite) Test_Tariff400ngFullUnpackRateValidation() {
 		suite.verifyValidationErrors(&validTariff400ngFullUnpackRate, expErrors)
 	})
 
-	suite.T().Run("test invalid Tariff400ngFullUnpackRate", func(t *testing.T) {
+	suite.Run("test invalid Tariff400ngFullUnpackRate", func() {
 		invalidTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{}
 		expErrors := map[string][]string{
 			"schedule":             {"Schedule can not be blank."},
@@ -31,7 +30,7 @@ func (suite *ModelSuite) Test_Tariff400ngFullUnpackRateValidation() {
 		suite.verifyValidationErrors(&invalidTariff400ngFullUnpackRate, expErrors)
 	})
 
-	suite.T().Run("test negative RateMillicents, badly ordered dates for Tariff400ngFullUnpackRate", func(t *testing.T) {
+	suite.Run("test negative RateMillicents, badly ordered dates for Tariff400ngFullUnpackRate", func() {
 		now := time.Now()
 		invalidTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{
 			Schedule:           1,

--- a/pkg/models/tariff400ng_linehaul_rate_test.go
+++ b/pkg/models/tariff400ng_linehaul_rate_test.go
@@ -86,7 +86,7 @@ func (suite *ModelSuite) Test_FetchBaseLinehaulRate() {
 	// Test the best case
 	rate, err := FetchBaseLinehaulRate(suite.DB(), goodDistance, goodWeight, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Something went wrong with saving the test object: %s\n", err)
+		t.Errorf("Something went wrong with saving the test object: %s\n", err)
 	}
 	if rate != mySpecificRate {
 		t.Errorf("The record object didn't save!")

--- a/pkg/models/tariff400ng_linehaul_rate_test.go
+++ b/pkg/models/tariff400ng_linehaul_rate_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -10,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_Tariff400ngLinehaulRateValidation() {
-	suite.T().Run("test valid Tariff400ngLinehaulRate", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngLinehaulRate", func() {
 		now := time.Now()
 		validTariff400ngLinehaulRate := Tariff400ngLinehaulRate{
 			DistanceMilesLower: 100,
@@ -26,7 +25,7 @@ func (suite *ModelSuite) Test_Tariff400ngLinehaulRateValidation() {
 		suite.verifyValidationErrors(&validTariff400ngLinehaulRate, expErrors)
 	})
 
-	suite.T().Run("test invalid Tariff400ngLinehaulRate", func(t *testing.T) {
+	suite.Run("test invalid Tariff400ngLinehaulRate", func() {
 		invalidTariff400ngLinehaulRate := Tariff400ngLinehaulRate{}
 		expErrors := map[string][]string{
 			"distance_miles_lower": {"DistanceMilesLower can not be blank.", "0 is not less than 0."},
@@ -40,7 +39,7 @@ func (suite *ModelSuite) Test_Tariff400ngLinehaulRateValidation() {
 		suite.verifyValidationErrors(&invalidTariff400ngLinehaulRate, expErrors)
 	})
 
-	suite.T().Run("test negative RateCents, badly ordered dates for Tariff400ngLinehaulRate", func(t *testing.T) {
+	suite.Run("test negative RateCents, badly ordered dates for Tariff400ngLinehaulRate", func() {
 		now := time.Now()
 		invalidTariff400ngLinehaulRate := Tariff400ngLinehaulRate{
 			DistanceMilesLower: 100,

--- a/pkg/models/tariff400ng_service_area_test.go
+++ b/pkg/models/tariff400ng_service_area_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -10,7 +9,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_Tariff400ngServiceAreaValidation() {
-	suite.T().Run("test valid Tariff400ngServiceArea", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngServiceArea", func() {
 		now := time.Now()
 		validTariff400ngServiceArea := Tariff400ngServiceArea{
 			Name:               "Birmingham, AL",
@@ -28,7 +27,7 @@ func (suite *ModelSuite) Test_Tariff400ngServiceAreaValidation() {
 		suite.verifyValidationErrors(&validTariff400ngServiceArea, expErrors)
 	})
 
-	suite.T().Run("test invalid Tariff400ngServiceArea", func(t *testing.T) {
+	suite.Run("test invalid Tariff400ngServiceArea", func() {
 		invalidTariff400ngServiceArea := Tariff400ngServiceArea{}
 		expErrors := map[string][]string{
 			"name":                 {"Name can not be blank."},
@@ -43,7 +42,7 @@ func (suite *ModelSuite) Test_Tariff400ngServiceAreaValidation() {
 		suite.verifyValidationErrors(&invalidTariff400ngServiceArea, expErrors)
 	})
 
-	suite.T().Run("test other validations not exercised above for Tariff400ngServiceArea", func(t *testing.T) {
+	suite.Run("test other validations not exercised above for Tariff400ngServiceArea", func() {
 		now := time.Now()
 		invalidTariff400ngServiceArea := Tariff400ngServiceArea{
 			Name:               "Birmingham, AL",

--- a/pkg/models/tariff400ng_shorthaul_rate_test.go
+++ b/pkg/models/tariff400ng_shorthaul_rate_test.go
@@ -108,7 +108,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	// Test inclusivity CwtMilesLower
 	rate, err := FetchShorthaulRateCents(suite.DB(), 1000, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Unable to query shorthaul rate: %s", err)
+		t.Errorf("Unable to query shorthaul rate: %s", err)
 	}
 	if rate != rate1 {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate1)
@@ -145,7 +145,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	// Test the upper bound of the CwtMiles
 	rate, err = FetchShorthaulRateCents(suite.DB(), 2999, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Unable to query shorthaul rate: %s", err)
+		t.Errorf("Unable to query shorthaul rate: %s", err)
 	}
 	if rate != rate2 {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate2)
@@ -164,7 +164,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 
 	rate, err = FetchShorthaulRateCents(suite.DB(), 1000, testdatagen.DateOutsidePeakRateCycle)
 	if err != nil {
-		t.Fatalf("Unable to query shorthaul rate: %s", err)
+		t.Errorf("Unable to query shorthaul rate: %s", err)
 	}
 	if rate != rate3 {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate3)

--- a/pkg/models/tariff400ng_zip3_test.go
+++ b/pkg/models/tariff400ng_zip3_test.go
@@ -1,14 +1,12 @@
 package models_test
 
 import (
-	"testing"
-
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_Tariff400ngZip3Validation() {
-	suite.T().Run("test valid Tariff400ngZip3", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngZip3", func() {
 		validTariff400ngZip3 := Tariff400ngZip3{
 			Zip3:          "139",
 			BasepointCity: "Dogtown",
@@ -21,7 +19,7 @@ func (suite *ModelSuite) Test_Tariff400ngZip3Validation() {
 		suite.verifyValidationErrors(&validTariff400ngZip3, expErrors)
 	})
 
-	suite.T().Run("test invalid Tariff400ngZip3", func(t *testing.T) {
+	suite.Run("test invalid Tariff400ngZip3", func() {
 		invalidTariff400ngZip3 := Tariff400ngZip3{}
 		expErrors := map[string][]string{
 			"basepoint_city": {"BasepointCity can not be blank."},

--- a/pkg/models/tariff400ng_zip5_rate_area_test.go
+++ b/pkg/models/tariff400ng_zip5_rate_area_test.go
@@ -1,13 +1,11 @@
 package models_test
 
 import (
-	"testing"
-
 	. "github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) Test_Tariff400ngZip5RateAreaValidation() {
-	suite.T().Run("test valid Tariff400ngZip5RateArea", func(t *testing.T) {
+	suite.Run("test valid Tariff400ngZip5RateArea", func() {
 		validTariff400ngZip5RateArea := Tariff400ngZip5RateArea{
 			Zip5:     "13945",
 			RateArea: "US14",
@@ -16,7 +14,7 @@ func (suite *ModelSuite) Test_Tariff400ngZip5RateAreaValidation() {
 		suite.verifyValidationErrors(&validTariff400ngZip5RateArea, expErrors)
 	})
 
-	suite.T().Run("test invalid Tariff400ngZip5RateArea", func(t *testing.T) {
+	suite.Run("test invalid Tariff400ngZip5RateArea", func() {
 		invalidTariff400ngZip5RateArea := Tariff400ngZip5RateArea{}
 		expErrors := map[string][]string{
 			"zip5":      {"Zip5 not in range(5, 5)"},

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -114,7 +114,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 	// Increment offer count twice
 	performance, err := IncrementTSPPerformanceOfferCount(suite.DB(), perf.ID)
 	if err != nil {
-		t.Fatalf("Could not increment offer_count: %v", err)
+		t.Errorf("Could not increment offer_count: %v", err)
 	}
 	if performance.OfferCount != 1 {
 		t.Errorf("Wrong OfferCount returned: expected %d, got %d", 1, performance.OfferCount)
@@ -122,7 +122,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 
 	performance, err = IncrementTSPPerformanceOfferCount(suite.DB(), perf.ID)
 	if err != nil {
-		t.Fatalf("Could not increment offer_count: %v", err)
+		t.Errorf("Could not increment offer_count: %v", err)
 	}
 	if performance.OfferCount != 2 {
 		t.Errorf("Wrong OfferCount returned: expected %d, got %d", 2, performance.OfferCount)
@@ -130,7 +130,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 
 	performance = TransportationServiceProviderPerformance{}
 	if err := suite.DB().Find(&performance, perf.ID); err != nil {
-		t.Fatalf("could not find perf: %v", err)
+		t.Errorf("could not find perf: %v", err)
 	}
 
 	if performance.OfferCount != 2 {
@@ -158,12 +158,12 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 
 	err := AssignQualityBandToTSPPerformance(suite.DB(), band, perf.ID)
 	if err != nil {
-		t.Fatalf("Did not update quality band: %v", err)
+		t.Errorf("Did not update quality band: %v", err)
 	}
 
 	performance := TransportationServiceProviderPerformance{}
 	if err := suite.DB().Find(&performance, perf.ID); err != nil {
-		t.Fatalf("could not find perf: %v", err)
+		t.Errorf("could not find perf: %v", err)
 	}
 
 	if performance.QualityBand == nil {
@@ -776,7 +776,7 @@ func (suite *ModelSuite) Test_FetchDiscountRatesBVS() {
 
 	discountRate, sitRate, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", moveDate)
 	if err != nil {
-		t.Fatalf("Failed to find tsp performance: %s", err)
+		t.Errorf("Failed to find tsp performance: %s", err)
 	}
 
 	expectedLinehaul := unit.DiscountRate(.505)
@@ -848,7 +848,7 @@ func (suite *ModelSuite) Test_FetchDiscountRatesSameBVS() {
 
 	discountRate, sitRate, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", moveDate)
 	if err != nil {
-		t.Fatalf("Failed to find tsp performance: %s", err)
+		t.Errorf("Failed to find tsp performance: %s", err)
 	}
 
 	expectedLinehaul := targetTspPerformance.LinehaulRate
@@ -895,21 +895,21 @@ func (suite *ModelSuite) Test_FetchDiscountRatesPerformancePeriodBoundaries() {
 	suite.MustSave(&tspPerformance)
 
 	if _, _, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", ppEnd); err != nil {
-		t.Fatalf("Failed to find tsp performance for last day in performance period: %s", err)
+		t.Errorf("Failed to find tsp performance for last day in performance period: %s", err)
 	}
 
 	if _, _, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", ppStart); err != nil {
-		t.Fatalf("Failed to find tsp performance for first day in performance period: %s", err)
+		t.Errorf("Failed to find tsp performance for first day in performance period: %s", err)
 	}
 
 	// discount rates are being hard coded so ignore this test
 	// if _, _, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", ppStart.Add(time.Hour*-24)); err == nil {
-	// 	t.Fatalf("Should not have found a TSPP for the last day before the start of a performance period: %s", err)
+	// 	t.Errorf("Should not have found a TSPP for the last day before the start of a performance period: %s", err)
 	// }
 
 	// discount rates are being hard coded so ignore this test
 	// if _, _, err := FetchDiscountRates(suite.DB(), "77901", "67401", "2", ppEnd.Add(time.Hour*24)); err == nil {
-	// 	t.Fatalf("Should not have found a TSPP for the first day following a performance period: %s", err)
+	// 	t.Errorf("Should not have found a TSPP for the first day following a performance period: %s", err)
 	// }
 }
 

--- a/pkg/models/validators_test.go
+++ b/pkg/models/validators_test.go
@@ -43,7 +43,7 @@ func TestStringInList_IsValid(t *testing.T) {
 			validator.IsValid(errs)
 
 			if errs.Count() != 0 {
-				t.Fatalf("wrong number of errors; expected %d, got %d", 0, errs.Count())
+				t.Errorf("wrong number of errors; expected %d, got %d", 0, errs.Count())
 			}
 		})
 	}
@@ -64,10 +64,10 @@ func TestStringInList_IsValid(t *testing.T) {
 			fieldErrors := errs.Get("field_name")
 
 			if len(fieldErrors) != 1 {
-				t.Fatalf("wrong number of errors; expected %d, got %d", 1, len(fieldErrors))
+				t.Errorf("wrong number of errors; expected %d, got %d", 1, len(fieldErrors))
 			}
 			if fieldErrors[0] != expected {
-				t.Fatalf("wrong validation message; expected %s, got %s", expected, fieldErrors[0])
+				t.Errorf("wrong validation message; expected %s, got %s", expected, fieldErrors[0])
 			}
 		})
 	}
@@ -210,7 +210,7 @@ func TestOptionalStringInclusion_IsValid(t *testing.T) {
 
 		expected := fmt.Sprintf("%s is not in the list [%s].", fieldName, strings.Join(targetStrings, ", "))
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 
@@ -251,7 +251,7 @@ func TestFloat64IsPresent_IsValid(t *testing.T) {
 		testErrors := errs.Get(fieldName)
 		expected := fmt.Sprintf("%s can not be blank.", validator.Name)
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 
@@ -267,7 +267,7 @@ func TestFloat64IsPresent_IsValid(t *testing.T) {
 
 		testErrors := errs.Get(fieldName)
 		if testErrors[0] != customMessage {
-			t.Fatalf("wrong validation message; expected %s, got %s", customMessage, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", customMessage, testErrors[0])
 		}
 	})
 }
@@ -297,7 +297,7 @@ func TestFloat64IsGreaterThan_IsValid(t *testing.T) {
 		testErrors := errs.Get(fieldName)
 		expected := fmt.Sprintf("%f is not greater than %f.", validator.Field, validator.Compared)
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 
@@ -313,7 +313,7 @@ func TestFloat64IsGreaterThan_IsValid(t *testing.T) {
 
 		testErrors := errs.Get(fieldName)
 		if testErrors[0] != customMessage {
-			t.Fatalf("wrong validation message; expected %s, got %s", customMessage, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", customMessage, testErrors[0])
 		}
 	})
 }
@@ -332,14 +332,14 @@ func Test_OptionalUUIDIsPresent(t *testing.T) {
 	errors := validate.NewErrors()
 	v.IsValid(errors)
 	if errors.Count() > 0 {
-		t.Fatalf("got errors when should be valid: %v", errors)
+		t.Errorf("got errors when should be valid: %v", errors)
 	}
 	// test with nil pointer
 	v = models.OptionalUUIDIsPresent{Name: "Name", Field: nil}
 	errors = validate.NewErrors()
 	v.IsValid(errors)
 	if errors.Count() > 0 {
-		t.Fatalf("got errors when should be valid: %v", errors)
+		t.Errorf("got errors when should be valid: %v", errors)
 	}
 
 	// negative test
@@ -350,10 +350,10 @@ func Test_OptionalUUIDIsPresent(t *testing.T) {
 	errors = validate.NewErrors()
 	v.IsValid(errors)
 	if errors.Count() != 1 {
-		t.Fatalf("got wrong number of errors: %v", errors)
+		t.Errorf("got wrong number of errors: %v", errors)
 	}
 	if errors.Get("name")[0] != "Name can not be blank." {
-		t.Fatalf("wrong error; expected %s, got %s", "Name can not be blank.", errors.Get("name")[0])
+		t.Errorf("wrong error; expected %s, got %s", "Name can not be blank.", errors.Get("name")[0])
 	}
 }
 
@@ -371,7 +371,7 @@ func Test_OptionalPoundIsNonNegative_isValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() != 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -381,7 +381,7 @@ func Test_OptionalPoundIsNonNegative_isValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() > 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -393,7 +393,7 @@ func Test_OptionalPoundIsNonNegative_isValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() > 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -412,7 +412,7 @@ func Test_OptionalPoundIsNonNegative_isValid(t *testing.T) {
 		testErrors := errs.Get(name)
 		expected := fmt.Sprintf("%d is less than zero.", *v.Field)
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 }
@@ -431,7 +431,7 @@ func Test_OptionalPoundIsPositive_isValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() != 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -441,7 +441,7 @@ func Test_OptionalPoundIsPositive_isValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() > 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -460,7 +460,7 @@ func Test_OptionalPoundIsPositive_isValid(t *testing.T) {
 		testErrors := errs.Get(name)
 		expected := fmt.Sprintf("%d is less than or equal to zero", *v.Field)
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 
@@ -478,7 +478,7 @@ func Test_OptionalPoundIsPositive_isValid(t *testing.T) {
 		testErrors := errs.Get(name)
 		expected := fmt.Sprintf("%d is less than or equal to zero", *v.Field)
 		if testErrors[0] != expected {
-			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+			t.Errorf("wrong validation message; expected %s, got %s", expected, testErrors[0])
 		}
 	})
 }
@@ -498,7 +498,7 @@ func Test_MustBeBothNilOrBothNotNil_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() != 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -512,7 +512,7 @@ func Test_MustBeBothNilOrBothNotNil_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() != 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -527,7 +527,7 @@ func Test_MustBeBothNilOrBothNotNil_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() == 0 {
-			t.Fatalf("should throw an error if %v is empty and %v is filled: %v", v.FieldName1, v.FieldName2, errs)
+			t.Errorf("should throw an error if %v is empty and %v is filled: %v", v.FieldName1, v.FieldName2, errs)
 		}
 	})
 
@@ -542,7 +542,7 @@ func Test_MustBeBothNilOrBothNotNil_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() == 0 {
-			t.Fatalf("should throw an error if %v is filled and %v is empty: %v", v.FieldName1, v.FieldName2, errs)
+			t.Errorf("should throw an error if %v is filled and %v is empty: %v", v.FieldName1, v.FieldName2, errs)
 		}
 	})
 }
@@ -574,7 +574,7 @@ func Test_ItemCanFitInsideCrate_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() != 0 {
-			t.Fatalf("got errors when should be valid: %v", errs)
+			t.Errorf("got errors when should be valid: %v", errs)
 		}
 	})
 
@@ -588,7 +588,7 @@ func Test_ItemCanFitInsideCrate_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() == 0 {
-			t.Fatalf("got no errors when should be invalid")
+			t.Errorf("got no errors when should be invalid")
 		}
 	})
 
@@ -602,7 +602,7 @@ func Test_ItemCanFitInsideCrate_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() == 0 {
-			t.Fatalf("got no errors when should be invalid")
+			t.Errorf("got no errors when should be invalid")
 		}
 	})
 
@@ -624,7 +624,7 @@ func Test_ItemCanFitInsideCrate_IsValid(t *testing.T) {
 		errs := validate.NewErrors()
 		v.IsValid(errs)
 		if errs.Count() == 0 {
-			t.Fatalf("got no errors when should be invalid")
+			t.Errorf("got no errors when should be invalid")
 		}
 	})
 }

--- a/pkg/models/webhook_notification_test.go
+++ b/pkg/models/webhook_notification_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -20,7 +19,7 @@ func (suite *ModelSuite) TestWebhookNotification() {
 	paymentRequestID := paymentRequest.ID
 	mtoID := paymentRequest.MoveTaskOrderID
 
-	suite.T().Run("test full notification", func(t *testing.T) {
+	suite.Run("test full notification", func() {
 		// Normal notification with Object in payload
 		trace := uuid.Must(uuid.NewV4())
 		newNotification := models.WebhookNotification{
@@ -37,7 +36,7 @@ func (suite *ModelSuite) TestWebhookNotification() {
 		suite.verifyValidationErrors(&newNotification, expErrors)
 	})
 
-	suite.T().Run("test simple notification", func(t *testing.T) {
+	suite.Run("test simple notification", func() {
 		// Allowing for a simple message notification, with an eventkey and payload
 		newNotification := models.WebhookNotification{
 			EventKey: "PaymentRequest.Update",
@@ -50,7 +49,7 @@ func (suite *ModelSuite) TestWebhookNotification() {
 		suite.verifyValidationErrors(&newNotification, expErrors)
 	})
 
-	suite.T().Run("test notification with validation errors", func(t *testing.T) {
+	suite.Run("test notification with validation errors", func() {
 		trace := uuid.Must(uuid.NewV4())
 		newNotification := models.WebhookNotification{
 			EventKey: "",

--- a/pkg/models/webhook_subscription_test.go
+++ b/pkg/models/webhook_subscription_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -27,7 +25,7 @@ func (suite *ModelSuite) TestWebhookSubscription_NotNullConstraint() {
 
 func (suite *ModelSuite) TestWebhookSubscription_Instantiation() {
 
-	suite.T().Run("Default subscription", func(t *testing.T) {
+	suite.Run("Default subscription", func() {
 		webhookSubscription := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
 
 		verrs, err := suite.DB().ValidateAndSave(&webhookSubscription)
@@ -39,7 +37,7 @@ func (suite *ModelSuite) TestWebhookSubscription_Instantiation() {
 		suite.Equal(0, webhookSubscription.Severity)
 	})
 
-	suite.T().Run("Updated subscription severity", func(t *testing.T) {
+	suite.Run("Updated subscription severity", func() {
 		webhookSubscription := testdatagen.MakeWebhookSubscription(suite.DB(), testdatagen.Assertions{
 			WebhookSubscription: models.WebhookSubscription{
 				Severity: 2,

--- a/pkg/models/zip3_distance_test.go
+++ b/pkg/models/zip3_distance_test.go
@@ -1,13 +1,11 @@
 package models_test
 
 import (
-	"testing"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) TestZip3DistanceValidations() {
-	suite.T().Run("test valid Zip3Distance", func(t *testing.T) {
+	suite.Run("test valid Zip3Distance", func() {
 		validZip3Distance := models.Zip3Distance{
 			FromZip3:      "010",
 			ToZip3:        "011",
@@ -17,7 +15,7 @@ func (suite *ModelSuite) TestZip3DistanceValidations() {
 		suite.verifyValidationErrors(&validZip3Distance, expErrors)
 	})
 
-	suite.T().Run("test invalid Zip3Distance", func(t *testing.T) {
+	suite.Run("test invalid Zip3Distance", func() {
 		emptyZip3Distance := models.Zip3Distance{}
 		expErrors := map[string][]string{
 			"from_zip3":      {"FromZip3 not in range(3, 3)"},
@@ -27,7 +25,7 @@ func (suite *ModelSuite) TestZip3DistanceValidations() {
 		suite.verifyValidationErrors(&emptyZip3Distance, expErrors)
 	})
 
-	suite.T().Run("test when from_zip3 is not a length of 3", func(t *testing.T) {
+	suite.Run("test when from_zip3 is not a length of 3", func() {
 		invalidFromZip3Distance := models.Zip3Distance{
 			FromZip3:      "01",
 			ToZip3:        "011",
@@ -39,7 +37,7 @@ func (suite *ModelSuite) TestZip3DistanceValidations() {
 		suite.verifyValidationErrors(&invalidFromZip3Distance, expErrors)
 	})
 
-	suite.T().Run("test when to_zip3 is not a length of 3", func(t *testing.T) {
+	suite.Run("test when to_zip3 is not a length of 3", func() {
 		invalidToZip3Distance := models.Zip3Distance{
 			FromZip3:      "010",
 			ToZip3:        "0115",
@@ -51,7 +49,7 @@ func (suite *ModelSuite) TestZip3DistanceValidations() {
 		suite.verifyValidationErrors(&invalidToZip3Distance, expErrors)
 	})
 
-	suite.T().Run("test when distance_miles is not provided", func(t *testing.T) {
+	suite.Run("test when distance_miles is not provided", func() {
 		invalidDistance := models.Zip3Distance{
 			FromZip3: "010",
 			ToZip3:   "011",


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12842) for this change

## Summary

Converts all tests in `./pkg/models` to use transactions.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)