### PR TITLE
Adding ability to cancel shipments as GHC Prime in the Simulator UI

### DIFF
--- a/src/services/primeApi.js
+++ b/src/services/primeApi.js
@@ -143,7 +143,7 @@ export function updatePrimeMTOShipmentStatus({
   // this time. See documentation here:
   // https://transcom.github.io/mymove-docs/api/prime#tag/mtoShipment/operation/updateMTOShipmentStatus
   const body = {
-    status: 'CANCELLATION_REQUESTED',
+    status: 'CANCELED',
   };
   return makePrimeSimulatorRequest(
     operationPath,

--- a/src/services/primeApi.js
+++ b/src/services/primeApi.js
@@ -129,3 +129,29 @@ export function updatePrimeMTOShipmentReweigh({
     { schemaKey, normalize },
   );
 }
+
+// updatePrimeMTOShipmentStatus This function is used to by the Prime Simulator
+// to send a cancellation request to the Prime API.
+export function updatePrimeMTOShipmentStatus({
+  mtoShipmentID,
+  ifMatchETag,
+  normalize = false,
+  schemaKey = 'mtoShipment',
+}) {
+  const operationPath = 'mtoShipment.updateMTOShipmentStatus';
+  // Default body is defined here as we can only send a status of CANCELED at
+  // this time. See documentation here:
+  // https://transcom.github.io/mymove-docs/api/prime#tag/mtoShipment/operation/updateMTOShipmentStatus
+  const body = {
+    status: 'CANCELLATION_REQUESTED',
+  };
+  return makePrimeSimulatorRequest(
+    operationPath,
+    {
+      mtoShipmentID,
+      'If-Match': ifMatchETag,
+      body,
+    },
+    { schemaKey, normalize },
+  );
+}


### PR DESCRIPTION
## There is no Jira ticket for this change

## Summary

This request was sparked from this Slack thread

=>🔒 https://ustcdp3.slack.com/archives/CP6PTUPQF/p1662497292471289


## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Login to the Office app as a TOO
1. Select a move and navigate to the _Move task order_ tab
1. Find the **Request Cancellation** blue link attached to the shipment and click it
1. Login to the Prime Simulator
1. Choose a move that has not been approved yet and click into details
1. Navigate to **Update Shipment** and click button
1. Click on **Cancel Shipment** on the top left of the page above _Shipment
   Dates_.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the ephemeral environment 
- [ ] Request review from a member of a different team.
