### PR TITLE
[MB-13510] Add gci linter to make go import order/grouping more consistent

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,9 @@
 linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/transcom/mymove)
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
@@ -32,6 +37,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - gci
     - gofmt
     - goimports
     - gomodguard

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         types: [go]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -50,7 +50,9 @@ repos:
         exclude: ^public/swagger-ui/
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.46.2
+    # This is a revision after 1.48.0 that includes a patched revive. Will update to a tag when new release is cut.
+    # See: https://github.com/golangci/golangci-lint/issues/2997
+    rev: 7d2648ca3f942beef43a3fd15efcdbc89968e1b4
     hooks:
       - id: golangci-lint
         entry: bash -c 'exec golangci-lint run ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
@@ -74,7 +76,7 @@ repos:
         language: script
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.32.1
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to MyMove
 
-Anyone is welcome to contribute code changes and additions to this project. If you'd like your changes merged into the master branch, please read the following document before opening a [pull request](https://github.com/transcom/mymove/pulls).
+Anyone is welcome to contribute code changes and additions to this project. If you'd like your changes merged into the master branch, please read the following document before opening a [pull request][pulls].
 
 There are several ways in which you can help improve this project:
 
-1. Fix an existing [issue](https://github.com/transcom/mymove/issues) and submit a [pull request](https://github.com/transcom/mymove/pulls).
-1. Review open [pull requests](https://github.com/transcom/mymove/pulls).
-1. Report a new [issue](https://github.com/transcom/mymove/issues). _Only do this after you've made sure the behavior or problem you're observing isn't already documented in an open issue._
+1. Fix an existing [issue][issues] and submit a [pull request][pulls].
+1. Review open [pull requests][pulls].
+1. Report a new [issue][issues]. _Only do this after you've made sure the behavior or problem you're observing isn't already documented in an open issue._
 
 ## Table of Contents
 
@@ -37,17 +37,17 @@ We use a number of tools to evaluate the quality and security of this project's 
 
 ## Code Style
 
-Please review our [front end](https://github.com/transcom/mymove/blob/master/docs/frontend.md) and [back end](https://github.com/transcom/mymove/blob/master/docs/backend.md) coding guidelines and do your best to follow the conventions and choices described therein.
+Please review our [front end](https://transcom.github.io/mymove-docs/docs/frontend) and [back end](https://transcom.github.io/mymove-docs/docs/backend) coding guidelines and do your best to follow the conventions and choices described therein.
 
 Code formatting conventions are defined in the `.editorconfig` file which uses the [EditorConfig](http://editorconfig.org) syntax. There are [plugins for a variety of editors](http://editorconfig.org/#download) that utilize the settings in the `.editorconfig` file. It is recommended that you install the EditorConfig plugin for your editor of choice.
 
 ## Legalese
 
-Before submitting a pull request to this repository for the first time, you'll need to sign a [Developer Certificate of Origin](https://developercertificate.org) (DCO). To read and agree to the DCO, you'll add your name and email address to [CONTRIBUTORS.md](https://github.com/transcom/mymove/blob/master/CONTRIBUTORS.md). At a high level, this tells us that you have the right to submit the work you're contributing in your pull request and says that you consent to us treating the contribution in a way consistent with the license associated with this software (as described in [LICENSE.md](https://github.com/transcom/mymove/blob/master/LICENSE.md)) and its documentation ("Project").
+Before submitting a pull request to this repository for the first time, you'll need to sign a [Developer Certificate of Origin](https://developercertificate.org) (DCO). To read and agree to the DCO, you'll add your name and email address to [CONTRIBUTORS.md][contributors]. At a high level, this tells us that you have the right to submit the work you're contributing in your pull request and says that you consent to us treating the contribution in a way consistent with the license associated with this software (as described in [LICENSE.md][license]) and its documentation ("Project").
 
 You may submit contributions anonymously or under a pseudonym if you'd like, but we need to be able to reach you at the email address you provide when agreeing to the DCO. Contributions you make to this public Department of Defense repository are completely voluntary. When you submit a pull request, you're offering your contribution without expectation of payment and you expressly waive any future pay claims against the U.S. Federal Government related to your contribution.
 
-[contributors]: https://github.com/transcom/move.mil/blob/master/CONTRIBUTORS.md
-[issues]: https://github.com/transcom/move.mil/issues
-[license]: https://github.com/transcom/move.mil/blob/master/LICENSE.md
-[pulls]: https://github.com/transcom/move.mil/pulls
+[contributors]: https://github.com/transcom/mymove/blob/master/CONTRIBUTORS.md
+[issues]: https://github.com/transcom/mymove/issues
+[license]: https://github.com/transcom/mymove/blob/master/LICENSE.txt
+[pulls]: https://github.com/transcom/mymove/pulls

--- a/cmd/generate-shipment-summary/main.go
+++ b/cmd/generate-shipment-summary/main.go
@@ -8,23 +8,20 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging"
-	"github.com/transcom/mymove/pkg/rateengine"
-	"github.com/transcom/mymove/pkg/route"
-
-	"github.com/transcom/mymove/pkg/auth"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/rateengine"
+	"github.com/transcom/mymove/pkg/route"
 )
 
 // hereRequestTimeout is how long to wait on HERE request before timing out (15 seconds).

--- a/cmd/ghc-pricing-parser/main.go
+++ b/cmd/ghc-pricing-parser/main.go
@@ -14,9 +14,8 @@ import (
 	"github.com/pterm/pterm/putils"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
 	"github.com/tealeg/xlsx/v3"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/cli"

--- a/cmd/ghc-transit-time-parser/main.go
+++ b/cmd/ghc-transit-time-parser/main.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
 	"github.com/tealeg/xlsx/v3"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/cli"

--- a/cmd/milmove-tasks/post_file_to_gex.go
+++ b/cmd/milmove-tasks/post_file_to_gex.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/certs"

--- a/cmd/milmove-tasks/process_edis.go
+++ b/cmd/milmove-tasks/process_edis.go
@@ -8,9 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/certs"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -21,6 +18,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/certs"
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/db/sequence"
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"

--- a/cmd/milmove-tasks/send_payment_reminder_email.go
+++ b/cmd/milmove-tasks/send_payment_reminder_email.go
@@ -5,13 +5,12 @@ import (
 	"log"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/cmd/milmove-tasks/send_post_move_survey_email.go
+++ b/cmd/milmove-tasks/send_post_move_survey_email.go
@@ -6,13 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -17,14 +17,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gobuffalo/pop/v6"
-
 	"github.com/alexedwards/scs/redisstore"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/gobuffalo/pop/v6"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/gomodule/redigo/redis"
 	"github.com/pkg/errors"

--- a/cmd/prime-api-client/prime/create_mto_service_item.go
+++ b/cmd/prime-api-client/prime/create_mto_service_item.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoServiceItem "github.com/transcom/mymove/pkg/gen/primeclient/mto_service_item"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 )

--- a/cmd/prime-api-client/prime/create_mto_shipment.go
+++ b/cmd/prime-api-client/prime/create_mto_shipment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
 )
 

--- a/cmd/prime-api-client/prime/get_move_task_order.go
+++ b/cmd/prime-api-client/prime/get_move_task_order.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mto "github.com/transcom/mymove/pkg/gen/primeclient/move_task_order"
 )
 

--- a/cmd/prime-api-client/prime/list_moves.go
+++ b/cmd/prime-api-client/prime/list_moves.go
@@ -8,13 +8,11 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mto "github.com/transcom/mymove/pkg/gen/primeclient/move_task_order"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 )

--- a/cmd/prime-api-client/prime/update_mto_shipment.go
+++ b/cmd/prime-api-client/prime/update_mto_shipment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
 )
 

--- a/cmd/prime-api-client/prime/update_mto_shipment_address.go
+++ b/cmd/prime-api-client/prime/update_mto_shipment_address.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
 )
 

--- a/cmd/prime-api-client/prime/update_mto_shipment_status.go
+++ b/cmd/prime-api-client/prime/update_mto_shipment_status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoShipment "github.com/transcom/mymove/pkg/gen/primeclient/mto_shipment"
 )
 

--- a/cmd/prime-api-client/support/create_move_task_order.go
+++ b/cmd/prime-api-client/support/create_move_task_order.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	movetaskorderclient "github.com/transcom/mymove/pkg/gen/supportclient/move_task_order"
 )
 

--- a/cmd/prime-api-client/support/create_webhook_notification.go
+++ b/cmd/prime-api-client/support/create_webhook_notification.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	webhookclient "github.com/transcom/mymove/pkg/gen/supportclient/webhook"
 )
 

--- a/cmd/prime-api-client/support/get_move_task_order.go
+++ b/cmd/prime-api-client/support/get_move_task_order.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mto "github.com/transcom/mymove/pkg/gen/supportclient/move_task_order"
 )
 

--- a/cmd/prime-api-client/support/list_mto_payment_requests.go
+++ b/cmd/prime-api-client/support/list_mto_payment_requests.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	paymentrequestclient "github.com/transcom/mymove/pkg/gen/supportclient/payment_request"
 )
 

--- a/cmd/prime-api-client/support/list_mtos.go
+++ b/cmd/prime-api-client/support/list_mtos.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mto "github.com/transcom/mymove/pkg/gen/supportclient/move_task_order"
 )
 

--- a/cmd/prime-api-client/support/make_move_task_order_available.go
+++ b/cmd/prime-api-client/support/make_move_task_order_available.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mto "github.com/transcom/mymove/pkg/gen/supportclient/move_task_order"
 )
 

--- a/cmd/prime-api-client/support/recalculate_payment_request.go
+++ b/cmd/prime-api-client/support/recalculate_payment_request.go
@@ -10,14 +10,12 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
-
-	paymentrequestclient "github.com/transcom/mymove/pkg/gen/supportclient/payment_request"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
+	paymentrequestclient "github.com/transcom/mymove/pkg/gen/supportclient/payment_request"
 )
 
 // InitRecalculatePaymentRequestFlags declares which flags are enabled

--- a/cmd/prime-api-client/support/update_mto_service_item_status.go
+++ b/cmd/prime-api-client/support/update_mto_service_item_status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoserviceitem "github.com/transcom/mymove/pkg/gen/supportclient/mto_service_item"
 )
 

--- a/cmd/prime-api-client/support/update_mto_shipment_status.go
+++ b/cmd/prime-api-client/support/update_mto_shipment_status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	mtoShipment "github.com/transcom/mymove/pkg/gen/supportclient/mto_shipment"
 )
 

--- a/cmd/prime-api-client/support/update_payment_request_status.go
+++ b/cmd/prime-api-client/support/update_payment_request_status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/cmd/prime-api-client/utils"
-
 	paymentrequestclient "github.com/transcom/mymove/pkg/gen/supportclient/payment_request"
 )
 

--- a/cmd/prime-api-client/utils/connection.go
+++ b/cmd/prime-api-client/utils/connection.go
@@ -60,7 +60,6 @@ func CreatePrimeClientWithCACStoreParam(v *viper.Viper, store *pksigner.Store) (
 			MinVersion:         tls.VersionTLS12,
 			MaxVersion:         tls.VersionTLS12,
 		}
-		tlsConfig.BuildNameToCertificate()
 		transport := &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}
@@ -134,7 +133,6 @@ func CreatePrimeClient(v *viper.Viper) (*primeClient.Mymove, *pksigner.Store, er
 			MinVersion:         tls.VersionTLS12,
 			MaxVersion:         tls.VersionTLS12,
 		}
-		tlsConfig.BuildNameToCertificate()
 		transport := &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}
@@ -208,7 +206,6 @@ func CreateSupportClient(v *viper.Viper) (*supportClient.Mymove, *pksigner.Store
 			MinVersion:         tls.VersionTLS12,
 			MaxVersion:         tls.VersionTLS12,
 		}
-		tlsConfig.BuildNameToCertificate()
 		transport := &http.Transport{
 			TLSClientConfig: tlsConfig,
 		}

--- a/cmd/webhook-client/command_test.go
+++ b/cmd/webhook-client/command_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
-	"github.com/spf13/cobra"
-
 	"github.com/transcom/mymove/pkg/logging"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // WebhookClientTestingSuite is a suite for testing the webhook client

--- a/cmd/webhook-client/webhook_notify.go
+++ b/cmd/webhook-client/webhook_notify.go
@@ -8,12 +8,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/cmd/webhook-client/utils"
 	"github.com/transcom/mymove/cmd/webhook-client/webhook"
 	"github.com/transcom/mymove/pkg/appcontext"
