### PR TITLE
Update route for Privacy and Security Policy page

### DIFF
--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,7 +1,7 @@
 export const generalRoutes = {
   HOME_PATH: '/',
   SIGN_IN_PATH: '/sign-in',
-  PRIVACY_SECURITY_POLICY_PATH: '/privacy-security',
+  PRIVACY_SECURITY_POLICY_PATH: '/privacy-and-security-policy',
   ACCESSIBILITY_PATH: '/accessibility',
 };
 

--- a/src/scenes/MyMove/index.test.js
+++ b/src/scenes/MyMove/index.test.js
@@ -27,7 +27,7 @@ describe('ConnectedCustomerApp tests', () => {
     });
 
     it('renders the Privacy & Security policy route', () => {
-      const { queryByText } = renderRoute('/privacy-security');
+      const { queryByText } = renderRoute('/privacy-and-security-policy');
       expect(queryByText('Privacy & Security Policy')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## There is no Jira ticket for this change

## Summary

This was not resolving correctly in our documentation nor our footer on
the page. Rather than updating the documentation and footer links, I've
opted to update the route that we support for this content.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the login page
1. Click the **Privacy and Security Policy** link in the future
1. Observe that the page loads and contains the correct content
