### PR TITLE
Now displaying confirmation message when customer signs and submits order

### DIFF
--- a/src/constants/MoveHistory/EventTemplates/submitMoveForApproval.js
+++ b/src/constants/MoveHistory/EventTemplates/submitMoveForApproval.js
@@ -1,11 +1,13 @@
+import a from 'constants/MoveHistory/Database/Actions';
 import o from 'constants/MoveHistory/UIDisplay/Operations';
+import t from 'constants/MoveHistory/Database/Tables';
 import d from 'constants/MoveHistory/UIDisplay/DetailsTypes';
 
 export default {
-  action: '*',
+  action: a.UPDATE,
   eventName: o.submitMoveForApproval,
-  tableName: '*',
+  tableName: t.moves,
   detailsType: d.PLAIN_TEXT,
   getEventNameDisplay: () => 'Submitted move',
-  getDetailsPlainText: () => '-',
+  getDetails: () => 'Received customer signature',
 };

--- a/src/constants/MoveHistory/EventTemplates/submitMoveForApproval.test.js
+++ b/src/constants/MoveHistory/EventTemplates/submitMoveForApproval.test.js
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import getTemplate from 'constants/MoveHistory/TemplateManager';
+import e from 'constants/MoveHistory/EventTemplates/submitMoveForApproval';
+
+describe('When a customer signs and submits a move request', () => {
+  const item = {
+    action: 'UPDATE',
+    changedValues: { status: 'NEEDS SERVICE COUNSELING' },
+    eventName: 'submitMoveForApproval',
+    tableName: 'moves',
+  };
+
+  it('displays a confirmation message in the details column', () => {
+    const result = getTemplate(item);
+
+    expect(result).toMatchObject(e);
+    render(result.getDetails(item));
+    expect(screen.getByText('Received customer signature')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## [Jira ticket](https://dp3.atlassian.net/browse/MB-11226) for this change

## Summary

Acceptance criteria has been met in terms of displaying the plain text message in the details column. I believe the customer information being displayed will be handled by this [pull request](https://github.com/transcom/mymove/pull/9313) once merged.

## Setup to Run Your Code

<details>
<summary>💻 You will need to use three separate terminals to test this locally.</summary>

##### Terminal 1

Start the Server locally.

```sh
make server_run
```

##### Terminal 2

Start the Customer UI locally.

```sh
make client_run
```

##### Terminal 3

Start the office client locally.

```sh
make office_client_run
```

</details>

## Verification Steps for Author

These are to be checked by the author.

- [x] Have the Jira acceptance criteria been met for this change?

## Verification Steps for Reviewers

These are to be checked by a reviewer.

1. Create a new customer and go through the entire move process ensuring you sign and submit.
2. Login as a service counselor and visit the move history tab.
3. The event should read "Submitted move" and the details should read "Received customer signature".

### Frontend

- [ ] User facing changes have been reviewed by design.
- [x] There are no new console errors in the browser devtools
- [x] There are no new console errors in the test output

## Screenshots

<img width="1327" alt="Screen Shot 2022-10-06 at 3 47 05 PM" src="https://user-images.githubusercontent.com/111928238/194432397-f00411b4-8deb-430a-9b23-b201bd7e9ef1.png">

