### PR TITLE
MB-12739 Remove manual role checks in handlers and add permissions tags.

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -351,7 +351,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "update.customer"
+        ]
       },
       "parameters": [
         {
@@ -2283,7 +2286,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "update.excessWeightRisk"
+        ]
       },
       "parameters": [
         {
@@ -2530,7 +2536,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "read.paymentRequest"
+        ]
       },
       "parameters": [
         {
@@ -2573,7 +2582,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "read.shipmentsPaymentSITBalance"
+        ]
       },
       "parameters": [
         {
@@ -2652,7 +2664,10 @@ func init() {
           "500": {
             "$ref": "#/responses/ServerError"
           }
-        }
+        },
+        "x-permissions": [
+          "update.paymentRequest"
+        ]
       }
     },
     "/pws-violations": {
@@ -8821,7 +8836,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "update.customer"
+        ]
       },
       "parameters": [
         {
@@ -11305,7 +11323,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "update.excessWeightRisk"
+        ]
       },
       "parameters": [
         {
@@ -11616,7 +11637,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "read.paymentRequest"
+        ]
       },
       "parameters": [
         {
@@ -11671,7 +11695,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "read.shipmentsPaymentSITBalance"
+        ]
       },
       "parameters": [
         {
@@ -11771,7 +11798,10 @@ func init() {
               "$ref": "#/definitions/Error"
             }
           }
-        }
+        },
+        "x-permissions": [
+          "update.paymentRequest"
+        ]
       }
     },
     "/pws-violations": {

--- a/pkg/handlers/authentication/permissions.go
+++ b/pkg/handlers/authentication/permissions.go
@@ -18,22 +18,31 @@ type RolePermissions struct {
 var TOO = RolePermissions{
 	RoleType: roles.RoleTypeTOO,
 	Permissions: []string{"update.move", "create.serviceItem",
-		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances", "update.billableWeight", "create.shipmentCancellation", "create.SITExtension", "update.SITExtension", "create.shipmentDiversionRequest", "create.reweighRequest", "update.MTOServiceItem", "read.paymentRequest", "update.paymentServiceItemStatus"},
+		"update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances", "update.billableWeight",
+		"create.shipmentCancellation", "create.SITExtension", "update.SITExtension", "create.shipmentDiversionRequest",
+		"create.reweighRequest", "update.MTOServiceItem", "read.paymentRequest", "update.paymentServiceItemStatus",
+		"update.excessWeightRisk"},
 }
 
 var TIO = RolePermissions{
-	RoleType:    roles.RoleTypeTIO,
-	Permissions: []string{"create.serviceItem", "update.shipment", "update.financialReviewFlag", "update.orders", "update.allowances", "update.billableWeight", "update.maxBillableWeight", "create.ShipmentCancellation", "create.shipmentDiversionRequest", "create.reweighRequest", "update.MTOServiceItem", "read.paymentRequest", "update.paymentServiceItemStatus"},
+	RoleType: roles.RoleTypeTIO,
+	Permissions: []string{"create.serviceItem", "update.shipment", "update.financialReviewFlag", "update.orders",
+		"update.allowances", "update.billableWeight", "update.maxBillableWeight", "create.ShipmentCancellation",
+		"create.shipmentDiversionRequest", "create.reweighRequest", "update.MTOServiceItem", "read.paymentRequest",
+		"update.paymentServiceItemStatus", "read.shipmentsPaymentSITBalance"},
 }
 
 var ServicesCounselor = RolePermissions{
-	RoleType:    roles.RoleTypeServicesCounselor,
-	Permissions: []string{"update.financialReviewFlag", "update.shipment", "update.orders", "update.allowances", "update.billableWeight", "create.shipmentDiversionRequest", "create.reweighRequest", "update.MTOServiceItem"},
+	RoleType: roles.RoleTypeServicesCounselor,
+	Permissions: []string{"update.financialReviewFlag", "update.shipment", "update.orders", "update.allowances",
+		"update.billableWeight", "create.shipmentDiversionRequest", "create.reweighRequest", "update.MTOServiceItem",
+		"update.customer"},
 }
 
 var QAECSR = RolePermissions{
-	RoleType:    roles.RoleTypeQaeCsr,
-	Permissions: []string{"read.paymentRequest", "create.evaluationReport", "update.evaluationReport", "delete.evaluationReport", "create.reportViolation"},
+	RoleType: roles.RoleTypeQaeCsr,
+	Permissions: []string{"read.paymentRequest", "create.evaluationReport", "update.evaluationReport",
+		"delete.evaluationReport", "create.reportViolation"},
 }
 
 var AllRolesPermissions = []RolePermissions{TOO, TIO, ServicesCounselor, QAECSR}

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/transcom/mymove/pkg/gen/ghcmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
-	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 )
 
@@ -55,12 +54,6 @@ type UpdateCustomerHandler struct {
 func (h UpdateCustomerHandler) Handle(params customercodeop.UpdateCustomerParams) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
-
-			if !appCtx.Session().IsOfficeUser() || !appCtx.Session().Roles.HasRole(roles.RoleTypeServicesCounselor) {
-				forbiddenError := apperror.NewForbiddenError("user is not authenticated with service counselor office role")
-				appCtx.Logger().Error(forbiddenError.Error())
-				return customercodeop.NewUpdateCustomerForbidden(), forbiddenError
-			}
 
 			customerID, err := uuid.FromString(params.CustomerID.String())
 			if err != nil {

--- a/pkg/handlers/ghcapi/orders.go
+++ b/pkg/handlers/ghcapi/orders.go
@@ -291,11 +291,6 @@ func (h UpdateBillableWeightHandler) Handle(
 				}
 			}
 
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
-				return handleError(apperror.NewForbiddenError("is not a TOO"))
-			}
-
 			orderID := uuid.FromStringOrNil(params.OrderID.String())
 			dbAuthorizedWeight := swag.Int(int(*params.Body.AuthorizedWeight))
 			updatedOrder, moveID, err := h.excessWeightRiskManager.UpdateBillableWeightAsTOO(
@@ -346,11 +341,6 @@ func (h UpdateMaxBillableWeightAsTIOHandler) Handle(
 				default:
 					return orderop.NewUpdateMaxBillableWeightAsTIOInternalServerError(), err
 				}
-			}
-
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) {
-				return handleError(apperror.NewForbiddenError("is not a TIO"))
 			}
 
 			orderID := uuid.FromStringOrNil(params.OrderID.String())
