### PR TITLE
[MB-12949] add aws logging mechanism

### DIFF
--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -45,6 +45,11 @@ echo
 curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
 
 #####
+## Log failure to AWS. Failure logs can be found in the log group `aws/lambda/circleci-logging`
+#####
+aws events put-events --entries '[{ "Source": "circleci.logging", "DetailType": "CircleCI failure", "Detail": "{ \"message\": \"'"$message"'\" }"}]'
+
+#####
 ## Exit and do nothing else unless a deploy job
 #####
 if [[ $CIRCLE_JOB != *"deploy"* ]]; then

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -47,7 +47,9 @@ curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
 #####
 ## Log failure to AWS. Failure logs can be found in the log group `aws/lambda/circleci-logging`
 #####
-aws events put-events --entries '[{ "Source": "circleci.logging", "DetailType": "CircleCI failure", "Detail": "{ \"message\": \"'"$message"'\" }"}]'
+if [[ $CIRCLE_JOB != *"deploy"* ]]; then
+  aws events put-events --entries '[{ "Source": "circleci.logging", "DetailType": "CircleCI failure", "Detail": "{ \"message\": \"'"$message"'\" }"}]'
+fi
 
 #####
 ## Exit and do nothing else unless a deploy job

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -46,16 +46,12 @@ curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
 
 #####
 ## Log failure to AWS. Failure logs can be found in the log group `aws/lambda/circleci-logging`
-#####
-if [[ $CIRCLE_JOB != *"deploy"* ]]; then
-  aws events put-events --entries '[{ "Source": "circleci.logging", "DetailType": "CircleCI failure", "Detail": "{ \"message\": \"'"$message"'\" }"}]'
-fi
-
-#####
 ## Exit and do nothing else unless a deploy job
 #####
 if [[ $CIRCLE_JOB != *"deploy"* ]]; then
   exit 0
+else
+  aws events put-events --entries '[{ "Source": "circleci.logging", "DetailType": "CircleCI failure", "Detail": "{ \"message\": \"'"$message"'\" }"}]'
 fi
 
 #####


### PR DESCRIPTION
Adds a mechanism to log failures to a cloudwatch log group called `aws/lambda/circleci-logging`