### PR TITLE
MB-11293: Document when Service Councilor submits the move.

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/index.js
+++ b/src/constants/MoveHistory/EventTemplates/index.js
@@ -44,3 +44,4 @@ export { default as uploadAmendedOrders } from './uploadAmendedOrders';
 export { default as updateMTOShipmentStatus } from './updateMTOShipmentStatus';
 export { default as updateMTOServiceItemMoveStatus } from './createMTOServiceItemUpdateMoveStatus';
 export { default as updateMoveEstimatedExcessWeight } from './updateMTOShipmentPrimeEstimatedExcessWeight';
+export { default as updateMTOStatusServiceCounselingCompleted } from './updateMTOStatusServiceCounselingCompleted';

--- a/src/constants/MoveHistory/EventTemplates/updateMTOStatusServiceCounselingCompleted.js
+++ b/src/constants/MoveHistory/EventTemplates/updateMTOStatusServiceCounselingCompleted.js
@@ -1,0 +1,15 @@
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
+import a from 'constants/MoveHistory/Database/Actions';
+import t from 'constants/MoveHistory/Database/Tables';
+
+export default {
+  action: a.UPDATE,
+  eventName: o.updateMTOStatusServiceCounselingCompleted,
+  tableName: t.moves,
+  detailsType: d.PLAIN_TEXT,
+  getEventNameDisplay: () => `Updated shipment`,
+  getDetailsPlainText: () => {
+    return `Counseling Completed`;
+  },
+};

--- a/src/constants/MoveHistory/EventTemplates/updateMTOStatusServiceCounselingCompleted.test.js
+++ b/src/constants/MoveHistory/EventTemplates/updateMTOStatusServiceCounselingCompleted.test.js
@@ -1,0 +1,18 @@
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import e from 'constants/MoveHistory/EventTemplates/updateMTOStatusServiceCounselingCompleted';
+import a from 'constants/MoveHistory/Database/Actions';
+import t from 'constants/MoveHistory/Database/Tables';
+import o from 'constants/MoveHistory/UIDisplay/Operations';
+
+describe('When given a completed services counseling for a move', () => {
+  const item = {
+    action: a.UPDATE,
+    eventName: o.updateMTOStatusServiceCounselingCompleted,
+    tableName: t.moves,
+  };
+  it('correctly matches the update mto status services counseling completed event', () => {
+    const result = getTemplate(item);
+    expect(result).toMatchObject(e);
+    expect(result.getDetailsPlainText(item)).toEqual('Counseling Completed');
+  });
+});

--- a/src/constants/MoveHistory/UIDisplay/Operations.js
+++ b/src/constants/MoveHistory/UIDisplay/Operations.js
@@ -9,27 +9,28 @@ export default {
   createOrders: 'createOrders', // internal.yaml
   createPaymentRequest: 'createPaymentRequest', // prime.yaml
   createUpload: 'createUpload',
-  requestShipmentReweigh: 'requestShipmentReweigh',
   requestShipmentCancellation: 'requestShipmentCancellation', // ghc.yaml
   requestShipmentDiversion: 'requestShipmentDiversion', // ghc.yaml
+  requestShipmentReweigh: 'requestShipmentReweigh',
   setFinancialReviewFlag: 'setFinancialReviewFlag', // ghc.yaml
   submitAmendedOrders: 'submitAmendedOrders', // internal.yaml
   submitMoveForApproval: 'submitMoveForApproval', // internal.yaml
   updateAllowance: 'updateAllowance', // ghc.yaml
-  updateOrder: 'updateOrder', // ghc.yaml
-  updateOrders: 'updateOrders', // internal.yaml
+  updateBillableWeight: 'updateBillableWeight', // ghc.yaml
+  updateBillableWeightAsTIO: 'updateMaxBillableWeightAsTIO',
   updateMoveTaskOrder: 'updateMoveTaskOrder', // ghc.yaml
   updateMoveTaskOrderStatus: 'updateMoveTaskOrderStatus', // ghc.yaml
+  updateMTOReviewedBillableWeightsAt: 'UpdateMTOReviewedBillableWeightsAt',
   updateMTOServiceItemStatus: 'updateMTOServiceItemStatus', // ghc.yaml
   updateMTOServiceItem: 'updateMTOServiceItem', // ghc.yaml
   updateMTOShipment: 'updateMTOShipment', // ghc.yaml internal.yaml prime.yaml
   updateMTOShipmentAddress: 'updateMTOShipmentAddress', // prime.yaml
-  uploadAmendedOrders: 'uploadAmendedOrders', // internal.yaml
-  updateBillableWeight: 'updateBillableWeight', // ghc.yaml
-  updateBillableWeightAsTIO: 'updateMaxBillableWeightAsTIO',
+  updateMTOShipmentStatus: 'updateMTOShipmentStatus',
+  updateMTOStatusServiceCounselingCompleted: 'updateMTOStatusServiceCounselingCompleted',
+  updateOrder: 'updateOrder', // ghc.yaml
+  updateOrders: 'updateOrders', // internal.yaml
   updatePaymentRequestStatus: 'updatePaymentRequestStatus',
   updateReweigh: 'updateReweigh',
   updateServiceItemStatus: 'updateMTOServiceItemStatus',
-  updateMTOReviewedBillableWeightsAt: 'UpdateMTOReviewedBillableWeightsAt',
-  updateMTOShipmentStatus: 'updateMTOShipmentStatus',
+  uploadAmendedOrders: 'uploadAmendedOrders', // internal.yaml
 };


### PR DESCRIPTION
* added event template for counseling completed
* added test for event template
* updated index and operations files to include counseling completed

Co-authored-by: Juan Ruiz <ruizaj@truss.works>

## [Jira ticket](tbd) for this change

## Summary

Added an Event Template for the updateMTOStatusServiceCounselingCompleted event.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

1. Access the office app
2. Login as Services Counselor
3. Click on any move
4. Update anything that is required (RED indicators)
5. Click on Submit move details
6. Go to the Move History for that move
7. You should see an entry for the Updated Shipment with the plain text Counseling Completed

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Screenshots

BEFORE: 
![image](https://user-images.githubusercontent.com/110134470/192850690-29c23c8a-eef0-4ec0-b4d5-ab1d955efc2c.png)


AFTER - Counseling Completed now visible:
![image](https://user-images.githubusercontent.com/110134470/192850127-2cb03b36-b72f-4dd8-82c0-bef4f02796d4.png)

