### PR TITLE
Add delete button to evaluation reports tables.

### DIFF
--- a/src/components/ConfirmationModals/DeleteEvaluationReportConfirmationModal.jsx
+++ b/src/components/ConfirmationModals/DeleteEvaluationReportConfirmationModal.jsx
@@ -4,16 +4,16 @@ import { Button } from '@trussworks/react-uswds';
 
 import Modal, { ModalTitle, ModalClose, ModalActions, connectModal } from 'components/Modal/Modal';
 
-export const DeleteEvaluationReportConfirmationModal = ({ closeModal, submitModal }) => (
+export const DeleteEvaluationReportConfirmationModal = ({ closeModal, submitModal, isDeleteFromTable }) => (
   <Modal>
     <ModalClose handleClick={closeModal} />
     <ModalTitle>
-      <h3>Are you sure you want to cancel this report?</h3>
+      <h3>Are you sure you want to {isDeleteFromTable ? 'delete' : 'cancel'} this report?</h3>
     </ModalTitle>
     <p>You cannot undo this action.</p>
     <ModalActions autofocus="true">
       <Button data-focus="true" className="usa-button--destructive" type="submit" onClick={submitModal}>
-        Yes, Cancel
+        Yes, {isDeleteFromTable ? 'delete' : 'cancel'}
       </Button>
       <Button className="usa-button--secondary" type="button" onClick={closeModal} data-testid="modalBackButton">
         No, keep it
@@ -25,6 +25,11 @@ export const DeleteEvaluationReportConfirmationModal = ({ closeModal, submitModa
 DeleteEvaluationReportConfirmationModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
   submitModal: PropTypes.func.isRequired,
+  isDeleteFromTable: PropTypes.bool,
+};
+
+DeleteEvaluationReportConfirmationModal.defaultProps = {
+  isDeleteFromTable: false,
 };
 
 DeleteEvaluationReportConfirmationModal.displayName = 'DeleteEvaluationReportConfirmationModal';

--- a/src/components/ConfirmationModals/DeleteEvaluationReportConfirmationModal.test.jsx
+++ b/src/components/ConfirmationModals/DeleteEvaluationReportConfirmationModal.test.jsx
@@ -45,7 +45,7 @@ describe('DeleteEvaluationReportConfirmationModal', () => {
   it('calls the submit function when delete button is clicked', async () => {
     render(<DeleteEvaluationReportConfirmationModal submitModal={onSubmit} closeModal={onClose} />);
 
-    const deleteButton = await screen.findByRole('button', { name: 'Yes, Cancel' });
+    const deleteButton = await screen.findByRole('button', { name: 'Yes, cancel' });
 
     userEvent.click(deleteButton);
 

--- a/src/components/Office/EvaluationForm/EvaluationForm.jsx
+++ b/src/components/Office/EvaluationForm/EvaluationForm.jsx
@@ -71,7 +71,7 @@ const EvaluationForm = ({ evaluationReport, mtoShipments, customerInfo, grade })
     await deleteEvaluationReportMutation(reportId);
 
     // Reroute back to eval report page, include flag to know to show alert
-    history.push(`/moves/${moveCode}/evaluation-reports`, { showDeleteSuccess: true });
+    history.push(`/moves/${moveCode}/evaluation-reports`, { showCancelledSuccess: true });
   };
 
   // passed to the confrimation modal

--- a/src/components/Office/EvaluationForm/EvaluationForm.jsx
+++ b/src/components/Office/EvaluationForm/EvaluationForm.jsx
@@ -71,7 +71,7 @@ const EvaluationForm = ({ evaluationReport, mtoShipments, customerInfo, grade })
     await deleteEvaluationReportMutation(reportId);
 
     // Reroute back to eval report page, include flag to know to show alert
-    history.push(`/moves/${moveCode}/evaluation-reports`, { showCancelledSuccess: true });
+    history.push(`/moves/${moveCode}/evaluation-reports`, { showCanceledSuccess: true });
   };
 
   // passed to the confrimation modal

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.jsx
@@ -7,13 +7,31 @@ import { useLocation } from 'react-router';
 import styles from './EvaluationReportTable.module.scss';
 
 import ConnectedEvaluationReportConfirmationModal from 'components/ConfirmationModals/EvaluationReportConfirmationModal';
+import ConnectedDeleteEvaluationReportConfirmationModal from 'components/ConfirmationModals/DeleteEvaluationReportConfirmationModal';
 import { formatCustomerDate, formatEvaluationReportLocation, formatQAReportID } from 'utils/formatters';
 import { CustomerShape, EvaluationReportShape, ShipmentShape } from 'types';
 
-const EvaluationReportTable = ({ reports, shipments, emptyText, moveCode, customerInfo, grade }) => {
+const EvaluationReportTable = ({
+  reports,
+  shipments,
+  emptyText,
+  moveCode,
+  customerInfo,
+  grade,
+  setReportToDelete,
+  setIsDeleteModalOpen,
+  deleteReport,
+  isDeleteModalOpen,
+}) => {
   const location = useLocation();
   const [isViewReportModalVisible, setIsViewReportModalVisible] = useState(false);
   const [reportToView, setReportToView] = useState(undefined);
+
+  // whether or not the delete report modal is displaying
+  const toggleDeleteReportModal = (reportID) => {
+    setReportToDelete(reports.find((report) => report.id === reportID));
+    setIsDeleteModalOpen(!isDeleteModalOpen);
+  };
 
   const handleViewReportClick = (report) => {
     setReportToView(report);
@@ -48,9 +66,18 @@ const EvaluationReportTable = ({ reports, shipments, emptyText, moveCode, custom
           )}
           {!report.submittedAt && <a href={`${location.pathname}/${report.id}`}>Edit report</a>}
         </td>
-        <td className={styles.downloadColumn}>
-          <a href={`${location}/evaluation-reports/${report.id}/download`}>Download</a>
-        </td>
+        {report.submittedAt && (
+          <td className={styles.downloadColumn}>
+            <a href={`${location}/evaluation-reports/${report.id}/download`}>Download</a>
+          </td>
+        )}
+        {!report.submittedAt && (
+          <td className={styles.downloadColumn}>
+            <Button className="usa-button--unstyled" onClick={() => toggleDeleteReportModal(report.id)}>
+              Delete
+            </Button>
+          </td>
+        )}
       </tr>
     );
   };
@@ -67,6 +94,12 @@ const EvaluationReportTable = ({ reports, shipments, emptyText, moveCode, custom
 
   return (
     <div>
+      <ConnectedDeleteEvaluationReportConfirmationModal
+        isOpen={isDeleteModalOpen}
+        closeModal={toggleDeleteReportModal}
+        submitModal={deleteReport}
+        isDeleteFromTable
+      />
       {isViewReportModalVisible && reportToView && (
         <ConnectedEvaluationReportConfirmationModal
           isOpen={isViewReportModalVisible}
@@ -115,6 +148,10 @@ EvaluationReportTable.propTypes = {
   customerInfo: CustomerShape.isRequired,
   grade: PropTypes.string.isRequired,
   shipments: PropTypes.arrayOf(ShipmentShape),
+  setIsDeleteModalOpen: PropTypes.func.isRequired,
+  setReportToDelete: PropTypes.func.isRequired,
+  deleteReport: PropTypes.func.isRequired,
+  isDeleteModalOpen: PropTypes.bool.isRequired,
 };
 
 EvaluationReportTable.defaultProps = {

--- a/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
+++ b/src/components/Office/EvaluationReportTable/EvaluationReportTable.test.jsx
@@ -59,6 +59,10 @@ describe('EvaluationReportTable', () => {
           moveCode="FAKEIT"
           grade="E_4"
           customerInfo={customerInfo}
+          deleteReport={jest.fn()}
+          setReportToDelete={jest.fn()}
+          setIsDeleteModalOpen={jest.fn()}
+          isDeleteModalOpen={false}
         />
       </MockProviders>,
     );
@@ -79,6 +83,10 @@ describe('EvaluationReportTable', () => {
           moveCode="FAKEIT"
           grade="E_4"
           customerInfo={customerInfo}
+          deleteReport={jest.fn()}
+          setReportToDelete={jest.fn()}
+          setIsDeleteModalOpen={jest.fn()}
+          isDeleteModalOpen={false}
         />
       </MockProviders>,
     );
@@ -93,7 +101,7 @@ describe('EvaluationReportTable', () => {
 
     expect(screen.getByText('#QA-1F9D1')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Edit report' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Download' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
   it('renders table with a submitted report', () => {
     render(
@@ -105,6 +113,10 @@ describe('EvaluationReportTable', () => {
           moveCode="FAKEIT"
           grade="E_4"
           customerInfo={customerInfo}
+          deleteReport={jest.fn()}
+          setReportToDelete={jest.fn()}
+          setIsDeleteModalOpen={jest.fn()}
+          isDeleteModalOpen={false}
         />
       </MockProviders>,
     );

--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.jsx
@@ -8,7 +8,17 @@ import styles from './ShipmentEvaluationReports.module.scss';
 
 import { CustomerShape, EvaluationReportShape, ShipmentShape } from 'types';
 
-const ShipmentEvaluationReports = ({ shipments, reports, moveCode, customerInfo, grade }) => {
+const ShipmentEvaluationReports = ({
+  shipments,
+  reports,
+  moveCode,
+  customerInfo,
+  grade,
+  setReportToDelete,
+  setIsDeleteModalOpen,
+  deleteReport,
+  isDeleteModalOpen,
+}) => {
   const sortedShipments = shipments.sort((a, b) => moment(a.createdAt) - moment(b.createdAt));
 
   const shipmentRows = sortedShipments.map((shipment) => {
@@ -22,6 +32,10 @@ const ShipmentEvaluationReports = ({ shipments, reports, moveCode, customerInfo,
           grade={grade}
           shipments={[shipment]}
           emptyText="No QAE reports have been submitted for this shipment."
+          setReportToDelete={setReportToDelete}
+          setIsDeleteModalOpen={setIsDeleteModalOpen}
+          isDeleteModalOpen={isDeleteModalOpen}
+          deleteReport={deleteReport}
         />
       </div>
     );

--- a/src/pages/Office/EvaluationReports/EvaluationReports.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.jsx
@@ -87,9 +87,9 @@ const EvaluationReports = ({ customerInfo, grade }) => {
             <Alert type="success">Your report has been deleted</Alert>
           </div>
         )}
-        {location.state?.showCancelledSuccess && (
+        {location.state?.showCanceledSuccess && (
           <div className={evaluationReportsStyles.alert}>
-            <Alert type="success">Your report has been cancelled</Alert>
+            <Alert type="success">Your report has been canceled</Alert>
           </div>
         )}
         {location.state?.showSaveDraftSuccess && (

--- a/src/pages/Office/EvaluationReports/EvaluationReports.test.jsx
+++ b/src/pages/Office/EvaluationReports/EvaluationReports.test.jsx
@@ -104,7 +104,7 @@ describe('EvaluationReports', () => {
         </MockProviders>,
       );
 
-      const alert = await screen.getByText(/Your report has been canceled/);
+      const alert = await screen.getByText(/Your report has been deleted/);
       expect(alert).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

Adds a delete button to the evaluation report table that renders when a report is not submitted yet. This then lets the user delete draft reports from the table view.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a QAE/CSR
3. Go to the EVLRPT move using the move search
4. Go to the quality assurance tab
5. Find a draft report and click delete

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
![deletebuttonevaluationreport](https://user-images.githubusercontent.com/4325613/192362224-00b6031e-eb6b-41da-822a-1cf0e0bad575.gif)
