### PR TITLE
MB-13605: Fix flaky integration tests

### DIFF
--- a/cypress/integration/office/qaecsr/csrFlows.js
+++ b/cypress/integration/office/qaecsr/csrFlows.js
@@ -27,7 +27,7 @@ describe('Customer Support User Flows', () => {
 
     // Moves queue (eventually will come via QAE/CSR move search)
     cy.wait(['@getSortedOrders']);
-    cy.contains(moveLocator).click();
+    cy.contains(moveLocator).click({ force: true });
     cy.url().should('include', `/moves/${moveLocator}/details`);
 
     // Move Details page

--- a/cypress/integration/office/qaecsr/csrFlows.js
+++ b/cypress/integration/office/qaecsr/csrFlows.js
@@ -120,6 +120,10 @@ describe('Customer Support User Flows', () => {
     cy.contains('Sign out').click();
     cy.apiSignInAsUser('3b2cc1b0-31a2-4d1b-874f-0591f9127374', TIOOfficeUserType);
 
+    // Manual wait added to ensure that the queue loads before checking for the corresponding row
+    // For some reason, this won't work properly on CircleCI with a named intercept wait
+    cy.wait(2000);
+
     // Validate another user can not edit or delete the remark
     cy.contains(moveLocator).click({ force: true });
     cy.wait(['@getMoves', '@getOrders', '@getMTOShipments']);

--- a/cypress/integration/office/qaecsr/csrFlows.js
+++ b/cypress/integration/office/qaecsr/csrFlows.js
@@ -26,7 +26,8 @@ describe('Customer Support User Flows', () => {
     const editString = '-edit';
 
     // Moves queue (eventually will come via QAE/CSR move search)
-    cy.wait(['@getSortedOrders']);
+    cy.wait(2000);
+
     cy.contains(moveLocator).click({ force: true });
     cy.url().should('include', `/moves/${moveLocator}/details`);
 

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -184,7 +184,7 @@ describe('Services counselor user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('[data-testid="scAllowancesSave"]').should('be.enabled').click().should('be.disabled');
+      cy.get('[data-testid="scAllowancesSave"]').should('be.enabled').click({ force: true });
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
+++ b/cypress/integration/office/servicescounseling/servicesCounselingFlows.js
@@ -184,7 +184,7 @@ describe('Services counselor user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('[data-testid="scAllowancesSave"]').should('be.enabled').click({ force: true });
+      cy.get('[data-testid="scAllowancesSave"]').should('be.enabled').click();
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -301,7 +301,7 @@ describe('TOO user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button').contains('Save').should('be.enabled').click();
+      cy.get('button').contains('Save').should('be.enabled').click({ force: true });
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -301,7 +301,7 @@ describe('TOO user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button').contains('Save').should('be.enabled').click({ force: true });
+      cy.get('button').contains('Save').should('be.enabled').click();
     });
 
     cy.wait(['@patchAllowances']);

--- a/cypress/integration/office/txo/tooFlows.js
+++ b/cypress/integration/office/txo/tooFlows.js
@@ -301,7 +301,7 @@ describe('TOO user', () => {
       cy.get('input[name="dependentsAuthorized"]').siblings('label[for="dependentsAuthorizedInput"]').click();
 
       // Edit allowances page | Save
-      cy.get('button').contains('Save').should('be.enabled').click().should('be.disabled');
+      cy.get('button').contains('Save').should('be.enabled').click();
     });
 
     cy.wait(['@patchAllowances']);


### PR DESCRIPTION
## Jira ticket for this change: [MB-13605](https://dp3.atlassian.net/browse/MB-13605)

## Summary

This pull request adds fixes three of the most frequent flaky Cypress tests, which are currently experiencing up to a 10% failure rate in the `master` branch on CircleCI. (Further pull requests will address additional flaky Cypress tests, but there's no reason hold off on a PR until those are finished.)

* "Customer Support User Flows is able to add, edit, and delete a remark"
* "TOO user is able to edit allowances" (which also resolves failures in "TOO user is able to view SIT and create and edit SIT extensions")
* "Services counselor user is able to edit allowances"

As these Cypress tests are flaky, they could still fail in the future, but the `integration_tests_office` job on CircleCI was run 20 times with the latest commit and none of these tests failed in those iterations, so to me it indicates a relatively high level of confidence in resolving these race conditions.