### PR TITLE
Report preview styling fixes and cleanup

### DIFF
--- a/src/components/ConfirmationModals/EvaluationReportConfirmationModal.module.scss
+++ b/src/components/ConfirmationModals/EvaluationReportConfirmationModal.module.scss
@@ -10,4 +10,5 @@
 
 .titleSection {
   @include u-margin-top(4);
+  @include u-margin-right(0);
 }

--- a/src/components/Office/DefinitionLists/EvaluationReportList.jsx
+++ b/src/components/Office/DefinitionLists/EvaluationReportList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 
 import { formatEvaluationReportLocation } from '../../../utils/formatters';
 
@@ -23,7 +24,7 @@ const EvaluationReportList = ({ evaluationReport }) => {
   return (
     <div className={styles.OfficeDefinitionLists}>
       <dl className={descriptionListStyles.descriptionList}>
-        <div className={descriptionListStyles.row}>
+        <div className={classnames(descriptionListStyles.row, descriptionListStyles.noBorder)}>
           <dt>Evaluation type</dt>
           <dd>{capitalizeFirstLetterOnly(evaluationReport.type)}</dd>
         </div>

--- a/src/components/Office/EvaluationForm/EvaluationForm.jsx
+++ b/src/components/Office/EvaluationForm/EvaluationForm.jsx
@@ -178,8 +178,8 @@ const EvaluationForm = ({ evaluationReport, mtoShipments, customerInfo, grade })
   const isShipment = evaluationReport.type === EVALUATION_REPORT_TYPE.SHIPMENT;
 
   const modalTitle = (
-    <div>
-      <h3>Preview and submit {evaluationReport.type} report</h3>
+    <div className={styles.title}>
+      <h3>{`Preview and submit ${evaluationReport.type.toLowerCase()} report`}</h3>
       <p>Is all the information shown correct?</p>
     </div>
   );

--- a/src/components/Office/EvaluationForm/EvaluationForm.module.scss
+++ b/src/components/Office/EvaluationForm/EvaluationForm.module.scss
@@ -85,6 +85,16 @@
   width: 480px;
 }
 
+.title {
+  h3 {
+    @include u-margin-bottom(1);
+    font-size: 28px;
+    line-height: 34px;
+    @include u-color('base-darkest');
+  }
+  @include u-margin-bottom(4 !important);
+}
+
 .violationsGroup {
   @include u-padding-bottom(0.5);
   @include u-margin-top(0);

--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.jsx
@@ -10,6 +10,7 @@ import EvaluationReportShipmentDisplay from 'components/Office/EvaluationReportS
 import DataTable from 'components/DataTable';
 import DataTableWrapper from 'components/DataTableWrapper';
 import EvaluationReportList from 'components/Office/DefinitionLists/EvaluationReportList';
+import EVALUATION_REPORT_TYPE from 'constants/evaluationReports';
 import { ORDERS_BRANCH_OPTIONS, ORDERS_RANK_OPTIONS } from 'constants/orders';
 import { CustomerShape, EvaluationReportShape, ShipmentShape } from 'types';
 import { formatDateFromIso, formatQAReportID } from 'utils/formatters';
@@ -17,7 +18,7 @@ import { formatDate } from 'shared/dates';
 import { shipmentTypeLabels } from 'content/shipments';
 
 const EvaluationReportPreview = ({ evaluationReport, mtoShipments, moveCode, customerInfo, grade }) => {
-  const reportType = evaluationReport.type;
+  const isShipment = evaluationReport.type === EVALUATION_REPORT_TYPE.SHIPMENT;
   let mtoShipmentsToShow;
 
   if (evaluationReport.shipmentID) {
@@ -65,7 +66,7 @@ const EvaluationReportPreview = ({ evaluationReport, mtoShipments, moveCode, cus
       <div>
         <div className={styles.titleSection}>
           <div className={styles.pageHeader}>
-            <h1>{reportType === 'SHIPMENT' ? 'Shipment' : 'Move'} report</h1>
+            <h1>{`${isShipment ? 'Shipment' : 'Counseling'} report`}</h1>
             <div className={styles.pageHeaderDetails}>
               <h6>REPORT ID {formatQAReportID(evaluationReport.id)}</h6>
               <h6>MOVE CODE #{moveCode}</h6>
@@ -76,7 +77,7 @@ const EvaluationReportPreview = ({ evaluationReport, mtoShipments, moveCode, cus
         <div className={styles.section}>
           <Grid row>
             <Grid col desktop={{ col: 8 }}>
-              <h2>Move information</h2>
+              <h2>{`${isShipment ? 'Shipment' : 'Report'} information`}</h2>
               {mtoShipmentsToShow &&
                 mtoShipmentsToShow.map((mtoShipment) => (
                   <div key={mtoShipment.id} className={styles.shipmentDisplayContainer}>
@@ -91,15 +92,15 @@ const EvaluationReportPreview = ({ evaluationReport, mtoShipments, moveCode, cus
                 ))}
             </Grid>
             <Grid className={styles.qaeAndCustomerInfo} col desktop={{ col: 2 }}>
-              <DataTable columnHeaders={['Customer information']} dataRow={[customerInfoTableBody]} />
               <DataTable columnHeaders={['QAE']} dataRow={[officeUserInfoTableBody]} />
+              <DataTable columnHeaders={['Customer information']} dataRow={[customerInfoTableBody]} />
             </Grid>
           </Grid>
         </div>
       </div>
       <div className={styles.section}>
         <h2>Evaluation report</h2>
-        {reportType === 'SHIPMENT' && evaluationReport.location !== 'OTHER' && (
+        {isShipment && evaluationReport.location !== 'OTHER' && (
           <div className={styles.section}>
             <h3>Information</h3>
             <div className={styles.sideBySideDetails}>
@@ -137,10 +138,10 @@ const EvaluationReportPreview = ({ evaluationReport, mtoShipments, moveCode, cus
             <EvaluationReportList evaluationReport={evaluationReport} />
           </div>
         )}
-        {(reportType === 'COUNSELING' || evaluationReport.location === 'OTHER') && (
+        {(!isShipment || evaluationReport.location === 'OTHER') && (
           <div className={styles.section}>
             <h3>Information</h3>
-            <DataTableWrapper className={classnames(styles.detailsRight, 'table--data-point-group')}>
+            <DataTableWrapper className={classnames(styles.counselingDetails, 'table--data-point-group')}>
               <DataTable
                 columnHeaders={['Inspection date', 'Report submission']}
                 dataRow={[

--- a/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.module.scss
+++ b/src/components/Office/EvaluationReportPreview/EvaluationReportPreview.module.scss
@@ -1,25 +1,12 @@
 @import 'shared/styles/_basics';
 @import 'shared/styles/colors';
 
-.evaluationReportContainer {
-  @include u-padding-top(0);
-  @include u-padding-x(2);
-  @include u-padding-bottom(3);
-  @include u-bg('white');
-  @include u-padding-left(3);
-  @include u-padding-right(3);
-
-  :global .table--data-point-group {
-    @include u-margin-bottom(3);
-  }
-
-  :global .evaluationReport-heading {
-    @include u-margin-bottom(3);
-  }
+.evaluationReportPreview {
+  @include u-border-top('base-lighter');
 }
 
 .pageHeader {
-  @include u-margin-y(3);
+  @include u-margin-y(4);
   display: flex;
   justify-content: space-between;
 
@@ -40,27 +27,6 @@
   text-align: right;
 }
 
-.evaluationReportModal {
-  min-width: 1200px !important;
-  overflow-y: auto;
-  max-height: 90vh;
-  @include u-padding-bottom(5 !important);
-  dd {
-    width: 164px;
-  }
-}
-
-.approvalClose {
-  @include u-float('right');
-  @include u-padding-right(0);
-  cursor: pointer;
-  svg {
-    width: 24px;
-    height: 24px;
-    color: $base;
-  }
-}
-
 .sideBySideDetails {
   display: flex;
   justify-content: space-between;
@@ -68,18 +34,27 @@
 
 .detailsRight {
   @include u-margin-left(2);
+  @include u-margin-bottom(3);
 }
 
 .detailsLeft {
   @include u-margin-right(2);
+  @include u-margin-bottom(3);
+}
+
+.counselingDetails {
+  @include u-margin-bottom(3);
 }
 
 .section {
-  @include u-margin-top(4);
+  @include u-margin-top(2);
   @include u-padding(4);
   @include u-radius('05');
   @include u-border('base-lighter');
   @include u-border('1px');
+  h2 {
+    @include u-margin(0);
+  }
   h3 {
     @include u-margin-top(1);
   }
@@ -87,12 +62,6 @@
 
 .shipmentDisplayContainer {
   @include u-margin-top(2);
-}
-
-.buttonsGroup {
-  display: flex;
-  justify-content: flex-end;
-  @include u-margin-top(5);
 }
 
 .qaeRemarks {
@@ -104,6 +73,6 @@
 }
 
 .qaeAndCustomerInfo {
-  @include u-margin-left(36px);
-  @include u-margin-top(68px);
+  @include u-margin-left(4);
+  @include u-margin-top(6);
 }

--- a/src/pages/Office/EvaluationReports/EvaluationReports.test.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.test.jsx
@@ -41,7 +41,7 @@ describe('EvaluationReports', () => {
 
       render(
         <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/evaluation-reports`]}>
-          <EvaluationReports />
+          <EvaluationReports customerInfo={{}} grade="" />
         </MockProviders>,
       );
 
@@ -54,7 +54,7 @@ describe('EvaluationReports', () => {
 
       render(
         <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/details`]}>
-          <EvaluationReports />
+          <EvaluationReports customerInfo={{}} grade="" />
         </MockProviders>,
       );
 
@@ -75,7 +75,7 @@ describe('EvaluationReports', () => {
 
       render(
         <MockProviders initialEntries={[`/moves/${mockRequestedMoveCode}/evaluation-reports`]}>
-          <EvaluationReports />
+          <EvaluationReports customerInfo={{}} grade="" />
         </MockProviders>,
       );
 
@@ -100,7 +100,7 @@ describe('EvaluationReports', () => {
 
       render(
         <MockProviders>
-          <EvaluationReports />
+          <EvaluationReports customerInfo={{}} grade="" />
         </MockProviders>,
       );
 

--- a/src/styles/descriptionList.module.scss
+++ b/src/styles/descriptionList.module.scss
@@ -32,6 +32,13 @@
     }
   }
 
+  .noBorder {
+    dd,
+    dt {
+      @include u-border(0);
+    }
+  }
+
   .rowWithVisualCue::before {
     @include u-margin-y(0.5);
 
@@ -45,7 +52,7 @@
     @include u-margin-right(2px);
 
     outline-color: $mm-gold;
-    content: "";
+    content: '';
   }
 }
 


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary

This PR updates quite a bit of styling per feedback from Clare and from a few other one-off discrepancies I noticed while adjusting styles. It also does some styling cleanup to removed unused styles. 

### Fixed items
#### Clare requested:
- Lowercased SHIPMENT/COUNSELING in report title
- Added horizontal line between preview/submit section and report content
- Fixed h1 copy (Counseling report rather than Move report)
- Removed excess margins around h2s
- Fixed spacing/borders after date sections of preview
#### Other fixes included:
- Several font size/color fixes
- Fixed order of QAE/Customer Info sections (top right)
- Removed/Cleaned out unused styles
- Padding/margin tweaks throughout to better align with designs
- Fixed console warnings in unit tests

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>


https://user-images.githubusercontent.com/62263329/189449219-d1fbcfd8-b37e-423d-a0b6-61de90bcabd0.mov

