### PR TITLE
Mb 13703 move details page scroll bug nt

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -4,13 +4,13 @@
 
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-
-export default function ScrollToTop({ otherDep = null }) {
+// TODO: Make this function only take otherDeps, but change uses everywhere else
+export default function ScrollToTop({ otherDep = null, otherDeps = [] }) {
   const { pathname } = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname, otherDep]);
+  }, [pathname, otherDep, ...otherDeps]);
 
   return null;
 }

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -5,12 +5,12 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 // TODO: Make this function only take otherDeps, but change uses everywhere else
-export default function ScrollToTop({ otherDep = null, otherDeps = [] }) {
+export default function ScrollToTop({ otherDep = null }) {
   const { pathname } = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, [pathname, otherDep, ...otherDeps]);
+  }, [pathname, otherDep]);
 
   return null;
 }

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -4,7 +4,7 @@
 
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-// TODO: Make this function only take otherDeps, but change uses everywhere else
+
 export default function ScrollToTop({ otherDep = null }) {
   const { pathname } = useLocation();
 

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -297,7 +297,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
           />
         )}
         <GridContainer className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}>
-          <ScrollToTop otherDeps={[alertMessage, infoSavedAlert]} />
+          <ScrollToTop otherDep={alertMessage || infoSavedAlert} />
           <Grid row className={scMoveDetailsStyles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={scMoveDetailsStyles.alertContainer}>

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -45,7 +45,6 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   const [alertType, setAlertType] = useState('success');
   const [isSubmitModalVisible, setIsSubmitModalVisible] = useState(false);
   const [isFinancialModalVisible, setIsFinancialModalVisible] = useState(false);
-  const errorMessage = useState();
 
   const { order, move, mtoShipments, isLoading, isError } = useMoveDetailsQueries(moveCode);
   const { customer, entitlement: allowances } = order;
@@ -298,7 +297,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
           />
         )}
         <GridContainer className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}>
-          <ScrollToTop otherDep={errorMessage} />
+          <ScrollToTop otherDeps={[alertMessage, infoSavedAlert]} />
           <Grid row className={scMoveDetailsStyles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={scMoveDetailsStyles.alertContainer}>

--- a/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
+++ b/src/pages/Office/ServicesCounselingMoveDetails/ServicesCounselingMoveDetails.jsx
@@ -36,6 +36,7 @@ import { getShipmentTypeLabel } from 'utils/shipmentDisplay';
 import ButtonDropdown from 'components/ButtonDropdown/ButtonDropdown';
 import Restricted from 'components/Restricted/Restricted';
 import { permissionTypes } from 'constants/permissions';
+import ScrollToTop from 'components/ScrollToTop';
 
 const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCount }) => {
   const { moveCode } = useParams();
@@ -44,6 +45,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   const [alertType, setAlertType] = useState('success');
   const [isSubmitModalVisible, setIsSubmitModalVisible] = useState(false);
   const [isFinancialModalVisible, setIsFinancialModalVisible] = useState(false);
+  const errorMessage = useState();
 
   const { order, move, mtoShipments, isLoading, isError } = useMoveDetailsQueries(moveCode);
   const { customer, entitlement: allowances } = order;
@@ -272,7 +274,6 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
   };
 
   const allShipmentsDeleted = mtoShipments.every((shipment) => !!shipment.deletedAt);
-
   return (
     <div className={styles.tabContent}>
       <div className={styles.container}>
@@ -297,6 +298,7 @@ const ServicesCounselingMoveDetails = ({ infoSavedAlert, setUnapprovedShipmentCo
           />
         )}
         <GridContainer className={classnames(styles.gridContainer, scMoveDetailsStyles.ServicesCounselingMoveDetails)}>
+          <ScrollToTop otherDep={errorMessage} />
           <Grid row className={scMoveDetailsStyles.pageHeader}>
             {alertMessage && (
               <Grid col={12} className={scMoveDetailsStyles.alertContainer}>


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13703) for this change

## Summary

Getting some pre-commit errors related to the changes in `ScrollToTop.jsx`


## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>


##### Terminal 1

Start the UI locally.

```sh
make office_client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

Before starting make sure that there are test users for the office client.

1. Access the [office app](http://officelocal:3000/sign-in) in experimental
2. Login as a the service_counselor
3. select a move with a PPM
4. Edit the PPM and save changes
5. You will likely go to a page where you are asked to leave comments as the Service Counselor, do this and `save and continue`.
6. On the Move Details page, make sure that you see that the page starts at the top, and not in the middle of the page, so that you have to scroll to the top.
7. check out of my branch and check into master, then replicate steps 1-6, you should see that on the move details page, the page scrolling is off and does not bring the user to the top of the page. This is the bug that was fixed.

## Verification Steps for Author

These are to be checked by the author.

- [ X] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [X ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

