### PR TITLE
MB-12968 Updated webhook_subscription tests

### DIFF
--- a/pkg/services/webhook_subscription/webhook_subscription_creator_test.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_creator_test.go
@@ -1,8 +1,6 @@
 package webhooksubscription
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -12,18 +10,18 @@ import (
 
 func (suite *WebhookSubscriptionServiceSuite) TestCreateWebhookSubscription() {
 	queryBuilder := query.NewQueryBuilder()
-	subscriber := testdatagen.MakeContractor(suite.DB(), testdatagen.Assertions{})
-
-	webhookSubscriptionInfo := models.WebhookSubscription{
-		SubscriberID: subscriber.ID,
-		Status:       models.WebhookSubscriptionStatusActive,
-		EventKey:     "PaymentRequest.Update",
-		CallbackURL:  "/my/callback/url",
-	}
+	creator := NewWebhookSubscriptionCreator(queryBuilder)
 
 	// Happy path
-	suite.T().Run("If the subscription is created successfully it should be returned", func(t *testing.T) {
-		creator := NewWebhookSubscriptionCreator(queryBuilder)
+	suite.Run("If the subscription is created successfully it should be returned", func() {
+		subscriber := testdatagen.MakeContractor(suite.DB(), testdatagen.Assertions{})
+		webhookSubscriptionInfo := models.WebhookSubscription{
+			SubscriberID: subscriber.ID,
+			Status:       models.WebhookSubscriptionStatusActive,
+			EventKey:     "PaymentRequest.Update",
+			CallbackURL:  "/my/callback/url",
+		}
+
 		webhookSubscription, verrs, err := creator.CreateWebhookSubscription(suite.AppContextForTest(), &webhookSubscriptionInfo)
 		suite.NoError(err)
 		suite.Nil(verrs)
@@ -33,8 +31,8 @@ func (suite *WebhookSubscriptionServiceSuite) TestCreateWebhookSubscription() {
 	})
 
 	// Bad subscriber ID
-	suite.T().Run("If we are provided an organization that doesn't exist, the create should fail", func(t *testing.T) {
-		creator := NewWebhookSubscriptionCreator(queryBuilder)
+	suite.Run("If we are provided an organization that doesn't exist, the create should fail", func() {
+
 		invalidSubscription := models.WebhookSubscription{
 			SubscriberID: uuid.Must(uuid.FromString("b9c41d03-c730-4580-bd37-9ccf4845af6c")),
 			Status:       models.WebhookSubscriptionStatusActive,

--- a/pkg/services/webhook_subscription/webhook_subscription_fetcher_test.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_fetcher_test.go
@@ -1,8 +1,6 @@
 package webhooksubscription
 
 import (
-	"testing"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -15,10 +13,9 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionFetcher() {
 	builder := query.NewQueryBuilder()
 	fetcher := NewWebhookSubscriptionFetcher(builder)
 
-	webhookSubscription := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
-	webhookSubscriptionID := webhookSubscription.ID
-
-	suite.T().Run("Get a webhook subscription successfully", func(t *testing.T) {
+	suite.Run("Get a webhook subscription successfully", func() {
+		webhookSubscription := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
+		webhookSubscriptionID := webhookSubscription.ID
 		filters := []services.QueryFilter{query.NewQueryFilter("id", "=", webhookSubscription.ID.String())}
 
 		webhookSubscription, err := fetcher.FetchWebhookSubscription(suite.AppContextForTest(), filters)
@@ -27,7 +24,7 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionFetcher() {
 		suite.Equal(webhookSubscriptionID, webhookSubscription.ID)
 	})
 
-	suite.T().Run("Failure to fetch - return empty webhookSubscription and error", func(t *testing.T) {
+	suite.Run("Failure to fetch - return empty webhookSubscription and error", func() {
 		fakeID, err := uuid.NewV4()
 		suite.NoError(err)
 

--- a/pkg/services/webhook_subscription/webhook_subscription_updater_test.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_updater_test.go
@@ -1,7 +1,6 @@
 package webhooksubscription
 
 import (
-	"testing"
 	"time"
 
 	"github.com/transcom/mymove/pkg/etag"
@@ -17,13 +16,12 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionUpdater() {
 	builder := query.NewQueryBuilder()
 	updater := NewWebhookSubscriptionUpdater(builder)
 
-	// Create a webhook subscription
-	origSub := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
-
-	suite.T().Run("Updates a webhook subscription successfully", func(t *testing.T) {
+	suite.Run("Updates a webhook subscription successfully", func() {
 		// Testing:           WebhookSubscriptionUpdater
 		// Set up:            Provide a valid request to update an existing webhook subscription
 		// Expected Outcome:  We receive an updated model with no error and changed fields
+		// Create a webhook subscription
+		origSub := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
 		newSub := models.WebhookSubscription{
 			ID:          origSub.ID,
 			CallbackURL: "/this/is/changed",
@@ -42,7 +40,7 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionUpdater() {
 		suite.Equal(origSub.Status, updatedSub.Status)
 	})
 
-	suite.T().Run("Fails to find correct webhookSubscription - return empty webhookSubscription and error", func(t *testing.T) {
+	suite.Run("Fails to find correct webhookSubscription - return empty webhookSubscription and error", func() {
 		// Testing:           WebhookSubscriptionUpdater
 		// Set up:            Call the updater with an ID that doesn't exist
 		// Expected Outcome:  We receive a RecordNotFound error and no updatedSub
@@ -58,7 +56,7 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionUpdater() {
 		suite.Nil(updatedSub)
 	})
 
-	suite.T().Run("Fails to update - return empty webhookSubscription and error", func(t *testing.T) {
+	suite.Run("Fails to update - return empty webhookSubscription and error", func() {
 		// Testing:           WebhookSubscriptionUpdater
 		// Set up:            Call the updater with a subscription that doesn't exist
 		// Expected Outcome:  We receive an error and no updatedSub
@@ -77,10 +75,13 @@ func (suite *WebhookSubscriptionServiceSuite) TestWebhookSubscriptionUpdater() {
 		suite.Nil(updatedSub)
 	})
 
-	suite.T().Run("Fails to update - precondition failed", func(t *testing.T) {
+	suite.Run("Fails to update - precondition failed", func() {
 		// Testing:           WebhookSubscriptionUpdater
 		// Set up:            Call the updater with a stale eTag value
 		// Expected Outcome:  We receive an error and no updatedSub
+		// Create a webhook subscription
+		origSub := testdatagen.MakeDefaultWebhookSubscription(suite.DB())
+
 		newSub := models.WebhookSubscription{
 			ID:          origSub.ID,
 			CallbackURL: "/this/is/changed",


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12968) for this change

## Summary

Converts the package and tests in `./pkg/services/webhook_subscription` to use transactions.

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

A clean run of `make server_test` is sufficient.

## Verification Steps

- [x] No subtests are run with `suite.T().Run(...)` - they all use `suite.Run(...)`
- [x] There is no unjustified usage of `Truncate` in the tests
- [x] There is no unjustified usage of `suite.AppContextForTest().DB()` - instead `suite.DB()` is used directly
- [x] `Fatalf` is deprecated in favor of other assertions/checks
- [x] Go's `testing` package is only imported in the setup test file. (In this case there was no separate setup file)