### PR TITLE
MB-13577: Allow Decimals in Expense Amount 

### DIFF
--- a/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.jsx
+++ b/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.jsx
@@ -26,7 +26,7 @@ const validationSchema = Yup.object().shape({
   expenseType: Yup.string().required('Required'),
   description: Yup.string().required('Required'),
   paidWithGTCC: Yup.boolean().required('Required'),
-  amount: Yup.number().required('Required'),
+  amount: Yup.string().required('Required'),
   missingReceipt: Yup.boolean().required('Required'),
   receiptDocument: Yup.array().of(uploadShape).min(1, 'At least one upload is required'),
   sitStartDate: Yup.date()
@@ -123,8 +123,11 @@ const ExpenseForm = ({
                         label="Amount"
                         id="amount"
                         mask={Number}
-                        scale={0} // digits after point, 0 for integers
+                        scale={2} // digits after point, 0 for integers
                         signed={false} // disallow negative
+                        radix="." // fractional delimiter
+                        mapToRadix={['.']} // symbols to process as radix
+                        padFractionalZeros // if true, then pads zeros at end to the length of scale
                         thousandsSeparator=","
                         lazy={false} // immediate masking evaluation
                         prefix="$"

--- a/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.stories.jsx
+++ b/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.stories.jsx
@@ -56,7 +56,7 @@ ExistingExpenses.args = {
     description: 'bubble wrap',
     missingReceipt: false,
     paidWithGTCC: false,
-    amount: 600,
+    amount: '600',
     receiptDocument: {
       uploads: [
         {
@@ -90,7 +90,7 @@ SITExpenses.args = {
     description: '10x10 storage pod',
     missingReceipt: false,
     paidWithGTCC: false,
-    amount: 1600,
+    amount: '1600.97',
     sitStartDate: '2022-09-23',
     sitEndDate: '2022-12-25',
     receiptDocument: {

--- a/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/ExpenseForm/ExpenseForm.test.jsx
@@ -47,7 +47,7 @@ const expenseRequiredProps = {
     description: 'bubble wrap',
     missingReceipt: false,
     paidWithGTCC: false,
-    amount: 600,
+    amount: '600',
     receiptDocument: {
       uploads: [
         {
@@ -71,7 +71,7 @@ const sitExpenseProps = {
     description: '10x10 storage pod',
     missingReceipt: false,
     paidWithGTCC: false,
-    amount: 1600,
+    amount: '1600.99',
     sitStartDate: '2022-09-24',
     sitEndDate: '2022-12-26',
     receiptDocument: {

--- a/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
+++ b/src/components/form/fields/MaskedTextField/MaskedTextField.jsx
@@ -75,7 +75,11 @@ const MaskedTextField = ({
             blocks={blocks}
             lazy={lazy}
             onAccept={(val, masked) => {
-              helpers.setValue(masked.unmaskedValue);
+              if (props.scale === 0) {
+                helpers.setValue(masked.unmaskedValue);
+              } else {
+                helpers.setValue(val);
+              }
               // setValue is already triggering validation for this field so we should be able to skip it in setTouched
               helpers.setTouched(true, false);
             }}

--- a/src/types/shipment.js
+++ b/src/types/shipment.js
@@ -142,7 +142,7 @@ export const ExpenseShape = shape({
   missingReceipt: bool,
   receiptDocumentId: string,
   receiptDocument: DocumentShape,
-  amount: number,
+  amount: string,
   paidWithGTCC: bool,
   sitStartDate: string,
   sitEndDate: string,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13577) for this change

## Summary

This PR allows the expense amount to include decimals. 

**NOTE Engineering:** 
- This assumes we are storing the expense amount in cents in the database like we are with the estimated incentive amount

**NOTE Design:**
- If someone leaves the text field after inputting 160.9 a trailing zero will be padded to the end to make it 160.90
- This PR didn't change the styles of anything on the page. Only the behavior of the Amount field on the expense form to allow decimal inputs

## Setup to Run Your Code

Start the Storybook locally.

```sh
make storybook
```
**If you don't want to run storybook locally, changes can be viewed here:** 

## Screenshots
<img width="824" alt="Screen Shot 2022-08-23 at 9 08 16 AM" src="https://user-images.githubusercontent.com/67110378/186166680-ec067963-5e26-4f66-9192-4b63ce8a76e5.png">
