### PR TITLE
MB-13099 Print diff on test coverage regression

### DIFF
--- a/scripts/ensure-go-test-coverage
+++ b/scripts/ensure-go-test-coverage
@@ -17,6 +17,10 @@ def total_coverage_percent(filename):
         percent = line.split()[-1]
         return float(percent.rstrip('%'))
 
+def coverage_diff(filename1, filename2):
+  os.system(f"git --no-pager diff --no-index -U0 '{filename1}' '{filename2}'")
+
+
 baseline_file = sys.argv[1]
 new_file = sys.argv[2]
 
@@ -33,5 +37,8 @@ print(f"Baseline test coverage: {baseline_percent}")
 print(f"New test coverage: {new_percent}")
 
 if new_percent < baseline_percent:
-  print("Test Coverage has decreased")
+  print("Test Coverage has decreased\n")
+  print("Below is the diff of the baseline test coverage compared to this PR")
+  print("Note, not all changes will be meaningful, look for test coverage %% decreases")
+  coverage_diff(baseline_file, new_file)
   sys.exit(1)

--- a/scripts/ensure-go-test-coverage
+++ b/scripts/ensure-go-test-coverage
@@ -18,6 +18,8 @@ def total_coverage_percent(filename):
         return float(percent.rstrip('%'))
 
 def coverage_diff(filename1, filename2):
+  if not filename1 or not filename2:
+    return
   os.system(f"git --no-pager diff --no-index -U0 '{filename1}' '{filename2}'")
 
 
@@ -37,8 +39,11 @@ print(f"Baseline test coverage: {baseline_percent}")
 print(f"New test coverage: {new_percent}")
 
 if new_percent < baseline_percent:
-  print("Test Coverage has decreased\n")
-  print("Below is the diff of the baseline test coverage compared to this PR")
-  print("Note, not all changes will be meaningful, look for test coverage %% decreases")
+  print("\n--- DIFF of the baseline test coverage compared to this PR ---")
+  print("    Note, not all changes will be meaningful, look for test coverage %% decreases\n")
   coverage_diff(baseline_file, new_file)
+
+  print(f"\nBaseline test coverage: {baseline_percent}")
+  print(f"New test coverage: {new_percent}")
+  print("Test Coverage has decreased\n")
   sys.exit(1)


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13099) for this change

## Summary

This is for the case where user fails the test coverage check. 
It would be good to compare the previous and current coverage.txt files to help the dev figure out where they might have reduced coverage. 
Adds a diff - specifically `git diff --no-index` to the error condition. 
It's not perfect (shows line number changes, or test increases too) but it's helpful to narrow down. 

## Setup to Run Your Code

You can't actually see this change on CI until you have reduced test coverage so you can just try it in your local environment instead. You need to generate some coverage files. 

You can download `coverage.txt` here:
https://app.circleci.com/pipelines/github/transcom/mymove/43187/workflows/d76c886e-f9af-49ef-9761-64b4838fafcd/jobs/677391/artifacts

Then make a copy and edit some percentages in the copy. 
Run the script in mymove repo
```
./scripts/ensure-go-test-coverage coverage.txt coverage-copy.txt
```
You should see the diff of the two files. 

## Verification Steps

- [x] The changes you made show up in the diff. 
- [x] There's no unexpected errors
