### PR TITLE
MB-13444: Resolve upload validation for weight tickets

### DIFF
--- a/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.jsx
@@ -122,9 +122,8 @@ const WeightTicketUpload = ({
           className={fieldName}
           labelIdle={UploadDropZoneLabel}
           labelIdleMobile={UploadDropZoneLabelMobile}
-          createUpload={(file) => onCreateUpload(fieldName, file)}
+          createUpload={(file) => onCreateUpload(fieldName, file, setFieldTouched)}
           onChange={(err, upload) => {
-            setFieldTouched(fieldName, true);
             onUploadComplete(err);
             fileUploadRef.current.removeFile(upload.id);
           }}
@@ -376,11 +375,12 @@ const WeightTicketForm = ({
                               <FileUpload
                                 name="proofOfTrailerOwnershipDocument"
                                 className="proofOfTrailerOwnershipDocument"
-                                createUpload={(file) => onCreateUpload('proofOfTrailerOwnershipDocument', file)}
+                                createUpload={(file) =>
+                                  onCreateUpload('proofOfTrailerOwnershipDocument', file, formikProps.setFieldTouched)
+                                }
                                 labelIdle={UploadDropZoneLabel}
                                 labelIdleMobile={UploadDropZoneLabelMobile}
                                 onChange={(err, upload) => {
-                                  formikProps.setFieldTouched('proofOfTrailerOwnershipDocument', true);
                                   onUploadComplete(err);
                                   proofOfTrailerOwnershipDocumentRef.current.removeFile(upload.id);
                                 }}

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -58,13 +58,14 @@ const WeightTickets = () => {
     }
   }, [weightTicketId, moveId, mtoShipmentId, history, dispatch, mtoShipment]);
 
-  const handleCreateUpload = async (fieldName, file) => {
+  const handleCreateUpload = async (fieldName, file, setFieldTouched) => {
     const documentId = currentWeightTicket[`${fieldName}Id`];
 
     createUploadForDocument(file, documentId)
       .then((upload) => {
         mtoShipment.ppmShipment.weightTickets[currentIndex][fieldName].uploads.push(upload);
         dispatch(updateMTOShipment(mtoShipment));
+        setFieldTouched(fieldName, true);
         return upload;
       })
       .catch(() => {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13444) for this change

## Summary

This should, resolve the issue we were seeing in demo where we would see the validation error of needing at least 1 file even after a file has been uploaded. The root cause seemed to be related with the fact that the `onChange` function would sometimes trigger before the `createUpload`.

## Setup to Run Your Code / Verification steps

To recreate the issue please run the main branch with the modified environment variable so that you are using the dev s3 to store files instead of local. Steps to do this can be found on https://dp3.atlassian.net/wiki/spaces/MT/pages/1470955567/How+to+test+storing+data+in+S3+locally. You should use the file that is linked [here](https://dp3.atlassian.net/browse/MB-13444?focusedCommentId=23290).

Once you have verified the issue please switch back to this branch and using the same modified environment variables described above, verify if you are still seeing this issue.
