### PR TITLE
[MB-12493] Styling for quality assurance reports page

### DIFF
--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@trussworks/react-uswds';
 import classnames from 'classnames';
@@ -7,10 +6,10 @@ import classnames from 'classnames';
 import styles from './EvaluationReportShipmentInfo.module.scss';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
-import { formatEvaluationReportShipmentAddress } from 'utils/formatters';
+import { formatEvaluationReportShipmentAddress, formatShortShipmentID } from 'utils/formatters';
 import { ShipmentShape } from 'types/shipment';
 
-const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
+const EvaluationReportShipmentInfo = ({ shipment }) => {
   let heading;
   let pickupAddress;
   let destinationAddress;
@@ -53,7 +52,7 @@ const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
       <div className={styles.shipmentInfoContainer}>
         <div className={styles.shipmentInfo}>
           <h4>
-            {heading} Shipment ID #{shipmentNumber}
+            {heading} Shipment ID {formatShortShipmentID(shipment.id)}
           </h4>
           <small>
             {pickupAddress} <FontAwesomeIcon icon="arrow-right" /> {destinationAddress}
@@ -66,7 +65,6 @@ const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
 };
 EvaluationReportShipmentInfo.propTypes = {
   shipment: ShipmentShape.isRequired,
-  shipmentNumber: PropTypes.number.isRequired,
 };
 
 export default EvaluationReportShipmentInfo;

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@trussworks/react-uswds';
+import classnames from 'classnames';
+
+import styles from './EvaluationReportShipmentInfo.module.scss';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
 import { formatEvaluationReportShipmentAddress } from 'utils/formatters';
@@ -11,6 +14,7 @@ const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
   let heading;
   let pickupAddress;
   let destinationAddress;
