### PR TITLE
[MB-13578] Align advance initial values with formik values being submitted

### DIFF
--- a/src/components/Office/ShipmentForm/ShipmentForm.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.jsx
@@ -573,8 +573,8 @@ const ShipmentForm = (props) => {
                     showHint={false}
                     error={
                       errors.counselorRemarks &&
-                      (String(values.advanceRequested) !== String(mtoShipment.ppmShipment?.hasRequestedAdvance) ||
-                        String(values.advance) !== String(mtoShipment.ppmShipment?.advanceAmountRequested))
+                      (values.advanceRequested !== mtoShipment.ppmShipment?.hasRequestedAdvance ||
+                        values.advance !== mtoShipment.ppmShipment?.advanceAmountRequested)
                     }
                   />
                 )}

--- a/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.stories.jsx
@@ -84,6 +84,25 @@ const mockMtoShipment = {
   },
 };
 
+const mockPPMShipment = {
+  id: '4774f99f-bc94-467a-9469-b6f81657b9ef',
+  mtoShipmentId: mockMtoShipment.id,
+  expectedDepartureDate: '2022-12-31',
+  pickupPostalCode: '90210',
+  destinationPostalCode: '30813',
+  estimatedWeight: 2000,
+  sitExpected: false,
+  hasProGear: false,
+  estimatedIncentive: 1000000,
+};
+
+const mockMtoShipmentTypePPM = {
+  id: '2523b014-aac6-4443-8181-6df0a754329b',
+  moveTaskOrderId: 'e3b4eb5b-a19d-46a0-b155-dac3c49cc3f6',
+  shipmentType: SHIPMENT_OPTIONS.PPM,
+  ppmShipment: mockPPMShipment,
+};
+
 const mockMtoShipmentNoCustomerRemarks = {
   ...mockMtoShipment,
   customerRemarks: '',
@@ -107,104 +126,99 @@ export default {
   ],
 };
 
+const Template = (args) => <ShipmentForm {...args} />;
+
 // create shipment stories (form should not prefill customer data)
-export const HHGShipment = () => <ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} />;
+export const HHGShipment = Template.bind({});
+HHGShipment.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.HHG,
+};
 
 // edit shipment stories (form should prefill)
-export const EditHHGShipment = () => (
-  <ShipmentForm
-    {...defaultProps}
-    selectedMoveType={SHIPMENT_OPTIONS.HHG}
-    isCreatePage={false}
-    mtoShipment={mockMtoShipment}
-    userRole={roleTypes.SERVICES_COUNSELOR}
-  />
-);
+export const EditHHGShipment = Template.bind({});
+EditHHGShipment.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.HHG,
+  isCreatePage: false,
+  mtoShipment: mockMtoShipment,
+  userRole: roleTypes.SERVICES_COUNSELOR,
+};
 
 // edit shipment stories, no customer remarks (form should prefill)
-export const EditHHGShipmentNoCustRemarks = () => (
-  <ShipmentForm
-    {...defaultProps}
-    selectedMoveType={SHIPMENT_OPTIONS.HHG}
-    isCreatePage={false}
-    mtoShipment={mockMtoShipmentNoCustomerRemarks}
-    userRole={roleTypes.SERVICES_COUNSELOR}
-  />
-);
-
-export const HHGShipmentAsTOO = () => {
-  return <ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.HHG} userRole={roleTypes.TOO} />;
+export const EditHHGShipmentNoCustRemarks = Template.bind({});
+EditHHGShipmentNoCustRemarks.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.HHG,
+  isCreatePage: false,
+  mtoShipment: mockMtoShipmentNoCustomerRemarks,
+  userRole: roleTypes.SERVICES_COUNSELOR,
 };
 
-export const NTSShipmentWithoutCodes = () => {
-  return (
-    <ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.NTS} userRole={roleTypes.SERVICES_COUNSELOR} />
-  );
+export const HHGShipmentAsTOO = Template.bind({});
+HHGShipmentAsTOO.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.HHG,
+  userRole: roleTypes.TOO,
 };
 
-export const NTSShipmentWithCodes = () => {
-  return (
-    <ShipmentForm
-      {...defaultProps}
-      selectedMoveType={SHIPMENT_OPTIONS.NTS}
-      TACs={{ HHG: '1234', NTS: '5678' }}
-      SACs={{ HHG: '000012345' }}
-      userRole={roleTypes.SERVICES_COUNSELOR}
-    />
-  );
+export const NTSShipmentWithoutCodes = Template.bind({});
+NTSShipmentWithoutCodes.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.NTS,
+  userRole: roleTypes.SERVICES_COUNSELOR,
 };
 
