### PR TITLE
MB-13122 Update dependabot to also look at gh actions for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,11 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  labels:
+    - dependencies


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13122) for this change

## Summary

Update dependabot to also check gh actions for updates.

[Docs on updating gh actions w/dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

We do this in the [mymove-docs repo too](https://github.com/transcom/mymove-docs/blob/b2542d088debdf0b25973cf5a5aeda4ed3ccfaae/.github/dependabot.yml#L11-L18).

[h/t to @duncan-truss for recommending this](https://github.com/transcom/mymove-docs/pull/175#pullrequestreview-1060261356)