### PR TITLE
[ MB-11273 ] Display MTO agent when shipment created

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/createMTOShipmentAgent.js
+++ b/src/constants/MoveHistory/EventTemplates/createMTOShipmentAgent.js
@@ -2,11 +2,10 @@ import { formatMoveHistoryAgent } from 'utils/formatters';
 import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
 import t from 'constants/MoveHistory/Database/Tables';
 import a from 'constants/MoveHistory/Database/Actions';
-import o from 'constants/MoveHistory/UIDisplay/Operations';
 
 export default {
   action: a.INSERT,
-  eventName: o.updateMTOShipment,
+  eventName: '*',
   tableName: t.mto_agents,
   detailsType: d.LABELED,
   getEventNameDisplay: () => 'Updated shipment',

--- a/src/constants/MoveHistory/EventTemplates/createMTOShipmentAgent.test.js
+++ b/src/constants/MoveHistory/EventTemplates/createMTOShipmentAgent.test.js
@@ -19,7 +19,22 @@ describe('when given an mto shipment agents insert with mto agents table history
     context: [{ shipment_type: 'HHG' }],
   };
 
-  it('correctly matches the insert mto shipment agent event for releasing agents', () => {
+  const item2 = {
+    action: 'INSERT',
+    eventName: o.createMTOShipment,
+    tableName: 'mto_agents',
+    detailsType: d.LABELED,
+    changedValues: {
+      email: 'catalina@email.com',
+      first_name: 'Catalina',
+      last_name: 'Washington',
+      phone: '999-999-9999',
+      agent_type: 'RELEASING_AGENT',
+    },
+    context: [{ shipment_type: 'HHG' }],
+  };
+
+  it('correctly matches the insert mto shipment agent event for releasing agents when shipment updated', () => {
     const result = getTemplate(item);
     expect(result).toMatchObject(e);
     // expect to have formatted the agent correctly
@@ -39,7 +54,27 @@ describe('when given an mto shipment agents insert with mto agents table history
     });
   });
 
-  it('correctly matches the insert mto shipment agent event for receiving agents', () => {
+  it('correctly matches the insert mto shipment agent event for releasing agents when shipment created', () => {
+    const result = getTemplate(item2);
+    expect(result).toMatchObject(e);
+    // expect to have formatted the agent correctly
+    expect(
+      result.getDetailsLabeledDetails({
+        changedValues: item2.changedValues,
+        context: item2.context,
+      }),
+    ).toEqual({
+      releasing_agent: 'Catalina Washington, 999-999-9999, catalina@email.com',
+      email: 'catalina@email.com',
+      first_name: 'Catalina',
+      last_name: 'Washington',
+      phone: '999-999-9999',
+      agent_type: 'RELEASING_AGENT',
+      shipment_type: 'HHG',
+    });
+  });
+
+  it('correctly matches the insert mto shipment agent event for receiving agents when shipment updated', () => {
     const result = getTemplate(item);
     expect(result).toMatchObject(e);
     // expect to have formatted the agent correctly
@@ -54,6 +89,26 @@ describe('when given an mto shipment agents insert with mto agents table history
       first_name: 'Grace',
       last_name: 'Griffin',
       phone: '555-555-5555',
+      agent_type: 'RECEIVING_AGENT',
+      shipment_type: 'HHG',
+    });
+  });
+
+  it('correctly matches the insert mto shipment agent event for receiving agents when shipment created', () => {
+    const result = getTemplate(item2);
+    expect(result).toMatchObject(e);
+    // expect to have formatted the agent correctly
+    expect(
+      result.getDetailsLabeledDetails({
+        changedValues: { ...item2.changedValues, agent_type: 'RECEIVING_AGENT' },
+        context: item2.context,
+      }),
+    ).toEqual({
+      receiving_agent: 'Catalina Washington, 999-999-9999, catalina@email.com',
+      email: 'catalina@email.com',
+      first_name: 'Catalina',
+      last_name: 'Washington',
+      phone: '999-999-9999',
       agent_type: 'RECEIVING_AGENT',
       shipment_type: 'HHG',
     });

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -40,6 +40,7 @@ const LabeledDetails = ({ historyRecord, getDetailsLabeledDetails }) => {
   }
 
   // Check for shipment_type to use it as a header for the row
+  // TODO: [ MB-12182 ] This will include a shipment ID label in the future
   if ('shipment_type' in changedValuesToUse) {
     shipmentDisplay = shipmentTypes[changedValuesToUse.shipment_type];
     shipmentDisplay += ' shipment';


### PR DESCRIPTION
## Summary
A new shipment add
did not quite display just so
thus we fixed it all

## [Jira ticket](https://dp3.atlassian.net/browse/MB-11273) for this change

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access a move that needs counseling
2. Login as a services counselor
3. Add an HHG shipment to the move - Make sure to include a Releasing agent and/or a Receiving agent - this is important!
5. View move history

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Frontend

- [x] User facing changes have been reviewed by design.
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output

## Screenshots
<img width="1223" alt="Screen Shot 2022-09-26 at 2 59 41 PM" src="https://user-images.githubusercontent.com/110431091/192379654-c4c4f416-e46a-416a-a6dd-e08bba646a5f.png">
