### PR TITLE
Update file for go 1.19 formatting

### DIFF
--- a/pkg/handlers/ghcapi/report_violations.go
+++ b/pkg/handlers/ghcapi/report_violations.go
@@ -21,7 +21,7 @@ type AssociateReportViolationsHandler struct {
 	services.ReportViolationsCreator
 }
 
-//Handle is the handler for associating violations with reports
+// Handle is the handler for associating violations with reports
 func (h AssociateReportViolationsHandler) Handle(params reportViolationop.AssociateReportViolationsParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {


### PR DESCRIPTION
## Summary

When running a `pre-commit run -a` (run all files through all pre-commit hooks), I noticed I had a changed file due to a trivial formatting change.  Probably just a case of #9219 not running that file through the 1.19 formatter somehow (although I'm a little surprised the build that happened on the merge didn't flag that).

## Setup to Run Your Code

- `pre-commit clean && pre-commit install && pre-commit install-hooks` to reset/update hooks
- `pre-commit run -a` to run all files through all pre-commit hooks
- Verify everything passes and there are no locally modified files.
