### PR TITLE
[MB-12679] Minor updates to API docs for Prime PPM deletion

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -404,20 +404,20 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}": {
       "delete": {
-        "description": "### Functionality\nThis endpoint deletes an individual shipment by ID.\n\n### Errors\nThe mtoShipment should be associated with an MTO that is available to prime.\nThe mtoShipment must be a PPM shipment\nCounseling should not have already been completed for the associated MTO\n",
+        "description": "### Functionality\nThis endpoint deletes an individual shipment by ID.\n\n### Errors\n* The mtoShipment should be associated with an MTO that is available to prime.\n* The mtoShipment must be a PPM shipment.\n* Counseling should not have already been completed for the associated MTO.\n",
         "produces": [
           "application/json"
         ],
         "tags": [
           "mtoShipment"
         ],
-        "summary": "Deletes a shipment by ID",
+        "summary": "deleteMTOShipment",
         "operationId": "deleteMTOShipment",
         "parameters": [
           {
             "type": "string",
             "format": "uuid",
-            "description": "ID of the shipment to be deleted",
+            "description": "UUID of the shipment to be deleted",
             "name": "mtoShipmentID",
             "in": "path",
             "required": true
@@ -425,7 +425,7 @@ func init() {
         ],
         "responses": {
           "204": {
-            "description": "Successfully soft deleted the shipment"
+            "description": "Successfully deleted the MTO shipment."
           },
           "400": {
             "$ref": "#/responses/InvalidRequest"
@@ -4142,20 +4142,20 @@ func init() {
     },
     "/mto-shipments/{mtoShipmentID}": {
       "delete": {
-        "description": "### Functionality\nThis endpoint deletes an individual shipment by ID.\n\n### Errors\nThe mtoShipment should be associated with an MTO that is available to prime.\nThe mtoShipment must be a PPM shipment\nCounseling should not have already been completed for the associated MTO\n",
+        "description": "### Functionality\nThis endpoint deletes an individual shipment by ID.\n\n### Errors\n* The mtoShipment should be associated with an MTO that is available to prime.\n* The mtoShipment must be a PPM shipment.\n* Counseling should not have already been completed for the associated MTO.\n",
         "produces": [
           "application/json"
         ],
         "tags": [
           "mtoShipment"
         ],
-        "summary": "Deletes a shipment by ID",
+        "summary": "deleteMTOShipment",
         "operationId": "deleteMTOShipment",
         "parameters": [
           {
             "type": "string",
             "format": "uuid",
-            "description": "ID of the shipment to be deleted",
+            "description": "UUID of the shipment to be deleted",
             "name": "mtoShipmentID",
             "in": "path",
             "required": true
@@ -4163,7 +4163,7 @@ func init() {
         ],
         "responses": {
           "204": {
-            "description": "Successfully soft deleted the shipment"
+            "description": "Successfully deleted the MTO shipment."
           },
           "400": {
             "description": "The request payload is invalid.",

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment.go
@@ -31,15 +31,15 @@ func NewDeleteMTOShipment(ctx *middleware.Context, handler DeleteMTOShipmentHand
 
 /* DeleteMTOShipment swagger:route DELETE /mto-shipments/{mtoShipmentID} mtoShipment deleteMTOShipment
 
-Deletes a shipment by ID
+deleteMTOShipment
 
 ### Functionality
 This endpoint deletes an individual shipment by ID.
 
 ### Errors
-The mtoShipment should be associated with an MTO that is available to prime.
-The mtoShipment must be a PPM shipment
-Counseling should not have already been completed for the associated MTO
+* The mtoShipment should be associated with an MTO that is available to prime.
+* The mtoShipment must be a PPM shipment.
+* Counseling should not have already been completed for the associated MTO.
 
 
 */

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_parameters.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_parameters.go
@@ -31,7 +31,7 @@ type DeleteMTOShipmentParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*ID of the shipment to be deleted
+	/*UUID of the shipment to be deleted
 	  Required: true
 	  In: path
 	*/

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/delete_m_t_o_shipment_responses.go
@@ -16,7 +16,7 @@ import (
 // DeleteMTOShipmentNoContentCode is the HTTP code returned for type DeleteMTOShipmentNoContent
 const DeleteMTOShipmentNoContentCode int = 204
 
-/*DeleteMTOShipmentNoContent Successfully soft deleted the shipment
+/*DeleteMTOShipmentNoContent Successfully deleted the MTO shipment.
 
 swagger:response deleteMTOShipmentNoContent
 */

--- a/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_parameters.go
+++ b/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_parameters.go
@@ -61,7 +61,7 @@ type DeleteMTOShipmentParams struct {
 
 	/* MtoShipmentID.
 
-	   ID of the shipment to be deleted
+	   UUID of the shipment to be deleted
 
 	   Format: uuid
 	*/

--- a/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_responses.go
+++ b/pkg/gen/primeclient/mto_shipment/delete_m_t_o_shipment_responses.go
@@ -77,7 +77,7 @@ func NewDeleteMTOShipmentNoContent() *DeleteMTOShipmentNoContent {
 
 /* DeleteMTOShipmentNoContent describes a response with status code 204, with default header values.
 
-Successfully soft deleted the shipment
+Successfully deleted the MTO shipment.
 */
 type DeleteMTOShipmentNoContent struct {
 }

--- a/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
+++ b/pkg/gen/primeclient/mto_shipment/mto_shipment_client.go
@@ -193,15 +193,15 @@ func (a *Client) CreateSITExtension(params *CreateSITExtensionParams, opts ...Cl
 }
 
 /*
-  DeleteMTOShipment deletes a shipment by ID
+  DeleteMTOShipment deletes m t o shipment
 
   ### Functionality
 This endpoint deletes an individual shipment by ID.
 
 ### Errors
-The mtoShipment should be associated with an MTO that is available to prime.
-The mtoShipment must be a PPM shipment
-Counseling should not have already been completed for the associated MTO
+* The mtoShipment should be associated with an MTO that is available to prime.
+* The mtoShipment must be a PPM shipment.
+* Counseling should not have already been completed for the associated MTO.
 
 */
 func (a *Client) DeleteMTOShipment(params *DeleteMTOShipmentParams, opts ...ClientOption) (*DeleteMTOShipmentNoContent, error) {

--- a/swagger-def/prime.yaml
+++ b/swagger-def/prime.yaml
@@ -273,22 +273,22 @@ paths:
         '500':
           $ref: '#/responses/ServerError'
     delete:
-      summary: Deletes a shipment by ID
+      summary: deleteMTOShipment
       description: |
         ### Functionality
         This endpoint deletes an individual shipment by ID.
 
         ### Errors
-        The mtoShipment should be associated with an MTO that is available to prime.
-        The mtoShipment must be a PPM shipment
-        Counseling should not have already been completed for the associated MTO
+        * The mtoShipment should be associated with an MTO that is available to prime.
+        * The mtoShipment must be a PPM shipment.
+        * Counseling should not have already been completed for the associated MTO.
       operationId: deleteMTOShipment
       tags:
         - mtoShipment
       produces:
         - application/json
       parameters:
-        - description: ID of the shipment to be deleted
+        - description: UUID of the shipment to be deleted
           in: path
           name: mtoShipmentID
           required: true
@@ -296,7 +296,7 @@ paths:
           type: string
       responses:
         '204':
-          description: Successfully soft deleted the shipment
+          description: Successfully deleted the MTO shipment.
         '400':
           $ref: '#/responses/InvalidRequest'
         '403':

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -364,7 +364,7 @@ paths:
         '500':
           $ref: '#/responses/ServerError'
     delete:
-      summary: Deletes a shipment by ID
+      summary: deleteMTOShipment
       description: >
         ### Functionality
 
@@ -373,19 +373,20 @@ paths:
 
         ### Errors
 
-        The mtoShipment should be associated with an MTO that is available to
+        * The mtoShipment should be associated with an MTO that is available to
         prime.
 
-        The mtoShipment must be a PPM shipment
+        * The mtoShipment must be a PPM shipment.
 
-        Counseling should not have already been completed for the associated MTO
+        * Counseling should not have already been completed for the associated
+        MTO.
       operationId: deleteMTOShipment
       tags:
         - mtoShipment
       produces:
         - application/json
       parameters:
-        - description: ID of the shipment to be deleted
+        - description: UUID of the shipment to be deleted
           in: path
           name: mtoShipmentID
           required: true
@@ -393,7 +394,7 @@ paths:
           type: string
       responses:
         '204':
-          description: Successfully soft deleted the shipment
+          description: Successfully deleted the MTO shipment.
         '400':
           $ref: '#/responses/InvalidRequest'
         '403':


### PR DESCRIPTION
## [Jira ticket](MB-12679) for this change

## Summary

This PR just makes some small adjustments to the existing prime API documentation in #8773 to be a little more consistent with other pre-existing docs.

### Additional steps

To see the Redocusaurus-based documentation locally, follow the instructions on [this page](https://transcom.github.io/mymove-docs/docs/tools/docusaurus/redocusaurus/).

Once this PR is merged, the updates should appear automatically on [this page](https://transcom.github.io/mymove-docs/api/prime/#operation/deleteMTOShipment).

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?
