### PR TITLE
[ MB-13183 ] Add in bucket name

### DIFF
--- a/config/env/exp.export-db-data.env
+++ b/config/env/exp.export-db-data.env
@@ -1,4 +1,4 @@
-BUCKET_NAME=test-db-export
+BUCKET_NAME=data-warehouse-us-gov-west-1
 DB_IAM=true
 DB_NAME=app
 DB_PORT=5432


### PR DESCRIPTION
This name is constructed from the values that we're passing in the
`transcom/transcom-infrasec-gov-nonato` repository. At the time of this
commit, the value lives in the transcom/transcom-infrasec-gov-nonato#523
Pull Request.

This value can be set in two places either in the repository above or
by the transcom/terraform-aws-app-environment repository's default value
for the `s3_data_warehouse_bucket` variable.
