### PR TITLE
[ MB-11968 ] Add some documentation to local sign-in

### DIFF
--- a/pkg/handlers/authentication/devlocal.go
+++ b/pkg/handlers/authentication/devlocal.go
@@ -147,7 +147,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						<button type="submit" data-hook="existing-user-login">Login</button>
 					</p>
 				</form>
-			  <h4>Showing the first {{$.QueryLimit}} users by creation date:</h4>
+			  <h4>Showing the first {{$.QueryLimit}} users by creation date in ascending order:</h4>
 			  {{range .Identities}}
 				<form method="post" action="/devlocal-auth/login">
 					<p id="{{.ID}}">


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11968) for this change

## Summary

Originally, @afoon, @kctruss, and I tried to add the user's Role to the output
on the login page. This didn't actually work out because we saw issues with
`identities.Role` being an empty list on the Template for the local login. So
instead we opted for adding a heading that explains which direction users are
created in. This is super helpful for folks manually creating users.
