### PR TITLE
[MB-12746] Fix nil dereferences when generating PDFs

### DIFF
--- a/pkg/paperwork/evaluation_report.go
+++ b/pkg/paperwork/evaluation_report.go
@@ -322,8 +322,15 @@ func FormatValuesShipment(shipment models.MTOShipment) ShipmentValues {
 		vals.PPMDestinationZIP = shipment.PPMShipment.DestinationPostalCode
 		vals.PPMDepartureDate = shipment.PPMShipment.ExpectedDepartureDate.Format(dateFormat)
 	}
-	if shipment.StorageFacility != nil || shipment.StorageFacilityID != nil {
-		vals.StorageFacility = fmt.Sprintf("%s\n%s", *shipment.StorageFacility.Phone, *shipment.StorageFacility.Email)
+	if shipment.StorageFacility != nil {
+		if shipment.StorageFacility.Phone != nil && shipment.StorageFacility.Email != nil {
+			vals.StorageFacility = fmt.Sprintf("%s\n%s", *shipment.StorageFacility.Phone, *shipment.StorageFacility.Email)
+		} else if shipment.StorageFacility.Phone != nil {
+			vals.StorageFacility = *shipment.StorageFacility.Phone
+		} else if shipment.StorageFacility.Email != nil {
+			vals.StorageFacility = *shipment.StorageFacility.Email
+		}
+
 		if shipment.ShipmentType == models.MTOShipmentTypeHHGOutOfNTSDom {
 			vals.PickupAddress = formatSingleLineAddress(shipment.StorageFacility.Address)
 		}


### PR DESCRIPTION
## [Jira ticket](tbd) for this change

## Summary
The code that handled displaying the contact info for storage facilities in NTS shipment cards in the PDFs did not handle the case where there was a missing phone number or email. This resulted in a 500 error.

Jira comment where Bo calls out this bug: https://dp3.atlassian.net/browse/MB-12746?focusedCommentId=23986
[Staging logs for the error Bo saw](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logsV2:logs-insights$3FqueryDetail$3D$257E$2528end$257E$25272022-10-06T18*3a41*3a50.545Z$257Estart$257E$25272022-10-06T18*3a27*3a23.548Z$257EtimeType$257E$2527ABSOLUTE$257Etz$257E$2527Local$257EeditorString$257E$2527fields*20*40timestamp*2c*20*40message*0a*7c*20filter*20level*20*3d*20*27error*27*20AND*20msg*20*21*3d*20*27Bad*20Hostname*27*0a*7c*20sort*20*40timestamp*20desc$257EisLiveTail$257Efalse$257EqueryId$257E$25275361f25a-863f-40ee-9ad1-dc109f8b2dc5$257Esource$257E$2528$257E$2527ecs-tasks-app-stg$257E$2527ecs-tasks-app-client-tls-stg$2529$2529)
```
milmove_trace_id: 9b3284f5-a72e-4f51-848c-76188d3ca908
error: runtime error: invalid memory address or nil pointer dereference
stacktrace:
github.com/transcom/mymove/pkg/middleware.Recovery.func1.1.1
/home/circleci/transcom/mymove/pkg/middleware/recovery.go:39
github.com/transcom/mymove/pkg/paperwork.FormatValuesShipment
/home/circleci/transcom/mymove/pkg/paperwork/evaluation_report.go:326
github.com/transcom/mymove/pkg/paperwork.(*EvaluationReportFormFiller).shipmentCard
/home/circleci/transcom/mymove/pkg/paperwork/evaluation_report_form_creator.go:305
```

## Setup to Run Your Code

<details>
<summary>💻 You will need to use separate terminals to test this locally.</summary>

##### Terminal 1

Start the UI locally.

```sh
make client_run
```

##### Terminal 2

Start the Go server locally.

```sh
make server_run
```

</details>

### Additional steps
- Make devseed data (if you haven't already)
```sh
make db_dev_e2e_populate
```
- Set some storage facility contact info to NULL using the queries below. It should work when phone number is NULL, email is NULL, and when both are NULL.
- Log in to office app as a QAE/CSR user
- Attempt to download the NTS shipment report for EVLRPT
- If you don't run into an internal server error, and are able to see the shipment report PDF, then the fix was successful

```sql
-- Sets all phone numbers for storage facilities associated with move EVLRPT
update storage_facilities
set phone = NULL
where id in (
    select ms.storage_facility_id
    from mto_shipments ms
    where ms.move_id = (select id from moves where locator = 'EVLRPT')
);

-- Set emails to NULL
update storage_facilities
set phone = NULL
where id in (
    select ms.storage_facility_id
    from mto_shipments ms
    where ms.move_id = (select id from moves where locator = 'EVLRPT')
);
```

https://user-images.githubusercontent.com/2627844/194408616-4cac2f91-1995-46e3-8d5e-095ffce3b502.mov


