### PR TITLE
Reformat files for go 1.19

### DIFF
--- a/cmd/webhook-client/post_webhook_notify.go
+++ b/cmd/webhook-client/post_webhook_notify.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transcom/mymove/cmd/webhook-client/utils"
 )
 
-//WebhookRequest is the body of our request
+// WebhookRequest is the body of our request
 type WebhookRequest struct {
 	ID          string `json:"id"`
 	EventName   string `json:"eventName"`

--- a/cmd/webhook-client/webhook/webhook_test.go
+++ b/cmd/webhook-client/webhook/webhook_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
-//RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
+// RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package webhook
 

--- a/pkg/apperror/errors.go
+++ b/pkg/apperror/errors.go
@@ -43,7 +43,7 @@ func (e PreconditionFailedError) Error() string {
 	return fmt.Sprintf("Precondition failed on update to object with ID: '%s'. The If-Match header value did not match the eTag for this record.", e.id.String())
 }
 
-//NotFoundError is returned when a given struct is not found
+// NotFoundError is returned when a given struct is not found
 type NotFoundError struct {
 	id      uuid.UUID
 	message string
@@ -115,7 +115,7 @@ func (b *BadDataError) Error() string {
 	return fmt.Sprintf("Data received from requester is bad: %s: %s", b.baseError.code, b.badDataMsg)
 }
 
-//InvalidInputError is returned when an update fails a validation rule
+// InvalidInputError is returned when an update fails a validation rule
 type InvalidInputError struct {
 	id               uuid.UUID
 	ValidationErrors *validate.Errors
@@ -177,7 +177,7 @@ func NewQueryError(objectType string, err error, msgOverride string) QueryError 
 	}
 }
 
-//InvalidCreateInputError is returned when an update fails a validation rule
+// InvalidCreateInputError is returned when an update fails a validation rule
 type InvalidCreateInputError struct {
 	ValidationErrors *validate.Errors
 	message          string
@@ -198,7 +198,7 @@ func (e InvalidCreateInputError) Error() string {
 	return fmt.Sprintf("Invalid input for ID: %s", e.ValidationErrors)
 }
 
-//ConflictError is returned when a given struct is not found
+// ConflictError is returned when a given struct is not found
 type ConflictError struct {
 	id      uuid.UUID
 	message string

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -35,14 +35,14 @@ func (e *errInvalidHostname) Error() string {
 }
 
 // GorillaCSRFToken is the name of the base CSRF token
-//RA Summary: gosec - G101 - Password Management: Hardcoded Password
-//RA: This line was flagged because it detected use of the word "token"
-//RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
-//RA: This variable does not store an application token.
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Validator: jneuner@mitre.org
-//RA Modified Severity: CAT III
+// RA Summary: gosec - G101 - Password Management: Hardcoded Password
+// RA: This line was flagged because it detected use of the word "token"
+// RA: This line is used to identify the name of the token. GorillaCSRFToken is the name of the base CSRF token.
+// RA: This variable does not store an application token.
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Validator: jneuner@mitre.org
+// RA Modified Severity: CAT III
 // #nosec G101
 const GorillaCSRFToken = "_gorilla_csrf"
 

--- a/pkg/db/utilities/utilities.go
+++ b/pkg/db/utilities/utilities.go
@@ -138,8 +138,9 @@ func GetHasManyForeignKeyAssociations(model interface{}) []interface{} {
 // If you are filtering on a join table(s) or need to disambiguate multiple tables with deleted_at columns, then you
 // will need to pass in the model(s) so we can derive the real table names:
 // db.Scope(utilities.ExcludeDeletedScope(models.MTOShipment{})).
-//     Join("mto_shipments", "mto_shipments.move_id = moves.id").
-//     All(&moves)
+//
+//	Join("mto_shipments", "mto_shipments.move_id = moves.id").
+//	All(&moves)
 //
 // You won't be able to use this if you have given your table name(s) an alias, so just fall back to a normal where.
 // You also cannot combine Scopes with RawQuery, which disregards any Join, Where, Scope, or Eager that may have been

--- a/pkg/ecs/task_metadata.go
+++ b/pkg/ecs/task_metadata.go
@@ -2,7 +2,7 @@ package ecs
 
 // TaskMetadata is used for parsing AWS ECS task metadata.
 //
-//	- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html
+//   - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html
 type TaskMetadata struct {
 	Cluster  string `json:"cluster"`
 	Family   string `json:"family"`

--- a/pkg/edi/edi824/parser.go
+++ b/pkg/edi/edi824/parser.go
@@ -19,7 +19,7 @@ type functionalGroupCounter struct {
 	ts        []transactionSetCounter
 }
 
-// 	ISA > FGs > TSs > OTI|TED
+// ISA > FGs > TSs > OTI|TED
 type counterData struct {
 	fgCounter int
 	fg        []functionalGroupCounter

--- a/pkg/edi/edi997/parser.go
+++ b/pkg/edi/edi997/parser.go
@@ -26,7 +26,7 @@ type functionalGroupCounter struct {
 	ts        []transactionSetCounter
 }
 
-// 	ISA > FGs > TSs > FGR > TSRs > DSs
+// ISA > FGs > TSs > FGR > TSRs > DSs
 type counterData struct {
 	fgCounter int
 	fg        []functionalGroupCounter

--- a/pkg/fakedata_approved/fakedata_approved.go
+++ b/pkg/fakedata_approved/fakedata_approved.go
@@ -353,8 +353,9 @@ func IsValidFakeDataAddressStrict(address string) (bool, error) {
 
 /*
 IsValidFakeDataPhone - checks for the format
- "999-999-999" or
- "###-555-####"
+
+	"999-999-999" or
+	"###-555-####"
 */
 func IsValidFakeDataPhone(phone string) (bool, error) {
 	// Make a Regex to say we only want numbers

--- a/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package adminapi
 

--- a/pkg/handlers/adminapi/users_test.go
+++ b/pkg/handlers/adminapi/users_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package adminapi
 

--- a/pkg/handlers/authentication/devlocal_test.go
+++ b/pkg/handlers/authentication/devlocal_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
-//RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
+// RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package authentication
 

--- a/pkg/handlers/ghcapi/evaluation_report.go
+++ b/pkg/handlers/ghcapi/evaluation_report.go
@@ -49,7 +49,7 @@ type CreateEvaluationReportHandler struct {
 	services.EvaluationReportCreator
 }
 
-//Handle is the handler for creating an evaluation report
+// Handle is the handler for creating an evaluation report
 func (h CreateEvaluationReportHandler) Handle(params evaluationReportop.CreateEvaluationReportParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package ghcapi
 

--- a/pkg/handlers/ghcapi/mto_agent.go
+++ b/pkg/handlers/ghcapi/mto_agent.go
@@ -17,13 +17,13 @@ import (
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
-//ListMTOAgentsHandler is a struct for the handler.
+// ListMTOAgentsHandler is a struct for the handler.
 type ListMTOAgentsHandler struct {
 	handlers.HandlerConfig
 	services.ListFetcher
 }
 
-//Handle handles the handling for listing MTO Agents.
+// Handle handles the handling for listing MTO Agents.
 func (h ListMTOAgentsHandler) Handle(params mtoagentop.FetchMTOAgentListParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package internalapi
 

--- a/pkg/handlers/internalapi/moving_expense_test.go
+++ b/pkg/handlers/internalapi/moving_expense_test.go
@@ -18,9 +18,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-//
-//CREATE TEST
-//
+// CREATE TEST
 func (suite *HandlerSuite) TestCreateMovingExpenseHandler() {
 	// Reusable objects
 	movingExpenseCreator := movingexpenseservice.NewMovingExpenseCreator()

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package internalapi
 

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package internalapi
 

--- a/pkg/handlers/internalapi/signed_certifications_test.go
+++ b/pkg/handlers/internalapi/signed_certifications_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package internalapi
 

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package internalapi
 

--- a/pkg/handlers/internalapi/weight_ticket_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_test.go
@@ -18,9 +18,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-//
 // CREATE TEST
-//
 func (suite *HandlerSuite) TestCreateWeightTicketHandler() {
 	// Reusable objects
 	weightTicketCreator := weightticket.NewCustomerWeightTicketCreator()

--- a/pkg/handlers/ordersapi/api_test.go
+++ b/pkg/handlers/ordersapi/api_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
-//RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
+// RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package ordersapi
 

--- a/pkg/handlers/supportapi/mto_service_item_test.go
+++ b/pkg/handlers/supportapi/mto_service_item_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package supportapi
 

--- a/pkg/handlers/supportapi/payment_request_test.go
+++ b/pkg/handlers/supportapi/payment_request_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used set up environment variables
-//RA: Given the functions causing the lint errors are used to set environment variables for testing purposes, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used set up environment variables
+// RA: Given the functions causing the lint errors are used to set environment variables for testing purposes, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package supportapi
 

--- a/pkg/migrate/Buffer_test.go
+++ b/pkg/migrate/Buffer_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package migrate
 

--- a/pkg/migrate/ListFiles_test.go
+++ b/pkg/migrate/ListFiles_test.go
@@ -44,12 +44,12 @@ func TestListFilesForS3WithInvalidClient(t *testing.T) {
 	assert.Error(t, expectedErr, err)
 }
 
-//mock interface
+// mock interface
 type mockS3Client struct {
 	s3iface.S3API
 }
 
-//mock function
+// mock function
 func (m *mockS3Client) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	// mock response/functionality
 	var files []*s3.Object

--- a/pkg/migrate/ReadInSQL_test.go
+++ b/pkg/migrate/ReadInSQL_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to clean up file created for unit test
-//RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to clean up file created for unit test
+// RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 // #nosec G307
 package migrate

--- a/pkg/migrate/SplitStatements_test.go
+++ b/pkg/migrate/SplitStatements_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to clean up file created for unit test
-//RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to clean up file created for unit test
+// RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 // #nosec G307
 package migrate

--- a/pkg/migrate/isAfterSpace_test.go
+++ b/pkg/migrate/isAfterSpace_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package migrate
 

--- a/pkg/migrate/untilNewLine_test.go
+++ b/pkg/migrate/untilNewLine_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package migrate
 

--- a/pkg/migrate/untilSpace_test.go
+++ b/pkg/migrate/untilSpace_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package migrate
 

--- a/pkg/models/ghc_diesel_fuel_price.go
+++ b/pkg/models/ghc_diesel_fuel_price.go
@@ -28,7 +28,7 @@ func (g *GHCDieselFuelPrice) Validate(tx *pop.Connection) (*validate.Errors, err
 	), nil
 }
 
-//TableName overrides the table name used by Pop.
+// TableName overrides the table name used by Pop.
 func (g GHCDieselFuelPrice) TableName() string {
 	return "ghc_diesel_fuel_prices"
 }

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -39,9 +39,9 @@ func (e *Entitlement) Validate(*pop.Connection) (*validate.Errors, error) {
 }
 
 // SetWeightAllotment sets the weight allotment
-//TODO probably want to reconsider keeping grade a string rather than enum
-//TODO and possibly consider creating ghc specific GetWeightAllotment should the two
-//TODO diverge in the future
+// TODO probably want to reconsider keeping grade a string rather than enum
+// TODO and possibly consider creating ghc specific GetWeightAllotment should the two
+// TODO diverge in the future
 func (e *Entitlement) SetWeightAllotment(grade string) {
 	wa := GetWeightAllotment(ServiceMemberRank(grade))
 	e.weightAllotment = &wa

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package models_test
 

--- a/pkg/models/mto_agents.go
+++ b/pkg/models/mto_agents.go
@@ -12,7 +12,7 @@ import (
 // MTOAgentType represents the type label for move task order agent
 type MTOAgentType string
 
-//Constants for the MTOAgentType
+// Constants for the MTOAgentType
 const (
 	MTOAgentReleasing MTOAgentType = "RELEASING_AGENT"
 	MTOAgentReceiving MTOAgentType = "RECEIVING_AGENT"
@@ -33,10 +33,10 @@ type MTOAgent struct {
 	DeletedAt     *time.Time   `db:"deleted_at"`
 }
 
-//MTOAgents is a collection of MTOAgent
+// MTOAgents is a collection of MTOAgent
 type MTOAgents []MTOAgent
 
-//Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 func (m *MTOAgent) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	var vs []validate.Validator
 	vs = append(vs, &validators.UUIDIsPresent{Field: m.MTOShipmentID, Name: "MTOShipmentID"})
@@ -63,7 +63,7 @@ func (m *MTOAgent) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(vs...), nil
 }
 
-//TableName overrides the table name used by Pop.
+// TableName overrides the table name used by Pop.
 func (m MTOAgent) TableName() string {
 	return "mto_agents"
 }

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package models_test
 

--- a/pkg/models/re_intl_accessorial_price.go
+++ b/pkg/models/re_intl_accessorial_price.go
@@ -11,14 +11,14 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-//Market represents the market for an international move
+// Market represents the market for an international move
 type Market string
 
 func (m Market) String() string {
 	return string(m)
 }
 
-//This lists available markets for international accessorial pricing
+// This lists available markets for international accessorial pricing
 const (
 	MarketConus  Market = "C"
 	MarketOconus Market = "O"

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -104,7 +104,7 @@ func (d Dollar) String() string {
 	return p.Sprintf("$%.2f", d)
 }
 
-//FormattedMovingExpenses is an object representing the service member's moving expenses formatted for the SSW
+// FormattedMovingExpenses is an object representing the service member's moving expenses formatted for the SSW
 type FormattedMovingExpenses struct {
 	ContractedExpenseMemberPaid Dollar
 	ContractedExpenseGTCCPaid   Dollar
@@ -267,7 +267,7 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 	return ssd, nil
 }
 
-//SSWMaxWeightEntitlement weight allotment for the shipment summary worksheet.
+// SSWMaxWeightEntitlement weight allotment for the shipment summary worksheet.
 type SSWMaxWeightEntitlement struct {
 	Entitlement   unit.Pound
 	ProGear       unit.Pound
@@ -390,7 +390,7 @@ func formatActualObligationAdvance(data ShipmentSummaryFormData) string {
 	return FormatDollars(0)
 }
 
-//FormatRank formats the service member's rank for Shipment Summary Worksheet
+// FormatRank formats the service member's rank for Shipment Summary Worksheet
 func FormatRank(rank *ServiceMemberRank) string {
 	var rankDisplayValue = map[ServiceMemberRank]string{
 		ServiceMemberRankE1:                      "E-1",
@@ -451,7 +451,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage3(data ShipmentSummaryFormData)
 	return page3
 }
 
-//FormatSignature formats a service member's signature for the Shipment Summary Worksheet
+// FormatSignature formats a service member's signature for the Shipment Summary Worksheet
 func FormatSignature(sm ServiceMember) string {
 	first := derefStringTypes(sm.FirstName)
 	last := derefStringTypes(sm.LastName)
@@ -466,12 +466,12 @@ func FormatSignatureDate(signature SignedCertification) string {
 	return dt
 }
 
-//FormatLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
+// FormatLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
 func FormatLocation(dutyLocation DutyLocation) string {
 	return fmt.Sprintf("%s, %s %s", dutyLocation.Name, dutyLocation.Address.State, dutyLocation.Address.PostalCode)
 }
 
-//FormatServiceMemberFullName formats ServiceMember full name for Shipment Summary Worksheet
+// FormatServiceMemberFullName formats ServiceMember full name for Shipment Summary Worksheet
 func FormatServiceMemberFullName(serviceMember ServiceMember) string {
 	lastName := derefStringTypes(serviceMember.LastName)
 	suffix := derefStringTypes(serviceMember.Suffix)
@@ -483,7 +483,7 @@ func FormatServiceMemberFullName(serviceMember ServiceMember) string {
 	return strings.TrimSpace(fmt.Sprintf("%s, %s %s", lastName, firstName, middleName))
 }
 
-//FormatAllShipments formats Shipment line items for the Shipment Summary Worksheet
+// FormatAllShipments formats Shipment line items for the Shipment Summary Worksheet
 func FormatAllShipments(ppms PersonallyProcuredMoves) ShipmentSummaryWorkSheetShipments {
 	totalShipments := len(ppms)
 	formattedShipments := ShipmentSummaryWorkSheetShipments{}
@@ -517,7 +517,7 @@ func FetchMovingExpensesShipmentSummaryWorksheet(move Move, db *pop.Connection, 
 	return movingExpenseDocuments, nil
 }
 
-//SubTotalExpenses groups moving expenses by type and payment method
+// SubTotalExpenses groups moving expenses by type and payment method
 func SubTotalExpenses(expenseDocuments MovingExpenses) map[string]float64 {
 	var expenseType string
 	totals := make(map[string]float64)
@@ -542,7 +542,7 @@ func getExpenseType(expense MovingExpense) string {
 	return fmt.Sprintf("%s%s", expenseType, "MemberPaid")
 }
 
-//FormatCurrentPPMStatus formats FormatCurrentPPMStatus for the Shipment Summary Worksheet
+// FormatCurrentPPMStatus formats FormatCurrentPPMStatus for the Shipment Summary Worksheet
 func FormatCurrentPPMStatus(ppm PersonallyProcuredMove) string {
 	if ppm.Status == "PAYMENT_REQUESTED" {
 		return "At destination"
@@ -550,12 +550,12 @@ func FormatCurrentPPMStatus(ppm PersonallyProcuredMove) string {
 	return FormatEnum(string(ppm.Status), " ")
 }
 
-//FormatPPMNumberAndType formats FormatShipmentNumberAndType for the Shipment Summary Worksheet
+// FormatPPMNumberAndType formats FormatShipmentNumberAndType for the Shipment Summary Worksheet
 func FormatPPMNumberAndType(i int) string {
 	return fmt.Sprintf("%02d - PPM", i+1)
 }
 
-//FormatPPMWeight formats a ppms NetWeight for the Shipment Summary Worksheet
+// FormatPPMWeight formats a ppms NetWeight for the Shipment Summary Worksheet
 func FormatPPMWeight(ppm PersonallyProcuredMove) string {
 	if ppm.NetWeight != nil {
 		wtg := FormatWeights(unit.Pound(*ppm.NetWeight))
@@ -564,7 +564,7 @@ func FormatPPMWeight(ppm PersonallyProcuredMove) string {
 	return ""
 }
 
-//FormatPPMPickupDate formats a shipments ActualPickupDate for the Shipment Summary Worksheet
+// FormatPPMPickupDate formats a shipments ActualPickupDate for the Shipment Summary Worksheet
 func FormatPPMPickupDate(ppm PersonallyProcuredMove) string {
 	if ppm.OriginalMoveDate != nil {
 		return FormatDate(*ppm.OriginalMoveDate)
@@ -572,14 +572,14 @@ func FormatPPMPickupDate(ppm PersonallyProcuredMove) string {
 	return ""
 }
 
-//FormatOrdersTypeAndOrdersNumber formats OrdersTypeAndOrdersNumber for Shipment Summary Worksheet
+// FormatOrdersTypeAndOrdersNumber formats OrdersTypeAndOrdersNumber for Shipment Summary Worksheet
 func FormatOrdersTypeAndOrdersNumber(order Order) string {
 	issuingBranch := FormatOrdersType(order)
 	ordersNumber := derefStringTypes(order.OrdersNumber)
 	return fmt.Sprintf("%s/%s", issuingBranch, ordersNumber)
 }
 
-//FormatServiceMemberAffiliation formats ServiceMemberAffiliation in human friendly format
+// FormatServiceMemberAffiliation formats ServiceMemberAffiliation in human friendly format
 func FormatServiceMemberAffiliation(affiliation *ServiceMemberAffiliation) string {
 	if affiliation != nil {
 		return FormatEnum(string(*affiliation), " ")
@@ -587,7 +587,7 @@ func FormatServiceMemberAffiliation(affiliation *ServiceMemberAffiliation) strin
 	return ""
 }
 
-//FormatOrdersType formats OrdersType for Shipment Summary Worksheet
+// FormatOrdersType formats OrdersType for Shipment Summary Worksheet
 func FormatOrdersType(order Order) string {
 	switch order.OrdersType {
 	case internalmessages.OrdersTypePERMANENTCHANGEOFSTATION:
@@ -597,26 +597,26 @@ func FormatOrdersType(order Order) string {
 	}
 }
 
-//FormatDate formats Dates for Shipment Summary Worksheet
+// FormatDate formats Dates for Shipment Summary Worksheet
 func FormatDate(date time.Time) string {
 	dateLayout := "02-Jan-2006"
 	return date.Format(dateLayout)
 }
 
-//FormatEnum titlecases string const types (e.g. THIS_CONSTANT -> This Constant)
-//outSep specifies the character to use for rejoining the string
+// FormatEnum titlecases string const types (e.g. THIS_CONSTANT -> This Constant)
+// outSep specifies the character to use for rejoining the string
 func FormatEnum(s string, outSep string) string {
 	words := strings.Replace(strings.ToLower(s), "_", " ", -1)
 	return strings.Replace(cases.Title(language.English).String(words), " ", outSep, -1)
 }
 
-//FormatWeights formats a unit.Pound using 000s separator
+// FormatWeights formats a unit.Pound using 000s separator
 func FormatWeights(wtg unit.Pound) string {
 	p := message.NewPrinter(language.English)
 	return p.Sprintf("%d", wtg)
 }
 
-//FormatDollars formats an int using 000s separator
+// FormatDollars formats an int using 000s separator
 func FormatDollars(dollars float64) string {
 	p := message.NewPrinter(language.English)
 	return p.Sprintf("$%.2f", dollars)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package models_test
 

--- a/pkg/models/transportation_office_test.go
+++ b/pkg/models/transportation_office_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package models_test
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package models_test
 

--- a/pkg/notifications/notification_sender.go
+++ b/pkg/notifications/notification_sender.go
@@ -32,6 +32,7 @@ type emailContent struct {
 }
 
 // NotificationSender is an interface for sending notifications
+//
 //go:generate mockery --name NotificationSender --disable-version-string
 type NotificationSender interface {
 	SendNotification(appCtx appcontext.AppContext, notification Notification) error

--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -15,20 +15,20 @@ type ppmComputer interface {
 	ComputePPMMoveCosts(appCtx appcontext.AppContext, weight unit.Pound, originPickupZip5 string, originDutyLocationZip5 string, destinationZip5 string, distanceMilesFromOriginPickupZip int, distanceMilesFromOriginDutyLocationZip int, date time.Time, daysInSit int) (cost rateengine.CostDetails, err error)
 }
 
-//SSWPPMComputer a rate engine wrapper with helper functions to simplify ppm cost calculations specific to shipment summary worksheet
+// SSWPPMComputer a rate engine wrapper with helper functions to simplify ppm cost calculations specific to shipment summary worksheet
 type SSWPPMComputer struct {
 	ppmComputer
 }
 
-//NewSSWPPMComputer creates a SSWPPMComputer
+// NewSSWPPMComputer creates a SSWPPMComputer
 func NewSSWPPMComputer(PPMComputer ppmComputer) *SSWPPMComputer {
 	return &SSWPPMComputer{ppmComputer: PPMComputer}
 }
 
-//ObligationType type corresponding to obligation sections of shipment summary worksheet
+// ObligationType type corresponding to obligation sections of shipment summary worksheet
 type ObligationType int
 
-//ComputeObligations is helper function for computing the obligations section of the shipment summary worksheet
+// ComputeObligations is helper function for computing the obligations section of the shipment summary worksheet
 func (sswPpmComputer *SSWPPMComputer) ComputeObligations(appCtx appcontext.AppContext, ssfd models.ShipmentSummaryFormData, planner route.Planner) (obligation models.Obligations, err error) {
 	firstPPM, err := sswPpmComputer.nilCheckPPM(ssfd)
 	if err != nil {

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -389,10 +389,11 @@ func Parse(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, par
 // in the xlsxDataSheets array
 //
 // Should not need to edit this function when adding new processing functions
-//     to add new processing functions update:
-//         a.) add new verify function for your processing
-//         b.) add new process function for your processing
-//         c.) update InitDataSheetInfo() with a.) and b.)
+//
+//	to add new processing functions update:
+//	    a.) add new verify function for your processing
+//	    b.) add new process function for your processing
+//	    c.) update InitDataSheetInfo() with a.) and b.)
 func process(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, params ParamConfig, sheetIndex int, tableFromSliceCreator services.TableFromSliceCreator) error {
 	xlsxInfo := xlsxDataSheets[sheetIndex]
 

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -7,7 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-//same values used in each parse and verify function
+// same values used in each parse and verify function
 const feeColIndexStart int = 6  // start at column 6 to get the rates
 const feeRowIndexStart int = 10 // start at row 10 to get the rates
 const originPriceAreaIDColumn int = 2

--- a/pkg/parser/transittime/parse.go
+++ b/pkg/parser/transittime/parse.go
@@ -166,10 +166,11 @@ func Parse(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, par
 // in the xlsxDataSheets array
 //
 // Should not need to edit this function when adding new processing functions
-//     to add new processing functions update:
-//         a.) add new verify function for your processing
-//         b.) add new process function for your processing
-//         c.) update InitDataSheetInfo() with a.) and b.)
+//
+//	to add new processing functions update:
+//	    a.) add new verify function for your processing
+//	    b.) add new process function for your processing
+//	    c.) update InitDataSheetInfo() with a.) and b.)
 func process(appCtx appcontext.AppContext, xlsxDataSheets []XlsxDataSheetInfo, params ParamConfig, sheetIndex int, tableFromSliceCreator services.TableFromSliceCreator) error {
 	xlsxInfo := xlsxDataSheets[sheetIndex]
 	var description string

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package serviceparamvaluelookups
 

--- a/pkg/payment_request/service_param_value_lookups/service_params_cache.go
+++ b/pkg/payment_request/service_param_value_lookups/service_params_cache.go
@@ -32,7 +32,7 @@ type ParamKeyValue struct {
 // ParamKeyValueCacheMap maps service param key string to the param cached value
 type ParamKeyValueCacheMap map[models.ServiceItemParamName]ParamKeyValue
 
-//MTOShipmentParamKeyMap maps an MTOShipmentID to a map of param caches for that shipment
+// MTOShipmentParamKeyMap maps an MTOShipmentID to a map of param caches for that shipment
 type MTOShipmentParamKeyMap map[uuid.UUID]ParamKeyValueCacheMap
 
 /******

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -234,7 +234,7 @@ func (re *RateEngine) computePPM(
 // 	return cost, nil
 // }
 
-//computePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
+// computePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
 func (re *RateEngine) computePPMIncludingLHDiscount(appCtx appcontext.AppContext, weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost CostComputation, err error) {
 
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(appCtx.DB(),

--- a/pkg/route/dtod_planner_test.go
+++ b/pkg/route/dtod_planner_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package route
 

--- a/pkg/route/dtod_zip5_distance.go
+++ b/pkg/route/dtod_zip5_distance.go
@@ -45,6 +45,7 @@ import (
 
 // DTODPlannerMileage is the interface for connecting to DTOD SOAP service and requesting distance mileage
 // NOTE: Placing this in a separate package/directory to avoid a circular dependency from an existing mock.
+//
 //go:generate mockery --name DTODPlannerMileage --outpkg ghcmocks --output ./ghcmocks --disable-version-string
 type DTODPlannerMileage interface {
 	DTODZip5Distance(appCtx appcontext.AppContext, pickup string, destination string) (int, error)

--- a/pkg/route/hhg_planner_test.go
+++ b/pkg/route/hhg_planner_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package route
 

--- a/pkg/route/planner.go
+++ b/pkg/route/planner.go
@@ -105,12 +105,14 @@ func zip3TransitDistanceHelper(appCtx appcontext.AppContext, planner Planner, so
 
 // SoapCaller provides an interface for the Call method of the gosoap Client so it can be mocked.
 // NOTE: Placing this in a separate package/directory to avoid a circular dependency from an existing mock.
+//
 //go:generate mockery --name SoapCaller --outpkg ghcmocks --output ./ghcmocks --disable-version-string
 type SoapCaller interface {
 	Call(m string, p gosoap.SoapParams) (res *gosoap.Response, err error)
 }
 
 // Planner is the interface needed by Handlers to be able to evaluate the distance to be used for move accounting
+//
 //go:generate mockery --name Planner --disable-version-string
 type Planner interface {
 	TransitDistance(appCtx appcontext.AppContext, source *models.Address, destination *models.Address) (int, error)

--- a/pkg/services/admin_user.go
+++ b/pkg/services/admin_user.go
@@ -10,6 +10,7 @@ import (
 )
 
 // AdminUserListFetcher is the exported interface for fetching multiple admin users
+//
 //go:generate mockery --name AdminUserListFetcher --disable-version-string
 type AdminUserListFetcher interface {
 	FetchAdminUserList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.AdminUsers, error)
@@ -17,18 +18,21 @@ type AdminUserListFetcher interface {
 }
 
 // AdminUserFetcher is the exported interface for fetching a single admin user
+//
 //go:generate mockery --name AdminUserFetcher --disable-version-string
 type AdminUserFetcher interface {
 	FetchAdminUser(appCtx appcontext.AppContext, filters []QueryFilter) (models.AdminUser, error)
 }
 
 // AdminUserCreator is the exported interface for creating an admin user
+//
 //go:generate mockery --name AdminUserCreator --disable-version-string
 type AdminUserCreator interface {
 	CreateAdminUser(appCtx appcontext.AppContext, user *models.AdminUser, organizationIDFilter []QueryFilter) (*models.AdminUser, *validate.Errors, error)
 }
 
 // AdminUserUpdater is the exported interface for creating an admin user
+//
 //go:generate mockery --name AdminUserUpdater --disable-version-string
 type AdminUserUpdater interface {
 	UpdateAdminUser(appCtx appcontext.AppContext, id uuid.UUID, payload *adminmessages.AdminUserUpdatePayload) (*models.AdminUser, *validate.Errors, error)

--- a/pkg/services/customer.go
+++ b/pkg/services/customer.go
@@ -8,12 +8,14 @@ import (
 )
 
 // CustomerFetcher is the service object interface for FetchCustomer
+//
 //go:generate mockery --name CustomerFetcher --disable-version-string
 type CustomerFetcher interface {
 	FetchCustomer(appCtx appcontext.AppContext, customerID uuid.UUID) (*models.ServiceMember, error)
 }
 
 // CustomerUpdater is the service object interface for updating fields of a ServiceMember
+//
 //go:generate mockery --name CustomerUpdater --disable-version-string
 type CustomerUpdater interface {
 	UpdateCustomer(appCtx appcontext.AppContext, eTag string, customer models.ServiceMember) (*models.ServiceMember, error)

--- a/pkg/services/customer_support_remarks.go
+++ b/pkg/services/customer_support_remarks.go
@@ -9,6 +9,7 @@ import (
 )
 
 // CustomerSupportRemarksFetcher is the exported interface for fetching office remarks for a move.
+//
 //go:generate mockery --name CustomerSupportRemarksFetcher --disable-version-string
 type CustomerSupportRemarksFetcher interface {
 	ListCustomerSupportRemarks(appCtx appcontext.AppContext, moveCode string) (*models.CustomerSupportRemarks, error)

--- a/pkg/services/db_tools.go
+++ b/pkg/services/db_tools.go
@@ -3,6 +3,7 @@ package services
 import "github.com/transcom/mymove/pkg/appcontext"
 
 // TableFromSliceCreator creates and populates a table based on a model slice
+//
 //go:generate mockery --name TableFromSliceCreator --disable-version-string
 type TableFromSliceCreator interface {
 	CreateTableFromSlice(appCtx appcontext.AppContext, slice interface{}) error

--- a/pkg/services/electronic_order.go
+++ b/pkg/services/electronic_order.go
@@ -6,6 +6,7 @@ import (
 )
 
 // ElectronicOrderListFetcher is the exported interface for fetching multiple electronic orders
+//
 //go:generate mockery --name ElectronicOrderListFetcher --disable-version-string
 type ElectronicOrderListFetcher interface {
 	FetchElectronicOrderList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.ElectronicOrders, error)
@@ -13,6 +14,7 @@ type ElectronicOrderListFetcher interface {
 }
 
 // ElectronicOrderCategoryCountFetcher is the exported interface for fetching counts of Electronic orders based on provided category QueryFilters.
+//
 //go:generate mockery --name ElectronicOrderCategoryCountFetcher --disable-version-string
 type ElectronicOrderCategoryCountFetcher interface {
 	FetchElectronicOrderCategoricalCounts(appCtx appcontext.AppContext, filters []QueryFilter, andFilters *[]QueryFilter) (map[interface{}]int, error)

--- a/pkg/services/evaluation_report.go
+++ b/pkg/services/evaluation_report.go
@@ -8,6 +8,7 @@ import (
 )
 
 // EvaluationReportFetcher is the service object interface for fetching all the evaluation reports for a move as a particular office user
+//
 //go:generate mockery --name EvaluationReportFetcher --disable-version-string
 type EvaluationReportFetcher interface {
 	FetchEvaluationReports(appCtx appcontext.AppContext, reportType models.EvaluationReportType, moveID uuid.UUID, officeUserID uuid.UUID) (models.EvaluationReports, error)

--- a/pkg/services/fetch.go
+++ b/pkg/services/fetch.go
@@ -3,12 +3,14 @@ package services
 import "github.com/transcom/mymove/pkg/appcontext"
 
 // Fetcher is the exported interface for fetching a record
+//
 //go:generate mockery --name Fetcher --disable-version-string
 type Fetcher interface {
 	FetchRecord(appCtx appcontext.AppContext, model interface{}, filters []QueryFilter) error
 }
 
 // ListFetcher is the exported interface for fetching multiple records
+//
 //go:generate mockery --name ListFetcher --disable-version-string
 type ListFetcher interface {
 	FetchRecordList(appCtx appcontext.AppContext, model interface{}, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) error

--- a/pkg/services/ghc_rate_engine.go
+++ b/pkg/services/ghc_rate_engine.go
@@ -9,6 +9,7 @@ import (
 )
 
 // ServiceItemPricer prices a generic payment service item for a GHC move
+//
 //go:generate mockery --name ServiceItemPricer --disable-version-string
 type ServiceItemPricer interface {
 	PriceServiceItem(appCtx appcontext.AppContext, item models.PaymentServiceItem) (unit.Cents, models.PaymentServiceItemParams, error)
@@ -29,6 +30,7 @@ type ParamsPricer interface {
 }
 
 // ManagementServicesPricer prices management services for a GHC move
+//
 //go:generate mockery --name ManagementServicesPricer --disable-version-string
 type ManagementServicesPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingDisplayParams, error)
@@ -36,6 +38,7 @@ type ManagementServicesPricer interface {
 }
 
 // CounselingServicesPricer prices counseling services for a GHC move
+//
 //go:generate mockery --name CounselingServicesPricer --disable-version-string
 type CounselingServicesPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, mtoAvailableToPrimeAt time.Time) (unit.Cents, PricingDisplayParams, error)
@@ -43,6 +46,7 @@ type CounselingServicesPricer interface {
 }
 
 // DomesticLinehaulPricer prices domestic linehaul for a GHC move
+//
 //go:generate mockery --name DomesticLinehaulPricer --disable-version-string
 type DomesticLinehaulPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -50,6 +54,7 @@ type DomesticLinehaulPricer interface {
 }
 
 // DomesticShorthaulPricer prices the domestic shorthaul for a GHC Move
+//
 //go:generate mockery --name DomesticShorthaulPricer --disable-version-string
 type DomesticShorthaulPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (unit.Cents, PricingDisplayParams, error)
@@ -57,6 +62,7 @@ type DomesticShorthaulPricer interface {
 }
 
 // DomesticOriginPricer prices the domestic origin for a GHC Move
+//
 //go:generate mockery --name DomesticOriginPricer --disable-version-string
 type DomesticOriginPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -64,6 +70,7 @@ type DomesticOriginPricer interface {
 }
 
 // DomesticDestinationPricer prices the domestic destination price for a GHC Move
+//
 //go:generate mockery --name DomesticDestinationPricer --disable-version-string
 type DomesticDestinationPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -71,6 +78,7 @@ type DomesticDestinationPricer interface {
 }
 
 // DomesticOriginShuttlingPricer prices the domestic origin shuttling service for a GHC Move
+//
 //go:generate mockery --name DomesticOriginShuttlingPricer --disable-version-string
 type DomesticOriginShuttlingPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int) (unit.Cents, PricingDisplayParams, error)
@@ -78,6 +86,7 @@ type DomesticOriginShuttlingPricer interface {
 }
 
 // DomesticDestinationShuttlingPricer prices the domestic origin shuttling service for a GHC Move
+//
 //go:generate mockery --name DomesticDestinationShuttlingPricer --disable-version-string
 type DomesticDestinationShuttlingPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int) (unit.Cents, PricingDisplayParams, error)
@@ -85,6 +94,7 @@ type DomesticDestinationShuttlingPricer interface {
 }
 
 // DomesticCratingPricer prices the domestic crating service for a GHC Move
+//
 //go:generate mockery --name DomesticCratingPricer --disable-version-string
 type DomesticCratingPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, billedCubicFeet unit.CubicFeet, servicesScheduleOrigin int) (unit.Cents, PricingDisplayParams, error)
@@ -92,6 +102,7 @@ type DomesticCratingPricer interface {
 }
 
 // DomesticUncratingPricer prices the domestic uncrating service for a GHC Move
+//
 //go:generate mockery --name DomesticUncratingPricer --disable-version-string
 type DomesticUncratingPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, billedCubicFeet unit.CubicFeet, servicesScheduleDest int) (unit.Cents, PricingDisplayParams, error)
@@ -99,6 +110,7 @@ type DomesticUncratingPricer interface {
 }
 
 // DomesticPackPricer prices the domestic packing for a GHC Move
+//
 //go:generate mockery --name DomesticPackPricer --disable-version-string
 type DomesticPackPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -106,6 +118,7 @@ type DomesticPackPricer interface {
 }
 
 // DomesticNTSPackPricer prices the domestic packing for an NTS shipment of a GHC Move
+//
 //go:generate mockery --name DomesticNTSPackPricer --disable-version-string
 type DomesticNTSPackPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleOrigin int, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -113,6 +126,7 @@ type DomesticNTSPackPricer interface {
 }
 
 // DomesticUnpackPricer prices the domestic unpacking for a GHC Move
+//
 //go:generate mockery --name DomesticUnpackPricer --disable-version-string
 type DomesticUnpackPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, servicesScheduleDest int, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -120,6 +134,7 @@ type DomesticUnpackPricer interface {
 }
 
 // FuelSurchargePricer prices the fuel surcharge price for a GHC Move
+//
 //go:generate mockery --name FuelSurchargePricer --disable-version-string
 type FuelSurchargePricer interface {
 	Price(appCtx appcontext.AppContext, actualPickupDate time.Time, distance unit.Miles, weight unit.Pound, fscWeightBasedDistanceMultiplier float64, eiaFuelPrice unit.Millicents, isPPM bool) (unit.Cents, PricingDisplayParams, error)
@@ -127,6 +142,7 @@ type FuelSurchargePricer interface {
 }
 
 // DomesticOriginFirstDaySITPricer prices domestic origin first day SIT for a GHC move
+//
 //go:generate mockery --name DomesticOriginFirstDaySITPricer --disable-version-string
 type DomesticOriginFirstDaySITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -134,6 +150,7 @@ type DomesticOriginFirstDaySITPricer interface {
 }
 
 // DomesticDestinationFirstDaySITPricer prices domestic destination first day SIT for a GHC move
+//
 //go:generate mockery --name DomesticDestinationFirstDaySITPricer --disable-version-string
 type DomesticDestinationFirstDaySITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -141,6 +158,7 @@ type DomesticDestinationFirstDaySITPricer interface {
 }
 
 // DomesticFirstDaySITPricer prices domestic origin or destination first day SIT for a GHC move
+//
 //go:generate mockery --name DomesticFirstDaySITPricer --disable-version-string
 type DomesticFirstDaySITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -148,6 +166,7 @@ type DomesticFirstDaySITPricer interface {
 }
 
 // DomesticOriginAdditionalDaysSITPricer prices domestic origin additional days SIT for a GHC move
+//
 //go:generate mockery --name DomesticOriginAdditionalDaysSITPricer --disable-version-string
 type DomesticOriginAdditionalDaysSITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -155,6 +174,7 @@ type DomesticOriginAdditionalDaysSITPricer interface {
 }
 
 // DomesticDestinationAdditionalDaysSITPricer prices domestic destination additional days SIT for a GHC move
+//
 //go:generate mockery --name DomesticDestinationAdditionalDaysSITPricer --disable-version-string
 type DomesticDestinationAdditionalDaysSITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -162,6 +182,7 @@ type DomesticDestinationAdditionalDaysSITPricer interface {
 }
 
 // DomesticAdditionalDaysSITPricer prices domestic origin or domestic additional days SIT for a GHC move
+//
 //go:generate mockery --name DomesticAdditionalDaysSITPricer --disable-version-string
 type DomesticAdditionalDaysSITPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, numberOfDaysInSIT int, disableWeightMinimum bool) (unit.Cents, PricingDisplayParams, error)
@@ -169,6 +190,7 @@ type DomesticAdditionalDaysSITPricer interface {
 }
 
 // DomesticOriginSITPickupPricer prices domestic origin SIT pickup for a GHC move
+//
 //go:generate mockery --name DomesticOriginSITPickupPricer --disable-version-string
 type DomesticOriginSITPickupPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipSITOriginOriginal string, zipSITOriginActual string, distance unit.Miles) (unit.Cents, PricingDisplayParams, error)
@@ -176,6 +198,7 @@ type DomesticOriginSITPickupPricer interface {
 }
 
 // DomesticDestinationSITDeliveryPricer prices domestic destination SIT delivery for a GHC move
+//
 //go:generate mockery --name DomesticDestinationSITDeliveryPricer --disable-version-string
 type DomesticDestinationSITDeliveryPricer interface {
 	Price(appCtx appcontext.AppContext, contractCode string, requestedPickupDate time.Time, weight unit.Pound, serviceArea string, sitSchedule int, zipDest string, zipSITDest string, distance unit.Miles) (unit.Cents, PricingDisplayParams, error)

--- a/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
+++ b/pkg/services/ghcrateengine/fuel_surcharge_pricer_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package ghcrateengine
 

--- a/pkg/services/invoice.go
+++ b/pkg/services/invoice.go
@@ -22,24 +22,28 @@ const (
 )
 
 // GexSender is an interface for sending and receiving a request
+//
 //go:generate mockery --name GexSender --disable-version-string
 type GexSender interface {
 	SendToGex(channel GEXChannel, edi string, filename string) (resp *http.Response, err error)
 }
 
 // GHCPaymentRequestInvoiceGenerator is the exported interface for generating an invoice
+//
 //go:generate mockery --name GHCPaymentRequestInvoiceGenerator --disable-version-string
 type GHCPaymentRequestInvoiceGenerator interface {
 	Generate(appCtx appcontext.AppContext, paymentRequest models.PaymentRequest, sendProductionInvoice bool) (ediinvoice.Invoice858C, error)
 }
 
 // SyncadaSFTPSender is the exported interface for sending an EDI to Syncada
+//
 //go:generate mockery --name SyncadaSFTPSender --disable-version-string
 type SyncadaSFTPSender interface {
 	SendToSyncadaViaSFTP(appCtx appcontext.AppContext, localDataReader io.Reader, syncadaFileName string) (int64, error)
 }
 
 // SFTPFiler is the exported interface for an SFTP client file
+//
 //go:generate mockery --name SFTPFiler --disable-version-string
 type SFTPFiler interface {
 	Close() error
@@ -47,6 +51,7 @@ type SFTPFiler interface {
 }
 
 // SFTPClient is the exported interface for an SFTP client created for reading from and SFTP connection
+//
 //go:generate mockery --name SFTPClient --disable-version-string
 type SFTPClient interface {
 	ReadDir(p string) ([]os.FileInfo, error)
@@ -55,12 +60,14 @@ type SFTPClient interface {
 }
 
 // SyncadaSFTPReader is the exported interface for reading files from an SFTP connection
+//
 //go:generate mockery --name SyncadaSFTPReader --disable-version-string
 type SyncadaSFTPReader interface {
 	FetchAndProcessSyncadaFiles(appCtx appcontext.AppContext, pickupPath string, lastRead time.Time, processor SyncadaFileProcessor) (time.Time, error)
 }
 
 // SyncadaFileProcessor is the exported interface for processing EDI files from Syncada
+//
 //go:generate mockery --name SyncadaFileProcessor --disable-version-string
 type SyncadaFileProcessor interface {
 	ProcessFile(appCtx appcontext.AppContext, syncadaPath string, text string) error

--- a/pkg/services/invoice/process_edi824.go
+++ b/pkg/services/invoice/process_edi824.go
@@ -23,7 +23,7 @@ func NewEDI824Processor() services.SyncadaFileProcessor {
 	return &edi824Processor{}
 }
 
-//ProcessFile parses an EDI 824 response and updates the payment request status
+// ProcessFile parses an EDI 824 response and updates the payment request status
 func (e *edi824Processor) ProcessFile(appCtx appcontext.AppContext, path string, stringEDI824 string) error {
 	edi824 := ediResponse824.EDI{}
 	err := edi824.Parse(stringEDI824)

--- a/pkg/services/invoice/process_edi997.go
+++ b/pkg/services/invoice/process_edi997.go
@@ -22,7 +22,7 @@ func NewEDI997Processor() services.SyncadaFileProcessor {
 	return &edi997Processor{}
 }
 
-//ProcessFile parses an EDI 997 response and updates the payment request status
+// ProcessFile parses an EDI 997 response and updates the payment request status
 func (e *edi997Processor) ProcessFile(appCtx appcontext.AppContext, path string, stringEDI997 string) error {
 	edi997 := ediResponse997.EDI{}
 	err := edi997.Parse(stringEDI997)

--- a/pkg/services/invoice/syncada_sftp_sender_test.go
+++ b/pkg/services/invoice/syncada_sftp_sender_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values are used to set/unset environment variables needed for session creation in the unit test's local database
-//RA: Setting/unsetting of environment variables does not present any risks and are solely used for unit testing purposes
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values are used to set/unset environment variables needed for session creation in the unit test's local database
+// RA: Setting/unsetting of environment variables does not present any risks and are solely used for unit testing purposes
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package invoice
 

--- a/pkg/services/move.go
+++ b/pkg/services/move.go
@@ -11,6 +11,7 @@ import (
 )
 
 // MoveListFetcher is the exported interface for fetching multiple moves
+//
 //go:generate mockery --name MoveListFetcher --disable-version-string
 type MoveListFetcher interface {
 	FetchMoveList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.Moves, error)
@@ -18,6 +19,7 @@ type MoveListFetcher interface {
 }
 
 // MoveFetcher is the exported interface for fetching a move by locator
+//
 //go:generate mockery --name MoveFetcher --disable-version-string
 type MoveFetcher interface {
 	FetchMove(appCtx appcontext.AppContext, locator string, searchParams *MoveFetcherParams) (*models.Move, error)
@@ -35,6 +37,7 @@ type MoveFetcherParams struct {
 }
 
 // MoveRouter is the exported interface for routing moves at different stages
+//
 //go:generate mockery --name MoveRouter --disable-version-string
 type MoveRouter interface {
 	Approve(appCtx appcontext.AppContext, move *models.Move) error
@@ -46,6 +49,7 @@ type MoveRouter interface {
 }
 
 // MoveWeights is the exported interface for flagging a move with an excess weight risk
+//
 //go:generate mockery --name MoveWeights --disable-version-string
 type MoveWeights interface {
 	CheckExcessWeight(appCtx appcontext.AppContext, moveID uuid.UUID, updatedShipment models.MTOShipment) (*models.Move, *validate.Errors, error)
@@ -53,6 +57,7 @@ type MoveWeights interface {
 }
 
 // MoveExcessWeightUploader is the exported interface for uploading an excess weight document for a move
+//
 //go:generate mockery --name MoveExcessWeightUploader --disable-version-string
 type MoveExcessWeightUploader interface {
 	CreateExcessWeightUpload(
@@ -65,6 +70,7 @@ type MoveExcessWeightUploader interface {
 }
 
 // MoveFinancialReviewFlagSetter is the exported interface for flagging a move for financial review
+//
 //go:generate mockery --name MoveFinancialReviewFlagSetter --disable-version-string
 type MoveFinancialReviewFlagSetter interface {
 	SetFinancialReviewFlag(appCtx appcontext.AppContext, moveID uuid.UUID, eTag string, flagForReview bool, remarks *string) (*models.Move, error)

--- a/pkg/services/move/move_fetcher.go
+++ b/pkg/services/move/move_fetcher.go
@@ -19,7 +19,7 @@ func NewMoveFetcher() services.MoveFetcher {
 	return &moveFetcher{}
 }
 
-//FetchMove retrieves a Move if it is visible for a given locator
+// FetchMove retrieves a Move if it is visible for a given locator
 func (f moveFetcher) FetchMove(appCtx appcontext.AppContext, locator string, searchParams *services.MoveFetcherParams) (*models.Move, error) {
 	move := &models.Move{}
 	query := appCtx.DB().Where("locator = $1", locator)

--- a/pkg/services/move/move_router.go
+++ b/pkg/services/move/move_router.go
@@ -343,6 +343,7 @@ func (router moveRouter) Cancel(appCtx appcontext.AppContext, reason string, mov
 // CompleteServiceCounseling sets the move status to:
 //   - "Service Counseling Completed" if a non-PPM move
 //   - "Approved" if a PPM-only move
+//
 // This makes the move available to the TOO.  This gets called when the Service Counselor is done
 // reviewing the move and submits it.
 func (router moveRouter) CompleteServiceCounseling(appCtx appcontext.AppContext, move *models.Move) error {

--- a/pkg/services/move_history.go
+++ b/pkg/services/move_history.go
@@ -6,6 +6,7 @@ import (
 )
 
 // MoveHistoryFetcher is the exported interface for fetching a move by locator
+//
 //go:generate mockery --name MoveHistoryFetcher --disable-version-string
 type MoveHistoryFetcher interface {
 	FetchMoveHistory(appCtx appcontext.AppContext, params *FetchMoveHistoryParams) (*models.MoveHistory, int64, error)

--- a/pkg/services/move_history/move_history_fetcher.go
+++ b/pkg/services/move_history/move_history_fetcher.go
@@ -21,7 +21,7 @@ func NewMoveHistoryFetcher() services.MoveHistoryFetcher {
 	return &moveHistoryFetcher{}
 }
 
-//FetchMoveHistory retrieves a Move's history if it is visible for a given locator
+// FetchMoveHistory retrieves a Move's history if it is visible for a given locator
 func (f moveHistoryFetcher) FetchMoveHistory(appCtx appcontext.AppContext, params *services.FetchMoveHistoryParams) (*models.MoveHistory, int64, error) {
 	rawQuery, qerr := query.GetSQLQueryByName("move_history_fetcher")
 

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -20,18 +20,21 @@ type HiddenMove struct {
 type HiddenMoves []HiddenMove
 
 // MoveTaskOrderHider is the service object interface for Hide
+//
 //go:generate mockery --name MoveTaskOrderHider --disable-version-string
 type MoveTaskOrderHider interface {
 	Hide(appCtx appcontext.AppContext) (HiddenMoves, error)
 }
 
 // MoveTaskOrderCreator is the service object interface for CreateMoveTaskOrder
+//
 //go:generate mockery --name MoveTaskOrderCreator --disable-version-string
 type MoveTaskOrderCreator interface {
 	CreateMoveTaskOrder(appCtx appcontext.AppContext, moveTaskOrder *models.Move) (*models.Move, *validate.Errors, error)
 }
 
 // MoveTaskOrderFetcher is the service object interface for FetchMoveTaskOrder
+//
 //go:generate mockery --name MoveTaskOrderFetcher --disable-version-string
 type MoveTaskOrderFetcher interface {
 	FetchMoveTaskOrder(appCtx appcontext.AppContext, searchParams *MoveTaskOrderFetcherParams) (*models.Move, error)
@@ -39,7 +42,8 @@ type MoveTaskOrderFetcher interface {
 	ListPrimeMoveTaskOrders(appCtx appcontext.AppContext, searchParams *MoveTaskOrderFetcherParams) (models.Moves, error)
 }
 
-//MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder
+// MoveTaskOrderUpdater is the service object interface for updating fields of a MoveTaskOrder
+//
 //go:generate mockery --name MoveTaskOrderUpdater --disable-version-string
 type MoveTaskOrderUpdater interface {
 	MakeAvailableToPrime(appCtx appcontext.AppContext, moveTaskOrderID uuid.UUID, eTag string, includeServiceCodeMS bool, includeServiceCodeCS bool) (*models.Move, error)
@@ -50,7 +54,8 @@ type MoveTaskOrderUpdater interface {
 	ShowHide(appCtx appcontext.AppContext, moveTaskOrderID uuid.UUID, show *bool) (*models.Move, error)
 }
 
-//MoveTaskOrderChecker is the service object interface for checking if a MoveTaskOrder is in a certain state
+// MoveTaskOrderChecker is the service object interface for checking if a MoveTaskOrder is in a certain state
+//
 //go:generate mockery --name MoveTaskOrderChecker --disable-version-string
 type MoveTaskOrderChecker interface {
 	MTOAvailableToPrime(appCtx appcontext.AppContext, moveTaskOrderID uuid.UUID) (bool, error)

--- a/pkg/services/move_task_order/move_task_order_checker.go
+++ b/pkg/services/move_task_order/move_task_order_checker.go
@@ -19,7 +19,7 @@ func NewMoveTaskOrderChecker() services.MoveTaskOrderChecker {
 	return &moveTaskOrderChecker{}
 }
 
-//MTOAvailableToPrime retrieves a Move for a given UUID and checks if it is visible and available to prime
+// MTOAvailableToPrime retrieves a Move for a given UUID and checks if it is visible and available to prime
 func (f moveTaskOrderChecker) MTOAvailableToPrime(appCtx appcontext.AppContext, moveTaskOrderID uuid.UUID) (bool, error) {
 	mto := &models.Move{}
 	err := appCtx.DB().RawQuery("SELECT * FROM moves WHERE id = $1 AND show = TRUE", moveTaskOrderID).First(mto)

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -204,7 +204,7 @@ func setMTOQueryFilters(query *pop.Query, searchParams *services.MoveTaskOrderFe
 	// No return since this function uses pointers to modify the referenced query directly
 }
 
-//fetchReweigh retrieves a reweigh for a given shipment id
+// fetchReweigh retrieves a reweigh for a given shipment id
 func fetchReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID) (*models.Reweigh, error) {
 	reweigh := &models.Reweigh{}
 	err := appCtx.DB().

--- a/pkg/services/moving_expense.go
+++ b/pkg/services/moving_expense.go
@@ -8,12 +8,14 @@ import (
 )
 
 // MovingExpenseCreator creates a MovingExpense that is associated with a PPMShipment
+//
 //go:generate mockery --name MovingExpenseCreator --disable-version-string
 type MovingExpenseCreator interface {
 	CreateMovingExpense(appCtx appcontext.AppContext, ppmShipmentID uuid.UUID) (*models.MovingExpense, error)
 }
 
 // MovingExpenseUpdater updates a MovingExpense
+//
 //go:generate mockery --name MovingExpenseUpdater --disable-version-string
 type MovingExpenseUpdater interface {
 	UpdateMovingExpense(appCtx appcontext.AppContext, movingExpense models.MovingExpense, eTag string) (*models.MovingExpense, error)

--- a/pkg/services/mto_agent.go
+++ b/pkg/services/mto_agent.go
@@ -5,7 +5,8 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-//MTOAgentUpdater is the service object interface for UpdateMTOAgent
+// MTOAgentUpdater is the service object interface for UpdateMTOAgent
+//
 //go:generate mockery --name MTOAgentUpdater --disable-version-string
 type MTOAgentUpdater interface {
 	UpdateMTOAgentBasic(appCtx appcontext.AppContext, mtoAgent *models.MTOAgent, eTag string) (*models.MTOAgent, error)
@@ -13,6 +14,7 @@ type MTOAgentUpdater interface {
 }
 
 // MTOAgentCreator is the service object interface for CreateMTOAgent
+//
 //go:generate mockery --name MTOAgentCreator --disable-version-string
 type MTOAgentCreator interface {
 	CreateMTOAgentPrime(appCtx appcontext.AppContext, mtoAgent *models.MTOAgent) (*models.MTOAgent, error)

--- a/pkg/services/mto_service_item.go
+++ b/pkg/services/mto_service_item.go
@@ -9,12 +9,14 @@ import (
 )
 
 // MTOServiceItemCreator is the exported interface for creating a mto service item
+//
 //go:generate mockery --name MTOServiceItemCreator --disable-version-string
 type MTOServiceItemCreator interface {
 	CreateMTOServiceItem(appCtx appcontext.AppContext, serviceItem *models.MTOServiceItem) (*models.MTOServiceItems, *validate.Errors, error)
 }
 
 // MTOServiceItemUpdater is the exported interface for updating an mto service item
+//
 //go:generate mockery --name MTOServiceItemUpdater --disable-version-string
 type MTOServiceItemUpdater interface {
 	ApproveOrRejectServiceItem(appCtx appcontext.AppContext, mtoServiceItemID uuid.UUID, status models.MTOServiceItemStatus, rejectionReason *string, eTag string) (*models.MTOServiceItem, error)

--- a/pkg/services/mto_service_item/mto_service_item_creator_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package mtoserviceitem
 

--- a/pkg/services/mto_service_item/mto_service_item_updater_test.go
+++ b/pkg/services/mto_service_item/mto_service_item_updater_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package mtoserviceitem
 

--- a/pkg/services/mto_shipment.go
+++ b/pkg/services/mto_shipment.go
@@ -10,21 +10,23 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-//MTOShipmentFetcher is the service object interface for fetching all shipments of a move
+// MTOShipmentFetcher is the service object interface for fetching all shipments of a move
+//
 //go:generate mockery --name MTOShipmentFetcher --disable-version-string
 type MTOShipmentFetcher interface {
 	ListMTOShipments(appCtx appcontext.AppContext, moveID uuid.UUID) ([]models.MTOShipment, error)
 	GetShipment(appCtx appcontext.AppContext, shipmentID uuid.UUID, eagerAssociations ...string) (*models.MTOShipment, error)
 }
 
-//MTOShipmentUpdater is the service object interface for UpdateMTOShipment
+// MTOShipmentUpdater is the service object interface for UpdateMTOShipment
+//
 //go:generate mockery --name MTOShipmentUpdater --disable-version-string
 type MTOShipmentUpdater interface {
 	MTOShipmentsMTOAvailableToPrime(appCtx appcontext.AppContext, mtoShipmentID uuid.UUID) (bool, error)
 	UpdateMTOShipment(appCtx appcontext.AppContext, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)
 }
 
-//BillableWeightInputs is a type for capturing what should be returned when a shipments billable weight is calculated
+// BillableWeightInputs is a type for capturing what should be returned when a shipments billable weight is calculated
 type BillableWeightInputs struct {
 	CalculatedBillableWeight *unit.Pound
 	OriginalWeight           *unit.Pound
@@ -32,61 +34,71 @@ type BillableWeightInputs struct {
 	HadManualOverride        *bool
 }
 
-//ShipmentBillableWeightCalculator is the service object interface for approving a shipment diversion
+// ShipmentBillableWeightCalculator is the service object interface for approving a shipment diversion
+//
 //go:generate mockery --name ShipmentBillableWeightCalculator --disable-version-string
 type ShipmentBillableWeightCalculator interface {
 	CalculateShipmentBillableWeight(shipment *models.MTOShipment) (BillableWeightInputs, error)
 }
 
-//ShipmentDeleter is the service object interface for deleting a shipment
+// ShipmentDeleter is the service object interface for deleting a shipment
+//
 //go:generate mockery --name ShipmentDeleter --disable-version-string
 type ShipmentDeleter interface {
 	DeleteShipment(appCtx appcontext.AppContext, shipmentID uuid.UUID) (uuid.UUID, error)
 }
 
-//ShipmentApprover is the service object interface for approving a shipment
+// ShipmentApprover is the service object interface for approving a shipment
+//
 //go:generate mockery --name ShipmentApprover --disable-version-string
 type ShipmentApprover interface {
 	ApproveShipment(appCtx appcontext.AppContext, shipmentID uuid.UUID, eTag string) (*models.MTOShipment, error)
 }
 
-//ShipmentDiversionRequester is the service object interface for approving a shipment diversion
+// ShipmentDiversionRequester is the service object interface for approving a shipment diversion
+//
 //go:generate mockery --name ShipmentDiversionRequester --disable-version-string
 type ShipmentDiversionRequester interface {
 	RequestShipmentDiversion(appCtx appcontext.AppContext, shipmentID uuid.UUID, eTag string) (*models.MTOShipment, error)
 }
 
-//ShipmentDiversionApprover is the service object interface for approving a shipment diversion
+// ShipmentDiversionApprover is the service object interface for approving a shipment diversion
+//
 //go:generate mockery --name ShipmentDiversionApprover --disable-version-string
 type ShipmentDiversionApprover interface {
 	ApproveShipmentDiversion(appCtx appcontext.AppContext, shipmentID uuid.UUID, eTag string) (*models.MTOShipment, error)
 }
 
-//ShipmentRejecter is the service object interface for approving a shipment
+// ShipmentRejecter is the service object interface for approving a shipment
+//
 //go:generate mockery --name ShipmentRejecter --disable-version-string
 type ShipmentRejecter interface {
 	RejectShipment(appCtx appcontext.AppContext, shipmentID uuid.UUID, eTag string, reason *string) (*models.MTOShipment, error)
 }
 
-//ShipmentCancellationRequester is the service object interface for approving a shipment diversion
+// ShipmentCancellationRequester is the service object interface for approving a shipment diversion
+//
 //go:generate mockery --name ShipmentCancellationRequester --disable-version-string
 type ShipmentCancellationRequester interface {
 	RequestShipmentCancellation(appCtx appcontext.AppContext, shipmentID uuid.UUID, eTag string) (*models.MTOShipment, error)
 }
 
-//ShipmentReweighRequester is the service object interface for approving a shipment diversion
+// ShipmentReweighRequester is the service object interface for approving a shipment diversion
+//
 //go:generate mockery --name ShipmentReweighRequester --disable-version-string
 type ShipmentReweighRequester interface {
 	RequestShipmentReweigh(appCtx appcontext.AppContext, shipmentID uuid.UUID, requestor models.ReweighRequester) (*models.Reweigh, error)
 }
 
 // MTOShipmentStatusUpdater is the exported interface for updating an MTO shipment status
+//
 //go:generate mockery --name MTOShipmentStatusUpdater --disable-version-string
 type MTOShipmentStatusUpdater interface {
 	UpdateMTOShipmentStatus(appCtx appcontext.AppContext, shipmentID uuid.UUID, status models.MTOShipmentStatus, rejectionReason *string, eTag string) (*models.MTOShipment, error)
 }
 
 // MTOShipmentCreator is the exported interface for creating a shipment
+//
 //go:generate mockery --name MTOShipmentCreator --disable-version-string
 type MTOShipmentCreator interface {
 	CreateMTOShipment(appCtx appcontext.AppContext, MTOShipment *models.MTOShipment) (*models.MTOShipment, error)
@@ -98,6 +110,7 @@ type MTOShipmentAddressUpdater interface {
 }
 
 // ShipmentRouter is used for setting the status on shipments at different stages
+//
 //go:generate mockery --name ShipmentRouter --disable-version-string
 type ShipmentRouter interface {
 	Submit(appCtx appcontext.AppContext, shipment *models.MTOShipment) error
@@ -122,6 +135,7 @@ type SITStatus struct {
 }
 
 // ShipmentSITStatus is the interface for calculating SIT service item summary balances of shipments
+//
 //go:generate mockery --name ShipmentSITStatus --disable-version-string
 type ShipmentSITStatus interface {
 	CalculateShipmentsSITStatuses(appCtx appcontext.AppContext, shipments []models.MTOShipment) map[string]SITStatus

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -268,7 +268,7 @@ func (e StaleIdentifierError) Error() string {
 	return fmt.Sprintf("stale identifier: %s", e.StaleIdentifier)
 }
 
-//UpdateMTOShipment updates the mto shipment
+// UpdateMTOShipment updates the mto shipment
 func (f *mtoShipmentUpdater) UpdateMTOShipment(appCtx appcontext.AppContext, mtoShipment *models.MTOShipment, eTag string) (*models.MTOShipment, error) {
 	eagerAssociations := []string{"MoveTaskOrder",
 		"PickupAddress",

--- a/pkg/services/mto_shipment/shipment_billable_weight.go
+++ b/pkg/services/mto_shipment/shipment_billable_weight.go
@@ -9,7 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-//shipmentBillableWeightCalculator handles the db connection
+// shipmentBillableWeightCalculator handles the db connection
 type shipmentBillableWeightCalculator struct {
 }
 

--- a/pkg/services/office.go
+++ b/pkg/services/office.go
@@ -11,6 +11,7 @@ type OfficeFetcher interface {
 }
 
 // OfficeListFetcher is the exported interface for fetching multiple transportation offices
+//
 //go:generate mockery --name OfficeListFetcher --disable-version-string
 type OfficeListFetcher interface {
 	FetchOfficeList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.TransportationOffices, error)

--- a/pkg/services/office_user.go
+++ b/pkg/services/office_user.go
@@ -10,12 +10,14 @@ import (
 )
 
 // OfficeUserFetcher is the exported interface for fetching a single office user
+//
 //go:generate mockery --name OfficeUserFetcher --disable-version-string
 type OfficeUserFetcher interface {
 	FetchOfficeUser(appCtx appcontext.AppContext, filters []QueryFilter) (models.OfficeUser, error)
 }
 
 // OfficeUserFetcherPop is the exported interface for fetching a single office user
+//
 //go:generate mockery --name OfficeUserFetcherPop --disable-version-string
 type OfficeUserFetcherPop interface {
 	FetchOfficeUserByID(appCtx appcontext.AppContext, id uuid.UUID) (models.OfficeUser, error)
@@ -23,18 +25,21 @@ type OfficeUserFetcherPop interface {
 
 // OfficeUserGblocFetcher is the exported interface for fetching the GBLOC of the
 // currently signed in office user
+//
 //go:generate mockery --name OfficeUserGblocFetcher --disable-version-string
 type OfficeUserGblocFetcher interface {
 	FetchGblocForOfficeUser(appCtx appcontext.AppContext, id uuid.UUID) (string, error)
 }
 
 // OfficeUserCreator is the exported interface for creating an office user
+//
 //go:generate mockery --name OfficeUserCreator --disable-version-string
 type OfficeUserCreator interface {
 	CreateOfficeUser(appCtx appcontext.AppContext, user *models.OfficeUser, transportationIDFilter []QueryFilter) (*models.OfficeUser, *validate.Errors, error)
 }
 
 // OfficeUserUpdater is the exported interface for creating an office user
+//
 //go:generate mockery --name OfficeUserUpdater --disable-version-string
 type OfficeUserUpdater interface {
 	UpdateOfficeUser(appCtx appcontext.AppContext, id uuid.UUID, payload *adminmessages.OfficeUserUpdatePayload) (*models.OfficeUser, *validate.Errors, error)

--- a/pkg/services/office_user/customer/customer.go
+++ b/pkg/services/office_user/customer/customer.go
@@ -18,7 +18,7 @@ func NewCustomerFetcher() services.CustomerFetcher {
 	return &fetchCustomer{}
 }
 
-//FetchCustomer retrieves a Customer for a given UUID
+// FetchCustomer retrieves a Customer for a given UUID
 func (f fetchCustomer) FetchCustomer(appCtx appcontext.AppContext, customerID uuid.UUID) (*models.ServiceMember, error) {
 	customer := &models.ServiceMember{}
 	if err := appCtx.DB().Eager().Find(customer, customerID); err != nil {

--- a/pkg/services/order.go
+++ b/pkg/services/order.go
@@ -14,13 +14,15 @@ import (
 )
 
 // OrderFetcher is the service object interface for FetchOrder
+//
 //go:generate mockery --name OrderFetcher --disable-version-string
 type OrderFetcher interface {
 	FetchOrder(appCtx appcontext.AppContext, moveTaskOrderID uuid.UUID) (*models.Order, error)
 	ListOrders(appCtx appcontext.AppContext, officeUserID uuid.UUID, params *ListOrderParams) ([]models.Move, int, error)
 }
 
-//OrderUpdater is the service object interface for updating fields of an Order
+// OrderUpdater is the service object interface for updating fields of an Order
+//
 //go:generate mockery --name OrderUpdater --disable-version-string
 type OrderUpdater interface {
 	UploadAmendedOrdersAsCustomer(appCtx appcontext.AppContext, userID uuid.UUID, orderID uuid.UUID, file io.ReadCloser, filename string, storer storage.FileStorer) (models.Upload, string, *validate.Errors, error)
@@ -30,7 +32,8 @@ type OrderUpdater interface {
 	UpdateAllowanceAsCounselor(appCtx appcontext.AppContext, orderID uuid.UUID, payload ghcmessages.CounselingUpdateAllowancePayload, eTag string) (*models.Order, uuid.UUID, error)
 }
 
-//ExcessWeightRiskManager is the service object interface for updating the max billable weight for an Order's Entitlement
+// ExcessWeightRiskManager is the service object interface for updating the max billable weight for an Order's Entitlement
+//
 //go:generate mockery --name ExcessWeightRiskManager --disable-version-string
 type ExcessWeightRiskManager interface {
 	AcknowledgeExcessWeightRisk(appCtx appcontext.AppContext, moveID uuid.UUID, eTag string) (*models.Move, error)

--- a/pkg/services/organization.go
+++ b/pkg/services/organization.go
@@ -11,6 +11,7 @@ type OrganizationFetcher interface {
 }
 
 // OrganizationListFetcher is the exported interface for fetching multiple organizations
+//
 //go:generate mockery --name OrganizationListFetcher --disable-version-string
 type OrganizationListFetcher interface {
 	FetchOrganizationList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.Organizations, error)

--- a/pkg/services/paperwork/form_creator.go
+++ b/pkg/services/paperwork/form_creator.go
@@ -14,12 +14,14 @@ import (
 )
 
 // FileStorer is an interface for fileStorer implementation
+//
 //go:generate mockery --name FileStorer --disable-version-string
 type FileStorer interface {
 	Create(string) (afero.File, error)
 }
 
 // FormFiller is an interface for formFiller implementation
+//
 //go:generate mockery --name FormFiller --disable-version-string
 type FormFiller interface {
 	AppendPage(io.ReadSeeker, map[string]paperworkforms.FieldPos, interface{}) error

--- a/pkg/services/paperwork/form_creator_test.go
+++ b/pkg/services/paperwork/form_creator_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package paperwork
 

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -11,24 +11,28 @@ import (
 )
 
 // PaymentRequestCreator is the exported interface for creating a payment request
+//
 //go:generate mockery --name PaymentRequestCreator --disable-version-string
 type PaymentRequestCreator interface {
 	CreatePaymentRequestCheck(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest) (*models.PaymentRequest, error)
 }
 
 // PaymentRequestRecalculator is the exported interface for recalculating a payment request
+//
 //go:generate mockery --name PaymentRequestRecalculator --disable-version-string
 type PaymentRequestRecalculator interface {
 	RecalculatePaymentRequest(appCtx appcontext.AppContext, paymentRequestID uuid.UUID) (*models.PaymentRequest, error)
 }
 
 // PaymentRequestShipmentRecalculator is the exported interface for recalculating payment requests for a shipment
+//
 //go:generate mockery --name PaymentRequestShipmentRecalculator --disable-version-string
 type PaymentRequestShipmentRecalculator interface {
 	ShipmentRecalculatePaymentRequest(appCtx appcontext.AppContext, shipmentID uuid.UUID) (*models.PaymentRequests, error)
 }
 
 // PaymentRequestListFetcher is the exported interface for fetching a list of payment requests
+//
 //go:generate mockery --name PaymentRequestListFetcher --disable-version-string
 type PaymentRequestListFetcher interface {
 	FetchPaymentRequestList(appCtx appcontext.AppContext, officeUserID uuid.UUID, params *FetchPaymentRequestListParams) (*models.PaymentRequests, int, error)
@@ -36,30 +40,35 @@ type PaymentRequestListFetcher interface {
 }
 
 // PaymentRequestFetcher is the exported interface for fetching a payment request
+//
 //go:generate mockery --name PaymentRequestFetcher --disable-version-string
 type PaymentRequestFetcher interface {
 	FetchPaymentRequest(appCtx appcontext.AppContext, paymentRequestID uuid.UUID) (models.PaymentRequest, error)
 }
 
 // PaymentRequestReviewedFetcher is the exported interface for fetching all payment requests in 'reviewed' status
+//
 //go:generate mockery --name PaymentRequestReviewedFetcher --disable-version-string
 type PaymentRequestReviewedFetcher interface {
 	FetchReviewedPaymentRequest(appCtx appcontext.AppContext) (models.PaymentRequests, error)
 }
 
 // PaymentRequestStatusUpdater is the exported interface for updating the status of a payment request
+//
 //go:generate mockery --name PaymentRequestStatusUpdater --disable-version-string
 type PaymentRequestStatusUpdater interface {
 	UpdatePaymentRequestStatus(appCtx appcontext.AppContext, paymentRequest *models.PaymentRequest, eTag string) (*models.PaymentRequest, error)
 }
 
 // PaymentRequestUploadCreator is the exported interface for creating a payment request upload
+//
 //go:generate mockery --name PaymentRequestUploadCreator --disable-version-string
 type PaymentRequestUploadCreator interface {
 	CreateUpload(appCtx appcontext.AppContext, file io.ReadCloser, paymentRequestID uuid.UUID, userID uuid.UUID, filename string) (*models.Upload, error)
 }
 
 // PaymentRequestReviewedProcessor is the exported interface for processing reviewed payment requests
+//
 //go:generate mockery --name PaymentRequestReviewedProcessor --disable-version-string
 type PaymentRequestReviewedProcessor interface {
 	ProcessReviewedPaymentRequest(appCtx appcontext.AppContext)
@@ -97,6 +106,7 @@ type ShipmentPaymentSITBalance struct {
 
 // ShipmentsPaymentSITBalance is the exported interface for returning SIT balances for all shipments of a payment
 // request
+//
 //go:generate mockery --name ShipmentsPaymentSITBalance --disable-version-string
 type ShipmentsPaymentSITBalance interface {
 	ListShipmentPaymentSITBalance(appCtx appcontext.AppContext, paymentRequestID uuid.UUID) ([]ShipmentPaymentSITBalance, error)

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -19,7 +19,7 @@ func NewPaymentRequestFetcher() services.PaymentRequestFetcher {
 	return &paymentRequestFetcher{}
 }
 
-//FetchPaymentRequest finds the payment request by id
+// FetchPaymentRequest finds the payment request by id
 func (p *paymentRequestFetcher) FetchPaymentRequest(appCtx appcontext.AppContext, paymentRequestID uuid.UUID) (models.PaymentRequest, error) {
 	var paymentRequest models.PaymentRequest
 

--- a/pkg/services/payment_request/payment_request_reviewed_fetcher.go
+++ b/pkg/services/payment_request/payment_request_reviewed_fetcher.go
@@ -17,7 +17,7 @@ func NewPaymentRequestReviewedFetcher() services.PaymentRequestReviewedFetcher {
 	return &paymentRequestReviewedFetcher{}
 }
 
-//FetchReviewedPaymentRequest finds all payment request with status 'reviewed'
+// FetchReviewedPaymentRequest finds all payment request with status 'reviewed'
 func (p *paymentRequestReviewedFetcher) FetchReviewedPaymentRequest(appCtx appcontext.AppContext) (models.PaymentRequests, error) {
 	var reviewedPaymentRequests models.PaymentRequests
 	err := appCtx.DB().Q().

--- a/pkg/services/payment_request/payment_request_reviewed_processor.go
+++ b/pkg/services/payment_request/payment_request_reviewed_processor.go
@@ -18,7 +18,7 @@ import (
 	"github.com/transcom/mymove/pkg/services/invoice"
 )
 
-//GexSendError is returned when there is an error sending an EDI to GEX
+// GexSendError is returned when there is an error sending an EDI to GEX
 type GexSendError struct {
 	paymentRequestID uuid.UUID
 	err              error

--- a/pkg/services/payment_request/upload_creator_test.go
+++ b/pkg/services/payment_request/upload_creator_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to clean up file created for unit test
-//RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to clean up file created for unit test
+// RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package paymentrequest
 

--- a/pkg/services/payment_service_item.go
+++ b/pkg/services/payment_service_item.go
@@ -9,6 +9,7 @@ import (
 )
 
 // PaymentServiceItemStatusUpdater is the exported interface for updating a payment service item
+//
 //go:generate mockery --name PaymentServiceItemStatusUpdater --disable-version-string
 type PaymentServiceItemStatusUpdater interface {
 	UpdatePaymentServiceItemStatus(appCtx appcontext.AppContext, paymentServiceItemID uuid.UUID,

--- a/pkg/services/postal_code.go
+++ b/pkg/services/postal_code.go
@@ -12,6 +12,7 @@ const (
 )
 
 // PostalCodeValidator is the service object interface for ValidatePostalCode
+//
 //go:generate mockery --name PostalCodeValidator --disable-version-string
 type PostalCodeValidator interface {
 	ValidatePostalCode(appCtx appcontext.AppContext, postalCode string, postalCodeType PostalCodeType) (bool, error)

--- a/pkg/services/ppmshipment.go
+++ b/pkg/services/ppmshipment.go
@@ -9,18 +9,21 @@ import (
 )
 
 // PPMShipmentCreator creates a PPM shipment
+//
 //go:generate mockery --name PPMShipmentCreator --disable-version-string
 type PPMShipmentCreator interface {
 	CreatePPMShipmentWithDefaultCheck(appCtx appcontext.AppContext, ppmshipment *models.PPMShipment) (*models.PPMShipment, error)
 }
 
 // PPMShipmentUpdater updates a PPM shipment
+//
 //go:generate mockery --name PPMShipmentUpdater --disable-version-string
 type PPMShipmentUpdater interface {
 	UpdatePPMShipmentWithDefaultCheck(appCtx appcontext.AppContext, ppmshipment *models.PPMShipment, mtoShipmentID uuid.UUID) (*models.PPMShipment, error)
 }
 
 // PPMEstimator estimates the cost of a PPM shipment
+//
 //go:generate mockery --name PPMEstimator --disable-version-string
 type PPMEstimator interface {
 	EstimateIncentiveWithDefaultChecks(appCtx appcontext.AppContext, oldPPMShipment models.PPMShipment, newPPMShipment *models.PPMShipment) (*unit.Cents, *unit.Cents, error)

--- a/pkg/services/pws_violation.go
+++ b/pkg/services/pws_violation.go
@@ -6,6 +6,7 @@ import (
 )
 
 // PWSViolationsFetcher is the exported interface for fetching office remarks for a move.
+//
 //go:generate mockery --name PWSViolationsFetcher --disable-version-string
 type PWSViolationsFetcher interface {
 	GetPWSViolations(appCtx appcontext.AppContext) (*models.PWSViolations, error)

--- a/pkg/services/query.go
+++ b/pkg/services/query.go
@@ -2,6 +2,7 @@ package services
 
 // QueryFilter is an interface to allow passing filter values into query interfaces
 // Ex `FetchMany` takes a list of filters
+//
 //go:generate mockery --name QueryFilter --disable-version-string
 type QueryFilter interface {
 	Column() string
@@ -14,6 +15,7 @@ type QueryFilter interface {
 type NewQueryFilter func(column string, comparator string, value interface{}) QueryFilter
 
 // QueryAssociation is an interface to allow passing association values into query interfaces
+//
 //go:generate mockery --name QueryAssociation --disable-version-string
 type QueryAssociation interface {
 	Field() string
@@ -24,6 +26,7 @@ type QueryAssociation interface {
 type NewQueryAssociation func(field string) QueryAssociation
 
 // QueryAssociations is an interface to allow
+//
 //go:generate mockery --name QueryAssociations --disable-version-string
 type QueryAssociations interface {
 	StringGetAssociations() []string

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
-//RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate test data for use in the unit test
+// RA: Creation of test data generation for unit test consumption does not present any unexpected states and conditions
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package query
 

--- a/pkg/services/query_order.go
+++ b/pkg/services/query_order.go
@@ -1,6 +1,7 @@
 package services
 
 // QueryOrder describes the "order by" clause in a sql query
+//
 //go:generate mockery --name QueryOrder --disable-version-string
 type QueryOrder interface {
 	Column() *string

--- a/pkg/services/reweigh/rules.go
+++ b/pkg/services/reweigh/rules.go
@@ -85,7 +85,7 @@ func checkRequiredFields() reweighValidator {
 	})
 }
 
-//checks that the shipment associated with the reweigh is available to Prime
+// checks that the shipment associated with the reweigh is available to Prime
 func checkPrimeAvailability(checker services.MoveTaskOrderChecker) reweighValidator {
 	return reweighValidatorFunc(func(appCtx appcontext.AppContext, newReweigh models.Reweigh, oldReweigh *models.Reweigh, shipment *models.MTOShipment) error {
 		if shipment == nil {

--- a/pkg/services/shipment_orchestrator.go
+++ b/pkg/services/shipment_orchestrator.go
@@ -6,12 +6,14 @@ import (
 )
 
 // ShipmentCreator creates a shipment, taking into account different shipment types and their needs.
+//
 //go:generate mockery --name ShipmentCreator --disable-version-string
 type ShipmentCreator interface {
 	CreateShipment(appCtx appcontext.AppContext, shipment *models.MTOShipment) (*models.MTOShipment, error)
 }
 
 // ShipmentUpdater updates a shipment, taking into account different shipment types and their needs.
+//
 //go:generate mockery --name ShipmentUpdater --disable-version-string
 type ShipmentUpdater interface {
 	UpdateShipment(appCtx appcontext.AppContext, shipment *models.MTOShipment, eTag string) (*models.MTOShipment, error)

--- a/pkg/services/sit_extension.go
+++ b/pkg/services/sit_extension.go
@@ -7,24 +7,27 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-//SITExtensionApprover is the service object interface for approving a SIT extension
+// SITExtensionApprover is the service object interface for approving a SIT extension
+//
 //go:generate mockery --name SITExtensionApprover --disable-version-string
 type SITExtensionApprover interface {
 	ApproveSITExtension(appCtx appcontext.AppContext, shipmentID uuid.UUID, sitExtensionID uuid.UUID, approvedDays int, officeRemarks *string, eTag string) (*models.MTOShipment, error)
 }
 
-//SITExtensionDenier is the service object interface for denying a SIT extension
+// SITExtensionDenier is the service object interface for denying a SIT extension
+//
 //go:generate mockery --name SITExtensionDenier --disable-version-string
 type SITExtensionDenier interface {
 	DenySITExtension(appCtx appcontext.AppContext, shipmentID uuid.UUID, sitExtensionID uuid.UUID, officeRemarks *string, eTag string) (*models.MTOShipment, error)
 }
 
-//SITExtensionCreator creates a SIT extension
+// SITExtensionCreator creates a SIT extension
 type SITExtensionCreator interface {
 	CreateSITExtension(appCtx appcontext.AppContext, sitExtension *models.SITExtension) (*models.SITExtension, error)
 }
 
-//SITExtensionCreatorAsTOO is the service object interface to create an approved SIT extension
+// SITExtensionCreatorAsTOO is the service object interface to create an approved SIT extension
+//
 //go:generate mockery --name SITExtensionCreatorAsTOO --disable-version-string
 type SITExtensionCreatorAsTOO interface {
 	CreateSITExtensionAsTOO(appCtx appcontext.AppContext, sitExtension *models.SITExtension, shipmentID uuid.UUID, eTag string) (*models.MTOShipment, error)

--- a/pkg/services/sit_extension/rules.go
+++ b/pkg/services/sit_extension/rules.go
@@ -71,7 +71,7 @@ func checkSITExtensionPending() sitExtensionValidator {
 	})
 }
 
-//checks that the shipment associated with the reweigh is available to Prime
+// checks that the shipment associated with the reweigh is available to Prime
 func checkPrimeAvailability(checker services.MoveTaskOrderChecker) sitExtensionValidator {
 	return sitExtensionValidatorFunc(func(appCtx appcontext.AppContext, sitExtension models.SITExtension, shipment *models.MTOShipment) error {
 		if shipment == nil {

--- a/pkg/services/support/move_task_order.go
+++ b/pkg/services/support/move_task_order.go
@@ -7,6 +7,7 @@ import (
 )
 
 // InternalMoveTaskOrderCreator is the service object interface for InternalCreateMoveTaskOrder
+//
 //go:generate mockery --name InternalMoveTaskOrderCreator --disable-version-string
 type InternalMoveTaskOrderCreator interface {
 	InternalCreateMoveTaskOrder(appCtx appcontext.AppContext, moveTaskOrder supportmessages.MoveTaskOrder) (*models.Move, error)

--- a/pkg/services/tsp.go
+++ b/pkg/services/tsp.go
@@ -7,6 +7,7 @@ import (
 
 // TransportationServiceProviderPerformanceFetcher is the exported interface for fetching
 // a single transportation service provider performance
+//
 //go:generate mockery --name TransportationServiceProviderPerformanceFetcher --disable-version-string
 type TransportationServiceProviderPerformanceFetcher interface {
 	FetchTransportationServiceProviderPerformance(appCtx appcontext.AppContext, filters []QueryFilter) (models.TransportationServiceProviderPerformance, error)
@@ -14,6 +15,7 @@ type TransportationServiceProviderPerformanceFetcher interface {
 
 // TransportationServiceProviderPerformanceListFetcher is the exported interface for fetching
 // a list of transportation service provider performances
+//
 //go:generate mockery --name TransportationServiceProviderPerformanceListFetcher --disable-version-string
 type TransportationServiceProviderPerformanceListFetcher interface {
 	FetchTransportationServiceProviderPerformanceList(appCtx appcontext.AppContext, filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.TransportationServiceProviderPerformances, error)

--- a/pkg/services/upload.go
+++ b/pkg/services/upload.go
@@ -31,12 +31,14 @@ type UploadInformation struct {
 }
 
 // UploadInformationFetcher is the service object interface for FetchUploadInformation
+//
 //go:generate mockery --name UploadInformationFetcher --disable-version-string
 type UploadInformationFetcher interface {
 	FetchUploadInformation(appCtx appcontext.AppContext, uuid uuid.UUID) (UploadInformation, error)
 }
 
 // UploadCreator is the service object interface for CreateUpload
+//
 //go:generate mockery --name UploadCreator --disable-version-string
 type UploadCreator interface {
 	CreateUpload(appCtx appcontext.AppContext, file io.ReadCloser, uploadFilename string, uploadType models.UploadType) (*models.Upload, error)

--- a/pkg/services/user.go
+++ b/pkg/services/user.go
@@ -11,18 +11,21 @@ import (
 )
 
 // UserFetcher is the service object interface for FetchUser
+//
 //go:generate mockery --name UserFetcher --disable-version-string
 type UserFetcher interface {
 	FetchUser(appCtx appcontext.AppContext, filters []QueryFilter) (models.User, error)
 }
 
 // UserUpdater is the service object interface for UpdateUser
+//
 //go:generate mockery --name UserUpdater --disable-version-string
 type UserUpdater interface {
 	UpdateUser(appCtx appcontext.AppContext, id uuid.UUID, user *models.User) (*models.User, *validate.Errors, error)
 }
 
 // UserSessionRevocation is the exported interface for revoking a user session
+//
 //go:generate mockery --name UserSessionRevocation --disable-version-string
 type UserSessionRevocation interface {
 	RevokeUserSession(appCtx appcontext.AppContext, id uuid.UUID, payload *adminmessages.UserUpdatePayload, sessionStore scs.Store) (*models.User, *validate.Errors, error)

--- a/pkg/services/user/user_session_revocation_test.go
+++ b/pkg/services/user/user_session_revocation_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package user
 

--- a/pkg/services/user/user_updater_test.go
+++ b/pkg/services/user/user_updater_test.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
-//RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
-//RA: in a unit test, then there is no risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used fetch data and assign data to a variable that is checked later on
+// RA: Given the return value is being checked in a different line and the functions that are flagged by the linter are being used to assign variables
+// RA: in a unit test, then there is no risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package user
 

--- a/pkg/services/users_roles.go
+++ b/pkg/services/users_roles.go
@@ -9,6 +9,7 @@ import (
 )
 
 // UserRoleAssociator is the service object interface for UpdateUserRoles
+//
 //go:generate mockery --name UserRoleAssociator --disable-version-string
 type UserRoleAssociator interface {
 	UpdateUserRoles(appCtx appcontext.AppContext, userID uuid.UUID, roles []roles.RoleType) ([]models.UsersRoles, error)

--- a/pkg/services/webhook_subscription.go
+++ b/pkg/services/webhook_subscription.go
@@ -8,18 +8,21 @@ import (
 )
 
 // WebhookSubscriptionFetcher is the service object interface for FetchWebhookSubscription
+//
 //go:generate mockery --name WebhookSubscriptionFetcher --disable-version-string
 type WebhookSubscriptionFetcher interface {
 	FetchWebhookSubscription(appCtx appcontext.AppContext, filters []QueryFilter) (models.WebhookSubscription, error)
 }
 
 // WebhookSubscriptionCreator is the exported interface for creating an admin user
+//
 //go:generate mockery --name WebhookSubscriptionCreator --disable-version-string
 type WebhookSubscriptionCreator interface {
 	CreateWebhookSubscription(appCtx appcontext.AppContext, subscription *models.WebhookSubscription) (*models.WebhookSubscription, *validate.Errors, error)
 }
 
-//WebhookSubscriptionUpdater is the service object interface for UpdateWebhookSubscription
+// WebhookSubscriptionUpdater is the service object interface for UpdateWebhookSubscription
+//
 //go:generate mockery --name WebhookSubscriptionUpdater --disable-version-string
 type WebhookSubscriptionUpdater interface {
 	UpdateWebhookSubscription(appCtx appcontext.AppContext, webhooksubscription *models.WebhookSubscription, severity *int64, eTag *string) (*models.WebhookSubscription, error)

--- a/pkg/services/weight_ticket.go
+++ b/pkg/services/weight_ticket.go
@@ -8,12 +8,14 @@ import (
 )
 
 // WeightTicketCreator creates a WeightTicket that is associated with a PPMShipment
+//
 //go:generate mockery --name WeightTicketCreator --disable-version-string
 type WeightTicketCreator interface {
 	CreateWeightTicket(appCtx appcontext.AppContext, ppmShipmentID uuid.UUID) (*models.WeightTicket, error)
 }
 
 // WeightTicketUpdater updates a WeightTicket
+//
 //go:generate mockery --name WeightTicketUpdater --disable-version-string
 type WeightTicketUpdater interface {
 	UpdateWeightTicket(appCtx appcontext.AppContext, weightTicket models.WeightTicket, eTag string) (*models.WeightTicket, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -30,6 +30,7 @@ import (
 type StoreResult struct{}
 
 // FileStorer is the set of methods needed to store and retrieve objects.
+//
 //go:generate mockery --name FileStorer --disable-version-string
 type FileStorer interface {
 	Store(string, io.ReadSeeker, string, *string) (*StoreResult, error)

--- a/pkg/testdatagen/scenario/devseed.go
+++ b/pkg/testdatagen/scenario/devseed.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package scenario
 

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1,11 +1,11 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
-//RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
-//RA: in which this would be considered a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to generate stub data for a localized version of the application.
+// RA: Given the data is being generated for local use and does not contain any sensitive information, there are no unexpected states and conditions
+// RA: in which this would be considered a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package scenario
 

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -6323,7 +6323,7 @@ func createMoveWithUniqueDestinationAddress(appCtx appcontext.AppContext) {
 }
 
 /*
-	Create Needs Service Counseling - pass in orders with all required information, shipment type, destination type, locator
+Create Needs Service Counseling - pass in orders with all required information, shipment type, destination type, locator
 */
 func createNeedsServicesCounseling(appCtx appcontext.AppContext, ordersType internalmessages.OrdersType, shipmentType models.MTOShipmentType, destinationType *models.DestinationType, locator string) {
 	db := appCtx.DB()
@@ -6390,7 +6390,7 @@ func createNeedsServicesCounseling(appCtx appcontext.AppContext, ordersType inte
 }
 
 /*
-	Create Needs Service Counseling without all required order information
+Create Needs Service Counseling without all required order information
 */
 func createNeedsServicesCounselingWithoutCompletedOrders(appCtx appcontext.AppContext, ordersType internalmessages.OrdersType, shipmentType models.MTOShipmentType, destinationType *models.DestinationType, locator string) {
 	db := appCtx.DB()

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -334,8 +334,7 @@ func getOrCreateUpload(db *pop.Connection, upload models.UserUpload, assertions 
 //
 // Usage example:
 //
-//     emptyDocument := GetOrCreateDocumentWithUploads(db, assertions.WeightTicket.EmptyDocument, assertions)
-//
+//	emptyDocument := GetOrCreateDocumentWithUploads(db, assertions.WeightTicket.EmptyDocument, assertions)
 func GetOrCreateDocumentWithUploads(db *pop.Connection, document models.Document, assertions Assertions) models.Document {
 	// hang on to UserUploads, if any, for later
 	userUploads := document.UserUploads

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -28,14 +28,14 @@ import (
 const charset = "abcdefghijklmnopqrstuvwxyz" +
 	"0123456789"
 
-//RA Summary: gosec - G404 - Insecure random number source (rand)
-//RA: gosec detected use of the insecure package math/rand rather than the more secure cryptographically secure pseudo-random number generator crypto/rand.
-//RA: This particular usage is mitigated by sourcing the seed from crypto/rand in order to create the new random number using math/rand.
-//RA: Second, as part of the testing suite, the need for a secure random number here is not necessary.
-//RA Developer Status: Mitigated
-//RA Validator: jneuner@mitre.org
-//RA Validator Status: Mitigated
-//RA Modified Severity: CAT III
+// RA Summary: gosec - G404 - Insecure random number source (rand)
+// RA: gosec detected use of the insecure package math/rand rather than the more secure cryptographically secure pseudo-random number generator crypto/rand.
+// RA: This particular usage is mitigated by sourcing the seed from crypto/rand in order to create the new random number using math/rand.
+// RA: Second, as part of the testing suite, the need for a secure random number here is not necessary.
+// RA Developer Status: Mitigated
+// RA Validator: jneuner@mitre.org
+// RA Validator Status: Mitigated
+// RA Modified Severity: CAT III
 // #nosec G404
 var seededRand = rand.New(random.NewCryptoSeededSource())
 

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to clean up file created for unit test
-//RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to clean up file created for unit test
+// RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package uploader_test
 

--- a/pkg/uploader/user_uploader_test.go
+++ b/pkg/uploader/user_uploader_test.go
@@ -1,10 +1,10 @@
-//RA Summary: gosec - errcheck - Unchecked return value
-//RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
-//RA: Functions with unchecked return values in the file are used to clean up file created for unit test
-//RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
-//RA Developer Status: Mitigated
-//RA Validator Status: Mitigated
-//RA Modified Severity: N/A
+// RA Summary: gosec - errcheck - Unchecked return value
+// RA: Linter flags errcheck error: Ignoring a method's return value can cause the program to overlook unexpected states and conditions.
+// RA: Functions with unchecked return values in the file are used to clean up file created for unit test
+// RA: Given the functions causing the lint errors are used to clean up local storage space after a unit test, it does not present a risk
+// RA Developer Status: Mitigated
+// RA Validator Status: Mitigated
+// RA Modified Severity: N/A
 // nolint:errcheck
 package uploader_test
 


### PR DESCRIPTION
## Summary

When [updating to go 1.19](https://github.com/transcom/mymove/pull/9205), it looks like we missed some files that needed to be reformatted with the new go 1.19 formatter.  Most (if not all) of the changes appear to be about making whitespace in comments more consistent.

## Setup to Run Your Code

Make sure you're on go 1.19 already (this is branched from `master` after the go 1.19 changes landed).

Reset your pre-commit hooks:
`pre-commit clean && pre-commit install && pre-commit install-hooks`

Run all files through pre-commit:
`pre-commit run -a`

Verify that everything passed and a `git status` still shows everything as up-to-date with no local changes.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
