### PR TITLE
MB-12436 - Display deleted values in move history details

### DIFF
--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -57,7 +57,8 @@ const LabeledDetails = ({ historyRecord, getDetailsLabeledDetails }) => {
     delete changedValuesToUse.service_item_name;
   }
 
-  // Filter out empty values unless they used to be non-empty
+  /* Filter out empty values unless they used to be non-empty
+     These values may be non-nullish in oldValues and nullish in changedValues */
   const dbFieldsToDisplay = Object.keys(fieldMappings).filter((dbField) => {
     return (
       changedValuesToUse[dbField] ||

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -12,6 +12,7 @@ import optionFields from 'constants/MoveHistory/Database/OptionFields';
 import { formatCustomerDate } from 'utils/formatters';
 
 const retrieveTextToDisplay = (fieldName, value) => {
+  const emptyValue = '—';
   const displayName = fieldMappings[fieldName];
   let displayValue = value;
 
@@ -23,6 +24,10 @@ const retrieveTextToDisplay = (fieldName, value) => {
     displayValue = optionFields[displayValue];
   } else if (dateFields[fieldName]) {
     displayValue = formatCustomerDate(displayValue);
+  }
+
+  if (!displayValue) {
+    displayValue = emptyValue;
   }
 
   return {

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -61,7 +61,7 @@ const LabeledDetails = ({ historyRecord, getDetailsLabeledDetails }) => {
   const dbFieldsToDisplay = Object.keys(fieldMappings).filter((dbField) => {
     return (
       changedValuesToUse[dbField] ||
-      (dbField in changedValuesToUse && historyRecord.oldValues && dbField in historyRecord.oldValues)
+      (dbField in changedValuesToUse && historyRecord.oldValues && historyRecord.oldValues[dbField])
     );
   });
 

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -56,10 +56,7 @@ const LabeledDetails = ({ historyRecord, getDetailsLabeledDetails }) => {
   const dbFieldsToDisplay = Object.keys(fieldMappings).filter((dbField) => {
     return (
       changedValuesToUse[dbField] ||
-      (changedValuesToUse &&
-        dbField in changedValuesToUse &&
-        historyRecord.oldValues &&
-        dbField in historyRecord.oldValues)
+      (dbField in changedValuesToUse && historyRecord.oldValues && dbField in historyRecord.oldValues)
     );
   });
 

--- a/src/pages/Office/MoveHistory/LabeledDetails.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.jsx
@@ -52,8 +52,15 @@ const LabeledDetails = ({ historyRecord, getDetailsLabeledDetails }) => {
     delete changedValuesToUse.service_item_name;
   }
 
+  // Filter out empty values unless they used to be non-empty
   const dbFieldsToDisplay = Object.keys(fieldMappings).filter((dbField) => {
-    return changedValuesToUse[dbField];
+    return (
+      changedValuesToUse[dbField] ||
+      (changedValuesToUse &&
+        dbField in changedValuesToUse &&
+        historyRecord.oldValues &&
+        dbField in historyRecord.oldValues)
+    );
   });
 
   return (

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -119,7 +119,6 @@ it('does render text for changed values that are blank when they exist in the ol
   const historyRecord = {
     changedValues: {
       billable_weight_cap: '200',
-      customer_remarks: 'Test customer remarks',
       counselor_remarks: '',
     },
     oldValues: {
@@ -129,7 +128,8 @@ it('does render text for changed values that are blank when they exist in the ol
 
   render(<LabeledDetails historyRecord={historyRecord} />);
 
-  expect(screen.getByText('Customer remarks')).toBeInTheDocument();
+  expect(screen.getByText('Counselor remarks')).toBeInTheDocument();
+  expect(screen.getByText('—', { exact: false })).toBeInTheDocument();
 
   expect(await screen.queryByText('These remarks were deleted')).not.toBeInTheDocument();
 });

--- a/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
+++ b/src/pages/Office/MoveHistory/LabeledDetails.test.jsx
@@ -114,3 +114,22 @@ describe('LabeledDetails', () => {
     expect(await screen.queryByText('Counselor remarks')).not.toBeInTheDocument();
   });
 });
+
+it('does render text for changed values that are blank when they exist in the old values (deleted values)', async () => {
+  const historyRecord = {
+    changedValues: {
+      billable_weight_cap: '200',
+      customer_remarks: 'Test customer remarks',
+      counselor_remarks: '',
+    },
+    oldValues: {
+      counselor_remarks: 'These remarks were deleted',
+    },
+  };
+
+  render(<LabeledDetails historyRecord={historyRecord} />);
+
+  expect(screen.getByText('Customer remarks')).toBeInTheDocument();
+
+  expect(await screen.queryByText('These remarks were deleted')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-12436) for this change

## Summary

In the move history details, historyrecord.changedValue values that are null/empty/missing are filtered out from display so that superfluous information isn't shown to the user. This PR should begin to display some exceptions to this rule, in which a changedValue that is empty _is_ displayed if it also exists as an oldValue -- in other words, when the value has ostensibly been deleted (as in the case of deleted Services Counselor remarks).


## Setup to Run Your Code

<details>
<summary>💻 You will need to use two separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the office app as a services counselor
2. Access the moved details page for any move
3. Edit any shipment, add remarks, and hit `save`
4. Edit the shipment again, delete the remarks, and hit `save`
5. Navigate to the move history table
6. Ensure that the move history record corresponding to the deletion of the remarks shows the necessary information

## Verification Steps for Author

These are to be checked by the author.

- [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
- [ ] Request review from a member of a different team.
- [ ] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

<!-- Fill out the next sections as you see fit, these are just suggestions. -->

### Frontend

- [ ] User facing changes have been reviewed by design.
- [ ] There are no aXe warnings for UI.
- [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
- [ ] There are no new console errors in the browser devtools
- [ ] There are no new console errors in the test output
- [ ] If this PR adds a new component to Storybook, it ensures the component is fully responsive, OR if it is intentionally not, a wrapping div using the `officeApp` class or custom `min-width` styling is used to hide any states the would not be visible to the user.


## Screenshots
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/97245917/194374201-c08d5ed5-6352-493c-8f13-f35b254c1fe5.png">