### PR TITLE
MB-14203: Fixes non-deterministic stories for ShipmentEvaluationReports

### DIFF
--- a/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.stories.jsx
+++ b/src/components/Office/EvaluationReportTable/ShipmentEvaluationReports.stories.jsx
@@ -41,7 +41,9 @@ const hhgShipment = {
     state: 'AK',
     postalCode: '90210',
   },
+  createdAt: '2020-01-01T00:01:00.999Z',
 };
+
 const ppmShipment = {
   id: '22222222-2222-2222-2222-222222222222',
   shipmentType: SHIPMENT_OPTIONS.PPM,
@@ -49,6 +51,7 @@ const ppmShipment = {
     pickupPostalCode: '89503',
     destinationPostalCode: '90210',
   },
+  createdAt: '2020-01-01T00:02:00.999Z',
 };
 
 const ntsShipment = {
@@ -63,7 +66,9 @@ const ntsShipment = {
   storageFacility: {
     facilityName: 'Awesome Storage LLC',
   },
+  createdAt: '2020-01-01T00:03:00.999Z',
 };
+
 const ntsrShipment = {
   id: '44444444-4444-4444-4444-444444444444',
   shipmentType: SHIPMENT_OPTIONS.NTSR,
@@ -76,6 +81,7 @@ const ntsrShipment = {
   storageFacility: {
     facilityName: 'Awesome Storage LLC',
   },
+  createdAt: '2020-01-01T00:04:00.999Z',
 };
 
 const shipments = [hhgShipment, ppmShipment, ntsShipment, ntsrShipment];
@@ -100,6 +106,7 @@ const reports = [
     violationsObserved: true,
   },
 ];
+
 export const empty = () => (
   <div className="officeApp">
     <ShipmentEvaluationReports reports={[]} />


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-14203) for this change

## Summary

This pull request updates the mock data in `src/components/Office/EvaluationReportTables/ShipmentEvaluationReports.stories.jsx` so that mock shipments passed in as a prop to the component include a `createdAt` property.

The underlying component accepts an array of shipments as a prop, and then sorts that array by the `createdAt` properties. Since the story's mock data does not include that value, the sorted order is non-deterministic; this causes the order of shipments displaying on the page to vary during runs of Happo, and creates unnecessary diffs that need to be resolved.

https://github.com/orgs/transcom/teams/truss-design: There is no functionality change to the application's behavior, just a small change to the code that presents data to Storybook. Note that Happo **may** cite these changes as diffs in this pull request, but this PR should fix the problem in future branches.

## Setup to Run Your Code

Start the Storybook locally.

```sh
make storybook
```

### Additional steps

1. In Storybook, view the `Office Components` -> `ShipmentEvaluationReports` -> `Single` story.
2. Verify that the order of shipments displays as HHG, followed by PPM, followed by NTS, followed by NTS-release.
3. View the `Single Read Only` story in the same section and verify Step 2 there as well.

## Verification Steps for Author

These are to be checked by the author.

- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.
