### PR TITLE
Add check to require cac for admin app authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch MB-13400-require-cac-for-admin-login
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -42,22 +42,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
+  integration-ignore-branch: &integration-ignore-branch MB-13400-require-cac-for-admin-login
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch MB-13400-require-cac-for-admin-login
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch placeholder_branch_name
+  client-ignore-branch: &client-ignore-branch MB-13400-require-cac-for-admin-login
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch placeholder_branch_name
+  server-ignore-branch: &server-ignore-branch MB-13400-require-cac-for-admin-login
 
 executors:
   av_medium:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch MB-13400-require-cac-for-admin-login
+  dp3-branch: &dp3-branch placeholder_branch_name
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env exp
+  dp3-env: &dp3-env placeholder_env
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -42,22 +42,22 @@ references:
   # set integration-ignore-branch to the branch if you want to IGNORE
   # integration tests, or `placeholder_branch_name` if you do want to
   # run them
-  integration-ignore-branch: &integration-ignore-branch MB-13400-require-cac-for-admin-login
+  integration-ignore-branch: &integration-ignore-branch placeholder_branch_name
 
   # set integration-mtls-ignore-branch to the branch if you want to
   # IGNORE mtls integration tests, or `placeholder_branch_name` if you
   # do want to run them
-  integration-mtls-ignore-branch: &integration-mtls-ignore-branch MB-13400-require-cac-for-admin-login
+  integration-mtls-ignore-branch: &integration-mtls-ignore-branch placeholder_branch_name
 
   # set client-ignore-branch to the branch if you want to IGNORE
   # client tests, or `placeholder_branch_name` if you do want to run
   # them
-  client-ignore-branch: &client-ignore-branch MB-13400-require-cac-for-admin-login
+  client-ignore-branch: &client-ignore-branch placeholder_branch_name
 
   # set server-ignore-branch to the branch if you want to IGNORE
   # server tests, or `placeholder_branch_name` if you do want to run
   # them
-  server-ignore-branch: &server-ignore-branch MB-13400-require-cac-for-admin-login
+  server-ignore-branch: &server-ignore-branch placeholder_branch_name
 
 executors:
   av_medium:

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -138,14 +138,7 @@ func (p LoginGovProvider) AuthorizationURL(r *http.Request) (*LoginGovData, erro
 	}
 
 	params := authURL.Query()
-	session := auth.SessionFromRequestContext(r)
-	// Logging into the Admin app will require a CAC.
-	if session.IsAdminApp() {
-		// This specifies that a user has been authenticated with an HSPD12 credential, via their CAC.
-		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
-	} else {
-		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/loa/1")
-	}
+	params.Add("acr_values", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
 	params.Add("nonce", state)
 	params.Set("scope", "openid email")
 

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -138,7 +138,14 @@ func (p LoginGovProvider) AuthorizationURL(r *http.Request) (*LoginGovData, erro
 	}
 
 	params := authURL.Query()
-	params.Add("acr_values", "http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
+	// Logging into the Admin app will require a CAC.
+	session := auth.SessionFromRequestContext(r)
+	if session.IsAdminApp() {
+		// This specifies that a user has been authenticated with an HSPD12 credential, via their CAC. Both acr_values must be specified.
+		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
+	} else {
+		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/loa/1")
+	}
 	params.Add("nonce", state)
 	params.Set("scope", "openid email")
 

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -138,7 +138,14 @@ func (p LoginGovProvider) AuthorizationURL(r *http.Request) (*LoginGovData, erro
 	}
 
 	params := authURL.Query()
-	params.Add("acr_values", "http://idmanagement.gov/ns/assurance/loa/1")
+	session := auth.SessionFromRequestContext(r)
+	// Logging into the Admin app will require a CAC.
+	if session.IsAdminApp() {
+		// This specifies that a user has been authenticated with an HSPD12 credential, via their CAC.
+		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
+	} else {
+		params.Add("acr_values", "http://idmanagement.gov/ns/assurance/loa/1")
+	}
 	params.Add("nonce", state)
 	params.Set("scope", "openid email")
 

--- a/pkg/handlers/authentication/login_gov.go
+++ b/pkg/handlers/authentication/login_gov.go
@@ -138,7 +138,7 @@ func (p LoginGovProvider) AuthorizationURL(r *http.Request) (*LoginGovData, erro
 	}
 
 	params := authURL.Query()
-	params.Add("acr_values", "http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
+	params.Add("acr_values", "http://idmanagement.gov/ns/assurance/ial/1 http://idmanagement.gov/ns/assurance/aal/3?hspd12=true")
 	params.Add("nonce", state)
 	params.Set("scope", "openid email")
 


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13400) for this change

## Summary

One of our ATO requirements is to require a CAC for user authentication in the Admin app. This adds a check to use login.gov's stricter credentials when logging into the admin app. This is the code implementation, there is also a setting change in login.gov that will be handled in another ticket.

[This page](https://developers.login.gov/oidc/) lists the different authentication parameters available.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
