### PR TITLE
MB-9444: Ensure separate session stores for different applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ client_deps: .check_hosts.stamp .check_node_version.stamp .client_deps.stamp ## 
 	scripts/copy-swagger-ui
 	touch .client_deps.stamp
 
-.client_build.stamp: .check_node_version.stamp $(wildcard src/**/*)
+.client_build.stamp: .check_node_version.stamp $(shell find src -type f)
 	yarn build
 	touch .client_build.stamp
 
@@ -263,30 +263,30 @@ bin/health-checker: cmd/health-checker
 bin/iws: cmd/iws
 	go build -ldflags "$(LDFLAGS)" -o bin/iws ./cmd/iws/iws.go
 
-PKG_GOSRC := $(wildcard pkg/**/*.go)
+PKG_GOSRC := $(shell find pkg -name '*.go')
 
-bin/milmove: $(wildcard cmd/milmove/**/*.go) $(PKG_GOSRC)
+bin/milmove: $(shell find cmd/milmove -name '*.go') $(PKG_GOSRC)
 	go build -gcflags="$(GOLAND_GC_FLAGS) $(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
 
-bin/milmove-tasks: $(wildcard cmd/milmove-tasks/**/*.go) $(PKG_GOSRC)
+bin/milmove-tasks: $(shell find cmd/milmove-tasks -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove-tasks ./cmd/milmove-tasks
 
-bin/prime-api-client: $(wildcard cmd/prime-api-client/**/*.go) $(PKG_GOSRC)
+bin/prime-api-client: $(shell find cmd/prime-api-client -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/prime-api-client ./cmd/prime-api-client
 
-bin/webhook-client: $(wildcard cmd/webhook-client/**/*.go) $(PKG_GOSRC)
+bin/webhook-client: $(shell find cmd/webhook-client -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/webhook-client ./cmd/webhook-client
 
-bin/read-alb-logs: $(wildcard cmd/read-alb-logs/**/*.go) $(PKG_GOSRC)
+bin/read-alb-logs: $(shell find cmd/read-alb-logs -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/read-alb-logs ./cmd/read-alb-logs
 
-bin/send-to-gex: $(wildcard cmd/send-to-gex/**/*.go) $(PKG_GOSRC)
+bin/send-to-gex: $(shell find cmd/send-to-gex -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/send-to-gex ./cmd/send-to-gex
 
-bin/tls-checker: $(wildcard cmd/tls-checker/**/*.go) $(PKG_GOSRC)
+bin/tls-checker: $(shell find cmd/tls-checker -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/tls-checker ./cmd/tls-checker
 
-bin/generate-payment-request-edi: $(wildcard cmd/generate-payment-request-edi/**/*.go) $(PKG_GOSRC)
+bin/generate-payment-request-edi: $(shell find cmd/generate-payment-request-edi -name '*.go') $(PKG_GOSRC)
 	go build -ldflags "$(LDFLAGS)" -o bin/generate-payment-request-edi ./cmd/generate-payment-request-edi
 
 pkg/assets/assets.go:
@@ -1141,6 +1141,10 @@ prune_volumes:  ## Prune docker volumes
 
 .PHONY: prune
 prune: prune_images prune_containers prune_volumes ## Prune docker containers, images, and volumes
+
+.PHONE: clean_server
+clean_server:
+	rm -f bin/milmove
 
 .PHONY: clean
 clean: ## Clean all generated files

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -17,7 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/alexedwards/scs/redisstore"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -482,17 +481,11 @@ func buildRoutingConfig(appCtx appcontext.AppContext, v *viper.Viper, redisPool 
 		appCtx.Logger().Fatal("Registering login provider", zap.Error(err))
 	}
 
-	redisEnabled := v.GetBool(cli.RedisEnabledFlag)
-	var sessionStore *redisstore.RedisStore
-	if redisEnabled {
-		sessionStore = redisstore.New(redisPool)
-	}
 	sessionIdleTimeout := time.Duration(v.GetInt(cli.SessionIdleTimeoutInMinutesFlag)) * time.Minute
 	sessionLifetime := time.Duration(v.GetInt(cli.SessionLifetimeInHoursFlag)) * time.Hour
 
 	useSecureCookie := !isDevOrTest
-	sessionManagers := auth.SetupSessionManagers(redisEnabled,
-		sessionStore, useSecureCookie,
+	sessionManagers := auth.SetupSessionManagers(redisPool, useSecureCookie,
 		sessionIdleTimeout, sessionLifetime)
 	routingConfig.AuthContext = authentication.NewAuthContext(appCtx.Logger(), loginGovProvider, loginGovCallbackProtocol, loginGovCallbackPort, sessionManagers)
 

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -57,16 +57,6 @@ func GetExpiryTimeFromMinutes(min int64) time.Time {
 	return time.Now().Add(time.Minute * time.Duration(min))
 }
 
-// GetCookie returns a cookie from a request
-func GetCookie(name string, r *http.Request) (*http.Cookie, error) {
-	for _, cookie := range r.Cookies() {
-		if cookie.Name == name {
-			return cookie, nil
-		}
-	}
-	return nil, errors.Errorf("Unable to find cookie: %s", name)
-}
-
 // DeleteCookie sends a delete request for the named cookie
 func DeleteCookie(w http.ResponseWriter, name string) {
 	c := http.Cookie{

--- a/pkg/auth/session_test.go
+++ b/pkg/auth/session_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/alexedwards/scs/redisstore"
-	"github.com/alexedwards/scs/v2"
 	"github.com/alexedwards/scs/v2/memstore"
 	"github.com/gomodule/redigo/redis"
 )
@@ -16,15 +14,6 @@ func (suite *authSuite) TestSetupSessionManagers() {
 	idleTimeout := 15 * time.Minute
 	lifetime := 24 * time.Hour
 	useSecureCookie := true
-	redisEnabled := true
-	sessionStore := memstore.New()
-
-	sessionManagers := SetupSessionManagers(
-		redisEnabled, sessionStore, useSecureCookie, idleTimeout, lifetime,
-	)
-	milSession := sessionManagers[0]
-	adminSession := sessionManagers[1]
-	officeSession := sessionManagers[2]
 
 	suite.Run("With redis enabled", func() {
 		// on local dev machines, this shares the same redis server as
@@ -40,85 +29,133 @@ func (suite *authSuite) TestSetupSessionManagers() {
 		pool := &redis.Pool{
 			Dial: func() (redis.Conn, error) { return redis.Dial("tcp", redisAddr) },
 		}
-		store := redisstore.New(pool)
 		sessionManagers := SetupSessionManagers(
-			redisEnabled, store, useSecureCookie, idleTimeout, lifetime,
+			pool, useSecureCookie, idleTimeout, lifetime,
 		)
 		milSessionManager := sessionManagers[0]
 		ctx := context.Background()
-		fakeSessionID := "fakeid"
+		//		fakeSessionID := "fakeid"
 		fakeSession := &Session{
 			Hostname: "fake",
 		}
-		expiry := time.Now().Add(30 * time.Minute).UTC()
-		b, err := milSessionManager.Codec.Encode(expiry,
-			map[string]interface{}{
-				fakeSessionID: fakeSession,
-			})
-		suite.NoError(err)
 
 		// make sure we can store and load from redis without error
-		suite.NoError(milSessionManager.Store.Commit("token", b, expiry))
+		fakeToken := "fake_token"
+		ctx, err := milSessionManager.Load(ctx, fakeToken)
+		suite.NoError(err)
+		sessionToken, _, err := milSessionManager.Commit(ctx)
+		suite.NoError(err)
+		milSessionManager.Put(ctx, "session", fakeSession)
 		_, err = milSessionManager.Load(ctx, "session")
 		suite.NoError(err)
+
+		// make sure all stores are unique
+		// before the change to use a separate redis prefix for each
+		// session manager, this test would fail
+		_, found, err := milSessionManager.Store.Find(sessionToken)
+		suite.NoError(err)
+		suite.True(found)
+
+		adminSessionManager := sessionManagers[1]
+		_, found, err = adminSessionManager.Store.Find(sessionToken)
+		suite.NoError(err)
+		suite.False(found)
+
+		officeSessionManager := sessionManagers[2]
+		_, found, err = officeSessionManager.Store.Find(sessionToken)
+		suite.NoError(err)
+		suite.False(found)
 	})
 
 	suite.Run("With a supported scs.Store other than redisstore", func() {
-		sessionStore = memstore.New()
 		sessionManagers := SetupSessionManagers(
-			redisEnabled, sessionStore, useSecureCookie, idleTimeout, lifetime,
+			nil, useSecureCookie, idleTimeout, lifetime,
 		)
-		milSession = sessionManagers[0]
-		adminSession = sessionManagers[1]
-		officeSession = sessionManagers[2]
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
 
-		suite.Equal(sessionStore, milSession.Store)
-		suite.Equal(sessionStore, adminSession.Store)
-		suite.Equal(sessionStore, officeSession.Store)
-
-	})
-
-	suite.Run("With Redis disabled", func() {
-		redisEnabled := false
-
-		sessionManagers := SetupSessionManagers(
-			redisEnabled, sessionStore, useSecureCookie, idleTimeout, lifetime,
-		)
-
-		suite.Equal([3]*scs.SessionManager{}, sessionManagers)
+		_, ok := milSession.Store.(*memstore.MemStore)
+		suite.Require().True(ok)
+		_, ok = adminSession.Store.(*memstore.MemStore)
+		suite.Require().True(ok)
+		_, ok = officeSession.Store.(*memstore.MemStore)
+		suite.Require().True(ok)
 	})
 
 	suite.Run("Session cookie names must be unique per app", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal("mil_session_token", milSession.Cookie.Name)
 		suite.Equal("admin_session_token", adminSession.Cookie.Name)
 		suite.Equal("office_session_token", officeSession.Cookie.Name)
 	})
 
 	suite.Run("All session managers have the same secure cookie setting", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal(useSecureCookie, milSession.Cookie.Secure)
 		suite.Equal(useSecureCookie, adminSession.Cookie.Secure)
 		suite.Equal(useSecureCookie, officeSession.Cookie.Secure)
 	})
 
 	suite.Run("All session managers have the same idleTimeout", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal(idleTimeout, milSession.IdleTimeout)
 		suite.Equal(idleTimeout, adminSession.IdleTimeout)
 		suite.Equal(idleTimeout, officeSession.IdleTimeout)
 	})
 
 	suite.Run("All session managers have the same lifetime", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal(lifetime, milSession.Lifetime)
 		suite.Equal(lifetime, adminSession.Lifetime)
 		suite.Equal(lifetime, officeSession.Lifetime)
 	})
 
 	suite.Run("All session managers have cookie path set to root", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal("/", milSession.Cookie.Path)
 		suite.Equal("/", adminSession.Cookie.Path)
 		suite.Equal("/", officeSession.Cookie.Path)
 	})
 
 	suite.Run("All session managers do not persist cookie", func() {
+		sessionManagers := SetupSessionManagers(
+			nil, useSecureCookie, idleTimeout, lifetime,
+		)
+		milSession := sessionManagers[0]
+		adminSession := sessionManagers[1]
+		officeSession := sessionManagers[2]
+
 		suite.Equal(false, milSession.Cookie.Persist)
 		suite.Equal(false, adminSession.Cookie.Persist)
 		suite.Equal(false, officeSession.Cookie.Persist)

--- a/pkg/handlers/authentication/auth_test.go
+++ b/pkg/handlers/authentication/auth_test.go
@@ -152,8 +152,6 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 		IDToken:         fakeToken,
 		Hostname:        OfficeTestHost,
 	}
-	ctx := auth.SetSessionInRequestContext(req, &session)
-	req = req.WithContext(ctx)
 	sessionManagers := suite.SetupSessionManagers()
 	officeSession := sessionManagers[2]
 	authContext := NewAuthContext(suite.Logger(), fakeLoginGovProvider(suite.Logger()), "http", callbackPort, sessionManagers)
@@ -161,6 +159,8 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 	handler := officeSession.LoadAndSave(NewLogoutHandler(authContext, handlerConfig))
 
 	rr := httptest.NewRecorder()
+	ctx := auth.SetSessionInRequestContext(req, &session)
+	req = req.WithContext(ctx)
 	handler.ServeHTTP(rr, req.WithContext(ctx))
 
 	if status := rr.Code; status != http.StatusOK {
@@ -179,6 +179,25 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 	suite.Equal(strconv.Itoa(callbackPort), postRedirectURI.Port())
 	token := params["id_token_hint"][0]
 	suite.Equal(fakeToken, token, "handler id_token")
+
+	noIDTokenSession := auth.Session{
+		ApplicationName: auth.OfficeApp,
+		UserID:          user.ID,
+		IDToken:         "",
+		Hostname:        OfficeTestHost,
+	}
+	ctx = auth.SetSessionInRequestContext(req, &noIDTokenSession)
+	req = req.WithContext(ctx)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req.WithContext(ctx))
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %d wanted %d", status, http.StatusOK)
+	}
+
+	redirectURI, err := url.Parse(rr.Body.String())
+	suite.NoError(err)
+	suite.Equal(OfficeTestHost, redirectURI.Hostname())
+	suite.Equal(strconv.Itoa(callbackPort), redirectURI.Port())
 }
 
 func (suite *AuthSuite) TestRequireAuthMiddleware() {
@@ -1194,4 +1213,9 @@ func (suite *AuthSuite) TestLoginGovAuthenticatedRedirect() {
 
 	suite.Equal(http.StatusTemporaryRedirect, rr.Code,
 		"handler returned wrong status code")
+	redirectURL, err := rr.Result().Location()
+	suite.NoError(err)
+	suite.Equal(OfficeTestHost, redirectURL.Hostname())
+	suite.Equal(strconv.Itoa(callbackPort), redirectURL.Port())
+	suite.Equal("/", redirectURL.EscapedPath())
 }

--- a/pkg/handlers/debug.go
+++ b/pkg/handlers/debug.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/auth"
+)
+
+func NewDebugSessionsHandler(handlerConfig HandlerConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		appCtx := handlerConfig.AppContextFromRequest(r)
+		m := make(map[string]map[string]auth.Session)
+
+		msm := handlerConfig.GetMilSessionManager()
+		msessions := make(map[string]auth.Session)
+		err := msm.Iterate(r.Context(), func(ctx context.Context) error {
+			obj := msm.Get(ctx, "session")
+			session, ok := obj.(auth.Session)
+			if ok {
+				token := msm.Token(ctx)
+				msessions[token] = session
+			}
+			return nil
+		})
+		if err != nil {
+			appCtx.Logger().Error("Error iteration mil sessions", zap.Error(err))
+		}
+		m[handlerConfig.AppNames().MilServername] = msessions
+
+		osm := handlerConfig.GetOfficeSessionManager()
+		osessions := make(map[string]auth.Session)
+		err = osm.Iterate(r.Context(), func(ctx context.Context) error {
+			obj := osm.Get(ctx, "session")
+			session, ok := obj.(auth.Session)
+			if ok {
+				token := osm.Token(ctx)
+				osessions[token] = session
+			}
+			return nil
+		})
+		if err != nil {
+			appCtx.Logger().Error("Error iteration office sessions", zap.Error(err))
+		}
+
+		m[handlerConfig.AppNames().OfficeServername] = osessions
+
+		asm := handlerConfig.GetAdminSessionManager()
+		asessions := make(map[string]auth.Session)
+		err = asm.Iterate(r.Context(), func(ctx context.Context) error {
+			obj := asm.Get(ctx, "session")
+			session, ok := obj.(auth.Session)
+			if ok {
+				token := asm.Token(ctx)
+				asessions[token] = session
+			}
+			return nil
+		})
+		if err != nil {
+			appCtx.Logger().Error("Error iteration admin sessions", zap.Error(err))
+		}
+		m[handlerConfig.AppNames().AdminServername] = asessions
+
+		w.Header().Add("Content-type", "application/json")
+
+		err = json.NewEncoder(w).Encode(m)
+		if err != nil {
+			appCtx.Logger().Error("redis write error", zap.Error(err))
+			http.Error(w, "redis write error", http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/pkg/handlers/debug_test.go
+++ b/pkg/handlers/debug_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type HandlersSuite struct {
+	BaseHandlerTestSuite
+}
+
+func TestHandlersSuite(t *testing.T) {
+	hs := &HandlersSuite{
+		BaseHandlerTestSuite: NewBaseHandlerTestSuite(notifications.NewStubNotificationSender("milmovelocal"), testingsuite.CurrentPackage(), testingsuite.WithPerTestTransaction()),
+	}
+	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
+}
+
+func (suite *HandlersSuite) TestDebugSessionsHandler() {
+	user := testdatagen.MakeDefaultUser(suite.DB())
+
+	handlerConfig := suite.HandlerConfig()
+	sessionManagers := auth.SetupSessionManagers(nil, false,
+		time.Duration(180), time.Duration(180))
+	handlerConfig.SetSessionManagers(sessionManagers)
+
+	milHost := handlerConfig.appNames.MilServername
+
+	fakeToken := "some_token"
+	session := auth.Session{
+		ApplicationName: auth.MilApp,
+		IDToken:         fakeToken,
+		Hostname:        milHost,
+		UserID:          user.ID,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/debug/sessions", milHost), nil)
+	ctx := auth.SetSessionInRequestContext(req, &session)
+	req = req.WithContext(ctx)
+
+	h := NewDebugSessionsHandler(handlerConfig)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	suite.Equal(http.StatusOK, rr.Code)
+	body := rr.Body.Bytes()
+	// as this is for debugging, just make sure it returns something
+	suite.True(len(body) > 0, body)
+}

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -1,9 +1,7 @@
 package routing
 
 import (
-	"context"
 	"encoding/hex"
-	"encoding/json"
 	"net/http"
 	"net/http/pprof"
 	"path"
@@ -265,67 +263,7 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 		debug.HandleFunc("/trace", pprof.Trace).Methods("GET")
 		debug.Handle("/threadcreate", pprof.Handler("threadcreate")).Methods("GET")
 		debug.HandleFunc("/symbol", pprof.Symbol).Methods("GET")
-		debug.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {
-			m := make(map[string]map[string]auth.Session)
-
-			msm := routingConfig.HandlerConfig.GetMilSessionManager()
-			msessions := make(map[string]auth.Session)
-			err := msm.Iterate(r.Context(), func(ctx context.Context) error {
-				obj := msm.Get(ctx, "session")
-				session, ok := obj.(auth.Session)
-				if ok {
-					token := msm.Token(ctx)
-					msessions[token] = session
-				}
-				return nil
-			})
-			if err != nil {
-				appCtx.Logger().Error("Error iteration mil sessions", zap.Error(err))
-			}
-			m[routingConfig.HandlerConfig.AppNames().MilServername] = msessions
-
-			osm := routingConfig.HandlerConfig.GetOfficeSessionManager()
-			osessions := make(map[string]auth.Session)
-			err = osm.Iterate(r.Context(), func(ctx context.Context) error {
-				obj := osm.Get(ctx, "session")
-				session, ok := obj.(auth.Session)
-				if ok {
-					token := osm.Token(ctx)
-					osessions[token] = session
-				}
-				return nil
-			})
-			if err != nil {
-				appCtx.Logger().Error("Error iteration office sessions", zap.Error(err))
-			}
-
-			m[routingConfig.HandlerConfig.AppNames().OfficeServername] = osessions
-
-			asm := routingConfig.HandlerConfig.GetAdminSessionManager()
-			asessions := make(map[string]auth.Session)
-			err = asm.Iterate(r.Context(), func(ctx context.Context) error {
-				obj := asm.Get(ctx, "session")
-				session, ok := obj.(auth.Session)
-				if ok {
-					token := asm.Token(ctx)
-					asessions[token] = session
-				}
-				return nil
-			})
-			if err != nil {
-				appCtx.Logger().Error("Error iteration admin sessions", zap.Error(err))
-			}
-			m[routingConfig.HandlerConfig.AppNames().AdminServername] = asessions
-
-			w.Header().Add("Content-type", "application/json")
-
-			err = json.NewEncoder(w).Encode(m)
-			if err != nil {
-				appCtx.Logger().Error("redis write error", zap.Error(err))
-				http.Error(w, "redis write error", http.StatusInternalServerError)
-				return
-			}
-		}).Methods("GET")
+		debug.HandleFunc("/sessions", handlers.NewDebugSessionsHandler(routingConfig.HandlerConfig)).Methods("GET")
 	} else {
 		debug.HandleFunc("/", http.NotFound).Methods("GET")
 	}

--- a/pkg/handlers/routing/routing_init.go
+++ b/pkg/handlers/routing/routing_init.go
@@ -1,7 +1,9 @@
 package routing
 
 import (
+	"context"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/pprof"
 	"path"
@@ -248,7 +250,7 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 	root.Use(sessionCookieMiddleware)
 	root.Use(middleware.RequestLogger(appCtx.Logger()))
 
-	debug := root.PathPrefix("/debug/pprof/").Subrouter()
+	debug := root.PathPrefix("/debug/pprof").Subrouter()
 	debug.Use(userAuthMiddleware)
 	if routingConfig.ServeDebugPProf {
 		appCtx.Logger().Info("Enabling pprof routes")
@@ -263,6 +265,67 @@ func InitRouting(appCtx appcontext.AppContext, redisPool *redis.Pool,
 		debug.HandleFunc("/trace", pprof.Trace).Methods("GET")
 		debug.Handle("/threadcreate", pprof.Handler("threadcreate")).Methods("GET")
 		debug.HandleFunc("/symbol", pprof.Symbol).Methods("GET")
+		debug.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {
+			m := make(map[string]map[string]auth.Session)
+
+			msm := routingConfig.HandlerConfig.GetMilSessionManager()
+			msessions := make(map[string]auth.Session)
+			err := msm.Iterate(r.Context(), func(ctx context.Context) error {
+				obj := msm.Get(ctx, "session")
+				session, ok := obj.(auth.Session)
+				if ok {
+					token := msm.Token(ctx)
+					msessions[token] = session
+				}
+				return nil
+			})
+			if err != nil {
+				appCtx.Logger().Error("Error iteration mil sessions", zap.Error(err))
+			}
+			m[routingConfig.HandlerConfig.AppNames().MilServername] = msessions
+
+			osm := routingConfig.HandlerConfig.GetOfficeSessionManager()
+			osessions := make(map[string]auth.Session)
+			err = osm.Iterate(r.Context(), func(ctx context.Context) error {
+				obj := osm.Get(ctx, "session")
+				session, ok := obj.(auth.Session)
+				if ok {
+					token := osm.Token(ctx)
+					osessions[token] = session
+				}
+				return nil
+			})
+			if err != nil {
+				appCtx.Logger().Error("Error iteration office sessions", zap.Error(err))
+			}
+
+			m[routingConfig.HandlerConfig.AppNames().OfficeServername] = osessions
+
+			asm := routingConfig.HandlerConfig.GetAdminSessionManager()
+			asessions := make(map[string]auth.Session)
+			err = asm.Iterate(r.Context(), func(ctx context.Context) error {
+				obj := asm.Get(ctx, "session")
+				session, ok := obj.(auth.Session)
+				if ok {
+					token := asm.Token(ctx)
+					asessions[token] = session
+				}
+				return nil
+			})
+			if err != nil {
+				appCtx.Logger().Error("Error iteration admin sessions", zap.Error(err))
+			}
+			m[routingConfig.HandlerConfig.AppNames().AdminServername] = asessions
+
+			w.Header().Add("Content-type", "application/json")
+
+			err = json.NewEncoder(w).Encode(m)
+			if err != nil {
+				appCtx.Logger().Error("redis write error", zap.Error(err))
+				http.Error(w, "redis write error", http.StatusInternalServerError)
+				return
+			}
+		}).Methods("GET")
 	} else {
 		debug.HandleFunc("/", http.NotFound).Methods("GET")
 	}

--- a/pkg/handlers/routing/routing_init_test.go
+++ b/pkg/handlers/routing/routing_init_test.go
@@ -77,6 +77,7 @@ func (suite *RoutingSuite) setupRouting() *Config {
 		ServePrimeSimulator: true,
 		ServeGHC:            true,
 		ServeDevlocalAuth:   true,
+		ServeOrders:         true,
 	}
 
 	return rConfig

--- a/pkg/handlers/routing/routing_init_test.go
+++ b/pkg/handlers/routing/routing_init_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alexedwards/scs/v2/memstore"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 
@@ -47,7 +46,7 @@ func (suite *RoutingSuite) setupRouting() *Config {
 	handlerConfig := suite.HandlerConfig()
 	handlerConfig.SetAppNames(appNames)
 
-	sessionManagers := auth.SetupSessionManagers(true, memstore.New(), false,
+	sessionManagers := auth.SetupSessionManagers(nil, false,
 		time.Duration(180), time.Duration(180))
 	handlerConfig.SetSessionManagers(sessionManagers)
 

--- a/pkg/testdatagen/make_client_cert.go
+++ b/pkg/testdatagen/make_client_cert.go
@@ -8,7 +8,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func MakeDevClientCert(db *pop.Connection, assertions Assertions) {
+func MakeDevClientCert(db *pop.Connection, assertions Assertions) models.ClientCert {
 	clientCert := models.ClientCert{
 		ID:                          uuid.Must(uuid.FromString("190b1e07-eef8-445a-9696-5a2b49ee488d")),
 		Sha256Digest:                "2c0c1fc67a294443292a9e71de0c71cc374fe310e8073f8cdc15510f6b0ef4db",
@@ -38,5 +38,7 @@ func MakeDevClientCert(db *pop.Connection, assertions Assertions) {
 		// client cert already exists; update existing client cert
 		mergeModels(existingCert, clientCert)
 		MustSave(db, existingCert)
+		return *existingCert
 	}
+	return clientCert
 }


### PR DESCRIPTION
## [MB-9444](https://dp3.atlassian.net/browse/MB-9444)

## Summary

This probably does not fix the issue entirely, but does seem like a possible contributor to our login issues.

The old config used a single store across the admin, office, and customer apps. That meant it was theoretically possible for e.g. a request to the admin app to retrieve an office session. I have not been able to find a smoking gun indicating that is causing login problems, but seems like a related bug we should fix to ensure it's not a contributing factor.

Testing this involves inspecting the sessions. I added a new endpoint under the pprof debugging route to dump out the session information. Before the fix, iterating through all milmove sessions would include office sessions. Same for iterating through admin sessions.

## Setup to Run Your Code

##### Terminal 1

Start the Storybook locally.

```sh
make server_run
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

</details>

### Additional steps

1. Access the office app
2. Login as a TOO
3. Access the admin app
4. Login as an admin
5. Go to http://officelocal:3000/debug/pprof/sessions

See that only the admin sessions are associated with the admin host and only the office sessions are associated with the office host.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