+  let shipmentAccentStyle;
 
   switch (shipment.shipmentType) {
     case SHIPMENT_OPTIONS.HHG:
@@ -19,21 +23,25 @@ const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
       heading = 'HHG';
       pickupAddress = formatEvaluationReportShipmentAddress(shipment.pickupAddress);
       destinationAddress = formatEvaluationReportShipmentAddress(shipment.destinationAddress);
+      shipmentAccentStyle = styles.hhgShipmentType;
       break;
     case SHIPMENT_OPTIONS.NTS:
       heading = 'NTS';
       pickupAddress = formatEvaluationReportShipmentAddress(shipment.pickupAddress);
       destinationAddress = shipment.storageFacility.facilityName;
+      shipmentAccentStyle = styles.ntsShipmentType;
       break;
     case SHIPMENT_OPTIONS.NTSR:
       heading = 'NTS-Release';
       pickupAddress = shipment.storageFacility.facilityName;
       destinationAddress = formatEvaluationReportShipmentAddress(shipment.destinationAddress);
+      shipmentAccentStyle = styles.ntsrShipmentType;
       break;
     case SHIPMENT_OPTIONS.PPM:
       heading = 'PPM';
       pickupAddress = shipment.ppmShipment.pickupPostalCode;
       destinationAddress = shipment.ppmShipment.destinationPostalCode;
+      shipmentAccentStyle = styles.ppmShipmentType;
       break;
     default:
       break;
@@ -41,14 +49,18 @@ const EvaluationReportShipmentInfo = ({ shipment, shipmentNumber }) => {
 
   return (
     <>
-      <div />
-      <h4>
-        {heading} Shipment ID #{shipmentNumber}
-      </h4>
-      <small>
-        {pickupAddress} <FontAwesomeIcon icon="arrow-right" /> {destinationAddress}
-      </small>
-      <Button>Create report</Button>
+      <div className={classnames(styles.shipmentAccent, shipmentAccentStyle)} />
+      <div className={styles.shipmentInfoContainer}>
+        <div className={styles.shipmentInfo}>
+          <h4>
+            {heading} Shipment ID #{shipmentNumber}
+          </h4>
+          <small>
+            {pickupAddress} <FontAwesomeIcon icon="arrow-right" /> {destinationAddress}
+          </small>
+        </div>
+        <Button>Create report</Button>
+      </div>
     </>
   );
 };

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
@@ -22,6 +22,9 @@ h4 {
 }
 small {
   color: $base-dark;
+  svg {
+    @include u-margin-x(1);
+  }
 }
 .shipmentInfo {
   @include u-margin-bottom(3);

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
@@ -1,0 +1,45 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.shipmentInfoContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+
+  button {
+    @include u-margin-top(0);
+  }
+}
+h2 {
+  @include u-margin-bottom(3);
+}
+h4 {
+  @include u-margin-top(0);
+  @include u-margin-bottom(0);
+  @include u-font-weight('bold');
+}
+small {
+  color: $base-dark;
+}
+.shipmentInfo {
+  @include u-margin-bottom(3);
+}
+.shipmentAccent {
+  @include u-margin-bottom(1);
+  width: 24px;
+  height: 6px;
+}
+.hhgShipmentType {
+  background-color: $accent-hhg;
+}
+.ppmShipmentType {
+  background-color: $accent-ppm;
+}
+.ntsShipmentType {
+  background-color: $accent-nts;
+}
+.ntsrShipmentType {
+  background-color: $accent-ntsr;
+}

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
@@ -11,21 +11,22 @@
   button {
     @include u-margin(0);
   }
-}
-h2 {
-  @include u-margin-bottom(3);
-}
-h4 {
-  @include u-margin-top(0);
-  @include u-margin-bottom(0);
-  @include u-font-weight('bold');
-}
-small {
-  color: $base-dark;
-  svg {
-    @include u-margin-x(1);
+  h2 {
+    @include u-margin-bottom(3);
+  }
+  h4 {
+    @include u-margin-top(0);
+    @include u-margin-bottom(0);
+    @include u-font-weight('bold');
+  }
+  small {
+    color: $base-dark;
+    svg {
+      @include u-margin-x(1);
+    }
   }
 }
+
 .shipmentInfo {
   @include u-margin-bottom(3);
 }

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.module.scss
@@ -9,7 +9,7 @@
   width: 100%;
 
   button {
-    @include u-margin-top(0);
+    @include u-margin(0);
   }
 }
 h2 {

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.stories.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.stories.jsx
@@ -63,22 +63,22 @@ const ntsrShipment = {
 
 export const hhg = () => (
   <div className="officeApp">
-    <EvaluationReportShipmentInfo shipment={hhgShipment} shipmentNumber={1} />
+    <EvaluationReportShipmentInfo shipment={hhgShipment} />
   </div>
 );
 
 export const nts = () => (
   <div className="officeApp">
-    <EvaluationReportShipmentInfo shipment={ntsShipment} shipmentNumber={2} />
+    <EvaluationReportShipmentInfo shipment={ntsShipment} />
   </div>
 );
 export const ntsr = () => (
   <div className="officeApp">
-    <EvaluationReportShipmentInfo shipment={ntsrShipment} shipmentNumber={3} />
+    <EvaluationReportShipmentInfo shipment={ntsrShipment} />
   </div>
 );
 export const ppm = () => (
   <div className="officeApp">
-    <EvaluationReportShipmentInfo shipment={ppmShipment} shipmentNumber={4} />
+    <EvaluationReportShipmentInfo shipment={ppmShipment} />
   </div>
 );

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.test.jsx
@@ -67,28 +67,28 @@ const ppmShipment = {
 describe('EvaluationReportShipmentInfo', () => {
   it('renders HHG shipment', () => {
     render(<EvaluationReportShipmentInfo shipment={hhgShipment} shipmentNumber={1} />);
-    expect(screen.getByRole('heading', { level: 4, name: /HHG Shipment ID #1/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /HHG Shipment ID #C3C64/ })).toBeInTheDocument();
     expect(screen.getByText(/123 Any Street/)).toBeInTheDocument();
     expect(screen.getByText(/987 Any Avenue/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create report' })).toBeInTheDocument();
   });
   it('renders NTS shipment', () => {
     render(<EvaluationReportShipmentInfo shipment={ntsShipment} shipmentNumber={1} />);
-    expect(screen.getByRole('heading', { level: 4, name: /NTS Shipment ID #1/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /NTS Shipment ID #C3C64/ })).toBeInTheDocument();
     expect(screen.getByText(/123 Any Street/)).toBeInTheDocument();
     expect(screen.getByText(/Storage Facility/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create report' })).toBeInTheDocument();
   });
   it('renders NTS-R shipment', () => {
     render(<EvaluationReportShipmentInfo shipment={ntsReleaseShipment} shipmentNumber={1} />);
-    expect(screen.getByRole('heading', { level: 4, name: /NTS-Release Shipment ID #1/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /NTS-Release Shipment ID #C3C64/ })).toBeInTheDocument();
     expect(screen.getByText(/Storage Facility/)).toBeInTheDocument();
     expect(screen.getByText(/987 Any Avenue/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create report' })).toBeInTheDocument();
   });
   it('renders PPM shipment', () => {
     render(<EvaluationReportShipmentInfo shipment={ppmShipment} shipmentNumber={1} />);
-    expect(screen.getByRole('heading', { level: 4, name: /PPM Shipment ID #1/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: /PPM Shipment ID #C3C64/ })).toBeInTheDocument();
     expect(screen.getByText(/90210/)).toBeInTheDocument();
     expect(screen.getByText(/94535/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create report' })).toBeInTheDocument();

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -12,7 +12,7 @@ const EvaluationReportTable = ({ reports, emptyText }) => {
     return (
       <tr key={report.id}>
         <td className={styles.reportIDColumn}>
-          {formatQAReportID(report.id)} {report.submittedAt ? null : <Tag>DRAFT</Tag>}
+          {formatQAReportID(report.id)} {report.submittedAt ? null : <Tag className={styles.draftTag}>DRAFT</Tag>}
         </td>
         <td className={styles.dateSubmittedColumn}>{report.submittedAt && formatCustomerDate(report.submittedAt)}</td>
         <td className={styles.locationColumn}>{formatEvaluationReportLocation(report.location)}</td>

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -7,7 +7,7 @@ import styles from './EvaluationReportTable.module.scss';
 import { formatCustomerDate, formatEvaluationReportLocation, formatQAReportID } from 'utils/formatters';
 import { EvaluationReportShape } from 'types/evaluationReport';
 
-const EvaluationReportTable = ({ reports }) => {
+const EvaluationReportTable = ({ reports, emptyText }) => {
   const row = (report) => {
     return (
       <tr key={report.id}>
@@ -30,7 +30,7 @@ const EvaluationReportTable = ({ reports }) => {
   let tableRows = (
     <tr className={styles.emptyTableRow}>
       <td className={styles.emptyTableRow} colSpan={7}>
-        No QAE reports have been submitted for this shipment
+        {emptyText}
       </td>
     </tr>
   );
@@ -58,6 +58,7 @@ const EvaluationReportTable = ({ reports }) => {
 
 EvaluationReportTable.propTypes = {
   reports: PropTypes.arrayOf(EvaluationReportShape),
+  emptyText: PropTypes.string.isRequired,
 };
 
 EvaluationReportTable.defaultProps = {

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Tag } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
 
+import styles from './EvaluationReportTable.module.scss';
+
 import { formatCustomerDate, formatEvaluationReportLocation, formatQAReportID } from 'utils/formatters';
 import { EvaluationReportShape } from 'types/evaluationReport';
 
@@ -9,25 +11,27 @@ const EvaluationReportTable = ({ reports }) => {
   const row = (report) => {
     return (
       <tr key={report.id}>
-        <td>
+        <td className={styles.reportIDColumn}>
           {formatQAReportID(report.id)} {report.submittedAt ? null : <Tag>DRAFT</Tag>}
         </td>
-        <td>{report.submittedAt && formatCustomerDate(report.submittedAt)}</td>
-        <td>{formatEvaluationReportLocation(report.location)}</td>
-        <td>{report.violationsObserved ? 'Yes' : 'No'}</td>
-        <td>No</td>
-        <td>
+        <td className={styles.dateSubmittedColumn}>{report.submittedAt && formatCustomerDate(report.submittedAt)}</td>
+        <td className={styles.locationColumn}>{formatEvaluationReportLocation(report.location)}</td>
+        <td className={styles.violationsColumn}>{report.violationsObserved ? 'Yes' : 'No'}</td>
+        <td className={styles.seriousIncidentColumn}>No</td>
+        <td className={styles.viewReportColumn}>
           <a href={`/moves/${report.moveID}/evaluation-reports/${report.id}`}>View report</a>
         </td>
-        <td>
+        <td className={styles.downloadColumn}>
           <a href={`/moves/${report.moveID}/evaluation-reports/${report.id}/download`}>Download</a>
         </td>
       </tr>
     );
   };
   let tableRows = (
-    <tr>
-      <td colSpan={7}>No QAE reports have been submitted for this shipment</td>
+    <tr className={styles.emptyTableRow}>
+      <td className={styles.emptyTableRow} colSpan={7}>
+        No QAE reports have been submitted for this shipment
+      </td>
     </tr>
   );
   if (reports.length > 0) {
@@ -35,16 +39,16 @@ const EvaluationReportTable = ({ reports }) => {
   }
 
   return (
-    <table>
+    <table className={styles.evaluationReportTable}>
       <thead>
         <tr>
-          <th>Report ID</th>
-          <th>Date submitted</th>
-          <th>Location</th>
-          <th>Violations</th>
-          <th>Serious Incident</th>
-          <th aria-label="View report" />
-          <th aria-label="Download" />
+          <th className={styles.reportIDColumn}>Report ID</th>
+          <th className={styles.dateSubmittedColumn}>Date submitted</th>
+          <th className={styles.locationColumn}>Location</th>
+          <th className={styles.violationsColumn}>Violations</th>
+          <th className={styles.seriousIncidentColumn}>Serious Incident</th>
+          <th className={styles.viewReportColumn} aria-label="View report" />
+          <th className={styles.downloadColumn} aria-label="Download" />
         </tr>
       </thead>
       <tbody>{tableRows}</tbody>

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
@@ -25,6 +25,10 @@
     border-bottom-width: 0px;
   }
 
+  .draftTag {
+    background-color: $base-lighter;
+  }
+
   // The table will be displayed multiple times on the same
   // page, and we want all of the columns to line up, so we're
   // giving each of them a fixed width.

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
@@ -8,13 +8,17 @@
     @include u-font('body', '3xs');
     @include u-font-weight('bold');
     @include u-line-height('body', 2);
-    @include u-padding(1);
+    @include u-padding-x(1);
     color: $base-darker;
+    height: 32px;
   }
   td {
     min-width: 0px;
     color: $base-dark;
     @include u-line-height('body', 1);
+    @include u-padding-x(1);
+    padding-top: 12px;
+    padding-bottom: 12px;
   }
 
   .emptyTableRow {
@@ -28,16 +32,16 @@
     width: 150px;
   }
   .locationColumn {
-    width: 165px;
+    width: 163px;
   }
   .violationsColumn {
     width: 100px;
   }
   .seriousIncidentColumn {
-  width: 117px;
+  width: 118px;
   }
   .viewReportColumn {
-    width: 103px;
+    width: 105px;
   }
   .downloadColumn {
     width: 103px;

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
@@ -24,7 +24,10 @@
   .emptyTableRow {
     border-bottom-width: 0px;
   }
-  // TODO might be a better way to do this
+
+  // The table will be displayed multiple times on the same
+  // page, and we want all of the columns to line up, so we're
+  // giving each of them a fixed width.
   .reportIDColumn {
     width: 168px;
   }

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.module.scss
@@ -1,0 +1,45 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.evaluationReportTable {
+  th {
+    min-width: 0px;
+    @include u-font('body', '3xs');
+    @include u-font-weight('bold');
+    @include u-line-height('body', 2);
+    @include u-padding(1);
+    color: $base-darker;
+  }
+  td {
+    min-width: 0px;
+    color: $base-dark;
+    @include u-line-height('body', 1);
+  }
+
+  .emptyTableRow {
+    border-bottom-width: 0px;
+  }
+  // TODO might be a better way to do this
+  .reportIDColumn {
+    width: 168px;
+  }
+  .dateSubmittedColumn {
+    width: 150px;
+  }
+  .locationColumn {
+    width: 165px;
+  }
+  .violationsColumn {
+    width: 100px;
+  }
+  .seriousIncidentColumn {
+  width: 117px;
+  }
+  .viewReportColumn {
+    width: 103px;
+  }
+  .downloadColumn {
+    width: 103px;
+  }
+}

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.stories.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.stories.jsx
@@ -42,12 +42,12 @@ const reports = [
 
 export const empty = () => (
   <div className="officeApp">
-    <EvaluationReportTable reports={[]} />
+    <EvaluationReportTable reports={[]} emptyText="No QAE reports have been submitted for this shipment." />
   </div>
 );
 
 export const single = () => (
   <div className="officeApp">
-    <EvaluationReportTable reports={reports} />
+    <EvaluationReportTable reports={reports} emptyText="No QAE reports have been submitted for this shipment." />
   </div>
 );

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
@@ -24,22 +24,22 @@ const draftReport = {
 
 describe('EvaluationReportTable', () => {
   it('renders empty table', () => {
-    render(<EvaluationReportTable reports={[]} />);
+    render(<EvaluationReportTable reports={[]} emptyText="no reports for this" />);
     expect(screen.getByText('Report ID')).toBeInTheDocument();
     expect(screen.getByText('Date submitted')).toBeInTheDocument();
     expect(screen.getByText('Location')).toBeInTheDocument();
     expect(screen.getByText('Violations')).toBeInTheDocument();
     expect(screen.getByText('Serious Incident')).toBeInTheDocument();
-    expect(screen.getByText('No QAE reports have been submitted for this shipment')).toBeInTheDocument();
+    expect(screen.getByText('no reports for this')).toBeInTheDocument();
   });
   it('renders table with a draft report', () => {
-    render(<EvaluationReportTable reports={[draftReport]} />);
+    render(<EvaluationReportTable reports={[draftReport]} emptyText="no reports for this" />);
     expect(screen.getByText('Report ID')).toBeInTheDocument();
     expect(screen.getByText('Date submitted')).toBeInTheDocument();
     expect(screen.getByText('Location')).toBeInTheDocument();
     expect(screen.getByText('Violations')).toBeInTheDocument();
     expect(screen.getByText('Serious Incident')).toBeInTheDocument();
-    expect(screen.queryByText('No QAE reports have been submitted for this shipment')).not.toBeInTheDocument();
+    expect(screen.queryByText('no reports for this')).not.toBeInTheDocument();
 
     expect(screen.getByTestId('tag')).toHaveTextContent('DRAFT');
 
@@ -48,14 +48,14 @@ describe('EvaluationReportTable', () => {
     expect(screen.getByRole('link', { name: 'Download' })).toBeInTheDocument();
   });
   it('renders table with a submitted report', () => {
-    render(<EvaluationReportTable reports={[submittedReport]} />);
+    render(<EvaluationReportTable reports={[submittedReport]} emptyText="no reports for this" />);
     expect(screen.getByText('Report ID')).toBeInTheDocument();
     expect(screen.getByText('Date submitted')).toBeInTheDocument();
     expect(screen.getByText('Location')).toBeInTheDocument();
     expect(screen.getByText('Violations')).toBeInTheDocument();
     expect(screen.getByText('Serious Incident')).toBeInTheDocument();
 
-    expect(screen.queryByText('No QAE reports have been submitted for this shipment')).not.toBeInTheDocument();
+    expect(screen.queryByText('no reports for this')).not.toBeInTheDocument();
     expect(screen.queryByTestId('tag')).not.toBeInTheDocument();
 
     expect(screen.getByText('#QA-A7FDB')).toBeInTheDocument();

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -13,7 +13,10 @@ const ShipmentEvaluationReports = ({ shipments, reports }) => {
     return (
       <div key={shipment.id} className={styles.shipmentRow}>
         <EvaluationReportShipmentInfo shipment={shipment} />
-        <EvaluationReportTable reports={reports.filter((r) => r.shipmentID === shipment.id)} />
+        <EvaluationReportTable
+          reports={reports.filter((r) => r.shipmentID === shipment.id)}
+          emptyText="No QAE reports have been submitted for this shipment."
+        />
       </div>
     );
   });

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -22,10 +22,10 @@ const ShipmentEvaluationReports = ({ shipments, reports }) => {
   });
 
   return (
-    <>
+    <div className={styles.shipmentEvaluationReportsContainer}>
       <h2>Shipment QAE reports ({reports.length})</h2>
-      <div className={styles.gridContainer}>{shipmentRows}</div>
-    </>
+      <div className={styles.shipmentReportRows}>{shipmentRows}</div>
+    </div>
   );
 };
 

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import EvaluationReportTable from './EvaluationReportTable';
 import EvaluationReportShipmentInfo from './EvaluationReportShipmentInfo';
+import styles from './ShipmentEvaluationReports.module.scss';
 
 const ShipmentEvaluationReports = ({ shipments, reports }) => {
   const sortedShipments = shipments.sort((a, b) => moment(a.createdAt) - moment(b.createdAt));
@@ -18,7 +19,7 @@ const ShipmentEvaluationReports = ({ shipments, reports }) => {
     }
     const shipmentNumber = shipmentNumbersByType[shipmentType];
     return (
-      <div key={shipment.id}>
+      <div key={shipment.id} className={styles.shipmentRow}>
         <EvaluationReportShipmentInfo shipment={shipment} shipmentNumber={shipmentNumber} />
         <EvaluationReportTable reports={reports.filter((r) => r.shipmentID === shipment.id)} />
       </div>
@@ -28,7 +29,7 @@ const ShipmentEvaluationReports = ({ shipments, reports }) => {
   return (
     <>
       <h2>Shipment QAE reports ({reports.length})</h2>
-      {shipmentRows}
+      <div className={styles.gridContainer}>{shipmentRows}</div>
     </>
   );
 };

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -8,19 +8,11 @@ import styles from './ShipmentEvaluationReports.module.scss';
 
 const ShipmentEvaluationReports = ({ shipments, reports }) => {
   const sortedShipments = shipments.sort((a, b) => moment(a.createdAt) - moment(b.createdAt));
-  const shipmentNumbersByType = {};
 
   const shipmentRows = sortedShipments.map((shipment) => {
-    const { shipmentType } = shipment;
-    if (shipmentNumbersByType[shipmentType]) {
-      shipmentNumbersByType[shipmentType] += 1;
-    } else {
-      shipmentNumbersByType[shipmentType] = 1;
-    }
-    const shipmentNumber = shipmentNumbersByType[shipmentType];
     return (
       <div key={shipment.id} className={styles.shipmentRow}>
-        <EvaluationReportShipmentInfo shipment={shipment} shipmentNumber={shipmentNumber} />
+        <EvaluationReportShipmentInfo shipment={shipment} />
         <EvaluationReportTable reports={reports.filter((r) => r.shipmentID === shipment.id)} />
       </div>
     );

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
@@ -2,12 +2,13 @@
 @import 'shared/styles/_mixins';
 @import 'shared/styles/colors';
 
-.gridContainer {
-  display: flex;
-  flex-direction: column;
-  row-gap: 63px;
-}
-
-h2 {
-  @include u-margin-top(0);
+.shipmentEvaluationReportsContainer {
+  h2 {
+    @include u-margin-top(0);
+  }
+  .shipmentReportRows {
+    display: flex;
+    flex-direction: column;
+    row-gap: 63px;
+  }
 }

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
@@ -7,3 +7,7 @@
   flex-direction: column;
   row-gap: 63px;
 }
+
+h2 {
+  @include u-margin-top(0);
+}

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.module.scss
@@ -1,0 +1,9 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.gridContainer {
+  display: flex;
+  flex-direction: column;
+  row-gap: 63px;
+}

--- a/src/pages/Office/EvaluationReports/EvaluationReports.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.jsx
@@ -36,12 +36,19 @@ const EvaluationReports = () => {
             <Button>Create report</Button>
           </Grid>
           <Grid row>
-            <EvaluationReportTable reports={counselingEvaluationReports} />
+            <EvaluationReportTable
+              reports={counselingEvaluationReports}
+              emptyText="No QAE reports have been submitted for counseling."
+            />
           </Grid>
         </GridContainer>
         <GridContainer className={evaluationReportsStyles.evaluationReportSection}>
           <Grid row>
-            <ShipmentEvaluationReports reports={shipmentEvaluationReports} shipments={shipments} />
+            <ShipmentEvaluationReports
+              reports={shipmentEvaluationReports}
+              shipments={shipments}
+              emptyText="No QAE reports have been submitted for this shipment"
+            />
           </Grid>
         </GridContainer>
       </GridContainer>

--- a/src/pages/Office/EvaluationReports/EvaluationReports.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Button, Grid, GridContainer } from '@trussworks/react-uswds';
 
+import styles from '../TXOMoveInfo/TXOTab.module.scss';
+
+import evaluationReportsStyles from './EvaluationReports.module.scss';
+
 import { useEvaluationReportsQueries } from 'hooks/queries';
 import ShipmentEvaluationReports from 'components/Office/EvaluationReportTable/ShipmentEvaluationReports';
 import EvaluationReportTable from 'components/Office/EvaluationReportTable/EvaluationReportTable';
@@ -21,19 +25,27 @@ const EvaluationReports = () => {
   }
 
   return (
-    <GridContainer>
-      <Grid row>
-        <h1>Quality assurance reports</h1>
-      </Grid>
-      <Grid row>
-        <h2>Counseling QAE reports ({counselingEvaluationReports.length})</h2>
-        <Button>Create report</Button>
-        <EvaluationReportTable reports={counselingEvaluationReports} />
-      </Grid>
-      <Grid row>
-        <ShipmentEvaluationReports reports={shipmentEvaluationReports} shipments={shipments} />
-      </Grid>
-    </GridContainer>
+    <div className={styles.tabContent}>
+      <GridContainer>
+        <Grid row>
+          <h1>Quality assurance reports</h1>
+        </Grid>
+        <GridContainer className={evaluationReportsStyles.evaluationReportSection}>
+          <Grid row className={evaluationReportsStyles.counselingHeadingContainer}>
+            <h2>Counseling QAE reports ({counselingEvaluationReports.length})</h2>
+            <Button>Create report</Button>
+          </Grid>
+          <Grid row>
+            <EvaluationReportTable reports={counselingEvaluationReports} />
+          </Grid>
+        </GridContainer>
+        <GridContainer className={evaluationReportsStyles.evaluationReportSection}>
+          <Grid row>
+            <ShipmentEvaluationReports reports={shipmentEvaluationReports} shipments={shipments} />
+          </Grid>
+        </GridContainer>
+      </GridContainer>
+    </div>
   );
 };
 

--- a/src/pages/Office/EvaluationReports/EvaluationReports.module.scss
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.module.scss
@@ -8,7 +8,7 @@
   @include u-border('base-lighter');
   @include u-border('1px');
   @include u-padding-x(3);
-  @include u-padding-top(12px);
+  @include u-padding-top(36px);
   @include u-padding-bottom(36px);
   @include u-margin-bottom(28px);
 }
@@ -17,4 +17,10 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  h2 {
+    @include u-margin-top(0);
+  }
+  button {
+    @include u-margin(0);
+  }
 }

--- a/src/pages/Office/EvaluationReports/EvaluationReports.module.scss
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.module.scss
@@ -1,0 +1,20 @@
+@import 'shared/styles/_basics';
+@import 'shared/styles/_mixins';
+@import 'shared/styles/colors';
+
+.evaluationReportSection {
+  @include u-bg('white');
+  @include u-radius(4px);
+  @include u-border('base-lighter');
+  @include u-border('1px');
+  @include u-padding-x(3);
+  @include u-padding-top(12px);
+  @include u-padding-bottom(36px);
+  @include u-margin-bottom(28px);
+}
+
+.counselingHeadingContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -398,9 +398,16 @@ export function formatCentsTruncateWhole(cents) {
 }
 
 // Converts a uuid into a shortened ID that's suitable for displaying to users
+function getUUIDFirstFive(uuid) {
+  return uuid.substring(0, 5).toUpperCase();
+}
+
 export function formatQAReportID(uuid) {
-  const firstFive = uuid.substring(0, 5).toUpperCase();
-  return `#QA-${firstFive}`;
+  return `#QA-${getUUIDFirstFive(uuid)}`;
+}
+
+export function formatShortShipmentID(uuid) {
+  return `#${getUUIDFirstFive(uuid)}`;
 }
 
 export function formatEvaluationReportLocation(location) {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12493) for this change

## Summary

This PR adds CSS to the components used on the quality assurance page.
It should hopefully match [these designs](https://www.figma.com/file/5AhuEkaH3bJVrtffU3wp22/Milmove-Office-App?node-id=1512%3A22797)

I'm getting more comfortable using CSS to put things where I want them to go, but I don't feel like I know best-practices very well yet, so I'm very open to feedback and suggestions. 

In particular, I wasn't sure what the best way to set the column widths was. I wanted to match the designs, and have the column widths not change based on their contents, so that multiple instances of the table on the same page would line up. I set the widths to the exact pixel widths of the corresponding columns in the designs (+/- a couple of pixels to prevent text in the headings from wrapping). This works, but feels brittle.

<img width="882" alt="image" src="https://user-images.githubusercontent.com/2627844/180572978-ca5df6f1-1e53-4bfb-851e-33ea5bd9551d.png">

## Setup to Run Your Code
Populate the database with test data
```sh
make db_dev_e2e_populate
```
Start the server
```
make server_run
```
Start the client
```
make client_run
```

Open up the office app
Log in as a QAE/CSR user
Search for the move code EVLRPT
Navigate to the Quality Assurance tab
Check that this page matches the designs

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
