### PR TITLE
Fix dropdown behavior on shipment evaluation report

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -4712,7 +4712,7 @@ func init() {
         },
         "observedDate": {
           "type": "string",
-          "format": "date-time",
+          "format": "date",
           "x-nullable": true
         },
         "officeUser": {
@@ -13581,7 +13581,7 @@ func init() {
         },
         "observedDate": {
           "type": "string",
-          "format": "date-time",
+          "format": "date",
           "x-nullable": true
         },
         "officeUser": {

--- a/pkg/gen/ghcmessages/evaluation_report.go
+++ b/pkg/gen/ghcmessages/evaluation_report.go
@@ -62,8 +62,8 @@ type EvaluationReport struct {
 	MoveReferenceID *string `json:"moveReferenceID,omitempty"`
 
 	// observed date
-	// Format: date-time
-	ObservedDate *strfmt.DateTime `json:"observedDate,omitempty"`
+	// Format: date
+	ObservedDate *strfmt.Date `json:"observedDate,omitempty"`
 
 	// office user
 	OfficeUser *EvaluationReportOfficeUser `json:"officeUser,omitempty"`
@@ -257,7 +257,7 @@ func (m *EvaluationReport) validateObservedDate(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("observedDate", "body", "date-time", m.ObservedDate.String(), formats); err != nil {
+	if err := validate.FormatOf("observedDate", "body", "date", m.ObservedDate.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -184,7 +184,7 @@ func EvaluationReport(evaluationReport *models.EvaluationReport) *ghcmessages.Ev
 		Location:                location,
 		LocationDescription:     evaluationReport.LocationDescription,
 		MoveID:                  moveID,
-		ObservedDate:            handlers.FmtDateTimePtr(evaluationReport.ObservedDate),
+		ObservedDate:            handlers.FmtDatePtr(evaluationReport.ObservedDate),
 		Remarks:                 evaluationReport.Remarks,
 		ShipmentID:              shipmentID,
 		SubmittedAt:             handlers.FmtDateTimePtr(evaluationReport.SubmittedAt),

--- a/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/ghcapi/internal/payloads/payload_to_model.go
@@ -489,7 +489,7 @@ func EvaluationReportFromUpdate(evaluationReport *ghcmessages.EvaluationReport) 
 		TravelTimeMinutes:       travelTimeMinutes,
 		Location:                location,
 		LocationDescription:     evaluationReport.LocationDescription,
-		ObservedDate:            handlers.FmtDateTimePtrToPopPtr(evaluationReport.ObservedDate),
+		ObservedDate:            (*time.Time)(evaluationReport.ObservedDate),
 		EvaluationLengthMinutes: evaluationLengthMinutes,
 		ViolationsObserved:      evaluationReport.ViolationsObserved,
 		Remarks:                 evaluationReport.Remarks,

--- a/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
+++ b/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
@@ -101,6 +101,7 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
       inspectionDate: formatDateForSwagger(values.inspectionDate),
       evaluationLengthMinutes: evalMinutes,
       travelTimeMinutes: travelMinutes,
+      observedDate: formatDateForSwagger(values.observedDate),
     };
     const { eTag } = evaluationReport;
     mutateEvaluationReport({ reportID: reportId, ifMatchETag: eTag, body });
@@ -111,10 +112,12 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
     // hard coded until violations work
     violations: false,
     inspectionDate: evaluationReport.inspectionDate,
+    observedDate: evaluationReport.observedDate,
   };
   if (evaluationReport.location) {
     initialValues.evaluationLocation = evaluationReport.location.toLowerCase();
   }
+
   if (evaluationReport.locationDescription) {
     initialValues.otherEvaluationLocation = evaluationReport.locationDescription;
   }

--- a/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
+++ b/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
@@ -1,17 +1,7 @@
 import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import 'styles/office.scss';
-import {
-  GridContainer,
-  Grid,
-  Button,
-  Radio,
-  FormGroup,
-  Fieldset,
-  Dropdown,
-  Label,
-  Textarea,
-} from '@trussworks/react-uswds';
+import { GridContainer, Grid, Button, Radio, FormGroup, Fieldset, Label, Textarea } from '@trussworks/react-uswds';
 import { useParams, useHistory } from 'react-router';
 import { useMutation } from 'react-query';
 import { Formik, Field } from 'formik';
@@ -24,8 +14,7 @@ import { Form } from 'components/form/Form';
 import formStyles from 'styles/form.module.scss';
 import ConnectedDeleteEvaluationReportConfirmationModal from 'components/ConfirmationModals/DeleteEvaluationReportConfirmationModal';
 import { deleteEvaluationReport, saveEvaluationReport } from 'services/ghcApi';
-import { DatePickerInput } from 'components/form/fields';
-import Hint from 'components/Hint';
+import { DatePickerInput, DropdownInput } from 'components/form/fields';
 import { MILMOVE_LOG_LEVEL, milmoveLog } from 'utils/milmoveLog';
 import { formatDateForSwagger } from 'shared/dates';
 
@@ -150,8 +139,17 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
 
   const validationSchema = Yup.object().shape({});
 
-  const hours = [...Array(13).keys()];
-  const minutes = [0, 15, 30, 45];
+  const minutes = [
+    { key: '0', value: '0' },
+    { key: '15', value: '15' },
+    { key: '30', value: '30' },
+    { key: '45', value: '45' },
+  ];
+
+  const hours = [];
+  for (let i = 0; i < 13; i += 1) {
+    hours[i] = { key: String(i), value: String(i) };
+  }
 
   return (
     <>
@@ -217,10 +215,7 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                           <legend className="usa-label">Travel time to evaluation</legend>
                           <div className={styles.durationPickers}>
                             <div>
-                              <Hint htmlFor="hour" className={styles.hourLabel}>
-                                Hour
-                              </Hint>
-                              <Dropdown
+                              <DropdownInput
                                 id="hour"
                                 name="hour"
                                 label="Hour"
@@ -228,19 +223,11 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                                 onChange={(e) => {
                                   setFieldValue('hour', e.target.value);
                                 }}
-                              >
-                                {hours.map((option) => (
-                                  <option key={option} value={option} name={option}>
-                                    {option}
-                                  </option>
-                                ))}
-                              </Dropdown>
+                                options={hours}
+                              />
                             </div>
                             <div>
-                              <Hint htmlFor="minute" className={styles.minuteLabel}>
-                                Minute
-                              </Hint>
-                              <Dropdown
+                              <DropdownInput
                                 id="minute"
                                 name="minute"
                                 label="Minute"
@@ -248,13 +235,8 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                                 onChange={(e) => {
                                   setFieldValue('minute', e.target.value);
                                 }}
-                              >
-                                {minutes.map((option) => (
-                                  <option key={option} value={option}>
-                                    {option}
-                                  </option>
-                                ))}
-                              </Dropdown>
+                                options={minutes}
+                              />
                             </div>
                           </div>
                         </Fieldset>
@@ -322,10 +304,7 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                         <legend className="usa-label">Evaluation length</legend>
                         <div className={styles.durationPickers}>
                           <div>
-                            <Hint htmlFor="hour" className={styles.hourLabel}>
-                              Hour
-                            </Hint>
-                            <Dropdown
+                            <DropdownInput
                               id="hour"
                               name="evalLengthHour"
                               label="Hour"
@@ -333,19 +312,11 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                               onChange={(e) => {
                                 setFieldValue('evalLengthHour', e.target.value);
                               }}
-                            >
-                              {hours.map((option) => (
-                                <option key={option} value={option}>
-                                  {option}
-                                </option>
-                              ))}
-                            </Dropdown>
+                              options={hours}
+                            />
                           </div>
                           <div>
-                            <Hint htmlFor="minute" className={styles.minuteLabel}>
-                              Minute
-                            </Hint>
-                            <Dropdown
+                            <DropdownInput
                               id="minute"
                               name="evalLengthMinute"
                               label="Minute"
@@ -353,13 +324,8 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                               onChange={(e) => {
                                 setFieldValue('evalLengthMinute', e.target.value);
                               }}
-                            >
-                              {minutes.map((option) => (
-                                <option key={option} value={option}>
-                                  {option}
-                                </option>
-                              ))}
-                            </Dropdown>
+                              options={minutes}
+                            />
                           </div>
                         </div>
                       </Fieldset>

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -4434,7 +4434,7 @@ definitions:
         x-nullable: true
       observedDate:
         type: string
-        format: date-time
+        format: date
         x-nullable: true
       evaluationLengthMinutes:
         type: integer

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4580,7 +4580,7 @@ definitions:
         x-nullable: true
       observedDate:
         type: string
-        format: date-time
+        format: date
         x-nullable: true
       evaluationLengthMinutes:
         type: integer


### PR DESCRIPTION
## Summary

This will make it so setting `initialValues` for the time drop downs on shipment evaluation reports causes the right option to be selected.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as an office user
3. Go to a move and to the quality assurance tab
4. Create a shipment report
5. Fill out the form and select some time for one of the duration fields
6. Save the thing and then click on view report
7. See that your selection is there

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
