### PR TITLE
[ MB-13183 ] Removing export-db-data prepwork from DP3 Dockerfile

### DIFF
--- a/Dockerfile.tasks_dp3
+++ b/Dockerfile.tasks_dp3
@@ -1,13 +1,3 @@
-###########
-# BUILDER-POSTGRES #
-###########
-
-FROM alpine:3.15.4 as builder-pg
-WORKDIR /tmp
-RUN apk update && apk fetch -R postgresql-client
-RUN mkdir /apkg
-RUN for apkFile in *.apk; do tar -zxvf "${apkFile}" -C "/apkg" || exit 10; done
-
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base:latest
 
@@ -24,13 +14,5 @@ COPY config/tls/api.exp.dp3.us.chain.der.p7b /config/tls/api.exp.dp3.us.chain.de
 COPY bin/rds-ca-rsa4096-g1.pem /bin/rds-ca-rsa4096-g1.pem
 
 COPY bin/milmove-tasks /bin/milmove-tasks
-
-# Expose the /var/db-export volume mount to Fargate
-RUN mkdir -p /var/db-export
-VOLUME ["/var/db-export"]
-
-# Copy Postgresql and dependencies
-COPY --from=builder-pg --chown=root:root /apkg /
-ENV PATH="${PATH}:/usr/libexec/postgresql14"
 
 WORKDIR /bin


### PR DESCRIPTION
Since we aren't going to enable the Advana integration in environments
outside of the ATO boundary, we don't need this in our Dockerfile that
is used for dp3.us environments.
