### PR TITLE
MB-13198 Remove calculate sit button

### DIFF
--- a/src/components/Office/ShipmentCustomerSIT/ShipmentCustomerSIT.jsx
+++ b/src/components/Office/ShipmentCustomerSIT/ShipmentCustomerSIT.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Fieldset, FormGroup, Radio, Grid, Label, Button } from '@trussworks/react-uswds';
+import { Fieldset, FormGroup, Radio, Grid, Label } from '@trussworks/react-uswds';
 import { useField } from 'formik';
-import PropTypes from 'prop-types';
 
 import formStyles from 'styles/form.module.scss';
 import styles from 'components/Office/ShipmentForm/ShipmentForm.module.scss';
@@ -9,7 +8,7 @@ import MaskedTextField from 'components/form/fields/MaskedTextField/MaskedTextFi
 import SectionWrapper from 'components/Customer/SectionWrapper';
 import { DatePickerInput } from 'components/form/fields';
 
-const ShipmentCustomerSIT = ({ onCalculateClick }) => {
+const ShipmentCustomerSIT = () => {
   const [sitExpectedInput, , sitExpectedHelper] = useField('sitExpected');
   const sitExpected = sitExpectedInput.value === true;
 
@@ -20,28 +19,8 @@ const ShipmentCustomerSIT = ({ onCalculateClick }) => {
   const [sitLocationInput, , sitLocationHelper] = useField('sitLocation');
   const sitLocationValue = sitLocationInput.value || 'DESTINATION';
 
-  const [weightInput] = useField('sitEstimatedWeight');
-  const weightValue = weightInput.value;
-
-  const [startInput] = useField('sitEstimatedEntryDate');
-  const startValue = startInput.value;
-
-  const [endInput] = useField('sitEstimatedDepartureDate');
-  const endValue = endInput.value;
-
   const handleSITLocation = (event) => {
     sitLocationHelper.setValue(event.target.value);
-  };
-
-  const isCalculationEnabled =
-    !!startValue && startValue !== 'Invalid date' && !!endValue && endValue !== 'Invalid date' && !!weightValue;
-
-  const handleCalculateClick = async () => {
-    /*
-       The SIT calcuation work is being left for a later sprint.
-       We'll want to do _something_ with the results of this function.
-     */
-    onCalculateClick({ location: sitLocationValue, start: startValue, end: endValue, weight: weightValue });
   };
 
   return (
@@ -112,10 +91,6 @@ const ShipmentCustomerSIT = ({ onCalculateClick }) => {
                 <DatePickerInput name="sitEstimatedEntryDate" label="Estimated storage start" />
 
                 <DatePickerInput name="sitEstimatedDepartureDate" label="Estimated storage end" />
-
-                <Button type="button" secondary disabled={!isCalculationEnabled} onClick={handleCalculateClick}>
-                  Calculate SIT
-                </Button>
               </>
             )}
           </Grid>
@@ -126,11 +101,3 @@ const ShipmentCustomerSIT = ({ onCalculateClick }) => {
 };
 
 export default ShipmentCustomerSIT;
-
-ShipmentCustomerSIT.propTypes = {
-  onCalculateClick: PropTypes.func,
-};
-
-ShipmentCustomerSIT.defaultProps = {
-  onCalculateClick: () => {},
-};

--- a/src/components/Office/ShipmentCustomerSIT/ShipmentCustomerSIT.test.jsx
+++ b/src/components/Office/ShipmentCustomerSIT/ShipmentCustomerSIT.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 
@@ -29,34 +29,5 @@ describe('components/Office/ShipmentCustomerSIT', () => {
     userEvent.click(screen.getByLabelText('Yes'));
 
     expect(await screen.findByLabelText('Destination')).toBeChecked();
-  });
-
-  it('disables Calculate SIT button until all fields filled out', async () => {
-    const onCalculateClick = jest.fn();
-    render(
-      <Formik initialValues={{}}>
-        <ShipmentCustomerSIT onCalculateClick={onCalculateClick} />
-      </Formik>,
-    );
-
-    userEvent.click(screen.getByLabelText('Yes'));
-    expect(await screen.findByRole('button', { name: 'Calculate SIT' })).toBeDisabled();
-
-    userEvent.type(screen.getByLabelText('Estimated SIT weight'), '5725');
-    userEvent.type(screen.getByLabelText('Estimated storage start'), '02 May 2022');
-    userEvent.type(screen.getByLabelText('Estimated storage end'), '09 May 2022');
-
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Calculate SIT' })).toBeEnabled());
-
-    userEvent.click(screen.getByRole('button', { name: 'Calculate SIT' }));
-
-    await waitFor(() =>
-      expect(onCalculateClick).toBeCalledWith({
-        location: 'DESTINATION',
-        weight: '5725',
-        start: '02 May 2022',
-        end: '09 May 2022',
-      }),
-    );
   });
 });


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13198) for this change

## Summary
This PR removes the `Calculate SIT` button from the shipment form.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Run `DEVSEED_SUBSCENARIO=ppm_customer_flow make db_dev_e2e_populate`
2. Access the office app
3. Login as a service counselor
4. View `PPMSC1` and edit the shipment
5. Click `Yes` for `Does the customer plan to use SIT?`
6. Verify that there is no `Calculate SIT` button

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.


### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
Before:
<img width="640" alt="Screen Shot 2022-07-21 at 2 36 56 PM" src="https://user-images.githubusercontent.com/14057912/180300953-0e18f9ea-7f89-4e25-b7c5-af59844c8a6f.png">

After:
<img width="639" alt="Screen Shot 2022-07-21 at 2 37 30 PM" src="https://user-images.githubusercontent.com/14057912/180301066-16ebe5f8-ca9a-4224-89e7-bceae6e8238f.png">


