### PR TITLE
MB-13770 add status and reason to weight tickets table and model

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -758,3 +758,4 @@
 20220920143839_add_gbloc_for_navy_and_coast_guard.up.sql
 20220923135119_app_loadtest_cert_migration.up.sql
 20220927210523_remove-gidjin-cac.up.sql
+20220929012843_add_status_and_reason_fields_to_weight_tickets_table.up.sql

--- a/migrations/app/schema/20220929012843_add_status_and_reason_fields_to_weight_tickets_table.up.sql
+++ b/migrations/app/schema/20220929012843_add_status_and_reason_fields_to_weight_tickets_table.up.sql
@@ -1,0 +1,8 @@
+-- Add columns to track status and reason to weight_tickets table for office users to set
+
+ALTER TABLE weight_tickets
+	ADD COLUMN status ppm_document_status,
+	ADD COLUMN reason varchar;
+
+COMMENT on COLUMN weight_tickets.status IS 'Status of the weight ticket, e.g. APPROVED.';
+COMMENT on COLUMN weight_tickets.reason IS 'Contains the reason a weight ticket is excluded or rejected; otherwise null.';

--- a/pkg/models/weight_ticket.go
+++ b/pkg/models/weight_ticket.go
@@ -14,25 +14,27 @@ import (
 // WeightTicket represents the weight tickets and related data for a single trip of a PPM Shipment. Each trip should be
 // its own record.
 type WeightTicket struct {
-	ID                                uuid.UUID   `json:"id" db:"id"`
-	PPMShipmentID                     uuid.UUID   `json:"ppm_shipment_id" db:"ppm_shipment_id"`
-	PPMShipment                       PPMShipment `belongs_to:"ppm_shipments" fk_id:"ppm_shipment_id"`
-	CreatedAt                         time.Time   `json:"created_at" db:"created_at"`
-	UpdatedAt                         time.Time   `json:"updated_at" db:"updated_at"`
-	DeletedAt                         *time.Time  `json:"deleted_at" db:"deleted_at"`
-	VehicleDescription                *string     `json:"vehicle_description" db:"vehicle_description"`
-	EmptyWeight                       *unit.Pound `json:"empty_weight" db:"empty_weight"`
-	MissingEmptyWeightTicket          *bool       `json:"missing_empty_weight_ticket" db:"missing_empty_weight_ticket"`
-	EmptyDocumentID                   uuid.UUID   `json:"empty_document_id" db:"empty_document_id"`
-	EmptyDocument                     Document    `belongs_to:"documents" fk_id:"empty_document_id"`
-	FullWeight                        *unit.Pound `json:"full_weight" db:"full_weight"`
-	MissingFullWeightTicket           *bool       `json:"missing_full_weight_ticket" db:"missing_full_weight_ticket"`
-	FullDocumentID                    uuid.UUID   `json:"full_document_id" db:"full_document_id"`
-	FullDocument                      Document    `belongs_to:"documents" fk_id:"full_document_id"`
-	OwnsTrailer                       *bool       `json:"owns_trailer" db:"owns_trailer"`
-	TrailerMeetsCriteria              *bool       `json:"trailer_meets_criteria" db:"trailer_meets_criteria"`
-	ProofOfTrailerOwnershipDocumentID uuid.UUID   `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`
-	ProofOfTrailerOwnershipDocument   Document    `belongs_to:"documents" fk_id:"proof_of_trailer_ownership_document_id"`
+	ID                                uuid.UUID          `json:"id" db:"id"`
+	PPMShipmentID                     uuid.UUID          `json:"ppm_shipment_id" db:"ppm_shipment_id"`
+	PPMShipment                       PPMShipment        `belongs_to:"ppm_shipments" fk_id:"ppm_shipment_id"`
+	CreatedAt                         time.Time          `json:"created_at" db:"created_at"`
+	UpdatedAt                         time.Time          `json:"updated_at" db:"updated_at"`
+	DeletedAt                         *time.Time         `json:"deleted_at" db:"deleted_at"`
+	VehicleDescription                *string            `json:"vehicle_description" db:"vehicle_description"`
+	EmptyWeight                       *unit.Pound        `json:"empty_weight" db:"empty_weight"`
+	MissingEmptyWeightTicket          *bool              `json:"missing_empty_weight_ticket" db:"missing_empty_weight_ticket"`
+	EmptyDocumentID                   uuid.UUID          `json:"empty_document_id" db:"empty_document_id"`
+	EmptyDocument                     Document           `belongs_to:"documents" fk_id:"empty_document_id"`
+	FullWeight                        *unit.Pound        `json:"full_weight" db:"full_weight"`
+	MissingFullWeightTicket           *bool              `json:"missing_full_weight_ticket" db:"missing_full_weight_ticket"`
+	FullDocumentID                    uuid.UUID          `json:"full_document_id" db:"full_document_id"`
+	FullDocument                      Document           `belongs_to:"documents" fk_id:"full_document_id"`
+	OwnsTrailer                       *bool              `json:"owns_trailer" db:"owns_trailer"`
+	TrailerMeetsCriteria              *bool              `json:"trailer_meets_criteria" db:"trailer_meets_criteria"`
+	ProofOfTrailerOwnershipDocumentID uuid.UUID          `json:"proof_of_trailer_ownership_document_id" db:"proof_of_trailer_ownership_document_id"`
+	ProofOfTrailerOwnershipDocument   Document           `belongs_to:"documents" fk_id:"proof_of_trailer_ownership_document_id"`
+	Status                            *PPMDocumentStatus `json:"status" db:"status"`
+	Reason                            *string            `json:"reason" db:"reason"`
 }
 
 type WeightTickets []WeightTicket
@@ -49,5 +51,7 @@ func (w *WeightTicket) Validate(_ *pop.Connection) (*validate.Errors, error) {
 		&OptionalPoundIsNonNegative{Name: "FullWeight", Field: w.FullWeight},
 		&validators.UUIDIsPresent{Name: "FullDocumentID", Field: w.FullDocumentID},
 		&validators.UUIDIsPresent{Name: "ProofOfTrailerOwnershipDocumentID", Field: w.ProofOfTrailerOwnershipDocumentID},
+		&OptionalStringInclusion{Name: "Status", Field: (*string)(w.Status), List: AllowedPPMDocumentStatuses},
+		&StringIsNilOrNotBlank{Name: "Reason", Field: w.Reason},
 	), nil
 }


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-13770) for this change

## Summary

When we originally added the weight ticket table we didn’t add the status and reason fields. We started adding those when we got to the pro gear weight tickets and moving expenses tables. All of them need the fields though so this PR is to add them to the weight tickets table.

## Checking Changes

<details>
<summary>💻 Terminal setup</summary>

### Run migrations on top of existing db

You can run this the first time you pull it down to see it applies the migration properly on top of the existing DB. Not required though, you can also run the other command instead.

```sh
make db_dev_migrate
```

### Run all migrations

```sh
make db_dev_fresh
```

</details>

### Additional steps 

1. Access the DB however you usually do and see if the new columns are on the `weight_tickets` table correctly.

## Verification Steps for Author

These are to be checked by the author.

- [x] Request review from a member of a different team.
- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database