### PR TITLE
[MB-12602] Modifying the move history sql query to retrieve service member information

### DIFF
--- a/pkg/services/query/sql_scripts/move_history_fetcher.sql
+++ b/pkg/services/query/sql_scripts/move_history_fetcher.sql
@@ -391,15 +391,16 @@ WITH moves AS (
 			service_members_logs
 	) SELECT DISTINCT
 		combined_logs.*,
-		COALESCE(office_users.first_name, prime_user_first_name) AS session_user_first_name,
-		office_users.last_name AS session_user_last_name,
-		office_users.email AS session_user_email,
-		office_users.telephone AS session_user_telephone
-	FROM
-		combined_logs
+		COALESCE(office_users.first_name, prime_user_first_name, service_members.first_name) AS session_user_first_name,
+		COALESCE(office_users.last_name, service_members.last_name) AS session_user_last_name,
+		COALESCE(office_users.email, service_members.personal_email) AS session_user_email,
+		COALESCE(office_users.telephone, service_members.telephone) AS session_user_telephone
+FROM
+	combined_logs
 		LEFT JOIN users_roles ON session_userid = users_roles.user_id
 		LEFT JOIN roles ON users_roles.role_id = roles.id
 		LEFT JOIN office_users ON office_users.user_id = session_userid
+		LEFT JOIN service_members ON service_members.user_id = session_userid
 		LEFT JOIN (
 			SELECT 'Prime' AS prime_user_first_name
 			) prime_users ON roles.role_type = 'prime'


### PR DESCRIPTION
Co-authored-by: Katy Chambers <katyc@truss.works>

## [MB-12602](https://dp3.atlassian.net/browse/MB-12602) for this change

## Summary



## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Storybook locally.

```sh
make storybook
```

##### Terminal 2

Start the UI locally.

```sh
make client_run
```

##### Terminal 3

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps

<!-- Fill out the next section as you see fit, these are just suggestions. -->

1. Access the milmove app as a service member. 
2. Go through the process of creating a move, all the way through uploading orders, creating the HHG shipment and signing and submitting the move. (Make sure you use the correct GBLOC, Fort McCoy is a duty station that will show up easily for our normal local dev patterns)
3. Log into the office app as a services counselor and view the move history for the move just created.
4. You should see the customer information in the Modified By Column including Last name, First name, email and phone number

## Verification Steps for Author

These are to be checked by the author.

- [ ] Have the Jira acceptance criteria been met for this change?


## Screenshots
Before
![image](https://user-images.githubusercontent.com/110134470/194367758-43748f72-1407-4626-aa42-846d3b62b7dc.png)


After
![image](https://user-images.githubusercontent.com/110134470/194367245-343f1304-dba8-40f7-9c7c-01e69d6d8f1d.png)

