### PR TITLE
MB-13435: Remove gidjin's cac access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch exp
+  dp3-branch: &dp3-branch placeholder_branch_name
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env exp
+  dp3-env: &dp3-env placeholder_env
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ references:
   #
   # In addition, it's common practice to disable acceptance tests and
   # ignore tests for dp3 deploys. See the branch settings below.
-  dp3-branch: &dp3-branch placeholder_branch_name
+  dp3-branch: &dp3-branch exp
   # MUST BE ONE OF: loadtest, demo, exp.
   # These are used to pull in env vars so the spelling matters!
-  dp3-env: &dp3-env placeholder_env
+  dp3-env: &dp3-env exp
 
   # set acceptance-branch to the branch you want to ENABLE acceptance
   # tests, or `placeholder_branch_name` if you don't want to run them
@@ -277,7 +277,6 @@ commands:
             scripts/circleci-announce-broken-branch
           when: on_fail
 
-
   deploy_migrations_steps:
     parameters:
       ecr_env:
@@ -451,7 +450,6 @@ commands:
           no_output_timeout: 20m
       - announce_failure
 
-
   deploy_app_storybook:
     parameters:
       s3_bucket:
@@ -537,8 +535,7 @@ commands:
       application:
         type: string
     steps:
-      - run:
-          echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
+      - run: echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
           source $BASH_ENV
       - run:
           name: make server_test_build for <<parameters.application>>
@@ -1062,7 +1059,7 @@ jobs:
       # change the baseline of test results on master builds
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: server-tests-coverage
@@ -1103,7 +1100,7 @@ jobs:
       # change the baseline of test results on master builds
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: client-tests-coverage
@@ -1198,7 +1195,6 @@ jobs:
             - pkg/testdatagen/testdata
       - announce_failure
 
-
   # Compile the client side of the app once and persist the relevant
   # build artifacts to the workspace.
   # This way we don't have to re-run the build and since all necessary
@@ -1241,7 +1237,7 @@ jobs:
       # the cache
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >>]
+            equal: [master, << pipeline.git.branch >>]
           steps:
             save_cache:
               key: v2-node-modules-cache-{{ checksum "yarn.lock" }}
@@ -1737,8 +1733,8 @@ workflows:
           requires:
             - pre_deps_golang
           filters:
-              branches:
-                ignore: [*integration-mtls-ignore-branch, *integration-ignore-branch]
+            branches:
+              ignore: [*integration-mtls-ignore-branch, *integration-ignore-branch]
 
       - anti_virus:
           filters:

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -757,3 +757,4 @@
 20220919160852_create_report_violations_table.up.sql
 20220920143839_add_gbloc_for_navy_and_coast_guard.up.sql
 20220923135119_app_loadtest_cert_migration.up.sql
+20220927210523_remove-gidjin-cac.up.sql

--- a/migrations/app/schema/20220927210523_remove-gidjin-cac.up.sql
+++ b/migrations/app/schema/20220927210523_remove-gidjin-cac.up.sql
@@ -1,0 +1,2 @@
+-- Remove gidjin CAC using unique sha256 digest of client cert
+DELETE FROM client_certs WHERE sha256_digest='31d9903c22119796ebb7ea04321ae35ebd6265015aae260ff7662e66de0c6e1d';


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13435) for this change

## Summary

This pull request removes a user's CAC access to the application, following the model set in [#4299](https://github.com/transcom/mymove/pull/4299).

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)
