### PR TITLE
Saving the previous and current coverage files for Server tests only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1041,14 +1041,14 @@ jobs:
       - server_tests_step:
           application: app
       - run:
-          name: Ensure Test Coverage Increasing
-          command: |
-            ./scripts/ensure-go-test-coverage /tmp/coverage_baseline.txt tmp/test-results/gotest/app/go-coverage.txt
-      - run:
-          name: Ensure we save both the coverage baseline & the go-coverage text files
+          name: Ensure we save both the coverage baseline & the go-coverage text files before checking test coverage status
           command: |
             cp -v /tmp/coverage_baseline.txt ~/transcom/mymove/tmp/test-results/previous-coverage-baseline.txt
             cp -v ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ~/transcom/mymove/tmp/test-results/current-coverage.txt
+      - run:
+          name: Ensure Test Coverage Increasing
+          command: |
+            ./scripts/ensure-go-test-coverage /tmp/coverage_baseline.txt tmp/test-results/gotest/app/go-coverage.txt
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1044,6 +1044,11 @@ jobs:
           name: Ensure Test Coverage Increasing
           command: |
             ./scripts/ensure-go-test-coverage /tmp/coverage_baseline.txt tmp/test-results/gotest/app/go-coverage.txt
+      - run:
+          name: Ensure we save both the coverage baseline & the go-coverage text files
+          command: |
+            cp -v /tmp/coverage_baseline.txt ~/transcom/mymove/tmp/test-results/previous-coverage-baseline.txt
+            cp -v ~/transcom/mymove/tmp/test-results/gotest/app/go-coverage.txt ~/transcom/mymove/tmp/test-results/current-coverage.txt
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results


### PR DESCRIPTION
## There's no Jira ticket for this change

## Summary

Please see this Slack thread 🔒 for more information about this change. While
pairing with folks on Pamplemoose, we wanted to add some outputs to our Server
Test coverage so that engineers can use local Diff tools to better see the
output that is generated in the _Ensure Test Coverage Increasing_ build step of
our `server_test` stanza in our CircleCI configuration.

[=> Slack Thread 🔒](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1662660249079559)


### How do I test this?

You should be able to download two files from the Artifacts tab in CircleCI.
Here's some documentation on that in our MilMove Developer Portal.

[=> MilMove Documentation about Artifacts](https://transcom.github.io/mymove-docs/docs/backend/testing/run-e2e-tests#automated-tests-artifacts-from-continuous-integration)
