### PR TITLE
[MB-12016] Document when the System flags excess weight if total estimated weight > 90% weight allowance

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/index.js
+++ b/src/constants/MoveHistory/EventTemplates/index.js
@@ -42,3 +42,4 @@ export { default as updateMTOReviewedBillableWeightsAt } from './updateMTOReview
 export { default as uploadAmendedOrders } from './uploadAmendedOrders';
 export { default as updateMTOShipmentStatus } from './updateMTOShipmentStatus';
 export { default as updateMTOServiceItemMoveStatus } from './createMTOServiceItemUpdateMoveStatus';
+export { default as updateMoveEstimatedExcessWeight } from './updateMTOShipmentPrimeEstimatedExcessWeight';

--- a/src/constants/MoveHistory/EventTemplates/updateMTOShipmentPrimeEstimatedExcessWeight.js
+++ b/src/constants/MoveHistory/EventTemplates/updateMTOShipmentPrimeEstimatedExcessWeight.js
@@ -1,0 +1,17 @@
+import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import a from 'constants/MoveHistory/Database/Actions';
+import t from 'constants/MoveHistory/Database/Tables';
+
+export default {
+  action: a.UPDATE,
+  eventName: o.updateMTOShipment,
+  tableName: t.moves,
+  detailsType: d.PLAIN_TEXT,
+  getEventNameDisplay: () => 'Updated move',
+  getDetailsPlainText: (historyRecord) => {
+    return historyRecord.changedValues?.excess_weight_qualified_at
+      ? 'Flagged for excess weight, total estimated weight > 90% weight allowance'
+      : '-';
+  },
+};

--- a/src/constants/MoveHistory/EventTemplates/updateMTOShipmentPrimeEstimatedExcessWeight.test.js
+++ b/src/constants/MoveHistory/EventTemplates/updateMTOShipmentPrimeEstimatedExcessWeight.test.js
@@ -1,0 +1,24 @@
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import updateMTOShipmentPrimeEstimatedExcessWeight from 'constants/MoveHistory/EventTemplates/updateMTOShipmentPrimeEstimatedExcessWeight';
+
+describe("when Prime user updates a shipment's estimated to one that exceeds the weight limit", () => {
+  const item = {
+    action: 'UPDATE',
+    eventName: o.updateMTOShipment,
+    tableName: 'moves',
+    detailsType: d.PLAIN_TEXT,
+    eventNameDisplay: 'Updated move',
+    changedValues: {
+      excess_weight_qualified_at: '2022-09-07T21:26:47.833768+00:00',
+    },
+  };
+  it('correctly matches the Update mto shipment event', () => {
+    const result = getTemplate(item);
+    expect(result).toMatchObject(updateMTOShipmentPrimeEstimatedExcessWeight);
+    expect(result.getDetailsPlainText(item)).toEqual(
+      'Flagged for excess weight, total estimated weight > 90% weight allowance',
+    );
+  });
+});


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12606) for this change

## Summary

- [ ] Move History shoes details when prime enters an estimated weight >90% of allowed weight

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Find a new move as the TOO and submit a HHG shipment
2. Log in as the prime to update the shipment estimated weight. Use a value that’s ridiculous like 21,000. That should trigger the excess weight qualified at.
3. Log back in as TOO, locate the move and look at the move history.

These are to be checked by a reviewer.

 - [ ] Newly written tests are passing.

