### PR TITLE
Add PopTestSuite#PreloadData, use suite.T().Cleanup

### DIFF
--- a/pkg/handlers/ghcapi/customer_support_remarks_test.go
+++ b/pkg/handlers/ghcapi/customer_support_remarks_test.go
@@ -76,8 +76,13 @@ func (suite *HandlerSuite) TestListCustomerRemarksForMoveHandler() {
 }
 
 func (suite *HandlerSuite) TestCreateCustomerSupportRemarksHandler() {
-	move := testdatagen.MakeDefaultMove(suite.DB())
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	var move models.Move
+	var officeUser models.OfficeUser
+
+	suite.PreloadData(func() {
+		move = testdatagen.MakeDefaultMove(suite.DB())
+		officeUser = testdatagen.MakeDefaultOfficeUser(suite.DB())
+	})
 
 	suite.Run("Successful POST", func() {
 		handlerConfig := suite.HandlerConfig()

--- a/pkg/handlers/ghcapi/customer_support_remarks_test.go
+++ b/pkg/handlers/ghcapi/customer_support_remarks_test.go
@@ -79,12 +79,9 @@ func (suite *HandlerSuite) TestCreateCustomerSupportRemarksHandler() {
 	var move models.Move
 	var officeUser models.OfficeUser
 
-	suite.PreloadData(func() {
+	suite.Run("Successful POST", func() {
 		move = testdatagen.MakeDefaultMove(suite.DB())
 		officeUser = testdatagen.MakeDefaultOfficeUser(suite.DB())
-	})
-
-	suite.Run("Successful POST", func() {
 		handlerConfig := suite.HandlerConfig()
 
 		creator := &mocks.CustomerSupportRemarksCreator{}
@@ -121,6 +118,8 @@ func (suite *HandlerSuite) TestCreateCustomerSupportRemarksHandler() {
 	})
 
 	suite.Run("unsuccessful POST", func() {
+		move = testdatagen.MakeDefaultMove(suite.DB())
+
 		handlerConfig := suite.HandlerConfig()
 
 		creator := &mocks.CustomerSupportRemarksCreator{}

--- a/pkg/handlers/ghcapi/evaluation_report_test.go
+++ b/pkg/handlers/ghcapi/evaluation_report_test.go
@@ -223,7 +223,12 @@ func (suite *HandlerSuite) TestGetEvaluationReportByIDHandler() {
 }
 
 func (suite *HandlerSuite) TestCreateEvaluationReportHandler() {
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
+	var officeUser models.OfficeUser
+
+	suite.PreloadData(func() {
+		officeUser = testdatagen.MakeDefaultOfficeUser(suite.DB())
+	})
 
 	suite.Run("Successful POST", func() {
 

--- a/pkg/handlers/ghcapi/evaluation_report_test.go
+++ b/pkg/handlers/ghcapi/evaluation_report_test.go
@@ -226,10 +226,6 @@ func (suite *HandlerSuite) TestCreateEvaluationReportHandler() {
 
 	var officeUser models.OfficeUser
 
-	suite.PreloadData(func() {
-		officeUser = testdatagen.MakeDefaultOfficeUser(suite.DB())
-	})
-
 	suite.Run("Successful POST", func() {
 
 		handlerConfig := suite.HandlerConfig()

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -24,16 +24,21 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	submittedAt := availableToPrimeAt.Add(-1 * time.Hour)
 
 	ordersID := uuid.Must(uuid.NewV4())
-	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status:             models.MoveStatusAPPROVED,
-			AvailableToPrimeAt: &availableToPrimeAt,
-			SubmittedAt:        &submittedAt,
-			Orders:             models.Order{ID: ordersID},
-		},
+	var move models.Move
+	var requestUser models.User
+	suite.PreloadData(func() {
+		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+			Move: models.Move{
+				Status:             models.MoveStatusAPPROVED,
+				AvailableToPrimeAt: &availableToPrimeAt,
+				SubmittedAt:        &submittedAt,
+				Orders:             models.Order{ID: ordersID},
+			},
+		})
+
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
 	})
 
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 	params := moveops.GetMoveParams{
@@ -125,7 +130,10 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 
 func (suite *HandlerSuite) TestSearchMovesHandler() {
 
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
+	var requestUser models.User
+	suite.PreloadData(func() {
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
@@ -207,9 +215,12 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 }
 
 func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
-	move := testdatagen.MakeDefaultMove(suite.DB())
-
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
+	var move models.Move
+	var requestUser models.User
+	suite.PreloadData(func() {
+		move = testdatagen.MakeDefaultMove(suite.DB())
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
 	req = suite.AuthenticateUserRequest(req, requestUser)
 	defaultRemarks := "destination address is on the moon"

--- a/pkg/handlers/ghcapi/move_test.go
+++ b/pkg/handlers/ghcapi/move_test.go
@@ -1,6 +1,7 @@
 package ghcapi
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"time"
 
@@ -26,7 +27,7 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	ordersID := uuid.Must(uuid.NewV4())
 	var move models.Move
 	var requestUser models.User
-	suite.PreloadData(func() {
+	setupTestData := func() {
 		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
 			Move: models.Move{
 				Status:             models.MoveStatusAPPROVED,
@@ -35,18 +36,11 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 				Orders:             models.Order{ID: ordersID},
 			},
 		})
-
 		requestUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-
-	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
-	params := moveops.GetMoveParams{
-		HTTPRequest: req,
-		Locator:     move.Locator,
 	}
 
 	suite.Run("Successful move fetch", func() {
+		setupTestData()
 		mockFetcher := mocks.MoveFetcher{}
 
 		handler := GetMoveHandler{
@@ -59,6 +53,13 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			move.Locator,
 			mock.Anything,
 		).Return(&move, nil)
+
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		params := moveops.GetMoveParams{
+			HTTPRequest: req,
+			Locator:     move.Locator,
+		}
 
 		response := handler.Handle(params)
 		suite.IsType(&moveops.GetMoveOK{}, response)
@@ -79,18 +80,22 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 	})
 
 	suite.Run("Unsuccessful move fetch - empty string bad request", func() {
+		setupTestData()
 		mockFetcher := mocks.MoveFetcher{}
 
 		handler := GetMoveHandler{
 			HandlerConfig: suite.HandlerConfig(),
 			MoveFetcher:   &mockFetcher,
 		}
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
 
 		response := handler.Handle(moveops.GetMoveParams{HTTPRequest: req, Locator: ""})
 		suite.IsType(&moveops.GetMoveBadRequest{}, response)
 	})
 
 	suite.Run("Unsuccessful move fetch - locator not found", func() {
+		setupTestData()
 		mockFetcher := mocks.MoveFetcher{}
 
 		handler := GetMoveHandler{
@@ -103,12 +108,19 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			move.Locator,
 			mock.Anything,
 		).Return(&models.Move{}, apperror.NotFoundError{})
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		params := moveops.GetMoveParams{
+			HTTPRequest: req,
+			Locator:     move.Locator,
+		}
 
 		response := handler.Handle(params)
 		suite.IsType(&moveops.GetMoveNotFound{}, response)
 	})
 
 	suite.Run("Unsuccessful move fetch - internal server error", func() {
+		setupTestData()
 		mockFetcher := mocks.MoveFetcher{}
 
 		handler := GetMoveHandler{
@@ -122,6 +134,13 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 			mock.Anything,
 		).Return(&models.Move{}, apperror.QueryError{})
 
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		params := moveops.GetMoveParams{
+			HTTPRequest: req,
+			Locator:     move.Locator,
+		}
+
 		response := handler.Handle(params)
 		suite.IsType(&moveops.GetMoveInternalServerError{}, response)
 	})
@@ -131,13 +150,15 @@ func (suite *HandlerSuite) TestGetMoveHandler() {
 func (suite *HandlerSuite) TestSearchMovesHandler() {
 
 	var requestUser models.User
-	suite.PreloadData(func() {
+	setupTestData := func() *http.Request {
 		requestUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		return req
 
+	}
 	suite.Run("Successful move search by locator", func() {
+		req := setupTestData()
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		moves := models.Moves{move}
 
@@ -180,6 +201,7 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 	})
 
 	suite.Run("Successful move search by DoD ID", func() {
+		req := setupTestData()
 		move := testdatagen.MakeDefaultMove(suite.DB())
 		moves := models.Moves{move}
 
@@ -217,25 +239,18 @@ func (suite *HandlerSuite) TestSearchMovesHandler() {
 func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 	var move models.Move
 	var requestUser models.User
-	suite.PreloadData(func() {
+	setupTestData := func() (*http.Request, models.Move) {
 		move = testdatagen.MakeDefaultMove(suite.DB())
 		requestUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-	req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
-	req = suite.AuthenticateUserRequest(req, requestUser)
+		req := httptest.NewRequest("GET", "/move/#{move.locator}", nil)
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		return req, move
+	}
 	defaultRemarks := "destination address is on the moon"
 	fakeEtag := ""
-	params := moveops.SetFinancialReviewFlagParams{
-		HTTPRequest: req,
-		IfMatch:     &fakeEtag,
-		Body: moveops.SetFinancialReviewFlagBody{
-			Remarks:       &defaultRemarks,
-			FlagForReview: swag.Bool(true),
-		},
-		MoveID: *handlers.FmtUUID(move.ID),
-	}
 
 	suite.Run("Successful flag setting to true", func() {
+		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
 			HandlerConfig:                 suite.HandlerConfig(),
@@ -249,11 +264,21 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 			&defaultRemarks,
 		).Return(&move, nil)
 
+		params := moveops.SetFinancialReviewFlagParams{
+			HTTPRequest: req,
+			IfMatch:     &fakeEtag,
+			Body: moveops.SetFinancialReviewFlagBody{
+				Remarks:       &defaultRemarks,
+				FlagForReview: swag.Bool(true),
+			},
+			MoveID: *handlers.FmtUUID(move.ID),
+		}
 		response := handler.Handle(params)
 		suite.IsType(&moveops.SetFinancialReviewFlagOK{}, response)
 	})
 
 	suite.Run("Unsuccessful flag - missing remarks", func() {
+		req, move := setupTestData()
 		paramsNilRemarks := moveops.SetFinancialReviewFlagParams{
 			HTTPRequest: req,
 			IfMatch:     &fakeEtag,
@@ -267,11 +292,11 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 			HandlerConfig:                 suite.HandlerConfig(),
 			MoveFinancialReviewFlagSetter: &mockFlagSetter,
 		}
-
 		response := handler.Handle(paramsNilRemarks)
 		suite.IsType(&moveops.SetFinancialReviewFlagUnprocessableEntity{}, response)
 	})
 	suite.Run("Unsuccessful flag - move not found", func() {
+		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
 			HandlerConfig:                 suite.HandlerConfig(),
@@ -285,10 +310,21 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 			&defaultRemarks,
 		).Return(&models.Move{}, apperror.NotFoundError{})
 
+		params := moveops.SetFinancialReviewFlagParams{
+			HTTPRequest: req,
+			IfMatch:     &fakeEtag,
+			Body: moveops.SetFinancialReviewFlagBody{
+				Remarks:       &defaultRemarks,
+				FlagForReview: swag.Bool(true),
+			},
+			MoveID: *handlers.FmtUUID(move.ID),
+		}
+
 		response := handler.Handle(params)
 		suite.IsType(&moveops.SetFinancialReviewFlagNotFound{}, response)
 	})
 	suite.Run("Unsuccessful flag - internal server error", func() {
+		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
 			HandlerConfig:                 suite.HandlerConfig(),
@@ -302,11 +338,22 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 			&defaultRemarks,
 		).Return(&models.Move{}, apperror.QueryError{})
 
+		params := moveops.SetFinancialReviewFlagParams{
+			HTTPRequest: req,
+			IfMatch:     &fakeEtag,
+			Body: moveops.SetFinancialReviewFlagBody{
+				Remarks:       &defaultRemarks,
+				FlagForReview: swag.Bool(true),
+			},
+			MoveID: *handlers.FmtUUID(move.ID),
+		}
+
 		response := handler.Handle(params)
 		suite.IsType(&moveops.SetFinancialReviewFlagInternalServerError{}, response)
 	})
 
 	suite.Run("Unsuccessful flag - bad etag", func() {
+		req, move := setupTestData()
 		mockFlagSetter := mocks.MoveFinancialReviewFlagSetter{}
 		handler := SetFinancialReviewFlagHandler{
 			HandlerConfig:                 suite.HandlerConfig(),
@@ -319,6 +366,16 @@ func (suite *HandlerSuite) TestSetFinancialReviewFlagHandler() {
 			mock.AnythingOfType("bool"),
 			&defaultRemarks,
 		).Return(&models.Move{}, apperror.PreconditionFailedError{})
+
+		params := moveops.SetFinancialReviewFlagParams{
+			HTTPRequest: req,
+			IfMatch:     &fakeEtag,
+			Body: moveops.SetFinancialReviewFlagBody{
+				Remarks:       &defaultRemarks,
+				FlagForReview: swag.Bool(true),
+			},
+			MoveID: *handlers.FmtUUID(move.ID),
+		}
 
 		response := handler.Handle(params)
 		suite.IsType(&moveops.SetFinancialReviewFlagPreconditionFailed{}, response)

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -15,9 +15,13 @@ import (
 )
 
 func (suite *HandlerSuite) TestListMTOAgentsHandler() {
-	testMTOAgent := testdatagen.MakeDefaultMTOAgent(suite.DB())
+	var requestUser models.User
+	var testMTOAgent models.MTOAgent
+	suite.PreloadData(func() {
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+		testMTOAgent = testdatagen.MakeDefaultMTOAgent(suite.DB())
+	})
 
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
 	req := httptest.NewRequest("GET", fmt.Sprintf("/move-task-orders/%s/mto-agents", testMTOAgent.ID.String()), nil)
 	req = suite.AuthenticateAdminRequest(req, requestUser)
 

--- a/pkg/handlers/ghcapi/mto_agent_test.go
+++ b/pkg/handlers/ghcapi/mto_agent_test.go
@@ -3,6 +3,7 @@ package ghcapi
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
@@ -17,15 +18,16 @@ import (
 func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 	var requestUser models.User
 	var testMTOAgent models.MTOAgent
-	suite.PreloadData(func() {
+	setupTestData := func() *http.Request {
 		requestUser = testdatagen.MakeStubbedUser(suite.DB())
 		testMTOAgent = testdatagen.MakeDefaultMTOAgent(suite.DB())
-	})
-
-	req := httptest.NewRequest("GET", fmt.Sprintf("/move-task-orders/%s/mto-agents", testMTOAgent.ID.String()), nil)
-	req = suite.AuthenticateAdminRequest(req, requestUser)
+		req := httptest.NewRequest("GET", fmt.Sprintf("/move-task-orders/%s/mto-agents", testMTOAgent.ID.String()), nil)
+		req = suite.AuthenticateAdminRequest(req, requestUser)
+		return req
+	}
 
 	suite.Run("Successful Response", func() {
+		req := setupTestData()
 		params := mtoagentop.FetchMTOAgentListParams{
 			HTTPRequest: req,
 			ShipmentID:  strfmt.UUID(testMTOAgent.MTOShipmentID.String()),
@@ -50,6 +52,7 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 	})
 
 	suite.Run("Error Response", func() {
+		req := setupTestData()
 		params := mtoagentop.FetchMTOAgentListParams{
 			HTTPRequest: req,
 			ShipmentID:  strfmt.UUID(testMTOAgent.MTOShipmentID.String()),
@@ -74,6 +77,7 @@ func (suite *HandlerSuite) TestListMTOAgentsHandler() {
 	})
 
 	suite.Run("404 Response", func() {
+		req := setupTestData()
 		params := mtoagentop.FetchMTOAgentListParams{
 			HTTPRequest: req,
 			ShipmentID:  strfmt.UUID(testMTOAgent.MTOShipmentID.String()),

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -164,7 +164,10 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 
 	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
 		moveTaskOrderID, serviceItemID), nil)
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
+	var requestUser models.User
+	suite.PreloadData(func() {
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 	req = suite.AuthenticateUserRequest(req, requestUser)
 
 	params := mtoserviceitemop.UpdateMTOServiceItemStatusParams{

--- a/pkg/handlers/ghcapi/mto_service_items_test.go
+++ b/pkg/handlers/ghcapi/mto_service_items_test.go
@@ -161,26 +161,28 @@ func (suite *HandlerSuite) createServiceItem() (models.MTOServiceItem, models.Mo
 func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	moveTaskOrderID, _ := uuid.NewV4()
 	serviceItemID, _ := uuid.NewV4()
-
-	req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
-		moveTaskOrderID, serviceItemID), nil)
 	var requestUser models.User
-	suite.PreloadData(func() {
-		requestUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-	req = suite.AuthenticateUserRequest(req, requestUser)
 
-	params := mtoserviceitemop.UpdateMTOServiceItemStatusParams{
-		HTTPRequest:      req,
-		IfMatch:          etag.GenerateEtag(time.Now()),
-		Body:             &ghcmessages.PatchMTOServiceItemStatusPayload{Status: "APPROVED"},
-		MoveTaskOrderID:  moveTaskOrderID.String(),
-		MtoServiceItemID: serviceItemID.String(),
+	setupTestData := func() mtoserviceitemop.UpdateMTOServiceItemStatusParams {
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/mto_service_items/%s/status",
+			moveTaskOrderID, serviceItemID), nil)
+
+		req = suite.AuthenticateUserRequest(req, requestUser)
+		params := mtoserviceitemop.UpdateMTOServiceItemStatusParams{
+			HTTPRequest:      req,
+			IfMatch:          etag.GenerateEtag(time.Now()),
+			Body:             &ghcmessages.PatchMTOServiceItemStatusPayload{Status: "APPROVED"},
+			MoveTaskOrderID:  moveTaskOrderID.String(),
+			MtoServiceItemID: serviceItemID.String(),
+		}
+		return params
 	}
 
 	// With this first set of tests we'll use mocked service object responses so that we can make sure the handler
 	// is returning the right HTTP code given a set of circumstances.
 	suite.Run("404 - not found response", func() {
+		params := setupTestData()
 		serviceItemStatusUpdater := mocks.MTOServiceItemUpdater{}
 		fetcher := mocks.Fetcher{}
 		fetcher.On("FetchRecord",
@@ -199,6 +201,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	})
 
 	suite.Run("200 - success response", func() {
+		params := setupTestData()
 		serviceItemStatusUpdater := mocks.MTOServiceItemUpdater{}
 		fetcher := mocks.Fetcher{}
 		fetcher.On("FetchRecord",
@@ -225,6 +228,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	})
 
 	suite.Run("412 - precondition failed response", func() {
+		params := setupTestData()
+
 		serviceItemStatusUpdater := mocks.MTOServiceItemUpdater{}
 		fetcher := mocks.Fetcher{}
 		fetcher.On("FetchRecord",
@@ -251,6 +256,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	})
 
 	suite.Run("500 - internal server error response", func() {
+		params := setupTestData()
+
 		serviceItemStatusUpdater := mocks.MTOServiceItemUpdater{}
 		fetcher := mocks.Fetcher{}
 		fetcher.On("FetchRecord",
@@ -277,6 +284,8 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	})
 
 	suite.Run("422 - unprocessable entity response", func() {
+		params := setupTestData()
+
 		serviceItemStatusUpdater := mocks.MTOServiceItemUpdater{}
 		fetcher := mocks.Fetcher{}
 		params.MtoServiceItemID = ""
@@ -298,6 +307,7 @@ func (suite *HandlerSuite) TestUpdateMTOServiceItemStatusHandler() {
 	// With this we'll do a happy path integration test to ensure that the use of the service object
 	// by the handler is working as expected.
 	suite.Run("Successful rejected status update - Integration test", func() {
+
 		queryBuilder := query.NewQueryBuilder()
 		mtoServiceItem, move := suite.createServiceItem()
 		requestUser := testdatagen.MakeStubbedUser(suite.DB())

--- a/pkg/handlers/ghcapi/payment_request_test.go
+++ b/pkg/handlers/ghcapi/payment_request_test.go
@@ -225,11 +225,15 @@ func (suite *HandlerSuite) TestGetPaymentRequestsForMoveHandler() {
 func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 	paymentRequestID, _ := uuid.FromString("00000000-0000-0000-0000-000000000001")
 	officeUserUUID, _ := uuid.NewV4()
-	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true, OfficeUser: models.OfficeUser{ID: officeUserUUID}})
-	officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
-		RoleType: roles.RoleTypeTIO,
-	})
+	var officeUser models.OfficeUser
 
+	suite.PreloadData(func() {
+		officeUser = testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true, OfficeUser: models.OfficeUser{ID: officeUserUUID}})
+		officeUser.User.Roles = append(officeUser.User.Roles, roles.Role{
+			RoleType: roles.RoleTypeTIO,
+		})
+
+	})
 	paymentRequest := models.PaymentRequest{
 		ID:        paymentRequestID,
 		IsFinal:   false,
@@ -535,7 +539,11 @@ func (suite *HandlerSuite) TestUpdatePaymentRequestStatusHandler() {
 }
 
 func (suite *HandlerSuite) TestShipmentsSITBalanceHandler() {
-	officeUserTIO := testdatagen.MakeTIOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	var officeUserTIO models.OfficeUser
+
+	suite.PreloadData(func() {
+		officeUserTIO = testdatagen.MakeTIOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
+	})
 
 	suite.Run("successful response of the shipments SIT Balance handler", func() {
 		now := time.Now()

--- a/pkg/handlers/ghcapi/tac_test.go
+++ b/pkg/handlers/ghcapi/tac_test.go
@@ -6,11 +6,16 @@ import (
 	"strings"
 
 	tacop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/tac"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestTacValidation() {
-	user := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
+	var user models.OfficeUser
+
+	suite.PreloadData(func() {
+		user = testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
+	})
 
 	suite.Run("TAC validation", func() {
 		transportationAccountingCode := testdatagen.MakeDefaultTransportationAccountingCode(suite.DB())

--- a/pkg/handlers/ghcapi/tac_test.go
+++ b/pkg/handlers/ghcapi/tac_test.go
@@ -6,18 +6,13 @@ import (
 	"strings"
 
 	tacop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/tac"
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestTacValidation() {
-	var user models.OfficeUser
-
-	suite.PreloadData(func() {
-		user = testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
-	})
 
 	suite.Run("TAC validation", func() {
+		user := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{})
 		transportationAccountingCode := testdatagen.MakeDefaultTransportationAccountingCode(suite.DB())
 		tests := []struct {
 			tacCode string

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -389,7 +389,10 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 
 func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 
-	requestUser := testdatagen.MakeStubbedUser(suite.DB())
+	var requestUser models.User
+	suite.PreloadData(func() {
+		requestUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 
 	suite.Run("Successful patch - Integration Test", func() {
 		mto := testdatagen.MakeAvailableMove(suite.DB())

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -389,12 +389,8 @@ func (suite *HandlerSuite) TestCreateExcessWeightRecord() {
 
 func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 
-	var requestUser models.User
-	suite.PreloadData(func() {
-		requestUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-
 	suite.Run("Successful patch - Integration Test", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		mto := testdatagen.MakeAvailableMove(suite.DB())
 		eTag := etag.GenerateEtag(mto.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
@@ -463,6 +459,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	})
 
 	suite.Run("Unsuccessful patch - Integration Test - patch fail MTO not available", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		defaultMTO := testdatagen.MakeDefaultMove(suite.DB())
 		eTag := etag.GenerateEtag(defaultMTO.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", defaultMTO.ID.String()), nil)
@@ -492,6 +489,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	})
 
 	suite.Run("Patch failure - 500", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		mto := testdatagen.MakeAvailableMove(suite.DB())
 		eTag := etag.GenerateEtag(mto.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
@@ -526,6 +524,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	})
 
 	suite.Run("Patch failure - 404", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		mto := testdatagen.MakeAvailableMove(suite.DB())
 		eTag := etag.GenerateEtag(mto.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
@@ -558,6 +557,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	})
 
 	suite.Run("Patch failure - 409", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		mto := testdatagen.MakeAvailableMove(suite.DB())
 		eTag := etag.GenerateEtag(mto.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)
@@ -589,6 +589,7 @@ func (suite *HandlerSuite) TestUpdateMTOPostCounselingInfo() {
 	})
 
 	suite.Run("Patch failure - 422", func() {
+		requestUser := testdatagen.MakeStubbedUser(suite.DB())
 		mto := testdatagen.MakeAvailableMove(suite.DB())
 		eTag := etag.GenerateEtag(mto.UpdatedAt)
 		req := httptest.NewRequest("PATCH", fmt.Sprintf("/move_task_orders/%s/post-counseling-info", mto.ID.String()), nil)

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -47,6 +47,9 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 	shipmentCreator := shipmentorchestrator.NewShipmentCreator(mtoShipmentCreator, ppmShipmentCreator)
 	mockCreator := mocks.ShipmentCreator{}
 
+	var pickupAddress primemessages.Address
+	var destinationAddress primemessages.Address
+
 	setupTestData := func() (CreateMTOShipmentHandler, models.Move) {
 
 		move := testdatagen.MakeAvailableMove(suite.DB())
@@ -55,14 +58,7 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			shipmentCreator,
 			mtoChecker,
 		}
-		return handler, move
 
-	}
-
-	var pickupAddress primemessages.Address
-	var destinationAddress primemessages.Address
-
-	suite.PreloadData(func() {
 		// Make stubbed addresses just to collect address data for payload
 		newAddress := testdatagen.MakeStubbedAddress(suite.DB())
 		pickupAddress = primemessages.Address{
@@ -84,7 +80,9 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 			StreetAddress2: newAddress.StreetAddress2,
 			StreetAddress3: newAddress.StreetAddress3,
 		}
-	})
+		return handler, move
+
+	}
 
 	suite.Run("Successful POST - Integration Test", func() {
 		// Under Test: CreateMTOShipment handler code

--- a/pkg/handlers/primeapi/mto_shipment_test.go
+++ b/pkg/handlers/primeapi/mto_shipment_test.go
@@ -59,27 +59,32 @@ func (suite *HandlerSuite) TestCreateMTOShipmentHandler() {
 
 	}
 
-	// Make stubbed addresses just to collect address data for payload
-	newAddress := testdatagen.MakeStubbedAddress(suite.DB())
-	pickupAddress := primemessages.Address{
-		City:           &newAddress.City,
-		Country:        newAddress.Country,
-		PostalCode:     &newAddress.PostalCode,
-		State:          &newAddress.State,
-		StreetAddress1: &newAddress.StreetAddress1,
-		StreetAddress2: newAddress.StreetAddress2,
-		StreetAddress3: newAddress.StreetAddress3,
-	}
-	newAddress = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
-	destinationAddress := primemessages.Address{
-		City:           &newAddress.City,
-		Country:        newAddress.Country,
-		PostalCode:     &newAddress.PostalCode,
-		State:          &newAddress.State,
-		StreetAddress1: &newAddress.StreetAddress1,
-		StreetAddress2: newAddress.StreetAddress2,
-		StreetAddress3: newAddress.StreetAddress3,
-	}
+	var pickupAddress primemessages.Address
+	var destinationAddress primemessages.Address
+
+	suite.PreloadData(func() {
+		// Make stubbed addresses just to collect address data for payload
+		newAddress := testdatagen.MakeStubbedAddress(suite.DB())
+		pickupAddress = primemessages.Address{
+			City:           &newAddress.City,
+			Country:        newAddress.Country,
+			PostalCode:     &newAddress.PostalCode,
+			State:          &newAddress.State,
+			StreetAddress1: &newAddress.StreetAddress1,
+			StreetAddress2: newAddress.StreetAddress2,
+			StreetAddress3: newAddress.StreetAddress3,
+		}
+		newAddress = testdatagen.MakeAddress2(suite.DB(), testdatagen.Assertions{Stub: true})
+		destinationAddress = primemessages.Address{
+			City:           &newAddress.City,
+			Country:        newAddress.Country,
+			PostalCode:     &newAddress.PostalCode,
+			State:          &newAddress.State,
+			StreetAddress1: &newAddress.StreetAddress1,
+			StreetAddress2: newAddress.StreetAddress2,
+			StreetAddress3: newAddress.StreetAddress3,
+		}
+	})
 
 	suite.Run("Successful POST - Integration Test", func() {
 		// Under Test: CreateMTOShipment handler code

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -134,12 +134,9 @@ func (suite *PayloadsSuite) TestExcessWeightRecord() {
 
 	now := time.Now()
 	fakeFileStorer := test.NewFakeS3Storage(true)
-	var upload models.Upload
-	suite.PreloadData(func() {
-		upload = testdatagen.MakeStubbedUpload(suite.DB(), testdatagen.Assertions{})
-	})
 
 	suite.Run("Success - all data populated", func() {
+		upload := testdatagen.MakeStubbedUpload(suite.DB(), testdatagen.Assertions{})
 		move := models.Move{
 			ID:                         id,
 			ExcessWeightQualifiedAt:    &now,

--- a/pkg/handlers/primeapi/payloads/model_to_payload_test.go
+++ b/pkg/handlers/primeapi/payloads/model_to_payload_test.go
@@ -134,7 +134,10 @@ func (suite *PayloadsSuite) TestExcessWeightRecord() {
 
 	now := time.Now()
 	fakeFileStorer := test.NewFakeS3Storage(true)
-	upload := testdatagen.MakeStubbedUpload(suite.DB(), testdatagen.Assertions{})
+	var upload models.Upload
+	suite.PreloadData(func() {
+		upload = testdatagen.MakeStubbedUpload(suite.DB(), testdatagen.Assertions{})
+	})
 
 	suite.Run("Success - all data populated", func() {
 		move := models.Move{

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func (suite *HandlerSuite) TestCreateUploadHandler() {
-	primeUser := testdatagen.MakeStubbedUser(suite.DB())
+	var primeUser models.User
+	suite.PreloadData(func() {
+		primeUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
 	setupTestData := func() (CreateUploadHandler, models.PaymentRequest) {

--- a/pkg/handlers/primeapi/upload_test.go
+++ b/pkg/handlers/primeapi/upload_test.go
@@ -15,10 +15,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestCreateUploadHandler() {
-	var primeUser models.User
-	suite.PreloadData(func() {
-		primeUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
+
 	fakeS3 := storageTest.NewFakeS3Storage(true)
 
 	setupTestData := func() (CreateUploadHandler, models.PaymentRequest) {
@@ -34,6 +31,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 	}
 
 	suite.Run("successful create upload", func() {
+		primeUser := testdatagen.MakeStubbedUser(suite.DB())
 		handler, paymentRequest := setupTestData()
 		req := httptest.NewRequest("POST", fmt.Sprintf("/payment_requests/%s/uploads", paymentRequest.ID), nil)
 		req = suite.AuthenticateUserRequest(req, primeUser)
@@ -51,6 +49,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 	})
 
 	suite.Run("create upload fail - invalid payment request ID format", func() {
+		primeUser := testdatagen.MakeStubbedUser(suite.DB())
 		handler, paymentRequest := setupTestData()
 
 		badFormatID := strfmt.UUID("gb7b134a-7c44-45f2-9114-bb0831cc5db3")
@@ -69,6 +68,7 @@ func (suite *HandlerSuite) TestCreateUploadHandler() {
 	})
 
 	suite.Run("create upload fail - payment request not found", func() {
+		primeUser := testdatagen.MakeStubbedUser(suite.DB())
 		handler, paymentRequest := setupTestData()
 
 		badFormatID, _ := uuid.NewV4()

--- a/pkg/handlers/supportapi/move_task_order_test.go
+++ b/pkg/handlers/supportapi/move_task_order_test.go
@@ -65,11 +65,10 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 	params := movetaskorderops.HideNonFakeMoveTaskOrdersParams{
 		HTTPRequest: request,
 	}
-	handlerConfig := suite.HandlerConfig()
 
 	suite.Run("successfully hide fake moves", func() {
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			suite.HandlerConfig(),
 			movetaskorder.NewMoveTaskOrderHider(),
 		}
 		var moves models.Moves
@@ -104,7 +103,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 		}
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			suite.HandlerConfig(),
 			mockHider,
 		}
 
@@ -132,7 +131,7 @@ func (suite *HandlerSuite) TestHideNonFakeMoveTaskOrdersHandler() {
 
 		mockHider := &mocks.MoveTaskOrderHider{}
 		handler := HideNonFakeMoveTaskOrdersHandlerFunc{
-			handlerConfig,
+			suite.HandlerConfig(),
 			mockHider,
 		}
 		mockHider.On("Hide",

--- a/pkg/iws/iws_test.go
+++ b/pkg/iws/iws_test.go
@@ -12,9 +12,6 @@ type iwsSuite struct {
 	testingsuite.BaseTestSuite
 }
 
-func (suite *iwsSuite) SetupSuite() {
-}
-
 func TestIwsSuite(t *testing.T) {
 	suite.Run(t, new(iwsSuite))
 }

--- a/pkg/notifications/user_account_modified_test.go
+++ b/pkg/notifications/user_account_modified_test.go
@@ -9,12 +9,18 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *NotificationSuite) TestUserAccountModified() {
-	modifiedUser := testdatagen.MakeStubbedUser(suite.DB())
-	responsibleUser := testdatagen.MakeStubbedUser(suite.DB())
+	var modifiedUser models.User
+	var responsibleUser models.User
+
+	suite.PreloadData(func() {
+		modifiedUser = testdatagen.MakeStubbedUser(suite.DB())
+		responsibleUser = testdatagen.MakeStubbedUser(suite.DB())
+	})
 	session := auth.Session{
 		UserID:   responsibleUser.ID,
 		Hostname: "adminlocal",

--- a/pkg/notifications/user_account_modified_test.go
+++ b/pkg/notifications/user_account_modified_test.go
@@ -9,27 +9,23 @@ import (
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/apperror"
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *NotificationSuite) TestUserAccountModified() {
-	var modifiedUser models.User
-	var responsibleUser models.User
-
-	suite.PreloadData(func() {
-		modifiedUser = testdatagen.MakeStubbedUser(suite.DB())
-		responsibleUser = testdatagen.MakeStubbedUser(suite.DB())
-	})
-	session := auth.Session{
-		UserID:   responsibleUser.ID,
-		Hostname: "adminlocal",
-	}
 
 	subject := "[MilMove] User Account Activity Alert"
 	sysAdminEmail := "admin@test.com"
 
 	suite.Run("Create emails for all possible actions", func() {
+		modifiedUser := testdatagen.MakeStubbedUser(suite.DB())
+
+		responsibleUser := testdatagen.MakeStubbedUser(suite.DB())
+		session := auth.Session{
+			UserID:   responsibleUser.ID,
+			Hostname: "adminlocal",
+		}
+
 		// Set up test cases for each action:
 		testCases := map[string]struct {
 			action     string
@@ -39,55 +35,56 @@ func (suite *NotificationSuite) TestUserAccountModified() {
 				modifiedAt time.Time,
 			) (*UserAccountModified, error)
 		}{
-			"Success - User account created notification": {
+			"User account created notification": {
 				action:     "created",
 				newEmailer: NewUserAccountCreated,
 			},
-			"Success - User account activated notification": {
+			"User account activated notification": {
 				action:     "activated",
 				newEmailer: NewUserAccountActivated,
 			},
-			"Success - User account deactivated notification": {
+			"User account deactivated notification": {
 				action:     "deactivated",
 				newEmailer: NewUserAccountDeactivated,
 			},
-			"Success - User account removed notification": {
+			"User account removed notification": {
 				action:     "removed",
 				newEmailer: NewUserAccountRemoved,
 			},
 		}
 
 		// Loop through and run each test case:
-		for name, tc := range testCases {
-			suite.Run(name, func() {
-				emailer, err := tc.newEmailer(suite.AppContextWithSessionForTest(&session), sysAdminEmail, modifiedUser.ID, modifiedUser.UpdatedAt)
-				suite.Require().NoError(err)
-				suite.Require().NotNil(emailer)
+		for _, tc := range testCases {
 
-				emails, emailErr := emailer.emails(suite.AppContextWithSessionForTest(&session))
-				suite.Require().NoError(emailErr)
-				suite.Require().NotNil(emails)
-				suite.Equal(len(emails), 1)
+			emailer, err := tc.newEmailer(suite.AppContextWithSessionForTest(&session), sysAdminEmail, modifiedUser.ID, modifiedUser.UpdatedAt)
+			suite.Require().NoError(err)
+			suite.Require().NotNil(emailer)
 
-				email := emails[0]
-				// Check expected values against received values:
-				suite.Equal(sysAdminEmail, email.recipientEmail)
-				suite.Equal(subject, email.subject)
-				suite.NotEmpty(email.htmlBody)
-				suite.NotEmpty(email.textBody)
+			emails, emailErr := emailer.emails(suite.AppContextWithSessionForTest(&session))
+			suite.Require().NoError(emailErr)
+			suite.Require().NotNil(emails)
+			suite.Equal(len(emails), 1)
 
-				// Check email content:
-				suite.Contains(email.textBody, session.Hostname)
-				suite.Contains(email.textBody, fmt.Sprintf("Account %s", tc.action))
-				suite.Contains(email.textBody, fmt.Sprintf("Modified user ID: %s", modifiedUser.ID))
-				suite.Contains(email.textBody, fmt.Sprintf("Responsible user ID: %s", responsibleUser.ID))
-			})
+			email := emails[0]
+			// Check expected values against received values:
+			suite.Equal(sysAdminEmail, email.recipientEmail)
+			suite.Equal(subject, email.subject)
+			suite.NotEmpty(email.htmlBody)
+			suite.NotEmpty(email.textBody)
+
+			// Check email content:
+			suite.Contains(email.textBody, session.Hostname)
+			suite.Contains(email.textBody, fmt.Sprintf("Account %s", tc.action))
+			suite.Contains(email.textBody, fmt.Sprintf("Modified user ID: %s", modifiedUser.ID))
+			suite.Contains(email.textBody, fmt.Sprintf("Responsible user ID: %s", responsibleUser.ID))
+
 		}
 	})
 
 	suite.Run("Success - User account creation with no user in session", func() {
 		// Test case:   If a user just created their account, their userID information might not be in the session yet.
 		// Expectation: The email should use the modified user ID as the responsible user ID as well.
+		modifiedUser := testdatagen.MakeStubbedUser(suite.DB())
 		emptySessionCtx := suite.AppContextWithSessionForTest(&auth.Session{})
 
 		emailer, err := NewUserAccountCreated(emptySessionCtx, sysAdminEmail, modifiedUser.ID, modifiedUser.UpdatedAt)
@@ -107,6 +104,7 @@ func (suite *NotificationSuite) TestUserAccountModified() {
 	suite.Run("Fail - Session is nil", func() {
 		// Test case:   The session wasn't set in the AppContext, for some reason. Possibly dev error.
 		// Expectation: Initializing the UserAccountModified should return services.ContextError
+		modifiedUser := testdatagen.MakeStubbedUser(suite.DB())
 		nilSessionCtx := suite.AppContextForTest()
 
 		emailer, err := NewUserAccountCreated(nilSessionCtx, sysAdminEmail, modifiedUser.ID, modifiedUser.UpdatedAt)

--- a/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
@@ -9,17 +9,24 @@ func (suite *ServiceParamValueLookupsSuite) TestZipAddressLookup() {
 	pickupKey := models.ServiceItemParamNameZipPickupAddress
 	destKey := models.ServiceItemParamNameZipDestAddress
 
-	mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
+	var mtoServiceItem models.MTOServiceItem
+	var paymentRequest models.PaymentRequest
+	var paramLookup *ServiceItemParamKeyData
 
-	paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
-		testdatagen.Assertions{
-			PaymentRequest: models.PaymentRequest{
-				MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
-			},
-		})
+	suite.PreloadData(func() {
+		mtoServiceItem = testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
-	paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
-	suite.FatalNoError(err)
+		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+			testdatagen.Assertions{
+				PaymentRequest: models.PaymentRequest{
+					MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
+				},
+			})
+
+		var err error
+		paramLookup, err = ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
+	})
 
 	suite.Run("zip code for the pickup address is present on MTO Shipment", func() {
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), pickupKey)

--- a/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_address_lookup_test.go
@@ -9,32 +9,31 @@ func (suite *ServiceParamValueLookupsSuite) TestZipAddressLookup() {
 	pickupKey := models.ServiceItemParamNameZipPickupAddress
 	destKey := models.ServiceItemParamNameZipDestAddress
 
-	var mtoServiceItem models.MTOServiceItem
-	var paymentRequest models.PaymentRequest
-	var paramLookup *ServiceItemParamKeyData
+	setupTestData := func() (models.PaymentRequest, models.MTOServiceItem) {
+		mtoServiceItem := testdatagen.MakeDefaultMTOServiceItem(suite.DB())
 
-	suite.PreloadData(func() {
-		mtoServiceItem = testdatagen.MakeDefaultMTOServiceItem(suite.DB())
-
-		paymentRequest = testdatagen.MakePaymentRequest(suite.DB(),
+		paymentRequest := testdatagen.MakePaymentRequest(suite.DB(),
 			testdatagen.Assertions{
 				PaymentRequest: models.PaymentRequest{
 					MoveTaskOrderID: mtoServiceItem.MoveTaskOrderID,
 				},
 			})
-
-		var err error
-		paramLookup, err = ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
-		suite.FatalNoError(err)
-	})
+		return paymentRequest, mtoServiceItem
+	}
 
 	suite.Run("zip code for the pickup address is present on MTO Shipment", func() {
+		paymentRequest, mtoServiceItem := setupTestData()
+		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), pickupKey)
 		suite.FatalNoError(err)
 		suite.Equal(mtoServiceItem.MTOShipment.PickupAddress.PostalCode, valueStr)
 	})
 
 	suite.Run("zip code for the destination address is present on MTO Shipment", func() {
+		paymentRequest, mtoServiceItem := setupTestData()
+		paramLookup, err := ServiceParamLookupInitialize(suite.AppContextForTest(), suite.planner, mtoServiceItem, paymentRequest.ID, paymentRequest.MoveTaskOrderID, nil)
+		suite.FatalNoError(err)
 		valueStr, err := paramLookup.ServiceParamValue(suite.AppContextForTest(), destKey)
 		suite.FatalNoError(err)
 		suite.Equal(mtoServiceItem.MTOShipment.DestinationAddress.PostalCode, valueStr)

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func (suite *MoveServiceSuite) TestMoveApproval() {
-	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+	var move models.Move
+	suite.PreloadData(func() {
+		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+	})
 	moveRouter := NewMoveRouter()
 
 	suite.Run("from valid statuses", func() {
@@ -260,6 +263,7 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 
 	suite.Run("defaults to nil reason if empty string provided", func() {
 		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+
 		err := moveRouter.Cancel(suite.AppContextForTest(), "", &move)
 
 		suite.NoError(err)
@@ -304,8 +308,6 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 	})
 
 	suite.Run("from valid statuses", func() {
-		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
-
 		validStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -319,6 +321,8 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 		}
 		for _, tt := range validStatuses {
 			suite.Run(tt.desc, func() {
+				move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+
 				move.Status = tt.status
 				move.Orders.Status = models.OrderStatusSUBMITTED
 
@@ -331,8 +335,6 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 	})
 
 	suite.Run("from invalid statuses", func() {
-		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
-
 		invalidStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -341,6 +343,8 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 		}
 		for _, tt := range invalidStatuses {
 			suite.Run(tt.desc, func() {
+				move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+
 				move.Status = tt.status
 
 				err := moveRouter.Cancel(suite.AppContextForTest(), "", &move)
@@ -353,7 +357,10 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 }
 
 func (suite *MoveServiceSuite) TestSendToOfficeUser() {
-	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+	var move models.Move
+	suite.PreloadData(func() {
+		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
+	})
 	moveRouter := NewMoveRouter()
 
 	suite.Run("from valid statuses", func() {

--- a/pkg/services/move/move_router_test.go
+++ b/pkg/services/move/move_router_test.go
@@ -15,13 +15,10 @@ import (
 )
 
 func (suite *MoveServiceSuite) TestMoveApproval() {
-	var move models.Move
-	suite.PreloadData(func() {
-		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
-	})
 	moveRouter := NewMoveRouter()
 
 	suite.Run("from valid statuses", func() {
+		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
 		validStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -42,6 +39,7 @@ func (suite *MoveServiceSuite) TestMoveApproval() {
 	})
 
 	suite.Run("from invalid statuses", func() {
+		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
 		invalidStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -357,13 +355,10 @@ func (suite *MoveServiceSuite) TestMoveCancellation() {
 }
 
 func (suite *MoveServiceSuite) TestSendToOfficeUser() {
-	var move models.Move
-	suite.PreloadData(func() {
-		move = testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
-	})
 	moveRouter := NewMoveRouter()
 
 	suite.Run("from valid statuses", func() {
+		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
 		validStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -375,18 +370,17 @@ func (suite *MoveServiceSuite) TestSendToOfficeUser() {
 			{"Service Counseling Completed", models.MoveStatusServiceCounselingCompleted},
 		}
 		for _, tt := range validStatuses {
-			suite.Run(tt.desc, func() {
-				move.Status = tt.status
+			move.Status = tt.status
 
-				err := moveRouter.SendToOfficeUser(suite.AppContextForTest(), &move)
+			err := moveRouter.SendToOfficeUser(suite.AppContextForTest(), &move)
 
-				suite.NoError(err)
-				suite.Equal(models.MoveStatusAPPROVALSREQUESTED, move.Status)
-			})
+			suite.NoError(err)
+			suite.Equal(models.MoveStatusAPPROVALSREQUESTED, move.Status)
 		}
 	})
 
 	suite.Run("from invalid statuses", func() {
+		move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{Stub: true})
 		invalidStatuses := []struct {
 			desc   string
 			status models.MoveStatus
@@ -394,15 +388,13 @@ func (suite *MoveServiceSuite) TestSendToOfficeUser() {
 			{"Canceled", models.MoveStatusCANCELED},
 		}
 		for _, tt := range invalidStatuses {
-			suite.Run(tt.desc, func() {
-				move.Status = tt.status
+			move.Status = tt.status
 
-				err := moveRouter.SendToOfficeUser(suite.AppContextForTest(), &move)
+			err := moveRouter.SendToOfficeUser(suite.AppContextForTest(), &move)
 
-				suite.Error(err)
-				suite.Contains(err.Error(), fmt.Sprintf("The status for the move with ID %s", move.ID))
-				suite.Contains(err.Error(), "can not be sent to 'Approvals Requested' if the status is cancelled.")
-			})
+			suite.Error(err)
+			suite.Contains(err.Error(), fmt.Sprintf("The status for the move with ID %s", move.ID))
+			suite.Contains(err.Error(), "can not be sent to 'Approvals Requested' if the status is cancelled.")
 		}
 	})
 }

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -920,17 +920,23 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 }
 
 func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItemFailToCreateDOFSIT() {
-	// Set up data to use for all Origin SIT Service Item tests
-	move := testdatagen.MakeAvailableMove(suite.DB())
-	move.Status = models.MoveStatusAPPROVED
-	mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-		Move: move,
-	})
+	var move models.Move
+	var mtoShipment models.MTOShipment
+	var reServiceDOFSIT models.ReService
 
-	reServiceDOFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			Code: models.ReServiceCodeDOFSIT,
-		},
+	suite.PreloadData(func() {
+		// Set up data to use for all Origin SIT Service Item tests
+		move = testdatagen.MakeAvailableMove(suite.DB())
+		move.Status = models.MoveStatusAPPROVED
+		mtoShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: move,
+		})
+
+		reServiceDOFSIT = testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOFSIT,
+			},
+		})
 	})
 
 	sitEntryDate := time.Date(2020, time.October, 24, 0, 0, 0, 0, time.UTC)

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -920,30 +920,24 @@ func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItem() {
 }
 
 func (suite *MTOServiceItemServiceSuite) TestCreateOriginSITServiceItemFailToCreateDOFSIT() {
-	var move models.Move
-	var mtoShipment models.MTOShipment
-	var reServiceDOFSIT models.ReService
-
-	suite.PreloadData(func() {
-		// Set up data to use for all Origin SIT Service Item tests
-		move = testdatagen.MakeAvailableMove(suite.DB())
-		move.Status = models.MoveStatusAPPROVED
-		mtoShipment = testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
-			Move: move,
-		})
-
-		reServiceDOFSIT = testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-			ReService: models.ReService{
-				Code: models.ReServiceCodeDOFSIT,
-			},
-		})
-	})
 
 	sitEntryDate := time.Date(2020, time.October, 24, 0, 0, 0, 0, time.UTC)
 	sitPostalCode := "99999"
 	reason := "lorem ipsum"
 
 	suite.Run("Fail to create DOFSIT service item due to missing SITOriginHHGActualAddress", func() {
+		// Set up data to use for all Origin SIT Service Item tests
+		move := testdatagen.MakeAvailableMove(suite.DB())
+		move.Status = models.MoveStatusAPPROVED
+		mtoShipment := testdatagen.MakeMTOShipment(suite.DB(), testdatagen.Assertions{
+			Move: move,
+		})
+
+		reServiceDOFSIT := testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDOFSIT,
+			},
+		})
 
 		serviceItemDOFSIT := models.MTOServiceItem{
 			MoveTaskOrder:   move,

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -115,7 +115,11 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestSubmit() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -161,7 +165,11 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestCancel() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -207,7 +215,11 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestReject() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 	rejectionReason := "reason"
 
@@ -255,7 +267,11 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -301,7 +317,11 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 
 	suite.Run("fails when the Diversion field is false", func() {
@@ -357,10 +377,14 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestApproveDiversionUsesExternal() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+		shipment.UsesExternalVendor = true
+		shipment.Diversion = true
+	})
 	shipmentRouter := NewShipmentRouter()
-	shipment.UsesExternalVendor = true
-	shipment.Diversion = true
 
 	suite.Run("fails when the UsesExternal field is true", func() {
 		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
@@ -372,7 +396,11 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversionUsesExternal() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
-	shipment := testdatagen.MakeStubbedShipment(suite.DB())
+	var shipment models.MTOShipment
+
+	suite.PreloadData(func() {
+		shipment = testdatagen.MakeStubbedShipment(suite.DB())
+	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {

--- a/pkg/services/mto_shipment/shipment_router_test.go
+++ b/pkg/services/mto_shipment/shipment_router_test.go
@@ -115,11 +115,7 @@ func (suite *MTOShipmentServiceSuite) TestApprove() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestSubmit() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -130,6 +126,7 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
@@ -152,6 +149,7 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Submit(suite.AppContextForTest(), &shipment)
@@ -165,11 +163,7 @@ func (suite *MTOShipmentServiceSuite) TestSubmit() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestCancel() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -180,6 +174,7 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
@@ -202,6 +197,7 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Cancel(suite.AppContextForTest(), &shipment)
@@ -215,11 +211,7 @@ func (suite *MTOShipmentServiceSuite) TestCancel() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestReject() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 	rejectionReason := "reason"
 
@@ -231,6 +223,7 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
@@ -254,6 +247,7 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.Reject(suite.AppContextForTest(), &shipment, &rejectionReason)
@@ -267,11 +261,7 @@ func (suite *MTOShipmentServiceSuite) TestReject() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -282,6 +272,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
 
 			err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
@@ -304,6 +295,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.RequestDiversion(suite.AppContextForTest(), &shipment)
@@ -317,14 +309,11 @@ func (suite *MTOShipmentServiceSuite) TestRequestDiversion() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	suite.Run("fails when the Diversion field is false", func() {
+		shipment := testdatagen.MakeStubbedShipment(suite.DB())
 		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
 		suite.Error(err)
@@ -340,6 +329,7 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
 			shipment.Diversion = true
 
@@ -363,6 +353,7 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 			shipment.Diversion = true
 
@@ -377,16 +368,14 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversion() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestApproveDiversionUsesExternal() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-		shipment.UsesExternalVendor = true
-		shipment.Diversion = true
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	suite.Run("fails when the UsesExternal field is true", func() {
+
+		shipment := testdatagen.MakeStubbedShipment(suite.DB())
+		shipment.UsesExternalVendor = true
+		shipment.Diversion = true
 		err := shipmentRouter.ApproveDiversion(suite.AppContextForTest(), &shipment)
 
 		suite.Error(err)
@@ -396,11 +385,7 @@ func (suite *MTOShipmentServiceSuite) TestApproveDiversionUsesExternal() {
 }
 
 func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
-	var shipment models.MTOShipment
 
-	suite.PreloadData(func() {
-		shipment = testdatagen.MakeStubbedShipment(suite.DB())
-	})
 	shipmentRouter := NewShipmentRouter()
 
 	validStatuses := []struct {
@@ -411,7 +396,10 @@ func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 	}
 	for _, validStatus := range validStatuses {
 		suite.Run("from valid status: "+string(validStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = validStatus.status
+			shipment.UsesExternalVendor = true
+			shipment.Diversion = true
 
 			err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)
 
@@ -433,6 +421,7 @@ func (suite *MTOShipmentServiceSuite) TestRequestCancellation() {
 	}
 	for _, invalidStatus := range invalidStatuses {
 		suite.Run("from invalid status: "+string(invalidStatus.status), func() {
+			shipment := testdatagen.MakeStubbedShipment(suite.DB())
 			shipment.Status = invalidStatus.status
 
 			err := shipmentRouter.RequestCancellation(suite.AppContextForTest(), &shipment)

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"regexp"
 	"runtime"
 	"strings"
-	"testing"
+	"sync"
 	"time"
 
 	"github.com/gobuffalo/envy"
@@ -16,6 +17,9 @@ import (
 	_ "github.com/lib/pq" // Anonymously import lib/pq driver so it's available to Pop
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/DATA-DOG/go-txdb"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"
@@ -74,6 +78,13 @@ type PopTestSuite struct {
 
 	// Enable this flag to use per test transactions
 	usePerTestTransaction bool
+	// the preloadedTxnDb is used when PreloadData is invoked
+	preloadedTxnDb *sqlx.DB
+	// a mutex to make sure transactional tests aren't stepping on each other
+	txnMutex sync.Mutex
+	// tracking the *testing.T that are active to ensure multiple
+	// databases are not open at the same time
+	txnTestDb map[string]*pop.Connection
 }
 
 func dropDB(conn *pop.Connection, destination string) error {
@@ -140,7 +151,25 @@ func WithHighPrivPSQLRole() PopTestSuiteOption {
 // WithPerTestTransaction is a functional option that can be passed
 // into the NewPopTestSuite function to create a PopTestSuite that
 // runs each test inside a transaction and rolls back at the end of
-// the test. See also PopTestSuite#Run
+// the test. See also PopTestSuite#PreloadData for how to share data
+// between subtests. For implementation details see PopTestSuite#DB
+//
+// When WithPerTestTransaction is enabled, it means each subtest has a
+// database that is isolated from other tests.
+
+// If per test transaction is enabled and PreloadData has not been
+// called, each subtest gets a new connection. This means subtests are
+// really just like main tests, but subtests are a helpful way to
+// group tests together, which can be useful.
+//
+// When using per test transactions, it works both with
+//
+// suite.Run("name", func( { ... })
+//
+// and
+//
+// suite.T().Run("name", func(t *testing.T) { ... })
+
 func WithPerTestTransaction() PopTestSuiteOption {
 	return func(pts *PopTestSuite) {
 		pts.usePerTestTransaction = true
@@ -216,6 +245,8 @@ func NewPopTestSuite(packageName PackageName, opts ...PopTestSuiteOption) *PopTe
 		pts.lowPrivConn = pts.highPrivConn
 		pts.lowPrivConnDetails = pts.highPrivConnDetails
 	}
+
+	pts.txnTestDb = make(map[string]*pop.Connection)
 
 	return pts
 }
@@ -377,25 +408,172 @@ func (suite *PopTestSuite) findOrCreatePerTestTransactionDb() {
 	}
 }
 
-// DB returns a db connection
+// openTxnDb sets up the sqlx.DB for this test that will rollback
+// all changes when the db is closed
+func (suite *PopTestSuite) openTxnDb(name string) *sqlx.DB {
+	packageName := suite.PackageName.String()
+
+	s := "postgres://%s:%s@%s:%s/%s?%s"
+	dataSourceName := fmt.Sprintf(s, suite.lowPrivConnDetails.User,
+		suite.lowPrivConnDetails.Password,
+		suite.lowPrivConnDetails.Host,
+		suite.lowPrivConnDetails.Port,
+		suite.lowPrivConnDetails.Database,
+		suite.lowPrivConnDetails.OptionsString(""))
+
+	// See https://github.com/DATA-DOG/go-txdb for more information
+	// about how txdb works and why we need to register a fake driver
+	// and then connect to a fake database name
+	if !containsString(sql.Drivers(), fakePopSqlxDriverName) {
+		txdb.Register(fakePopSqlxDriverName, "postgres", dataSourceName)
+	}
+
+	dbSanitizer := regexp.MustCompile("[^a-zA-Z0-9_]")
+	fakeDbName := dbSanitizer.ReplaceAllString(packageName+"_"+name, "_")
+
+	suite.lowPrivConnDetails.Driver = fakePopSqlxDriverName
+	suite.lowPrivConnDetails.Options["application_name"] = fakeDbName
+	suite.lowPrivConnDetails.Database = fakeDbName
+	return sqlx.MustOpen(fakePopSqlxDriverName, fakeDbName)
+}
+
+// txnPopConnection wraps the sqlx.DB in a *pop.Connection
+func (suite *PopTestSuite) txnPopConnection(db *sqlx.DB) *pop.Connection {
+	popConn, err := pop.NewConnection(suite.lowPrivConnDetails)
+	if err != nil {
+		log.Panic(err)
+	}
+	suiteStore := &PopSuiteTxnStore{
+		db,
+		popConn,
+	}
+	popConn.Store = suiteStore
+	return popConn
+}
+
+// PreloadData sets up the data used by all subtests. It can only be
+// called once. Once it is called, all subtests will use the same
+// database, but will run inside a savepoint that are rolled back.
+// This way each subtest can reuse the preloaded data, but each
+// subtest cannot modify the data used by another test.
+//
+// Note that calling PreloadData automatically changes how suite.Run
+// works
+func (suite *PopTestSuite) PreloadData(f func()) {
+	if !suite.usePerTestTransaction {
+		log.Panic("Cannot use PreloadData without per test transaction")
+	}
+	if suite.preloadedTxnDb != nil {
+		log.Panic("Cannot call PreloadData multiple times in the same test")
+	}
+	// establish a database connection for the suite that will
+	// rollback when closed
+	suite.preloadedTxnDb = suite.openTxnDb("preload_data")
+	// set lowPrivConn so suite.DB() will return the pop connection
+	suite.lowPrivConn = suite.txnPopConnection(suite.preloadedTxnDb)
+	defer func() {
+		// ensure we unset the connection so that after preloading
+		// data a new pop connection will be established
+		suite.lowPrivConn = nil
+	}()
+	suite.T().Cleanup(func() {
+		err := suite.preloadedTxnDb.Close()
+		if err != nil {
+			log.Panic(err)
+		}
+		suite.preloadedTxnDb = nil
+	})
+	f()
+}
+
+// DB returns a db connection. It has logic to handle per test
+// transactions, both when PreloadData is called and when it is not
 func (suite *PopTestSuite) DB() *pop.Connection {
+	if !suite.usePerTestTransaction {
+		return suite.lowPrivConn
+	}
+
 	// Create the db connection on demand for per test transactions.
 	// This is necessary so that we know the current test name and can
 	// create a new txdb db connection per test
-	if suite.usePerTestTransaction {
+	suite.txnMutex.Lock()
+	defer suite.txnMutex.Unlock()
+	// set up the pop connection for PreloadData that will
+	// rollback at the end of the test
+	if suite.preloadedTxnDb != nil {
+		// At this point, PreloadData has been called, so we want to
+		// start a savepoint. This is what go-txdb does for us. See
+		// https://github.com/DATA-DOG/go-txdb/blob/master/db.go#L195
 		if suite.lowPrivConn == nil {
-			suite.lowPrivConn = suite.openTxnPopConnection()
+			tx, err := suite.preloadedTxnDb.Beginx()
+			if err != nil {
+				log.Panic(err)
+			}
+			suite.lowPrivConn = suite.txnPopConnection(suite.preloadedTxnDb)
+			// ensure the savepoint is rolled back when this test
+			// context (suite.T()) is finished
+			suite.T().Cleanup(func() {
+				suite.lowPrivConn = nil
+				err = tx.Rollback()
+				if err != nil {
+					log.Panic(err)
+				}
+			})
 		}
+		return suite.lowPrivConn
 	}
-	return suite.lowPrivConn
-}
 
-// setDB overrides the connection for per test transactions
-func (suite *PopTestSuite) setDB(conn *pop.Connection) {
-	if !suite.usePerTestTransaction {
-		log.Panic("Cannot use setDB wihout per test transaction")
+	// At this point, we know this is a transactional test that is not
+	// using PreloadData, so we can establish a new connection using
+	// go-txdb.
+	testingName := suite.T().Name()
+	popConn, ok := suite.txnTestDb[testingName]
+	if ok {
+		return popConn
 	}
-	suite.lowPrivConn = conn
+	// create a brand new database for this test so it is
+	// completely isolated
+	db := suite.openTxnDb(testingName)
+	popConn = suite.txnPopConnection(db)
+	suite.txnTestDb[testingName] = popConn
+
+	// To prevent accidental dependencies between tests, check and
+	// make sure that this test is only connecting to a single
+	// database at a time.
+	// This prevents situations like
+	//
+	// func (suite *MySuite) TopTest() {
+	//   move = makeMove(suite.DB())
+	//   suite.Run("subtest 1", func() {
+	//     suite.NoError(doSomething(&move))
+	//   })
+	//
+	//   modifyMove(&move)
+	//   suite.Run("subtest 2", func( {
+	//     suite.NoError(doSomethingElseWithModifiedMove(&move))
+	//   })
+	// }
+	if len(suite.txnTestDb) > 1 {
+		names := ""
+		i := 0
+		for k := range suite.txnTestDb {
+			if i == 0 {
+				names = k
+			} else {
+				names = names + "," + k
+			}
+			i++
+		}
+		log.Panic("Multiple test databases active simultaneously, use PreloadData: " + names)
+	}
+	suite.T().Cleanup(func() {
+		delete(suite.txnTestDb, testingName)
+		err := popConn.Close()
+		if err != nil {
+			log.Panic(err)
+		}
+	})
+	return popConn
 }
 
 // Logger returns the logger for the test suite
@@ -493,94 +671,6 @@ func (suite *PopTestSuite) NilOrNoVerrs(err error) {
 	default:
 		suite.Nil(err)
 	}
-}
-
-// Run, with WithPerTestTransaction enabled, means each subtest
-// gets a new connection and is isolated from both any database
-// changes made in the main test, and in sibling subtests.
-//
-// It would be nice if subtests could start a new transaction inside
-// the current connection so they could reuse db setup between
-// subtests. Unfortunately, because database/sql and pop do not
-// support nested transactions, this gets complicated and hairy
-// quickly. When testing that approach, connections wouldn't get
-// closed and cause other tests to hang or subtests would report
-// incorrect errors about transactions already being closed.
-//
-// And so, if per test transaction is enabled, each subtest gets a new
-// connection. This means subtests are really just like main tests,
-// but subtests are a helpful way to group tests together, which can
-// be useful. Setup has to be moved to a function that can be run once
-// per subtest. In testing, that was still faster with per test
-// transactions than the old way of cloning a db per package.
-//
-// If the code under test starts its own transaction, this is the
-// approach that should be used. If it does not use transactions, you
-// can probably get away with using RunWithPreloadedData (see below).
-//
-// When using per test transactions, watch out for subtests that do
-// not use testify.suite as they won't use this code and thus won't
-// get a per subtest connection. Tests that use the native testing
-// subtests look like
-//
-// suite.T().Run("name", func(t *testing.T) { ... })
-//
-// instead of
-//
-// suite.Run("name", func() { ... })
-//
-func (suite *PopTestSuite) Run(name string, subtest func()) bool {
-	oldDB := suite.lowPrivConn
-	oldT := suite.T()
-	defer suite.SetT(oldT)
-	return oldT.Run(name, func(t *testing.T) {
-		suite.SetT(t)
-		suite.logger = zaptest.NewLogger(t)
-		if suite.usePerTestTransaction {
-			subtestDb := suite.openTxnPopConnection()
-			suite.setDB(subtestDb)
-			defer func() {
-				err := subtestDb.Close()
-				if err != nil {
-					log.Fatalf("Closing Subtest DB Failed!: %v", err)
-				}
-				suite.setDB(oldDB)
-			}()
-			subtest()
-		} else {
-			subtest()
-		}
-	})
-}
-
-// RunWithPreloadedData, with WithPerTestTransaction enabled, means
-// each subtest will have access to preloaded data from the main test
-// but the subtest changes will get rolled back.
-//
-// This means each subtest is isolated from sibling tests but NOT
-// isolated from any db changes made in the main test.
-//
-// Each subtest will run in a transaction that rolls back when the
-// subtest returns.
-func (suite *PopTestSuite) RunWithPreloadedData(name string, subtest func()) bool {
-	if !suite.usePerTestTransaction {
-		log.Fatal("Cannot use RunWithPreloadedData without per test transaction")
-	}
-	// call suite.DB to ensure a connection is established outside the subtest
-	oldDB := suite.DB()
-	oldT := suite.T()
-	defer suite.SetT(oldT)
-	return oldT.Run(name, func(t *testing.T) {
-		suite.SetT(t)
-		err := oldDB.Rollback(func(tx *pop.Connection) {
-			suite.setDB(tx)
-			defer suite.setDB(oldDB)
-			subtest()
-		})
-		if err != nil {
-			log.Fatalf("Rollback of subtest %s failed: %v", name, err)
-		}
-	})
 }
 
 // TearDownTest runs the teardown per test. It will only do something

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -11,15 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DATA-DOG/go-txdb"
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/validate/v3"
+	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq" // Anonymously import lib/pq driver so it's available to Pop
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-
-	"github.com/DATA-DOG/go-txdb"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/transcom/mymove/pkg/appcontext"
 	"github.com/transcom/mymove/pkg/auth"

--- a/pkg/testingsuite/pop_suite_test.go
+++ b/pkg/testingsuite/pop_suite_test.go
@@ -3,23 +3,32 @@ package testingsuite
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *PopTestSuite) SetupTest() {
+type SimplePopSuite struct {
+	*PopTestSuite
+	models.ReServices
+}
+
+func (suite *SimplePopSuite) SetupTest() {
 
 }
 
-func TestPopTestSuite(t *testing.T) {
-	ps := NewPopTestSuite(CurrentPackage(), WithPerTestTransaction())
-	suite.Run(t, ps)
-	ps.TearDown()
+func TestSimplePopSuite(t *testing.T) {
+	sp := &SimplePopSuite{
+		PopTestSuite: NewPopTestSuite(CurrentPackage(), WithPerTestTransaction()),
+	}
+
+	suite.Run(t, sp)
+	sp.TearDown()
 }
 
-func (suite *PopTestSuite) TestRunWithPreloadData() {
+func (suite *SimplePopSuite) TestRunWithPreloadData() {
 	var address models.Address
 	suite.PreloadData(func() {
 		address = testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
@@ -56,7 +65,7 @@ func (suite *PopTestSuite) TestRunWithPreloadData() {
 
 }
 
-func (suite *PopTestSuite) TestMultipleDBPanic() {
+func (suite *SimplePopSuite) TestMultipleDBPanic() {
 	address := testdatagen.MakeAddress(suite.DB(), testdatagen.Assertions{})
 
 	suite.Run("Trying to use db in main and subtest panics", func() {
@@ -78,7 +87,7 @@ func (suite *PopTestSuite) TestMultipleDBPanic() {
 	})
 }
 
-func (suite *PopTestSuite) TestRun() {
+func (suite *SimplePopSuite) TestRun() {
 	var address2 models.Address
 	suite.Run("Subtest record creation", func() {
 		// Create address to search for in the next test
@@ -93,4 +102,125 @@ func (suite *PopTestSuite) TestRun() {
 		suite.NotEqual(address2.ID, foundAddress.ID)
 	})
 
+}
+
+type PreloadedPopSuite struct {
+	*PopTestSuite
+	models.ReServices
+}
+
+func (suite *PreloadedPopSuite) SetupTest() {
+
+}
+
+func (suite *PreloadedPopSuite) SetupSuite() {
+
+	suite.PreloadData(func() {
+		// Loads some data into database
+		// ReServiceCodeCS
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: suite.ReServices[0],
+		})
+
+		// ReServiceCodeMS
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: suite.ReServices[1],
+		})
+
+		// ReServiceCodeDCRT
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: suite.ReServices[2],
+		})
+	})
+
+}
+
+func (suite *PreloadedPopSuite) TearDownSuite() {
+	suite.PopTestSuite.TearDown()
+}
+
+func TestPreloadedPopSuite(t *testing.T) {
+	reservices := []models.ReService{
+		{
+			ID:   uuid.Must(uuid.NewV4()),
+			Code: models.ReServiceCodeCS,
+		},
+		{
+			ID:   uuid.Must(uuid.NewV4()),
+			Code: models.ReServiceCodeMS,
+		},
+		{
+			ID:   uuid.Must(uuid.NewV4()),
+			Code: models.ReServiceCodeDCRT,
+		},
+	}
+
+	hs := &PreloadedPopSuite{
+		PopTestSuite: NewPopTestSuite(CurrentPackage(), WithPerTestTransaction()),
+		ReServices:   reservices,
+	}
+
+	suite.Run(t, hs)
+}
+
+func (suite *PreloadedPopSuite) TestRunAlt() {
+
+	suite.Run("Run a test to check if preloads are available", func() {
+		// Under test:       suite.PreloadData
+		// Set up:           This suite has preloaded data in the SetupSuite function
+		//                   We only add one new reService in this subtest
+		// Expected outcome: The 3 preloaded reService items are found in the database
+
+		var foundReService models.ReService
+		for _, reservice := range suite.ReServices {
+			err := suite.DB().Find(&foundReService, reservice.ID)
+			suite.NoError(err, "Reservice %s not found", reservice.Code)
+		}
+		// Add a DUCRT ReService, this should not exist outside this subtest
+		testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+			ReService: models.ReService{
+				Code: models.ReServiceCodeDUCRT,
+			},
+		})
+
+	})
+	suite.Run("Run a test to check that subtests are isolated", func() {
+		// Under test:       suite.PreloadData
+		// Set up:           This suite has preloaded data in the SetupSuite function
+		// Expected outcome: The 3 preloaded reService items are found in the database
+		//                   The one new reService added in the subtest above is NOT found
+		var foundReService models.ReService
+		for _, reservice := range suite.ReServices {
+			err := suite.DB().Find(&foundReService, reservice.ID)
+			suite.NoError(err, "Reservice %s not found", reservice.Code)
+		}
+
+		var foundReServices []models.ReService
+		err := suite.DB().Where("code = ?", models.ReServiceCodeDUCRT).All(&foundReServices)
+		suite.NoError(err)
+		suite.Len(foundReServices, 0)
+	})
+
+}
+func (suite *PreloadedPopSuite) TestRunAltAgain() {
+
+	suite.Run("Run a second test to check if preloads are available", func() {
+		// Under test:       suite.PreloadData
+		// Set up:           This suite has preloaded data in the SetupSuite function
+		// Expected outcome: The 3 preloaded reService items are found in the database
+		//                   The one new reService added in the other test in this suite is NOT found
+
+		// Reason for a second test is to ensure they don't accidentally get cleaned up between tests
+		var foundReService models.ReService
+		for _, reservice := range suite.ReServices {
+			err := suite.DB().Find(&foundReService, reservice.ID)
+			suite.NoError(err, "Reservice %s not found", reservice.Code)
+
+		}
+
+		var foundReServices []models.ReService
+		err := suite.DB().Where("code = ?", models.ReServiceCodeDUCRT).All(&foundReServices)
+		suite.NoError(err)
+		suite.Len(foundReServices, 0)
+	})
 }


### PR DESCRIPTION
This change seems to greatly simplify the PopTestSuite code so we no
longer need to override suite.Run and no longer need a separate
RunWithPreloadedData

