### PR TITLE
[MB-12546] Fix missing QAE/CSR user when generating devseed data

### DIFF
--- a/pkg/testdatagen/scenario/subscenarios.go
+++ b/pkg/testdatagen/scenario/subscenarios.go
@@ -223,6 +223,7 @@ func subScenarioCustomerSupportRemarks(appCtx appcontext.AppContext) func() {
 
 func subScenarioEvaluationReport(appCtx appcontext.AppContext) func() {
 	return func() {
+		createQaeCsr(appCtx)
 		officeUser := models.OfficeUser{}
 		email := "qae_csr_role@office.mil"
 		err := appCtx.DB().Where("email = ?", email).First(&officeUser)


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

CircleCI is showing an error after running 
```
make db_dev_fresh
```
full log here: https://app.circleci.com/pipelines/github/transcom/mymove/43990/workflows/30d7574f-7902-477c-800e-193405175d53/jobs/693465

```
...
2022-08-02T19:00:21.040Z	INFO	scenario/devseed.go:81	running sub-scenario: evaluation_reports
2022-08-02T19:00:21.040Z	PANIC	scenario/subscenarios.go:230	failed to query OfficeUser in the DB: sql: no rows in result set
github.com/transcom/mymove/pkg/testdatagen/scenario.subScenarioEvaluationReport.func1
panic: failed to query OfficeUser in the DB: sql: no rows in result set

goroutine 1 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc000176000, {0x0, 0x0, 0x0})
	/home/circleci/go/pkg/mod/go.uber.org/zap@v1.21.0/zapcore/entry.go:232 +0x44c
go.uber.org/zap.(*Logger).Panic(0x14e80aa?, {0xc000cb7940?, 0xc001eef8f8?}, {0x0, 0x0, 0x0})
	/home/circleci/go/pkg/mod/go.uber.org/zap@v1.21.0/logger.go:230 +0x59
github.com/transcom/mymove/pkg/testdatagen/scenario.subScenarioEvaluationReport.func1()
	/home/circleci/transcom/mymove/pkg/testdatagen/scenario/subscenarios.go:230 +0x1c5
github.com/transcom/mymove/pkg/testdatagen/scenario.(*devSeedScenario).Run(0x6260c70, {0x533eb60, 0xc00000e630}, {0x0, 0x0})
	/home/circleci/transcom/mymove/pkg/testdatagen/scenario/devseed.go:83 +0x1ef
main.main()
	/home/circleci/transcom/mymove/cmd/generate-test-data/main.go:251 +0x11ed
exit status 2
make: *** [Makefile:564: db_dev_fresh] Error 1

Exited with code exit status 2
```
That command works fine for me locally.

However, if I run the evaluation report scenario on its own, it does fail with exactly the same error.
Which makes sense because it tries to use an existing office user in the database, that I think has been getting created in a different subscenario.

I was able to fix that, and I'm 90% sure this will fix the problem. But it's hard to be completely certain given that `make db_dev_fresh` has different behavior locally than it does in CI.

You can run this scenario on its own with:
```
make db_dev_reset
make db_dev_migrate
go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="dev_seed" --db-env="development" --named-sub-scenario="evaluation_reports"
```
And verify that this fails on master, but not on the current branch