### PR TITLE
MB-12926 add weight tickets table and model

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -737,3 +737,4 @@
 20220531203704_add_user_id_to_client_certs.up.sql
 20220531203716_add_user_for_each_client_cert.up.sql
 20220601203717_remove_old_ppm_advance_requested_columns.up.sql
+20220622225529_create_weight_tickets_table.up.sql

--- a/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
@@ -1,12 +1,9 @@
 CREATE TABLE weight_tickets
 (
-	id uuid PRIMARY KEY NOT NULL,
+	id uuid PRIMARY KEY,
 	ppm_shipment_id uuid NOT NULL
 		CONSTRAINT weight_tickets_ppm_shipments_id_fkey
 		REFERENCES ppm_shipments,
-	created_at timestamp NOT NULL,
-	updated_at timestamp NOT NULL,
-	deleted_at timestamptz,
 	vehicle_description varchar,
 	empty_weight int,
 	has_empty_weight_ticket bool,
@@ -22,16 +19,24 @@ CREATE TABLE weight_tickets
 	trailer_meets_criteria bool,
 	proof_of_trailer_ownership_document_id uuid
 		CONSTRAINT weight_tickets_proof_of_trailer_ownership_document_id_fkey
-		REFERENCES documents
+		REFERENCES documents,
+	created_at timestamp NOT NULL,
+	updated_at timestamp NOT NULL,
+	deleted_at timestamptz
 );
 
+CREATE INDEX weight_tickets_ppm_shipment_id_idx ON weight_tickets USING hash (ppm_shipment_id);
 CREATE INDEX weight_tickets_deleted_at_idx ON weight_tickets USING btree (deleted_at);
 
 COMMENT on TABLE weight_tickets IS 'Stores weight ticket docs associated with a trip for a PPM shipment.';
+COMMENT on COLUMN weight_tickets.ppm_shipment_id IS 'The ID of the PPM shipment that this set of weight tickets is for.';
 COMMENT on COLUMN weight_tickets.vehicle_description IS 'Stores a description of the vehicle used for the trip. E.g. make/model, type of truck/van, etc.';
 COMMENT on COLUMN weight_tickets.empty_weight IS 'Stores the weight of the vehicle when empty.';
 COMMENT on COLUMN weight_tickets.has_empty_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when empty.';
+COMMENT on COLUMN weight_tickets.empty_document_id IS 'The ID of the document that is associated with the user uploads containing the empty vehicle weight.';
 COMMENT on COLUMN weight_tickets.full_weight IS 'Stores the weight of the vehicle when full.';
 COMMENT on COLUMN weight_tickets.has_full_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when full.';
+COMMENT on COLUMN weight_tickets.empty_document_id IS 'The ID of the document that is associated with the user uploads containing the full vehicle weight.';
 COMMENT on COLUMN weight_tickets.owns_trailer IS 'Indicates if the customer used a trailer they own for the move.';
 COMMENT on COLUMN weight_tickets.trailer_meets_criteria IS 'Indicates if the trailer that the customer used meets all the criteria to be claimable.';
+COMMENT on COLUMN weight_tickets.proof_of_trailer_ownership_document_id IS 'The ID of the document that is associated with the user uploads containing the proof of trailer ownership.';

--- a/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
@@ -7,12 +7,12 @@ CREATE TABLE weight_tickets
 	vehicle_description varchar,
 	empty_weight int,
 	has_empty_weight_ticket bool,
-	empty_document_id uuid
+	empty_document_id uuid NOT NULL
 	    CONSTRAINT weight_tickets_empty_document_id_fkey
 	    REFERENCES documents,
 	full_weight int,
 	has_full_weight_ticket bool,
-	full_document_id uuid
+	full_document_id uuid NOT NULL
 	    CONSTRAINT weight_tickets_full_document_id_fkey
 		REFERENCES documents,
 	owns_trailer bool,

--- a/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
@@ -17,7 +17,7 @@ CREATE TABLE weight_tickets
 		REFERENCES documents,
 	owns_trailer bool,
 	trailer_meets_criteria bool,
-	proof_of_trailer_ownership_document_id uuid
+	proof_of_trailer_ownership_document_id uuid NOT NULL
 		CONSTRAINT weight_tickets_proof_of_trailer_ownership_document_id_fkey
 		REFERENCES documents,
 	created_at timestamp NOT NULL,

