### PR TITLE
Add info msg about how to solve to point people in the right direction

### DIFF
--- a/scripts/ensure-js-test-coverage
+++ b/scripts/ensure-js-test-coverage
@@ -4,6 +4,8 @@ import os.path
 import sys
 import xml.etree.ElementTree as ET
 
+HELP_URL = "https://transcom.github.io/mymove-docs/docs/frontend/testing/how-to-run-frontend-test-coverage-reports"
+
 if len(sys.argv) != 3:
   print(f"Usage: {sys.argv[0]} baseline_coverage.xml new_coverage.xml")
   sys.exit(1)
@@ -33,4 +35,5 @@ print(f"New test coverage: {new_percent}")
 
 if new_percent < baseline_percent:
   print("Test Coverage has decreased")
+  print(f"Refer to the following to learn how resolve this: {HELP_URL}")
   sys.exit(1)


### PR DESCRIPTION
## Summary
When test coverage fails this adds a message linking to our documentation about test coverage so folks know how to go about diagnosing and resolving the issue.

Added because this is a relatively new check and I don't think everyone knows that there is relevant documentation.