### PR TITLE
MB-13217 - Fix flaky integration test; extend use of function to navigate to move

### DIFF
--- a/cypress/integration/office/navigateToMove.js
+++ b/cypress/integration/office/navigateToMove.js
@@ -1,5 +1,5 @@
 export function navigateToMove(moveLocator) {
-  // TOO Moves queue
+  // Office Moves queue
   cy.wait(['@getSortedOrders']);
   cy.get('input[name="locator"]').as('moveCodeFilterInput');
 

--- a/cypress/integration/office/qaecsr/csrFlows.js
+++ b/cypress/integration/office/qaecsr/csrFlows.js
@@ -1,4 +1,5 @@
 import { QAECSROfficeUserType, TIOOfficeUserType } from '../../../support/constants';
+import { navigateToMove } from '../navigateToMove';
 
 describe('Customer Support User Flows', () => {
   before(() => {
@@ -25,13 +26,7 @@ describe('Customer Support User Flows', () => {
     const testRemarkText = 'This is a test remark';
     const editString = '-edit';
 
-    // Moves queue (eventually will come via QAE/CSR move search)
-    cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
-    cy.url().should('include', `/moves/${moveLocator}/details`);
-
-    // Move Details page
-    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    navigateToMove(moveLocator);
 
     // Go to Customer support remarks
     cy.contains('Customer support remarks').click();

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -1,5 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
-import { navigateToMove } from './tooNavigateToMove';
+import { navigateToMove } from '../navigateToMove';
 
 describe('TOO user', () => {
   before(() => {

--- a/cypress/integration/office/txo/tooFlowsNTS.js
+++ b/cypress/integration/office/txo/tooFlowsNTS.js
@@ -1,5 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
-import { navigateToMove } from './tooNavigateToMove';
+import { navigateToMove } from '../navigateToMove';
 
 describe('TOO user', () => {
   before(() => {

--- a/cypress/integration/office/txo/tooFlowsNTSR.js
+++ b/cypress/integration/office/txo/tooFlowsNTSR.js
@@ -1,5 +1,5 @@
 import { TOOOfficeUserType } from '../../../support/constants';
-import { navigateToMove } from './tooNavigateToMove';
+import { navigateToMove } from '../navigateToMove';
 
 describe('TOO user', () => {
   before(() => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13217) for this change

## Summary

The integration tests sometimes break when looking for a move in the moves queue without first filtering for it.
These changes should further extend the uses of a standard method for navigating to a move in the moves queue and hopefully address some test flakiness.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminal to test this locally.</summary>

##### Terminal 1

Run the integration tests

```sh
make e2e_test_fresh
```
On the cypress interface you can search for "csrFlows.js" to run the test that was flaky.

</details>

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
