### PR TITLE
[ MB-13183 ] Refactor ECS Deploy task definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ commands:
       - announce_failure
       - deploy:
           name: Deploy export db data service
-          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container export-db-data "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT}"
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container export-db-data "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks@${ECR_DIGEST}" "${APP_ENVIRONMENT} database-export"
           no_output_timeout: 20m
       - announce_failure
   deploy_app_steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,6 @@ commands:
             scripts/circleci-announce-broken-branch
           when: on_fail
 
-
   deploy_migrations_steps:
     parameters:
       ecr_env:
@@ -456,7 +455,6 @@ commands:
           no_output_timeout: 20m
       - announce_failure
 
-
   deploy_app_storybook:
     parameters:
       s3_bucket:
@@ -542,8 +540,7 @@ commands:
       application:
         type: string
     steps:
-      - run:
-          echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
+      - run: echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
           source $BASH_ENV
       - run:
           name: make server_test_build for <<parameters.application>>
@@ -1055,7 +1052,7 @@ jobs:
       # change the baseline of test results on master builds
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: server-tests-coverage
@@ -1096,7 +1093,7 @@ jobs:
       # change the baseline of test results on master builds
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: client-tests-coverage
@@ -1191,7 +1188,6 @@ jobs:
             - pkg/testdatagen/testdata
       - announce_failure
 
-
   # Compile the client side of the app once and persist the relevant
   # build artifacts to the workspace.
   # This way we don't have to re-run the build and since all necessary
@@ -1234,7 +1230,7 @@ jobs:
       # the cache
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: v2-node-modules-cache-{{ checksum "yarn.lock" }}
@@ -1730,8 +1726,8 @@ workflows:
           requires:
             - pre_deps_golang
           filters:
-              branches:
-                ignore: [*integration-mtls-ignore-branch, *integration-ignore-branch]
+            branches:
+              ignore: [*integration-mtls-ignore-branch, *integration-ignore-branch]
 
       - anti_virus:
           filters:

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -616,6 +616,15 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 			ReadonlyRootFilesystem: aws.Bool(true),
 			Privileged:             aws.Bool(false),
 			User:                   aws.String("1042"),
+			// "mountPoints": [
+			//   {
+			//     "containerPath": "/var/db-export",
+			//     "sourceVolume": "database_scratch"
+			//   }
+			// ],
+			// "ephemeralStorage": {
+			//   "sizeInGiB": 2
+			// },
 		},
 	}
 
@@ -649,6 +658,9 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		NetworkMode:             aws.String("awsvpc"),
 		RequiresCompatibilities: []*string{aws.String("FARGATE")},
 		TaskRoleArn:             aws.String(taskRoleArn),
+		// volume {
+		//   name = "database_scratch"
+		// }
 	}
 
 	// Registration is never allowed by default and requires a flag

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -38,6 +38,11 @@ const (
 	tagSeparator     string = ":"
 )
 
+// Valid ephemeral storage options
+var storage = []string{
+	"database-export",
+}
+
 // Valid services names
 var services = []string{
 	"app",
@@ -120,6 +125,7 @@ const (
 	memFlag                  string = "memory"
 	registerFlag             string = "register"
 	openTelemetrySidecarFlag string = "open-telemetry-sidecar"
+	storageFlag              string = "storage"
 )
 
 // ECRImage represents an ECR Image tag broken into its constituent parts
@@ -231,6 +237,9 @@ func initTaskDefFlags(flag *pflag.FlagSet) {
 
 	// Open Telemetry SideCar
 	flag.Bool(openTelemetrySidecarFlag, false, "Include open telemetry sidecar container")
+
+	// Create ephemeral storage
+	flag.String(storageFlag, "", fmt.Sprintf("The ephemeral storage type (choose %q)", storage))
 
 	// Dry Run or Registration
 	flag.Bool(dryRunFlag, false, "Execute as a dry-run without modifying AWS.")
@@ -616,16 +625,21 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 			ReadonlyRootFilesystem: aws.Bool(true),
 			Privileged:             aws.Bool(false),
 			User:                   aws.String("1042"),
-			// "mountPoints": [
-			//   {
-			//     "containerPath": "/var/db-export",
-			//     "sourceVolume": "database_scratch"
-			//   }
-			// ],
-			// "ephemeralStorage": {
-			//   "sizeInGiB": 2
-			// },
 		},
+	}
+
+	if v.GetString(storageFlag) == "database-export" {
+		mps := []*ecs.MountPoint{}
+		mps = append(mps, &ecs.MountPoint{
+			ContainerPath: aws.String("/var/db-export"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("database_scratch"),
+		})
+		containerDefinitions = append(containerDefinitions,
+			&ecs.ContainerDefinition{
+				MountPoints: mps,
+			},
+		)
 	}
 
 	if v.GetBool(openTelemetrySidecarFlag) {
@@ -658,9 +672,12 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		NetworkMode:             aws.String("awsvpc"),
 		RequiresCompatibilities: []*string{aws.String("FARGATE")},
 		TaskRoleArn:             aws.String(taskRoleArn),
-		// volume {
-		//   name = "database_scratch"
-		// }
+	}
+
+	if v.GetString(storageFlag) == "database-export" {
+		newTaskDefInput.Volumes = append(newTaskDefInput.Volumes, &ecs.Volume{
+			Name: aws.String("database_scratch"),
+		})
 	}
 
 	// Registration is never allowed by default and requires a flag

--- a/scripts/ecs-deploy-task-container
+++ b/scripts/ecs-deploy-task-container
@@ -9,10 +9,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly DIR
 
 usage() {
-    echo "$0 <name> <image> <environment>"
+    echo "$0 <name> <image> <environment> <storage_type>"
     exit 1
 }
-[[ -z $1 || -z $2 || -z $3 ]] && usage
+[[ -z $1 || -z $2 || -z $3 || -z $4 ]] && usage
 
 # Display command being run
 echo "$0 $*"
@@ -22,6 +22,7 @@ set -u
 readonly name=$1
 readonly image=$2
 readonly environment=$3
+readonly storage_type=$4
 
 readonly RESERVATION_CPU=256
 readonly RESERVATION_MEM=512
@@ -55,6 +56,7 @@ dry_run_task_definition_date=$("${DIR}/../bin/ecs-deploy" task-def \
   --image "${image}" \
   --cpu "${RESERVATION_CPU}" \
   --memory "${RESERVATION_MEM}" \
+  --storage "${storage_type}" \
   --variables-file "${variables_file}" \
   --entrypoint "/bin/milmove-tasks ${name}" \
   --dry-run)
@@ -73,6 +75,7 @@ task_definition_date_arn=$("${DIR}/../bin/ecs-deploy" task-def \
   --image "${image}" \
   --cpu "${RESERVATION_CPU}" \
   --memory "${RESERVATION_MEM}" \
+  --storage "${storage_type}" \
   --variables-file "${variables_file}" \
   --entrypoint "/bin/milmove-tasks ${name}" \
   --register)


### PR DESCRIPTION
We realized in transcom/terraform-aws-app-environment#215 that while we
define container and task definitions in Terraform, we override them in
the deployment of our ECS scheduled tasks within the
`cmd/ecs-deploy/task_def.go`. This means that rather than setting things
in our Terraform, we'll need to define the task and container in the Go
binary.
