### PR TITLE
Mb 13085 rename test run with rollback

### DIFF
--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -18,13 +18,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 	notAvailableMTO := testdatagen.MakeDefaultMove(suite.DB())
 	mtoChecker := NewMoveTaskOrderChecker()
 
-	suite.RunWithRollback("MTO is available and visible - success", func() {
+	suite.RunWithPreloadedData("MTO is available and visible - success", func() {
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), availableMTO.ID)
 		suite.Equal(availableToPrime, true)
 		suite.NoError(err)
 	})
 
-	suite.RunWithRollback("MTO is available but hidden - failure", func() {
+	suite.RunWithPreloadedData("MTO is available but hidden - failure", func() {
 		now := time.Now()
 		hide := false
 		availableHiddenMTO := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
@@ -41,13 +41,13 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderChecker() {
 		suite.Equal(availableToPrime, false)
 	})
 
-	suite.RunWithRollback("MTO is not available - no failure, but returns false", func() {
+	suite.RunWithPreloadedData("MTO is not available - no failure, but returns false", func() {
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), notAvailableMTO.ID)
 		suite.Equal(availableToPrime, false)
 		suite.NoError(err)
 	})
 
-	suite.RunWithRollback("MTO ID is not valid - failure", func() {
+	suite.RunWithPreloadedData("MTO ID is not valid - failure", func() {
 		badUUID := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
 		availableToPrime, err := mtoChecker.MTOAvailableToPrime(suite.AppContextForTest(), badUUID)
 		suite.Error(err)

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -159,7 +159,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 
 	mtoFetcher := NewMoveTaskOrderFetcher()
 
-	suite.RunWithRollback("all move task orders", func() {
+	suite.RunWithPreloadedData("all move task orders", func() {
 		searchParams := services.MoveTaskOrderFetcherParams{
 			IsAvailableToPrime: false,
 			IncludeHidden:      true,
@@ -177,7 +177,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		suite.NotNil(move.Orders.NewDutyLocation)
 	})
 
-	suite.RunWithRollback("default search - excludes hidden move task orders", func() {
+	suite.RunWithPreloadedData("default search - excludes hidden move task orders", func() {
 		moveTaskOrders, err := mtoFetcher.ListAllMoveTaskOrders(suite.AppContextForTest(), nil)
 		suite.NoError(err)
 
@@ -193,7 +193,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		}
 	})
 
-	suite.RunWithRollback("returns shipments that respect the external searchParams flag", func() {
+	suite.RunWithPreloadedData("returns shipments that respect the external searchParams flag", func() {
 		searchParams := services.MoveTaskOrderFetcherParams{
 			IncludeHidden:            false,
 			ExcludeExternalShipments: true,
@@ -213,7 +213,7 @@ func (suite *MoveTaskOrderServiceSuite) TestListAllMoveTaskOrdersFetcher() {
 		}
 	})
 
-	suite.RunWithRollback("all move task orders that are available to prime and using since", func() {
+	suite.RunWithPreloadedData("all move task orders that are available to prime and using since", func() {
 		now = time.Now()
 
 		testdatagen.MakeAvailableMove(suite.DB())

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake_test.go
@@ -80,14 +80,14 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_Hide() {
 
 	mtoHider := NewMoveTaskOrderHider()
 
-	suite.RunWithRollback("valid MTO, none to hide", func() {
+	suite.RunWithPreloadedData("valid MTO, none to hide", func() {
 		result, err := mtoHider.Hide(suite.AppContextForTest())
 		suite.NoError(err)
 
 		suite.Len(result, 0)
 	})
 
-	suite.RunWithRollback("invalid MTO, one to hide", func() {
+	suite.RunWithPreloadedData("invalid MTO, one to hide", func() {
 		// Change an MTO agent name to an invalid name.
 		mtoAgent.FirstName = swag.String("Beyonce")
 		suite.MustSave(&mtoAgent)
@@ -189,7 +189,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeServic
 	}
 
 	for idx, invalidData := range invalidFakeData {
-		suite.RunWithRollback(fmt.Sprintf("invalid fake Service Member data %d", idx), func() {
+		suite.RunWithPreloadedData(fmt.Sprintf("invalid fake Service Member data %d", idx), func() {
 			sm := testdatagen.MakeServiceMember(suite.DB(), invalidData)
 			result, reasons, err := IsValidFakeModelServiceMember(sm)
 			suite.NoError(err)
@@ -220,7 +220,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 		{MTOAgent: models.MTOAgent{Email: swag.String("billy@move.mil")}},
 	}
 	for idx, badData := range badFakeData {
-		suite.RunWithRollback(fmt.Sprintf("invalid fake MTOAgent data %d", idx), func() {
+		suite.RunWithPreloadedData(fmt.Sprintf("invalid fake MTOAgent data %d", idx), func() {
 			agent := testdatagen.MakeMTOAgent(suite.DB(), badData)
 			result, err := IsValidFakeModelMTOAgent(agent)
 			suite.NoError(err)
@@ -250,7 +250,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelB
 	}
 
 	for idx, invalidData := range invalidFakeData {
-		suite.RunWithRollback(fmt.Sprintf("invalid fake Backup Contact data %d", idx), func() {
+		suite.RunWithPreloadedData(fmt.Sprintf("invalid fake Backup Contact data %d", idx), func() {
 
 			bc := testdatagen.MakeBackupContact(suite.DB(), invalidData)
 			result, err = IsValidFakeModelBackupContact(bc)
@@ -368,7 +368,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderHider_isValidFakeModelM
 		invalidMTO4,
 	}
 	for idx, invalidData := range invalidFakeData {
-		suite.RunWithRollback(fmt.Sprintf("invalid fake MTOShipment data %d", idx), func() {
+		suite.RunWithPreloadedData(fmt.Sprintf("invalid fake MTOShipment data %d", idx), func() {
 			shipment := testdatagen.MakeMTOShipment(suite.DB(), invalidData)
 			result, reasons, err := IsValidFakeModelMTOShipment(shipment)
 			suite.NoError(err)

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -31,7 +31,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		moveRouter,
 	)
 
-	suite.RunWithRollback("Move status is updated successfully (with HHG shipment)", func() {
+	suite.RunWithPreloadedData("Move status is updated successfully (with HHG shipment)", func() {
 		move := testdatagen.MakeHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -47,7 +47,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Equal(models.MoveStatusServiceCounselingCompleted, actualMTO.Status)
 	})
 
-	suite.RunWithRollback("Move/shipment/PPM statuses are updated successfully (with PPM shipment)", func() {
+	suite.RunWithPreloadedData("Move/shipment/PPM statuses are updated successfully (with PPM shipment)", func() {
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -71,7 +71,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		}
 	})
 
-	suite.RunWithRollback("MTO status is updated successfully with facility info", func() {
+	suite.RunWithPreloadedData("MTO status is updated successfully with facility info", func() {
 		storageFacility := testdatagen.MakeStorageFacility(suite.DB(), testdatagen.Assertions{
 			StorageFacility: models.StorageFacility{
 				Address: testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{
@@ -109,7 +109,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Equal(actualMTO.Status, models.MoveStatusServiceCounselingCompleted)
 	})
 
-	suite.RunWithRollback("Invalid input error when there is no facility information on NTS-r shipment", func() {
+	suite.RunWithPreloadedData("Invalid input error when there is no facility information on NTS-r shipment", func() {
 		noFacilityInfoMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -135,7 +135,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "NTS-release shipment must include facility info")
 	})
 
-	suite.RunWithRollback("No shipments on move", func() {
+	suite.RunWithPreloadedData("No shipments on move", func() {
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusNeedsServiceCounseling,
@@ -150,7 +150,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "No shipments associated with move")
 	})
 
-	suite.RunWithRollback("MTO status is in a conflicted state", func() {
+	suite.RunWithPreloadedData("MTO status is in a conflicted state", func() {
 		draftMove := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status: models.MoveStatusDRAFT,
@@ -168,7 +168,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		suite.Contains(err.Error(), "The status for the Move")
 	})
 
-	suite.RunWithRollback("Etag is stale", func() {
+	suite.RunWithPreloadedData("Etag is stale", func() {
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
 		testdatagen.MakeMTOShipmentMinimal(suite.DB(), testdatagen.Assertions{
 			Move: move,
@@ -193,7 +193,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		moveRouter,
 	)
 
-	suite.RunWithRollback("MTO post counseling information is updated successfully", func() {
+	suite.RunWithPreloadedData("MTO post counseling information is updated successfully", func() {
 		// Make a couple of shipments for the move; one prime, one external
 		primeShipment := testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: expectedMTO,
@@ -248,7 +248,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		suite.Equal(models.PPMShipmentStatusWaitingOnCustomer, actualMTO.MTOShipments[0].PPMShipment.Status)
 	})
 
-	suite.RunWithRollback("Counseling isn't an approved service item", func() {
+	suite.RunWithPreloadedData("Counseling isn't an approved service item", func() {
 		testdatagen.MakePPMShipment(suite.DB(), testdatagen.Assertions{
 			Move: expectedMTO,
 			MTOShipment: models.MTOShipment{
@@ -262,7 +262,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 		suite.IsType(apperror.ConflictError{}, err)
 	})
 
-	suite.RunWithRollback("Etag is stale", func() {
+	suite.RunWithPreloadedData("Etag is stale", func() {
 		testdatagen.MakeMTOServiceItemBasic(suite.DB(), testdatagen.Assertions{
 			MTOServiceItem: models.MTOServiceItem{
 				Status: models.MTOServiceItemStatusApproved,
@@ -300,7 +300,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	)
 
 	// Case: Move successfully deactivated
-	suite.RunWithRollback("Success - Set show field to false", func() {
+	suite.RunWithPreloadedData("Success - Set show field to false", func() {
 		show = false
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, &show)
 
@@ -311,7 +311,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Move successfully activated
-	suite.RunWithRollback("Success - Set show field to true", func() {
+	suite.RunWithPreloadedData("Success - Set show field to true", func() {
 		show = true
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, &show)
 
@@ -333,7 +333,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Show input value is nil, not True or False
-	suite.RunWithRollback("Fail - Nil value in show field", func() {
+	suite.RunWithPreloadedData("Fail - Nil value in show field", func() {
 		updatedMove, err := updater.ShowHide(suite.AppContextForTest(), move.ID, nil)
 
 		suite.Nil(updatedMove)
@@ -344,7 +344,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 
 	// Case: Invalid input found while updating the move
 	// TODO: Is there a way to mock ValidateUpdate so that these tests actually mean something?
-	suite.RunWithRollback("Fail - Invalid input found on move", func() {
+	suite.RunWithPreloadedData("Fail - Invalid input found on move", func() {
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mockUpdater.On("ShowHide",
 			mock.AnythingOfType("*appcontext.appContext"),
@@ -360,7 +360,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_ShowHide() {
 	})
 
 	// Case: Query error encountered while updating the move
-	suite.RunWithRollback("Fail - Query error", func() {
+	suite.RunWithPreloadedData("Fail - Query error", func() {
 		mockUpdater := mocks.MoveTaskOrderUpdater{}
 		mockUpdater.On("ShowHide",
 			mock.AnythingOfType("*appcontext.appContext"),

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -519,7 +519,7 @@ func (suite *PopTestSuite) NilOrNoVerrs(err error) {
 //
 // If the code under test starts its own transaction, this is the
 // approach that should be used. If it does not use transactions, you
-// can probably get away with using RunWithRollback (see below).
+// can probably get away with using RunWithPreloadedData (see below).
 //
 // When using per test transactions, watch out for subtests that do
 // not use testify.suite as they won't use this code and thus won't
@@ -556,21 +556,18 @@ func (suite *PopTestSuite) Run(name string, subtest func()) bool {
 	})
 }
 
-// RunWithRollback, with WithPerTestTransaction enabled, means
-// each subtest will get rolled back. This means each subtest is
-// isolated from sibling tests but NOT isolated from any db changes
-// made in the main test.
+// RunWithPreloadedData, with WithPerTestTransaction enabled, means
+// each subtest will have access to preloaded data from the main test
+// but the subtest changes will get rolled back.
 //
-// RunWithRollback runs a subtest inside a transaction that is
-// rolled back. Not all tests will work with this approach
+// This means each subtest is isolated from sibling tests but NOT
+// isolated from any db changes made in the main test.
 //
-// See Run above for more details, but if the code under test does not
-// use transactions, this way of running subtests should work. If that
-// is true, you can reuse database models created in the main test in
-// each subtest.
-func (suite *PopTestSuite) RunWithRollback(name string, subtest func()) bool {
+// Each subtest will run in a transaction that rolls back when the
+// subtest returns.
+func (suite *PopTestSuite) RunWithPreloadedData(name string, subtest func()) bool {
 	if !suite.usePerTestTransaction {
-		log.Fatal("Cannot use RunWithRollback without per test transaction")
+		log.Fatal("Cannot use RunWithPreloadedData without per test transaction")
 	}
 	// call suite.DB to ensure a connection is established outside the subtest
 	oldDB := suite.DB()

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -498,8 +498,9 @@ func (suite *PopTestSuite) NilOrNoVerrs(err error) {
 	}
 }
 
-// Run overrides the default testify Run to ensure that the testdb is
-// torn down for per txn tests
+// Run, with WithPerTestTransaction enabled, means each subtest
+// gets a new connection and is isolated from both any database
+// changes made in the main test, and in sibling subtests.
 //
 // It would be nice if subtests could start a new transaction inside
 // the current connection so they could reuse db setup between
@@ -555,6 +556,11 @@ func (suite *PopTestSuite) Run(name string, subtest func()) bool {
 	})
 }
 
+// RunWithRollback, with WithPerTestTransaction enabled, means
+// each subtest will get rolled back. This means each subtest is
+// isolated from sibling tests but NOT isolated from any db changes
+// made in the main test.
+//
 // RunWithRollback runs a subtest inside a transaction that is
 // rolled back. Not all tests will work with this approach
 //

--- a/pkg/testingsuite/pop_suite_test.go
+++ b/pkg/testingsuite/pop_suite_test.go
@@ -19,10 +19,10 @@ func TestPopTestSuite(t *testing.T) {
 	ps.TearDown()
 }
 
-func (suite *PopTestSuite) TestRunWithRollback() {
+func (suite *PopTestSuite) TestRunWithPreloadedData() {
 	address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
 
-	suite.RunWithRollback("Main test records available in subtest", func() {
+	suite.RunWithPreloadedData("Main test records available in subtest", func() {
 		var foundAddress models.Address
 		err := suite.DB().Find(&foundAddress, address.ID)
 		suite.NoError(err)
@@ -31,12 +31,12 @@ func (suite *PopTestSuite) TestRunWithRollback() {
 	})
 
 	var address2 models.Address
-	suite.RunWithRollback("Subtest record creation", func() {
+	suite.RunWithPreloadedData("Subtest record creation", func() {
 		// Create address to search for in the next test
 		address2 = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
 	})
 
-	suite.RunWithRollback("Subtest record not found", func() {
+	suite.RunWithPreloadedData("Subtest record not found", func() {
 		// Check that address2 cannot be found
 		var foundAddress models.Address
 		err := suite.DB().Find(&foundAddress, address2.ID)

--- a/pkg/testingsuite/pop_suite_test.go
+++ b/pkg/testingsuite/pop_suite_test.go
@@ -1,0 +1,74 @@
+package testingsuite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *PopTestSuite) SetupTest() {
+
+}
+
+func TestPopTestSuite(t *testing.T) {
+	ps := NewPopTestSuite(CurrentPackage(), WithPerTestTransaction())
+	suite.Run(t, &ps)
+	ps.TearDown()
+}
+
+func (suite *PopTestSuite) TestRunWithRollback() {
+	address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+
+	suite.RunWithRollback("Main test records available in subtest", func() {
+		var foundAddress models.Address
+		err := suite.DB().Find(&foundAddress, address.ID)
+		suite.NoError(err)
+		suite.Equal(address.ID, foundAddress.ID)
+
+	})
+
+	var address2 models.Address
+	suite.RunWithRollback("Subtest record creation", func() {
+		// Create address to search for in the next test
+		address2 = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+	})
+
+	suite.RunWithRollback("Subtest record not found", func() {
+		// Check that address2 cannot be found
+		var foundAddress models.Address
+		err := suite.DB().Find(&foundAddress, address2.ID)
+		suite.Error(err)
+		suite.NotEqual(address2.ID, foundAddress.ID)
+	})
+
+}
+
+func (suite *PopTestSuite) TestRun() {
+	address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
+
+	suite.Run("Main test records not available in subtest", func() {
+		var foundAddress models.Address
+		err := suite.DB().Find(&foundAddress, address.ID)
+		suite.Error(err)
+		suite.Contains(err.Error(), "no rows in result set")
+
+	})
+
+	var address2 models.Address
+	suite.Run("Subtest record creation", func() {
+		// Create address to search for in the next test
+		address2 = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{})
+	})
+
+	suite.Run("Subtest record not found", func() {
+		// Check that address2 cannot be found
+		var foundAddress models.Address
+		err := suite.DB().Find(&foundAddress, address2.ID)
+		suite.Error(err)
+		suite.NotEqual(address2.ID, foundAddress.ID)
+	})
+
+}


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13085) for this change

## Summary

Renames `suite.RunWithRollback` to `suite.RunWithPreloadedData` based on input from `#prac-engineering`

Also adds tests for both `suite.Run()` and `suite.RunWithPreloadedData()` so that they have coverage regardless of whether they are used in tests. 

[Pattern for server tests conversion](https://transcom.github.io/mymove-docs/docs/backend/testing/running-server-tests-inside-a-transaction/) explains more about the approach used.

## Setup to Run Your Code

No functional changes, just tests. 

## Verification Steps

- Check the new test code at `pkg/testingsuite/pop_suite_test.go`
- A clean run of `make server_test` is sufficient.
