### PR TITLE
[MB-12816] Update PPM create payload to add secondary nullable string values

### DIFF
--- a/pkg/handlers/converters_strfmt.go
+++ b/pkg/handlers/converters_strfmt.go
@@ -26,6 +26,16 @@ func FmtDatePtrToPopPtr(date *strfmt.Date) *time.Time {
 	return &fmtDate
 }
 
+// FmtDatePtrToPopPtr converts go-swagger type to pop type
+func FmtDatePtrToPop(date *strfmt.Date) time.Time {
+	if date == nil {
+		return time.Time{}
+	}
+
+	fmtDate := time.Time(*date)
+	return fmtDate
+}
+
 // FmtDateTimePtrToPopPtr converts go-swagger type to pop type
 func FmtDateTimePtrToPopPtr(date *strfmt.DateTime) *time.Time {
 	if date == nil {

--- a/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/internalapi/internal/payloads/payload_to_model.go
@@ -113,20 +113,12 @@ func PPMShipmentModelFromCreate(ppmShipment *internalmessages.CreatePPMShipment)
 	}
 
 	model := &models.PPMShipment{
-		SITExpected: ppmShipment.SitExpected,
-	}
-
-	expectedDepartureDate := time.Time(*ppmShipment.ExpectedDepartureDate)
-	if !expectedDepartureDate.IsZero() {
-		model.ExpectedDepartureDate = expectedDepartureDate
-	}
-
-	if ppmShipment.PickupPostalCode != nil {
-		model.PickupPostalCode = *ppmShipment.PickupPostalCode
-	}
-
-	if ppmShipment.DestinationPostalCode != nil {
-		model.DestinationPostalCode = *ppmShipment.DestinationPostalCode
+		PickupPostalCode:               *ppmShipment.PickupPostalCode,
+		SecondaryPickupPostalCode:      handlers.FmtNullableStringToStringPtr(ppmShipment.SecondaryPickupPostalCode),
+		DestinationPostalCode:          *ppmShipment.DestinationPostalCode,
+		SecondaryDestinationPostalCode: handlers.FmtNullableStringToStringPtr(ppmShipment.SecondaryDestinationPostalCode),
+		SITExpected:                    ppmShipment.SitExpected,
+		ExpectedDepartureDate:          handlers.FmtDatePtrToPop(ppmShipment.ExpectedDepartureDate),
 	}
 
 	return model


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12816) for this change

## Summary

We forgot to go back and add secondary postal code fields during PPM shipment creation after adding the nullable strings to our PPM shipment updater.

I cleaned up the create PPM shipment payload to model method to add these fields and some convenience methods.  Then added to the handler integration tests when the optional postal codes are included.

I added request params and response payload validate calls to make sure our ppm shipment swagger models are also valid to catch bad testing params and to make sure load testing is getting a valid payload.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make db_dev_e2e_populate && make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as a customer such as `ppm.test.user1@example.com`
2. Add a new PPM shipment from the home screen
3. Select Yes for secondary pickup and destination postal code questions and enter values for those fields
4. Fill out the rest of the form and click the Save & Continue button.
5. Click the back button to return to the Date & Location page and you should see the secondary postal code values are filled in when going back to edit the form.
6. You could also continue on to the final review form to verify that the PPM shipment card shows the secondary postal code values as well and doesn't get cleared for instance.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

**Request:**
<img width="556" alt="Screen Shot 2022-07-01 at 12 32 40 PM" src="https://user-images.githubusercontent.com/52669884/176938018-b863f2d6-5c82-4cde-a47c-340ba7005909.png">

**Response:**
<img width="497" alt="Screen Shot 2022-07-01 at 12 33 07 PM" src="https://user-images.githubusercontent.com/52669884/176938036-7a4dbde7-1dfa-4549-877e-c63f92f4ff34.png">

<img width="601" alt="Screen Shot 2022-07-01 at 12 54 15 PM" src="https://user-images.githubusercontent.com/52669884/176937952-c8eb1107-10ce-400e-b453-efcc0c0fae85.png">