-export const NTSReleaseShipment = () => {
-  return (
-    <ShipmentForm
-      {...defaultProps}
-      selectedMoveType={SHIPMENT_OPTIONS.NTSR}
-      TACs={{ HHG: '1234', NTS: '5678' }}
-      SACs={{ HHG: '000012345', NTS: '6789ABC' }}
-      userRole={roleTypes.SERVICES_COUNSELOR}
-    />
-  );
+export const NTSShipmentWithCodes = Template.bind({});
+NTSShipmentWithCodes.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.NTS,
+  TACs: { HHG: '1234', NTS: '5678' },
+  SACs: { HHG: '000012345' },
+  userRole: roleTypes.SERVICES_COUNSELOR,
 };
 
-export const NTSShipmentAsTOO = () => {
-  return (
-    <ShipmentForm
-      {...defaultProps}
-      selectedMoveType={SHIPMENT_OPTIONS.NTS}
-      TACs={{ HHG: '1234', NTS: '5678' }}
-      SACs={{ HHG: '000012345' }}
-      userRole={roleTypes.TOO}
-    />
-  );
+export const NTSReleaseShipment = Template.bind({});
+NTSReleaseShipment.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.NTSR,
+  TACs: { HHG: '1234', NTS: '5678' },
+  SACs: { HHG: '000012345', NTS: '6789ABC' },
+  userRole: roleTypes.SERVICES_COUNSELOR,
 };
 
-export const ExternalVendorShipment = () => {
-  return (
-    <ShipmentForm
-      {...defaultProps}
-      selectedMoveType={SHIPMENT_OPTIONS.NTSR}
-      TACs={{ HHG: '1234', NTS: '5678' }}
-      SACs={{ HHG: '000012345', NTS: '6789ABC' }}
-      mtoShipment={{ ...mockMtoShipment, usesExternalVendor: true }}
-      userRole={roleTypes.TOO}
-    />
-  );
+export const NTSShipmentAsTOO = Template.bind({});
+NTSShipmentAsTOO.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.NTS,
+  TACs: { HHG: '1234', NTS: '5678' },
+  SACs: { HHG: '000012345' },
+  userRole: roleTypes.TOO,
 };
 
-export const PPMShipment = () => {
-  return (
-    <ShipmentForm {...defaultProps} selectedMoveType={SHIPMENT_OPTIONS.PPM} userRole={roleTypes.SERVICES_COUNSELOR} />
-  );
+export const ExternalVendorShipment = Template.bind({});
+ExternalVendorShipment.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.NTSR,
+  TACs: { HHG: '1234', NTS: '5678' },
+  SACs: { HHG: '000012345', NTS: '6789ABC' },
+  mtoShipment: { ...mockMtoShipment, usesExternalVendor: true },
+  userRole: roleTypes.TOO,
 };
 
