### PR TITLE
MB-12448 Disable editing ability on allowances and orders for QAE/CSR

### DIFF
--- a/cypress/integration/office/qaecsr/csrAllowancesOrdersFlows.js
+++ b/cypress/integration/office/qaecsr/csrAllowancesOrdersFlows.js
@@ -32,7 +32,7 @@ describe('QAE/CSR orders and allowances read only view', () => {
     cy.get('@results').first().click();
     cy.url().should('include', `/moves/${moveLocator}/details`);
 
-    // Navigate to Edit orders page
+    // Navigate to view orders page
     cy.get('[data-testid="view-orders"]').contains('View orders').click();
 
     cy.get('input[name="issueDate"]').should('be.disabled');
@@ -65,29 +65,27 @@ describe('QAE/CSR orders and allowances read only view', () => {
     // Move Details page
     cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
 
-    // Navigate to Edit allowances page
+    // Navigate to view allowances page
     cy.get('[data-testid="view-allowances"]').contains('View allowances').click();
 
     cy.wait(['@getMoves', '@getOrders']);
 
-    // Edit pro-gear, pro-gear spouse, RME, SIT, and OCIE fields
+    // read only pro-gear, pro-gear spouse, RME, SIT, and OCIE fields
     cy.get('input[name="proGearWeight"]').should('be.disabled');
     cy.get('input[name="proGearWeightSpouse"]').should('be.disabled');
     cy.get('input[name="requiredMedicalEquipmentWeight"]').should('be.disabled');
     cy.get('input[name="storageInTransit"]').should('be.disabled');
     cy.get('input[name="organizationalClothingAndIndividualEquipment"]').should('be.disabled');
 
-    // Edit grade and authorized weight
+    // read only grade and authorized weight
     cy.get('select[name=agency]').should('be.disabled');
     cy.get('select[name=agency]').should('be.disabled');
     cy.get('select[name="grade"]').should('be.disabled');
     cy.get('select[name="grade"]').should('be.disabled');
     cy.get('input[name="authorizedWeight"]').should('be.disabled');
-
-    //Edit DependentsAuthorized
     cy.get('input[name="dependentsAuthorized"]').should('be.disabled');
 
-    // Edit allowances page | Save
+    // no save button should exist
     cy.get('button').contains('Save').should('not.exist');
   });
 });

