### PR TITLE
[MB-13464] remove CVE-2022-37434 ignore, document how to ignore findings

### DIFF
--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -31,7 +31,7 @@ get_findings() {
 
   # To exclude certain findings, add a select statement at the end, e.g.:
   # validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-####-#####"))')
-  # 
+  #
   validFindings=$(echo "${findingsArray}" | jq 'del(.[])')
 
   # Save the total number of findings.

--- a/scripts/ecr-describe-image-scan-findings
+++ b/scripts/ecr-describe-image-scan-findings
@@ -29,14 +29,10 @@ get_findings() {
     findingsArray='[]'
   fi
 
-  # Exclude certain findings.
-  #
-  # ID: CVE-2022-37434
-  # Ticket to remove this exclusion: https://dp3.atlassian.net/browse/MB-13464
-  # Description:
-  # https://github.com/docker-library/official-images/pull/12929
-  # awaiting successful merge of the above PR.
-  validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-2022-37434"))')
+  # To exclude certain findings, add a select statement at the end, e.g.:
+  # validFindings=$(echo "${findingsArray}" | jq 'del(.[] | select(.name == "CVE-####-#####"))')
+  # 
+  validFindings=$(echo "${findingsArray}" | jq 'del(.[])')
 
   # Save the total number of findings.
   totalNumberOfFindings=$(echo "${findingsArray}" | jq -r ". | length")


### PR DESCRIPTION
- Removing the ignore added in [this PR](https://github.com/transcom/mymove/pull/9041), since the alpine image has been updated
- Also adding instructions on how to ignore specific CVEs for the future