-
-	"go.uber.org/zap"
 )
 
 const (

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -62,10 +62,10 @@ buildEnv {
     (import
       (builtins.fetchGit {
         # Descriptive name to make the store path easier to identify
-        name = "pre-commit-2.17.0";
+        name = "python3.10-pre-commit-2.20.0";
         url = "https://github.com/NixOS/nixpkgs/";
         ref = "refs/heads/nixpkgs-unstable";
-        rev = "7945280b9b2e348738cb9d164a0848feaf2c311d";
+        rev = "cd8d1784506a7c7eb0796772b73437e0b82fad57";
       })
       { }).pre-commit
 

--- a/pkg/auth/hostname_detector_test.go
+++ b/pkg/auth/hostname_detector_test.go
@@ -2,9 +2,7 @@ package auth
 
 import (
 	"net/http"
-
 	"net/http/httptest"
-
 	"strings"
 )
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -2,9 +2,8 @@ package cli
 
 import (
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 const (

--- a/pkg/cli/csrf.go
+++ b/pkg/cli/csrf.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/pkg/errors"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )

--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/XSAM/otelsql"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/rds"
 	pop "github.com/gobuffalo/pop/v6"
@@ -18,8 +19,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
-
-	"github.com/XSAM/otelsql"
 
 	iampg "github.com/transcom/mymove/pkg/iampostgres"
 )

--- a/pkg/db/utilities/utilities.go
+++ b/pkg/db/utilities/utilities.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
-
 	"github.com/gofrs/uuid"
 )
 

--- a/pkg/db/utilities/utilities_test.go
+++ b/pkg/db/utilities/utilities_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/pop/v6"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/db/utilities"

--- a/pkg/edi/edi997/parser_test.go
+++ b/pkg/edi/edi997/parser_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	edisegment "github.com/transcom/mymove/pkg/edi/segment"
-
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -3,21 +3,19 @@ package adminapi
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/go-openapi/runtime/middleware"
-
 	adminuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/admin_users"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func payloadForAdminUserModel(o models.AdminUser) *adminmessages.AdminUser {

--- a/pkg/handlers/adminapi/admin_users_test.go
+++ b/pkg/handlers/adminapi/admin_users_test.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/transcom/mymove/pkg/gen/adminmessages"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	adminuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/admin_users"
+	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	adminuser "github.com/transcom/mymove/pkg/services/admin_user"

--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -3,13 +3,6 @@ package adminapi
 import (
 	"log"
 
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
-	usersroles "github.com/transcom/mymove/pkg/services/users_roles"
-
-	"github.com/transcom/mymove/pkg/services/organization"
-
 	"github.com/go-openapi/loads"
 
 	"github.com/transcom/mymove/pkg/gen/adminapi"
@@ -19,13 +12,17 @@ import (
 	electronicorder "github.com/transcom/mymove/pkg/services/electronic_order"
 	fetch "github.com/transcom/mymove/pkg/services/fetch"
 	move "github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	"github.com/transcom/mymove/pkg/services/office"
 	officeuser "github.com/transcom/mymove/pkg/services/office_user"
+	"github.com/transcom/mymove/pkg/services/organization"
 	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	tspop "github.com/transcom/mymove/pkg/services/tsp"
 	"github.com/transcom/mymove/pkg/services/upload"
 	user "github.com/transcom/mymove/pkg/services/user"
+	usersroles "github.com/transcom/mymove/pkg/services/users_roles"
 	webhooksubscription "github.com/transcom/mymove/pkg/services/webhook_subscription"
 )
 

--- a/pkg/handlers/adminapi/api_test.go
+++ b/pkg/handlers/adminapi/api_test.go
@@ -5,16 +5,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/services/mocks"
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/mocks"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -4,16 +4,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	electronicorderop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/electronic_order"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func payloadForElectronicOrderModel(o models.ElectronicOrder) *adminmessages.ElectronicOrder {

--- a/pkg/handlers/adminapi/electronic_orders_test.go
+++ b/pkg/handlers/adminapi/electronic_orders_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	electronicorderop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/electronic_order"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 )

--- a/pkg/handlers/adminapi/moves.go
+++ b/pkg/handlers/adminapi/moves.go
@@ -3,24 +3,20 @@ package adminapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/audit"
-
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
-
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/go-openapi/runtime/middleware"
-
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	moveop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/move"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
+	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 // IndexMovesHandler returns a list of moves/MTOs via GET /moves

--- a/pkg/handlers/adminapi/moves_test.go
+++ b/pkg/handlers/adminapi/moves_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 
@@ -90,7 +89,7 @@ func (suite *HandlerSuite) TestIndexMovesHandlerHelpers() {
 func (suite *HandlerSuite) TestUpdateMoveHandler() {
 	setupHandler := func() UpdateMoveHandler {
 		builder := query.NewQueryBuilder()
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := move.NewMoveRouter()
 		return UpdateMoveHandler{
 			suite.HandlerConfig(),
 			movetaskorder.NewMoveTaskOrderUpdater(

--- a/pkg/handlers/adminapi/moves_test.go
+++ b/pkg/handlers/adminapi/moves_test.go
@@ -6,23 +6,18 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
-
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
-	"github.com/transcom/mymove/pkg/services/pagination"
-
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
 
 	moveop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/move"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	userop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/users"
-
 	officeuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office_users"
+	userop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/users"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -5,22 +5,17 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gofrs/uuid"
-
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/gen/adminmessages"
-
 	officeuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office_users"
+	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/services"
 	fetch "github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	officeuser "github.com/transcom/mymove/pkg/services/office_user"

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -3,16 +3,15 @@ package adminapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	officeop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func payloadForOfficeModel(o models.TransportationOffice) *adminmessages.TransportationOffice {

--- a/pkg/handlers/adminapi/organizations_test.go
+++ b/pkg/handlers/adminapi/organizations_test.go
@@ -3,14 +3,13 @@ package adminapi
 import (
 	"net/http"
 
-	"github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/organization"
-	organization2 "github.com/transcom/mymove/pkg/services/organization"
-
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/organization"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	organization2 "github.com/transcom/mymove/pkg/services/organization"
 	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/handlers/adminapi/transportation_service_provider_performances.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances.go
@@ -3,16 +3,15 @@ package adminapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	tsppop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/transportation_service_provider_performances"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func payloadForTSPPModel(o models.TransportationServiceProviderPerformance) *adminmessages.TransportationServiceProviderPerformance {

--- a/pkg/handlers/adminapi/upload_information.go
+++ b/pkg/handlers/adminapi/upload_information.go
@@ -1,17 +1,13 @@
 package adminapi
 
 import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/go-openapi/strfmt"
-
-	"github.com/gofrs/uuid"
-
-	"github.com/go-openapi/runtime/middleware"
-
 	uploadop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/upload"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/adminapi/upload_information_test.go
+++ b/pkg/handlers/adminapi/upload_information_test.go
@@ -5,18 +5,15 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/transcom/mymove/pkg/services/upload"
-
-	"github.com/stretchr/testify/mock"
-
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	uploadop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/upload"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	"github.com/transcom/mymove/pkg/services/upload"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/adminapi/users.go
+++ b/pkg/handlers/adminapi/users.go
@@ -3,19 +3,18 @@ package adminapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services/audit"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	userop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/users"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/adminapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/audit"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 

--- a/pkg/handlers/adminapi/webhook_subscriptions.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	webhooksubscriptionop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/webhook_subscriptions"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	webhooksubscription "github.com/transcom/mymove/pkg/services/webhook_subscription"
-	webhooksubscriptionservice "github.com/transcom/mymove/pkg/services/webhook_subscription"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
@@ -107,7 +106,7 @@ func (suite *HandlerSuite) TestGetWebhookSubscriptionHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		handler := GetWebhookSubscriptionHandler{
 			suite.HandlerConfig(),
-			webhooksubscriptionservice.NewWebhookSubscriptionFetcher(queryBuilder),
+			webhooksubscription.NewWebhookSubscriptionFetcher(queryBuilder),
 			query.NewQueryFilter,
 		}
 
@@ -237,7 +236,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
 			suite.HandlerConfig(),
-			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
+			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
 
@@ -274,7 +273,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
 			suite.HandlerConfig(),
-			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
+			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
 
@@ -318,7 +317,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
 			suite.HandlerConfig(),
-			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
+			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
 
@@ -345,7 +344,7 @@ func (suite *HandlerSuite) TestUpdateWebhookSubscriptionHandler() {
 		queryBuilder := query.NewQueryBuilder()
 		handler := UpdateWebhookSubscriptionHandler{
 			suite.HandlerConfig(),
-			webhooksubscriptionservice.NewWebhookSubscriptionUpdater(queryBuilder),
+			webhooksubscription.NewWebhookSubscriptionUpdater(queryBuilder),
 			query.NewQueryFilter,
 		}
 

--- a/pkg/handlers/adminapi/webhook_subscriptions_test.go
+++ b/pkg/handlers/adminapi/webhook_subscriptions_test.go
@@ -5,13 +5,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/etag"
 	webhooksubscriptionop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/webhook_subscriptions"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/authentication/auth.go
+++ b/pkg/handlers/authentication/auth.go
@@ -12,14 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/runtime/middleware"
-
-	"github.com/transcom/mymove/pkg/handlers"
-	"github.com/transcom/mymove/pkg/logging"
-	"github.com/transcom/mymove/pkg/models/roles"
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/alexedwards/scs/v2"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/openidConnect"
@@ -30,7 +24,11 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )

--- a/pkg/handlers/authentication/auth_test.go
+++ b/pkg/handlers/authentication/auth_test.go
@@ -11,25 +11,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/handlers"
-	"github.com/transcom/mymove/pkg/handlers/ghcapi"
-
-	"github.com/transcom/mymove/pkg/notifications/mocks"
-
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/alexedwards/scs/v2"
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
 	"github.com/markbates/goth"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/ghcapi"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/notifications/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -4,12 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/transcom/mymove/pkg/random"
-
-	"net/http"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/markbates/goth"
@@ -17,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/random"
 )
 
 const milProviderName = "milProvider"

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -1,15 +1,12 @@
 package authentication
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/spf13/cast"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-
 	"github.com/transcom/mymove/pkg/auth"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/models/roles"
 )
 

--- a/pkg/handlers/converters_strfmt.go
+++ b/pkg/handlers/converters_strfmt.go
@@ -3,13 +3,11 @@ package handlers
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/swagger/nullable"
-
+	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
-	"github.com/go-openapi/strfmt"
-
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/swagger/nullable"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -10,16 +10,14 @@ import (
 	openapierrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/lib/pq"
-
 	"github.com/gobuffalo/validate/v3"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/trace"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
+	"github.com/transcom/mymove/pkg/trace"
 	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
 )
 

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/go-openapi/runtime/middleware"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
 

--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -3,34 +3,28 @@ package ghcapi
 import (
 	"log"
 
-	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
-	"github.com/transcom/mymove/pkg/services/orchestrators/shipment"
-
-	"github.com/transcom/mymove/pkg/services/ppmshipment"
-
-	"github.com/transcom/mymove/pkg/services/fetch"
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	order "github.com/transcom/mymove/pkg/services/order"
-	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/transcom/mymove/pkg/services/office_user/customer"
-
-	customerserviceremarks "github.com/transcom/mymove/pkg/services/customer_support_remarks"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-
-	evaluationreport "github.com/transcom/mymove/pkg/services/evaluation_report"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-	paymentserviceitem "github.com/transcom/mymove/pkg/services/payment_service_item"
-
 	"github.com/go-openapi/loads"
 
 	"github.com/transcom/mymove/pkg/gen/ghcapi"
 	ghcops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations"
 	"github.com/transcom/mymove/pkg/handlers"
+	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
+	customerserviceremarks "github.com/transcom/mymove/pkg/services/customer_support_remarks"
+	evaluationreport "github.com/transcom/mymove/pkg/services/evaluation_report"
+	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/move"
 	movehistory "github.com/transcom/mymove/pkg/services/move_history"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+	"github.com/transcom/mymove/pkg/services/office_user/customer"
+	"github.com/transcom/mymove/pkg/services/orchestrators/shipment"
+	order "github.com/transcom/mymove/pkg/services/order"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	paymentserviceitem "github.com/transcom/mymove/pkg/services/payment_service_item"
+	"github.com/transcom/mymove/pkg/services/ppmshipment"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 // NewGhcAPIHandler returns a handler for the GHC API

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -3,14 +3,12 @@ package ghcapi
 import (
 	"testing"
 
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -3,22 +3,19 @@ package ghcapi
 import (
 	"database/sql"
 
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	customercodeop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // GetCustomerHandler fetches the information of a specific customer

--- a/pkg/handlers/ghcapi/customer_support_remarks.go
+++ b/pkg/handlers/ghcapi/customer_support_remarks.go
@@ -7,12 +7,11 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	customersupportremarksop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer_support_remarks"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
-
-	customersupportremarksop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer_support_remarks"
 )
 
 // ListCustomerSupportRemarksHandler is a struct that describes listing customer support remarks for a move

--- a/pkg/handlers/ghcapi/customer_support_remarks_test.go
+++ b/pkg/handlers/ghcapi/customer_support_remarks_test.go
@@ -6,13 +6,11 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	customersupportremarksop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer_support_remarks"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/handlers/ghcapi/customer_test.go
+++ b/pkg/handlers/ghcapi/customer_test.go
@@ -3,18 +3,15 @@ package ghcapi
 import (
 	"net/http/httptest"
 
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/models/roles"
-	customerservice "github.com/transcom/mymove/pkg/services/office_user/customer"
-
-	customerops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer"
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/go-openapi/strfmt"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
+	"github.com/transcom/mymove/pkg/etag"
+	customerops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models/roles"
+	customerservice "github.com/transcom/mymove/pkg/services/office_user/customer"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestGetCustomerHandlerIntegration() {

--- a/pkg/handlers/ghcapi/evaluation_report.go
+++ b/pkg/handlers/ghcapi/evaluation_report.go
@@ -1,21 +1,18 @@
 package ghcapi
 
 import (
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	evaluationReportop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/evaluation_reports"
 	moveop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/handlers/ghcapi/evaluation_report_test.go
+++ b/pkg/handlers/ghcapi/evaluation_report_test.go
@@ -5,21 +5,19 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/go-openapi/swag"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services/mocks"
-
 	evaluationReportop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/evaluation_reports"
 	moveop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	evaluationreportservice "github.com/transcom/mymove/pkg/services/evaluation_report"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -5,19 +5,16 @@ import (
 	"math"
 	"time"
 
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/storage"
 )

--- a/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
@@ -3,16 +3,14 @@ package payloads
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-	"github.com/transcom/mymove/pkg/handlers"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MTOAgentModel model

--- a/pkg/handlers/ghcapi/move.go
+++ b/pkg/handlers/ghcapi/move.go
@@ -3,18 +3,15 @@ package ghcapi
 import (
 	"errors"
 
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
-	"go.uber.org/zap"
-
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	moveop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/handlers/ghcapi/move_history.go
+++ b/pkg/handlers/ghcapi/move_history.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	moveop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -1,25 +1,21 @@
 package ghcapi
 
 import (
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/transcom/mymove/pkg/services/event"
-
-	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
-
-	"github.com/go-openapi/runtime/middleware"
-
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/event"
 )
 
 // GetMoveTaskOrderHandler fetches a Move Task Order

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move_task_order"
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/models"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
@@ -61,7 +60,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 		},
 	})
 	request := httptest.NewRequest("GET", "/move-task-orders/{moveTaskOrderID}", nil)
-	params := move_task_order.GetMoveTaskOrderParams{
+	params := movetaskorderops.GetMoveTaskOrderParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: moveTaskOrder.ID.String(),
 	}
@@ -76,7 +75,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 	moveTaskOrderResponse := response.(*movetaskorderops.GetMoveTaskOrderOK)
 	moveTaskOrderPayload := moveTaskOrderResponse.Payload
 
-	suite.Assertions.IsType(&move_task_order.GetMoveTaskOrderOK{}, response)
+	suite.Assertions.IsType(&movetaskorderops.GetMoveTaskOrderOK{}, response)
 	suite.Equal(strfmt.UUID(moveTaskOrder.ID.String()), moveTaskOrderPayload.ID)
 	suite.Nil(moveTaskOrderPayload.AvailableToPrimeAt)
 	// TODO: Check that the *moveTaskOrderPayload.Status is not "canceled"
@@ -120,7 +119,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 			ServiceCodeMS: true,
 			ServiceCodeCS: true,
 		}
-		params := move_task_order.UpdateMoveTaskOrderStatusParams{
+		params := movetaskorderops.UpdateMoveTaskOrderStatusParams{
 			HTTPRequest:      request,
 			MoveTaskOrderID:  move.ID.String(),
 			IfMatch:          etag.GenerateEtag(move.UpdatedAt),
@@ -147,7 +146,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationSuccess() {
 		suite.DB().Find(&updatedMove, movePayload.ID)
 		suite.Equal(models.MoveStatusAPPROVED, updatedMove.Status)
 
-		suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
+		suite.Assertions.IsType(&movetaskorderops.UpdateMoveTaskOrderStatusOK{}, response)
 		suite.Equal(strfmt.UUID(move.ID.String()), movePayload.ID)
 		suite.NotNil(movePayload.AvailableToPrimeAt)
 		suite.HasWebhookNotification(move.ID, traceID) // this action always creates a notification for the Prime
@@ -183,7 +182,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
-	params := move_task_order.UpdateMoveTaskOrderStatusParams{
+	params := movetaskorderops.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(time.Now()),
@@ -204,7 +203,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithStaleEta
 	// make the request
 	handler := UpdateMoveTaskOrderStatusHandlerFunc{handlerConfig, moveUpdater}
 	response := handler.Handle(params)
-	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusPreconditionFailed{}, response)
+	suite.Assertions.IsType(&movetaskorderops.UpdateMoveTaskOrderStatusPreconditionFailed{}, response)
 }
 
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncompleteOrder() {
@@ -219,7 +218,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	request = suite.AuthenticateUserRequest(request, requestUser)
-	params := move_task_order.UpdateMoveTaskOrderStatusParams{
+	params := movetaskorderops.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
@@ -235,8 +234,8 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegrationWithIncomple
 	}
 	response := handler.Handle(params)
 
-	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusUnprocessableEntity{}, response)
-	invalidResponse := response.(*move_task_order.UpdateMoveTaskOrderStatusUnprocessableEntity).Payload
+	suite.Assertions.IsType(&movetaskorderops.UpdateMoveTaskOrderStatusUnprocessableEntity{}, response)
+	invalidResponse := response.(*movetaskorderops.UpdateMoveTaskOrderStatusUnprocessableEntity).Payload
 	errorDetail := invalidResponse.Detail
 
 	suite.Contains(*errorDetail, "TransportationAccountingCode cannot be blank.")
@@ -269,7 +268,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 			},
 		})
 
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: move.ID.String(),
 			IfMatch:         etag.GenerateEtag(move.UpdatedAt),
@@ -281,7 +280,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 		moveTaskOrderPayload := moveTaskOrderResponse.Payload
 		suite.NoError(moveTaskOrderPayload.Validate(strfmt.Default))
 
-		suite.IsType(&move_task_order.UpdateMTOStatusServiceCounselingCompletedOK{}, response)
+		suite.IsType(&movetaskorderops.UpdateMTOStatusServiceCounselingCompletedOK{}, response)
 		suite.Equal(strfmt.UUID(move.ID.String()), moveTaskOrderPayload.ID)
 		suite.NotNil(moveTaskOrderPayload.ServiceCounselingCompletedAt)
 		suite.EqualValues(models.MoveStatusServiceCounselingCompleted, moveTaskOrderPayload.Status)
@@ -293,13 +292,13 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 		forbiddenUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{})
 		forbiddenRequest := suite.AuthenticateOfficeRequest(request, forbiddenUser)
 
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest: forbiddenRequest,
 		}
 
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
-		suite.IsType(&move_task_order.UpdateMTOStatusServiceCounselingCompletedForbidden{}, response)
+		suite.IsType(&movetaskorderops.UpdateMTOStatusServiceCounselingCompletedForbidden{}, response)
 	})
 
 	suite.Run("Unsuccessful move status update to Service Counseling Completed, not found - Integration", func() {
@@ -307,14 +306,14 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 		request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status/service-counseling-completed", nil)
 		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{})
 		request = suite.AuthenticateOfficeRequest(request, requestUser)
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: uuid.Must(uuid.NewV4()).String(),
 		}
 
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
-		suite.IsType(&move_task_order.UpdateMTOStatusServiceCounselingCompletedNotFound{}, response)
+		suite.IsType(&movetaskorderops.UpdateMTOStatusServiceCounselingCompletedNotFound{}, response)
 	})
 
 	suite.Run("Unsuccessful move status update to Service Counseling Completed, eTag does not match - Integration", func() {
@@ -327,7 +326,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 			Move: move,
 		})
 
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: move.ID.String(),
 			IfMatch:         etag.GenerateEtag(time.Now()),
@@ -335,7 +334,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
-		suite.IsType(&move_task_order.UpdateMTOStatusServiceCounselingCompletedPreconditionFailed{}, response)
+		suite.IsType(&movetaskorderops.UpdateMTOStatusServiceCounselingCompletedPreconditionFailed{}, response)
 	})
 
 	suite.Run("Unsuccessful move status update to Service Counseling Completed, state conflict - Integration", func() {
@@ -352,7 +351,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 			Move: draftMove,
 		})
 
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: draftMove.ID.String(),
 			IfMatch:         etag.GenerateEtag(draftMove.UpdatedAt),
@@ -360,7 +359,7 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
-		suite.IsType(&move_task_order.UpdateMTOStatusServiceCounselingCompletedConflict{}, response)
+		suite.IsType(&movetaskorderops.UpdateMTOStatusServiceCounselingCompletedConflict{}, response)
 	})
 
 	suite.Run("Unsuccessful move status update to Service Counseling Completed, misc mocked errors - Integration", func() {
@@ -372,14 +371,14 @@ func (suite *HandlerSuite) TestUpdateMTOStatusServiceCounselingCompletedHandler(
 			mockError       error
 			handlerResponse middleware.Responder
 		}{
-			{apperror.InvalidInputError{}, &move_task_order.UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity{}},
-			{apperror.QueryError{}, &move_task_order.UpdateMTOStatusServiceCounselingCompletedInternalServerError{}},
-			{errors.New("generic error"), &move_task_order.UpdateMTOStatusServiceCounselingCompletedInternalServerError{}},
+			{apperror.InvalidInputError{}, &movetaskorderops.UpdateMTOStatusServiceCounselingCompletedUnprocessableEntity{}},
+			{apperror.QueryError{}, &movetaskorderops.UpdateMTOStatusServiceCounselingCompletedInternalServerError{}},
+			{errors.New("generic error"), &movetaskorderops.UpdateMTOStatusServiceCounselingCompletedInternalServerError{}},
 		}
 
 		move := testdatagen.MakeStubbedMoveWithStatus(suite.DB(), models.MoveStatusNeedsServiceCounseling)
 		eTag := etag.GenerateEtag(move.UpdatedAt)
-		params := move_task_order.UpdateMTOStatusServiceCounselingCompletedParams{
+		params := movetaskorderops.UpdateMTOStatusServiceCounselingCompletedParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: move.ID.String(),
 			IfMatch:         eTag,
@@ -433,7 +432,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/tio-remarks", nil)
 		request = suite.AuthenticateUserRequest(request, requestUser)
 
-		params := move_task_order.UpdateMoveTIORemarksParams{
+		params := movetaskorderops.UpdateMoveTIORemarksParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: move.ID.String(),
 			Body:            &ghcmessages.Move{TioRemarks: &remarks},
@@ -444,7 +443,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		moveTaskOrderResponse := response.(*movetaskorderops.UpdateMoveTIORemarksOK)
 		moveTaskOrderPayload := moveTaskOrderResponse.Payload
 
-		suite.Assertions.IsType(&move_task_order.UpdateMoveTIORemarksOK{}, response)
+		suite.Assertions.IsType(&movetaskorderops.UpdateMoveTIORemarksOK{}, response)
 		updatedMove := models.Move{}
 		suite.DB().Find(&updatedMove, moveTaskOrderPayload.ID)
 		suite.Equal(moveTaskOrderPayload.TioRemarks, updatedMove.TIORemarks)
@@ -455,7 +454,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/tio-remarks", nil)
 		request = suite.AuthenticateUserRequest(request, requestUser)
 
-		params := move_task_order.UpdateMoveTIORemarksParams{
+		params := movetaskorderops.UpdateMoveTIORemarksParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: move.ID.String(),
 			Body:            &ghcmessages.Move{TioRemarks: &remarks},
@@ -463,7 +462,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
 
-		suite.Assertions.IsType(&move_task_order.UpdateMoveTIORemarksPreconditionFailed{}, response)
+		suite.Assertions.IsType(&movetaskorderops.UpdateMoveTIORemarksPreconditionFailed{}, response)
 	})
 
 	suite.Run("Unsuccessful move TIO Remarks update, not found", func() {
@@ -471,7 +470,7 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/tio-remarks", nil)
 		request = suite.AuthenticateUserRequest(request, requestUser)
 
-		params := move_task_order.UpdateMoveTIORemarksParams{
+		params := movetaskorderops.UpdateMoveTIORemarksParams{
 			HTTPRequest:     request,
 			MoveTaskOrderID: uuid.Must(uuid.NewV4()).String(),
 			Body:            &ghcmessages.Move{TioRemarks: &remarks},
@@ -479,6 +478,6 @@ func (suite *HandlerSuite) TestUpdateMoveTIORemarksHandler() {
 		response := handler.Handle(params)
 		suite.IsNotErrResponse(response)
 
-		suite.Assertions.IsType(&move_task_order.UpdateMoveTIORemarksNotFound{}, response)
+		suite.Assertions.IsType(&movetaskorderops.UpdateMoveTIORemarksNotFound{}, response)
 	})
 }

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -16,29 +16,22 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
-
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/trace"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
-
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move_task_order"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -4,23 +4,18 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/go-openapi/swag"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
+	moveops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
-	moveops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/move"
 )
 
 func (suite *HandlerSuite) TestGetMoveHandler() {

--- a/pkg/handlers/ghcapi/mto_agent.go
+++ b/pkg/handlers/ghcapi/mto_agent.go
@@ -3,20 +3,18 @@ package ghcapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	mtoagentop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_agent"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
-
-	mtoagentop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_agent"
 )
 
 //ListMTOAgentsHandler is a struct for the handler.

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"net/http/httptest"
 
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/mock"
 
+	mtoagentop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_agent"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
-	mtoagentop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_agent"
 )
 
 func (suite *HandlerSuite) TestListMTOAgentsHandler() {

--- a/pkg/handlers/ghcapi/mto_service_items.go
+++ b/pkg/handlers/ghcapi/mto_service_items.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	mtoserviceitemop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_service_item"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -6,24 +6,22 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/trace"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	mtoserviceitemop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_service_item"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 func (suite *HandlerSuite) TestListMTOServiceItemHandler() {

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -3,25 +3,21 @@ package ghcapi
 import (
 	"fmt"
 
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/notifications"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/go-openapi/runtime/middleware"
-	"go.uber.org/zap"
-
-	"github.com/gofrs/uuid"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_shipment"
 	shipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/shipment"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/event"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
 	moveservices "github.com/transcom/mymove/pkg/services/move"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
@@ -481,7 +480,7 @@ func (suite *HandlerSuite) TestApproveShipmentHandler() {
 		eTag := etag.GenerateEtag(shipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
 		builder := query.NewQueryBuilder()
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		approver := mtoshipment.NewShipmentApprover(
 			mtoshipment.NewShipmentRouter(),
 			mtoserviceitem.NewMTOServiceItemCreator(builder, moveRouter),
@@ -1579,7 +1578,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1631,7 +1630,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1674,7 +1673,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1718,7 +1717,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1763,7 +1762,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1807,7 +1806,7 @@ func (suite *HandlerSuite) TestRequestShipmentReweighHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(400, nil)
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 		// Get shipment payment request recalculator service
@@ -1874,7 +1873,7 @@ func (suite *HandlerSuite) TestApproveSITExtensionHandler() {
 		})
 		eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		sitExtensionApprover := mtoshipment.NewSITExtensionApprover(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/approve", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
@@ -1923,7 +1922,7 @@ func (suite *HandlerSuite) TestDenySITExtensionHandler() {
 		})
 		eTag := etag.GenerateEtag(mtoShipment.UpdatedAt)
 		officeUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		moveRouter := moverouter.NewMoveRouter()
+		moveRouter := moveservices.NewMoveRouter()
 		sitExtensionDenier := mtoshipment.NewSITExtensionDenier(moveRouter)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/shipments/%s/sit-extension/%s/deny", mtoShipment.ID.String(), sitExtension.ID.String()), nil)
 		req = suite.AuthenticateOfficeRequest(req, officeUser)
@@ -2105,7 +2104,7 @@ func (suite *HandlerSuite) makeCreateMTOShipmentSubtestData() (subtestData *crea
 }
 
 func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 
 	suite.Run("Successful POST - Integration Test", func() {
 		handlerConfig := suite.HandlerConfig()
@@ -2297,7 +2296,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 		handlerConfig := suite.HandlerConfig()
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moverouter.NewMoveRouter())
+		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveservices.NewMoveRouter())
 		ppmEstimator := mocks.PPMEstimator{}
 		ppmCreator := ppmshipment.NewPPMShipmentCreator(&ppmEstimator)
 		shipmentCreator := shipmentorchestrator.NewShipmentCreator(creator, ppmCreator)
@@ -2407,7 +2406,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandlerUsingPPM() {
 		handlerConfig := suite.HandlerConfig()
 		builder := query.NewQueryBuilder()
 		fetcher := fetch.NewFetcher(builder)
-		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moverouter.NewMoveRouter())
+		creator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveservices.NewMoveRouter())
 		ppmEstimator := mocks.PPMEstimator{}
 		shipmentCreator := shipmentorchestrator.NewShipmentCreator(creator, ppmshipment.NewPPMShipmentCreator(&ppmEstimator))
 		handler := CreateMTOShipmentHandler{
@@ -2558,7 +2557,7 @@ func (suite *HandlerSuite) TestUpdateShipmentHandler() {
 		mock.Anything,
 		mock.Anything,
 	).Return(400, nil)
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 
 	// Get shipment payment request recalculator service

--- a/pkg/handlers/ghcapi/mto_shipment_test.go
+++ b/pkg/handlers/ghcapi/mto_shipment_test.go
@@ -5,44 +5,35 @@ import (
 	"net/http/httptest"
 	"time"
 
-	shipmentorchestrator "github.com/transcom/mymove/pkg/services/orchestrators/shipment"
-	"github.com/transcom/mymove/pkg/services/ppmshipment"
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/transcom/mymove/pkg/swagger/nullable"
-
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	moveservices "github.com/transcom/mymove/pkg/services/move"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-	"github.com/transcom/mymove/pkg/trace"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
 	"github.com/go-openapi/strfmt"
-
-	"github.com/gofrs/uuid"
-
-	routemocks "github.com/transcom/mymove/pkg/route/mocks"
-
 	"github.com/gobuffalo/validate/v3"
-
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/mto_shipment"
 	shipmentops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/shipment"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moveservices "github.com/transcom/mymove/pkg/services/move"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
-
+	shipmentorchestrator "github.com/transcom/mymove/pkg/services/orchestrators/shipment"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	"github.com/transcom/mymove/pkg/services/ppmshipment"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/swagger/nullable"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 type listMTOShipmentsSubtestData struct {

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -9,9 +9,8 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	orderop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/order"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -4,34 +4,28 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/swagger/nullable"
-	"github.com/transcom/mymove/pkg/trace"
-
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-	"github.com/transcom/mymove/pkg/services/query"
-
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/uploader"
-
-	"github.com/go-openapi/swag"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/gofrs/uuid"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	orderop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/order"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	orderservice "github.com/transcom/mymove/pkg/services/order"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/swagger/nullable"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *HandlerSuite) TestGetOrderHandlerIntegration() {

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -5,26 +5,22 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/transcom/mymove/pkg/services/event"
-
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/services/audit"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_requests"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/event"
 )
 
 // GetPaymentRequestForMoveHandler gets payment requests associated with a move

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -6,25 +6,21 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/models/roles"
-	"github.com/transcom/mymove/pkg/trace"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
-	"github.com/transcom/mymove/pkg/testdatagen"
-
-	"github.com/gofrs/uuid"
-
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_requests"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 func (suite *HandlerSuite) TestFetchPaymentRequestHandler() {

--- a/pkg/handlers/ghcapi/payment_service_items.go
+++ b/pkg/handlers/ghcapi/payment_service_items.go
@@ -3,23 +3,21 @@ package ghcapi
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/event"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	paymentServiceItemOp "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_service_item"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	modelToPayload "github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/event"
 	"github.com/transcom/mymove/pkg/services/query"
-
-	paymentServiceItemOp "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_service_item"
 )
 
 // UpdatePaymentServiceItemStatusHandler updates payment service item status

--- a/pkg/handlers/ghcapi/payment_service_items_test.go
+++ b/pkg/handlers/ghcapi/payment_service_items_test.go
@@ -5,22 +5,17 @@ import (
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
-
-	paymentServiceItemService "github.com/transcom/mymove/pkg/services/payment_service_item"
-	"github.com/transcom/mymove/pkg/trace"
-
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/go-openapi/swag"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/etag"
+	paymentServiceItemOp "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_service_item"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	paymentServiceItemService "github.com/transcom/mymove/pkg/services/payment_service_item"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
-	paymentServiceItemOp "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_service_item"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 type updatePaymentSubtestData struct {

--- a/pkg/handlers/ghcapi/queues.go
+++ b/pkg/handlers/ghcapi/queues.go
@@ -1,23 +1,20 @@
 package ghcapi
 
 import (
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
-
 	"github.com/gobuffalo/pop/v6"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/go-openapi/runtime/middleware"
-	"go.uber.org/zap"
-
 	"github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/queues"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // GetMovesQueueHandler returns the moves for the TOO queue user via GET /queues/moves

--- a/pkg/handlers/ghcapi/queues_test.go
+++ b/pkg/handlers/ghcapi/queues_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/queues"
+	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services/mocks"

--- a/pkg/handlers/internalapi/addresses.go
+++ b/pkg/handlers/internalapi/addresses.go
@@ -6,11 +6,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-
 	addressop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/addresses"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/gen/internalapi"
 	internalops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations"
-
 	"github.com/transcom/mymove/pkg/handlers"
 	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
 	"github.com/transcom/mymove/pkg/services/fetch"

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -3,12 +3,11 @@ package internalapi
 import (
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/internalapi/duty_locations.go
+++ b/pkg/handlers/internalapi/duty_locations.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-
 	locationop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/duty_locations"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -1,19 +1,17 @@
 package internalapi
 
 import (
-	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -4,22 +4,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/gobuffalo/validate/v3"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
-
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) TestCreateMoveDocumentHandler() {

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -6,28 +6,24 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/pkg/errors"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"
-
-	"github.com/transcom/mymove/pkg/assets"
-	"github.com/transcom/mymove/pkg/paperwork"
-	"github.com/transcom/mymove/pkg/rateengine"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/gobuffalo/validate/v3"
-
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/assets"
+	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"
 	moveop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/moves"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"
 )

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -15,22 +15,19 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/route/mocks"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	moveop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/moves"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/route/mocks"
 	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) TestPatchMoveHandler() {

--- a/pkg/handlers/internalapi/mto_shipment.go
+++ b/pkg/handlers/internalapi/mto_shipment.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"

--- a/pkg/handlers/internalapi/mto_shipment_test.go
+++ b/pkg/handlers/internalapi/mto_shipment_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/swagger/nullable"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
@@ -31,6 +29,7 @@ import (
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/services/ppmshipment"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/swagger/nullable"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/handlers/internalapi/office.go
+++ b/pkg/handlers/internalapi/office.go
@@ -3,18 +3,17 @@ package internalapi
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	officeop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/office"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // ApproveMoveHandler approves a move via POST /moves/{moveId}/approve

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
@@ -13,6 +11,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -12,9 +12,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/uploader"
-
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -22,6 +19,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func payloadForUploadModelFromAmendedOrdersUpload(storer storage.FileStorer, upload models.Upload, url string) (*internalmessages.UploadPayload, error) {

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -5,17 +5,14 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services/move"
-
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/go-openapi/swag"
-
 	"github.com/gofrs/uuid"
 
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/move"
 	orderservice "github.com/transcom/mymove/pkg/services/order"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/unit"
-
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testdatagen/scenario"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) setupPersonallyProcuredMoveIncentiveTest(ordersID uuid.UUID) {

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -13,23 +13,20 @@ import (
 	"net/http/httptest"
 	"time"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testdatagen/scenario"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) setupPersonallyProcuredMoveTest() {

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -1,16 +1,15 @@
 package internalapi
 
 import (
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage"
 )

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -14,8 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
@@ -24,6 +22,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/internalapi/signed_certifications.go
+++ b/pkg/handlers/internalapi/signed_certifications.go
@@ -3,10 +3,9 @@ package internalapi
 import (
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"

--- a/pkg/handlers/internalapi/transportation_offices.go
+++ b/pkg/handlers/internalapi/transportation_offices.go
@@ -5,10 +5,9 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-
 	transportationofficeop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/transportation_offices"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -8,14 +8,13 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/transcom/mymove/pkg/auth"
 	userop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/users"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // ShowLoggedInUserHandler returns the logged in user

--- a/pkg/handlers/internalapi/users_test.go
+++ b/pkg/handlers/internalapi/users_test.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/go-openapi/swag"
 
-	officeuser "github.com/transcom/mymove/pkg/services/office_user"
-
 	userop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/users"
 	"github.com/transcom/mymove/pkg/models"
+	officeuser "github.com/transcom/mymove/pkg/services/office_user"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/internalapi/weight_ticket.go
+++ b/pkg/handlers/internalapi/weight_ticket.go
@@ -5,9 +5,8 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	weightticketops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/internalapi/internal/payloads"

--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -5,19 +5,17 @@ import (
 	"fmt"
 	"net/http/httptest"
 
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/etag"
+	weightticketops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
-	weightticketops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	weightticket "github.com/transcom/mymove/pkg/services/weight_ticket"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 //

--- a/pkg/handlers/ordersapi/api_test.go
+++ b/pkg/handlers/ordersapi/api_test.go
@@ -12,14 +12,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/authentication"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/ordersapi/get_orders_test.go
+++ b/pkg/handlers/ordersapi/get_orders_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/gen/ordersapi/ordersoperations"
 	"github.com/transcom/mymove/pkg/handlers"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -3,30 +3,26 @@ package primeapi
 import (
 	"log"
 
-	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
-	"github.com/transcom/mymove/pkg/services/orchestrators/shipment"
-	"github.com/transcom/mymove/pkg/services/ppmshipment"
-
-	"github.com/transcom/mymove/pkg/services/upload"
-
-	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
-
 	"github.com/go-openapi/loads"
-
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	"github.com/transcom/mymove/pkg/services/move"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-	"github.com/transcom/mymove/pkg/services/reweigh"
-	sitextension "github.com/transcom/mymove/pkg/services/sit_extension"
 
 	"github.com/transcom/mymove/pkg/gen/primeapi"
 	"github.com/transcom/mymove/pkg/gen/primeapi/primeoperations"
 	"github.com/transcom/mymove/pkg/handlers"
+	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
 	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
+	"github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+	"github.com/transcom/mymove/pkg/services/orchestrators/shipment"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	"github.com/transcom/mymove/pkg/services/ppmshipment"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/services/reweigh"
+	sitextension "github.com/transcom/mymove/pkg/services/sit_extension"
+	"github.com/transcom/mymove/pkg/services/upload"
 )
 
 // NewPrimeAPI returns the Prime API

--- a/pkg/handlers/primeapi/api.go
+++ b/pkg/handlers/primeapi/api.go
@@ -14,17 +14,16 @@ import (
 	"github.com/go-openapi/loads"
 
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	move "github.com/transcom/mymove/pkg/services/move"
+	"github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-	reweigh "github.com/transcom/mymove/pkg/services/reweigh"
+	"github.com/transcom/mymove/pkg/services/reweigh"
 	sitextension "github.com/transcom/mymove/pkg/services/sit_extension"
 
 	"github.com/transcom/mymove/pkg/gen/primeapi"
 	"github.com/transcom/mymove/pkg/gen/primeapi/primeoperations"
-	primeops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/query"
@@ -39,7 +38,7 @@ func NewPrimeAPI(handlerConfig handlers.HandlerConfig) *primeoperations.MymoveAP
 	if err != nil {
 		log.Fatalln(err)
 	}
-	primeAPI := primeops.NewMymoveAPI(primeSpec)
+	primeAPI := primeoperations.NewMymoveAPI(primeSpec)
 	queryBuilder := query.NewQueryBuilder()
 	moveRouter := move.NewMoveRouter()
 	moveWeights := move.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())

--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -3,14 +3,13 @@ package primeapi
 import (
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -4,21 +4,17 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // ListMovesHandler lists moves with the option to filter since a particular date. Optimized ver.

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -5,36 +5,27 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
-	"github.com/go-openapi/swag"
-
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services/upload"
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/strfmt"
-
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
+	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/services/mocks"
-
-	"github.com/transcom/mymove/pkg/services/fetch"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	"github.com/transcom/mymove/pkg/services/query"
-
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/services/upload"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/primeapi/mto_agent.go
+++ b/pkg/handlers/primeapi/mto_agent.go
@@ -8,14 +8,11 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/services"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // CreateMTOAgentHandler is the handler to create an agent

--- a/pkg/handlers/primeapi/mto_agent_test.go
+++ b/pkg/handlers/primeapi/mto_agent_test.go
@@ -6,22 +6,19 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/etag"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoagent "github.com/transcom/mymove/pkg/services/mto_agent"
-
-	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 type updateMTOAgentSubtestData struct {

--- a/pkg/handlers/primeapi/mto_service_item.go
+++ b/pkg/handlers/primeapi/mto_service_item.go
@@ -4,22 +4,18 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/handlers/primeapi/mto_service_item_test.go
+++ b/pkg/handlers/primeapi/mto_service_item_test.go
@@ -6,18 +6,13 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-
 	"github.com/gobuffalo/validate/v3"
-
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_service_item"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
@@ -25,6 +20,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -4,23 +4,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
-	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
-
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
-
-	"github.com/go-openapi/runtime/middleware"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/models"
-
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 )
 
 // CreateMTOShipmentHandler is the handler to create MTO shipments

--- a/pkg/handlers/primeapi/mto_shipment_address.go
+++ b/pkg/handlers/primeapi/mto_shipment_address.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/handlers/primeapi/mto_shipment_address_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_address_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http/httptest"
 
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
@@ -13,6 +11,7 @@ import (
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
 	moveservices "github.com/transcom/mymove/pkg/services/move"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 
@@ -50,7 +49,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	builder := query.NewQueryBuilder()
 	mtoChecker := movetaskorder.NewMoveTaskOrderChecker()
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	fetcher := fetch.NewFetcher(builder)
 	mtoShipmentCreator := mtoshipment.NewMTOShipmentCreator(builder, fetcher, moveRouter)
 	ppmEstimator := mocks.PPMEstimator{}
@@ -483,7 +482,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentHandler() {
 
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	// Get shipment payment request recalculator service
 	creator := paymentrequest.NewPaymentRequestCreator(planner, ghcrateengine.NewServiceItemPricer())
@@ -1174,7 +1173,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentAddressLogic() {
 		mock.Anything,
 		mock.Anything,
 	).Return(400, nil)
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	// Get shipment payment request recalculator service
 	creator := paymentrequest.NewPaymentRequestCreator(planner, ghcrateengine.NewServiceItemPricer())
@@ -1354,7 +1353,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentDateLogic() {
 	// Create a handler object to use in the tests
 	builder := query.NewQueryBuilder()
 	fetcher := fetch.NewFetcher(builder)
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	// Get shipment payment request recalculator service
 	creator := paymentrequest.NewPaymentRequestCreator(planner, ghcrateengine.NewServiceItemPricer())
@@ -1886,7 +1885,7 @@ func (suite *HandlerSuite) TestUpdateMTOShipmentStatusHandler() {
 		mock.Anything,
 		mock.Anything,
 	).Return(400, nil)
-	moveRouter := moverouter.NewMoveRouter()
+	moveRouter := moveservices.NewMoveRouter()
 	moveWeights := moveservices.NewMoveWeights(mtoshipment.NewShipmentReweighRequester())
 	// Get shipment payment request recalculator service
 	creator := paymentrequest.NewPaymentRequestCreator(planner, ghcrateengine.NewServiceItemPricer())

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -6,43 +6,33 @@ import (
 	"net/http/httptest"
 	"time"
 
-	shipmentorchestrator "github.com/transcom/mymove/pkg/services/orchestrators/shipment"
-	"github.com/transcom/mymove/pkg/services/ppmshipment"
-
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	moveservices "github.com/transcom/mymove/pkg/services/move"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-
-	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-
-	"github.com/gofrs/uuid"
-
-	"github.com/go-openapi/swag"
-
-	routemocks "github.com/transcom/mymove/pkg/route/mocks"
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/models"
+	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moveservices "github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
+	shipmentorchestrator "github.com/transcom/mymove/pkg/services/orchestrators/shipment"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	"github.com/transcom/mymove/pkg/services/ppmshipment"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {

--- a/pkg/handlers/primeapi/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload.go
@@ -3,21 +3,18 @@ package payloads
 import (
 	"time"
 
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-
-	"github.com/transcom/mymove/pkg/storage"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/storage"
 )
 
 // MoveTaskOrder payload

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -3,17 +3,15 @@ package payloads
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/etag"
-
-	"github.com/transcom/mymove/pkg/storage/test"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/storage/test"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *PayloadsSuite) TestMoveTaskOrder() {

--- a/pkg/handlers/primeapi/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/payloads/payload_to_model.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/primemessages"

--- a/pkg/handlers/primeapi/payloads/payloads_test.go
+++ b/pkg/handlers/primeapi/payloads/payloads_test.go
@@ -3,12 +3,11 @@ package payloads
 import (
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -4,19 +4,17 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
-	"github.com/gobuffalo/validate/v3"
-
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_request"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/handlers/primeapi/payment_request_test.go
+++ b/pkg/handlers/primeapi/payment_request_test.go
@@ -6,29 +6,25 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/gobuffalo/validate/v3"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/services/audit"
-
 	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/auth"
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_request"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
+	"github.com/transcom/mymove/pkg/services/audit"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 const (

--- a/pkg/handlers/primeapi/reweigh.go
+++ b/pkg/handlers/primeapi/reweigh.go
@@ -6,11 +6,9 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/handlers/primeapi/reweigh_test.go
+++ b/pkg/handlers/primeapi/reweigh_test.go
@@ -5,21 +5,19 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/etag"
+	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/gofrs/uuid"
-
-	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/etag"
-	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-	"github.com/transcom/mymove/pkg/handlers"
 	reweighservice "github.com/transcom/mymove/pkg/services/reweigh"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/primeapi/sit_extension.go
+++ b/pkg/handlers/primeapi/sit_extension.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/services"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // CreateSITExtensionHandler is the handler to create a sit extension

--- a/pkg/handlers/primeapi/sit_extension_test.go
+++ b/pkg/handlers/primeapi/sit_extension_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-
 	moverouter "github.com/transcom/mymove/pkg/services/move"
 	sitextensionservice "github.com/transcom/mymove/pkg/services/sit_extension"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -4,22 +4,17 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
-
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/gofrs/uuid"
-
-	"go.uber.org/zap"
-
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_request"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 func payloadForPaymentRequestUploadModel(u models.Upload) *primemessages.Upload {

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -5,14 +5,11 @@ import (
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/models"
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-
 	"github.com/gofrs/uuid"
 
 	uploadop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_request"
-
+	"github.com/transcom/mymove/pkg/models"
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/handlers/supportapi/api.go
+++ b/pkg/handlers/supportapi/api.go
@@ -4,24 +4,22 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-	"github.com/transcom/mymove/pkg/services/invoice"
-	internalmovetaskorder "github.com/transcom/mymove/pkg/services/support/move_task_order"
-
 	"github.com/benbjohnson/clock"
 	"github.com/go-openapi/loads"
-
-	"github.com/transcom/mymove/pkg/services/fetch"
-	"github.com/transcom/mymove/pkg/services/query"
 
 	"github.com/transcom/mymove/pkg/gen/supportapi"
 	supportops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/services/fetch"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
+	"github.com/transcom/mymove/pkg/services/invoice"
 	move "github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	"github.com/transcom/mymove/pkg/services/query"
+	internalmovetaskorder "github.com/transcom/mymove/pkg/services/support/move_task_order"
 )
 
 // NewSupportAPIHandler returns a handler for the Prime API

--- a/pkg/handlers/supportapi/api_test.go
+++ b/pkg/handlers/supportapi/api_test.go
@@ -3,12 +3,11 @@ package supportapi
 import (
 	"testing"
 
-	"github.com/transcom/mymove/pkg/testingsuite"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload.go
@@ -3,19 +3,17 @@ package payloads
 import (
 	"time"
 
-	"github.com/go-openapi/swag"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/services"
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	primepayloads "github.com/transcom/mymove/pkg/handlers/primeapi/payloads"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // MoveTaskOrders payload

--- a/pkg/handlers/supportapi/internal/payloads/model_to_payload_test.go
+++ b/pkg/handlers/supportapi/internal/payloads/model_to_payload_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/handlers"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/supportapi/internal/payloads/payload_to_model.go
@@ -3,16 +3,14 @@ package payloads
 import (
 	"time"
 
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/transcom/mymove/pkg/handlers"
-	"github.com/transcom/mymove/pkg/services/event"
-
 	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/event"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/handlers/supportapi/move_task_order.go
+++ b/pkg/handlers/supportapi/move_task_order.go
@@ -3,21 +3,17 @@ package supportapi
 import (
 	"time"
 
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/services/support"
-
-	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
-
-	"github.com/go-openapi/runtime/middleware"
-
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/support"
 )
 
 // ListMTOsHandler lists move task orders with the option to filter since a particular date

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -25,8 +25,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/move_task_order"
-	supportmessages "github.com/transcom/mymove/pkg/gen/supportmessages"
+	"github.com/transcom/mymove/pkg/gen/supportmessages"
 
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -69,7 +68,7 @@ func (suite *HandlerSuite) TestListMTOsHandler() {
 
 func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/hide", nil)
-	params := move_task_order.HideNonFakeMoveTaskOrdersParams{
+	params := movetaskorderops.HideNonFakeMoveTaskOrdersParams{
 		HTTPRequest: request,
 	}
 	handlerConfig := suite.HandlerConfig()
@@ -165,7 +164,7 @@ func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
 		},
 	})
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/available-to-prime", nil)
-	params := move_task_order.MakeMoveTaskOrderAvailableParams{
+	params := movetaskorderops.MakeMoveTaskOrderAvailableParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: move.ID.String(),
 		IfMatch:         etag.GenerateEtag(move.UpdatedAt),
@@ -185,7 +184,7 @@ func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
 	moveResponse := response.(*movetaskorderops.MakeMoveTaskOrderAvailableOK)
 	movePayload := moveResponse.Payload
 
-	suite.Assertions.IsType(&move_task_order.MakeMoveTaskOrderAvailableOK{}, response)
+	suite.Assertions.IsType(&movetaskorderops.MakeMoveTaskOrderAvailableOK{}, response)
 	suite.Equal(movePayload.ID, strfmt.UUID(move.ID.String()))
 	suite.NotNil(movePayload.AvailableToPrimeAt)
 }
@@ -193,7 +192,7 @@ func (suite *HandlerSuite) TestMakeMoveAvailableHandlerIntegrationSuccess() {
 func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	request := httptest.NewRequest("GET", "/move-task-orders/{moveTaskOrderID}", nil)
-	params := move_task_order.GetMoveTaskOrderParams{
+	params := movetaskorderops.GetMoveTaskOrderParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: move.ID.String(),
 	}
@@ -204,7 +203,7 @@ func (suite *HandlerSuite) TestGetMoveTaskOrder() {
 	}
 	response := handler.Handle(params)
 	suite.IsNotErrResponse(response)
-	suite.IsType(&move_task_order.GetMoveTaskOrderOK{}, response)
+	suite.IsType(&movetaskorderops.GetMoveTaskOrderOK{}, response)
 
 	moveResponse := response.(*movetaskorderops.GetMoveTaskOrderOK)
 	movePayload := moveResponse.Payload
@@ -352,7 +351,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 		// Now we'll try to approve this MTO and verify that it was successfully made available to the Prime
 		approvalRequest := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/available-to-prime", nil)
-		approvalParams := move_task_order.MakeMoveTaskOrderAvailableParams{
+		approvalParams := movetaskorderops.MakeMoveTaskOrderAvailableParams{
 			HTTPRequest:     approvalRequest,
 			MoveTaskOrderID: createdMTO.ID.String(),
 			IfMatch:         createdMTO.ETag,
@@ -370,7 +369,7 @@ func (suite *HandlerSuite) TestCreateMoveTaskOrderRequestHandler() {
 
 		// VERIFY RESULTS
 		suite.IsNotErrResponse(approvalResponse)
-		suite.Assertions.IsType(&move_task_order.MakeMoveTaskOrderAvailableOK{}, approvalResponse)
+		suite.Assertions.IsType(&movetaskorderops.MakeMoveTaskOrderAvailableOK{}, approvalResponse)
 		approvalOKResponse := approvalResponse.(*movetaskorderops.MakeMoveTaskOrderAvailableOK)
 		approvedMTO := approvalOKResponse.Payload
 

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -4,32 +4,26 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
-	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
-	internalmovetaskorder "github.com/transcom/mymove/pkg/services/support/move_task_order"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/services/query"
-	supportMocks "github.com/transcom/mymove/pkg/services/support/mocks"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/gen/supportmessages"
-
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/move_task_order"
+	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/query"
+	supportMocks "github.com/transcom/mymove/pkg/services/support/mocks"
+	internalmovetaskorder "github.com/transcom/mymove/pkg/services/support/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_service_item"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/handlers/supportapi/mto_service_item.go
+++ b/pkg/handlers/supportapi/mto_service_item.go
@@ -11,11 +11,9 @@ import (
 	mtoserviceitemops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_service_item"
 	"github.com/transcom/mymove/pkg/models"
 
-	//"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/services"
-	//"go.uber.org/zap"
 )
 
 // UpdateMTOServiceItemStatusHandler patches shipments

--- a/pkg/handlers/supportapi/mto_service_item_test.go
+++ b/pkg/handlers/supportapi/mto_service_item_test.go
@@ -12,20 +12,16 @@ package supportapi
 import (
 	"net/http/httptest"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
-	"github.com/transcom/mymove/pkg/gen/supportmessages"
-
-	"github.com/transcom/mymove/pkg/models"
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
 	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	mtoserviceitemop "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_service_item"
+	"github.com/transcom/mymove/pkg/gen/supportmessages"
+	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
+	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/handlers/supportapi/mto_shipment.go
+++ b/pkg/handlers/supportapi/mto_shipment.go
@@ -1,22 +1,18 @@
 package supportapi
 
 import (
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/models"
-	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
-
-	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
-
-	"github.com/go-openapi/runtime/middleware"
-
 	mtoshipmentops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/mto_shipment"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 )
 
 // UpdateMTOShipmentStatusHandlerFunc updates the status of a MTO Shipment

--- a/pkg/handlers/supportapi/mto_shipment_test.go
+++ b/pkg/handlers/supportapi/mto_shipment_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -20,6 +18,7 @@ import (
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/fetch"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/handlers/supportapi/payment_request.go
+++ b/pkg/handlers/supportapi/payment_request.go
@@ -5,18 +5,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/spf13/viper"
-
-	"github.com/transcom/mymove/pkg/cli"
-	"github.com/transcom/mymove/pkg/services/invoice"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/cli"
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/payment_request"
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -24,6 +20,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/event"
+	"github.com/transcom/mymove/pkg/services/invoice"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 )
 

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -16,30 +16,26 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/go-openapi/strfmt"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/trace"
-
 	"github.com/transcom/mymove/pkg/db/sequence"
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/etag"
+	paymentrequestop "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/payment_request"
+	supportmessages "github.com/transcom/mymove/pkg/gen/supportmessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/invoice"
-	"github.com/transcom/mymove/pkg/services/query"
-	"github.com/transcom/mymove/pkg/unit"
-
-	supportmessages "github.com/transcom/mymove/pkg/gen/supportmessages"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/mock"
-
-	paymentrequestop "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/payment_request"
-	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/trace"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {

--- a/pkg/handlers/supportapi/webhook_notification.go
+++ b/pkg/handlers/supportapi/webhook_notification.go
@@ -6,12 +6,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/gen/supportmessages"
-	"github.com/transcom/mymove/pkg/services/event"
-
 	webhookops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/webhook"
+	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/supportapi/internal/payloads"
+	"github.com/transcom/mymove/pkg/services/event"
 )
 
 // ReceiveWebhookNotificationHandler passes through a message

--- a/pkg/handlers/supportapi/webhook_notification_test.go
+++ b/pkg/handlers/supportapi/webhook_notification_test.go
@@ -3,17 +3,15 @@ package supportapi
 import (
 	"net/http/httptest"
 
-	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/services/event"
-	"github.com/transcom/mymove/pkg/trace"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 
 	webhookops "github.com/transcom/mymove/pkg/gen/supportapi/supportoperations/webhook"
 	supportmessages "github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/services/event"
+	"github.com/transcom/mymove/pkg/trace"
 )
 
 func (suite *HandlerSuite) TestCreateWebhookNotification() {

--- a/pkg/iampostgres/iampostgres.go
+++ b/pkg/iampostgres/iampostgres.go
@@ -15,9 +15,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/jmoiron/sqlx"
-	"go.uber.org/zap"
-
 	pg "github.com/lib/pq"
+	"go.uber.org/zap"
 )
 
 type config struct {

--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 

--- a/pkg/iws/rbs_person_lookup.go
+++ b/pkg/iws/rbs_person_lookup.go
@@ -124,7 +124,6 @@ func NewRBSPersonLookup(host string, dodCACertPackage string, certString string,
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
 	}
-	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 
 	return &RBSPersonLookup{

--- a/pkg/middleware/openapi.go
+++ b/pkg/middleware/openapi.go
@@ -3,11 +3,10 @@ package middleware
 import (
 	"net/http"
 
-	sdktrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/trussworks/otelhttp"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	sdktrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/transcom/mymove/pkg/audit"
 	"github.com/transcom/mymove/pkg/logging"

--- a/pkg/middleware/request_logger.go
+++ b/pkg/middleware/request_logger.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/felixge/httpsnoop"
 	"github.com/gofrs/uuid"
-
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"

--- a/pkg/middleware/trace.go
+++ b/pkg/middleware/trace.go
@@ -4,11 +4,10 @@ import (
 	"net/http"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-
-	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/trace"

--- a/pkg/migrate/ListFiles.go
+++ b/pkg/migrate/ListFiles.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/afero"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/spf13/afero"
 )
 
 // FileHelper is an afero filesystem struct

--- a/pkg/migrate/ListFiles_test.go
+++ b/pkg/migrate/ListFiles_test.go
@@ -6,10 +6,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/migrate/ReadInSQL_test.go
+++ b/pkg/migrate/ReadInSQL_test.go
@@ -14,9 +14,8 @@ import (
 	"os"
 	"testing"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestReadInSQLLine(t *testing.T) {

--- a/pkg/models/duty_location.go
+++ b/pkg/models/duty_location.go
@@ -4,12 +4,11 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )

--- a/pkg/models/edi_errors_test.go
+++ b/pkg/models/edi_errors_test.go
@@ -2,10 +2,9 @@ package models_test
 
 import (
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/gofrs/uuid"
 )
 
 func (suite *ModelSuite) TestEdiErrors() {

--- a/pkg/models/edi_processing.go
+++ b/pkg/models/edi_processing.go
@@ -6,9 +6,8 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
-	"go.uber.org/zap/zapcore"
-
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap/zapcore"
 )
 
 // EDIProcessing represents an email sent to a service member

--- a/pkg/models/evaluation_report.go
+++ b/pkg/models/evaluation_report.go
@@ -3,11 +3,9 @@ package models
 import (
 	"time"
 
-	"github.com/gobuffalo/validate/v3/validators"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
-
+	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
 )
 

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
-
 	"github.com/gofrs/uuid"
 )
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
-	"github.com/transcom/mymove/pkg/random"
-
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
@@ -19,6 +15,8 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/db/dberr"
+	"github.com/transcom/mymove/pkg/db/utilities"
+	"github.com/transcom/mymove/pkg/random"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/move_document.go
+++ b/pkg/models/move_document.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"

--- a/pkg/models/move_document_test.go
+++ b/pkg/models/move_document_test.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/transcom/mymove/pkg/auth"
 	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestBasicMoveDocumentInstantiation() {

--- a/pkg/models/move_document_test.go
+++ b/pkg/models/move_document_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -13,7 +12,7 @@ import (
 )
 
 func (suite *ModelSuite) TestBasicMoveDocumentInstantiation() {
-	moveDoc := &models.MoveDocument{}
+	moveDoc := &MoveDocument{}
 
 	expErrors := map[string][]string{
 		"document_id":        {"DocumentID can not be blank."},
@@ -32,14 +31,14 @@ func (suite *ModelSuite) TestFetchApprovedMovingExpenseDocuments() {
 	sm := ppm.Move.Orders.ServiceMember
 
 	assertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   "OK",
 			MoveDocumentType:         "EXPENSE",
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
@@ -50,7 +49,7 @@ func (suite *ModelSuite) TestFetchApprovedMovingExpenseDocuments() {
 
 	deletedAt := time.Date(2019, 8, 7, 0, 0, 0, 0, time.UTC)
 	deleteAssertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
@@ -58,7 +57,7 @@ func (suite *ModelSuite) TestFetchApprovedMovingExpenseDocuments() {
 			MoveDocumentType:         "EXPENSE",
 			DeletedAt:                &deletedAt,
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 			DeletedAt:       &deletedAt,
@@ -120,15 +119,15 @@ func (suite *ModelSuite) TestFetchMovingExpenseDocumentsStorageExpense() {
 	start := time.Date(2016, 01, 01, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2016, 01, 16, 0, 0, 0, 0, time.UTC)
 	storageExpense := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   "OK",
 			MoveDocumentType:         "EXPENSE",
 		},
-		MovingExpenseDocument: models.MovingExpenseDocument{
-			MovingExpenseType:    models.MovingExpenseTypeSTORAGE,
+		MovingExpenseDocument: MovingExpenseDocument{
+			MovingExpenseType:    MovingExpenseTypeSTORAGE,
 			RequestedAmountCents: 100,
 			PaymentMethod:        "GTCC",
 			ReceiptMissing:       false,
@@ -160,28 +159,28 @@ func (suite *ModelSuite) TestFetchMovingExpenseDocuments() {
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	sm := ppm.Move.Orders.ServiceMember
 	awaitingReview := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   MoveDocumentStatusAWAITINGREVIEW,
 			MoveDocumentType:         "EXPENSE",
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
 	}
 	status := MoveDocumentStatusOK
 	ok := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   status,
 			MoveDocumentType:         "EXPENSE",
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
@@ -248,11 +247,11 @@ func (suite *ModelSuite) TestFetchMoveDocument() {
 	sm := move.Orders.ServiceMember
 
 	moveDocument := testdatagen.MakeMoveDocument(suite.DB(), testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID: move.ID,
 			Move:   move,
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
@@ -296,11 +295,11 @@ func (suite *ModelSuite) TestMoveDocumentStatuses() {
 	sm := move.Orders.ServiceMember
 
 	moveDocument := testdatagen.MakeMoveDocument(suite.DB(), testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID: move.ID,
 			Move:   move,
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
@@ -346,14 +345,14 @@ func (suite *ModelSuite) TestDeleteMoveDocument() {
 	sm := ppm.Move.Orders.ServiceMember
 
 	assertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   "OK",
 			MoveDocumentType:         "EXPENSE",
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -71,7 +70,7 @@ func (suite *ModelSuite) TestGenerateReferenceID() {
 
 func (suite *ModelSuite) TestFetchMove() {
 
-	setupTestData := func() (*auth.Session, models.Order) {
+	setupTestData := func() (*auth.Session, Order) {
 
 		order := testdatagen.MakeDefaultOrder(suite.DB())
 		testdatagen.MakeDefaultContractor(suite.DB())
@@ -168,7 +167,7 @@ func (suite *ModelSuite) TestFetchMove() {
 		session, order := setupTestData()
 		// Create a hidden move
 		hiddenMove := testdatagen.MakeHiddenHHGMoveWithShipment(suite.DB(), testdatagen.Assertions{
-			Order: models.Order{
+			Order: Order{
 				ID: order.ID,
 			},
 		})

--- a/pkg/models/mto_service_item_dimensions.go
+++ b/pkg/models/mto_service_item_dimensions.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // DimensionType determines what type of dimension for a service item

--- a/pkg/models/mto_service_item_dimensions_test.go
+++ b/pkg/models/mto_service_item_dimensions_test.go
@@ -1,11 +1,10 @@
 package models_test
 
 import (
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) TestMTOServiceItemDimension() {

--- a/pkg/models/notifications.go
+++ b/pkg/models/notifications.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
-
 	"github.com/gofrs/uuid"
 )
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -3,8 +3,6 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
@@ -12,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 

--- a/pkg/models/payment_service_item.go
+++ b/pkg/models/payment_service_item.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // PaymentServiceItemStatus is a type of Payment Service Item Status

--- a/pkg/models/payment_service_item_test.go
+++ b/pkg/models/payment_service_item_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) TestPaymentServiceItemValidation() {

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
-
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -101,14 +100,14 @@ func (suite *ModelSuite) TestFetchMoveDocumentsForTypes() {
 	sm := ppm.Move.Orders.ServiceMember
 
 	assertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
 			Status:                   "OK",
 			MoveDocumentType:         "EXPENSE",
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 		},
@@ -119,7 +118,7 @@ func (suite *ModelSuite) TestFetchMoveDocumentsForTypes() {
 
 	deletedAt := time.Date(2019, 8, 7, 0, 0, 0, 0, time.UTC)
 	deleteAssertions := testdatagen.Assertions{
-		MoveDocument: models.MoveDocument{
+		MoveDocument: MoveDocument{
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
@@ -127,7 +126,7 @@ func (suite *ModelSuite) TestFetchMoveDocumentsForTypes() {
 			MoveDocumentType:         "EXPENSE",
 			DeletedAt:                &deletedAt,
 		},
-		Document: models.Document{
+		Document: Document{
 			ServiceMemberID: sm.ID,
 			ServiceMember:   sm,
 			DeletedAt:       &deletedAt,

--- a/pkg/models/ppm_shipment.go
+++ b/pkg/models/ppm_shipment.go
@@ -4,12 +4,11 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/prime_upload_test.go
+++ b/pkg/models/prime_upload_test.go
@@ -1,13 +1,12 @@
 package models_test
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/db/dberr"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
-	"github.com/gofrs/uuid"
 )
 
 func (suite *ModelSuite) Test_PrimeUploadCreate() {

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -15,7 +14,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: orders,
-		Move: models.Move{
+		Move: Move{
 			ID:   uuid.FromStringOrNil("7024c8c5-52ca-4639-bf69-dd8238308c98"),
 			Show: swag.Bool(true),
 		},
@@ -23,7 +22,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMShow() {
 
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
 		ServiceMember: move.Orders.ServiceMember,
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
+		PersonallyProcuredMove: PersonallyProcuredMove{
 			Move:   move,
 			MoveID: move.ID,
 		},
@@ -40,7 +39,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 		Order: orders,
-		Move: models.Move{
+		Move: Move{
 			ID:   uuid.FromStringOrNil("7024c8c5-52ca-4639-bf69-dd8238308c98"),
 			Show: swag.Bool(false),
 		},
@@ -48,7 +47,7 @@ func (suite *ModelSuite) TestCreateMoveWithPPMNoShow() {
 
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
 		ServiceMember: move.Orders.ServiceMember,
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
+		PersonallyProcuredMove: PersonallyProcuredMove{
 			Move:   move,
 			MoveID: move.ID,
 		},
@@ -78,16 +77,16 @@ func (suite *ModelSuite) TestCreateNewMoveWithNoPPMShow() {
 
 func (suite *ModelSuite) TestShowPPMQueue() {
 	all := map[string]bool{
-		string(models.PPMStatusAPPROVED):         true,
-		string(models.PPMStatusPAYMENTREQUESTED): true,
-		string(models.PPMStatusCOMPLETED):        true,
-		string(models.PPMStatusSUBMITTED):        true,
-		string(models.PPMStatusDRAFT):            true,
+		string(PPMStatusAPPROVED):         true,
+		string(PPMStatusPAYMENTREQUESTED): true,
+		string(PPMStatusCOMPLETED):        true,
+		string(PPMStatusSUBMITTED):        true,
+		string(PPMStatusDRAFT):            true,
 	}
 
 	new := map[string]bool{
-		string(models.PPMStatusSUBMITTED): true,
-		string(models.PPMStatusDRAFT):     true,
+		string(PPMStatusSUBMITTED): true,
+		string(PPMStatusDRAFT):     true,
 	}
 
 	tests := []struct {
@@ -96,39 +95,39 @@ func (suite *ModelSuite) TestShowPPMQueue() {
 		want       map[string]bool
 	}{
 		{input: "new", movesCount: 2, want: new},
-		{input: "ppm_payment_requested", movesCount: 1, want: map[string]bool{string(models.PPMStatusPAYMENTREQUESTED): true}},
-		{input: "ppm_completed", movesCount: 1, want: map[string]bool{string(models.PPMStatusCOMPLETED): true}},
-		{input: "ppm_approved", movesCount: 1, want: map[string]bool{string(models.PPMStatusAPPROVED): true}},
+		{input: "ppm_payment_requested", movesCount: 1, want: map[string]bool{string(PPMStatusPAYMENTREQUESTED): true}},
+		{input: "ppm_completed", movesCount: 1, want: map[string]bool{string(PPMStatusCOMPLETED): true}},
+		{input: "ppm_approved", movesCount: 1, want: map[string]bool{string(PPMStatusAPPROVED): true}},
 		{input: "all", movesCount: 5, want: all},
 	}
 
 	// Make PPMs with different statuses
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			Status: models.PPMStatusAPPROVED,
+		PersonallyProcuredMove: PersonallyProcuredMove{
+			Status: PPMStatusAPPROVED,
 		},
 	})
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			Status: models.PPMStatusPAYMENTREQUESTED,
+		PersonallyProcuredMove: PersonallyProcuredMove{
+			Status: PPMStatusPAYMENTREQUESTED,
 		},
 	})
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			Status: models.PPMStatusCOMPLETED,
+		PersonallyProcuredMove: PersonallyProcuredMove{
+			Status: PPMStatusCOMPLETED,
 		},
 	})
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusSUBMITTED,
+		Move: Move{
+			Status: MoveStatusSUBMITTED,
 		},
 	})
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusAPPROVED,
+		Move: Move{
+			Status: MoveStatusAPPROVED,
 		},
-		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			Status: models.PPMStatusSUBMITTED,
+		PersonallyProcuredMove: PersonallyProcuredMove{
+			Status: PPMStatusSUBMITTED,
 		},
 	})
 

--- a/pkg/models/re_domestic_accessorial_price.go
+++ b/pkg/models/re_domestic_accessorial_price.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // ReDomesticAccessorialPrice model struct

--- a/pkg/models/re_domestic_accessorial_price_test.go
+++ b/pkg/models/re_domestic_accessorial_price_test.go
@@ -1,11 +1,10 @@
 package models_test
 
 import (
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) TestReDomesticAccessorialPriceValidation() {

--- a/pkg/models/re_intl_accessorial_price.go
+++ b/pkg/models/re_intl_accessorial_price.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 //Market represents the market for an international move

--- a/pkg/models/re_intl_other_price.go
+++ b/pkg/models/re_intl_other_price.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // ReIntlOtherPrice is the ghc rate engine international price

--- a/pkg/models/re_intl_price.go
+++ b/pkg/models/re_intl_price.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // ReIntlPrice is the ghc rate engine international price

--- a/pkg/models/re_task_order_fee.go
+++ b/pkg/models/re_task_order_fee.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // ReTaskOrderFee model struct

--- a/pkg/models/service_item_param_key.go
+++ b/pkg/models/service_item_param_key.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
-
 	"github.com/gofrs/uuid"
 )
 

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-	"github.com/transcom/mymove/pkg/models"
 
 	"github.com/transcom/mymove/pkg/auth"
 	. "github.com/transcom/mymove/pkg/models"
@@ -151,7 +150,7 @@ func (suite *ModelSuite) TestFetchServiceMemberNotForUser() {
 }
 
 func (suite *ModelSuite) TestFetchLatestOrders() {
-	setupTestData := func() (models.Order, *auth.Session) {
+	setupTestData := func() (Order, *auth.Session) {
 
 		user := testdatagen.MakeDefaultUser(suite.DB())
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -12,16 +12,14 @@ package models_test
 import (
 	"time"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {

--- a/pkg/models/signed_certification.go
+++ b/pkg/models/signed_certification.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-
-	"github.com/transcom/mymove/pkg/auth"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/auth"
 )
 
 // SignedCertificationType represents the types of certificates

--- a/pkg/models/sit_extension.go
+++ b/pkg/models/sit_extension.go
@@ -3,11 +3,10 @@ package models
 import (
 	"time"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
 )
 
 // SITExtensionRequestReason type for SIT Extension Request Reason

--- a/pkg/models/sit_extension_test.go
+++ b/pkg/models/sit_extension_test.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestSITExtensionCreation() {

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -1,9 +1,9 @@
 package models_test
 
 import (
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *ModelSuite) Test_ValidateUpload() {

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -1,11 +1,8 @@
 package models
 
 import (
-	"time"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
 	"strings"
+	"time"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
@@ -14,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/models/roles"
 )
 
 // User is an entity with a registered uuid and email at login.gov

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,15 +1,13 @@
 package models_test
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/jackc/pgerrcode"
 
-	"github.com/transcom/mymove/pkg/db/dberr"
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/db/dberr"
 	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	userroles "github.com/transcom/mymove/pkg/services/users_roles"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/models/user_upload_test.go
+++ b/pkg/models/user_upload_test.go
@@ -1,14 +1,13 @@
 package models_test
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/jackc/pgerrcode"
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/db/dberr"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
-	"github.com/gofrs/uuid"
 )
 
 func (suite *ModelSuite) Test_UserUploadCreate() {

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -5,17 +5,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
-	"github.com/gofrs/uuid"
-
+	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
+	"github.com/gofrs/uuid"
 	"github.com/rickar/cal/v2"
 
-	"github.com/gobuffalo/pop/v6"
-
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/validators_test.go
+++ b/pkg/models/validators_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/transcom/mymove/pkg/gen/primemessages"
-
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/gobuffalo/validate/v3"
-
 	"github.com/transcom/mymove/pkg/dates"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -3,15 +3,14 @@ package models
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/auth"
-
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gobuffalo/validate/v3/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // WeightTicketSetType represents types of weight ticket sets

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -6,15 +6,13 @@ import (
 	html "html/template"
 	text "text/template"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/assets"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/assets"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 var (

--- a/pkg/notifications/move_reviewed.go
+++ b/pkg/notifications/move_reviewed.go
@@ -7,14 +7,12 @@ import (
 	text "text/template"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/assets"
-
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/assets"
+	"github.com/transcom/mymove/pkg/models"
 )
 
 const surveyLink = "https://www.surveymonkey.com/r/MilMovePt3-08191"

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -7,7 +7,6 @@ import (
 	text "text/template"
 
 	"github.com/dustin/go-humanize"
-
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 

--- a/pkg/notifications/notification_stub.go
+++ b/pkg/notifications/notification_stub.go
@@ -2,10 +2,9 @@ package notifications
 
 import (
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-
-	"go.uber.org/zap"
 )
 
 // StubNotificationSender mocks an SES client for local usage

--- a/pkg/notifications/user_account_modified.go
+++ b/pkg/notifications/user_account_modified.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/assets"
 )
 

--- a/pkg/notifications/user_account_modified_test.go
+++ b/pkg/notifications/user_account_modified_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -5,13 +5,10 @@ import (
 	"time"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/route"
-
-	"github.com/transcom/mymove/pkg/rateengine"
-
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/rateengine"
+	"github.com/transcom/mymove/pkg/route"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 type ppmComputer interface {

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -8,10 +8,9 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/route/mocks"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
+	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/parser/transittime/parse_transit_times.go
+++ b/pkg/parser/transittime/parse_transit_times.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/payment_request/service_param_value_lookups/contract_code_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/contract_code_lookup_test.go
@@ -3,10 +3,9 @@ package serviceparamvaluelookups
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ServiceParamValueLookupsSuite) TestContractCodeLookup() {

--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/payment_request/service_param_value_lookups/distance_zip_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip_lookup_test.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/route/mocks"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/payment_request/service_param_value_lookups/eia_fuel_price_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/eia_fuel_price_lookup.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/payment_request/service_param_value_lookups/mto_available_to_prime_at_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/mto_available_to_prime_at_lookup_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/route/mocks"

--- a/pkg/payment_request/service_param_value_lookups/service_params_cache.go
+++ b/pkg/payment_request/service_param_value_lookups/service_params_cache.go
@@ -3,10 +3,10 @@ package serviceparamvaluelookups
 import (
 	"fmt"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/gofrs/uuid"
 )
 
 /*

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -3,12 +3,11 @@ package rateengine
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/route/dtod_zip5_distance.go
+++ b/pkg/route/dtod_zip5_distance.go
@@ -37,9 +37,8 @@ The Request to DTOD using the service ProcessRequest which looks like
 import (
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/tiaguinho/gosoap"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	idleTimeout   = 120 * time.Second // 2 minutes
-	maxHeaderSize = 1 * 1000 * 1000   // 1 Megabyte
+	idleTimeout       = 120 * time.Second // 2 minutes
+	readHeaderTimeout = 60 * time.Second  // 1 minute
+	maxHeaderSize     = 1 * 1000 * 1000   // 1 Megabyte
 )
 
 // ErrMissingCACert represents an error caused by server config that requires
@@ -141,23 +142,18 @@ func CreateNamedServer(input *CreateNamedServerInput) (*NamedServer, error) {
 			NextProtos:               []string{"h2"},
 			PreferServerCipherSuites: true,
 		}
-
-		// Map certificates with the CommonName / DNSNames to support
-		// Server Name Indication (SNI). In other words this will tell
-		// the TLS listener to sever the appropriate certificate matching
-		// the requested hostname.
-		tlsConfig.BuildNameToCertificate()
 	}
 
 	srv := &NamedServer{
 		Name: input.Name,
 		Server: &http.Server{
-			Addr:           address,
-			ErrorLog:       newStandardLogger(input.Logger),
-			Handler:        input.HTTPHandler,
-			IdleTimeout:    idleTimeout,
-			MaxHeaderBytes: maxHeaderSize,
-			TLSConfig:      tlsConfig,
+			Addr:              address,
+			ErrorLog:          newStandardLogger(input.Logger),
+			Handler:           input.HTTPHandler,
+			IdleTimeout:       idleTimeout,
+			MaxHeaderBytes:    maxHeaderSize,
+			ReadHeaderTimeout: readHeaderTimeout,
+			TLSConfig:         tlsConfig,
 		},
 	}
 	return srv, nil

--- a/pkg/services/admin_user/admin_user_creator.go
+++ b/pkg/services/admin_user/admin_user_creator.go
@@ -3,13 +3,12 @@ package adminuser
 import (
 	"strings"
 
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )

--- a/pkg/services/admin_user/admin_user_creator_test.go
+++ b/pkg/services/admin_user/admin_user_creator_test.go
@@ -4,18 +4,15 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/notifications/mocks"
-
-	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/notifications/mocks"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/admin_user/admin_user_fetcher_test.go
+++ b/pkg/services/admin_user/admin_user_fetcher_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/gobuffalo/validate/v3"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"

--- a/pkg/services/customer_support_remarks/customer_support_remarks_creator_test.go
+++ b/pkg/services/customer_support_remarks/customer_support_remarks_creator_test.go
@@ -2,7 +2,6 @@ package customersupportremarks
 
 import (
 	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/customer_support_remarks/customer_support_remarks_deleter.go
+++ b/pkg/services/customer_support_remarks/customer_support_remarks_deleter.go
@@ -7,11 +7,10 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/services/customer_support_remarks/customer_support_remarks_updater_test.go
+++ b/pkg/services/customer_support_remarks/customer_support_remarks_updater_test.go
@@ -4,12 +4,10 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/auth"
-
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/auth"
 	customersupportremarksop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/customer_support_remarks"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/evaluation_report/evaluation_report_creator_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_creator_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/evaluation_report/evaluation_report_deleter.go
+++ b/pkg/services/evaluation_report/evaluation_report_deleter.go
@@ -6,11 +6,10 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/services/evaluation_report/evaluation_report_fetcher.go
+++ b/pkg/services/evaluation_report/evaluation_report_fetcher.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/evaluation_report/evaluation_report_fetcher_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_fetcher_test.go
@@ -3,11 +3,10 @@ package evaluationreport
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/evaluation_report/evaluation_report_updater.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 type evaluationReportUpdater struct {

--- a/pkg/services/evaluation_report/evaluation_report_updater_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater_test.go
@@ -3,11 +3,10 @@ package evaluationreport
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/event/event.go
+++ b/pkg/services/event/event.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/event/event_test.go
+++ b/pkg/services/event/event_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 type EventServiceSuite struct {

--- a/pkg/services/fuelprice/diesel_fuel_price_storer.go
+++ b/pkg/services/fuelprice/diesel_fuel_price_storer.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-
-	"go.uber.org/zap"
-
 	"math"
 	"net/http"
 	"net/url"
@@ -17,6 +14,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/dates"

--- a/pkg/services/ghcimport/import_re_intl_prices.go
+++ b/pkg/services/ghcimport/import_re_intl_prices.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (gre *GHCRateEngineImporter) importREInternationalPrices(appCtx appcontext.AppContext) error {

--- a/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_destination_pricer_test.go
@@ -4,11 +4,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 const (

--- a/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_linehaul_pricer.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ghcrateengine/domestic_nts_pack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_nts_pack_pricer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ghcrateengine/domestic_origin_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer.go
@@ -5,11 +5,10 @@ import (
 	"math"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_origin_pricer_test.go
@@ -4,11 +4,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 const (

--- a/pkg/services/ghcrateengine/domestic_pack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_pack_pricer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer_test.go
@@ -4,11 +4,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 const (

--- a/pkg/services/ghcrateengine/domestic_unpack_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_unpack_pricer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ghcrateengine/fuel_surcharge_pricer.go
+++ b/pkg/services/ghcrateengine/fuel_surcharge_pricer.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/appcontext"

--- a/pkg/services/ghcrateengine/pricer_helpers.go
+++ b/pkg/services/ghcrateengine/pricer_helpers.go
@@ -8,9 +8,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/invoice/gex_sender_http_test.go
+++ b/pkg/services/invoice/gex_sender_http_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testingsuite"
-
-	"github.com/stretchr/testify/suite"
 )
 
 type GexSuite struct {

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator.go
@@ -9,15 +9,13 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/sequence"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services"
-
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	edisegment "github.com/transcom/mymove/pkg/edi/segment"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 /*

--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/db/sequence"
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	edisegment "github.com/transcom/mymove/pkg/edi/segment"

--- a/pkg/services/invoice/process_edi824.go
+++ b/pkg/services/invoice/process_edi824.go
@@ -10,7 +10,6 @@ import (
 	"github.com/transcom/mymove/pkg/apperror"
 	ediResponse824 "github.com/transcom/mymove/pkg/edi/edi824"
 	edisegment "github.com/transcom/mymove/pkg/edi/segment"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/invoice/process_edi824_test.go
+++ b/pkg/services/invoice/process_edi824_test.go
@@ -10,7 +10,6 @@ import (
 	ediResponse824 "github.com/transcom/mymove/pkg/edi/edi824"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 

--- a/pkg/services/invoice/process_edi997.go
+++ b/pkg/services/invoice/process_edi997.go
@@ -7,9 +7,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	edisegment "github.com/transcom/mymove/pkg/edi/segment"
-
 	ediResponse997 "github.com/transcom/mymove/pkg/edi/edi997"
+	edisegment "github.com/transcom/mymove/pkg/edi/segment"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/invoice/process_edi997_test.go
+++ b/pkg/services/invoice/process_edi997_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 

--- a/pkg/services/invoice/syncada_sftp_reader.go
+++ b/pkg/services/invoice/syncada_sftp_reader.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/pkg/sftp"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/services/invoice/syncada_sftp_reader_test.go
+++ b/pkg/services/invoice/syncada_sftp_reader_test.go
@@ -8,12 +8,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
-
-	"github.com/stretchr/testify/suite"
-
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 

--- a/pkg/services/move/excess_weight_uploader.go
+++ b/pkg/services/move/excess_weight_uploader.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move/excess_weight_uploader_test.go
+++ b/pkg/services/move/excess_weight_uploader_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/upload"
 	"github.com/transcom/mymove/pkg/storage/test"

--- a/pkg/services/move/financial_review_flag_setter.go
+++ b/pkg/services/move/financial_review_flag_setter.go
@@ -3,16 +3,14 @@ package move
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 type financialReviewFlagSetter struct {

--- a/pkg/services/move/financial_review_flag_setter_test.go
+++ b/pkg/services/move/financial_review_flag_setter_test.go
@@ -4,13 +4,10 @@ import (
 	"errors"
 
 	"github.com/go-openapi/swag"
-
-	"github.com/transcom/mymove/pkg/etag"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -7,13 +7,11 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/pkg/errors"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-	"github.com/transcom/mymove/pkg/uploader"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *MoveServiceSuite) TestMoveApproval() {

--- a/pkg/services/move/move_searcher_test.go
+++ b/pkg/services/move/move_searcher_test.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/go-openapi/swag"
 
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/move/move_weights.go
+++ b/pkg/services/move/move_weights.go
@@ -8,9 +8,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move/move_weights_test.go
+++ b/pkg/services/move/move_weights_test.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
-
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/move/validation.go
+++ b/pkg/services/move/validation.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/move_document.go
+++ b/pkg/services/move_document.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/move_documents/generic_move_document_updater.go
+++ b/pkg/services/move_documents/generic_move_document_updater.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/move_documents/move_document_updater.go
+++ b/pkg/services/move_documents/move_document_updater.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move_documents/ppm_completer.go
+++ b/pkg/services/move_documents/ppm_completer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/move_documents/storage_expense_updater.go
+++ b/pkg/services/move_documents/storage_expense_updater.go
@@ -3,12 +3,11 @@ package movedocument
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/move_documents/weight_ticket_updater.go
+++ b/pkg/services/move_documents/weight_ticket_updater.go
@@ -3,12 +3,11 @@ package movedocument
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/move_history/move_history_fetcher_test.go
+++ b/pkg/services/move_history/move_history_fetcher_test.go
@@ -10,20 +10,18 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/services/reweigh"
-
-	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/services/reweigh"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
-
-	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 )
 
 func (suite *MoveHistoryServiceSuite) TestMoveFetcher() {

--- a/pkg/services/move_task_order/move_task_order_checker.go
+++ b/pkg/services/move_task_order/move_task_order_checker.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move_task_order/move_task_order_checker_test.go
+++ b/pkg/services/move_task_order/move_task_order_checker_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
-
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/move_task_order/move_task_order_hide_non_fake.go
+++ b/pkg/services/move_task_order/move_task_order_hide_non_fake.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/go-openapi/swag"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/move_task_order/move_task_order_updater.go
+++ b/pkg/services/move_task_order/move_task_order_updater.go
@@ -4,17 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
-
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/order"

--- a/pkg/services/move_task_order/move_task_order_updater_test.go
+++ b/pkg/services/move_task_order/move_task_order_updater_test.go
@@ -5,17 +5,14 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
-
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/services/mocks"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/mocks"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	. "github.com/transcom/mymove/pkg/services/move_task_order"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/mto_agent/mto_agent_creator.go
+++ b/pkg/services/mto_agent/mto_agent_creator.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_agent/mto_agent_creator_test.go
+++ b/pkg/services/mto_agent/mto_agent_creator_test.go
@@ -5,9 +5,8 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/mto_agent/mto_agent_updater_test.go
+++ b/pkg/services/mto_agent/mto_agent_updater_test.go
@@ -5,10 +5,8 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/etag"
-
+	"github.com/transcom/mymove/pkg/models"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/mto_agent/rules.go
+++ b/pkg/services/mto_agent/rules.go
@@ -6,9 +6,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_agent/rules_test.go
+++ b/pkg/services/mto_agent/rules_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_agent/validation.go
+++ b/pkg/services/mto_agent/validation.go
@@ -3,9 +3,8 @@ package mtoagent
 import (
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_agent/validation_test.go
+++ b/pkg/services/mto_agent/validation_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -9,9 +9,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -14,21 +14,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/services/query"
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/gobuffalo/validate/v3"
-
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 type testCreateMTOServiceItemQueryBuilder struct {

--- a/pkg/services/mto_service_item/mto_service_item_updater.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -12,25 +12,20 @@ package mtoserviceitem
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-	"github.com/transcom/mymove/pkg/uploader"
-
-	"github.com/transcom/mymove/pkg/handlers"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/swag"
-
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/services/query"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *MTOServiceItemServiceSuite) TestMTOServiceItemUpdater() {

--- a/pkg/services/mto_service_item/mto_service_item_validators.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_service_item/mto_service_item_validators_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_validators_test.go
@@ -5,15 +5,13 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-
-	"github.com/gobuffalo/validate/v3"
-
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/mto_service_item/validation.go
+++ b/pkg/services/mto_service_item/validation.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/mto_shipment/mto_shipment_address_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_address_updater.go
@@ -4,13 +4,11 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/mto_shipment_fetcher.go
+++ b/pkg/services/mto_shipment/mto_shipment_fetcher.go
@@ -3,13 +3,11 @@ package mtoshipment
 import (
 	"database/sql"
 
-	"github.com/transcom/mymove/pkg/db/utilities"
-
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	weightticket "github.com/transcom/mymove/pkg/services/weight_ticket"

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/getlantern/deepcopy"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/route"

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -4,24 +4,20 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	notificationMocks "github.com/transcom/mymove/pkg/notifications/mocks"
 	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/fetch"
-
 	mockservices "github.com/transcom/mymove/pkg/services/mocks"
 	moveservices "github.com/transcom/mymove/pkg/services/move"
 	mtoserviceitem "github.com/transcom/mymove/pkg/services/mto_service_item"
-
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/mto_shipment/shipment_approver.go
+++ b/pkg/services/mto_shipment/shipment_approver.go
@@ -1,13 +1,11 @@
 package mtoshipment
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"

--- a/pkg/services/mto_shipment/shipment_approver_test.go
+++ b/pkg/services/mto_shipment/shipment_approver_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route/mocks"

--- a/pkg/services/mto_shipment/shipment_billable_weight.go
+++ b/pkg/services/mto_shipment/shipment_billable_weight.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/mto_shipment/shipment_billable_weight_test.go
+++ b/pkg/services/mto_shipment/shipment_billable_weight_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/mto_shipment/shipment_cancellation_requester.go
+++ b/pkg/services/mto_shipment/shipment_cancellation_requester.go
@@ -3,9 +3,8 @@ package mtoshipment
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/shipment_cancellation_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_cancellation_requester_test.go
@@ -3,12 +3,10 @@ package mtoshipment
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"

--- a/pkg/services/mto_shipment/shipment_deleter.go
+++ b/pkg/services/mto_shipment/shipment_deleter.go
@@ -4,9 +4,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/db/utilities"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_shipment/shipment_deleter_test.go
+++ b/pkg/services/mto_shipment/shipment_deleter_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/mto_shipment/shipment_diversion_approver.go
+++ b/pkg/services/mto_shipment/shipment_diversion_approver.go
@@ -3,9 +3,8 @@ package mtoshipment
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/shipment_diversion_approver_test.go
+++ b/pkg/services/mto_shipment/shipment_diversion_approver_test.go
@@ -3,12 +3,10 @@ package mtoshipment
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"

--- a/pkg/services/mto_shipment/shipment_diversion_requester.go
+++ b/pkg/services/mto_shipment/shipment_diversion_requester.go
@@ -3,9 +3,8 @@ package mtoshipment
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/shipment_diversion_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_diversion_requester_test.go
@@ -3,12 +3,10 @@ package mtoshipment
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"

--- a/pkg/services/mto_shipment/shipment_rejecter.go
+++ b/pkg/services/mto_shipment/shipment_rejecter.go
@@ -3,9 +3,8 @@ package mtoshipment
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/shipment_rejecter_test.go
+++ b/pkg/services/mto_shipment/shipment_rejecter_test.go
@@ -3,12 +3,10 @@ package mtoshipment
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"

--- a/pkg/services/mto_shipment/shipment_reweigh_requester.go
+++ b/pkg/services/mto_shipment/shipment_reweigh_requester.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/mto_shipment/shipment_reweigh_requester_test.go
+++ b/pkg/services/mto_shipment/shipment_reweigh_requester_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/mto_shipment/sit_extension_approver.go
+++ b/pkg/services/mto_shipment/sit_extension_approver.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/sit_extension_approver_test.go
+++ b/pkg/services/mto_shipment/sit_extension_approver_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	moverouter "github.com/transcom/mymove/pkg/services/move"

--- a/pkg/services/mto_shipment/sit_extension_creator_as_too.go
+++ b/pkg/services/mto_shipment/sit_extension_creator_as_too.go
@@ -6,14 +6,12 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 type sitExtensionCreatorAsTOO struct {

--- a/pkg/services/mto_shipment/sit_extension_creator_as_too_test.go
+++ b/pkg/services/mto_shipment/sit_extension_creator_as_too_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/mto_shipment/sit_extension_denier.go
+++ b/pkg/services/mto_shipment/sit_extension_denier.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/mto_shipment/sit_extension_denier_test.go
+++ b/pkg/services/mto_shipment/sit_extension_denier_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	moverouter "github.com/transcom/mymove/pkg/services/move"

--- a/pkg/services/mto_shipment/validation.go
+++ b/pkg/services/mto_shipment/validation.go
@@ -3,14 +3,12 @@ package mtoshipment
 import (
 	"fmt"
 
-	"github.com/transcom/mymove/pkg/models/roles"
-
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 )
 
 type validator interface {

--- a/pkg/services/mto_shipment/validation_test.go
+++ b/pkg/services/mto_shipment/validation_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/auth"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/office_user/customer/customer.go
+++ b/pkg/services/office_user/customer/customer.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/office_user/customer/customer_updater_test.go
+++ b/pkg/services/office_user/customer/customer_updater_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/office_user/office_user_creator.go
+++ b/pkg/services/office_user/office_user_creator.go
@@ -3,13 +3,12 @@ package officeuser
 import (
 	"strings"
 
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )

--- a/pkg/services/office_user/office_user_creator_test.go
+++ b/pkg/services/office_user/office_user_creator_test.go
@@ -4,19 +4,15 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/transcom/mymove/pkg/notifications"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/notifications/mocks"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/auth"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/notifications/mocks"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/office_user/office_user_fetcher_test.go
+++ b/pkg/services/office_user/office_user_fetcher_test.go
@@ -4,17 +4,15 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/gobuffalo/validate/v3"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 type testOfficeUserQueryBuilder struct {

--- a/pkg/services/office_user/office_user_updater_test.go
+++ b/pkg/services/office_user/office_user_updater_test.go
@@ -4,14 +4,12 @@ import (
 	"database/sql"
 
 	"github.com/go-openapi/strfmt"
-
-	"github.com/transcom/mymove/pkg/services/query"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *OfficeUserServiceSuite) TestUpdateOfficeUser() {

--- a/pkg/services/order.go
+++ b/pkg/services/order.go
@@ -8,10 +8,9 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/storage"
-
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/storage"
 )
 
 // OrderFetcher is the service object interface for FetchOrder

--- a/pkg/services/order/excess_weight_risk_manager.go
+++ b/pkg/services/order/excess_weight_risk_manager.go
@@ -7,11 +7,9 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/order/excess_weight_risk_manager_test.go
+++ b/pkg/services/order/excess_weight_risk_manager_test.go
@@ -3,18 +3,15 @@ package order
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/uploader"
-
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *OrderServiceSuite) TestUpdateBillableWeightAsTOO() {

--- a/pkg/services/order/order_fetcher.go
+++ b/pkg/services/order/order_fetcher.go
@@ -10,9 +10,8 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/order/order_fetcher_test.go
+++ b/pkg/services/order/order_fetcher_test.go
@@ -6,9 +6,8 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/order/order_updater.go
+++ b/pkg/services/order/order_updater.go
@@ -10,9 +10,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/services/order/order_updater_test.go
+++ b/pkg/services/order/order_updater_test.go
@@ -4,22 +4,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/move"
-	"github.com/transcom/mymove/pkg/swagger/nullable"
-
 	"github.com/go-openapi/strfmt"
-
-	storageTest "github.com/transcom/mymove/pkg/storage/test"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/handlers"
-
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
+	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/move"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
+	"github.com/transcom/mymove/pkg/swagger/nullable"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/order/validation.go
+++ b/pkg/services/order/validation.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gobuffalo/validate/v3/validators"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/services/paperwork/form_creator_test.go
+++ b/pkg/services/paperwork/form_creator_test.go
@@ -12,19 +12,17 @@ package paperwork
 import (
 	"time"
 
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/services"
-	"github.com/transcom/mymove/pkg/services/paperwork/mocks"
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	paperworkforms "github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/services"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
+	"github.com/transcom/mymove/pkg/services/paperwork/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
 	serviceparamlookups "github.com/transcom/mymove/pkg/payment_request/service_param_value_lookups"

--- a/pkg/services/payment_request/payment_request_creator_test.go
+++ b/pkg/services/payment_request/payment_request_creator_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/services/ghcrateengine"
-
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
+	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/payment_request/payment_request_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_fetcher_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *PaymentRequestServiceSuite) TestFetchPaymentRequest() {

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -6,15 +6,13 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	officeuser "github.com/transcom/mymove/pkg/services/office_user"
-
-	"github.com/transcom/mymove/pkg/models"
 )
 
 type paymentRequestListFetcher struct {

--- a/pkg/services/payment_request/payment_request_list_fetcher_test.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/go-openapi/swag"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/payment_request/payment_request_recalculator.go
+++ b/pkg/services/payment_request/payment_request_recalculator.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/payment_request/payment_request_recalculator_test.go
+++ b/pkg/services/payment_request/payment_request_recalculator_test.go
@@ -12,13 +12,11 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/services/query"
-
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -10,13 +10,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services/invoice"
-
 	"github.com/transcom/mymove/pkg/db/sequence"
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/models"
 	paymentrequesthelper "github.com/transcom/mymove/pkg/payment_request"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/invoice"
 )
 
 //GexSendError is returned when there is an error sending an EDI to GEX

--- a/pkg/services/payment_request/payment_request_reviewed_processor_test.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor_test.go
@@ -11,18 +11,14 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/db/sequence"
 	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
-	"github.com/transcom/mymove/pkg/services"
-
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/services/invoice"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/invoice"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/payment_request/payment_request_service_test.go
+++ b/pkg/services/payment_request/payment_request_service_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/testingsuite"

--- a/pkg/services/payment_request/payment_request_shipment_recalculate.go
+++ b/pkg/services/payment_request/payment_request_shipment_recalculate.go
@@ -3,9 +3,8 @@ package paymentrequest
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
+++ b/pkg/services/payment_request/payment_request_shipment_recalculate_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/services/mocks"
-
 	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/payment_request/payment_request_shipments_sit_balance.go
+++ b/pkg/services/payment_request/payment_request_shipments_sit_balance.go
@@ -5,11 +5,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/payment_request/payment_request_status_updater.go
+++ b/pkg/services/payment_request/payment_request_status_updater.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/payment_request/rules.go
+++ b/pkg/services/payment_request/rules.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -7,13 +7,12 @@ import (
 	"path"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/uploader"
 )

--- a/pkg/services/payment_request/upload_creator_test.go
+++ b/pkg/services/payment_request/upload_creator_test.go
@@ -13,13 +13,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage/test"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 

--- a/pkg/services/payment_request/validation.go
+++ b/pkg/services/payment_request/validation.go
@@ -3,10 +3,8 @@ package paymentrequest
 import (
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/payment_service_item/payment_service_item_status_updater.go
+++ b/pkg/services/payment_service_item/payment_service_item_status_updater.go
@@ -8,9 +8,8 @@ import (
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
+++ b/pkg/services/payment_service_item/payment_service_item_status_updater_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/payment_service_item/validation.go
+++ b/pkg/services/payment_service_item/validation.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/ppmshipment.go
+++ b/pkg/services/ppmshipment.go
@@ -3,10 +3,9 @@ package services
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // PPMShipmentCreator creates a PPM shipment

--- a/pkg/services/ppmshipment/ppm_estimator_test.go
+++ b/pkg/services/ppmshipment/ppm_estimator_test.go
@@ -3,15 +3,12 @@ package ppmshipment
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 
-	prhelpermocks "github.com/transcom/mymove/pkg/payment_request/mocks"
-
-	"github.com/transcom/mymove/pkg/route/mocks"
-
-	"github.com/gofrs/uuid"
-
 	"github.com/transcom/mymove/pkg/models"
+	prhelpermocks "github.com/transcom/mymove/pkg/payment_request/mocks"
+	"github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/ppmshipment/ppm_shipment_creator_test.go
+++ b/pkg/services/ppmshipment/ppm_shipment_creator_test.go
@@ -3,9 +3,8 @@ package ppmshipment
 import (
 	"fmt"
 
-	"github.com/stretchr/testify/mock"
-
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"

--- a/pkg/services/ppmshipment/rules_test.go
+++ b/pkg/services/ppmshipment/rules_test.go
@@ -4,12 +4,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *PPMShipmentSuite) TestValidationRules() {

--- a/pkg/services/ppmshipment/validation_test.go
+++ b/pkg/services/ppmshipment/validation_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -7,15 +7,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"github.com/lib/pq"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/services/reweigh/reweigh_creator.go
+++ b/pkg/services/reweigh/reweigh_creator.go
@@ -5,13 +5,10 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
-
-	"github.com/transcom/mymove/pkg/services"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // reweighCreator sets up the service object

--- a/pkg/services/reweigh/reweigh_creator_test.go
+++ b/pkg/services/reweigh/reweigh_creator_test.go
@@ -3,10 +3,9 @@ package reweigh
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/reweigh/reweigh_updater.go
+++ b/pkg/services/reweigh/reweigh_updater.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"

--- a/pkg/services/reweigh/reweigh_updater_test.go
+++ b/pkg/services/reweigh/reweigh_updater_test.go
@@ -3,17 +3,16 @@ package reweigh
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/etag"
+	"github.com/transcom/mymove/pkg/models"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/services/query"
-
-	"github.com/gofrs/uuid"
-
-	"github.com/transcom/mymove/pkg/etag"
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/services/reweigh/rules.go
+++ b/pkg/services/reweigh/rules.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/reweigh/rules_test.go
+++ b/pkg/services/reweigh/rules_test.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/transcom/mymove/pkg/apperror"
-	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
-	"github.com/transcom/mymove/pkg/testdatagen"
-
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ReweighSuite) TestValidationRules() {

--- a/pkg/services/reweigh/validation.go
+++ b/pkg/services/reweigh/validation.go
@@ -3,12 +3,10 @@ package reweigh
 import (
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services"
-
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // checks business requirements

--- a/pkg/services/sit_extension/rules.go
+++ b/pkg/services/sit_extension/rules.go
@@ -1,17 +1,15 @@
 package sitextension
 
 import (
-	"github.com/gobuffalo/validate/v3"
-
-	"github.com/transcom/mymove/pkg/apperror"
-
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/services"
-
 	"fmt"
 
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
 )
 
 // checkShipmentID checks that a shipmentID is not nil and returns a verification error if it is

--- a/pkg/services/sit_extension/rules_test.go
+++ b/pkg/services/sit_extension/rules_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	movetaskorder "github.com/transcom/mymove/pkg/services/move_task_order"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/services/sit_extension/sit_extension_creator.go
+++ b/pkg/services/sit_extension/sit_extension_creator.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/sit_extension/sit_extension_creator_test.go
+++ b/pkg/services/sit_extension/sit_extension_creator_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	moverouter "github.com/transcom/mymove/pkg/services/move"

--- a/pkg/services/sit_extension/validation.go
+++ b/pkg/services/sit_extension/validation.go
@@ -3,9 +3,8 @@ package sitextension
 import (
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/support/move_task_order/move_task_order_creator.go
+++ b/pkg/services/support/move_task_order/move_task_order_creator.go
@@ -4,21 +4,20 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/apperror"
-	"github.com/transcom/mymove/pkg/services/support"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/gen/supportmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/office_user/customer"
+	"github.com/transcom/mymove/pkg/services/support"
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/services/upload.go
+++ b/pkg/services/upload.go
@@ -4,11 +4,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/transcom/mymove/pkg/models"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/models"
 )
 
 // UploadInformation contains information for uploads

--- a/pkg/services/upload/upload_creator.go
+++ b/pkg/services/upload/upload_creator.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/storage"

--- a/pkg/services/upload/upload_information_fetcher.go
+++ b/pkg/services/upload/upload_information_fetcher.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/services"
 )
 

--- a/pkg/services/user/user_fetcher_test.go
+++ b/pkg/services/user/user_fetcher_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/gobuffalo/validate/v3"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"

--- a/pkg/services/user/user_updater.go
+++ b/pkg/services/user/user_updater.go
@@ -6,10 +6,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"
 )

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -12,14 +12,11 @@ package user
 import (
 	"github.com/stretchr/testify/mock"
 
-	"github.com/transcom/mymove/pkg/notifications/mocks"
-
 	"github.com/transcom/mymove/pkg/appcontext"
-
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/notifications"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/notifications/mocks"
 	adminUser "github.com/transcom/mymove/pkg/services/admin_user"
 	officeUser "github.com/transcom/mymove/pkg/services/office_user"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/users_roles.go
+++ b/pkg/services/users_roles.go
@@ -1,11 +1,11 @@
 package services
 
 import (
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/gofrs/uuid"
 )
 
 // UserRoleAssociator is the service object interface for UpdateUserRoles

--- a/pkg/services/webhook_subscription/webhook_subscription_creator.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_creator.go
@@ -3,9 +3,8 @@ package webhooksubscription
 import (
 	"github.com/gobuffalo/validate/v3"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/webhook_subscription/webhook_subscription_updater.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_updater.go
@@ -3,9 +3,8 @@ package webhooksubscription
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/apperror"
-
 	"github.com/transcom/mymove/pkg/appcontext"
+	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/query"

--- a/pkg/services/webhook_subscription/webhook_subscription_updater_test.go
+++ b/pkg/services/webhook_subscription/webhook_subscription_updater_test.go
@@ -3,10 +3,9 @@ package webhooksubscription
 import (
 	"time"
 
-	"github.com/transcom/mymove/pkg/etag"
-
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/etag"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/telemetry/db.go
+++ b/pkg/telemetry/db.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/metric/instrument"
-
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"

--- a/pkg/testdatagen/make_moving_expense_document.go
+++ b/pkg/testdatagen/make_moving_expense_document.go
@@ -3,9 +3,8 @@ package testdatagen
 import (
 	"github.com/gobuffalo/pop/v6"
 
-	"github.com/transcom/mymove/pkg/unit"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MakeMovingExpenseDocument creates a single Moving Expense Document.

--- a/pkg/testdatagen/make_payment_request.go
+++ b/pkg/testdatagen/make_payment_request.go
@@ -3,13 +3,11 @@ package testdatagen
 import (
 	"fmt"
 
+	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/gobuffalo/pop/v6"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MakePaymentRequest creates a single PaymentRequest and associated set relationships

--- a/pkg/testdatagen/make_personally_procured_move.go
+++ b/pkg/testdatagen/make_personally_procured_move.go
@@ -2,7 +2,6 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop/v6"
-	//"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -4,13 +4,12 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/transcom/mymove/pkg/random"
-
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/random"
 )
 
 // RandomEdipi creates a random Edipi for a service member

--- a/pkg/testdatagen/make_transportation_service_provider.go
+++ b/pkg/testdatagen/make_transportation_service_provider.go
@@ -7,9 +7,8 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 
-	"github.com/transcom/mymove/pkg/random"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/random"
 )
 
 const alphanumericBytes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -5,17 +5,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
 	"github.com/gofrs/uuid"
-
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/uploader"
-
-	"github.com/gobuffalo/pop/v6"
-	"github.com/gobuffalo/validate/v3"
-
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 // MakeUpload creates a single Upload.

--- a/pkg/testdatagen/scenario/bandwidth.go
+++ b/pkg/testdatagen/scenario/bandwidth.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 	"github.com/transcom/mymove/pkg/uploader"

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -11,9 +11,8 @@ package scenario
 
 import (
 	"github.com/transcom/mymove/pkg/appcontext"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/transcom/mymove/pkg/models"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/uploader"
 )
 

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -15,20 +15,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/transcom/mymove/pkg/appcontext"
-	"github.com/transcom/mymove/pkg/services"
-	moverouter "github.com/transcom/mymove/pkg/services/move"
-
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/gofrs/uuid"
-
+	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/dates"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/services"
+	moverouter "github.com/transcom/mymove/pkg/services/move"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 	"github.com/transcom/mymove/pkg/uploader"

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -7,12 +7,17 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/etag"
+	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/random"
 	routemocks "github.com/transcom/mymove/pkg/route/mocks"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/ghcrateengine"
@@ -21,17 +26,9 @@ import (
 	mtoshipment "github.com/transcom/mymove/pkg/services/mto_shipment"
 	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
 	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
 	"github.com/transcom/mymove/pkg/uploader"
-
-	"github.com/gofrs/uuid"
-	"go.uber.org/zap"
-
-	fakedata "github.com/transcom/mymove/pkg/fakedata_approved"
-	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/random"
-
-	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 // NamedScenario is a data generation scenario that has a name

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -12,21 +12,17 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/models/roles"
-
-	"github.com/transcom/mymove/pkg/random"
-
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gofrs/uuid"
 	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-
-	"github.com/transcom/mymove/pkg/uploader"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/models/roles"
+	"github.com/transcom/mymove/pkg/random"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 // Assertions defines assertions about what the data contains

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -10,18 +10,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gobuffalo/envy"
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	_ "github.com/lib/pq" // Anonymously import lib/pq driver so it's available to Pop
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/random"
-
-	"github.com/gobuffalo/envy"
-	"github.com/gobuffalo/pop/v6"
-	"github.com/gobuffalo/validate/v3"
-
-	_ "github.com/lib/pq" // Anonymously import lib/pq driver so it's available to Pop
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -21,8 +21,7 @@ import (
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
 
-	// Anonymously import lib/pq driver so it's available to Pop
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // Anonymously import lib/pq driver so it's available to Pop
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz" +

--- a/pkg/uploader/prime_uploader_test.go
+++ b/pkg/uploader/prime_uploader_test.go
@@ -2,7 +2,6 @@ package uploader_test
 
 import (
 	"github.com/transcom/mymove/pkg/storage/test"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/uploader"
 )

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -16,18 +16,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-
-	"github.com/transcom/mymove/pkg/models"
-
-	"github.com/transcom/mymove/pkg/storage/mocks"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage"
+	"github.com/transcom/mymove/pkg/storage/mocks"
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testingsuite"
 	"github.com/transcom/mymove/pkg/uploader"

--- a/pkg/uploader/user_uploader_test.go
+++ b/pkg/uploader/user_uploader_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 
 	"github.com/transcom/mymove/pkg/storage/test"
-
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/uploader"
 )


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13510) for this change

## Summary

_Note: I had a similar draft PR #8593 a few months ago (now closed in lieu of this one) that attempted to do something similar.  At the time, I ran into some `gci` issues that caused me to abandon it until some upstream fixes were made._

I've noticed that the order of our go imports has seemed a little random and getting more so over time.  Ideally, the imports would be organized as follows (alphabetically within a section):

```
import (
    [system packages]

    [third-party packages]

    [project packages]
)
```

However, when a blank line is added between imports, `goimports` won't regroup the grouped imports to be with other similar groups.  In this PR, I used the [gci linter](https://github.com/daixiang0/gci) via `golangci-lint` to do the reorganization which eliminates extra sections and groups like I think we want.

A lot of files have changed, but you should be able to follow the commits as so:

1. **Update all pre-commit hooks; fix issues discovered by updates:** this updates all of our pre-commit hooks (via `pre-commit autoupdate`) to their latest versions, then fixes a few new issues that popped up from the updated versions of `golangci-lint` and `markdownlint`.  I needed the latest `golangci-lint` for `gci` to work properly.
1. **Update nix config to use pre-commit 2.20:** don't think that was required, but I noticed the `nix` config was several versions behind a brew'd version as well as what we use in the `circleci-docker` repository.
1. **Removed some import duplication that was causing inconsistent import formatting by linter (and just confusing):** fixed some import duplication and import comments that were causing `gci` to flip import order back and forth when run.  I assume it was unintentional (although legal) to have the import duplication.
1. **Add gci linter to golangci-lint to format order/grouping of go imports:** added the `gci` linter and settings to `golangci-lint` and included the go files where `gci` fixed the import order (appears to be most of them).

To test it, try changing the order of imports on a file or two, do a `git add` on them, then run:
`pre-commit run golangci-lint`

To try it on all files (it shouldn't touch generated files),
`pre-commit run -a golangci-lint`

## Special Notes

- one of the new linter issues I had to fix involved setting a `ReadHeaderTimeout` in addition to the existing `IdleTimeout` (`gosec` rule `G112: Potential slowloris attack`).  Since it wasn't set previously, I think there was no timeout.  I set it to 60 seconds (half of the 120 second idle timeout), but I could use some advice on if another value makes more sense.
- ~~there is a performance problem when running the `revive` linter under `golangci-lint` in the latest 1.47.*+ versions.  Temporarily, `golangci-lint` [has turned off some `revive` rules](https://github.com/golangci/golangci-lint/issues/2997#issuecomment-1190681977) as a workaround until it can be fixed upstream.  I'm hoping this might be fixed by the time we would consider merging this, so I'm making this a draft PR for now.  If not, we'll have to assess if it makes sense to upgrade now and have some rules turned off for a bit.~~
- the performance problem noted above has been fixed in `revive` and merged into `golangci-lint` (along with reversing the rules that had been temporarily turned off).  However, a new tagged version of `golangci-lint` has not been released yet as of this writing.  This PR is now using a specific hash of `golangci-lint` that is several commits beyond the latest `1.48.0` tagged version.  Leaving this on draft still for the moment to see if a tagged version shows up.
 

