### PR TITLE
MB-13995 - Fix flaky server test TestGHCInvoiceSuite

### DIFF
--- a/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
+++ b/pkg/services/invoice/ghc_payment_request_invoice_generator_test.go
@@ -437,7 +437,11 @@ func (suite *GHCInvoiceSuite) TestAllGenerateEdi() {
 		suite.IsType(&edisegment.N3{}, destAddress)
 		n3 := *destAddress
 		suite.Equal(address.StreetAddress1, n3.AddressInformation1)
-		suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
+		if address.StreetAddress2 == nil {
+			suite.Empty(n3.AddressInformation2)
+		} else {
+			suite.Equal(*address.StreetAddress2, n3.AddressInformation2)
+		}
 		// city state info
 		n4 := result.Header.DestinationPostalDetails
 		suite.IsType(edisegment.N4{}, n4)

--- a/pkg/testdatagen/make_duty_location.go
+++ b/pkg/testdatagen/make_duty_location.go
@@ -71,28 +71,31 @@ func FetchOrMakeDefaultNewOrdersDutyLocation(db *pop.Connection) models.DutyLoca
 	// Check if Fort Gordon exists, if not, create
 	// Move date picker for this test case only works with an address of street name "Fort Gordon"
 	fortGordon, err := models.FetchDutyLocationByName(db, "Fort Gordon")
-	if err != nil {
-		fortGordonAssertions := Assertions{
-			Address: models.Address{
-				City:       "Augusta",
-				State:      "GA",
-				PostalCode: "30813",
-			},
-			DutyLocation: models.DutyLocation{
-				Name: "Fort Gordon",
-			},
+	if err == nil {
+		fortGordon.TransportationOffice, err = models.FetchDutyLocationTransportationOffice(db, fortGordon.ID)
+		if err == nil {
+			return fortGordon
 		}
-		FetchOrMakeTariff400ngZip3(db, Assertions{
-			Tariff400ngZip3: models.Tariff400ngZip3{
-				Zip3:          "308",
-				BasepointCity: "Harlem",
-				State:         "GA",
-				ServiceArea:   "208",
-				RateArea:      "US45",
-				Region:        "12",
-			},
-		})
-		return MakeDutyLocation(db, fortGordonAssertions)
 	}
-	return fortGordon
+	fortGordonAssertions := Assertions{
+		Address: models.Address{
+			City:       "Augusta",
+			State:      "GA",
+			PostalCode: "30813",
+		},
+		DutyLocation: models.DutyLocation{
+			Name: "Fort Gordon",
+		},
+	}
+	FetchOrMakeTariff400ngZip3(db, Assertions{
+		Tariff400ngZip3: models.Tariff400ngZip3{
+			Zip3:          "308",
+			BasepointCity: "Harlem",
+			State:         "GA",
+			ServiceArea:   "208",
+			RateArea:      "US45",
+			Region:        "12",
+		},
+	})
+	return MakeDutyLocation(db, fortGordonAssertions)
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13995) for this change

## Summary

Some assertions in TestGHCInvoiceSuite were failing due to missing info in the dutyLocation data. I added a null check for an optional field (Address2) and added a fetch for the Transportation Office in the case that the default Fort Gordon data is being used.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use one terminal to test this locally.</summary>

##### Terminal 1

Run the offending server tests...

```sh
go test ./pkg/services/invoice
```

...or all of the server tests, since a testdatagen function was changed
```sh
make server_test
```

If necessary, reset your test db

```sh
make db_test_reset db_test_migrate
```

</details>


## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

## Screenshots