-export const PPMShipmentAdvance = () => {
-  return (
-    <ShipmentForm
-      {...defaultProps}
-      selectedMoveType={SHIPMENT_OPTIONS.PPM}
-      userRole={roleTypes.SERVICES_COUNSELOR}
-      isAdvancePage
-      mtoShipment={{ ppmShipment: { estimatedIncentive: 1000000 } }}
-    />
-  );
+export const PPMShipment = Template.bind({});
+PPMShipment.args = {
+  ...defaultProps,
+  selectedMoveType: SHIPMENT_OPTIONS.PPM,
+  userRole: roleTypes.SERVICES_COUNSELOR,
+};
+
+export const PPMShipmentAdvance = Template.bind({});
+PPMShipmentAdvance.args = {
+  ...defaultProps,
+  isCreatePage: false,
+  selectedMoveType: SHIPMENT_OPTIONS.PPM,
+  userRole: roleTypes.SERVICES_COUNSELOR,
+  isAdvancePage: true,
+  mtoShipment: mockMtoShipmentTypePPM,
 };

--- a/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
+++ b/src/components/Office/ShipmentForm/ShipmentForm.test.jsx
@@ -868,8 +868,8 @@ describe('ShipmentForm component', () => {
     pickupPostalCode: '12345',
     destinationPostalCode: '54321',
     sitLocation: 'DESTINATION',
-    departureDate: '2022-10-29',
-    entryDate: '2022-08-06',
+    sitEstimatedDepartureDate: '2022-10-29',
+    sitEstimatedEntryDate: '2022-08-06',
     sitExpected: true,
   };
 

--- a/src/components/Office/ShipmentForm/ppmShipmentSchema.js
+++ b/src/components/Office/ShipmentForm/ppmShipmentSchema.js
@@ -79,9 +79,7 @@ const ppmShipmentSchema = ({
 
     counselorRemarks: Yup.string().when(['advance', 'advanceRequested'], {
       is: (advance, advanceRequested) =>
-        isAdvancePage &&
-        (Number(advance) !== advanceAmountRequested / 100 ||
-          advanceRequested?.toString() !== hasRequestedAdvance?.toString()),
+        isAdvancePage && (Number(advance) !== advanceAmountRequested / 100 || advanceRequested !== hasRequestedAdvance),
       then: (schema) => schema.required('Required'),
     }),
   });

--- a/src/utils/formatMtoShipment.js
+++ b/src/utils/formatMtoShipment.js
@@ -106,7 +106,7 @@ export function formatPpmShipmentForDisplay({ counselorRemarks = '', ppmShipment
     spouseProGearWeight: (ppmShipment.spouseProGearWeight || '').toString(),
 
     estimatedIncentive: ppmShipment.estimatedIncentive,
-    advanceRequested: ppmShipment.hasRequestedAdvance?.toString() || 'false',
+    advanceRequested: ppmShipment.hasRequestedAdvance ?? false,
     advance: (ppmShipment.advanceAmountRequested / 100 || '').toString(),
 
     counselorRemarks,
@@ -248,7 +248,7 @@ export function formatPpmShipmentForAPI(formValues) {
     sitExpected: !!formValues.sitExpected,
     estimatedWeight: Number(formValues.estimatedWeight || '0'),
     hasProGear: !!formValues.hasProGear,
-    hasRequestedAdvance: formValues.advanceRequested === 'true',
+    hasRequestedAdvance: formValues.advanceRequested,
   };
 
   if (formValues.hasProGear) {

--- a/src/utils/formatMtoShipment.test.js
+++ b/src/utils/formatMtoShipment.test.js
@@ -400,7 +400,7 @@ describe('formatPpmShipmentForDisplay', () => {
 
     expect(display.estimatedWeight).toEqual('');
     expect(display.hasProGear).toEqual(false);
-    expect(display.advanceRequested).toEqual('false');
+    expect(display.advanceRequested).toEqual(false);
   });
 
   it('converts an existing shipment to formatted display values', () => {
@@ -422,7 +422,7 @@ describe('formatPpmShipmentForDisplay', () => {
       proGearWeight: 1000,
 
       estimatedIncentive: 400000,
-      advanceRequested: true,
+      hasRequestedAdvance: true,
       advanceAmountRequested: 200000,
     };
 
@@ -432,6 +432,7 @@ describe('formatPpmShipmentForDisplay', () => {
     expect(display.sitEstimatedWeight).toEqual('2750');
     expect(display.estimatedWeight).toEqual('9000');
     expect(display.proGearWeight).toEqual('1000');
+    expect(display.advanceRequested).toEqual(true);
     expect(display.advance).toEqual('2000');
     expect(display.counselorRemarks).toEqual('test remarks');
   });
@@ -455,7 +456,7 @@ describe('formatPpmShipmentForAPI', () => {
       hasProGear: true,
       proGearWeight: '1000',
 
-      advanceRequested: 'true',
+      advanceRequested: true,
       advance: '2000',
 
       counselorRemarks: 'test remarks',


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13578) for this change

## Summary

The Services Counselor PPM Shipment advance form was not saving updated values properly because there was a mismatch between how initial values were being set to a string value ("true" or "false") and what was produced in the handleSubmit values (cast to boolean) object.

The best way I've found to debug some of these problems is to use the React devtools to inspect the Formik state of initialValues and the values properties to make sure they reflect the shipment data on load or after form interaction.

Ephemeral environment deployment: https://office-milmove-pr-9099.mymove.sandbox.truss.coffee/

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make db_dev_e2e_populate && make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login as the Services Counselor user to the office app
2. Select the move with code `PPMSIT` from the queue
3. Locate the PPM shipment and see that an advance of 5,987 was initially requested.
4. Click on the Edit Shipment button
5. Press Save and Continue as no edits are needed on the first page of the form.
6. Decline the advance by selecting No for Advance requested.
7. Enter some remarks and click Save and Continue.
8. View the PPM shipment card now says No for advance requested.
9. Edit the form again and request and advance.
10. Changes should now be saved properly and reflected in the shipment card and form.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
