### PR TITLE
Set width for evaluation form and supporting component containers to 960px

### DIFF
--- a/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
+++ b/src/components/Office/DefinitionLists/ShipmentDefinitionLists.module.scss
@@ -51,7 +51,7 @@
   @include u-padding-left(1);
   dd {
     font-size: 13px;
-    width: 206px;
+    width: 106px;
     word-break: break-all;
   }
   dt {

--- a/src/components/Office/EvaluationForm/EvaluationForm.module.scss
+++ b/src/components/Office/EvaluationForm/EvaluationForm.module.scss
@@ -5,7 +5,7 @@
 .buttonContainer {
   @include u-padding(0);
   @include u-margin-bottom(115px);
-  max-width: 1200px;
+  width: 960px;
 }
 
 .buttonRow {
@@ -29,7 +29,8 @@
   @include u-padding-right(6);
   @include u-padding-left(6);
   @include u-margin-bottom(2);
-  max-width: 920px;
+  max-width: 960px;
+  width: 960px;
 }
 
 .durationPickers {

--- a/src/components/Office/EvaluationForm/EvaluationForm.module.scss
+++ b/src/components/Office/EvaluationForm/EvaluationForm.module.scss
@@ -29,7 +29,7 @@
   @include u-padding-right(6);
   @include u-padding-left(6);
   @include u-margin-bottom(2);
-  max-width: 1200px;
+  max-width: 920px;
 }
 
 .durationPickers {

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
@@ -12,7 +12,8 @@
 
 .cardContainer {
   @include u-padding-bottom(40px);
-  max-width: 920px;
+  max-width: 960px;
+  width: 960px;
   @include u-bg('white');
   @include u-radius('05');
   @include u-border('base-lighter');

--- a/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
+++ b/src/components/Office/EvaluationReportShipmentInfo/EvaluationReportShipmentInfo.module.scss
@@ -12,7 +12,7 @@
 
 .cardContainer {
   @include u-padding-bottom(40px);
-  max-width: 1200px;
+  max-width: 920px;
   @include u-bg('white');
   @include u-radius('05');
   @include u-border('base-lighter');
@@ -29,5 +29,5 @@
 }
 
 .shipmentCardColumn {
-  width: 818px;
+  width: 602px;
 }

--- a/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
@@ -24,7 +24,7 @@
 }
 
 .container {
-  max-width: 920px;
+  max-width: 960px;
   @include u-padding-left(0);
   @include u-padding-right(0);
 }

--- a/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
+++ b/src/pages/Office/EvaluationReport/EvaluationReport.module.scss
@@ -24,7 +24,7 @@
 }
 
 .container {
-  max-width: 1200px;
+  max-width: 920px;
   @include u-padding-left(0);
   @include u-padding-right(0);
 }


### PR DESCRIPTION

## Summary

This does what the title says and aligns the first page of evaluation reports to this width assumption.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a QAE/CSR
3. Navigate to the EVLRPT move (local/ephemeral) or another move (other deployed environments)
4. Click on quality assurance
5. Create or edit a report
6. View the form for the report

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

## Screenshots

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/4325613/190189184-4c6e727c-00c2-4997-9ac5-23bda234c50f.png">

