### PR TITLE
Remove evaluation report violations when observed violations is 'no'

### DIFF
--- a/pkg/services/evaluation_report/evaluation_report_updater.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater.go
@@ -51,6 +51,23 @@ func (u evaluationReportUpdater) UpdateEvaluationReport(appCtx appcontext.AppCon
 	evaluationReport.MoveID = originalReport.MoveID
 	evaluationReport.ShipmentID = originalReport.ShipmentID
 	evaluationReport.Type = originalReport.Type
+
+	if evaluationReport.ViolationsObserved != nil && !*evaluationReport.ViolationsObserved {
+		// Check to see if there are existing report_violations for this report
+		existingReportViolations := models.ReportViolations{}
+		err = appCtx.DB().Where("report_id = ?", evaluationReport.ID).All(&existingReportViolations)
+		if err != nil {
+			return err
+		}
+		// Delete the existing reportViolations
+		if len(existingReportViolations) > 0 {
+			err = appCtx.DB().Destroy(existingReportViolations)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	verrs, err := appCtx.DB().ValidateAndSave(evaluationReport)
 	if err != nil {
 		return err

--- a/pkg/services/evaluation_report/evaluation_report_updater_test.go
+++ b/pkg/services/evaluation_report/evaluation_report_updater_test.go
@@ -159,6 +159,27 @@ func (suite EvaluationReportSuite) TestUpdateEvaluationReport() {
 		suite.Equal(report.Remarks, updatedReport.Remarks)
 		suite.Nil(updatedReport.SubmittedAt)
 	})
+
+	suite.Run("saving report with pre-existing violations should delete them if violationsObserved is false", func() {
+		report := testdatagen.MakeEvaluationReport(suite.DB(), testdatagen.Assertions{})
+		testdatagen.MakeReportViolation(suite.DB(), testdatagen.Assertions{ReportViolation: models.ReportViolation{
+			ReportID:    report.ID,
+			Violation:   models.PWSViolation{},
+			ViolationID: uuid.UUID{},
+		}})
+		report.ViolationsObserved = swag.Bool(false)
+
+		// do the update
+		err := updater.UpdateEvaluationReport(suite.AppContextForTest(), &report, report.OfficeUserID, etag.GenerateEtag(report.UpdatedAt))
+		suite.NoError(err)
+
+		var reportViolations models.ReportViolations
+		err = suite.DB().Where("report_id = ?", report.ID).All(&reportViolations)
+		suite.NoError(err)
+		// we shouldn't find any report violations, which means this object should have a 0 length
+		suite.Equal(0, len(reportViolations))
+	})
+
 	suite.Run("saving report does not overwrite readonly fields", func() {
 		// Create a report and save it to the database
 		move := testdatagen.MakeDefaultMove(suite.DB())


### PR DESCRIPTION
## Summary

This adds a check in the services layer that will remove reportViolations when the observedViolations value is false. That condition happens when the user selects 'No' for the observed violations option on the first page of the evaluation report flow.

Going to wait to merge this after the save draft and submission work for reports with violations is done.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app
2. Login as a QAE/CSR user
3. Search for a move (if you're local or on ephemeral there's always `EVLRPT`)
4. Go to the quality assurance tab
5. Create a new report or edit an existing draft
6. Proceed to the violations page of the report process and save some violation selections
7. Click on the submit button as if you're going to submit the report (a preview modal will come up)
8. Notice that there's violations on that modal and then close it without submitting
9. Go back to the first page and select 'No' for the question about whether the report has violations.
10. Go to submit the report and see that there aren't violations on the report

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
