### PR TITLE
MB-13647: Display correct trip number when modifying or adding a weight ticket

### DIFF
--- a/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.jsx
@@ -3,7 +3,7 @@ import React, { createRef } from 'react';
 import { Field, Formik } from 'formik';
 import classnames from 'classnames';
 import { Button, ErrorMessage, Form, FormGroup, Label, Link, Radio } from '@trussworks/react-uswds';
-import { string, bool, func, shape } from 'prop-types';
+import { string, bool, func, shape, number } from 'prop-types';
 
 import ppmStyles from 'components/Customer/PPM/PPM.module.scss';
 import styles from 'components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.module.scss';
@@ -422,7 +422,7 @@ const WeightTicketForm = ({
 
 WeightTicketForm.propTypes = {
   weightTicket: WeightTicketShape,
-  tripNumber: string,
+  tripNumber: number,
   onCreateUpload: func.isRequired,
   onUploadComplete: func.isRequired,
   onUploadDelete: func,
@@ -433,7 +433,7 @@ WeightTicketForm.propTypes = {
 WeightTicketForm.defaultProps = {
   weightTicket: undefined,
   onUploadDelete: undefined,
-  tripNumber: '1',
+  tripNumber: 1,
 };
 
 export default WeightTicketForm;

--- a/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.stories.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.stories.jsx
@@ -37,7 +37,7 @@ Blank.args = {
     shipmentType: SHIPMENT_OPTIONS.PPM,
     ppmShipment: {},
   },
-  tripNumber: '1',
+  tripNumber: 1,
 };
 
 export const ExistingWeightTickets = Template.bind({});
@@ -93,7 +93,7 @@ ExistingWeightTickets.args = {
     ownsTrailer: false,
     trailerMeetsCriteria: false,
   },
-  tripNumber: '1',
+  tripNumber: 1,
 };
 
 export const MissingWeightTickets = Template.bind({});
@@ -141,7 +141,7 @@ MissingWeightTickets.args = {
     ownsTrailer: false,
     trailerMeetsCriteria: false,
   },
-  tripNumber: '1',
+  tripNumber: 1,
 };
 
 export const TrailerOwnership = Template.bind({});
@@ -207,5 +207,5 @@ TrailerOwnership.args = {
       ],
     },
   },
-  tripNumber: '1',
+  tripNumber: 1,
 };

--- a/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.test.jsx
+++ b/src/components/Customer/PPM/Closeout/WeightTicketForm/WeightTicketForm.test.jsx
@@ -17,7 +17,7 @@ const defaultProps = {
     fullWeightDocumentId: '1ec00b40-447d-4c22-ac73-708b98b8bc20',
     trailerOwnershipDocumentId: '5bf3ed20-08dd-4d8e-92ad-7603bb6377a5',
   },
-  tripNumber: '2',
+  tripNumber: 2,
   onCreateUpload: jest.fn(),
   onUploadComplete: jest.fn(),
   onUploadDelete: jest.fn(),

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { generatePath, useHistory, useParams, useLocation } from 'react-router-dom';
+import { generatePath, useHistory, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert, Grid, GridContainer } from '@trussworks/react-uswds';
-import qs from 'query-string';
 
 import { selectMTOShipmentById, selectWeightTicketAndIndexById } from 'store/entities/selectors';
 import { customerRoutes, generalRoutes } from 'constants/routes';
@@ -22,10 +21,6 @@ const WeightTickets = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { moveId, mtoShipmentId, weightTicketId } = useParams();
-
-  const { search } = useLocation();
-
-  const { tripNumber } = qs.parse(search);
 
   const mtoShipment = useSelector((state) => selectMTOShipmentById(state, mtoShipmentId));
   const { weightTicket: currentWeightTicket, index: currentIndex } = useSelector((state) =>
@@ -163,7 +158,7 @@ const WeightTickets = () => {
             </div>
             <WeightTicketForm
               weightTicket={currentWeightTicket}
-              tripNumber={tripNumber}
+              tripNumber={currentIndex + 1}
               onCreateUpload={handleCreateUpload}
               onUploadComplete={handleUploadComplete}
               onUploadDelete={handleUploadDelete}

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
@@ -206,7 +206,7 @@ describe('Weight Tickets page', () => {
     expect(screen.getByText('You must upload at least one set of weight tickets to get paid for your PPM.'));
 
     // renders form content
-    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Trip 2');
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Trip 1');
   });
 
   it('replaces the router history with newly created weight ticket id', async () => {
@@ -236,7 +236,7 @@ describe('Weight Tickets page', () => {
 
   it('calls patch weight ticket with the appropriate payload', async () => {
     createWeightTicket.mockResolvedValue(mockWeightTicketWithUploads);
-    selectWeightTicketAndIndexById.mockReturnValue({ weightTicket: mockWeightTicketWithUploads, index: 0 });
+    selectWeightTicketAndIndexById.mockReturnValue({ weightTicket: mockWeightTicketWithUploads, index: 1 });
     patchWeightTicket.mockResolvedValue({});
 
     render(<WeightTickets />, { wrapper: MockProviders });
@@ -275,13 +275,13 @@ describe('Weight Tickets page', () => {
 
   it('displays an error if patchWeightTicket fails', async () => {
     createWeightTicket.mockResolvedValue(mockWeightTicketWithUploads);
-    selectWeightTicketAndIndexById.mockReturnValue({ weightTicket: mockWeightTicketWithUploads, index: 0 });
+    selectWeightTicketAndIndexById.mockReturnValue({ weightTicket: mockWeightTicketWithUploads, index: 4 });
     patchWeightTicket.mockRejectedValueOnce('an error occurred');
 
     render(<WeightTickets />, { wrapper: MockProviders });
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Trip 2');
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Trip 5');
     });
     userEvent.type(screen.getByLabelText('Vehicle description'), 'DMC Delorean');
     userEvent.type(screen.getByLabelText('Empty weight'), '4999');

--- a/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
+++ b/src/pages/MyMove/PPM/Closeout/WeightTickets/WeightTickets.test.jsx
@@ -29,9 +29,6 @@ jest.mock('react-router-dom', () => ({
     moveId: 'cc03c553-d317-46af-8b2d-3c9f899f6451',
     mtoShipmentId: '6b7a5769-4393-46fb-a4c4-d3f6ac7584c7',
   })),
-  useLocation: () => ({
-    search: 'tripNumber=2',
-  }),
 }));
 
 jest.mock('services/internalApi', () => ({


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13647) for this change

## Summary

Rather than relying on passing in the correct tripNumber using the url we can instead use the calculated index. When no index is found we are creating a new weight ticket.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the customer app (milmovelocal:3000)
2. Login as `readyForFinalComplete@ppm.approved`
3. Click `Upload PPM Documents`
4. Edit/add weight tickets and verify that the trip number displayed is correct.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

https://user-images.githubusercontent.com/84742904/188759308-829f4b2f-d236-4fda-a0a1-f406d97f548e.mov

