### PR TITLE
[MB-14174] Fixes non-deterministic shipment IDs causing Happo diffs

### DIFF
--- a/src/pages/MyMove/Home/index.stories.jsx
+++ b/src/pages/MyMove/Home/index.stories.jsx
@@ -135,7 +135,11 @@ const amendedOrderProps = {
 
 const propsForApprovedPPMShipment = {
   ...shipmentSelectionProps,
-  mtoShipments: [createApprovedPPMShipment()],
+  mtoShipments: [
+    createApprovedPPMShipment({
+      id: 'abcd1234-0000-0000-0000-000000000000',
+    }),
+  ],
   move: {
     ...withShipmentProps.move,
     status: MOVE_STATUSES.APPROVED,
@@ -146,7 +150,10 @@ const propsForApprovedPPMShipment = {
 const propsForCloseoutCompletePPMShipment = {
   ...shipmentSelectionProps,
   mtoShipments: [
-    createPPMShipmentWithFinalIncentive({ ppmShipment: { status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL } }),
+    createPPMShipmentWithFinalIncentive({
+      id: 'abcd1234-0000-0000-0000-000000000000',
+      ppmShipment: { status: ppmShipmentStatuses.NEEDS_PAYMENT_APPROVAL },
+    }),
   ],
   move: {
     ...withShipmentProps.move,


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14174) for this change

## Summary

This pull request updates the calls in `src/pages/MyMove/Home/index.stories.jsx` to the recently-implemented PPM Shipment factory, specifically to hard-code an ID for the generated shipments. 

Because the first eight characters of the shipment ID is displayed in the `ShipmentListItem` component on-page in the `Home / Approved PPM` and `Home / PPM Closeout Finished` stories, randomly generating a shipment ID will cause Happo to display a different value each time; this pull request will cause it to be permanently set to display as `#ABCD1234`.

@transcom/truss-design: There is no functionality change to the application's behavior, just a small change to the code that presents data to Storybook.

## Setup to Run Your Code

Start the Storybook locally.

```sh
make storybook
```

### Additional steps

1. In Storybook, view the `Customer Components` -> `Pages` -> `Home` -> `Approved PPM` story.
2. Verify that the eight-character shipment ID for the sole item listed in the Shipments step displays as `#ABCD1234`.
3. View the `PPM Closeout Finished` story in the same section and verify Step 2 there as well.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