--- a/cypress/integration/office/qaecsr/csrAllowancesOrdersFlows.js
+++ b/cypress/integration/office/qaecsr/csrAllowancesOrdersFlows.js
@@ -1,0 +1,93 @@
+import { QAECSROfficeUserType } from '../../../support/constants';
+
+describe('QAE/CSR orders and allowances read only view', () => {
+  before(() => {
+    cy.prepareOfficeApp();
+  });
+
+  beforeEach(() => {
+    cy.intercept('**/ghc/v1/swagger.yaml').as('getGHCClient');
+    cy.intercept('**/ghc/v1/moves/search').as('getSearchResults');
+    cy.intercept('**/ghc/v1/move/**').as('getMoves');
+    cy.intercept('GET', '**/ghc/v1/orders/**').as('getOrders');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_shipments').as('getMTOShipments');
+    cy.intercept('**/ghc/v1/move_task_orders/**/mto_service_items').as('getMTOServiceItems');
+
+    const userId = '2419b1d6-097f-4dc4-8171-8f858967b4db';
+    cy.apiSignInAsUser(userId, QAECSROfficeUserType);
+  });
+
+  it('is able to see orders and form is read only', () => {
+    const moveLocator = 'QAEHLP';
+    cy.get('input[name="searchText"]').as('moveCodeSearchInput');
+    cy.get('@moveCodeSearchInput').type(moveLocator).blur();
+    cy.get('button').contains('Search').click();
+    cy.wait(['@getSearchResults']);
+
+    cy.get('tbody > tr').as('results');
+    cy.get('@results').should('have.length', 1);
+    cy.get('@results').first().contains(moveLocator);
+
+    // click result to navigate to move details page
+    cy.get('@results').first().click();
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+
+    // Navigate to Edit orders page
+    cy.get('[data-testid="view-orders"]').contains('View orders').click();
+
+    cy.get('input[name="issueDate"]').should('be.disabled');
+    cy.get('input[name="reportByDate"]').should('be.disabled');
+    cy.get('select[name="departmentIndicator"]').should('be.disabled');
+    cy.get('input[name="ordersNumber"]').should('be.disabled');
+    cy.get('select[name="ordersType"]').should('be.disabled');
+    cy.get('select[name="ordersTypeDetail"]').should('be.disabled');
+    cy.get('input[name="tac"]').should('be.disabled');
+    cy.get('input[name="sac"]').should('be.disabled');
+    // no save button should exist
+    cy.get('button').contains('Save').should('not.exist');
+  });
+
+  it('is able to see allowances and the form is read only', () => {
+    const moveLocator = 'QAEHLP';
+    cy.get('input[name="searchText"]').as('moveCodeSearchInput');
+    cy.get('@moveCodeSearchInput').type(moveLocator).blur();
+    cy.get('button').contains('Search').click();
+    cy.wait(['@getSearchResults']);
+
+    cy.get('tbody > tr').as('results');
+    cy.get('@results').should('have.length', 1);
+    cy.get('@results').first().contains(moveLocator);
+
+    // click result to navigate to move details page
+    cy.get('@results').first().click();
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+
+    // Move Details page
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+
+    // Navigate to Edit allowances page
+    cy.get('[data-testid="view-allowances"]').contains('View allowances').click();
+
+    cy.wait(['@getMoves', '@getOrders']);
+
+    // Edit pro-gear, pro-gear spouse, RME, SIT, and OCIE fields
+    cy.get('input[name="proGearWeight"]').should('be.disabled');
+    cy.get('input[name="proGearWeightSpouse"]').should('be.disabled');
+    cy.get('input[name="requiredMedicalEquipmentWeight"]').should('be.disabled');
+    cy.get('input[name="storageInTransit"]').should('be.disabled');
+    cy.get('input[name="organizationalClothingAndIndividualEquipment"]').should('be.disabled');
+
+    // Edit grade and authorized weight
+    cy.get('select[name=agency]').should('be.disabled');
+    cy.get('select[name=agency]').should('be.disabled');
+    cy.get('select[name="grade"]').should('be.disabled');
+    cy.get('select[name="grade"]').should('be.disabled');
+    cy.get('input[name="authorizedWeight"]').should('be.disabled');
+
+    //Edit DependentsAuthorized
+    cy.get('input[name="dependentsAuthorized"]').should('be.disabled');
+
+    // Edit allowances page | Save
+    cy.get('button').contains('Save').should('not.exist');
+  });
+});

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1772,7 +1772,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "update.orders"
+        ]
       },
       "parameters": [
         {
@@ -9350,7 +9353,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "update.orders"
+        ]
       },
       "parameters": [
         {

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -80,11 +80,6 @@ func (h UpdateOrderHandler) Handle(params orderop.UpdateOrderParams) middleware.
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() ||
-				(!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) && !appCtx.Session().Roles.HasRole(roles.RoleTypeTIO)) {
-				return handleError(apperror.NewForbiddenError("is not a TXO"))
-			}
-
 			orderID := uuid.FromStringOrNil(params.OrderID.String())
 			updatedOrder, moveID, err := h.orderUpdater.UpdateOrderAsTOO(
 				appCtx,
@@ -188,11 +183,6 @@ func (h UpdateAllowanceHandler) Handle(params orderop.UpdateAllowanceParams) mid
 				default:
 					return orderop.NewUpdateAllowanceInternalServerError(), err
 				}
-			}
-
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
-				return handleError(apperror.NewForbiddenError("is not a TOO"))
 			}
 
 			orderID := uuid.FromStringOrNil(params.OrderID.String())

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -516,39 +516,6 @@ func (suite *HandlerSuite) TestUpdateOrderHandler() {
 		suite.Equal(body.NtsSac.Value, ordersPayload.NtsSac)
 	})
 
-	suite.Run("Returns a 403 when the user does not have TXO role", func() {
-		handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
-		subtestData := suite.makeUpdateOrderHandlerSubtestData()
-		order := subtestData.order
-		body := subtestData.body
-
-		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.UpdateOrderParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.OrderUpdater{}
-		handler := UpdateOrderHandler{
-			handlerConfig,
-			updater,
-			&mocks.MoveTaskOrderUpdater{},
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateOrderAsTOO", 0)
-		updater.AssertNumberOfCalls(suite.T(), "UpdateOrderAsCounselor", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.UpdateOrderForbidden{}, response)
-	})
-
 	// We need to confirm whether a user who only has the TIO role should indeed
 	// be authorized to update orders. If not, we also need to prevent them from
 	// clicking the Edit Orders button in the frontend.
@@ -1047,38 +1014,6 @@ func (suite *HandlerSuite) TestUpdateAllowanceHandler() {
 		suite.Equal(*body.ProGearWeightSpouse, ordersPayload.Entitlement.ProGearWeightSpouse)
 		suite.Equal(*body.RequiredMedicalEquipmentWeight, ordersPayload.Entitlement.RequiredMedicalEquipmentWeight)
 		suite.Equal(*body.StorageInTransit, *ordersPayload.Entitlement.StorageInTransit)
-	})
-
-	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		handlerConfig := handlers.NewHandlerConfig(suite.DB(), suite.Logger())
-		subtestData := suite.makeUpdateAllowanceHandlerSubtestData()
-		order := subtestData.order
-		body := subtestData.body
-
-		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.UpdateAllowanceParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.OrderUpdater{}
-		handler := UpdateAllowanceHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateAllowanceAsTOO", 0)
-		updater.AssertNumberOfCalls(suite.T(), "UpdateAllowanceAsCounselor", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.UpdateAllowanceForbidden{}, response)
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {

--- a/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
+++ b/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
@@ -110,7 +110,7 @@ export const DutyLocationSearchBoxComponent = (props) => {
         boxShadow: state.isFocused ? `0 0 0 0.26667rem ${uswdsBlue}` : '',
       }),
       singleValue: () => {
-        const color = uswdsBlack;
+        const color = '#1B1B1B';
         return { color };
       },
       valueContainer: (provided) => ({

--- a/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
+++ b/src/components/DutyLocationSearchBox/DutyLocationSearchBox.jsx
@@ -77,10 +77,49 @@ const customStyles = {
 };
 
 export const DutyLocationSearchBoxComponent = (props) => {
-  const { searchDutyLocations, showAddress, title, input, name, errorMsg, displayAddress, hint, placeholder } = props;
+  const {
+    searchDutyLocations,
+    showAddress,
+    title,
+    input,
+    name,
+    errorMsg,
+    displayAddress,
+    hint,
+    placeholder,
+    isDisabled,
+  } = props;
   const { value, onChange, name: inputName } = input;
 
   const [inputValue, setInputValue] = useState('');
+  let disabledStyles = {};
+  if (isDisabled) {
+    disabledStyles = {
+      ...customStyles,
+      control: (provided, state) => ({
+        ...provided,
+        backgroundColor: '#DCDEE0',
+        borderRadius: '0px',
+        borderColor: uswdsBlack,
+        padding: '0.1rem',
+        maxWidth: '32rem',
+        ':hover': {
+          ...styles[':hover'],
+          borderColor: uswdsBlack,
+        },
+        boxShadow: state.isFocused ? `0 0 0 0.26667rem ${uswdsBlue}` : '',
+      }),
+      singleValue: () => {
+        const color = uswdsBlack;
+        return { color };
+      },
+      valueContainer: (provided) => ({
+        ...provided,
+        display: 'flex',
+        backgroundColor: '#DCDEE0',
+      }),
+    };
+  }
 
   const loadOptions = debounce((query, callback) => {
     if (!query || query.length < MIN_SEARCH_LENGTH) {
@@ -128,7 +167,6 @@ export const DutyLocationSearchBoxComponent = (props) => {
 
   const noOptionsMessage = () => (inputValue.length ? 'No Options' : '');
   const hasDutyLocation = !!value && !!value.address;
-
   return (
     <FormGroup>
       <div className="labelWrapper">
@@ -151,7 +189,8 @@ export const DutyLocationSearchBoxComponent = (props) => {
           placeholder={placeholder || 'Start typing a duty location...'}
           value={hasDutyLocation ? value : null}
           noOptionsMessage={noOptionsMessage}
-          styles={customStyles}
+          styles={isDisabled ? disabledStyles : customStyles}
+          isDisabled={isDisabled}
         />
       </div>
       {displayAddress && hasDutyLocation && (
@@ -165,8 +204,14 @@ export const DutyLocationSearchBoxComponent = (props) => {
 };
 
 export const DutyLocationSearchBoxContainer = (props) => {
+  const { isDisabled } = props;
   return (
-    <DutyLocationSearchBoxComponent {...props} searchDutyLocations={SearchDutyLocations} showAddress={ShowAddress} />
+    <DutyLocationSearchBoxComponent
+      {...props}
+      searchDutyLocations={SearchDutyLocations}
+      showAddress={ShowAddress}
+      isDisabled={isDisabled}
+    />
   );
 };
 
@@ -182,6 +227,7 @@ DutyLocationSearchBoxContainer.propTypes = {
   }),
   hint: PropTypes.node,
   placeholder: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 DutyLocationSearchBoxContainer.defaultProps = {
@@ -195,16 +241,19 @@ DutyLocationSearchBoxContainer.defaultProps = {
   },
   hint: '',
   placeholder: 'Start typing a duty location...',
+  isDisabled: false,
 };
 
 DutyLocationSearchBoxComponent.propTypes = {
   ...DutyLocationSearchBoxContainer.propTypes,
   searchDutyLocations: PropTypes.func.isRequired,
   showAddress: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
 };
 
 DutyLocationSearchBoxComponent.defaultProps = {
   ...DutyLocationSearchBoxContainer.defaultProps,
+  isDisabled: false,
 };
 
 export default DutyLocationSearchBoxContainer;

--- a/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
+++ b/src/components/Office/AllowancesDetailForm/AllowancesDetailForm.jsx
@@ -10,7 +10,14 @@ import { EntitlementShape } from 'types/order';
 import { formatWeight } from 'utils/formatters';
 import Hint from 'components/Hint';
 
-const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions, editableAuthorizedWeight }) => {
+const AllowancesDetailForm = ({
+  header,
+  entitlements,
+  rankOptions,
+  branchOptions,
+  editableAuthorizedWeight,
+  formIsDisabled,
+}) => {
   return (
     <div className={styles.AllowancesDetailForm}>
       {header && <h3 data-testid="header">{header}</h3>}
@@ -25,6 +32,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         signed={false} // disallow negative
         thousandsSeparator=","
         lazy={false} // immediate masking evaluation
+        isDisabled={formIsDisabled}
       >
         <Hint data-testid="proGearWeightHint">
           <p>Max. 2,000 lbs</p>
@@ -42,6 +50,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         signed={false} // disallow negative
         thousandsSeparator=","
         lazy={false} // immediate masking evaluation
+        isDisabled={formIsDisabled}
       >
         <Hint data-testid="proGearWeightSpouseHint">
           <p>Max. 500 lbs</p>
@@ -59,6 +68,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         signed={false} // disallow negative
         thousandsSeparator=","
         lazy={false} // immediate masking evaluation
+        isDisabled={formIsDisabled}
       />
       <DropdownInput
         data-testid="branchInput"
@@ -66,6 +76,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         label="Branch"
         options={branchOptions}
         showDropdownPlaceholderText={false}
+        isDisabled={formIsDisabled}
       />
       <DropdownInput
         data-testid="rankInput"
@@ -73,6 +84,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         label="Rank"
         options={rankOptions}
         showDropdownPlaceholderText={false}
+        isDisabled={formIsDisabled}
       />
       <MaskedTextField
         data-testid="sitInput"
@@ -85,6 +97,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
         signed={false} // disallow negative
         thousandsSeparator=","
         lazy={false} // immediate masking evaluation
+        isDisabled={formIsDisabled}
       />
       <div className={styles.wrappedCheckbox}>
         <CheckboxField
@@ -92,6 +105,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
           id="ocieInput"
           name="organizationalClothingAndIndividualEquipment"
           label="OCIE authorized (Army only)"
+          isDisabled={formIsDisabled}
         />
       </div>
 
@@ -107,6 +121,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
           signed={false} // disallow negative
           thousandsSeparator=","
           lazy={false} // immediate masking evaluation
+          isDisabled={formIsDisabled}
         />
       )}
 
@@ -126,6 +141,7 @@ const AllowancesDetailForm = ({ header, entitlements, rankOptions, branchOptions
           data-testid="dependentsAuthorizedInput"
           name="dependentsAuthorized"
           label="Dependents authorized"
+          isDisabled={formIsDisabled}
         />
       </div>
     </div>
@@ -138,11 +154,13 @@ AllowancesDetailForm.propTypes = {
   branchOptions: DropdownArrayOf.isRequired,
   header: PropTypes.string,
   editableAuthorizedWeight: PropTypes.bool,
+  formIsDisabled: PropTypes.bool,
 };
 
 AllowancesDetailForm.defaultProps = {
   header: null,
   editableAuthorizedWeight: false,
+  formIsDisabled: false,
 };
 
 export default AllowancesDetailForm;

--- a/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
+++ b/src/components/Office/OrdersDetailForm/OrdersDetailForm.jsx
@@ -27,6 +27,7 @@ const OrdersDetailForm = ({
   showOrdersAcknowledgement,
   ordersType,
   setFieldValue,
+  formIsDisabled,
 }) => {
   const [formOrdersType, setFormOrdersType] = useState(ordersType);
   const reportDateRowLabel = formatLabelReportByDate(formOrdersType);
@@ -34,19 +35,32 @@ const OrdersDetailForm = ({
   const isRetirementOrSeparation = ['RETIREMENT', 'SEPARATION'].includes(formOrdersType);
   return (
     <div className={styles.OrdersDetailForm}>
-      <DutyLocationInput name="originDutyLocation" label="Current duty location" displayAddress={false} />
+      <DutyLocationInput
+        name="originDutyLocation"
+        label="Current duty location"
+        displayAddress={false}
+        isDisabled={formIsDisabled}
+      />
       <DutyLocationInput
         name="newDutyLocation"
         label={isRetirementOrSeparation ? 'HOR, HOS or PLEAD' : 'New duty location'}
         displayAddress={false}
         placeholder={isRetirementOrSeparation ? 'Enter a city or ZIP' : 'Start typing a duty location...'}
+        isDisabled={formIsDisabled}
       />
-      <DatePickerInput name="issueDate" label="Date issued" />
-      <DatePickerInput name="reportByDate" label={reportDateRowLabel} />
+      <DatePickerInput name="issueDate" label="Date issued" disabled={formIsDisabled} />
+      <DatePickerInput name="reportByDate" label={reportDateRowLabel} disabled={formIsDisabled} />
       {showDepartmentIndicator && (
-        <DropdownInput name="departmentIndicator" label="Department indicator" options={deptIndicatorOptions} />
+        <DropdownInput
+          name="departmentIndicator"
+          label="Department indicator"
+          options={deptIndicatorOptions}
+          isDisabled={formIsDisabled}
+        />
       )}
-      {showOrdersNumber && <TextField name="ordersNumber" label="Orders number" id="ordersNumberInput" />}
+      {showOrdersNumber && (
+        <TextField name="ordersNumber" label="Orders number" id="ordersNumberInput" isDisabled={formIsDisabled} />
+      )}
       <DropdownInput
         name="ordersType"
         label="Orders type"
@@ -55,9 +69,15 @@ const OrdersDetailForm = ({
           setFormOrdersType(e.target.value);
           setFieldValue('ordersType', e.target.value);
         }}
+        isDisabled={formIsDisabled}
       />
       {showOrdersTypeDetail && (
-        <DropdownInput name="ordersTypeDetail" label="Orders type detail" options={ordersTypeDetailOptions} />
+        <DropdownInput
+          name="ordersTypeDetail"
+          label="Orders type detail"
+          options={ordersTypeDetailOptions}
+          isDisabled={formIsDisabled}
+        />
       )}
 
       {showHHGTac && showHHGSac && <h3>HHG accounting codes</h3>}
@@ -70,9 +90,19 @@ const OrdersDetailForm = ({
           inputTestId="hhgTacInput"
           warning={hhgTacWarning}
           validate={validateHHGTac}
+          isDisabled={formIsDisabled}
         />
       )}
-      {showHHGSac && <TextField name="sac" label="SAC" id="hhgSacInput" data-testid="hhgSacInput" optional />}
+      {showHHGSac && (
+        <TextField
+          name="sac"
+          label="SAC"
+          id="hhgSacInput"
+          data-testid="hhgSacInput"
+          isDisabled={formIsDisabled}
+          optional
+        />
+      )}
 
       {showNTSTac && showNTSSac && <h3>NTS accounting codes</h3>}
       {showNTSTac && (
@@ -84,10 +114,20 @@ const OrdersDetailForm = ({
           inputTestId="ntsTacInput"
           warning={ntsTacWarning}
           validate={validateNTSTac}
+          isDisabled={formIsDisabled}
           optional
         />
       )}
-      {showNTSSac && <TextField name="ntsSac" label="SAC" id="ntsSacInput" data-testid="ntsSacInput" optional />}
+      {showNTSSac && (
+        <TextField
+          name="ntsSac"
+          label="SAC"
+          id="ntsSacInput"
+          isDisabled={formIsDisabled}
+          data-testid="ntsSacInput"
+          optional
+        />
+      )}
 
       {showOrdersAcknowledgement && (
         <div className={styles.wrappedCheckbox}>
@@ -95,6 +135,7 @@ const OrdersDetailForm = ({
             id="ordersAcknowledgementInput"
             name="ordersAcknowledgement"
             label="I have read the new orders"
+            isDisabled={formIsDisabled}
           />
         </div>
       )}
@@ -120,6 +161,7 @@ OrdersDetailForm.propTypes = {
   showOrdersAcknowledgement: bool,
   ordersType: string.isRequired,
   setFieldValue: func.isRequired,
+  formIsDisabled: bool,
 };
 
 OrdersDetailForm.defaultProps = {
@@ -137,6 +179,7 @@ OrdersDetailForm.defaultProps = {
   showNTSTac: true,
   showNTSSac: true,
   showOrdersAcknowledgement: false,
+  formIsDisabled: false,
 };
 
 export default OrdersDetailForm;

--- a/src/components/form/fields/CheckboxField.jsx
+++ b/src/components/form/fields/CheckboxField.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Field, useField } from 'formik';
 import { Checkbox } from '@trussworks/react-uswds';
 
+import './CheckboxField.module.scss';
+
 /**
  * This component renders a checkbox
  *
@@ -13,17 +15,24 @@ import { Checkbox } from '@trussworks/react-uswds';
  * ReactUSWDS components directly.
  */
 
-export const CheckboxField = ({ name, id, label, ...inputProps }) => {
+export const CheckboxField = ({ name, id, label, isDisabled, ...inputProps }) => {
   const [fieldProps] = useField({ name, type: 'checkbox' });
 
-  /* eslint-disable-next-line react/jsx-props-no-spreading */
-  return <Field id={id} as={Checkbox} name={name} label={label} {...fieldProps} {...inputProps} />;
+  return (
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    <Field id={id} as={Checkbox} name={name} label={label} disabled={isDisabled} {...fieldProps} {...inputProps} />
+  );
 };
 
 CheckboxField.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+CheckboxField.defaultProps = {
+  isDisabled: false,
 };
 
 export default CheckboxField;

--- a/src/components/form/fields/CheckboxField.module.scss
+++ b/src/components/form/fields/CheckboxField.module.scss
@@ -4,5 +4,9 @@
   .usa-checkbox__input:disabled + .usa-checkbox__label, .usa-radio__input:disabled + .usa-radio__label {
     color: $base-darker;
   }
+  .usa-checkbox__label:before {
+    background-color: $base-darker !important;
+    box-shadow: 0 0 0 2px $base-dark !important;
+  }
 
 }

--- a/src/components/form/fields/CheckboxField.module.scss
+++ b/src/components/form/fields/CheckboxField.module.scss
@@ -4,9 +4,10 @@
   .usa-checkbox__input:disabled + .usa-checkbox__label, .usa-radio__input:disabled + .usa-radio__label {
     color: $base-darker;
   }
-  .usa-checkbox__label:before {
-    background-color: $base-darker !important;
-    box-shadow: 0 0 0 2px $base-dark !important;
+  .usa-checkbox__input:disabled + .usa-checkbox__label:before {
+    background-color: $base-darker;
+    box-shadow: 0 0 0 2px $base-dark;
   }
+
 
 }

--- a/src/components/form/fields/CheckboxField.module.scss
+++ b/src/components/form/fields/CheckboxField.module.scss
@@ -1,0 +1,8 @@
+@import 'shared/styles/colors';
+
+:global {
+  .usa-checkbox__input:disabled + .usa-checkbox__label, .usa-radio__input:disabled + .usa-radio__label {
+    color: $base-darker;
+  }
+
+}

--- a/src/components/form/fields/DropdownInput.jsx
+++ b/src/components/form/fields/DropdownInput.jsx
@@ -7,9 +7,10 @@ import { Dropdown, FormGroup, Label } from '@trussworks/react-uswds';
 import { ErrorMessage } from 'components/form/ErrorMessage';
 // import { OptionalTag } from 'components/form/OptionalTag';
 import { DropdownArrayOf } from 'types/form';
+import './DropdownInput.module.scss';
 
 export const DropdownInput = (props) => {
-  const { id, name, label, options, showDropdownPlaceholderText, ...inputProps } = props;
+  const { id, name, label, options, showDropdownPlaceholderText, isDisabled, ...inputProps } = props;
   const [field, meta] = useField(props);
   const hasError = meta.touched && !!meta.error;
 
@@ -26,7 +27,7 @@ export const DropdownInput = (props) => {
       </div>
       <ErrorMessage display={hasError}>{meta.error}</ErrorMessage>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <Dropdown id={inputId.current} {...field} {...inputProps}>
+      <Dropdown id={inputId.current} {...field} disabled={isDisabled} {...inputProps}>
         {showDropdownPlaceholderText && <option value="">- Select -</option>}
         {options &&
           options.map(({ key, value }) => (
@@ -49,11 +50,13 @@ DropdownInput.propTypes = {
   // ex: [ { key: 'key', value: 'value' } ]
   options: DropdownArrayOf.isRequired,
   showDropdownPlaceholderText: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 DropdownInput.defaultProps = {
   id: undefined,
   showDropdownPlaceholderText: true,
+  isDisabled: false,
 };
 
 export default DropdownInput;

--- a/src/components/form/fields/DropdownInput.module.scss
+++ b/src/components/form/fields/DropdownInput.module.scss
@@ -1,0 +1,5 @@
+@import 'shared/styles/colors';
+
+select:disabled {
+  background-color: $border-color;
+}

--- a/src/components/form/fields/DropdownInput.module.scss
+++ b/src/components/form/fields/DropdownInput.module.scss
@@ -2,6 +2,7 @@
 
 select:disabled {
   background-color: $border-color;
+  opacity: 1.0;
   pointer-events: none;
 }
 

--- a/src/components/form/fields/DropdownInput.module.scss
+++ b/src/components/form/fields/DropdownInput.module.scss
@@ -2,4 +2,6 @@
 
 select:disabled {
   background-color: $border-color;
+  pointer-events: none;
 }
+

--- a/src/components/form/fields/DutyLocationInput.jsx
+++ b/src/components/form/fields/DutyLocationInput.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import DutyLocationSearchBox from 'components/DutyLocationSearchBox/DutyLocationSearchBox';
+import './DropdownInput.module.scss';
 
 // TODO: refactor component when we can to make it more user friendly with Formik
 export const DutyLocationInput = (props) => {
-  const { label, name, displayAddress, hint, placeholder } = props;
+  const { label, name, displayAddress, hint, placeholder, isDisabled } = props;
   const [field, meta, helpers] = useField(props);
 
   const errorString = meta.value?.name ? meta.error?.name || meta.error : '';
@@ -24,6 +25,7 @@ export const DutyLocationInput = (props) => {
       displayAddress={displayAddress}
       hint={hint}
       placeholder={placeholder}
+      isDisabled={isDisabled}
     />
   );
 };
@@ -36,12 +38,14 @@ DutyLocationInput.propTypes = {
   displayAddress: PropTypes.bool,
   hint: PropTypes.node,
   placeholder: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 DutyLocationInput.defaultProps = {
   displayAddress: true,
   hint: '',
   placeholder: '',
+  isDisabled: false,
 };
 
 export default DutyLocationInput;

--- a/src/components/form/fields/DutyLocationInput.module.scss
+++ b/src/components/form/fields/DutyLocationInput.module.scss
@@ -1,0 +1,5 @@
+@import 'shared/styles/colors';
+
+input:disabled {
+  color: $base-darker;
+}

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
@@ -80,7 +80,7 @@ const MaskedTextField = ({
               helpers.setTouched(true, false);
             }}
             onBlur={field.onBlur}
-            disabled
+            disabled={isDisabled}
             {...props}
           />
           {suffix && <div className="suffix">{suffix}</div>}

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
@@ -35,6 +35,7 @@ const MaskedTextField = ({
   error,
   suffix,
   prefix,
+  isDisabled,
   ...props
 }) => {
   const [field, metaProps, helpers] = useField({ id, name, validate, ...props });
@@ -79,6 +80,7 @@ const MaskedTextField = ({
               helpers.setTouched(true, false);
             }}
             onBlur={field.onBlur}
+            disabled
             {...props}
           />
           {suffix && <div className="suffix">{suffix}</div>}
@@ -100,6 +102,7 @@ const MaskedTextField = ({
             helpers.setTouched(true, false);
           }}
           onBlur={field.onBlur}
+          disabled={isDisabled}
           {...props}
         />
       )}
@@ -133,6 +136,7 @@ MaskedTextField.propTypes = {
   optional: PropTypes.bool,
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 MaskedTextField.defaultProps = {
@@ -157,6 +161,7 @@ MaskedTextField.defaultProps = {
   optional: false,
   error: false,
   errorMessage: '',
+  isDisabled: false,
 };
 
 export default MaskedTextField;

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.module.scss
@@ -27,3 +27,7 @@
         padding-left: 25px;
     }
 }
+
+input:disabled {
+  background-color: $border-color;
+}

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.stories.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.stories.jsx
@@ -27,6 +27,22 @@ export const MaskedTextFieldDefaultState = () => (
     )}
   </Formik>
 );
+export const MaskedTextFieldDisabledState = () => (
+  <Formik initialValues={{}}>
+    {() => (
+      <Form>
+        <MaskedTextField
+          id="input-type-text"
+          label="Text input label"
+          hint={labelHint}
+          name="input-type-text"
+          type="text"
+          isDisabled
+        />
+      </Form>
+    )}
+  </Formik>
+);
 export const MaskedTextFieldWithWarning = () => (
   <Formik initialValues={{}}>
     {() => (

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.test.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.test.jsx
@@ -49,7 +49,6 @@ describe('MaskedTextField', () => {
       expect(textInputMinimal.prop('className')).toBe('sample-class');
     });
   });
-
   describe('with id prop', () => {
     const wrapper = shallow(
       <MaskedTextField className="sample-class" id="lastName" label="Last Name" type="text" name="lastName" />,

--- a/src/components/form/fields/TextField/TextField.jsx
+++ b/src/components/form/fields/TextField/TextField.jsx
@@ -31,6 +31,7 @@ const TextField = ({
   error,
   errorMessage,
   errorClassName,
+  isDisabled,
   ...inputProps
 }) => {
   const [fieldProps, metaProps] = useField({ name, validate, type });
@@ -58,7 +59,7 @@ const TextField = ({
 
       {showWarning && <Hint data-testid="textInputWarning">{warning}</Hint>}
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <TextInput id={id} name={name} {...fieldProps} {...inputProps} />
+      <TextInput id={id} name={name} disabled={isDisabled} {...fieldProps} {...inputProps} />
     </FormGroup>
   );
 };
@@ -76,6 +77,7 @@ TextField.propTypes = {
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
   errorClassName: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 TextField.defaultProps = {
@@ -88,6 +90,7 @@ TextField.defaultProps = {
   error: false,
   errorMessage: '',
   errorClassName: '',
+  isDisabled: false,
 };
 
 export default TextField;

--- a/src/components/form/fields/TextField/TextField.stories.jsx
+++ b/src/components/form/fields/TextField/TextField.stories.jsx
@@ -21,6 +21,22 @@ export const TextFieldDefaultState = () => (
     )}
   </Formik>
 );
+export const TextFieldDisabledState = () => (
+  <Formik initialValues={{}}>
+    {() => (
+      <Form>
+        <TextField
+          id="input-type-text"
+          label="Text input label"
+          hint={labelHint}
+          name="input-type-text"
+          isDisabled
+          type="text"
+        />
+      </Form>
+    )}
+  </Formik>
+);
 export const TextFieldWithWarning = () => (
   <Formik initialValues={{}}>
     {() => (

--- a/src/pages/Office/MoveAllowances/MoveAllowances.jsx
+++ b/src/pages/Office/MoveAllowances/MoveAllowances.jsx
@@ -18,6 +18,8 @@ import { useOrdersDocumentQueries } from 'hooks/queries';
 import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
 import { dropdownInputOptions } from 'utils/formatters';
 import { ORDERS } from 'constants/queryKeys';
+import { permissionTypes } from 'constants/permissions';
+import Restricted from 'components/Restricted/Restricted';
 
 const rankDropdownOptions = dropdownInputOptions(ORDERS_RANK_OPTIONS);
 
@@ -158,23 +160,38 @@ const MoveAllowances = () => {
                 </div>
               </div>
               <div className={styles.body}>
-                <AllowancesDetailForm
-                  entitlements={order.entitlement}
-                  rankOptions={rankDropdownOptions}
-                  branchOptions={branchDropdownOption}
-                  editableAuthorizedWeight
-                />
+                <Restricted
+                  to={permissionTypes.updateAllowances}
+                  fallback={
+                    <AllowancesDetailForm
+                      entitlements={order.entitlement}
+                      rankOptions={rankDropdownOptions}
+                      branchOptions={branchDropdownOption}
+                      editableAuthorizedWeight
+                      formIsDisabled
+                    />
+                  }
+                >
+                  <AllowancesDetailForm
+                    entitlements={order.entitlement}
+                    rankOptions={rankDropdownOptions}
+                    branchOptions={branchDropdownOption}
+                    editableAuthorizedWeight
+                  />
+                </Restricted>
               </div>
-              <div className={styles.bottom}>
-                <div className={styles.buttonGroup}>
-                  <Button disabled={formik.isSubmitting} type="submit">
-                    Save
-                  </Button>
-                  <Button type="button" secondary onClick={handleClose}>
-                    Cancel
-                  </Button>
+              <Restricted to={permissionTypes.updateAllowances}>
+                <div className={styles.bottom}>
+                  <div className={styles.buttonGroup}>
+                    <Button disabled={formik.isSubmitting} type="submit">
+                      Save
+                    </Button>
+                    <Button type="button" secondary onClick={handleClose}>
+                      Cancel
+                    </Button>
+                  </div>
                 </div>
-              </div>
+              </Restricted>
             </div>
           </form>
         )}

--- a/src/pages/Office/Orders/Orders.jsx
+++ b/src/pages/Office/Orders/Orders.jsx
@@ -20,6 +20,8 @@ import { ORDERS } from 'constants/queryKeys';
 import { useOrdersDocumentQueries } from 'hooks/queries';
 import { TAC_VALIDATION_ACTIONS, reducer, initialState } from 'reducers/tacValidation';
 import { LOA_TYPE } from 'shared/constants';
+import Restricted from 'components/Restricted/Restricted';
+import { permissionTypes } from 'constants/permissions';
 
 const deptIndicatorDropdownOptions = dropdownInputOptions(DEPARTMENT_INDICATOR_OPTIONS);
 const ordersTypeDropdownOptions = dropdownInputOptions(ORDERS_TYPE_OPTIONS);
@@ -191,29 +193,50 @@ const Orders = () => {
                   </div>
                 </div>
                 <div className={styles.body}>
-                  <OrdersDetailForm
-                    deptIndicatorOptions={deptIndicatorDropdownOptions}
-                    ordersTypeOptions={ordersTypeDropdownOptions}
-                    ordersTypeDetailOptions={ordersTypeDetailsDropdownOptions}
-                    hhgTacWarning={hhgTacWarning}
-                    ntsTacWarning={ntsTacWarning}
-                    validateHHGTac={handleHHGTacValidation}
-                    validateNTSTac={handleNTSTacValidation}
-                    showOrdersAcknowledgement={hasAmendedOrders}
-                    ordersType={order.order_type}
-                    setFieldValue={formik.setFieldValue}
-                  />
+                  <Restricted
+                    to={permissionTypes.updateOrders}
+                    fallback={
+                      <OrdersDetailForm
+                        deptIndicatorOptions={deptIndicatorDropdownOptions}
+                        ordersTypeOptions={ordersTypeDropdownOptions}
+                        ordersTypeDetailOptions={ordersTypeDetailsDropdownOptions}
+                        hhgTacWarning={hhgTacWarning}
+                        ntsTacWarning={ntsTacWarning}
+                        validateHHGTac={handleHHGTacValidation}
+                        validateNTSTac={handleNTSTacValidation}
+                        showOrdersAcknowledgement={hasAmendedOrders}
+                        ordersType={order.order_type}
+                        setFieldValue={formik.setFieldValue}
+                        formIsDisabled
+                      />
+                    }
+                  >
+                    <OrdersDetailForm
+                      deptIndicatorOptions={deptIndicatorDropdownOptions}
+                      ordersTypeOptions={ordersTypeDropdownOptions}
+                      ordersTypeDetailOptions={ordersTypeDetailsDropdownOptions}
+                      hhgTacWarning={hhgTacWarning}
+                      ntsTacWarning={ntsTacWarning}
+                      validateHHGTac={handleHHGTacValidation}
+                      validateNTSTac={handleNTSTacValidation}
+                      showOrdersAcknowledgement={hasAmendedOrders}
+                      ordersType={order.order_type}
+                      setFieldValue={formik.setFieldValue}
+                    />
+                  </Restricted>
                 </div>
-                <div className={styles.bottom}>
-                  <div className={styles.buttonGroup}>
-                    <Button type="submit" disabled={formik.isSubmitting}>
-                      Save
-                    </Button>
-                    <Button type="button" secondary onClick={handleClose}>
-                      Cancel
-                    </Button>
+                <Restricted to={permissionTypes.updateOrders}>
+                  <div className={styles.bottom}>
+                    <div className={styles.buttonGroup}>
+                      <Button disabled={formik.isSubmitting} type="submit">
+                        Save
+                      </Button>
+                      <Button type="button" secondary onClick={handleClose}>
+                        Cancel
+                      </Button>
+                    </div>
                   </div>
-                </div>
+                </Restricted>
               </div>
             </form>
           );

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -255,6 +255,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.orders
     get:
       produces:
         - application/json

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -269,6 +269,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.orders
     get:
       produces:
         - application/json


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

This PR creates a read-only version of the allowances and orders document viewer pages for users with the QAE/CSR role. It also adds the `updates.orders` x-permission to the orders update handler that the disabled form would interact with (the `update.allowances` permission was already in place for the allowances handler).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a QAE/CSR
3. Navigate to a move
4. Click on view allowances or view orders
5. See a read only version of the form

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots

https://user-images.githubusercontent.com/4325613/176244742-4189bee2-d348-4831-af0e-2910980c97ee.mp4


