### PR TITLE
[MB-12377] set ppm shipment's approvedAt

### DIFF
--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -97,6 +97,8 @@ func (o moveTaskOrderUpdater) UpdateStatusServiceCounselingCompleted(appCtx appc
 
 				if move.MTOShipments[i].PPMShipment != nil {
 					move.MTOShipments[i].PPMShipment.Status = models.PPMShipmentStatusWaitingOnCustomer
+					now := time.Now()
+					move.MTOShipments[i].PPMShipment.ApprovedAt = &now
 
 					verrs, err = appCtx.DB().ValidateAndSave(move.MTOShipments[i].PPMShipment)
 					if verrs != nil && verrs.HasAny() {
@@ -339,6 +341,7 @@ func (o *moveTaskOrderUpdater) UpdatePostCounselingInfo(appCtx appcontext.AppCon
 		for i := range moveTaskOrder.MTOShipments {
 			if moveTaskOrder.MTOShipments[i].PPMShipment != nil {
 				moveTaskOrder.MTOShipments[i].PPMShipment.Status = models.PPMShipmentStatusWaitingOnCustomer
+				moveTaskOrder.MTOShipments[i].PPMShipment.ApprovedAt = &now
 
 				verrs, err = appCtx.DB().ValidateAndSave(moveTaskOrder.MTOShipments[i].PPMShipment)
 				if verrs != nil && verrs.HasAny() {

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -67,6 +67,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdateStatusSer
 		for _, shipment := range actualMTO.MTOShipments {
 			suite.Equal(models.MTOShipmentStatusApproved, shipment.Status)
 			ppmShipment := *shipment.PPMShipment
+			suite.NotNil(ppmShipment.ApprovedAt)
 			suite.Equal(models.PPMShipmentStatusWaitingOnCustomer, ppmShipment.Status)
 		}
 	})
@@ -245,6 +246,7 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderUpdater_UpdatePostCouns
 
 		suite.NotNil(actualMTO.PrimeCounselingCompletedAt)
 		suite.Equal(models.PPMShipmentStatusWaitingOnCustomer, actualMTO.MTOShipments[0].PPMShipment.Status)
+		suite.NotNil(actualMTO.MTOShipments[0].PPMShipment.ApprovedAt)
 	})
 
 	suite.Run("Counseling isn't an approved service item", func() {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12377) for this change

## Summary

This PR sets the PPM Shipment `approved_at` date when the shipment is approved, instead of displaying "Invalid Date."

Note that an approval date is present on a PPM card under "Manage your PPM" on the customer app.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```
f
##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as `readyToFinish2@ppm.approved` [here](https://my-milmove-pr-8939.mymove.sandbox.truss.coffee/), or as a customer with an approved PPM shipment. To approve a PPM, create a move with one on the customer side, view the move on the office side, then submit the move details.
2. Scroll to "Manage your PPM".

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

![Screen Shot 2022-07-21 at 4 54 44 PM](https://user-images.githubusercontent.com/1245800/180313818-a6bae3d4-4e96-49db-afa4-109f23300b8f.png)

