### PR TITLE
MB-13502 Fixing some QAE formatting and display issues discovered during UAT testing

### DIFF
--- a/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
+++ b/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
@@ -54,8 +54,6 @@ describe('Quality Evaluation Report Flows', () => {
     // go to the QAE report section
     cy.contains('Quality assurance').click();
     cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
-
-    // create report object to edit
     cy.get('[data-testid="shipmentEvaluationCreate"]').click();
     cy.wait(['@getEvaluationReport']);
     cy.get('[data-testid="textarea"]').type('this is a remark');
@@ -63,6 +61,7 @@ describe('Quality Evaluation Report Flows', () => {
     cy.url().should('include', `/moves/${moveLocator}/evaluation-reports`);
     cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
     cy.contains('Your draft report has been saved');
+    // On this run through the cancel button should kick us back to the reports list view.
     cy.contains('View report').click();
     cy.wait(['@getEvaluationReport']);
     cy.get('[data-testid="cancelForUpdated"]').click();

--- a/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
+++ b/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
@@ -43,4 +43,30 @@ describe('Quality Evaluation Report Flows', () => {
     cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
     cy.contains('Your draft report has been saved');
   });
+
+  it('does not prompt to delete report after first save', () => {
+    const moveLocator = 'TEST12';
+    cy.wait(['@getSortedOrders']);
+    cy.contains(moveLocator).click();
+    // Move Details page
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // go to the QAE report section
+    cy.contains('Quality assurance').click();
+    cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
+
+    // create report object to edit
+    cy.get('[data-testid="shipmentEvaluationCreate"]').click();
+    cy.wait(['@getEvaluationReport']);
+    cy.get('[data-testid="textarea"]').type('this is a remark');
+    cy.contains('Save draft').click();
+    cy.url().should('include', `/moves/${moveLocator}/evaluation-reports`);
+    cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
+    cy.contains('Your draft report has been saved');
+    cy.contains('View report').click();
+    cy.wait(['@getEvaluationReport']);
+    cy.get('[data-testid="cancelForUpdated"]').click();
+    cy.url().should('include', `/moves/${moveLocator}/evaluation-reports`);
+    cy.contains('View report');
+  });
 });

--- a/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
+++ b/cypress/integration/office/qaecsr/qaeEvaluationReportFlow.js
@@ -68,4 +68,21 @@ describe('Quality Evaluation Report Flows', () => {
     cy.url().should('include', `/moves/${moveLocator}/evaluation-reports`);
     cy.contains('View report');
   });
+  it('does prompt to delete if the report has not been saved since creation', () => {
+    const moveLocator = 'TEST12';
+    cy.wait(['@getSortedOrders']);
+    cy.contains(moveLocator).click();
+    // Move Details page
+    cy.wait(['@getMoves', '@getOrders', '@getMTOShipments', '@getMTOServiceItems']);
+    cy.url().should('include', `/moves/${moveLocator}/details`);
+    // go to the QAE report section
+    cy.contains('Quality assurance').click();
+    cy.wait(['@getMTOShipments', '@getShipmentEvaluationReports', '@getCounselingEvaluationReports']);
+    cy.get('[data-testid="shipmentEvaluationCreate"]').click();
+    cy.wait(['@getEvaluationReport']);
+    cy.contains('Cancel').click();
+    cy.contains('Yes, Cancel').click();
+    cy.url().should('include', `/moves/${moveLocator}/evaluation-reports`);
+    cy.contains('Your report has been canceled');
+  });
 });

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -4741,6 +4741,11 @@ func init() {
         "type": {
           "$ref": "#/definitions/EvaluationReportType"
         },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
         "violationsObserved": {
           "type": "boolean",
           "x-nullable": true
@@ -13610,6 +13615,11 @@ func init() {
         },
         "type": {
           "$ref": "#/definitions/EvaluationReportType"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
         },
         "violationsObserved": {
           "type": "boolean",

--- a/pkg/gen/ghcmessages/evaluation_report.go
+++ b/pkg/gen/ghcmessages/evaluation_report.go
@@ -88,6 +88,11 @@ type EvaluationReport struct {
 	// type
 	Type EvaluationReportType `json:"type,omitempty"`
 
+	// updated at
+	// Read Only: true
+	// Format: date-time
+	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
+
 	// violations observed
 	ViolationsObserved *bool `json:"violationsObserved,omitempty"`
 }
@@ -145,6 +150,10 @@ func (m *EvaluationReport) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUpdatedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -336,6 +345,18 @@ func (m *EvaluationReport) validateType(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *EvaluationReport) validateUpdatedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.UpdatedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("updatedAt", "body", "date-time", m.UpdatedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ContextValidate validate this evaluation report based on the context it is used
 func (m *EvaluationReport) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -373,6 +394,10 @@ func (m *EvaluationReport) ContextValidate(ctx context.Context, formats strfmt.R
 	}
 
 	if err := m.contextValidateType(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateUpdatedAt(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -483,6 +508,15 @@ func (m *EvaluationReport) contextValidateType(ctx context.Context, formats strf
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("type")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *EvaluationReport) contextValidateUpdatedAt(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "updatedAt", "body", strfmt.DateTime(m.UpdatedAt)); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -194,6 +194,7 @@ func EvaluationReport(evaluationReport *models.EvaluationReport) *ghcmessages.Ev
 		MoveReferenceID:         evaluationReport.Move.ReferenceID,
 		OfficeUser:              &evaluationReportOfficeUserPayload,
 		ETag:                    etag.GenerateEtag(evaluationReport.UpdatedAt),
+		UpdatedAt:               strfmt.DateTime(evaluationReport.UpdatedAt),
 	}
 	return payload
 }

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -15,6 +15,7 @@ import { OrdersLOAShape } from 'types/order';
 import { shipmentStatuses } from 'constants/shipments';
 import { ShipmentStatusesOneOf } from 'types/shipment';
 import { formatAddress, retrieveSAC, retrieveTAC } from 'utils/shipmentDisplay';
+import { formatShortIDWithPound } from 'utils/formatters';
 
 const EvaluationReportShipmentDisplay = ({
   shipmentType,
@@ -59,7 +60,7 @@ const EvaluationReportShipmentDisplay = ({
             )}
             {displayInfo.usesExternalVendor && <Tag>external vendor</Tag>}
           </div>
-          <div className={styles.headingShipmentID}>Shipment ID: #{shipmentId.slice(0, 5).toUpperCase()}</div>
+          <div className={styles.headingShipmentID}>Shipment ID: {formatShortIDWithPound(shipmentId)}</div>
           <FontAwesomeIcon className={styles.icon} icon={expandableIconClasses} onClick={handleExpandClick} />
         </div>
         {isExpanded && displayInfo.shipmentType === SHIPMENT_OPTIONS.NTS && (

--- a/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportShipmentInfo.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 import styles from './EvaluationReportShipmentInfo.module.scss';
 
 import { SHIPMENT_OPTIONS } from 'shared/constants';
-import { formatEvaluationReportShipmentAddress, formatShortShipmentID } from 'utils/formatters';
+import { formatEvaluationReportShipmentAddress, formatShortIDWithPound } from 'utils/formatters';
 import { ShipmentShape } from 'types/shipment';
 import { milmoveLog, MILMOVE_LOG_LEVEL } from 'utils/milmoveLog';
 import { createEvaluationReportForShipment } from 'services/ghcApi';
@@ -78,7 +78,7 @@ const EvaluationReportShipmentInfo = ({ shipment }) => {
       <div className={styles.shipmentInfoContainer}>
         <div className={styles.shipmentInfo}>
           <h4>
-            {heading} Shipment ID {formatShortShipmentID(shipment.id)}
+            {heading} Shipment ID {formatShortIDWithPound(shipment.id)}
           </h4>
           <small>
             {pickupAddress} <FontAwesomeIcon icon="arrow-right" /> {destinationAddress}

--- a/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
+++ b/src/components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm.jsx
@@ -30,6 +30,10 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
     setIsDeleteModelOpen(!isDeleteModelOpen);
   };
 
+  const cancelForUpdatedReport = () => {
+    history.push(`/moves/${moveCode}/evaluation-reports`);
+  };
+
   const cancelReport = async () => {
     // Close the modal
     setIsDeleteModelOpen(!isDeleteModelOpen);
@@ -383,9 +387,21 @@ const ShipmentEvaluationForm = ({ evaluationReport }) => {
                 <Grid row>
                   <Grid col>
                     <div className={styles.buttonRow}>
-                      <Button className="usa-button--unstyled" onClick={toggleCancelModel} type="button">
-                        Cancel
-                      </Button>
+                      {evaluationReport.updatedAt === evaluationReport.createdAt && (
+                        <Button className="usa-button--unstyled" onClick={toggleCancelModel} type="button">
+                          Cancel
+                        </Button>
+                      )}
+                      {!(evaluationReport.updatedAt === evaluationReport.createdAt) && (
+                        <Button
+                          className="usa-button--unstyled"
+                          data-testid="cancelForUpdated"
+                          onClick={cancelForUpdatedReport}
+                          type="button"
+                        >
+                          Cancel
+                        </Button>
+                      )}
                       <Button data-testid="saveDraft" type="submit" className="usa-button--secondary">
                         Save draft
                       </Button>

--- a/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
+++ b/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
@@ -10,7 +10,7 @@ import shipmentEvaluationReportStyles from './ShipmentEvaluationReport.module.sc
 
 import ShipmentEvaluationForm from 'components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm';
 import { useShipmentEvaluationReportQueries } from 'hooks/queries';
-import { formatShortIDWithPound } from 'utils/formatters';
+import { formatQAReportID } from 'utils/formatters';
 import DataTable from 'components/DataTable';
 import { CustomerShape } from 'types';
 import { OrdersShape } from 'types/customerShapes';
@@ -64,7 +64,7 @@ const ShipmentEvaluationReport = ({ customerInfo, orders }) => {
         <div className={styles.pageHeader}>
           <h1>Shipment report</h1>
           <div className={styles.pageHeaderDetails}>
-            <h6>REPORT ID {formatShortIDWithPound(reportId)}</h6>
+            <h6>REPORT ID {formatQAReportID(reportId)}</h6>
             <h6>MOVE CODE #{moveCode}</h6>
             <h6>MTO REFERENCE ID #{mtoRefId}</h6>
           </div>

--- a/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
+++ b/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
@@ -5,11 +5,12 @@ import classnames from 'classnames';
 import { useParams } from 'react-router';
 
 import styles from '../TXOMoveInfo/TXOTab.module.scss';
-import ShipmentEvaluationForm from '../../../components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm';
 
 import shipmentEvaluationReportStyles from './ShipmentEvaluationReport.module.scss';
 
+import ShipmentEvaluationForm from 'components/Office/ShipmentEvaluationForm/ShipmentEvaluationForm';
 import { useShipmentEvaluationReportQueries } from 'hooks/queries';
+import { formatShortIDWithPound } from 'utils/formatters';
 import DataTable from 'components/DataTable';
 import { CustomerShape } from 'types';
 import { OrdersShape } from 'types/customerShapes';
@@ -63,8 +64,8 @@ const ShipmentEvaluationReport = ({ customerInfo, orders }) => {
         <div className={styles.pageHeader}>
           <h1>Shipment report</h1>
           <div className={styles.pageHeaderDetails}>
-            <h6>REPORT ID #{reportId}</h6>
-            <h6>MOVE CODE {moveCode}</h6>
+            <h6>REPORT ID {formatShortIDWithPound(reportId)}</h6>
+            <h6>MOVE CODE #{moveCode}</h6>
             <h6>MTO REFERENCE ID #{mtoRefId}</h6>
           </div>
         </div>

--- a/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
+++ b/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.jsx
@@ -45,14 +45,16 @@ const ShipmentEvaluationReport = ({ customerInfo, orders }) => {
     </>
   );
 
-  const officeUserInfoTableBody = (
+  const officeUserInfoTableBody = evaluationReport.officeUser ? (
     <>
-      {customerInfo.last_name}, {customerInfo.first_name}
+      {evaluationReport.officeUser.lastName}, {evaluationReport.officeUser.firstName}
       <br />
-      {customerInfo.phone}
+      {evaluationReport.officeUser.phone}
       <br />
-      {customerInfo.email}
+      {evaluationReport.officeUser.email}
     </>
+  ) : (
+    ''
   );
 
   return (

--- a/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.test.jsx
+++ b/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.test.jsx
@@ -34,8 +34,8 @@ describe('ShipmentEvaluationReport', () => {
       const h1 = screen.getByRole('heading', { name: 'Shipment report', level: 1 });
       expect(h1).toBeInTheDocument();
 
-      expect(screen.getByText(`REPORT ID #${mockReportId}`)).toBeInTheDocument();
-      expect(screen.getByText(`MOVE CODE ${mockMoveCode}`)).toBeInTheDocument();
+      expect(screen.getByText(`REPORT ID #${mockReportId.slice(0, 5).toUpperCase()}`)).toBeInTheDocument();
+      expect(screen.getByText(`MOVE CODE #${mockMoveCode}`)).toBeInTheDocument();
       expect(screen.getByText('MTO REFERENCE ID #')).toBeInTheDocument();
 
       // Page content sections

--- a/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.test.jsx
+++ b/src/pages/Office/ShipmentEvaluationReport/ShipmentEvaluationReport.test.jsx
@@ -34,7 +34,7 @@ describe('ShipmentEvaluationReport', () => {
       const h1 = screen.getByRole('heading', { name: 'Shipment report', level: 1 });
       expect(h1).toBeInTheDocument();
 
-      expect(screen.getByText(`REPORT ID #${mockReportId.slice(0, 5).toUpperCase()}`)).toBeInTheDocument();
+      expect(screen.getByText(`REPORT ID #QA-${mockReportId.slice(0, 5).toUpperCase()}`)).toBeInTheDocument();
       expect(screen.getByText(`MOVE CODE #${mockMoveCode}`)).toBeInTheDocument();
       expect(screen.getByText('MTO REFERENCE ID #')).toBeInTheDocument();
 

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -174,6 +174,9 @@ export const formatPrimeAPIFullAddress = (address) => {
 
 export const formatEvaluationReportShipmentAddress = (address) => {
   const { streetAddress1, city, state, postalCode } = address;
+  if (!streetAddress1 || !city || !state) {
+    return postalCode;
+  }
   return `${streetAddress1}, ${city}, ${state} ${postalCode}`;
 };
 

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -409,7 +409,7 @@ export function formatQAReportID(uuid) {
   return `#QA-${getUUIDFirstFive(uuid)}`;
 }
 
-export function formatShortShipmentID(uuid) {
+export function formatShortIDWithPound(uuid) {
   return `#${getUUIDFirstFive(uuid)}`;
 }
 

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -4460,6 +4460,10 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+      updatedAt:
+        type: string
+        format: date-time
+        readOnly: true
   CreateShipmentEvaluationReport:
     type: object
     description: Minimal set of info needed to create a shipment evaluation report, which is just a shipment ID.

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -4606,6 +4606,10 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+      updatedAt:
+        type: string
+        format: date-time
+        readOnly: true
   CreateShipmentEvaluationReport:
     type: object
     description: >-


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13502) for this change

## Summary

A grab bag of fixes for things we found in the last round of UAT. This addresses the following:
* The null address bug on the reports list page
* Shortening the report ID and using the # character with the move code
* Using office user info in the QAE info block
* Cancel button should not prompt for soft deletion if the report has been saved after creation

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
3. Login as a
4.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