@@ -405,11 +395,6 @@ func (h AcknowledgeExcessWeightRiskHandler) Handle(
 				default:
 					return orderop.NewAcknowledgeExcessWeightRiskInternalServerError(), err
 				}
-			}
-
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTOO) {
-				return handleError(apperror.NewForbiddenError("is not a TOO"))
 			}
 
 			orderID := uuid.FromStringOrNil(params.OrderID.String())

--- a/pkg/handlers/ghcapi/orders_test.go
+++ b/pkg/handlers/ghcapi/orders_test.go
@@ -762,38 +762,6 @@ func (suite *HandlerSuite) TestCounselingUpdateOrderHandler() {
 		suite.Equal(body.NtsSac.Value, ordersPayload.NtsSac)
 	})
 
-	suite.Run("Returns a 403 when the user does not have Counselor role", func() {
-		handlerConfig := suite.HandlerConfig()
-		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
-		order := subtestData.order
-		body := subtestData.body
-
-		requestUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.CounselingUpdateOrderParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.OrderUpdater{}
-		handler := CounselingUpdateOrderHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateOrderAsTOO", 0)
-		updater.AssertNumberOfCalls(suite.T(), "UpdateOrderAsCounselor", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.CounselingUpdateOrderForbidden{}, response)
-	})
-
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
 		handlerConfig := suite.HandlerConfig()
 		subtestData := suite.makeCounselingUpdateOrderHandlerSubtestData()
@@ -1207,37 +1175,6 @@ func (suite *HandlerSuite) TestCounselingUpdateAllowanceHandler() {
 		suite.Equal(*body.StorageInTransit, *ordersPayload.Entitlement.StorageInTransit)
 	})
 
-	suite.Run("Returns a 403 when the user does not have Counselor role", func() {
-		handlerConfig := suite.HandlerConfig()
-		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
-		order := move.Orders
-
-		requestUser := testdatagen.MakeTOOOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.CounselingUpdateAllowanceParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.OrderUpdater{}
-		handler := CounselingUpdateAllowanceHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateAllowanceAsTOO", 0)
-		updater.AssertNumberOfCalls(suite.T(), "UpdateAllowanceAsCounselor", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.CounselingUpdateAllowanceForbidden{}, response)
-	})
-
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
 		handlerConfig := suite.HandlerConfig()
 		move := testdatagen.MakeNeedsServiceCounselingMove(suite.DB())