--- a/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
@@ -1,0 +1,37 @@
+CREATE TABLE weight_tickets
+(
+	id uuid PRIMARY KEY NOT NULL,
+	ppm_shipment_id uuid NOT NULL
+		CONSTRAINT weight_tickets_ppm_shipments_id_fkey
+		REFERENCES ppm_shipments,
+	created_at timestamp NOT NULL,
+	updated_at timestamp NOT NULL,
+	deleted_at timestamptz,
+	vehicle_description varchar,
+	empty_weight int,
+	has_empty_weight_ticket bool,
+	empty_document_id uuid
+	    CONSTRAINT weight_tickets_empty_document_id_fkey
+	    REFERENCES documents,
+	full_weight int,
+	has_full_weight_ticket bool,
+	full_document_id uuid
+	    CONSTRAINT weight_tickets_full_document_id_fkey
+		REFERENCES documents,
+	owns_trailer bool,
+	trailer_meets_criteria bool,
+	proof_of_trailer_ownership_document_id uuid
+		CONSTRAINT weight_tickets_proof_of_trailer_ownership_document_id_fkey
+		REFERENCES documents
+);
+
+CREATE INDEX weight_tickets_deleted_at_idx ON weight_tickets USING btree (deleted_at);
+
+COMMENT on TABLE weight_tickets IS 'Stores weight ticket docs associated with a trip for a PPM shipment.';
+COMMENT on COLUMN weight_tickets.vehicle_description IS 'Stores a description of the vehicle used for the trip. E.g. make/model, type of truck/van, etc.';
+COMMENT on COLUMN weight_tickets.empty_weight IS 'Stores the weight of the vehicle when empty.';
+COMMENT on COLUMN weight_tickets.has_empty_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when empty.';
+COMMENT on COLUMN weight_tickets.full_weight IS 'Stores the weight of the vehicle when full.';
+COMMENT on COLUMN weight_tickets.has_full_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when full.';
+COMMENT on COLUMN weight_tickets.owns_trailer IS 'Indicates if the customer used a trailer they own for the move.';
+COMMENT on COLUMN weight_tickets.trailer_meets_criteria IS 'Indicates if the trailer that the customer used meets all the criteria to be claimable.';

