### PR TITLE
MB-9033 - Fix flaky tests

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -46,8 +46,13 @@ describe('The document viewer', function () {
       cy.get('input[name="notes"]').type('burn after reading');
       cy.get('button.submit').should('be.disabled');
 
+      cy.intercept('/internal/uploads').as('uploadFile');
       cy.upload_file('.filepond--root', 'sample-orders.png');
+      cy.wait('@uploadFile');
+
+      cy.intercept('/internal/moves/*/move_documents').as('postDocument');
       cy.get('button.submit', { timeout: fileUploadTimeout }).should('not.be.disabled').click();
+      cy.wait('@postDocument');
     });
     it('can upload a weight ticket set', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
@@ -58,8 +63,13 @@ describe('The document viewer', function () {
       cy.get('input[name="notes"]').type('burn after reading');
       cy.get('button.submit').should('be.disabled');
 
+      cy.intercept('/internal/uploads').as('uploadFile');
       cy.upload_file('.filepond--root', 'sample-orders.png');
+      cy.wait('@uploadFile');
+
+      cy.intercept('/internal/moves/*/move_documents').as('postDocument');
       cy.get('button.submit', { timeout: fileUploadTimeout }).should('not.be.disabled').click();
+      cy.wait('@postDocument');
     });
 
     it('shows the newly uploaded document in the document list tab', () => {
@@ -83,8 +93,13 @@ describe('The document viewer', function () {
 
       cy.get('button.submit').should('be.disabled');
 
+      cy.intercept('/internal/uploads').as('uploadFile');
       cy.upload_file('.filepond--root', 'sample-orders.png');
-      cy.get('button.submit', { timeout: fileUploadTimeout }).should('not.be.disabled').click();
+      cy.wait('@uploadFile');
+
+      cy.intercept('/internal/moves/*/moving_expense_documents').as('postExpenseDocument');
+      cy.get('button.submit').should('not.be.disabled').click();
+      cy.wait('@postExpenseDocument');
     });
     it('can select and update newly-uploaded expense document', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');

--- a/cypress/integration/office/qaecsr/moveSearch.js
+++ b/cypress/integration/office/qaecsr/moveSearch.js
@@ -8,6 +8,10 @@ describe('QAE/CSR Move Search', () => {
   beforeEach(() => {
     cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
     cy.intercept('**/ghc/v1/moves/search').as('getSearchResults');
+    cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    cy.intercept('**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
 
     const userId = '2419b1d6-097f-4dc4-8171-8f858967b4db';
     cy.apiSignInAsUser(userId, QAECSROfficeUserType);
@@ -27,6 +31,7 @@ describe('QAE/CSR Move Search', () => {
     // click result to navigate to move details page
     cy.get('@results').first().click();
     cy.url().should('include', `/moves/${moveLocator}/details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
   });
   it('is able to search by DOD ID', () => {
     const moveLocator = 'QAEHLP';
@@ -46,5 +51,6 @@ describe('QAE/CSR Move Search', () => {
     // click result to navigate to move details page
     cy.get('@results').first().click();
     cy.url().should('include', `/moves/${moveLocator}/details`);
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
   });
 });

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -1,4 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
+import { navigateToMove } from './tooNavigateToMove';
 
 describe('TOO user', () => {
   before(() => {
@@ -442,20 +443,3 @@ describe('TOO user', () => {
     cy.contains('The service member is unable to move into their new home at the expected time');
   });
 });
-
-function navigateToMove(moveLocator) {
-  // TOO Moves queue
-  cy.wait(['@getSortedOrders']);
-  cy.get('input[name="locator"]').as('moveCodeFilterInput');
-
-  // type in move code/locator to filter
-  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
-  cy.get('tbody > tr').as('results');
-
-  // click result to navigate to move details page
-  cy.get('@results').first().click();
-  cy.url().should('include', `/moves/${moveLocator}/details`);
-
-  // Move Details page
-  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
-}

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -30,13 +30,10 @@ describe('TOO user', () => {
   it('is able to approve a shipment', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
     cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
 
-    // Move Details page
-    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
     cy.get('#approved-shipments').should('not.exist');
     cy.get('#requested-shipments');
     cy.contains('Approve selected').should('be.disabled');
@@ -134,10 +131,8 @@ describe('TOO user', () => {
   it('is able to approve and reject mto service items', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
     cy.get('[data-testid="MoveTaskOrder-Tab"]').click();
     cy.wait(['@getMTOShipments', '@getMTOServiceItems']);
     cy.url().should('include', `/moves/${moveLocator}/mto`);
@@ -207,13 +202,8 @@ describe('TOO user', () => {
   it('is able to edit orders', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
-
-    // Move Details page
-    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
 
     // Navigate to Edit orders page
     cy.get('[data-testid="edit-orders"]').contains('Edit orders').click();
@@ -236,14 +226,11 @@ describe('TOO user', () => {
         .first()
         .click(0, 0);
 
-      cy.get('[class*="-control"]')
-        .eq(1)
-        .click(0, 0)
-        .type('JB McGuire-Dix-Lakehurst')
-        .get('[class*="-menu"]')
-        .find('[class*="-option"]')
-        .eq(5)
-        .click(0, 0);
+      // Wait for duty locations to populate to avoid flakiness
+      cy.intercept('/internal/duty_locations?search=JB%20McGuire-Dix-Lakehurst').as('dutyLocationSearch');
+      cy.get('[class*="-control"]').eq(1).as('dutyLocationSearchBox').click(0, 0).type('JB McGuire-Dix-Lakehurst');
+      cy.wait('@dutyLocationSearch');
+      cy.get('@dutyLocationSearchBox').get('[class*="-menu"]').find('[class*="-option"]').eq(5).click(0, 0);
 
       cy.get('input[name="issueDate"]').click({ force: true }).clear().type('16 Mar 2018');
       cy.get('input[name="reportByDate"]').click({ force: true }).clear().type('22 Mar 2018');
@@ -280,13 +267,8 @@ describe('TOO user', () => {
   it('is able to edit allowances', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
-
-    // Move Details page
-    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
 
     // Navigate to Edit allowances page
     cy.get('[data-testid="edit-allowances"]').contains('Edit allowances').click();
@@ -349,10 +331,9 @@ describe('TOO user', () => {
     const moveLocator = 'TEST12';
     const deliveryDate = new Date().toLocaleDateString('en-US');
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
+
     // Edit the shipment
     cy.get('[data-testid="ShipmentContainer"] .usa-button').first().click();
     // fill out some changes on the form
@@ -370,10 +351,9 @@ describe('TOO user', () => {
     const moveLocator = 'R3T1R3';
     const deliveryDate = new Date().toLocaleDateString('en-US');
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
+
     // Edit the shipment
     cy.get('[data-testid="ShipmentContainer"] .usa-button').first().click();
     // fill out some changes on the form
@@ -391,10 +371,9 @@ describe('TOO user', () => {
   it('is able to request cancellation for a shipment', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
+
     cy.get('[data-testid="MoveTaskOrder-Tab"]').click();
     // cy.wait(['@getMTOShipments', '@getMTOServiceItems']);
     cy.url().should('include', `/moves/${moveLocator}/mto`);
@@ -429,10 +408,9 @@ describe('TOO user', () => {
   it('is able to view SIT and create and edit SIT extensions', () => {
     const moveLocator = 'TEST12';
 
-    // TOO Moves queue
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // Navigate to Move details page from TOO Moves queue
+    navigateToMove(moveLocator);
+
     cy.get('[data-testid="MoveTaskOrder-Tab"]').click();
     cy.wait(['@getMTOShipments', '@getMTOServiceItems']);
     cy.url().should('include', `/moves/${moveLocator}/mto`);
@@ -464,3 +442,20 @@ describe('TOO user', () => {
     cy.contains('The service member is unable to move into their new home at the expected time');
   });
 });
+
+function navigateToMove(moveLocator) {
+  // TOO Moves queue
+  cy.wait(['@getSortedOrders']);
+  cy.get('input[name="locator"]').as('moveCodeFilterInput');
+
+  // type in move code/locator to filter
+  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+  cy.get('tbody > tr').as('results');
+
+  // click result to navigate to move details page
+  cy.get('@results').first().click();
+  cy.url().should('include', `/moves/${moveLocator}/details`);
+
+  // Move Details page
+  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+}

--- a/cypress/integration/office/txo/tooFlowsNTS.js
+++ b/cypress/integration/office/txo/tooFlowsNTS.js
@@ -423,7 +423,14 @@ function editTacSac() {
 function navigateToMove(moveLocator) {
   // TOO Moves queue
   cy.wait(['@getSortedOrders']);
-  cy.contains(moveLocator).click();
+  cy.get('input[name="locator"]').as('moveCodeFilterInput');
+
+  // type in move code/locator to filter
+  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+  cy.get('tbody > tr').as('results');
+
+  // click result to navigate to move details page
+  cy.get('@results').first().click();
   cy.url().should('include', `/moves/${moveLocator}/details`);
 
   // Move Details page

--- a/cypress/integration/office/txo/tooFlowsNTS.js
+++ b/cypress/integration/office/txo/tooFlowsNTS.js
@@ -1,4 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
+import { navigateToMove } from './tooNavigateToMove';
 
 describe('TOO user', () => {
   before(() => {
@@ -418,21 +419,4 @@ function editTacSac() {
   cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
   cy.get('[data-testid="NTStac"]').contains('F123');
   cy.get('[data-testid="NTSsac"]').contains('3L988AS098F');
-}
-
-function navigateToMove(moveLocator) {
-  // TOO Moves queue
-  cy.wait(['@getSortedOrders']);
-  cy.get('input[name="locator"]').as('moveCodeFilterInput');
-
-  // type in move code/locator to filter
-  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
-  cy.get('tbody > tr').as('results');
-
-  // click result to navigate to move details page
-  cy.get('@results').first().click();
-  cy.url().should('include', `/moves/${moveLocator}/details`);
-
-  // Move Details page
-  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
 }

--- a/cypress/integration/office/txo/tooFlowsNTSR.js
+++ b/cypress/integration/office/txo/tooFlowsNTSR.js
@@ -350,7 +350,7 @@ describe('TOO user', () => {
   });
 
   it('TOO can submit service items on an NTS-only move handled by an external vendor', () => {
-    navigateToMove('EXTNTS');
+    navigateToMove('EXTNTR');
 
     cy.get('#approved-shipments').should('not.exist');
     cy.get('#requested-shipments');
@@ -398,7 +398,7 @@ describe('TOO user', () => {
     cy.wait(['@patchMTOStatus']);
 
     // Redirected to Move Task Order page
-    cy.url().should('include', `/moves/EXTNTS/mto`);
+    cy.url().should('include', `/moves/EXTNTR/mto`);
 
     cy.get('[role="main"]').contains('This move does not have any approved shipments yet.');
   });
@@ -435,7 +435,14 @@ function editTacSac() {
 function navigateToMove(moveLocator) {
   // TOO Moves queue
   cy.wait(['@getSortedOrders']);
-  cy.contains(moveLocator).click();
+  cy.get('input[name="locator"]').as('moveCodeFilterInput');
+
+  // type in move code/locator to filter
+  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+  cy.get('tbody > tr').as('results');
+
+  // click result to navigate to move details page
+  cy.get('@results').first().click();
   cy.url().should('include', `/moves/${moveLocator}/details`);
 
   // Move Details page

--- a/cypress/integration/office/txo/tooFlowsNTSR.js
+++ b/cypress/integration/office/txo/tooFlowsNTSR.js
@@ -1,4 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
+import { navigateToMove } from './tooNavigateToMove';
 
 describe('TOO user', () => {
   before(() => {
@@ -430,21 +431,4 @@ function editTacSac() {
   cy.get('[data-testid="sacSDN"]').contains('4K988AS098F');
   cy.get('[data-testid="NTStac"]').contains('F123');
   cy.get('[data-testid="NTSsac"]').contains('3L988AS098F');
-}
-
-function navigateToMove(moveLocator) {
-  // TOO Moves queue
-  cy.wait(['@getSortedOrders']);
-  cy.get('input[name="locator"]').as('moveCodeFilterInput');
-
-  // type in move code/locator to filter
-  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
-  cy.get('tbody > tr').as('results');
-
-  // click result to navigate to move details page
-  cy.get('@results').first().click();
-  cy.url().should('include', `/moves/${moveLocator}/details`);
-
-  // Move Details page
-  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
 }

--- a/cypress/integration/office/txo/tooNavigateToMove.js
+++ b/cypress/integration/office/txo/tooNavigateToMove.js
@@ -1,0 +1,16 @@
+export function navigateToMove(moveLocator) {
+  // TOO Moves queue
+  cy.wait(['@getSortedOrders']);
+  cy.get('input[name="locator"]').as('moveCodeFilterInput');
+
+  // type in move code/locator to filter
+  cy.get('@moveCodeFilterInput').type(moveLocator).blur();
+  cy.get('tbody > tr').as('results');
+
+  // click result to navigate to move details page
+  cy.get('@results').first().click();
+  cy.url().should('include', `/moves/${moveLocator}/details`);
+
+  // Move Details page
+  cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-9033) for this change

## Summary

This PR should address all of the integration test failures that cropped up during the MB-9033 dependency upgrades.
It will likely be merged to master once #8724 is merged.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminal to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

To run all of the tests from scratch, you can use:
```sh
make e2e_test_fresh
```
If there are issues with the chrome tests (if chrome crashes during the test run), it may be due to a memory issue. In that case, you can add the following line to cypress.json and rerun in order to not retain snapshots and save some memory.

`"numTestsKeptInMemory": 0,`

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots
