### PR TITLE
[ MB-11281 ] Enable destination type to be displayed in Move history table

### DIFF
--- a/src/constants/MoveHistory/Database/FieldMappings.js
+++ b/src/constants/MoveHistory/Database/FieldMappings.js
@@ -57,4 +57,5 @@ export default {
   first_available_delivery_time: 'First available delivery time',
   second_available_delivery_time: 'Second available delivery time',
   reweigh_weight: 'Reweigh weight',
+  destination_address_type: 'Destination type',
 };

--- a/src/constants/MoveHistory/Database/OptionFields.js
+++ b/src/constants/MoveHistory/Database/OptionFields.js
@@ -4,6 +4,7 @@ import {
   ORDERS_TYPE_DETAILS_OPTIONS,
   ORDERS_TYPE_OPTIONS,
 } from 'constants/orders';
+import { shipmentDestinationTypes } from 'constants/shipments';
 
 // This is to map the human-readable text to the options
 export default {
@@ -11,4 +12,5 @@ export default {
   ...ORDERS_TYPE_DETAILS_OPTIONS,
   ...ORDERS_TYPE_OPTIONS,
   ...ORDERS_RANK_OPTIONS,
+  ...shipmentDestinationTypes,
 };

--- a/src/constants/MoveHistory/EventTemplates/updateMTOShipment.js
+++ b/src/constants/MoveHistory/EventTemplates/updateMTOShipment.js
@@ -12,6 +12,7 @@ export default {
   getDetailsLabeledDetails: (historyRecord) => {
     return {
       shipment_type: historyRecord.oldValues.shipment_type,
+      // TODO: [ MB-12182 ] This will include a shipment ID label in the future
       ...historyRecord.changedValues,
     };
   },

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -8,7 +8,7 @@ import fieldMappings from 'constants/MoveHistory/Database/FieldMappings';
 import weightFields from 'constants/MoveHistory/Database/WeightFields';
 import { shipmentTypes } from 'constants/shipments';
 import { HistoryLogRecordShape } from 'constants/MoveHistory/UIDisplay/HistoryLogShape';
-import optionFields from 'constants/MoveHistory/Database/Orders';
+import optionFields from 'constants/MoveHistory/Database/OptionFields';
 import { formatCustomerDate } from 'utils/formatters';
 
 const retrieveTextToDisplay = (fieldName, value) => {

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -36,6 +36,7 @@ describe('LabeledDetails', () => {
         grade: 'E_1',
         actual_pickup_date: '2022-01-01',
         prime_actual_weight: '100 lbs',
+        destination_address_type: 'HOME_OF_SELECTION',
       },
     };
     it.each([
@@ -64,6 +65,7 @@ describe('LabeledDetails', () => {
       ['Dept. indicator', ': Air Force'],
       ['Departure date', ': 01 Jan 2022'],
       ['Shipment weight', ': 100 lbs'],
+      ['Destination type', ': Home of selection (HOS)'],
     ])('it renders %s%s', (displayName, value) => {
       render(<LabeledDetails historyRecord={historyRecord} />);
 


### PR DESCRIPTION

## [MB-11281](https://dp3.atlassian.net/browse/MB-11281) for this change

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a service councilor
3. Modify a shipment for a move (Any move with a shipment should work, I used BT93XH most recently)
4. Make sure that you modify the Destination Type, which is located under the address in the Delivery Location section
5. Go to the Move History for that move
6. You should see an entry for the Updated Shipment with the Destination Type info

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots
Before: 
![image](https://user-images.githubusercontent.com/110134470/192378586-16b59cc1-6c20-438d-a8ec-9878db8086d3.png)

After:
![image](https://user-images.githubusercontent.com/110134470/192378625-b51c1724-11e7-42cd-afa9-d4ac2771d172.png)