--- a/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220622225529_create_weight_tickets_table.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE weight_tickets
+  CREATE TABLE weight_tickets
 (
 	id uuid PRIMARY KEY,
 	ppm_shipment_id uuid NOT NULL
@@ -6,12 +6,12 @@ CREATE TABLE weight_tickets
 		REFERENCES ppm_shipments,
 	vehicle_description varchar,
 	empty_weight int,
-	has_empty_weight_ticket bool,
+	missing_empty_weight_ticket bool,
 	empty_document_id uuid NOT NULL
 	    CONSTRAINT weight_tickets_empty_document_id_fkey
 	    REFERENCES documents,
 	full_weight int,
-	has_full_weight_ticket bool,
+	missing_full_weight_ticket bool,
 	full_document_id uuid NOT NULL
 	    CONSTRAINT weight_tickets_full_document_id_fkey
 		REFERENCES documents,
@@ -32,10 +32,10 @@ COMMENT on TABLE weight_tickets IS 'Stores weight ticket docs associated with a 
 COMMENT on COLUMN weight_tickets.ppm_shipment_id IS 'The ID of the PPM shipment that this set of weight tickets is for.';
 COMMENT on COLUMN weight_tickets.vehicle_description IS 'Stores a description of the vehicle used for the trip. E.g. make/model, type of truck/van, etc.';
 COMMENT on COLUMN weight_tickets.empty_weight IS 'Stores the weight of the vehicle when empty.';
-COMMENT on COLUMN weight_tickets.has_empty_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when empty.';
+COMMENT on COLUMN weight_tickets.missing_empty_weight_ticket IS 'Indicates if the customer is missing a weight ticket for the vehicle weight.';
 COMMENT on COLUMN weight_tickets.empty_document_id IS 'The ID of the document that is associated with the user uploads containing the empty vehicle weight.';
 COMMENT on COLUMN weight_tickets.full_weight IS 'Stores the weight of the vehicle when full.';
-COMMENT on COLUMN weight_tickets.has_full_weight_ticket IS 'Indicates if the customer has a weight ticket for the vehicle weight when full.';
+COMMENT on COLUMN weight_tickets.missing_full_weight_ticket IS 'Indicates if the customer is missing a weight ticket for the vehicle weight.';
 COMMENT on COLUMN weight_tickets.empty_document_id IS 'The ID of the document that is associated with the user uploads containing the full vehicle weight.';
 COMMENT on COLUMN weight_tickets.owns_trailer IS 'Indicates if the customer used a trailer they own for the move.';
 COMMENT on COLUMN weight_tickets.trailer_meets_criteria IS 'Indicates if the trailer that the customer used meets all the criteria to be claimable.';

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -77,7 +77,7 @@ type PPMShipment struct {
 	SITEstimatedEntryDate          *time.Time        `json:"sit_estimated_entry_date" db:"sit_estimated_entry_date"`
 	SITEstimatedDepartureDate      *time.Time        `json:"sit_estimated_departure_date" db:"sit_estimated_departure_date"`
 	SITEstimatedCost               *unit.Cents       `json:"sit_estimated_cost" db:"sit_estimated_cost"`
-	WeightTickets                  WeightTickets     `has_many:"weight_tickets" fk_id:"ppm_shipment_id" order_by:"created_at desc"`
+	WeightTickets                  WeightTickets     `has_many:"weight_tickets" fk_id:"ppm_shipment_id" order_by:"created_at asc"`
 }
 
 // PPMShipments is a list of PPMs

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -77,6 +77,7 @@ type PPMShipment struct {
 	SITEstimatedEntryDate          *time.Time        `json:"sit_estimated_entry_date" db:"sit_estimated_entry_date"`
 	SITEstimatedDepartureDate      *time.Time        `json:"sit_estimated_departure_date" db:"sit_estimated_departure_date"`
 	SITEstimatedCost               *unit.Cents       `json:"sit_estimated_cost" db:"sit_estimated_cost"`
+	WeightTickets                  WeightTickets     `has_many:"weight_tickets" fk_id:"ppm_shipment_id" order_by:"created_at desc"`
 }
 
 // PPMShipments is a list of PPMs

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+type WeightTicket struct {
+	ID                                uuid.UUID   `json:"id" db:"id"`
+	PPMShipmentID                     uuid.UUID   `json:"ppm_shipment_id" db:"ppm_shipment_id"`
+	PPMShipment                       PPMShipment `belongs_to:"ppm_shipments" fk_id:"ppm_shipment_id"`
+	CreatedAt                         time.Time   `json:"created_at" db:"created_at"`
+	UpdatedAt                         time.Time   `json:"updated_at" db:"updated_at"`
+	DeletedAt                         *time.Time  `json:"deleted_at" db:"deleted_at"`
+	VehicleDescription                *string     `json:"vehicle_description" db:"vehicle_description"`
+	EmptyWeight                       *unit.Pound `json:"empty_weight" db:"empty_weight"`
+	HasEmptyWeightTicket              *bool       `json:"has_empty_weight_ticket" db:"has_empty_weight_ticket"`
+	EmptyDocumentID                   *uuid.UUID  `json:"empty_document_id" db:"empty_document_id"`
+	EmptyDocument                     *Document   `belongs_to:"documents" fk_id:"empty_document_id"`
+	FullWeight                        *unit.Pound `json:"full_weight" db:"full_weight"`
+	HasFullWeightTicket               *bool       `json:"has_full_weight_ticket" db:"has_full_weight_ticket"`
+	FullDocumentID                    *uuid.UUID  `json:"full_document_id" db:"full_document_id"`
+	FullDocument                      *Document   `belongs_to:"documents" fk_id:"full_document_id"`
+	OwnsTrailer                       *bool       `json:"owns_trailer" db:"owns_trailer"`
+	TrailerMeetsCriteria              *bool       `json:"trailer_meets_criteria" db:"trailer_meets_criteria"`
+	ProofOfTrailerOwnershipDocumentID *uuid.UUID  `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`
+	ProofOfTrailerOwnershipDocument   *Document   `belongs_to:"documents" fk_id:"proof_of_trailer_ownership_document_id"`
+}
+
+type WeightTickets []WeightTicket

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -9,8 +9,7 @@ import (
 )
 
 // WeightTicket represents the weight tickets and related data for a single trip of a PPM Shipment. Each trip should be
-// its own record. EmptyDocumentID and FullDocumentID are pointers, but based on our plan for how we'll be using this
-// model, they should be filled in. Mainly made pointers to give us wiggle room if our implementation changes.
+// its own record.
 type WeightTicket struct {
 	ID                                uuid.UUID   `json:"id" db:"id"`
 	PPMShipmentID                     uuid.UUID   `json:"ppm_shipment_id" db:"ppm_shipment_id"`
@@ -21,12 +20,12 @@ type WeightTicket struct {
 	VehicleDescription                *string     `json:"vehicle_description" db:"vehicle_description"`
 	EmptyWeight                       *unit.Pound `json:"empty_weight" db:"empty_weight"`
 	HasEmptyWeightTicket              *bool       `json:"has_empty_weight_ticket" db:"has_empty_weight_ticket"`
-	EmptyDocumentID                   *uuid.UUID  `json:"empty_document_id" db:"empty_document_id"`
-	EmptyDocument                     *Document   `belongs_to:"documents" fk_id:"empty_document_id"`
+	EmptyDocumentID                   uuid.UUID   `json:"empty_document_id" db:"empty_document_id"`
+	EmptyDocument                     Document    `belongs_to:"documents" fk_id:"empty_document_id"`
 	FullWeight                        *unit.Pound `json:"full_weight" db:"full_weight"`
 	HasFullWeightTicket               *bool       `json:"has_full_weight_ticket" db:"has_full_weight_ticket"`
-	FullDocumentID                    *uuid.UUID  `json:"full_document_id" db:"full_document_id"`
-	FullDocument                      *Document   `belongs_to:"documents" fk_id:"full_document_id"`
+	FullDocumentID                    uuid.UUID   `json:"full_document_id" db:"full_document_id"`
+	FullDocument                      Document    `belongs_to:"documents" fk_id:"full_document_id"`
 	OwnsTrailer                       *bool       `json:"owns_trailer" db:"owns_trailer"`
 	TrailerMeetsCriteria              *bool       `json:"trailer_meets_criteria" db:"trailer_meets_criteria"`
 	ProofOfTrailerOwnershipDocumentID *uuid.UUID  `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -3,6 +3,9 @@ package models
 import (
 	"time"
 
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/unit"
@@ -33,3 +36,18 @@ type WeightTicket struct {
 }
 
 type WeightTickets []WeightTicket
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate,
+// pop.ValidateAndUpdate) method. This should contain validation that is for data integrity. Business validation should
+// occur in service objects.
+func (w *WeightTicket) Validate(_ *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&OptionalTimeIsPresent{Name: "DeletedAt", Field: w.DeletedAt},
+		&StringIsNilOrNotBlank{Name: "VehicleDescription", Field: w.VehicleDescription},
+		&OptionalPoundIsNonNegative{Name: "EmptyWeight", Field: w.EmptyWeight},
+		&validators.UUIDIsPresent{Name: "EmptyDocumentID", Field: w.EmptyDocumentID},
+		&OptionalPoundIsNonNegative{Name: "FullWeight", Field: w.FullWeight},
+		&validators.UUIDIsPresent{Name: "FullDocumentID", Field: w.FullDocumentID},
+		&OptionalUUIDIsPresent{Name: "ProofOfTrailerOwnershipDocumentID", Field: w.ProofOfTrailerOwnershipDocumentID},
+	), nil
+}

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -31,8 +31,8 @@ type WeightTicket struct {
 	FullDocument                      Document    `belongs_to:"documents" fk_id:"full_document_id"`
 	OwnsTrailer                       *bool       `json:"owns_trailer" db:"owns_trailer"`
 	TrailerMeetsCriteria              *bool       `json:"trailer_meets_criteria" db:"trailer_meets_criteria"`
-	ProofOfTrailerOwnershipDocumentID *uuid.UUID  `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`
-	ProofOfTrailerOwnershipDocument   *Document   `belongs_to:"documents" fk_id:"proof_of_trailer_ownership_document_id"`
+	ProofOfTrailerOwnershipDocumentID uuid.UUID   `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`
+	ProofOfTrailerOwnershipDocument   Document    `belongs_to:"documents" fk_id:"proof_of_trailer_ownership_document_id"`
 }
 
 type WeightTickets []WeightTicket
@@ -48,6 +48,6 @@ func (w *WeightTicket) Validate(_ *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Name: "EmptyDocumentID", Field: w.EmptyDocumentID},
 		&OptionalPoundIsNonNegative{Name: "FullWeight", Field: w.FullWeight},
 		&validators.UUIDIsPresent{Name: "FullDocumentID", Field: w.FullDocumentID},
-		&OptionalUUIDIsPresent{Name: "ProofOfTrailerOwnershipDocumentID", Field: w.ProofOfTrailerOwnershipDocumentID},
+		&validators.UUIDIsPresent{Name: "ProofOfTrailerOwnershipDocumentID", Field: w.ProofOfTrailerOwnershipDocumentID},
 	), nil
 }

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -9,7 +9,8 @@ import (
 )
 
 // WeightTicket represents the weight tickets and related data for a single trip of a PPM Shipment. Each trip should be
-// its own record
+// its own record. EmptyDocumentID and FullDocumentID are pointers, but based on our plan for how we'll be using this
+// model, they should be filled in. Mainly made pointers to give us wiggle room if our implementation changes.
 type WeightTicket struct {
 	ID                                uuid.UUID   `json:"id" db:"id"`
 	PPMShipmentID                     uuid.UUID   `json:"ppm_shipment_id" db:"ppm_shipment_id"`

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -22,11 +22,11 @@ type WeightTicket struct {
 	DeletedAt                         *time.Time  `json:"deleted_at" db:"deleted_at"`
 	VehicleDescription                *string     `json:"vehicle_description" db:"vehicle_description"`
 	EmptyWeight                       *unit.Pound `json:"empty_weight" db:"empty_weight"`
-	HasEmptyWeightTicket              *bool       `json:"has_empty_weight_ticket" db:"has_empty_weight_ticket"`
+	MissingEmptyWeightTicket          *bool       `json:"missing_empty_weight_ticket" db:"missing_empty_weight_ticket"`
 	EmptyDocumentID                   uuid.UUID   `json:"empty_document_id" db:"empty_document_id"`
 	EmptyDocument                     Document    `belongs_to:"documents" fk_id:"empty_document_id"`
 	FullWeight                        *unit.Pound `json:"full_weight" db:"full_weight"`
-	HasFullWeightTicket               *bool       `json:"has_full_weight_ticket" db:"has_full_weight_ticket"`
+	MissingFullWeightTicket           *bool       `json:"missing_full_weight_ticket" db:"missing_full_weight_ticket"`
 	FullDocumentID                    uuid.UUID   `json:"full_document_id" db:"full_document_id"`
 	FullDocument                      Document    `belongs_to:"documents" fk_id:"full_document_id"`
 	OwnsTrailer                       *bool       `json:"owns_trailer" db:"owns_trailer"`

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -8,6 +8,8 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// WeightTicket represents the weight tickets and related data for a single trip of a PPM Shipment. Each trip should be
+// its own record
 type WeightTicket struct {
 	ID                                uuid.UUID   `json:"id" db:"id"`
 	PPMShipmentID                     uuid.UUID   `json:"ppm_shipment_id" db:"ppm_shipment_id"`

--- a/pkg/models/weight_ticket_test.go
+++ b/pkg/models/weight_ticket_test.go
@@ -16,18 +16,20 @@ func (suite *ModelSuite) TestWeightTicketValidation() {
 	}{
 		"Successful create": {
 			weightTicket: models.WeightTicket{
-				EmptyWeight:     models.PoundPointer(unit.Pound(0)),
-				EmptyDocumentID: uuid.Must(uuid.NewV4()),
-				FullWeight:      models.PoundPointer(unit.Pound(0)),
-				FullDocumentID:  uuid.Must(uuid.NewV4()),
+				EmptyWeight:                       models.PoundPointer(unit.Pound(0)),
+				EmptyDocumentID:                   uuid.Must(uuid.NewV4()),
+				FullWeight:                        models.PoundPointer(unit.Pound(0)),
+				FullDocumentID:                    uuid.Must(uuid.NewV4()),
+				ProofOfTrailerOwnershipDocumentID: uuid.Must(uuid.NewV4()),
 			},
 			expectedErrs: nil,
 		},
 		"Missing UUIDs": {
 			weightTicket: models.WeightTicket{},
 			expectedErrs: map[string][]string{
-				"empty_document_id": {"EmptyDocumentID can not be blank."},
-				"full_document_id":  {"FullDocumentID can not be blank."},
+				"empty_document_id":                      {"EmptyDocumentID can not be blank."},
+				"full_document_id":                       {"FullDocumentID can not be blank."},
+				"proof_of_trailer_ownership_document_id": {"ProofOfTrailerOwnershipDocumentID can not be blank."},
 			},
 		},
 		"Optional fields are valid": {
@@ -38,14 +40,13 @@ func (suite *ModelSuite) TestWeightTicketValidation() {
 				EmptyDocumentID:                   uuid.Must(uuid.NewV4()),
 				FullWeight:                        models.PoundPointer(unit.Pound(-1)),
 				FullDocumentID:                    uuid.Must(uuid.NewV4()),
-				ProofOfTrailerOwnershipDocumentID: models.UUIDPointer(uuid.Nil),
+				ProofOfTrailerOwnershipDocumentID: uuid.Must(uuid.NewV4()),
 			},
 			expectedErrs: map[string][]string{
-				"deleted_at":                             {"DeletedAt can not be blank."},
-				"vehicle_description":                    {"VehicleDescription can not be blank."},
-				"empty_weight":                           {"-1 is less than zero."},
-				"full_weight":                            {"-1 is less than zero."},
-				"proof_of_trailer_ownership_document_id": {"ProofOfTrailerOwnershipDocumentID can not be blank."},
+				"deleted_at":          {"DeletedAt can not be blank."},
+				"vehicle_description": {"VehicleDescription can not be blank."},
+				"empty_weight":        {"-1 is less than zero."},
+				"full_weight":         {"-1 is less than zero."},
 			},
 		},
 	}

--- a/pkg/models/weight_ticket_test.go
+++ b/pkg/models/weight_ticket_test.go
@@ -1,0 +1,61 @@
+package models_test
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ModelSuite) TestWeightTicketValidation() {
+	testCases := map[string]struct {
+		weightTicket models.WeightTicket
+		expectedErrs map[string][]string
+	}{
+		"Successful create": {
+			weightTicket: models.WeightTicket{
+				EmptyWeight:     models.PoundPointer(unit.Pound(0)),
+				EmptyDocumentID: uuid.Must(uuid.NewV4()),
+				FullWeight:      models.PoundPointer(unit.Pound(0)),
+				FullDocumentID:  uuid.Must(uuid.NewV4()),
+			},
+			expectedErrs: nil,
+		},
+		"Missing UUIDs": {
+			weightTicket: models.WeightTicket{},
+			expectedErrs: map[string][]string{
+				"empty_document_id": {"EmptyDocumentID can not be blank."},
+				"full_document_id":  {"FullDocumentID can not be blank."},
+			},
+		},
+		"Optional fields are valid": {
+			weightTicket: models.WeightTicket{
+				DeletedAt:                         models.TimePointer(time.Time{}),
+				VehicleDescription:                models.StringPointer(""),
+				EmptyWeight:                       models.PoundPointer(unit.Pound(-1)),
+				EmptyDocumentID:                   uuid.Must(uuid.NewV4()),
+				FullWeight:                        models.PoundPointer(unit.Pound(-1)),
+				FullDocumentID:                    uuid.Must(uuid.NewV4()),
+				ProofOfTrailerOwnershipDocumentID: models.UUIDPointer(uuid.Nil),
+			},
+			expectedErrs: map[string][]string{
+				"deleted_at":                             {"DeletedAt can not be blank."},
+				"vehicle_description":                    {"VehicleDescription can not be blank."},
+				"empty_weight":                           {"-1 is less than zero."},
+				"full_weight":                            {"-1 is less than zero."},
+				"proof_of_trailer_ownership_document_id": {"ProofOfTrailerOwnershipDocumentID can not be blank."},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		name := name
+		tc := tc
+
+		suite.Run(name, func() {
+			suite.verifyValidationErrors(&tc.weightTicket, tc.expectedErrs)
+		})
+	}
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12926) for this change

The ticket above is to track the work, but the details are in the [discovery ticket](https://dp3.atlassian.net/browse/MB-12857).

## Summary

This adds a new `WeightTicket` model and a corresponding `weight_tickets` table that will be used to track weight tickets for PPMs.

Do the field names and comments on the table columns make sense?

## Checking Changes

<details>
<summary>💻 Terminal setup</summary>

### Run migrations on top of existing db

You can run this the first time you pull it down to see it applies the migration properly on top of the existing DB. Not required though, you can also run the other command instead.

```sh
make db_dev_migrate
```

### Run all migrations

```sh
make db_dev_fresh
```

</details>

### Additional steps 

1. Access the DB however you usually do and see if the new table is there correctly

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