@@ -1361,37 +1298,6 @@ func (suite *HandlerSuite) TestUpdateMaxBillableWeightAsTIOHandler() {
 		suite.Assertions.IsType(&orderop.UpdateMaxBillableWeightAsTIOOK{}, response)
 		suite.Equal(order.ID.String(), ordersPayload.ID.String())
 		suite.Equal(body.AuthorizedWeight, ordersPayload.Entitlement.AuthorizedWeight)
-	})
-
-	suite.Run("Returns a 403 when the user does not have TIO role", func() {
-		handlerConfig := suite.HandlerConfig()
-		subtestData := suite.makeUpdateMaxBillableWeightAsTIOHandlerSubtestData()
-		order := subtestData.order
-		body := subtestData.body
-
-		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.UpdateMaxBillableWeightAsTIOParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.ExcessWeightRiskManager{}
-		handler := UpdateMaxBillableWeightAsTIOHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateMaxBillableWeightAsTIO", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.UpdateMaxBillableWeightAsTIOForbidden{}, response)
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
@@ -1526,37 +1432,6 @@ func (suite *HandlerSuite) TestUpdateBillableWeightHandler() {
 		suite.Assertions.IsType(&orderop.UpdateBillableWeightOK{}, response)
 		suite.Equal(order.ID.String(), ordersPayload.ID.String())
 		suite.Equal(body.AuthorizedWeight, ordersPayload.Entitlement.AuthorizedWeight)
-	})
-
-	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		handlerConfig := suite.HandlerConfig()
-		subtestData := suite.makeUpdateBillableWeightHandlerSubtestData()
-		order := subtestData.order
-		body := subtestData.body
-
-		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.UpdateBillableWeightParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-			Body:        body,
-		}
-
-		suite.NoError(params.Body.Validate(strfmt.Default))
-
-		updater := &mocks.ExcessWeightRiskManager{}
-		handler := UpdateBillableWeightHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "UpdateBillableWeightAsTOO", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.UpdateBillableWeightForbidden{}, response)
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {
@@ -1733,36 +1608,6 @@ func (suite *HandlerSuite) TestAcknowledgeExcessWeightRiskHandler() {
 		suite.Assertions.IsType(&orderop.AcknowledgeExcessWeightRiskOK{}, response)
 		suite.Equal(move.ID.String(), movePayload.ID.String())
 		suite.NotNil(movePayload.ExcessWeightAcknowledgedAt)
-	})
-
-	suite.Run("Returns a 403 when the user does not have TOO role", func() {
-		handlerConfig := suite.HandlerConfig()
-		now := time.Now()
-		move := testdatagen.MakeApprovalsRequestedMove(suite.DB(), testdatagen.Assertions{
-			Move: models.Move{ExcessWeightQualifiedAt: &now},
-		})
-		order := move.Orders
-
-		requestUser := testdatagen.MakeServicesCounselorOfficeUser(suite.DB(), testdatagen.Assertions{Stub: true})
-		request = suite.AuthenticateOfficeRequest(request, requestUser)
-
-		params := orderop.AcknowledgeExcessWeightRiskParams{
-			HTTPRequest: request,
-			OrderID:     strfmt.UUID(order.ID.String()),
-			IfMatch:     etag.GenerateEtag(order.UpdatedAt),
-		}
-
-		updater := &mocks.ExcessWeightRiskManager{}
-		handler := AcknowledgeExcessWeightRiskHandler{
-			handlerConfig,
-			updater,
-		}
-
-		updater.AssertNumberOfCalls(suite.T(), "AcknowledgeExcessWeightRisk", 0)
-
-		response := handler.Handle(params)
-
-		suite.IsType(&orderop.AcknowledgeExcessWeightRiskForbidden{}, response)
 	})
 
 	suite.Run("Returns 404 when updater returns NotFoundError", func() {

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -17,7 +17,6 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/models/roles"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/audit"
 	"github.com/transcom/mymove/pkg/services/event"
@@ -74,14 +73,6 @@ func (h GetPaymentRequestHandler) Handle(
 ) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) {
-				forbiddenErr := apperror.NewForbiddenError(
-					"user is not authenticated with TIO office role",
-				)
-				appCtx.Logger().Error(forbiddenErr.Error())
-				return paymentrequestop.NewGetPaymentRequestForbidden(), forbiddenErr
-			}
 
 			paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
 			if err != nil {
@@ -131,15 +122,6 @@ func (h UpdatePaymentRequestStatusHandler) Handle(
 ) middleware.Responder {
 	return h.AuditableAppContextFromRequestWithErrors(params.HTTPRequest,
 		func(appCtx appcontext.AppContext) (middleware.Responder, error) {
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) {
-				forbiddenErr := apperror.NewForbiddenError(
-					"user is not authenticated with TIO office role",
-				)
-				appCtx.Logger().Error(forbiddenErr.Error())
-
-				return paymentrequestop.NewUpdatePaymentRequestStatusForbidden(), forbiddenErr
-			}
 
 			paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
 			if err != nil {
@@ -268,13 +250,6 @@ func (h ShipmentsSITBalanceHandler) Handle(
 				default:
 					return paymentrequestop.NewGetShipmentsPaymentSITBalanceInternalServerError(), err
 				}
-			}
-
-			if !appCtx.Session().IsOfficeUser() ||
-				!appCtx.Session().Roles.HasRole(roles.RoleTypeTIO) {
-				return handleError(
-					apperror.NewForbiddenError("user is not authorized with the TIO role"),
-				)
 			}
 
 			shipmentSITBalances, err := h.ListShipmentPaymentSITBalance(appCtx, paymentRequestID)

--- a/swagger-def/ghc.yaml
+++ b/swagger-def/ghc.yaml
@@ -95,6 +95,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.customer
   '/move/{locator}':
     parameters:
       - description: Code used to identify a move in the system
@@ -426,6 +428,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.excessWeightRisk
   '/orders/{orderID}/update-billable-weight':
     parameters:
       - description: ID of order to use
@@ -1720,6 +1724,8 @@ paths:
       description: Fetches an instance of a payment request by id
       operationId: getPaymentRequest
       summary: Fetches a payment request by id
+      x-permissions:
+        - read.paymentRequest
   '/moves/{locator}/customer-support-remarks':
     parameters:
       - description: move code to identify a move for customer support remarks
@@ -2213,6 +2219,8 @@ paths:
       description: Returns all shipment payment request SIT usage to support partial SIT invoicing
       operationId: getShipmentsPaymentSITBalance
       summary: Returns all shipment payment request SIT usage to support partial SIT invoicing
+      x-permissions:
+        - read.shipmentsPaymentSITBalance
   '/payment-requests/{paymentRequestID}/status':
     patch:
       consumes:
@@ -2259,6 +2267,8 @@ paths:
       description: Updates status of a payment request by id
       operationId: updatePaymentRequestStatus
       summary: Updates status of a payment request by id
+      x-permissions:
+        - update.paymentRequest
   /documents/{documentId}:
     get:
       summary: Returns a document

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -107,6 +107,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.customer
   /move/{locator}:
     parameters:
       - description: Code used to identify a move in the system
@@ -452,6 +454,8 @@ paths:
           $ref: '#/responses/UnprocessableEntity'
         '500':
           $ref: '#/responses/ServerError'
+      x-permissions:
+        - update.excessWeightRisk
   /orders/{orderID}/update-billable-weight:
     parameters:
       - description: ID of order to use
@@ -1760,6 +1764,8 @@ paths:
       description: Fetches an instance of a payment request by id
       operationId: getPaymentRequest
       summary: Fetches a payment request by id
+      x-permissions:
+        - read.paymentRequest
   /moves/{locator}/customer-support-remarks:
     parameters:
       - description: move code to identify a move for customer support remarks
@@ -2273,6 +2279,8 @@ paths:
       summary: >-
         Returns all shipment payment request SIT usage to support partial SIT
         invoicing
+      x-permissions:
+        - read.shipmentsPaymentSITBalance
   /payment-requests/{paymentRequestID}/status:
     patch:
       consumes:
@@ -2319,6 +2327,8 @@ paths:
       description: Updates status of a payment request by id
       operationId: updatePaymentRequestStatus
       summary: Updates status of a payment request by id
+      x-permissions:
+        - update.paymentRequest
   /documents/{documentId}:
     get:
       summary: Returns a document


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12739) for this change

## Summary

This does some clean up of the old way we were handling checking roles in the GHCAPI (office app) and migrates those instances over to using the tags system (x-permissions). You'll also see that I removed some tests that were exercising the 403 response through the Handle function directly since those don't apply anymore (it happens in a different layer now).

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the
2. Login as a
3.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.

### Backend

- [ ] Code follows the guidelines for [Logging](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide#logging)
- [ ] The requirements listed in [Querying the Database Safely](https://transcom.github.io/mymove-docs/docs/dev/contributing/backend/Backend-Programming-Guide/#querying-the-database-safely) have been satisfied.

### Database

#### Any new migrations/schema changes:

- [ ] Follows our guidelines for [Zero-Downtime Deploys](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#zero-downtime-migrations)
- [ ] Have been communicated to #g-database
- [ ] Secure migrations have been tested following the instructions in our [docs](https://transcom.github.io/mymove-docs/docs/dev/contributing/database/Database-Migrations#secure-migrations)

## Screenshots
