### PR TITLE
MB-13424 QAE can view shipments when editing/creating a counseling evaluation report

### DIFF
--- a/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSRShipmentInfoList.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import shipmentDefinitionListsStyles from './ShipmentDefinitionLists.module.scss';
 
@@ -279,43 +278,41 @@ const NTSRShipmentInfoList = ({
   );
 
   const evaluationReportDetails = (
-    <GridContainer className={shipmentDefinitionListsStyles.evaluationReportDLContainer}>
-      <Grid row className={shipmentDefinitionListsStyles.evaluationReportRow}>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list"
-          >
-            {isExpanded && scheduledPickupDateElement}
-            {isExpanded && actualPickupDateElement}
-            {isExpanded && storageFacilityContactInfoElement}
-          </dl>
-        </Grid>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list"
-          >
-            {isExpanded && scheduledDeliveryDateElement}
-            {isExpanded && requiredDeliveryDateElement}
-            {isExpanded && actualDeliveryDateElement}
-            {isExpanded && receivingAgentElement}
-          </dl>
-        </Grid>
-      </Grid>
-    </GridContainer>
+    <div className={shipmentDefinitionListsStyles.sideBySideContainer}>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list"
+        >
+          {isExpanded && scheduledPickupDateElement}
+          {isExpanded && actualPickupDateElement}
+          {isExpanded && storageFacilityContactInfoElement}
+        </dl>
+      </div>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list"
+        >
+          {isExpanded && scheduledDeliveryDateElement}
+          {isExpanded && requiredDeliveryDateElement}
+          {isExpanded && actualDeliveryDateElement}
+          {isExpanded && receivingAgentElement}
+        </dl>
+      </div>
+    </div>
   );
 
   return <div>{isForEvaluationReport ? evaluationReportDetails : defaultDetails}</div>;

--- a/src/components/Office/DefinitionLists/NTSShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/NTSShipmentInfoList.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import shipmentDefinitionListsStyles from './ShipmentDefinitionLists.module.scss';
 
@@ -276,43 +275,41 @@ const NTSShipmentInfoList = ({
   );
 
   const evaluationReportDetails = (
-    <GridContainer className={shipmentDefinitionListsStyles.evaluationReportDLContainer}>
-      <Grid row className={shipmentDefinitionListsStyles.evaluationReportRow}>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list"
-          >
-            {isExpanded && scheduledPickupDateElement}
-            {isExpanded && actualPickupDateElement}
-            {isExpanded && releasingAgentElement}
-          </dl>
-        </Grid>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list"
-          >
-            {isExpanded && scheduledDeliveryDateElement}
-            {isExpanded && requiredDeliveryDateElement}
-            {isExpanded && actualDeliveryDateElement}
-            {isExpanded && storageFacilityContactInfoElement}
-          </dl>
-        </Grid>
-      </Grid>
-    </GridContainer>
+    <div className={shipmentDefinitionListsStyles.sideBySideContainer}>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list"
+        >
+          {isExpanded && scheduledPickupDateElement}
+          {isExpanded && actualPickupDateElement}
+          {isExpanded && releasingAgentElement}
+        </dl>
+      </div>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list"
+        >
+          {isExpanded && scheduledDeliveryDateElement}
+          {isExpanded && requiredDeliveryDateElement}
+          {isExpanded && actualDeliveryDateElement}
+          {isExpanded && storageFacilityContactInfoElement}
+        </dl>
+      </div>
+    </div>
   );
 
   return <div>{isForEvaluationReport ? evaluationReportDetails : defaultDetails}</div>;

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -49,7 +49,7 @@ const PPMShipmentInfoList = ({
     <div className={expectedDepartureDateElementFlags.classes}>
       <dt>Departure date</dt>
       <dd data-testid="expectedDepartureDate">
-        {expectedDepartureDate && formatDate(expectedDepartureDate, 'DD MMM YYYY')}
+        {(expectedDepartureDate && formatDate(expectedDepartureDate, 'DD MMM YYYY')) || '—'}
       </dd>
     </div>
   );

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -73,8 +73,10 @@ const PPMShipmentInfoList = ({
   const destinationZIPElementFlags = getDisplayFlags('DestinationZIP');
   const destinationZIPElement = (
     <div className={destinationZIPElementFlags.classes}>
-      <dt>Destination ZIP</dt>
-      <dd data-testid="destinationZIP">{destinationPostalCode}</dd>
+      <dt className={shipmentDefinitionListsStyles.ppmRightLonerDataRow}>Destination ZIP</dt>
+      <dd className={shipmentDefinitionListsStyles.ppmRightLonerDataRow} data-testid="destinationZIP">
+        {destinationPostalCode}
+      </dd>
     </div>
   );
 

--- a/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/PPMShipmentInfoList.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import shipmentDefinitionListsStyles from './ShipmentDefinitionLists.module.scss';
 
@@ -174,40 +173,37 @@ const PPMShipmentInfoList = ({
   );
 
   const evaluationReportDetails = (
-    <GridContainer className={shipmentDefinitionListsStyles.evaluationReportDLContainer}>
-      <Grid row className={shipmentDefinitionListsStyles.evaluationReportRow}>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list-left"
-          >
-            {isExpanded && originZIPElement}
-            {isExpanded && expectedDepartureDateElement}
-          </dl>
-        </Grid>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              shipmentDefinitionListsStyles.evaluationReportDLRight,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list-right"
-          >
-            {isExpanded && destinationZIPElement}
-          </dl>
-        </Grid>
-      </Grid>
-    </GridContainer>
+    <div className={shipmentDefinitionListsStyles.sideBySideContainer}>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list-left"
+        >
+          {isExpanded && originZIPElement}
+          {isExpanded && expectedDepartureDateElement}
+        </dl>
+      </div>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list-right"
+        >
+          {isExpanded && destinationZIPElement}
+        </dl>
+      </div>
+    </div>
   );
 
   return <div>{isForEvaluationReport ? evaluationReportDetails : defaultDetails}</div>;

--- a/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
@@ -43,18 +43,27 @@
 .evaluationReportDL {
   @include u-margin-left(0 !important);
   @include u-margin-right(0 !important);
+}
+
+.sideBySideContainer {
+  display: flex;
+  justify-content: space-between;
+  @include u-padding-left(1);
   dd {
-    @include u-width(106px);
     font-size: 13px;
+    width: 106px;
+    word-break: break-all;
   }
   dt {
     font-size: 13px;
   }
 }
 
-.evaluationReportDLRight {
-  @include u-padding-left(16px);
+.sidebySideItem {
+  flex-grow: 1;
 }
+
+
 
 
 

--- a/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
@@ -63,6 +63,12 @@
   flex-grow: 1;
 }
 
+.ppmRightLonerDataRow {
+  border-bottom-color: $base-lighter;
+  border-bottom-width: 1px !important;
+  border-bottom-style: solid;
+}
+
 
 
 

--- a/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
@@ -51,7 +51,7 @@
   @include u-padding-left(1);
   dd {
     font-size: 13px;
-    width: 106px;
+    width: 206px;
     word-break: break-all;
   }
   dt {

--- a/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
@@ -81,7 +81,10 @@ const ShipmentInfoList = ({
   const scheduledPickupDateElement = (
     <div className={scheduledPickupDateElementFlags.classes}>
       <dt>Scheduled pickup date</dt>
-      <dd data-testid="requestedPickupDate">{scheduledPickupDate && formatDate(scheduledPickupDate, 'DD MMM YYYY')}</dd>
+      <dd data-testid="requestedPickupDate">
+        {(scheduledPickupDate && formatDate(scheduledPickupDate, 'DD MMM YYYY')) ||
+          getMissingOrDash('scheduledPickupDate')}
+      </dd>
     </div>
   );
 
@@ -89,7 +92,10 @@ const ShipmentInfoList = ({
   const requestedPickupDateElement = (
     <div className={requestedPickupDateElementFlags.classes}>
       <dt>Requested pickup date</dt>
-      <dd data-testid="requestedPickupDate">{requestedPickupDate && formatDate(requestedPickupDate, 'DD MMM YYYY')}</dd>
+      <dd data-testid="requestedPickupDate">
+        {(requestedPickupDate && formatDate(requestedPickupDate, 'DD MMM YYYY')) ||
+          getMissingOrDash('requestedPickupDate')}
+      </dd>
     </div>
   );
 
@@ -97,7 +103,9 @@ const ShipmentInfoList = ({
   const actualPickupDateElement = (
     <div className={requestedPickupDateElementFlags.classes}>
       <dt>Actual pickup date</dt>
-      <dd data-testid="actualPickupDate">{actualPickupDate && formatDate(actualPickupDate, 'DD MMM YYYY')}</dd>
+      <dd data-testid="actualPickupDate">
+        {(actualPickupDate && formatDate(actualPickupDate, 'DD MMM YYYY')) || getMissingOrDash('actualPickupDate')}
+      </dd>
     </div>
   );
 
@@ -147,7 +155,9 @@ const ShipmentInfoList = ({
   const pickupAddressElement = (
     <div className={pickupAddressElementFlags.classes}>
       <dt>Origin address</dt>
-      <dd data-testid="pickupAddress">{pickupAddress && formatAddress(pickupAddress)}</dd>
+      <dd data-testid="pickupAddress">
+        {(pickupAddress && formatAddress(pickupAddress)) || getMissingOrDash('pickupAddress')}
+      </dd>
     </div>
   );
 

--- a/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
+++ b/src/components/Office/DefinitionLists/ShipmentInfoList.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import shipmentDefinitionListsStyles from './ShipmentDefinitionLists.module.scss';
 
@@ -230,45 +229,43 @@ const ShipmentInfoList = ({
   );
 
   const evaluationReportDetails = (
-    <GridContainer className={shipmentDefinitionListsStyles.evaluationReportDLContainer}>
-      <Grid row className={shipmentDefinitionListsStyles.evaluationReportRow}>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list-left"
-          >
-            {showElement(scheduledPickupDateElement) && scheduledPickupDateElement}
-            {showElement(actualPickupDateElementFlags) && actualPickupDateElement}
-            {showElement(requestedDeliveryDateElementFlags) && requestedDeliveryDateElement}
-            {showElement(agentsElementFlags) && releasingAgentElement}
-          </dl>
-        </Grid>
-        <Grid col={6}>
-          <dl
-            className={classNames(
-              shipmentDefinitionListsStyles.evaluationReportDL,
-              shipmentDefinitionListsStyles.evaluationReportDLRight,
-              styles.descriptionList,
-              styles.tableDisplay,
-              styles.compact,
-              className,
-            )}
-            data-testid="shipment-info-list-right"
-          >
-            {showElement(scheduledDeliveryDateElementFlags) && scheduledDeliveryDateElement}
-            {showElement(requiredDeliveryDateElementFlags) && requiredDeliveryDateElement}
-            {showElement(actualDeliveryDateElementFlags) && actualDeliveryDateElement}
-            {showElement(agentsElementFlags) && receivingAgentElement}
-          </dl>
-        </Grid>
-      </Grid>
-    </GridContainer>
+    <div className={shipmentDefinitionListsStyles.sideBySideContainer}>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list-left"
+        >
+          {showElement(scheduledPickupDateElement) && scheduledPickupDateElement}
+          {showElement(actualPickupDateElementFlags) && actualPickupDateElement}
+          {showElement(requestedDeliveryDateElementFlags) && requestedDeliveryDateElement}
+          {showElement(agentsElementFlags) && releasingAgentElement}
+        </dl>
+      </div>
+      <div className={shipmentDefinitionListsStyles.sidebySideItem}>
+        <dl
+          className={classNames(
+            shipmentDefinitionListsStyles.evaluationReportDL,
+            shipmentDefinitionListsStyles.evaluationReportDLRight,
+            styles.descriptionList,
+            styles.tableDisplay,
+            styles.compact,
+            className,
+          )}
+          data-testid="shipment-info-list-right"
+        >
+          {showElement(scheduledDeliveryDateElementFlags) && scheduledDeliveryDateElement}
+          {showElement(requiredDeliveryDateElementFlags) && requiredDeliveryDateElement}
+          {showElement(actualDeliveryDateElementFlags) && actualDeliveryDateElement}
+          {showElement(agentsElementFlags) && receivingAgentElement}
+        </dl>
+      </div>
+    </div>
   );
 
   return <div>{isForEvaluationReport ? evaluationReportDetails : defaultDetails}</div>;

--- a/src/components/Office/EvaluationForm/EvaluationForm.module.scss
+++ b/src/components/Office/EvaluationForm/EvaluationForm.module.scss
@@ -24,7 +24,10 @@
   @include u-radius('05');
   @include u-border('base-lighter');
   @include u-border('1px');
-  @include u-padding(4);
+  @include u-padding-top(4);
+  @include u-padding-bottom(4);
+  @include u-padding-right(6);
+  @include u-padding-left(6);
   @include u-margin-bottom(2);
   max-width: 1200px;
 }

--- a/src/components/Office/EvaluationForm/EvaluationForm.module.scss
+++ b/src/components/Office/EvaluationForm/EvaluationForm.module.scss
@@ -5,6 +5,7 @@
 .buttonContainer {
   @include u-padding(0);
   @include u-margin-bottom(115px);
+  max-width: 1200px;
 }
 
 .buttonRow {
@@ -25,6 +26,7 @@
   @include u-border('1px');
   @include u-padding(4);
   @include u-margin-bottom(2);
+  max-width: 1200px;
 }
 
 .durationPickers {

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -49,9 +49,9 @@ const EvaluationReportShipmentDisplay = ({
       <ShipmentContainer className={containerClasses} shipmentType={shipmentType}>
         <div className={styles.heading}>
           <div className={styles.headingTagWrapper}>
-            <h3>
+            <h5>
               <label id={`shipment-display-label-${shipmentId}`}>{displayInfo.heading}</label>
-            </h3>
+            </h5>
             {displayInfo.isDiversion && <Tag>diversion</Tag>}
             {displayInfo.shipmentStatus === shipmentStatuses.CANCELED && <Tag className="usa-tag--red">cancelled</Tag>}
             {displayInfo.shipmentStatus === shipmentStatuses.DIVERSION_REQUESTED && <Tag>diversion requested</Tag>}
@@ -60,23 +60,23 @@ const EvaluationReportShipmentDisplay = ({
             )}
             {displayInfo.usesExternalVendor && <Tag>external vendor</Tag>}
           </div>
-          <div className={styles.headingShipmentID}>Shipment ID: {formatShortIDWithPound(shipmentId)}</div>
+          <h6 className={styles.headingShipmentID}>Shipment ID: {formatShortIDWithPound(shipmentId)}</h6>
           <FontAwesomeIcon className={styles.icon} icon={expandableIconClasses} onClick={handleExpandClick} />
         </div>
         {isExpanded && displayInfo.shipmentType === SHIPMENT_OPTIONS.NTS && (
           <div className={styles.ntsHeaderText}>
-            <div className={styles.ntsHeaderTextField}>Pickup address</div>
-            <div className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>
+            <h6 className={styles.ntsHeaderTextField}>Pickup address</h6>
+            <h6 className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>
               {displayInfo?.storageFacility ? displayInfo.storageFacility.facilityName : ''}
-            </div>
+            </h6>
           </div>
         )}
         {isExpanded && displayInfo.shipmentType === SHIPMENT_OPTIONS.NTSR && (
           <div className={styles.ntsHeaderText}>
-            <div className={styles.ntsHeaderTextField}>
+            <h6 className={styles.ntsHeaderTextField}>
               {displayInfo?.storageFacility ? displayInfo.storageFacility.facilityName : ''}
-            </div>
-            <div className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>Delivery address</div>
+            </h6>
+            <h6 className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>Delivery address</h6>
           </div>
         )}
         {isExpanded && (displayInfo.pickupAddress || displayInfo.destinationAddress) && (

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -82,12 +82,12 @@ const EvaluationReportShipmentDisplay = ({
         {isExpanded && (displayInfo.pickupAddress || displayInfo.destinationAddress) && (
           <div className={styles.shipmentAddresses}>
             <div className={classnames(styles.shipmentAddressTextFields, styles.shipmentAddressLeft)}>
-              {pickupAddressString}
+              {pickupAddressString || '—'}
             </div>
             <div className={styles.shipmentAddressArrow}>
               <FontAwesomeIcon icon="arrow-right" />
             </div>
-            <div className={styles.shipmentAddressTextFields}>{destinationAddressString}</div>
+            <div className={styles.shipmentAddressTextFields}>{destinationAddressString || '—'}</div>
           </div>
         )}
         <ShipmentInfoListSelector

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.jsx
@@ -66,7 +66,7 @@ const EvaluationReportShipmentDisplay = ({
         {isExpanded && displayInfo.shipmentType === SHIPMENT_OPTIONS.NTS && (
           <div className={styles.ntsHeaderText}>
             <div className={styles.ntsHeaderTextField}>Pickup address</div>
-            <div className={styles.ntsHeaderTextField}>
+            <div className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>
               {displayInfo?.storageFacility ? displayInfo.storageFacility.facilityName : ''}
             </div>
           </div>
@@ -76,12 +76,14 @@ const EvaluationReportShipmentDisplay = ({
             <div className={styles.ntsHeaderTextField}>
               {displayInfo?.storageFacility ? displayInfo.storageFacility.facilityName : ''}
             </div>
-            <div className={styles.ntsHeaderTextField}>Delivery address</div>
+            <div className={classnames(styles.ntsHeaderTextField, styles.ntsHeaderTextRight)}>Delivery address</div>
           </div>
         )}
-        {isExpanded && displayInfo.pickupAddress && displayInfo.destinationAddress && (
+        {isExpanded && (displayInfo.pickupAddress || displayInfo.destinationAddress) && (
           <div className={styles.shipmentAddresses}>
-            <div className={styles.shipmentAddressTextFields}>{pickupAddressString}</div>
+            <div className={classnames(styles.shipmentAddressTextFields, styles.shipmentAddressLeft)}>
+              {pickupAddressString}
+            </div>
             <div className={styles.shipmentAddressArrow}>
               <FontAwesomeIcon icon="arrow-right" />
             </div>

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
@@ -16,6 +16,8 @@
   color: $base-dark;
   font-size: 13px;
   @include u-padding-right(17px);
+  @include u-margin-top(0);
+  @include u-margin-bottom(0);
 }
 
 .ntsHeaderText {
@@ -29,6 +31,8 @@
 .ntsHeaderTextField {
   flex-grow: 1;
   @include u-padding-left(1);
+  @include u-margin-top(2px);
+  @include u-margin-bottom(1);
 }
 
 .ntsHeaderTextRight {
@@ -63,8 +67,10 @@
     justify-items: flex-start;
     @include u-text('base-darkest');
     @include u-margin(0);
-    @include u-padding(2);
-
+    @include u-padding-left(2);
+    @include u-padding-right(2);
+    @include u-padding-bottom(2);
+    @include u-padding-top(12px);
     h3 {
       display: inline;
       font-weight: normal;
@@ -86,6 +92,10 @@
       display: flex;
       align-items: center;
       flex-grow: 1;
+      h5 {
+        @include u-margin-top(0);
+        @include u-margin-bottom(0);
+      }
     }
 
     :global(.usa-checkbox__label) {

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
@@ -9,6 +9,7 @@
   @include u-padding-left(8px);
   @include u-padding-right(8px);
   width: 100%;
+  word-break: break-word;
 }
 
 .headingShipmentID {
@@ -19,20 +20,26 @@
 
 .ntsHeaderText {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-between;
   font-size: 15px;
   @include u-padding-left(8px);
   color: $base-dark;
 }
 
 .ntsHeaderTextField {
-  width: 50%;
+  flex-grow: 1;
+  @include u-padding-left(1);
+}
+
+.ntsHeaderTextRight {
+  @include u-margin-left(5);
 }
 
 .shipmentAddressArrow {
-  flex: 0;
-  @include u-padding-left(17px);
-  @include u-padding-right(17px);
+  //flex: 0;
+  flex-grow: 0;
+  @include u-margin-left(0);
+  @include u-margin-right(1);
   @include u-padding-top(4px);
   svg {
     display: block;
@@ -41,7 +48,12 @@
 }
 
 .shipmentAddressTextFields {
-    flex: 1;
+  flex: 1;
+  @include u-padding-left(1);
+}
+
+.shipmentAddressLeft {
+  max-width: 46.5%;
 }
 
 .ShipmentCard {

--- a/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
+++ b/src/components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay.module.scss
@@ -24,8 +24,12 @@
   display: flex;
   justify-content: space-between;
   font-size: 15px;
-  @include u-padding-left(8px);
   color: $base-dark;
+  @include u-padding-left(8px);
+  :last-of-type {
+    @include u-padding-left(0);
+  }
+
 }
 
 .ntsHeaderTextField {

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { GridContainer, Grid } from '@trussworks/react-uswds';
-import 'styles/office.scss';
+import { GridContainer } from '@trussworks/react-uswds';
+import classnames from 'classnames';
 
 import styles from '../EvaluationReportTable/EvaluationReportContainer.module.scss';
+import 'styles/office.scss';
 
 import evaluationReportStyles from './EvaluationReportShipmentInfo.module.scss';
 
@@ -47,12 +48,15 @@ const EvaluationReportShipmentInfo = ({ shipments, report, customerInfo, orders 
 
   return (
     <GridContainer className={evaluationReportStyles.cardContainer}>
-      <Grid row>
-        <Grid col desktop={{ col: 8 }}>
+      <div className={evaluationReportStyles.sidebySideContainer}>
+        <div>
           <h2>{report.type === 'SHIPMENT' ? 'Shipment' : 'Move'} information</h2>
           {shipments.length > 0 &&
             shipments.map((shipment) => (
-              <div key={shipment.id} className={styles.shipmentDisplayContainer}>
+              <div
+                key={shipment.id}
+                className={classnames(styles.shipmentDisplayContainer, evaluationReportStyles.shipmentCardColumn)}
+              >
                 <EvaluationReportShipmentDisplay
                   isSubmitted
                   key={shipment.id}
@@ -62,17 +66,12 @@ const EvaluationReportShipmentInfo = ({ shipments, report, customerInfo, orders 
                 />
               </div>
             ))}
-        </Grid>
-        <Grid
-          className={evaluationReportStyles.qaeAndCustomerInfo}
-          col
-          desktop={{ col: 2 }}
-          data-testid="qaeAndCustomerInfo"
-        >
-          <DataTable columnHeaders={['Customer information']} dataRow={[customerInfoTableBody]} />
+        </div>
+        <div className={evaluationReportStyles.qaeAndCustomerInfo} data-testid="qaeAndCustomerInfo">
           <DataTable columnHeaders={['QAE']} dataRow={[officeUserInfoTableBody]} />
-        </Grid>
-      </Grid>
+          <DataTable columnHeaders={['Customer information']} dataRow={[customerInfoTableBody]} />
+        </div>
+      </div>
     </GridContainer>
   );
 };

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.jsx
@@ -3,6 +3,8 @@ import { PropTypes } from 'prop-types';
 import { GridContainer, Grid } from '@trussworks/react-uswds';
 import 'styles/office.scss';
 
+import styles from '../EvaluationReportTable/EvaluationReportContainer.module.scss';
+
 import evaluationReportStyles from './EvaluationReportShipmentInfo.module.scss';
 
 import DataTable from 'components/DataTable';
@@ -10,8 +12,8 @@ import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
 import { shipmentTypeLabels } from 'content/shipments';
 import EvaluationReportShipmentDisplay from 'components/Office/EvaluationReportShipmentDisplay/EvaluationReportShipmentDisplay';
 
-const EvaluationReportShipmentInfo = ({ shipment, report, customerInfo, orders }) => {
-  const shipmentDisplayInfo = () => ({
+const EvaluationReportShipmentInfo = ({ shipments, report, customerInfo, orders }) => {
+  const shipmentDisplayInfo = (shipment) => ({
     ...shipment,
     heading: shipmentTypeLabels[shipment.shipmentType],
     isDiversion: shipment.diversion,
@@ -47,15 +49,19 @@ const EvaluationReportShipmentInfo = ({ shipment, report, customerInfo, orders }
     <GridContainer className={evaluationReportStyles.cardContainer}>
       <Grid row>
         <Grid col desktop={{ col: 8 }}>
-          <h2>Shipment information</h2>
-          {shipment.id && (
-            <EvaluationReportShipmentDisplay
-              isSubmitted
-              shipmentId={shipment.id}
-              displayInfo={shipmentDisplayInfo(shipment)}
-              shipmentType={shipment.shipmentType}
-            />
-          )}
+          <h2>{report.type === 'SHIPMENT' ? 'Shipment' : 'Move'} information</h2>
+          {shipments.length > 0 &&
+            shipments.map((shipment) => (
+              <div key={shipment.id} className={styles.shipmentDisplayContainer}>
+                <EvaluationReportShipmentDisplay
+                  isSubmitted
+                  key={shipment.id}
+                  shipmentId={shipment.id}
+                  displayInfo={shipmentDisplayInfo(shipment)}
+                  shipmentType={shipment.shipmentType}
+                />
+              </div>
+            ))}
         </Grid>
         <Grid
           className={evaluationReportStyles.qaeAndCustomerInfo}
@@ -73,7 +79,7 @@ const EvaluationReportShipmentInfo = ({ shipment, report, customerInfo, orders }
 
 EvaluationReportShipmentInfo.propTypes = {
   report: PropTypes.object.isRequired,
-  shipment: PropTypes.object.isRequired,
+  shipments: PropTypes.arrayOf(PropTypes.object).isRequired,
   customerInfo: PropTypes.object.isRequired,
   orders: PropTypes.object.isRequired,
 };

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
@@ -3,16 +3,31 @@
 @import 'shared/styles/colors';
 
 .qaeAndCustomerInfo {
-  @include u-margin-left(36px);
   @include u-margin-top(68px);
+  @include u-width(218px);
+  th, td {
+    min-width: 218px !important;
+  }
 }
 
 .cardContainer {
   @include u-padding-bottom(40px);
+  max-width: 1200px;
   @include u-bg('white');
   @include u-radius('05');
   @include u-border('base-lighter');
   @include u-border('1px');
-  @include u-padding(4);
+  @include u-padding-top(4);
+  @include u-padding-left(0);
+  @include u-padding-right(0);
   @include u-margin-bottom(4);
+}
+
+.sidebySideContainer {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.shipmentCardColumn {
+  width: 884px;
 }

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
@@ -29,5 +29,5 @@
 }
 
 .shipmentCardColumn {
-  width: 884px;
+  width: 818px;
 }

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.test.jsx
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.test.jsx
@@ -26,6 +26,7 @@ describe('EvaluationReportShipmentInfo', () => {
         phone: '+441234567890',
         email: 'abc@123.com',
       },
+      type: 'SHIPMENT',
     };
 
     const mockShipment = {
@@ -75,7 +76,7 @@ describe('EvaluationReportShipmentInfo', () => {
         customerInfo={mockCustomerInfo}
         orders={mockOrders}
         report={mockReport}
-        shipment={mockShipment}
+        shipments={[mockShipment]}
       />,
     );
 

--- a/src/components/Office/EvaluationReportTable/EvaluationReportContainer.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportContainer.jsx
@@ -17,7 +17,7 @@ import styles from './EvaluationReportContainer.module.scss';
 import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
 import { CustomerShape } from 'types';
 import { shipmentTypeLabels } from 'content/shipments';
-import { useViewEvaluationReportQueries } from 'hooks/queries';
+import { useEvaluationReportQueries } from 'hooks/queries';
 import descriptionListStyles from 'styles/descriptionList.module.scss';
 
 const EvaluationReportContainer = ({
@@ -28,7 +28,7 @@ const EvaluationReportContainer = ({
   grade,
   setIsModalVisible,
 }) => {
-  const { evaluationReport, mtoShipments } = useViewEvaluationReportQueries(evaluationReportId);
+  const { evaluationReport, mtoShipments } = useEvaluationReportQueries(evaluationReportId);
   let mtoShipmentsToShow;
 
   if (shipmentId && mtoShipments) {

--- a/src/components/Office/EvaluationReportTable/EvaluationReportContainer.module.scss
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportContainer.module.scss
@@ -45,6 +45,9 @@
   overflow-y: auto;
   max-height: 90vh;
   @include u-padding-bottom(5 !important);
+  dd {
+    width: 164px;
+  }
 }
 
 .approvalClose {

--- a/src/components/Office/EvaluationReportTable/EvaluationReportContainer.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportContainer.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { useViewEvaluationReportQueries } from '../../../hooks/queries';
+import { useEvaluationReportQueries } from '../../../hooks/queries';
 
 import EvaluationReportContainer from './EvaluationReportContainer';
 
 jest.mock('hooks/queries', () => ({
-  useViewEvaluationReportQueries: jest.fn(),
+  useEvaluationReportQueries: jest.fn(),
 }));
 
 const setIsModalVisible = jest.fn();
@@ -253,7 +253,7 @@ const viewReportReturn = { evaluationReport, mtoShipments };
 
 describe('Evaluation Report Container', () => {
   it('renders the sample text', async () => {
-    useViewEvaluationReportQueries.mockReturnValue(viewReportReturn);
+    useEvaluationReportQueries.mockReturnValue(viewReportReturn);
 
     render(
       <EvaluationReportContainer

--- a/src/hooks/queries.js
+++ b/src/hooks/queries.js
@@ -371,7 +371,7 @@ export const useMovePaymentRequestsQueries = (moveCode) => {
   };
 };
 
-export const useViewEvaluationReportQueries = (reportID) => {
+export const useEvaluationReportQueries = (reportID) => {
   const { data: evaluationReport = {}, ...viewEvaluationReportQuery } = useQuery(
     [EVALUATION_REPORT, reportID],
     getEvaluationReportByID,

--- a/src/pages/Office/EvaluationReport/EvaluationReport.jsx
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.jsx
@@ -18,16 +18,24 @@ import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 const EvaluationReport = ({ customerInfo, orders }) => {
   const { reportId } = useParams();
   const { evaluationReport, mtoShipments } = useEvaluationReportQueries(reportId);
+
+  let mtoShipmentsToShow;
+  if (evaluationReport.shipmentID && mtoShipments) {
+    mtoShipmentsToShow = [mtoShipments.find((shipment) => shipment.id === evaluationReport.shipmentID)];
+  } else {
+    mtoShipmentsToShow = mtoShipments;
+  }
+
   return (
     <div className={classnames(styles.tabContent, evaluationReportStyles.tabContent)}>
-      <GridContainer>
+      <GridContainer className={evaluationReportStyles.container}>
         <QaeReportHeader report={evaluationReport} />
 
-        {mtoShipments?.length > 0 && (
+        {mtoShipmentsToShow?.length > 0 && (
           <EvaluationReportShipmentInfo
             customerInfo={customerInfo}
             orders={orders}
-            shipments={mtoShipments}
+            shipments={mtoShipmentsToShow}
             report={evaluationReport}
           />
         )}

--- a/src/pages/Office/EvaluationReport/EvaluationReport.jsx
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.jsx
@@ -9,34 +9,28 @@ import styles from '../TXOMoveInfo/TXOTab.module.scss';
 import evaluationReportStyles from './EvaluationReport.module.scss';
 
 import EvaluationForm from 'components/Office/EvaluationForm/EvaluationForm';
-import { useShipmentEvaluationReportQueries } from 'hooks/queries';
+import { useEvaluationReportQueries } from 'hooks/queries';
 import { CustomerShape } from 'types';
 import { OrdersShape } from 'types/customerShapes';
-import EvaluationReportMoveInfo from 'components/Office/EvaluationReportMoveInfo/EvaluationReportMoveInfo';
 import EvaluationReportShipmentInfo from 'components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo';
 import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
-import EVALUATION_REPORT_TYPE from 'constants/evaluationReports';
 
 const EvaluationReport = ({ customerInfo, orders }) => {
   const { reportId } = useParams();
-  const { evaluationReport, mtoShipment } = useShipmentEvaluationReportQueries(reportId);
-  const isShipment = evaluationReport.type === EVALUATION_REPORT_TYPE.SHIPMENT;
+  const { evaluationReport, mtoShipments } = useEvaluationReportQueries(reportId);
   return (
     <div className={classnames(styles.tabContent, evaluationReportStyles.tabContent)}>
       <GridContainer>
         <QaeReportHeader report={evaluationReport} />
 
-        {isShipment ? (
+        {mtoShipments?.length > 0 && (
           <EvaluationReportShipmentInfo
             customerInfo={customerInfo}
             orders={orders}
-            shipment={mtoShipment}
+            shipments={mtoShipments}
             report={evaluationReport}
           />
-        ) : (
-          <EvaluationReportMoveInfo customerInfo={customerInfo} orders={orders} />
         )}
-
         <EvaluationForm evaluationReport={evaluationReport} />
       </GridContainer>
     </div>

--- a/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
@@ -22,3 +22,9 @@
 
   @include u-padding-top(8);
 }
+
+.container {
+  max-width: 1200px;
+  @include u-padding-left(0);
+  @include u-padding-right(0);
+}

--- a/src/pages/Office/EvaluationReport/EvaluationReport.test.jsx
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.test.jsx
@@ -6,7 +6,7 @@ import ReactRouter from 'react-router';
 import EvaluationReport from './EvaluationReport';
 
 import { MockProviders } from 'testUtils';
-import { useShipmentEvaluationReportQueries } from 'hooks/queries';
+import { useEvaluationReportQueries } from 'hooks/queries';
 
 const mockReportId = 'db30c135-1d6d-4a0d-a6d5-f408474f6ee2';
 const mockMtoRefId = '6789-1234';
@@ -21,7 +21,7 @@ const mockOrders = {
 };
 
 jest.mock('hooks/queries', () => ({
-  useShipmentEvaluationReportQueries: jest.fn(),
+  useEvaluationReportQueries: jest.fn(),
 }));
 
 const mockShipmentData = {
@@ -32,47 +32,49 @@ const mockShipmentData = {
     type: 'SHIPMENT',
     moveReferenceID: mockMtoRefId,
   },
-  mtoShipment: {
-    actualPickupDate: '2020-03-16',
-    approvedDate: '2022-08-16T00:00:00.000Z',
-    billableWeightCap: 4000,
-    billableWeightJustification: 'heavy',
-    createdAt: '2022-08-16T00:00:22.316Z',
-    customerRemarks: 'Please treat gently',
-    destinationAddress: {
-      city: 'Fairfield',
-      country: 'US',
-      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTQ0MDha',
-      id: '1cf638df-1c1e-4c03-916a-bd20f7ec58ce',
-      postalCode: '94535',
-      state: 'CA',
-      streetAddress1: '987 Any Avenue',
-      streetAddress2: 'P.O. Box 9876',
-      streetAddress3: 'c/o Some Person',
+  mtoShipments: [
+    {
+      actualPickupDate: '2020-03-16',
+      approvedDate: '2022-08-16T00:00:00.000Z',
+      billableWeightCap: 4000,
+      billableWeightJustification: 'heavy',
+      createdAt: '2022-08-16T00:00:22.316Z',
+      customerRemarks: 'Please treat gently',
+      destinationAddress: {
+        city: 'Fairfield',
+        country: 'US',
+        eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTQ0MDha',
+        id: '1cf638df-1c1e-4c03-916a-bd20f7ec58ce',
+        postalCode: '94535',
+        state: 'CA',
+        streetAddress1: '987 Any Avenue',
+        streetAddress2: 'P.O. Box 9876',
+        streetAddress3: 'c/o Some Person',
+      },
+      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTY2N1o=',
+      id: 'c37ccf04-637c-4afc-9ef6-dee1555e16ef',
+      moveTaskOrderID: '35eb1c36-8916-46f4-a72a-32267c9cb070',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTIzOTZa',
+        id: 'c0cf15bb-96ee-443a-982e-0e9ef2b9a80d',
+        postalCode: '90210',
+        state: 'CA',
+        streetAddress1: '123 Any Street',
+        streetAddress2: 'P.O. Box 12345',
+        streetAddress3: 'c/o Some Person',
+      },
+      primeActualWeight: 2000,
+      primeEstimatedWeight: 1400,
+      requestedDeliveryDate: '2020-03-15',
+      requestedPickupDate: '2020-03-15',
+      scheduledPickupDate: '2020-03-16',
+      shipmentType: 'HHG',
+      status: 'APPROVED',
+      updatedAt: '2022-08-16T00:00:22.316Z',
     },
-    eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTY2N1o=',
-    id: 'c37ccf04-637c-4afc-9ef6-dee1555e16ef',
-    moveTaskOrderID: '35eb1c36-8916-46f4-a72a-32267c9cb070',
-    pickupAddress: {
-      city: 'Beverly Hills',
-      country: 'US',
-      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTIzOTZa',
-      id: 'c0cf15bb-96ee-443a-982e-0e9ef2b9a80d',
-      postalCode: '90210',
-      state: 'CA',
-      streetAddress1: '123 Any Street',
-      streetAddress2: 'P.O. Box 12345',
-      streetAddress3: 'c/o Some Person',
-    },
-    primeActualWeight: 2000,
-    primeEstimatedWeight: 1400,
-    requestedDeliveryDate: '2020-03-15',
-    requestedPickupDate: '2020-03-15',
-    scheduledPickupDate: '2020-03-16',
-    shipmentType: 'HHG',
-    status: 'APPROVED',
-    updatedAt: '2022-08-16T00:00:22.316Z',
-  },
+  ],
 };
 
 const mockCounselingData = {
@@ -83,52 +85,54 @@ const mockCounselingData = {
     type: 'COUNSELING',
     moveReferenceID: mockMtoRefId,
   },
-  mtoShipment: {
-    actualPickupDate: '2020-03-16',
-    approvedDate: '2022-08-16T00:00:00.000Z',
-    billableWeightCap: 4000,
-    billableWeightJustification: 'heavy',
-    createdAt: '2022-08-16T00:00:22.316Z',
-    customerRemarks: 'Please treat gently',
-    destinationAddress: {
-      city: 'Fairfield',
-      country: 'US',
-      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTQ0MDha',
-      id: '1cf638df-1c1e-4c03-916a-bd20f7ec58ce',
-      postalCode: '94535',
-      state: 'CA',
-      streetAddress1: '987 Any Avenue',
-      streetAddress2: 'P.O. Box 9876',
-      streetAddress3: 'c/o Some Person',
+  mtoShipments: [
+    {
+      actualPickupDate: '2020-03-16',
+      approvedDate: '2022-08-16T00:00:00.000Z',
+      billableWeightCap: 4000,
+      billableWeightJustification: 'heavy',
+      createdAt: '2022-08-16T00:00:22.316Z',
+      customerRemarks: 'Please treat gently',
+      destinationAddress: {
+        city: 'Fairfield',
+        country: 'US',
+        eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTQ0MDha',
+        id: '1cf638df-1c1e-4c03-916a-bd20f7ec58ce',
+        postalCode: '94535',
+        state: 'CA',
+        streetAddress1: '987 Any Avenue',
+        streetAddress2: 'P.O. Box 9876',
+        streetAddress3: 'c/o Some Person',
+      },
+      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTY2N1o=',
+      id: 'c37ccf04-637c-4afc-9ef6-dee1555e16ef',
+      moveTaskOrderID: '35eb1c36-8916-46f4-a72a-32267c9cb070',
+      pickupAddress: {
+        city: 'Beverly Hills',
+        country: 'US',
+        eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTIzOTZa',
+        id: 'c0cf15bb-96ee-443a-982e-0e9ef2b9a80d',
+        postalCode: '90210',
+        state: 'CA',
+        streetAddress1: '123 Any Street',
+        streetAddress2: 'P.O. Box 12345',
+        streetAddress3: 'c/o Some Person',
+      },
+      primeActualWeight: 2000,
+      primeEstimatedWeight: 1400,
+      requestedDeliveryDate: '2020-03-15',
+      requestedPickupDate: '2020-03-15',
+      scheduledPickupDate: '2020-03-16',
+      shipmentType: 'HHG',
+      status: 'APPROVED',
+      updatedAt: '2022-08-16T00:00:22.316Z',
     },
-    eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTY2N1o=',
-    id: 'c37ccf04-637c-4afc-9ef6-dee1555e16ef',
-    moveTaskOrderID: '35eb1c36-8916-46f4-a72a-32267c9cb070',
-    pickupAddress: {
-      city: 'Beverly Hills',
-      country: 'US',
-      eTag: 'MjAyMi0wOC0xNlQwMDowMDoyMi4zMTIzOTZa',
-      id: 'c0cf15bb-96ee-443a-982e-0e9ef2b9a80d',
-      postalCode: '90210',
-      state: 'CA',
-      streetAddress1: '123 Any Street',
-      streetAddress2: 'P.O. Box 12345',
-      streetAddress3: 'c/o Some Person',
-    },
-    primeActualWeight: 2000,
-    primeEstimatedWeight: 1400,
-    requestedDeliveryDate: '2020-03-15',
-    requestedPickupDate: '2020-03-15',
-    scheduledPickupDate: '2020-03-16',
-    shipmentType: 'HHG',
-    status: 'APPROVED',
-    updatedAt: '2022-08-16T00:00:22.316Z',
-  },
+  ],
 };
 
 describe('EvaluationReport', () => {
   it('renders the page components for shipment report', async () => {
-    useShipmentEvaluationReportQueries.mockReturnValue(mockShipmentData);
+    useEvaluationReportQueries.mockReturnValue(mockShipmentData);
     jest.spyOn(ReactRouter, 'useParams').mockReturnValue({ reportId: mockReportId });
 
     render(
@@ -154,7 +158,7 @@ describe('EvaluationReport', () => {
   });
 
   it('renders the page components for counseling report', async () => {
-    useShipmentEvaluationReportQueries.mockReturnValue(mockCounselingData);
+    useEvaluationReportQueries.mockReturnValue(mockCounselingData);
     jest.spyOn(ReactRouter, 'useParams').mockReturnValue({ reportId: mockReportId });
     render(
       <MockProviders initialEntries={[`/moves/LR4T8V/evaluation-reports/${mockReportId}`]}>

--- a/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
+++ b/src/pages/Office/EvaluationViolations/EvaluationViolations.jsx
@@ -10,7 +10,7 @@ import styles from '../TXOMoveInfo/TXOTab.module.scss';
 import evaluationViolationsStyles from './EvaluationViolations.module.scss';
 
 import ConnectedDeleteEvaluationReportConfirmationModal from 'components/ConfirmationModals/DeleteEvaluationReportConfirmationModal';
-import { useShipmentEvaluationReportQueries } from 'hooks/queries';
+import { useEvaluationReportQueries } from 'hooks/queries';
 import { deleteEvaluationReport } from 'services/ghcApi';
 import QaeReportHeader from 'components/Office/QaeReportHeader/QaeReportHeader';
 
@@ -18,7 +18,7 @@ const EvaluationViolations = () => {
   const { moveCode, reportId } = useParams();
   const history = useHistory();
 
-  const { evaluationReport } = useShipmentEvaluationReportQueries(reportId);
+  const { evaluationReport } = useEvaluationReportQueries(reportId);
 
   const handleBackToEvalForm = () => {
     // TODO: Save as draft before rerouting

--- a/src/pages/Office/EvaluationViolations/EvaluationViolations.test.jsx
+++ b/src/pages/Office/EvaluationViolations/EvaluationViolations.test.jsx
@@ -12,7 +12,7 @@ const mockReportId = 'db30c135-1d6d-4a0d-a6d5-f408474f6ee2';
 const mockMtoRefId = '6789-1234';
 
 jest.mock('hooks/queries', () => ({
-  useShipmentEvaluationReportQueries: jest.fn(() => ({
+  useEvaluationReportQueries: jest.fn(() => ({
     isLoading: false,
     isError: false,
     evaluationReport: {


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13424) for this change

## Summary

This adds shipment information to the edit form view for evaluation reports.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a QAE/CSR
3. Search for the move code `EVLRPT`
4. Click `Quality assurance` in the move navigation bar
5. Click on `edit report` for the existing draft counseling evaluation report
6. Look at the counseling report form page and see that the shipments information is there

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots

<img width="669" alt="image" src="https://user-images.githubusercontent.com/4325613/186240200-e0707c34-1be6-4d3f-9fe0-818d0362f7a4.png">

