### PR TITLE
MB-13120 Bump terser from 5.14.0 to 5.14.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19897,9 +19897,9 @@ terser@^4.1.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.0.0, terser@^5.10.0, terser@^5.3.4, terser@^5.7.2:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.0.tgz#eefeec9af5153f55798180ee2617f390bdd285e2"
-  integrity sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
+  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13120) for this change

## Summary

This is to fix the `yarn audit` issue with `terser`


![image](https://user-images.githubusercontent.com/35938642/180855546-d3890d87-4aaf-4533-bcd0-66b82375ac62.png)

https://github.com/transcom/mymove/pull/8935#issuecomment-1190974638

#8930 covered the 4.8.1 update, but still need to update the 5.14.0 version.

<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/terser/terser/blob/master/CHANGELOG.md">terser's changelog</a>.</em></p>
<blockquote>
<h2>v5.14.2</h2>
<ul>
<li>Security fix for RegExps that should not be evaluated (regexp DDOS)</li>
<li>Source maps improvements terser/terser/pull/1211</li>
<li>Performance improvements in long property access evaluation terser/terser/pull/1213</li>
</ul>

<h2>v5.14.1</h2>
<ul>
<li>keep_numbers option added to TypeScript defs terser/terser/pull/1208</li>
<li>Fixed parsing of nested template strings terser/terser/pull/1204</li>
</ul>
</blockquote>
</details>
